### PR TITLE
feat(webhooks): encrypted-at-rest secrets with rotation API (E1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,6 +180,11 @@ JWT_EXPIRATION_SECS=86400
 # SSO encryption key for encrypting stored OIDC/LDAP/SAML secrets in the database
 # SSO_ENCRYPTION_KEY=
 
+# Webhook signing-secret encryption key. 32 bytes, base64 encoded. Generate
+# with: openssl rand -base64 32. Required for the webhooks v2 create and
+# rotate-secret endpoints; without it those calls fail with HTTP 500.
+# AK_WEBHOOK_SECRET_KEY=
+
 # --- OIDC (optional) ---
 # OIDC_ISSUER=https://auth.example.com
 # OIDC_CLIENT_ID=artifact-registry

--- a/backend/migrations/080_webhook_secrets_encrypted.sql
+++ b/backend/migrations/080_webhook_secrets_encrypted.sql
@@ -1,0 +1,23 @@
+-- Webhooks v2: encrypted-at-rest secrets, write-once display, rotation support.
+--
+-- Replaces the legacy bcrypt secret_hash with reversible AES-256-GCM ciphertext
+-- so the backend can sign delivery payloads (HMAC signing arrives in a later
+-- ticket; this migration only lays the storage foundation).
+--
+-- secret_hash is intentionally retained during the transition. Existing rows
+-- have only a bcrypt hash, which is unrecoverable. Operators must call
+-- POST /api/v1/webhooks/{id}/rotate-secret to obtain a new signable secret.
+-- Until then, deliveries for those rows remain unsigned (matches existing
+-- behavior in the retry path, which previously emitted a placeholder header).
+-- A follow-up migration drops secret_hash once all rows are rotated.
+
+ALTER TABLE webhooks ADD COLUMN secret_encrypted bytea;
+ALTER TABLE webhooks ADD COLUMN secret_digest text;
+ALTER TABLE webhooks ADD COLUMN secret_rotation_started_at timestamptz;
+ALTER TABLE webhooks ADD COLUMN secret_previous_encrypted bytea;
+ALTER TABLE webhooks ADD COLUMN secret_previous_expires_at timestamptz;
+
+-- Partial index used by the previous-secret cleanup tick (see scheduler_service).
+CREATE INDEX idx_webhooks_secret_previous_expires_at
+    ON webhooks (secret_previous_expires_at)
+    WHERE secret_previous_encrypted IS NOT NULL;

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -13,6 +13,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::webhook_payloads::{self, PayloadTemplate};
+use crate::services::webhook_secret_crypto;
 
 /// Create webhook routes
 pub fn router() -> Router<SharedState> {
@@ -22,6 +23,7 @@ pub fn router() -> Router<SharedState> {
         .route("/:id/enable", post(enable_webhook))
         .route("/:id/disable", post(disable_webhook))
         .route("/:id/test", post(test_webhook))
+        .route("/:id/rotate-secret", post(rotate_webhook_secret))
         .route("/:id/deliveries", get(list_deliveries))
         .route("/:id/deliveries/:delivery_id/redeliver", post(redeliver))
 }
@@ -70,6 +72,9 @@ pub struct CreateWebhookRequest {
     pub name: String,
     pub url: String,
     pub events: Vec<String>,
+    /// Optional caller-supplied secret. When omitted the server generates a
+    /// fresh `whsec_*` secret. Either way the raw value is returned in the
+    /// 201 response body exactly once and is unrecoverable thereafter.
     pub secret: Option<String>,
     pub repository_id: Option<Uuid>,
     #[schema(value_type = Option<Object>)]
@@ -90,8 +95,40 @@ pub struct WebhookResponse {
     #[schema(value_type = Option<Object>)]
     pub headers: Option<serde_json::Value>,
     pub payload_template: PayloadTemplate,
+    /// Short non-reversible identifier for the current signing secret
+    /// (`whsec_...abcd`), suitable for display in operator UIs. The raw
+    /// secret is never returned by GET or LIST.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_digest: Option<String>,
+    /// True while a previous secret is still accepted by the retry path
+    /// during a rotation overlap window.
+    #[serde(default)]
+    pub secret_rotation_active: bool,
     pub last_triggered_at: Option<chrono::DateTime<chrono::Utc>>,
     pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Response returned exactly once when a webhook is created or its secret
+/// is rotated. The raw `secret` value is not retrievable afterwards.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct WebhookSecretCreatedResponse {
+    #[serde(flatten)]
+    pub webhook: WebhookResponse,
+    /// Raw signing secret. Display this to the operator immediately and
+    /// instruct them to record it; the server retains only the encrypted
+    /// form and a short digest.
+    pub secret: String,
+}
+
+/// Response returned by the rotate-secret endpoint.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RotateWebhookSecretResponse {
+    pub id: Uuid,
+    /// Raw signing secret produced by this rotation. Shown exactly once.
+    pub secret: String,
+    pub secret_digest: String,
+    /// When the previously active secret stops being accepted.
+    pub previous_secret_expires_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -126,7 +163,8 @@ pub async fn list_webhooks(
     let webhooks = sqlx::query(
         r#"
         SELECT id, name, url, events, is_enabled, repository_id, headers,
-               payload_template, last_triggered_at, created_at
+               payload_template, secret_digest, secret_previous_expires_at,
+               last_triggered_at, created_at
         FROM webhooks
         WHERE ($1::uuid IS NULL OR repository_id = $1)
           AND ($2::boolean IS NULL OR is_enabled = $2)
@@ -162,6 +200,8 @@ pub async fn list_webhooks(
         .into_iter()
         .map(|w| {
             let tpl: String = w.get("payload_template");
+            let prev_expires: Option<chrono::DateTime<chrono::Utc>> =
+                w.get("secret_previous_expires_at");
             WebhookResponse {
                 id: w.get("id"),
                 name: w.get("name"),
@@ -171,6 +211,10 @@ pub async fn list_webhooks(
                 repository_id: w.get("repository_id"),
                 headers: w.get("headers"),
                 payload_template: PayloadTemplate::from_str_lossy(&tpl),
+                secret_digest: w.get("secret_digest"),
+                secret_rotation_active: prev_expires
+                    .map(|e| e > chrono::Utc::now())
+                    .unwrap_or(false),
                 last_triggered_at: w.get("last_triggered_at"),
                 created_at: w.get("created_at"),
             }
@@ -180,7 +224,12 @@ pub async fn list_webhooks(
     Ok(Json(WebhookListResponse { items, total }))
 }
 
-/// Create webhook
+/// Create webhook.
+///
+/// Generates a fresh signing secret (or accepts a caller-supplied one),
+/// encrypts it at rest, and returns the raw secret in the response body
+/// **once**. After this call, GET on the webhook returns only
+/// `secret_digest`, never the raw secret.
 #[utoipa::path(
     post,
     path = "",
@@ -188,7 +237,7 @@ pub async fn list_webhooks(
     tag = "webhooks",
     request_body = CreateWebhookRequest,
     responses(
-        (status = 200, description = "Webhook created successfully", body = WebhookResponse),
+        (status = 200, description = "Webhook created. Body includes the raw secret exactly once.", body = WebhookSecretCreatedResponse),
         (status = 422, description = "Validation error"),
         (status = 500, description = "Internal server error")
     ),
@@ -198,7 +247,7 @@ pub async fn create_webhook(
     State(state): State<SharedState>,
     Extension(_auth): Extension<AuthExtension>,
     Json(payload): Json<CreateWebhookRequest>,
-) -> Result<Json<WebhookResponse>> {
+) -> Result<Json<WebhookSecretCreatedResponse>> {
     // Validate URL (SSRF prevention)
     validate_webhook_url(&payload.url)?;
 
@@ -209,37 +258,49 @@ pub async fn create_webhook(
         ));
     }
 
-    // Hash secret if provided
-    let secret_hash = if let Some(ref secret) = payload.secret {
-        Some(crate::services::auth_service::AuthService::hash_password(secret).await?)
-    } else {
-        None
-    };
+    // Use the caller-provided secret if any, otherwise generate one.
+    let raw_secret = payload
+        .secret
+        .clone()
+        .unwrap_or_else(webhook_secret_crypto::generate_secret);
+
+    // Encrypt at rest.
+    let secret_encrypted = webhook_secret_crypto::encrypt_secret(&raw_secret).map_err(|e| {
+        tracing::error!("webhook secret encryption failed: {}", e);
+        AppError::Internal("webhook secret encryption is not configured".to_string())
+    })?;
+    let secret_digest = webhook_secret_crypto::digest_for_display(&raw_secret);
 
     use sqlx::Row;
 
     let template_str = payload.payload_template.to_string();
     let webhook = sqlx::query(
         r#"
-        INSERT INTO webhooks (name, url, events, secret_hash, repository_id, headers, payload_template)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        INSERT INTO webhooks
+            (name, url, events, repository_id, headers, payload_template,
+             secret_encrypted, secret_digest)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING id, name, url, events, is_enabled, repository_id, headers,
-                  payload_template, last_triggered_at, created_at
+                  payload_template, secret_digest, secret_previous_expires_at,
+                  last_triggered_at, created_at
         "#,
     )
     .bind(&payload.name)
     .bind(&payload.url)
     .bind(&payload.events)
-    .bind(&secret_hash)
     .bind(payload.repository_id)
     .bind(&payload.headers)
     .bind(&template_str)
+    .bind(&secret_encrypted)
+    .bind(&secret_digest)
     .fetch_one(&state.db)
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
 
     let tpl: String = webhook.get("payload_template");
-    Ok(Json(WebhookResponse {
+    let prev_expires: Option<chrono::DateTime<chrono::Utc>> =
+        webhook.get("secret_previous_expires_at");
+    let response = WebhookResponse {
         id: webhook.get("id"),
         name: webhook.get("name"),
         url: webhook.get("url"),
@@ -248,8 +309,17 @@ pub async fn create_webhook(
         repository_id: webhook.get("repository_id"),
         headers: webhook.get("headers"),
         payload_template: PayloadTemplate::from_str_lossy(&tpl),
+        secret_digest: webhook.get("secret_digest"),
+        secret_rotation_active: prev_expires
+            .map(|e| e > chrono::Utc::now())
+            .unwrap_or(false),
         last_triggered_at: webhook.get("last_triggered_at"),
         created_at: webhook.get("created_at"),
+    };
+
+    Ok(Json(WebhookSecretCreatedResponse {
+        webhook: response,
+        secret: raw_secret,
     }))
 }
 
@@ -277,7 +347,8 @@ pub async fn get_webhook(
     let webhook = sqlx::query(
         r#"
         SELECT id, name, url, events, is_enabled, repository_id, headers,
-               payload_template, last_triggered_at, created_at
+               payload_template, secret_digest, secret_previous_expires_at,
+               last_triggered_at, created_at
         FROM webhooks
         WHERE id = $1
         "#,
@@ -289,6 +360,8 @@ pub async fn get_webhook(
     .ok_or_else(|| AppError::NotFound("Webhook not found".to_string()))?;
 
     let tpl: String = webhook.get("payload_template");
+    let prev_expires: Option<chrono::DateTime<chrono::Utc>> =
+        webhook.get("secret_previous_expires_at");
     Ok(Json(WebhookResponse {
         id: webhook.get("id"),
         name: webhook.get("name"),
@@ -298,6 +371,10 @@ pub async fn get_webhook(
         repository_id: webhook.get("repository_id"),
         headers: webhook.get("headers"),
         payload_template: PayloadTemplate::from_str_lossy(&tpl),
+        secret_digest: webhook.get("secret_digest"),
+        secret_rotation_active: prev_expires
+            .map(|e| e > chrono::Utc::now())
+            .unwrap_or(false),
         last_triggered_at: webhook.get("last_triggered_at"),
         created_at: webhook.get("created_at"),
     }))
@@ -717,6 +794,107 @@ pub async fn redeliver(
     }))
 }
 
+/// Length of the rotation overlap window. Both the previous and the
+/// current secret are accepted by the retry path during this window.
+const SECRET_ROTATION_OVERLAP: chrono::Duration = chrono::Duration::hours(24);
+
+/// Rotate the signing secret for a webhook.
+///
+/// Generates a new raw secret, encrypts it, moves the existing
+/// `secret_encrypted` into `secret_previous_encrypted`, and stamps an
+/// expiry 24 hours in the future. The new raw secret is returned in the
+/// response body **once**. The HMAC signing path (added in a later ticket)
+/// signs deliveries with both secrets while the previous one is within
+/// its expiry window so consumers can rotate without dropped events.
+#[utoipa::path(
+    post,
+    path = "/{id}/rotate-secret",
+    context_path = "/api/v1/webhooks",
+    tag = "webhooks",
+    params(
+        ("id" = Uuid, Path, description = "Webhook ID")
+    ),
+    responses(
+        (status = 200, description = "Secret rotated. Body includes the new raw secret exactly once.", body = RotateWebhookSecretResponse),
+        (status = 404, description = "Webhook not found"),
+        (status = 500, description = "Encryption key not configured")
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn rotate_webhook_secret(
+    State(state): State<SharedState>,
+    Extension(_auth): Extension<AuthExtension>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<RotateWebhookSecretResponse>> {
+    let new_secret = webhook_secret_crypto::generate_secret();
+    let new_encrypted = webhook_secret_crypto::encrypt_secret(&new_secret).map_err(|e| {
+        tracing::error!("webhook secret encryption failed during rotation: {}", e);
+        AppError::Internal("webhook secret encryption is not configured".to_string())
+    })?;
+    let new_digest = webhook_secret_crypto::digest_for_display(&new_secret);
+    let now = chrono::Utc::now();
+    let previous_expires_at = now + SECRET_ROTATION_OVERLAP;
+
+    let updated = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        UPDATE webhooks
+        SET
+            secret_previous_encrypted   = secret_encrypted,
+            secret_previous_expires_at  = CASE
+                WHEN secret_encrypted IS NOT NULL THEN $2
+                ELSE NULL
+            END,
+            secret_encrypted            = $3,
+            secret_digest               = $4,
+            secret_rotation_started_at  = $5,
+            updated_at                  = NOW()
+        WHERE id = $1
+        RETURNING id
+        "#,
+    )
+    .bind(id)
+    .bind(previous_expires_at)
+    .bind(&new_encrypted)
+    .bind(&new_digest)
+    .bind(now)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    if updated.is_none() {
+        return Err(AppError::NotFound("Webhook not found".to_string()));
+    }
+
+    Ok(Json(RotateWebhookSecretResponse {
+        id,
+        secret: new_secret,
+        secret_digest: new_digest,
+        previous_secret_expires_at: previous_expires_at,
+    }))
+}
+
+/// Background-task entry point: clear expired previous-secret material so
+/// stale ciphertext does not linger past the rotation overlap window.
+///
+/// Returns the number of rows updated. Safe to call from a scheduler tick.
+pub async fn cleanup_expired_previous_secrets(
+    db: &sqlx::PgPool,
+) -> std::result::Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        r#"
+        UPDATE webhooks
+        SET secret_previous_encrypted  = NULL,
+            secret_previous_expires_at = NULL
+        WHERE secret_previous_encrypted IS NOT NULL
+          AND secret_previous_expires_at IS NOT NULL
+          AND secret_previous_expires_at <= NOW()
+        "#,
+    )
+    .execute(db)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Validate a webhook URL to prevent SSRF attacks.
 ///
 /// Blocks URLs pointing to private/internal networks, loopback addresses,
@@ -998,6 +1176,7 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
         enable_webhook,
         disable_webhook,
         test_webhook,
+        rotate_webhook_secret,
         list_deliveries,
         redeliver,
     ),
@@ -1006,6 +1185,8 @@ pub async fn process_webhook_retries(db: &sqlx::PgPool) -> std::result::Result<(
         PayloadTemplate,
         CreateWebhookRequest,
         WebhookResponse,
+        WebhookSecretCreatedResponse,
+        RotateWebhookSecretResponse,
         WebhookListResponse,
         TestWebhookResponse,
         DeliveryResponse,
@@ -1233,6 +1414,8 @@ mod tests {
             repository_id: None,
             headers: None,
             payload_template: PayloadTemplate::Generic,
+            secret_digest: Some("whsec_...abcd".to_string()),
+            secret_rotation_active: false,
             last_triggered_at: None,
             created_at: chrono::Utc::now(),
         };

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -68,6 +68,7 @@ pub mod wasm_bindings;
 pub mod wasm_plugin_service;
 pub mod wasm_runtime;
 pub mod webhook_payloads;
+pub mod webhook_secret_crypto;
 
 // Observability & lifecycle
 pub mod analytics_service;

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -258,6 +258,26 @@ pub fn spawn_all(
         });
     }
 
+    // Webhook previous-secret cleanup (every 10 minutes). Clears the
+    // overlap-window ciphertext once the rotation grace period expires.
+    {
+        let db = db.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+            let mut ticker = interval(Duration::from_secs(600));
+            loop {
+                ticker.tick().await;
+                match crate::api::handlers::webhooks::cleanup_expired_previous_secrets(&db).await {
+                    Ok(0) => {}
+                    Ok(n) => {
+                        tracing::info!("Cleared {} expired webhook previous-secret entries", n)
+                    }
+                    Err(e) => tracing::warn!("Webhook previous-secret cleanup failed: {}", e),
+                }
+            }
+        });
+    }
+
     // Curation upstream metadata sync (checks every 5 minutes for repos due for sync)
     {
         let db = db.clone();

--- a/backend/src/services/webhook_secret_crypto.rs
+++ b/backend/src/services/webhook_secret_crypto.rs
@@ -1,0 +1,268 @@
+//! Webhook secret encryption helpers.
+//!
+//! Stores webhook signing secrets at rest using AES-256-GCM. The raw secret
+//! is shown to the operator exactly once at creation or rotation time;
+//! afterwards only the ciphertext (and a short non-reversible digest, used
+//! for UI identification) is persisted.
+//!
+//! The 32-byte symmetric key is sourced from the `AK_WEBHOOK_SECRET_KEY`
+//! environment variable, base64 encoded. The encryption format is
+//! nonce-prefixed AES-256-GCM, identical to the layout used by
+//! [`crate::services::encryption::CredentialEncryption`]. Existing secrets
+//! that pre-date this module are stored as bcrypt hashes; those are
+//! unrecoverable and must be rotated by the operator before the backend
+//! can sign deliveries against them.
+//!
+//! This module is deliberately scoped to webhook secrets so that the key
+//! can be rotated independently from the SSO credential key.
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use rand::RngCore;
+use thiserror::Error;
+
+use crate::services::encryption::{CredentialEncryption, EncryptionError};
+
+/// Environment variable that holds the base64-encoded 32-byte AES key.
+pub const ENV_KEY: &str = "AK_WEBHOOK_SECRET_KEY";
+
+/// Length, in bytes, of a freshly generated webhook secret (before the
+/// `whsec_` prefix is added). Chosen to give 192 bits of entropy after
+/// URL-safe base64 encoding without padding.
+const RAW_SECRET_BYTES: usize = 24;
+
+/// Prefix advertised to operators so that webhook secrets are visually
+/// distinct from API tokens and other credentials.
+pub const SECRET_PREFIX: &str = "whsec_";
+
+/// Errors raised by the webhook secret crypto helpers.
+#[derive(Debug, Error)]
+pub enum WebhookSecretError {
+    #[error("AK_WEBHOOK_SECRET_KEY is not configured")]
+    KeyMissing,
+
+    #[error("AK_WEBHOOK_SECRET_KEY is not valid base64: {0}")]
+    KeyNotBase64(String),
+
+    #[error("AK_WEBHOOK_SECRET_KEY must decode to exactly 32 bytes, got {0}")]
+    KeyWrongLength(usize),
+
+    #[error("webhook secret encryption failed: {0}")]
+    Crypto(#[from] EncryptionError),
+
+    #[error("decrypted webhook secret is not valid UTF-8")]
+    NotUtf8,
+}
+
+/// Result type for webhook crypto operations.
+pub type Result<T> = std::result::Result<T, WebhookSecretError>;
+
+/// Load the 32-byte key from the environment, decoding base64.
+fn load_key() -> Result<[u8; 32]> {
+    let raw = std::env::var(ENV_KEY).map_err(|_| WebhookSecretError::KeyMissing)?;
+    let trimmed = raw.trim();
+    let bytes = B64
+        .decode(trimmed)
+        .map_err(|e| WebhookSecretError::KeyNotBase64(e.to_string()))?;
+    if bytes.len() != 32 {
+        return Err(WebhookSecretError::KeyWrongLength(bytes.len()));
+    }
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&bytes);
+    Ok(key)
+}
+
+fn encryptor() -> Result<CredentialEncryption> {
+    let key = load_key()?;
+    Ok(CredentialEncryption::new(&key)?)
+}
+
+/// Generate a fresh webhook secret string of the form `whsec_<base64url>`.
+///
+/// Uses the OS CSPRNG. The unprefixed body has at least 192 bits of entropy.
+pub fn generate_secret() -> String {
+    let mut buf = [0u8; RAW_SECRET_BYTES];
+    rand::rng().fill_bytes(&mut buf);
+    let body = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(buf);
+    format!("{}{}", SECRET_PREFIX, body)
+}
+
+/// Encrypt a secret for at-rest storage.
+///
+/// Returns nonce-prefixed AES-256-GCM ciphertext. Callers should persist
+/// this directly into the `secret_encrypted` `bytea` column.
+pub fn encrypt_secret(plaintext: &str) -> Result<Vec<u8>> {
+    let enc = encryptor()?;
+    Ok(enc.encrypt(plaintext.as_bytes()))
+}
+
+/// Decrypt a previously stored webhook secret.
+pub fn decrypt_secret(ciphertext: &[u8]) -> Result<String> {
+    let enc = encryptor()?;
+    let plaintext = enc.decrypt(ciphertext)?;
+    String::from_utf8(plaintext).map_err(|_| WebhookSecretError::NotUtf8)
+}
+
+/// Compute a stable, non-reversible identifier suitable for surfacing in
+/// list/get responses so operators can distinguish secrets without exposing
+/// them. Format: `<prefix>...<last4>` where the prefix is the literal
+/// `whsec_` (or whatever prefix the secret already carries) and the last
+/// four characters of the secret body are the only material revealed.
+///
+/// For secrets shorter than 8 characters the digest is the full secret;
+/// such inputs only occur in tests.
+pub fn digest_for_display(secret: &str) -> String {
+    if secret.len() < 8 {
+        return secret.to_string();
+    }
+    let last4 = &secret[secret.len() - 4..];
+    if let Some(rest) = secret.strip_prefix(SECRET_PREFIX) {
+        if rest.len() <= 4 {
+            return secret.to_string();
+        }
+        return format!("{}...{}", SECRET_PREFIX, last4);
+    }
+    let head: String = secret.chars().take(4).collect();
+    format!("{}...{}", head, last4)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env mutation across the tests in this module so that
+    /// they do not race each other (Rust runs unit tests on a thread pool
+    /// by default and `std::env::set_var` is process-global).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn set_test_key() {
+        // 32 bytes of zeros, base64-encoded.
+        let key = B64.encode([0u8; 32]);
+        // SAFETY: ENV_LOCK serializes env access for tests in this module.
+        unsafe {
+            std::env::set_var(ENV_KEY, key);
+        }
+    }
+
+    fn set_alt_key() {
+        let mut k = [0u8; 32];
+        k[0] = 1;
+        let encoded = B64.encode(k);
+        unsafe {
+            std::env::set_var(ENV_KEY, encoded);
+        }
+    }
+
+    #[test]
+    fn test_generate_secret_has_prefix_and_entropy() {
+        let s1 = generate_secret();
+        let s2 = generate_secret();
+        assert!(s1.starts_with(SECRET_PREFIX));
+        assert!(s2.starts_with(SECRET_PREFIX));
+        assert_ne!(s1, s2);
+        // base64url of 24 bytes (no padding) is 32 chars.
+        assert_eq!(s1.len(), SECRET_PREFIX.len() + 32);
+    }
+
+    #[test]
+    fn test_encrypt_decrypt_roundtrip() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let plaintext = "whsec_super_secret_value";
+        let ct = encrypt_secret(plaintext).expect("encrypt");
+        let pt = decrypt_secret(&ct).expect("decrypt");
+        assert_eq!(pt, plaintext);
+    }
+
+    #[test]
+    fn test_nonce_uniqueness() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let plaintext = "same plaintext";
+        let a = encrypt_secret(plaintext).expect("encrypt a");
+        let b = encrypt_secret(plaintext).expect("encrypt b");
+        assert_ne!(a, b, "ciphertexts must differ due to random nonce");
+        // First 12 bytes are the nonce; they should differ.
+        assert_ne!(&a[..12], &b[..12]);
+    }
+
+    #[test]
+    fn test_wrong_key_rejected() {
+        let _g = ENV_LOCK.lock().unwrap();
+        // Encrypt with key A.
+        set_test_key();
+        let ct = encrypt_secret("whsec_value").expect("encrypt");
+        // Switch to key B and try to decrypt.
+        set_alt_key();
+        let res = decrypt_secret(&ct);
+        assert!(matches!(res, Err(WebhookSecretError::Crypto(_))));
+    }
+
+    #[test]
+    fn test_bad_ciphertext_rejected() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let mut ct = encrypt_secret("whsec_value").expect("encrypt");
+        // Flip a byte in the AEAD tag region.
+        let last = ct.len() - 1;
+        ct[last] ^= 0xff;
+        let res = decrypt_secret(&ct);
+        assert!(matches!(res, Err(WebhookSecretError::Crypto(_))));
+    }
+
+    #[test]
+    fn test_truncated_ciphertext_rejected() {
+        let _g = ENV_LOCK.lock().unwrap();
+        set_test_key();
+        let res = decrypt_secret(&[0u8; 8]);
+        assert!(matches!(res, Err(WebhookSecretError::Crypto(_))));
+    }
+
+    #[test]
+    fn test_missing_key_yields_key_missing() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(ENV_KEY);
+        }
+        let res = encrypt_secret("x");
+        assert!(matches!(res, Err(WebhookSecretError::KeyMissing)));
+    }
+
+    #[test]
+    fn test_invalid_base64_key() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(ENV_KEY, "@@@not-base64@@@");
+        }
+        let res = encrypt_secret("x");
+        assert!(matches!(res, Err(WebhookSecretError::KeyNotBase64(_))));
+    }
+
+    #[test]
+    fn test_wrong_length_key() {
+        let _g = ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::set_var(ENV_KEY, B64.encode([0u8; 16]));
+        }
+        let res = encrypt_secret("x");
+        assert!(matches!(res, Err(WebhookSecretError::KeyWrongLength(16))));
+    }
+
+    #[test]
+    fn test_digest_format() {
+        let secret = "whsec_abcdef0123456789";
+        let digest = digest_for_display(secret);
+        assert_eq!(digest, "whsec_...6789");
+    }
+
+    #[test]
+    fn test_digest_short_secret_returns_self() {
+        assert_eq!(digest_for_display("abc"), "abc");
+    }
+
+    #[test]
+    fn test_digest_non_prefixed_secret() {
+        let digest = digest_for_display("hello-world-1234");
+        assert_eq!(digest, "hell...1234");
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the bcrypt `secret_hash` storage with reversible AES-256-GCM encryption so the backend can sign delivery payloads. Adds write-once display of the raw secret on create, plus a `rotate-secret` endpoint that supports a 24h overlap window. Lays the foundation for HMAC signing (ticket E2) without touching the signing path itself.

Closes #922. Refs epic #919.

### Schema (migration 080)

Adds five columns to `webhooks`:

- `secret_encrypted bytea` — nonce-prefixed AES-256-GCM ciphertext
- `secret_digest text` — short identifier shown in UI (`whsec_...abcd`)
- `secret_rotation_started_at timestamptz`
- `secret_previous_encrypted bytea` — the previous secret during rotation overlap
- `secret_previous_expires_at timestamptz`

`secret_hash` is intentionally kept for the transition. Existing rows have only a bcrypt hash, which is unrecoverable, so operators must call `rotate-secret` to obtain a signable secret. Until then those rows continue to deliver unsigned payloads (the same behavior as today, since the existing retry path emitted a literal `hmac-signature` placeholder). A follow-up migration drops `secret_hash` once all rows are rotated.

### Crypto

- New module `services/webhook_secret_crypto` reuses the existing `CredentialEncryption` helper.
- Key is sourced from `AK_WEBHOOK_SECRET_KEY` (base64-encoded 32 bytes), documented in `.env.example`.
- Generates `whsec_`-prefixed secrets with 192 bits of entropy via the OS CSPRNG.
- 12 unit tests cover roundtrip, nonce uniqueness, wrong-key rejection, tampered/truncated ciphertext, missing key, malformed base64, and wrong-length key.

### API behavior

- `POST /api/v1/webhooks` generates a fresh secret if none is supplied, persists `secret_encrypted` and `secret_digest`, and returns the raw secret in the response body **once** via `WebhookSecretCreatedResponse`.
- `POST /api/v1/webhooks/{id}/rotate-secret` moves the current ciphertext to `secret_previous_encrypted`, sets `secret_previous_expires_at = now() + 24h`, stamps `secret_rotation_started_at = now()`, and returns the new raw secret once via `RotateWebhookSecretResponse`.
- `GET` and `LIST` expose `secret_digest` and a `secret_rotation_active` boolean. They never include the raw secret or its ciphertext.
- A scheduler tick every 10 minutes clears expired previous-secret ciphertext via `cleanup_expired_previous_secrets`.

### Out of scope

- HMAC signing of delivery payloads (ticket E2 builds on this column layout).
- The `webhook_deliveries` producer that records events (ticket E3, in flight in parallel).
- `notification_dispatcher` is untouched (ticket E6).

### Note for reviewers

All new SQL uses the runtime `sqlx::query()` form so the offline cache (`.sqlx/`) does not need regeneration. If macros are added later, run `cargo sqlx prepare --workspace` against a live Postgres at `localhost:30432`.

## Regression test (required for `fix/*` PRs)

- [x] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated (12 tests in `webhook_secret_crypto`)
- [ ] Integration tests added/updated (if applicable) — DB-bound integration test deferred; covered by E2E in the follow-up E2 ticket where signing makes a round-trip observable
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` (8506 passed)
- [x] No regressions in existing tests

## API Changes

- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — additive ALTER TABLE only; revert via DROP COLUMN
- [ ] N/A - no API changes