### PR TITLE
chore(deps): bump rustls-webpki to 0.103.13 (RUSTSEC-2026-0104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4616,9 +4616,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary

`cargo audit` on release/1.1.x flags `rustls-webpki` 0.103.12 for **RUSTSEC-2026-0104** ("Reachable panic in CRL parsing", published 2026-04-22). main is already on 0.103.13; bringing release/1.1.x in line.

This unblocks the Security Audit check on the in-flight v1.1.9 backports (#891, #899, #900). Once this lands, those PRs rebase and pick up the new lock automatically.

Cargo.lock-only change. No code, no behavioral change.

## Test Checklist
- [x] Unit tests added/updated -- N/A (deps-only)
- [x] Manually tested locally (`cargo build --workspace`: pass)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes