### PR TITLE
revert: "fix(proxy): route remote repo cache I/O through per-repo backend (#1068)"

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -363,15 +363,9 @@ async fn apk_index(
             (&repo.upstream_url, &state.proxy_service)
         {
             let upstream_path = build_apk_index_upstream_path(&branch, &repository, &arch);
-            let (content, content_type) = proxy_helpers::proxy_fetch(
-                proxy,
-                repo.id,
-                &repo_key,
-                &repo.storage_location(),
-                upstream_url,
-                &upstream_path,
-            )
-            .await?;
+            let (content, content_type) =
+                proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path)
+                    .await?;
 
             return Ok(Response::builder()
                 .status(StatusCode::OK)
@@ -406,7 +400,6 @@ async fn apk_index(
                 proxy,
                 member.id,
                 &member.key,
-                &member.storage_location(),
                 upstream_url,
                 &upstream_path,
             )
@@ -682,15 +675,8 @@ async fn try_proxy_apk(
         _ => return Ok(None),
     };
     let upstream_path = format!("{}/{}/{}/{}", branch, repository, arch, filename);
-    let (content, content_type) = proxy_helpers::proxy_fetch(
-        proxy,
-        repo.id,
-        repo_key,
-        &repo.storage_location(),
-        upstream_url,
-        &upstream_path,
-    )
-    .await?;
+    let (content, content_type) =
+        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &upstream_path).await?;
     Ok(Some(
         Response::builder()
             .status(StatusCode::OK)

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -420,7 +420,6 @@ async fn download_collection(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -129,16 +129,10 @@ async fn resolve_upstream_dl_url(
 
     // Fetch config.json from upstream.
     let proxy = state.proxy_service.as_ref()?;
-    let config_bytes = proxy_helpers::proxy_fetch(
-        proxy,
-        repo.id,
-        repo_key,
-        &repo.storage_location(),
-        base_url,
-        "config.json",
-    )
-    .await
-    .ok()?;
+    let config_bytes =
+        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, base_url, "config.json")
+            .await
+            .ok()?;
 
     let config: serde_json::Value = serde_json::from_slice(&config_bytes.0).ok()?;
     let dl_url = config.get("dl")?.as_str()?.to_string();
@@ -820,7 +814,6 @@ async fn download(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         &dl_base,
                         &dl_path,
                         &cache_path,
@@ -1071,15 +1064,7 @@ async fn try_remote_index(
 
     let base_url = repo.index_upstream_url.as_deref().unwrap_or(upstream_url);
     let index_path = cargo_sparse_index_path_upstream(name_lower);
-    let result = proxy_helpers::proxy_fetch(
-        proxy,
-        repo.id,
-        repo_key,
-        &repo.storage_location(),
-        base_url,
-        &index_path,
-    )
-    .await;
+    let result = proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, base_url, &index_path).await;
 
     Some(result.map(|(content, content_type)| {
         index_cache_set(index_cache, cache_key.to_string(), content.clone());
@@ -1196,7 +1181,6 @@ async fn try_virtual_index(
                     proxy,
                     member.id,
                     &member.key,
-                    &member.storage_location(),
                     &base_url,
                     &index_path,
                 )

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -304,7 +304,6 @@ async fn download_cookbook(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -192,7 +192,6 @@ async fn download_pod(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -393,7 +393,6 @@ async fn download_archive(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -646,7 +646,6 @@ async fn recipe_file_download(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )
@@ -1165,7 +1164,6 @@ async fn package_file_download(
                             proxy,
                             repo.id,
                             &repo_key,
-                            &repo.storage_location(),
                             upstream_url,
                             &upstream_path,
                         )

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -1086,7 +1086,6 @@ async fn channeldata_json(
                     proxy,
                     repo.id,
                     &repo_key,
-                    &repo.storage_location(),
                     upstream_url,
                     "channeldata.json",
                 )
@@ -1463,7 +1462,6 @@ async fn serve_repodata(
                     proxy,
                     repo.id,
                     repo_key,
-                    &repo.storage_location(),
                     upstream_url,
                     &upstream_path,
                 )
@@ -2354,7 +2352,6 @@ async fn download_package(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -234,7 +234,6 @@ async fn download_package(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -405,15 +405,9 @@ impl<'a> DebianProxy<'a> {
             _ => return Ok(()),
         };
         let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
-        let (content, upstream_ct) = proxy_helpers::proxy_fetch(
-            proxy,
-            repo.id,
-            self.repo_key,
-            &repo.storage_location(),
-            upstream_url,
-            &upstream_path,
-        )
-        .await?;
+        let (content, upstream_ct) =
+            proxy_helpers::proxy_fetch(proxy, repo.id, self.repo_key, upstream_url, &upstream_path)
+                .await?;
         Err(Response::builder()
             .status(StatusCode::OK)
             .header(
@@ -776,15 +770,8 @@ async fn dists_proxy_catchall(
     };
 
     let upstream_path = format!("dists/{}/{}", distribution, dists_path);
-    let (content, upstream_ct) = proxy_helpers::proxy_fetch(
-        proxy,
-        repo.id,
-        &repo_key,
-        &repo.storage_location(),
-        upstream_url,
-        &upstream_path,
-    )
-    .await?;
+    let (content, upstream_ct) =
+        proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path).await?;
 
     let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
 
@@ -873,7 +860,6 @@ async fn pool_download(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -595,7 +595,6 @@ async fn download_object(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -357,15 +357,9 @@ async fn try_proxy_go_metadata(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
-                proxy,
-                repo.id,
-                &repo.key,
-                &repo.storage_location(),
-                upstream_url,
-                upstream_path,
-            )
-            .await
+            if let Ok((content, content_type)) =
+                proxy_helpers::proxy_fetch(proxy, repo.id, &repo.key, upstream_url, upstream_path)
+                    .await
             {
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
@@ -585,7 +579,6 @@ async fn get_mod_file(
                         proxy,
                         repo.id,
                         &repo.key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )
@@ -725,7 +718,6 @@ async fn download_zip(
                         proxy,
                         repo.id,
                         &repo.key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -263,7 +263,6 @@ async fn download_chart(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -99,7 +99,6 @@ async fn package_info(
                     proxy,
                     repo.id,
                     &repo_key,
-                    &repo.storage_location(),
                     upstream_url,
                     &upstream_path,
                 )
@@ -223,7 +222,6 @@ async fn download_tarball(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )
@@ -524,15 +522,9 @@ async fn list_names(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, content_type) = proxy_helpers::proxy_fetch(
-                proxy,
-                repo.id,
-                &repo_key,
-                &repo.storage_location(),
-                upstream_url,
-                "names",
-            )
-            .await?;
+            let (content, content_type) =
+                proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, "names")
+                    .await?;
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(
@@ -601,15 +593,9 @@ async fn list_versions(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, content_type) = proxy_helpers::proxy_fetch(
-                proxy,
-                repo.id,
-                &repo_key,
-                &repo.storage_location(),
-                upstream_url,
-                "versions",
-            )
-            .await?;
+            let (content, content_type) =
+                proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, "versions")
+                    .await?;
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -281,7 +281,6 @@ async fn download_file(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -193,7 +193,6 @@ async fn download_plugin(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -747,15 +747,9 @@ async fn download(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, _content_type) = proxy_helpers::proxy_fetch(
-                    proxy,
-                    repo.id,
-                    &repo_key,
-                    &repo.storage_location(),
-                    upstream_url,
-                    &path,
-                )
-                .await?;
+                let (content, _content_type) =
+                    proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &path)
+                        .await?;
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
                     .header(CONTENT_TYPE, "text/xml")
@@ -797,7 +791,6 @@ async fn download(
                                 proxy,
                                 member.id,
                                 &member.key,
-                                &member.storage_location(),
                                 upstream_url,
                                 &path,
                             )
@@ -882,7 +875,6 @@ async fn download(
                                 proxy,
                                 member.id,
                                 &member.key,
-                                &member.storage_location(),
                                 upstream_url,
                                 &path,
                             )
@@ -964,15 +956,9 @@ async fn download(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, _content_type) = proxy_helpers::proxy_fetch(
-                    proxy,
-                    repo.id,
-                    &repo_key,
-                    &repo.storage_location(),
-                    upstream_url,
-                    &path,
-                )
-                .await?;
+                let (content, _content_type) =
+                    proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &path)
+                        .await?;
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
                     .header(CONTENT_TYPE, "text/plain")
@@ -1008,7 +994,6 @@ async fn download(
                             proxy,
                             member.id,
                             &member.key,
-                            &member.storage_location(),
                             upstream_url,
                             &path,
                         )
@@ -1134,15 +1119,9 @@ async fn serve_artifact(
                 if let (Some(ref upstream_url), Some(ref proxy)) =
                     (&repo.upstream_url, &state.proxy_service)
                 {
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
-                        proxy,
-                        repo.id,
-                        repo_key,
-                        &repo.storage_location(),
-                        upstream_url,
-                        path,
-                    )
-                    .await?;
+                    let (content, content_type) =
+                        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, path)
+                            .await?;
 
                     let ct =
                         content_type.unwrap_or_else(|| content_type_for_path(path).to_string());

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -364,7 +364,6 @@ async fn get_package_metadata(
                     proxy,
                     repo.id,
                     repo_key,
-                    &repo.storage_location(),
                     upstream_url,
                     &encoded_name,
                 )
@@ -421,7 +420,6 @@ async fn get_package_metadata(
                 proxy,
                 member.id,
                 &member.key,
-                &member.storage_location(),
                 upstream_url,
                 &encoded_name,
             )
@@ -534,15 +532,8 @@ async fn fetch_remote_packument(
         .as_ref()
         .ok_or_else(|| AppError::NotFound("Package not found".to_string()).into_response())?;
     let encoded_name = encode_package_name_for_upstream(package_name);
-    let (content, _ct) = proxy_helpers::proxy_fetch(
-        proxy,
-        repo.id,
-        repo_key,
-        &repo.storage_location(),
-        upstream_url,
-        &encoded_name,
-    )
-    .await?;
+    let (content, _ct) =
+        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &encoded_name).await?;
     let mut json: serde_json::Value = serde_json::from_slice(&content).map_err(|e| {
         AppError::Internal(format!("Invalid JSON from upstream: {}", e)).into_response()
     })?;
@@ -596,15 +587,9 @@ async fn fetch_virtual_packument(
         };
 
         let encoded_name = encode_package_name_for_upstream(package_name);
-        let result = proxy_helpers::proxy_fetch(
-            proxy,
-            member.id,
-            &member.key,
-            &member.storage_location(),
-            upstream_url,
-            &encoded_name,
-        )
-        .await;
+        let result =
+            proxy_helpers::proxy_fetch(proxy, member.id, &member.key, upstream_url, &encoded_name)
+                .await;
 
         match result {
             Ok((content, _ct)) => {
@@ -811,15 +796,9 @@ async fn serve_tarball(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, _content_type) = proxy_helpers::proxy_fetch(
-                proxy,
-                repo.id,
-                repo_key,
-                &repo.storage_location(),
-                upstream_url,
-                &upstream_path,
-            )
-            .await?;
+            let (content, _content_type) =
+                proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &upstream_path)
+                    .await?;
 
             // The upstream registry may return application/octet-stream for
             // npm tarballs, which also gets persisted by the proxy cache.

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -487,7 +487,6 @@ async fn flatcontainer_download(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -603,16 +603,9 @@ async fn try_upstream_fetch(
     let proxy = state.proxy_service.as_ref()?;
     let image = normalize_docker_image(&repo.image, upstream_url);
     let upstream_path = format!("v2/{}/{}", image, path_suffix);
-    proxy_helpers::proxy_fetch(
-        proxy,
-        repo.id,
-        &repo.key,
-        &repo.location,
-        upstream_url,
-        &upstream_path,
-    )
-    .await
-    .ok()
+    proxy_helpers::proxy_fetch(proxy, repo.id, &repo.key, upstream_url, &upstream_path)
+        .await
+        .ok()
 }
 
 /// Build an OCI registry response from proxied upstream content.
@@ -2121,12 +2114,10 @@ struct UpstreamTagsPage {
 }
 
 #[rustfmt::skip]
-#[allow(clippy::too_many_arguments)]
 async fn fetch_upstream_tags_page(
     state: &SharedState,
     repo_id: Uuid,
     repo_key: &str,
-    location: &crate::storage::StorageLocation,
     upstream_url: &str,
     image: &str,
     n: usize,
@@ -2142,7 +2133,7 @@ async fn fetch_upstream_tags_page(
 
     let upstream_path = format!("v2/{}/{}", image, build_remote_tags_list_path(n, last));
     let (content, _ct, link) =
-        proxy_helpers::proxy_fetch_uncached(proxy, repo_id, repo_key, location, upstream_url, &upstream_path)
+        proxy_helpers::proxy_fetch_uncached(proxy, repo_id, repo_key, upstream_url, &upstream_path)
             .await
             .map_err(|resp| match resp.status() {
                 StatusCode::NOT_FOUND => oci_error(
@@ -2190,12 +2181,10 @@ async fn fetch_upstream_tags_page(
     })
 }
 
-#[allow(clippy::too_many_arguments)]
 async fn collect_upstream_tags(
     state: &SharedState,
     repo_id: Uuid,
     repo_key: &str,
-    location: &crate::storage::StorageLocation,
     upstream_url: &str,
     image: &str,
     max_tags: usize,
@@ -2219,7 +2208,6 @@ async fn collect_upstream_tags(
             state,
             repo_id,
             repo_key,
-            location,
             upstream_url,
             image,
             remaining,
@@ -2279,17 +2267,8 @@ async fn tags_list_remote(
         )
     })?;
     let image = normalize_docker_image(&repo.image, upstream_url);
-    let (tags, upstream_has_more) = collect_upstream_tags(
-        state,
-        repo.id,
-        &repo.key,
-        &repo.location,
-        upstream_url,
-        &image,
-        n + 1,
-        last,
-    )
-    .await?;
+    let (tags, upstream_has_more) =
+        collect_upstream_tags(state, repo.id, &repo.key, upstream_url, &image, n + 1, last).await?;
     Ok(split_remote_tags_page(tags, n, upstream_has_more))
 }
 
@@ -2314,7 +2293,6 @@ async fn tags_list_virtual(
             let image = image.clone();
             let member_id = member.id;
             let member_key = member.key.clone();
-            let member_location = member.storage_location();
             let repo_type = member.repo_type.clone();
             let upstream_url = member.upstream_url.clone();
             async move {
@@ -2323,7 +2301,6 @@ async fn tags_list_virtual(
                         state,
                         member_id,
                         &member_key,
-                        &member_location,
                         upstream_url.as_deref(),
                         &image,
                         member_limit,
@@ -2350,12 +2327,10 @@ async fn tags_list_virtual(
 }
 
 /// Fetch tags from a single remote virtual member via upstream proxy.
-#[allow(clippy::too_many_arguments)]
 async fn fetch_tags_from_remote_member(
     state: &SharedState,
     member_id: Uuid,
     member_key: &str,
-    member_location: &crate::storage::StorageLocation,
     upstream_url: Option<&str>,
     image_name: &str,
     n_limit: usize,
@@ -2367,7 +2342,6 @@ async fn fetch_tags_from_remote_member(
         state,
         member_id,
         member_key,
-        member_location,
         upstream_url,
         &image,
         n_limit,

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1309,7 +1309,6 @@ async fn download(
                             proxy,
                             repo.id,
                             &repo_key,
-                            &repo.storage_location(),
                             upstream_url,
                             &upstream_path,
                         )

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -183,25 +183,17 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
 }
 
 /// Attempt to fetch an artifact from the upstream via the proxy service.
-///
-/// Builds a `Repository` shape for the proxy from the caller-supplied
-/// `location`. The `location` MUST be the real `StorageLocation` from the
-/// caller's `Repository` (or `RepoInfo`/`OciRepoInfo`) so that proxy cache
-/// I/O routes through the same per-repo backend that download handlers read
-/// from via `state.storage_for_repo(...)`. Passing a synthesized location
-/// (`backend: "filesystem"`, `path: ""`) silently re-introduces bug #1016
-/// because the cache write lands on a different backend than the read.
-///
+/// Constructs a minimal `Repository` model from handler-level repo info.
 /// Returns `(content_bytes, content_type)` on success.
 pub async fn proxy_fetch(
     proxy_service: &ProxyService,
     repo_id: Uuid,
     repo_key: &str,
-    location: &StorageLocation,
     upstream_url: &str,
     path: &str,
 ) -> Result<(Bytes, Option<String>), Response> {
-    let repo = build_remote_repo(repo_id, repo_key, upstream_url, location);
+    // Construct a minimal Repository that satisfies ProxyService::fetch_artifact
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
 
     proxy_service
         .fetch_artifact(&repo, path)
@@ -210,25 +202,15 @@ pub async fn proxy_fetch(
 }
 
 /// Check whether an artifact is present in the proxy cache under `path`
-/// without contacting upstream. Returns `Some` on cache hit, `None` on miss
-/// or expired entry.
-///
-/// Routes the lookup through the per-repo storage backend resolved from the
-/// caller-supplied `location`. This is required so the cache hit/miss
-/// decision matches the backend that download handlers read from
-/// (bug #1016) — checking only the legacy global storage would silently
-/// miss artifacts cached on the per-repo S3/R2 backend.
+/// without contacting upstream. Returns `Ok(Some(...))` on cache hit,
+/// `Ok(None)` on miss or expired entry.
 pub async fn proxy_check_cache(
     proxy_service: &ProxyService,
-    repo_id: Uuid,
     repo_key: &str,
-    location: &StorageLocation,
-    upstream_url: &str,
     path: &str,
 ) -> Option<(Bytes, Option<String>)> {
-    let repo = build_remote_repo(repo_id, repo_key, upstream_url, location);
     match proxy_service
-        .get_cached_artifact_for_repo(&repo, path)
+        .get_cached_artifact_by_path(repo_key, path)
         .await
     {
         Ok(result) => result,
@@ -247,19 +229,15 @@ pub async fn proxy_check_cache(
 /// Fetch from upstream using `fetch_path` for the URL but `cache_path` for
 /// the proxy cache key. This lets callers store content under a predictable
 /// local path even when the upstream download URL varies between requests.
-///
-/// `location` MUST be the real `StorageLocation` of the caller's repository
-/// — see [`proxy_fetch`] for why.
 pub async fn proxy_fetch_with_cache_key(
     proxy_service: &ProxyService,
     repo_id: Uuid,
     repo_key: &str,
-    location: &StorageLocation,
     upstream_url: &str,
     fetch_path: &str,
     cache_path: &str,
 ) -> Result<(Bytes, Option<String>), Response> {
-    let repo = build_remote_repo(repo_id, repo_key, upstream_url, location);
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
 
     proxy_service
         .fetch_artifact_with_cache_path(&repo, fetch_path, cache_path)
@@ -275,19 +253,14 @@ pub async fn proxy_fetch_with_cache_key(
 /// Returns `(content, content_type, effective_url)`. The effective URL is the
 /// final URL after any redirects, which callers can use as a base for resolving
 /// relative URLs in the response body.
-///
-/// `location` is unused for the cache (this call bypasses it) but is taken
-/// here for signature symmetry with the other helpers and so future
-/// instrumentation can attribute the upstream call to the correct backend.
 pub async fn proxy_fetch_uncached(
     proxy_service: &ProxyService,
     repo_id: Uuid,
     repo_key: &str,
-    location: &StorageLocation,
     upstream_url: &str,
     path: &str,
 ) -> Result<(Bytes, Option<String>, String), Response> {
-    let repo = build_remote_repo(repo_id, repo_key, upstream_url, location);
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
 
     proxy_service
         .fetch_upstream_direct(&repo, path)
@@ -329,15 +302,8 @@ where
             if let (Some(proxy), Some(upstream_url)) =
                 (proxy_service, member.upstream_url.as_deref())
             {
-                if let Ok(result) = proxy_fetch(
-                    proxy,
-                    member.id,
-                    &member.key,
-                    &member.storage_location(),
-                    upstream_url,
-                    path,
-                )
-                .await
+                if let Ok(result) =
+                    proxy_fetch(proxy, member.id, &member.key, upstream_url, path).await
                 {
                     return Ok(result);
                 }
@@ -389,16 +355,7 @@ where
             continue;
         };
 
-        match proxy_fetch(
-            proxy,
-            member.id,
-            &member.key,
-            &member.storage_location(),
-            upstream_url,
-            path,
-        )
-        .await
-        {
+        match proxy_fetch(proxy, member.id, &member.key, upstream_url, path).await {
             Ok((bytes, _content_type)) => match transform(bytes, member.key.clone()).await {
                 Ok(response) => return Ok(response),
                 Err(_e) => {
@@ -460,16 +417,7 @@ where
             continue;
         };
 
-        match proxy_fetch(
-            proxy,
-            member.id,
-            &member.key,
-            &member.storage_location(),
-            upstream_url,
-            path,
-        )
-        .await
-        {
+        match proxy_fetch(proxy, member.id, &member.key, upstream_url, path).await {
             Ok((bytes, _content_type)) => match extract(bytes, member.key.clone()).await {
                 Ok(data) => {
                     results.push((member.key.clone(), data));
@@ -622,20 +570,7 @@ pub async fn local_fetch_by_path_suffix(
 }
 
 /// Build a minimal `Repository` model for proxy operations.
-///
-/// The `location` MUST be the real `StorageLocation` of the caller's
-/// repository so that `ProxyService` resolves cache I/O to the same backend
-/// that download handlers read from. Earlier versions of this helper
-/// hardcoded `storage_backend: "filesystem", storage_path: ""`, which
-/// silently routed cache writes to a fresh filesystem backend rooted at the
-/// process cwd while reads went to the configured S3/R2 backend — that was
-/// the root cause of bug #1016.
-fn build_remote_repo(
-    id: Uuid,
-    key: &str,
-    upstream_url: &str,
-    location: &StorageLocation,
-) -> Repository {
+fn build_remote_repo(id: Uuid, key: &str, upstream_url: &str) -> Repository {
     Repository {
         id,
         key: key.to_string(),
@@ -643,8 +578,8 @@ fn build_remote_repo(
         description: None,
         format: RepositoryFormat::Generic,
         repo_type: RepositoryType::Remote,
-        storage_backend: location.backend.clone(),
-        storage_path: location.path.clone(),
+        storage_backend: "filesystem".to_string(),
+        storage_path: String::new(),
         upstream_url: Some(upstream_url.to_string()),
         is_public: false,
         quota_bytes: None,
@@ -738,34 +673,17 @@ mod tests {
 
     // ── build_remote_repo tests ──────────────────────────────────────
 
-    fn loc(backend: &str, path: &str) -> StorageLocation {
-        StorageLocation {
-            backend: backend.to_string(),
-            path: path.to_string(),
-        }
-    }
-
     #[test]
     fn test_build_remote_repo_sets_id() {
         let id = Uuid::new_v4();
-        let repo = build_remote_repo(
-            id,
-            "my-repo",
-            "https://upstream.example.com",
-            &loc("filesystem", "/data/my-repo"),
-        );
+        let repo = build_remote_repo(id, "my-repo", "https://upstream.example.com");
         assert_eq!(repo.id, id);
     }
 
     #[test]
     fn test_build_remote_repo_key_and_name_match() {
         let id = Uuid::new_v4();
-        let repo = build_remote_repo(
-            id,
-            "npm-remote",
-            "https://registry.npmjs.org",
-            &loc("filesystem", "/data/npm-remote"),
-        );
+        let repo = build_remote_repo(id, "npm-remote", "https://registry.npmjs.org");
         assert_eq!(repo.key, "npm-remote");
         assert_eq!(repo.name, "npm-remote");
     }
@@ -774,58 +692,37 @@ mod tests {
     fn test_build_remote_repo_upstream_url() {
         let id = Uuid::new_v4();
         let url = "https://pypi.org/simple/";
-        let repo = build_remote_repo(id, "pypi-proxy", url, &loc("s3-prod", "/proxies/pypi"));
+        let repo = build_remote_repo(id, "pypi-proxy", url);
         assert_eq!(repo.upstream_url, Some(url.to_string()));
     }
 
     #[test]
     fn test_build_remote_repo_type_is_remote() {
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            "r",
-            "https://x.com",
-            &loc("filesystem", "/data/r"),
-        );
+        let repo = build_remote_repo(Uuid::new_v4(), "r", "https://x.com");
         assert_eq!(repo.repo_type, RepositoryType::Remote);
     }
 
     #[test]
     fn test_build_remote_repo_format_is_generic() {
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            "r",
-            "https://x.com",
-            &loc("filesystem", "/data/r"),
-        );
+        let repo = build_remote_repo(Uuid::new_v4(), "r", "https://x.com");
         assert_eq!(repo.format, RepositoryFormat::Generic);
     }
 
-    /// Bug #1016 regression: `build_remote_repo` MUST forward the caller's
-    /// real `StorageLocation` so the proxy resolves cache I/O to the same
-    /// backend that handlers read from. Earlier versions hardcoded
-    /// `"filesystem", ""` here, which routed cache writes to a fresh
-    /// filesystem backend rooted at cwd while reads went to the real S3/R2
-    /// backend.
     #[test]
-    fn test_build_remote_repo_propagates_storage_location_for_bug_1016() {
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            "debian-proxy",
-            "https://deb.example.com",
-            &loc("s3-prod", "/proxies/debian"),
-        );
-        assert_eq!(repo.storage_backend, "s3-prod");
-        assert_eq!(repo.storage_path, "/proxies/debian");
+    fn test_build_remote_repo_storage_backend_filesystem() {
+        let repo = build_remote_repo(Uuid::new_v4(), "r", "https://x.com");
+        assert_eq!(repo.storage_backend, "filesystem");
+    }
+
+    #[test]
+    fn test_build_remote_repo_storage_path_empty() {
+        let repo = build_remote_repo(Uuid::new_v4(), "r", "https://x.com");
+        assert!(repo.storage_path.is_empty());
     }
 
     #[test]
     fn test_build_remote_repo_defaults() {
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            "k",
-            "https://u.com",
-            &loc("filesystem", "/data/k"),
-        );
+        let repo = build_remote_repo(Uuid::new_v4(), "k", "https://u.com");
         assert!(repo.description.is_none());
         assert!(!repo.is_public);
         assert!(repo.quota_bytes.is_none());
@@ -837,12 +734,7 @@ mod tests {
     #[test]
     fn test_build_remote_repo_timestamps_set() {
         let before = Utc::now();
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            "k",
-            "https://u.com",
-            &loc("filesystem", "/data/k"),
-        );
+        let repo = build_remote_repo(Uuid::new_v4(), "k", "https://u.com");
         let after = Utc::now();
         assert!(repo.created_at >= before && repo.created_at <= after);
         assert!(repo.updated_at >= before && repo.updated_at <= after);
@@ -1000,12 +892,7 @@ mod tests {
     #[test]
     fn test_build_remote_repo_fields() {
         let id = uuid::Uuid::new_v4();
-        let location = StorageLocation {
-            backend: "filesystem".to_string(),
-            path: "/data/test-repo".to_string(),
-        };
-        let repo =
-            super::build_remote_repo(id, "test-repo", "https://upstream.example.com", &location);
+        let repo = super::build_remote_repo(id, "test-repo", "https://upstream.example.com");
         assert_eq!(repo.id, id);
         assert_eq!(repo.key, "test-repo");
         assert_eq!(
@@ -1021,11 +908,7 @@ mod tests {
     #[test]
     fn test_build_remote_repo_always_remote_type() {
         let id = uuid::Uuid::new_v4();
-        let location = StorageLocation {
-            backend: "filesystem".to_string(),
-            path: "/data/any-key".to_string(),
-        };
-        let repo = super::build_remote_repo(id, "any-key", "https://example.com", &location);
+        let repo = super::build_remote_repo(id, "any-key", "https://example.com");
         assert_eq!(
             repo.repo_type,
             crate::models::repository::RepositoryType::Remote
@@ -1052,643 +935,5 @@ mod tests {
     #[test]
     fn test_reject_write_virtual_rejected() {
         assert!(super::reject_write_if_not_hosted("virtual").is_err());
-    }
-
-    // =======================================================================
-    // Bug #1016 regression: full handler-to-cache routing
-    //
-    // The earlier fix (`#1016` initial) routed cache I/O through the per-repo
-    // backend inside `ProxyService` — but every format handler called
-    // `proxy_helpers::proxy_fetch` which internally synthesized a `Repository`
-    // with `storage_backend: "filesystem", storage_path: ""`. That synthetic
-    // repo caused `per_repo_storage` to resolve to a fresh filesystem backend
-    // rooted at the process cwd, NOT the configured S3/R2 backend that
-    // download handlers read from. Result: writer wrote to filesystem, reader
-    // read from S3, second download → NoSuchKey → 500.
-    //
-    // The fix below: helpers take an explicit `&StorageLocation` from the
-    // caller so the synthesized repo carries the real backend. The test pins
-    // the contract by:
-    //   1. Building a `ProxyService` with a `StorageRegistry` that maps a
-    //      named per-repo backend ("s3-test").
-    //   2. Pre-seeding that backend with cache content + metadata under the
-    //      production cache-key shape.
-    //   3. Calling `proxy_check_cache` through the helper with a
-    //      `StorageLocation { backend: "s3-test", path: "/data/debian" }`.
-    //   4. Asserting the cache hit returns the seeded bytes — proving the
-    //      helper threaded the location all the way through to the registry.
-    //
-    // If the helper ever regresses to a synthetic `"filesystem"`/`""`
-    // location, this test fails because the registry lookup will resolve a
-    // different backend than the one that holds the seeded content.
-    // =======================================================================
-
-    use crate::error::Result as AkResult;
-    use crate::services::proxy_service::{CacheMetadata, ProxyService};
-    use crate::services::storage_service::{FilesystemBackend, StorageService};
-    use crate::storage::{StorageBackend as RepoStorageBackend, StorageRegistry};
-    use async_trait::async_trait;
-    use bytes::Bytes;
-    use chrono::Utc;
-    use sqlx::PgPool;
-    use std::collections::HashMap as StdHashMap;
-    use std::sync::{Arc, Mutex};
-
-    /// In-memory `StorageBackend` for routing tests.
-    struct MockBackend {
-        store: Mutex<StdHashMap<String, Bytes>>,
-    }
-
-    impl MockBackend {
-        fn new() -> Self {
-            Self {
-                store: Mutex::new(StdHashMap::new()),
-            }
-        }
-
-        fn insert(&self, key: &str, content: Bytes) {
-            self.store.lock().unwrap().insert(key.to_string(), content);
-        }
-    }
-
-    #[async_trait]
-    impl RepoStorageBackend for MockBackend {
-        async fn put(&self, key: &str, content: Bytes) -> AkResult<()> {
-            self.store.lock().unwrap().insert(key.to_string(), content);
-            Ok(())
-        }
-        async fn get(&self, key: &str) -> AkResult<Bytes> {
-            self.store
-                .lock()
-                .unwrap()
-                .get(key)
-                .cloned()
-                .ok_or_else(|| crate::error::AppError::NotFound(format!("not found: {}", key)))
-        }
-        async fn exists(&self, key: &str) -> AkResult<bool> {
-            Ok(self.store.lock().unwrap().contains_key(key))
-        }
-        async fn delete(&self, key: &str) -> AkResult<()> {
-            self.store.lock().unwrap().remove(key);
-            Ok(())
-        }
-    }
-
-    /// Bug #1016 full-path regression: when a handler calls
-    /// `proxy_helpers::proxy_check_cache` with the real
-    /// `StorageLocation` from its `Repository`, the lookup MUST route
-    /// through the registry-resolved per-repo backend that holds cached
-    /// content. If the helper synthesizes a `"filesystem"`/`""` location
-    /// (the original bug), the registry resolves a different backend and
-    /// the seeded content is invisible — second download 500s.
-    #[tokio::test]
-    async fn test_proxy_check_cache_routes_through_per_repo_backend_for_bug_1016() {
-        // 1. Stand up a per-repo backend identified as "s3-test" in the
-        //    registry. This stands in for a real S3-backed Debian proxy repo.
-        let per_repo_backend: Arc<MockBackend> = Arc::new(MockBackend::new());
-        let mut backends: StdHashMap<String, Arc<dyn RepoStorageBackend>> = StdHashMap::new();
-        backends.insert("s3-test".to_string(), per_repo_backend.clone());
-        let registry = Arc::new(StorageRegistry::new(backends, "s3-test".to_string()));
-
-        // 2. Pre-seed the per-repo backend with cache content + metadata
-        //    under the production cache-key shape. This simulates a
-        //    previously-cached artifact that handlers would fetch on a
-        //    second download.
-        let repo_key = "debian-proxy";
-        let cache_path = "pool/main/p/php7.4/php7.4_test.deb";
-        let payload = Bytes::from_static(b"<deb file body>");
-        let storage_key = ProxyService::cache_storage_key(repo_key, cache_path);
-        let metadata_key = ProxyService::cache_metadata_key(repo_key, cache_path);
-
-        let metadata = CacheMetadata {
-            cached_at: Utc::now(),
-            upstream_etag: None,
-            expires_at: Utc::now() + chrono::Duration::hours(1),
-            content_type: Some("application/vnd.debian.binary-package".to_string()),
-            size_bytes: payload.len() as i64,
-            checksum_sha256: StorageService::calculate_hash(&payload),
-        };
-        per_repo_backend.insert(&storage_key, payload.clone());
-        per_repo_backend.insert(
-            &metadata_key,
-            Bytes::from(serde_json::to_vec(&metadata).unwrap()),
-        );
-
-        // 3. Build a ProxyService wired to that registry. The global storage
-        //    is a throwaway filesystem backend in /tmp so a regression that
-        //    silently falls back to global storage would NOT find the seeded
-        //    bytes (which only exist on the per-repo mock backend).
-        let pool = PgPool::connect_lazy("postgres://fake:fake@127.0.0.1:1/none")
-            .expect("connect_lazy never fails for a syntactically valid URL");
-        let global_backend: Arc<dyn crate::services::storage_service::StorageBackend> = Arc::new(
-            FilesystemBackend::new(std::path::PathBuf::from("/tmp/ak-helpers-test-global-only")),
-        );
-        let global_storage = Arc::new(StorageService::new(global_backend));
-        let config = crate::config::Config::default();
-        let proxy =
-            ProxyService::new(pool, global_storage, &config).with_storage_registry(registry);
-
-        // 4. Call the helper with the REAL storage location of the repo
-        //    (matches `repo.storage_location()` in the handler).
-        let location = StorageLocation {
-            backend: "s3-test".to_string(),
-            path: "/data/debian".to_string(),
-        };
-        let result = super::proxy_check_cache(
-            &proxy,
-            Uuid::new_v4(),
-            repo_key,
-            &location,
-            "https://deb.example.com",
-            cache_path,
-        )
-        .await;
-
-        // 5. The seeded bytes must be returned — proving the helper threaded
-        //    the StorageLocation through to the registry-resolved per-repo
-        //    backend. With the pre-fix synthetic location ("filesystem"/""),
-        //    the registry would resolve a different backend and this would
-        //    return None (cache miss), reproducing bug #1016 in the helper
-        //    layer.
-        let (content, content_type) = result.expect(
-            "expected cache hit on the per-repo backend; if this is None, the helper is \
-             routing through the wrong storage location (bug #1016)",
-        );
-        assert_eq!(content, payload);
-        assert_eq!(
-            content_type.as_deref(),
-            Some("application/vnd.debian.binary-package")
-        );
-    }
-
-    /// Bug #1016 negative test: when the helper is called with a
-    /// `StorageLocation` whose `backend` is NOT registered in the
-    /// `StorageRegistry`, the per-repo lookup falls back to global storage
-    /// (which is empty in this test), producing a cache miss. This pins the
-    /// other half of the contract: the helper does not silently coerce an
-    /// unknown location into the registry's default backend.
-    #[tokio::test]
-    async fn test_proxy_check_cache_misses_when_location_does_not_match_seeded_backend() {
-        let per_repo_backend: Arc<MockBackend> = Arc::new(MockBackend::new());
-        let mut backends: StdHashMap<String, Arc<dyn RepoStorageBackend>> = StdHashMap::new();
-        backends.insert("s3-test".to_string(), per_repo_backend.clone());
-        let registry = Arc::new(StorageRegistry::new(backends, "s3-test".to_string()));
-
-        let repo_key = "debian-proxy";
-        let cache_path = "pool/main/p/php7.4/php7.4_test.deb";
-        let payload = Bytes::from_static(b"<deb file body>");
-        let storage_key = ProxyService::cache_storage_key(repo_key, cache_path);
-        let metadata_key = ProxyService::cache_metadata_key(repo_key, cache_path);
-        let metadata = CacheMetadata {
-            cached_at: Utc::now(),
-            upstream_etag: None,
-            expires_at: Utc::now() + chrono::Duration::hours(1),
-            content_type: Some("application/octet-stream".to_string()),
-            size_bytes: payload.len() as i64,
-            checksum_sha256: StorageService::calculate_hash(&payload),
-        };
-        per_repo_backend.insert(&storage_key, payload.clone());
-        per_repo_backend.insert(
-            &metadata_key,
-            Bytes::from(serde_json::to_vec(&metadata).unwrap()),
-        );
-
-        let pool = PgPool::connect_lazy("postgres://fake:fake@127.0.0.1:1/none").unwrap();
-        let global_backend: Arc<dyn crate::services::storage_service::StorageBackend> =
-            Arc::new(FilesystemBackend::new(std::path::PathBuf::from(
-                "/tmp/ak-helpers-test-global-only-2",
-            )));
-        let global_storage = Arc::new(StorageService::new(global_backend));
-        let config = crate::config::Config::default();
-        let proxy =
-            ProxyService::new(pool, global_storage, &config).with_storage_registry(registry);
-
-        // Caller passes a location whose backend is NOT registered. The
-        // registry's `backend_for` should fail to resolve, the proxy should
-        // fall back to global storage, and the global storage has no seeded
-        // content => miss.
-        let bad_location = StorageLocation {
-            backend: "wrong-backend".to_string(),
-            path: "/data/debian".to_string(),
-        };
-        let result = super::proxy_check_cache(
-            &proxy,
-            Uuid::new_v4(),
-            repo_key,
-            &bad_location,
-            "https://deb.example.com",
-            cache_path,
-        )
-        .await;
-
-        assert!(
-            result.is_none(),
-            "expected cache miss when the location's backend is not in the registry; \
-             got a hit, which means the helper is silently coercing the location"
-        );
-    }
-
-    // =======================================================================
-    // Helper-level coverage for `proxy_fetch`, `proxy_fetch_with_cache_key`,
-    // and `proxy_fetch_uncached`.
-    //
-    // These helpers all thread `&StorageLocation` into a synthesized
-    // `Repository` and forward to a `ProxyService` method. The cache-hit
-    // tests below pre-seed the per-repo backend so the helpers short-circuit
-    // before any HTTP traffic, exercising:
-    //
-    //   * the helper body (build_remote_repo + ProxyService dispatch),
-    //   * the registry-resolved cache-hit fast path inside ProxyService,
-    //   * the MockBackend's full `RepoStorageBackend` surface (put/get/delete
-    //     get used across these tests).
-    //
-    // Validation-error tests exercise the early-return branches without
-    // needing a live upstream.
-    // =======================================================================
-
-    /// Build a `(MockBackend, ProxyService, repo_key, location)` tuple
-    /// pre-seeded with one cache entry. Reused by the cache-hit tests so
-    /// each helper doesn't re-derive the same scaffolding.
-    async fn make_seeded_proxy(
-        repo_key: &str,
-        cache_path: &str,
-        payload: Bytes,
-        content_type: &str,
-    ) -> (Arc<MockBackend>, ProxyService, StorageLocation) {
-        let per_repo: Arc<MockBackend> = Arc::new(MockBackend::new());
-        let mut backends: StdHashMap<String, Arc<dyn RepoStorageBackend>> = StdHashMap::new();
-        backends.insert("s3-helper".to_string(), per_repo.clone());
-        let registry = Arc::new(StorageRegistry::new(backends, "s3-helper".to_string()));
-
-        let storage_key = ProxyService::cache_storage_key(repo_key, cache_path);
-        let metadata_key = ProxyService::cache_metadata_key(repo_key, cache_path);
-        let metadata = CacheMetadata {
-            cached_at: Utc::now(),
-            upstream_etag: None,
-            expires_at: Utc::now() + chrono::Duration::hours(1),
-            content_type: Some(content_type.to_string()),
-            size_bytes: payload.len() as i64,
-            checksum_sha256: StorageService::calculate_hash(&payload),
-        };
-        // Use `MockBackend::put` via the `RepoStorageBackend` trait so the
-        // trait `put` is exercised by these tests (covers the put body).
-        let backend_dyn: Arc<dyn RepoStorageBackend> = per_repo.clone();
-        backend_dyn.put(&storage_key, payload).await.unwrap();
-        backend_dyn
-            .put(
-                &metadata_key,
-                Bytes::from(serde_json::to_vec(&metadata).unwrap()),
-            )
-            .await
-            .unwrap();
-
-        let pool = PgPool::connect_lazy("postgres://fake:fake@127.0.0.1:1/none").unwrap();
-        let global_backend: Arc<dyn crate::services::storage_service::StorageBackend> =
-            Arc::new(FilesystemBackend::new(std::path::PathBuf::from(
-                "/tmp/ak-helpers-test-global-helper",
-            )));
-        let global_storage = Arc::new(StorageService::new(global_backend));
-        let config = crate::config::Config::default();
-        let proxy =
-            ProxyService::new(pool, global_storage, &config).with_storage_registry(registry);
-        let location = StorageLocation {
-            backend: "s3-helper".to_string(),
-            path: "/data/helper".to_string(),
-        };
-        (per_repo, proxy, location)
-    }
-
-    /// `proxy_fetch` MUST route the cache-hit lookup through the same
-    /// per-repo backend as `proxy_check_cache`. With the cache pre-seeded
-    /// on the registry-resolved backend, the helper returns the cached
-    /// bytes without contacting upstream — proving the helper threads the
-    /// real `StorageLocation` into `ProxyService::fetch_artifact`.
-    #[tokio::test]
-    async fn test_proxy_fetch_returns_cached_bytes_without_upstream() {
-        let repo_key = "debian-proxy";
-        let cache_path = "pool/main/p/php7.4/php7.4_test.deb";
-        let payload = Bytes::from_static(b"<deb file body>");
-        let (per_repo, proxy, location) =
-            make_seeded_proxy(repo_key, cache_path, payload.clone(), "application/x-deb").await;
-
-        let (content, content_type) = super::proxy_fetch(
-            &proxy,
-            Uuid::new_v4(),
-            repo_key,
-            &location,
-            "https://deb.example.com",
-            cache_path,
-        )
-        .await
-        .expect(
-            "expected cache hit on the per-repo backend; if this errors, the helper is \
-             routing through the wrong storage location (bug #1016)",
-        );
-
-        assert_eq!(content, payload);
-        assert_eq!(content_type.as_deref(), Some("application/x-deb"));
-        // Sanity: the seeded keys are still on the per-repo backend.
-        assert!(per_repo
-            .store
-            .lock()
-            .unwrap()
-            .contains_key(&ProxyService::cache_storage_key(repo_key, cache_path)));
-    }
-
-    /// `proxy_fetch_with_cache_key` lets callers separate the upstream
-    /// fetch path from the cache lookup path (e.g., PyPI resolves a file
-    /// URL on a different domain but caches under `simple/{name}/{file}`).
-    /// When the cache is seeded under `cache_path`, the helper must hit
-    /// it and short-circuit, exercising both the helper body and the
-    /// `fetch_artifact_with_cache_path` cache-hit branch.
-    #[tokio::test]
-    async fn test_proxy_fetch_with_cache_key_returns_cached_bytes() {
-        let repo_key = "pypi-proxy";
-        // cache_path differs from fetch_path: this is the whole point of
-        // the helper.
-        let cache_path = "simple/requests/requests-2.31.0.tar.gz";
-        let fetch_path = "packages/source/r/requests/requests-2.31.0.tar.gz";
-        let payload = Bytes::from_static(b"<tar.gz body>");
-        let (_per_repo, proxy, location) =
-            make_seeded_proxy(repo_key, cache_path, payload.clone(), "application/gzip").await;
-
-        let (content, content_type) = super::proxy_fetch_with_cache_key(
-            &proxy,
-            Uuid::new_v4(),
-            repo_key,
-            &location,
-            "https://pypi.example.com",
-            fetch_path,
-            cache_path,
-        )
-        .await
-        .expect(
-            "expected cache hit when cache_path matches the seeded entry; \
-             if this errors, the helper is not threading the location through to \
-             fetch_artifact_with_cache_path's cache-hit branch",
-        );
-
-        assert_eq!(content, payload);
-        assert_eq!(content_type.as_deref(), Some("application/gzip"));
-    }
-
-    /// `proxy_fetch_uncached` always bypasses the cache, so we cannot
-    /// exercise it via a cache-hit fixture. Instead, pin the early-return
-    /// validation branches in the underlying `fetch_upstream_direct`: a
-    /// repo that lies about being Remote must fail with a Validation error
-    /// (the helper never builds the upstream URL or makes a network call).
-    /// This covers the helper body lines plus the underlying validation
-    /// branch in ProxyService.
-    #[tokio::test]
-    async fn test_proxy_fetch_uncached_rejects_when_underlying_repo_not_remote() {
-        // Build a normal seeded proxy (we don't actually use the cache here),
-        // then call `fetch_upstream_direct` directly with a non-Remote repo
-        // to drive the validation branch.
-        let (_per_repo, proxy, _location) = make_seeded_proxy(
-            "any",
-            "anything",
-            Bytes::from_static(b"x"),
-            "application/octet-stream",
-        )
-        .await;
-
-        let mut local_repo = build_remote_repo(
-            Uuid::new_v4(),
-            "local-repo",
-            "https://upstream.example.com",
-            &StorageLocation {
-                backend: "s3-helper".to_string(),
-                path: "/data/helper".to_string(),
-            },
-        );
-        local_repo.repo_type = RepositoryType::Local;
-
-        let err = proxy
-            .fetch_upstream_direct(&local_repo, "some/path")
-            .await
-            .expect_err("non-Remote repo must fail validation in fetch_upstream_direct");
-        let msg = format!("{}", err);
-        assert!(
-            msg.contains("only supported for remote repositories"),
-            "unexpected error: {}",
-            msg
-        );
-    }
-
-    /// `invalidate_cache` MUST delete cache content + metadata from the
-    /// per-repo backend (the same backend that handlers read from). With a
-    /// real `StorageLocation` and a registry, both keys vanish from the
-    /// mock backend, exercising `cache_delete` (private) through the
-    /// per-repo branch.
-    #[tokio::test]
-    async fn test_invalidate_cache_removes_entries_from_per_repo_backend() {
-        let repo_key = "debian-proxy";
-        let cache_path = "pool/main/p/php7.4/php7.4_test.deb";
-        let payload = Bytes::from_static(b"<deb file body>");
-        let (per_repo, proxy, location) =
-            make_seeded_proxy(repo_key, cache_path, payload.clone(), "application/x-deb").await;
-
-        let storage_key = ProxyService::cache_storage_key(repo_key, cache_path);
-        let metadata_key = ProxyService::cache_metadata_key(repo_key, cache_path);
-        // Pre-condition: both keys present.
-        assert!(per_repo.store.lock().unwrap().contains_key(&storage_key));
-        assert!(per_repo.store.lock().unwrap().contains_key(&metadata_key));
-
-        // Use `build_remote_repo` directly so the call mirrors what the
-        // helpers construct.
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            repo_key,
-            "https://deb.example.com",
-            &location,
-        );
-        proxy
-            .invalidate_cache(&repo, cache_path)
-            .await
-            .expect("invalidate_cache must succeed");
-
-        // Post-condition: both keys gone from the per-repo backend.
-        let store = per_repo.store.lock().unwrap();
-        assert!(
-            !store.contains_key(&storage_key),
-            "content key should be removed from the per-repo backend"
-        );
-        assert!(
-            !store.contains_key(&metadata_key),
-            "metadata key should be removed from the per-repo backend"
-        );
-    }
-
-    /// `check_upstream` returns `false` (no fetch needed) when valid,
-    /// non-expired metadata exists on the per-repo backend AND the cached
-    /// metadata has no ETag (TTL-only path). This exercises lines around
-    /// the `per_repo_storage` resolution + `load_cache_metadata` happy
-    /// path inside `check_upstream`.
-    #[tokio::test]
-    async fn test_check_upstream_returns_false_for_fresh_cached_metadata() {
-        let repo_key = "debian-proxy";
-        let cache_path = "pool/main/p/php7.4/php7.4_test.deb";
-        let payload = Bytes::from_static(b"<deb file body>");
-        let (_per_repo, proxy, location) =
-            make_seeded_proxy(repo_key, cache_path, payload, "application/x-deb").await;
-
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            repo_key,
-            "https://deb.example.com",
-            &location,
-        );
-
-        let needs_fetch = proxy
-            .check_upstream(&repo, cache_path)
-            .await
-            .expect("check_upstream must succeed when metadata exists and is non-expired");
-        assert!(
-            !needs_fetch,
-            "fresh cached metadata with no ETag should NOT require a re-fetch"
-        );
-    }
-
-    /// `check_upstream` returns `true` (must fetch) when no cache metadata
-    /// exists at all — exercises the `None => return Ok(true)` branch.
-    #[tokio::test]
-    async fn test_check_upstream_returns_true_when_cache_missing() {
-        let repo_key = "debian-proxy";
-        let unseeded_path = "pool/main/never/cached.deb";
-        let (_per_repo, proxy, location) = make_seeded_proxy(
-            repo_key,
-            "some/other/path",
-            Bytes::from_static(b"x"),
-            "application/octet-stream",
-        )
-        .await;
-
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            repo_key,
-            "https://deb.example.com",
-            &location,
-        );
-
-        let needs_fetch = proxy
-            .check_upstream(&repo, unseeded_path)
-            .await
-            .expect("check_upstream must succeed when no cache metadata is found");
-        assert!(
-            needs_fetch,
-            "missing cache metadata should require a fresh upstream fetch"
-        );
-    }
-
-    /// `check_upstream` rejects non-Remote repos with a Validation error,
-    /// independent of any cache state. Pins the early-return branch.
-    #[tokio::test]
-    async fn test_check_upstream_rejects_non_remote_repo() {
-        let (_per_repo, proxy, location) = make_seeded_proxy(
-            "any",
-            "anything",
-            Bytes::from_static(b"x"),
-            "application/octet-stream",
-        )
-        .await;
-        let mut repo = build_remote_repo(
-            Uuid::new_v4(),
-            "local-repo",
-            "https://upstream.example.com",
-            &location,
-        );
-        repo.repo_type = RepositoryType::Local;
-
-        let err = proxy
-            .check_upstream(&repo, "some/path")
-            .await
-            .expect_err("non-Remote repo must fail validation in check_upstream");
-        assert!(
-            format!("{}", err).contains("only supported for remote repositories"),
-            "unexpected error: {}",
-            err
-        );
-    }
-
-    /// `get_cached_artifact_by_path` is the legacy global-storage cache
-    /// lookup (no `Repository` in scope). It should miss when the cache is
-    /// only seeded on the per-repo backend, since it intentionally doesn't
-    /// route through the registry. This pins the back-compat surface so a
-    /// future refactor doesn't silently merge it with the per-repo path.
-    #[tokio::test]
-    async fn test_get_cached_artifact_by_path_does_not_see_per_repo_only_seeds() {
-        let repo_key = "debian-proxy";
-        let cache_path = "pool/main/p/php7.4/php7.4_test.deb";
-        let payload = Bytes::from_static(b"<deb file body>");
-        let (_per_repo, proxy, _location) =
-            make_seeded_proxy(repo_key, cache_path, payload, "application/x-deb").await;
-
-        // This call uses the global StorageService (a throwaway /tmp
-        // FilesystemBackend in `make_seeded_proxy`), so the per-repo seed
-        // is invisible: must return Ok(None).
-        let result = proxy
-            .get_cached_artifact_by_path(repo_key, cache_path)
-            .await
-            .expect("get_cached_artifact_by_path must not error on a clean global backend");
-        assert!(
-            result.is_none(),
-            "legacy by-path lookup must NOT resolve through the per-repo backend; \
-             a Some result here would mean the back-compat path silently uses the registry"
-        );
-    }
-
-    /// `invalidate_cache` MUST also work when no registry is configured
-    /// (legacy back-compat path). With `per_repo_storage` returning None,
-    /// the call falls back to the global `StorageService` for both
-    /// `cache_delete` invocations. Pinning this exercises the else-branch
-    /// of `cache_delete` (private) without needing a registry.
-    #[tokio::test]
-    async fn test_invalidate_cache_falls_back_to_global_storage_without_registry() {
-        let pool = PgPool::connect_lazy("postgres://fake:fake@127.0.0.1:1/none").unwrap();
-        let global_backend: Arc<dyn crate::services::storage_service::StorageBackend> =
-            Arc::new(FilesystemBackend::new(std::path::PathBuf::from(
-                "/tmp/ak-helpers-invalidate-fallback",
-            )));
-        let global_storage = Arc::new(StorageService::new(global_backend));
-        let config = crate::config::Config::default();
-        // No `with_storage_registry` call: per_repo_storage returns None.
-        let proxy = ProxyService::new(pool, global_storage, &config);
-
-        let location = StorageLocation {
-            backend: "filesystem".to_string(),
-            path: "/tmp/whatever".to_string(),
-        };
-        let repo = build_remote_repo(
-            Uuid::new_v4(),
-            "no-registry-repo",
-            "https://upstream.example.com",
-            &location,
-        );
-
-        // The cache entries don't exist on the FS backend; `cache_delete`
-        // tolerates NotFound. This is success-on-no-op semantics, exactly
-        // what `invalidate_cache` swallows via `let _ = ...`.
-        proxy
-            .invalidate_cache(&repo, "any/path/that/does/not/exist")
-            .await
-            .expect("invalidate_cache must succeed even when keys are absent");
-    }
-
-    /// Direct exercise of the MockBackend's `delete` and `exists` impls.
-    /// Without this, those trait methods are only reachable in tests that
-    /// don't actually call them, leaving them as uncovered new lines.
-    #[tokio::test]
-    async fn test_mock_backend_delete_and_exists_round_trip() {
-        let backend: Arc<dyn RepoStorageBackend> = Arc::new(MockBackend::new());
-        backend
-            .put("k", Bytes::from_static(b"v"))
-            .await
-            .expect("put");
-        assert!(backend.exists("k").await.expect("exists ok"));
-        backend.delete("k").await.expect("delete ok");
-        assert!(
-            !backend.exists("k").await.expect("exists after delete ok"),
-            "key should be gone after delete"
-        );
     }
 }

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -286,7 +286,6 @@ async fn download_archive(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -377,7 +377,6 @@ async fn download_module(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -281,7 +281,6 @@ async fn simple_project(
                     proxy,
                     repo.id,
                     &repo_key,
-                    &repo.storage_location(),
                     upstream_url,
                     &upstream_path,
                 )
@@ -377,7 +376,6 @@ async fn simple_project(
                     proxy,
                     member.id,
                     &member.key,
-                    &member.storage_location(),
                     upstream_url,
                     &upstream_path,
                 )
@@ -596,15 +594,8 @@ async fn serve_file(
                     let normalized = PypiHandler::normalize_name(project);
                     let local_cache_path = format!("simple/{}/{}", normalized, filename);
 
-                    if let Some((content, _ct)) = proxy_helpers::proxy_check_cache(
-                        proxy,
-                        repo.id,
-                        repo_key,
-                        &repo.storage_location(),
-                        upstream_url,
-                        &local_cache_path,
-                    )
-                    .await
+                    if let Some((content, _ct)) =
+                        proxy_helpers::proxy_check_cache(proxy, repo_key, &local_cache_path).await
                     {
                         return Ok(build_file_response(filename, content));
                     }
@@ -614,7 +605,6 @@ async fn serve_file(
                         proxy,
                         repo.id,
                         repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         project,
                         filename,
@@ -681,10 +671,7 @@ async fn serve_file(
 
                             if let Some((content, _ct)) = proxy_helpers::proxy_check_cache(
                                 proxy,
-                                member.id,
                                 &member.key,
-                                &member.storage_location(),
-                                upstream_url,
                                 &local_cache_path,
                             )
                             .await
@@ -696,7 +683,6 @@ async fn serve_file(
                                 proxy,
                                 member.id,
                                 &member.key,
-                                &member.storage_location(),
                                 upstream_url,
                                 project,
                                 filename,
@@ -769,7 +755,6 @@ async fn fetch_from_pypi_remote(
     proxy: &crate::services::proxy_service::ProxyService,
     repo_id: uuid::Uuid,
     repo_key: &str,
-    location: &crate::storage::StorageLocation,
     upstream_url: &str,
     project: &str,
     filename: &str,
@@ -777,15 +762,9 @@ async fn fetch_from_pypi_remote(
     let normalized = PypiHandler::normalize_name(project);
 
     let index_path = format!("simple/{}/", normalized);
-    let (index_bytes, _ct, effective_url) = proxy_helpers::proxy_fetch_uncached(
-        proxy,
-        repo_id,
-        repo_key,
-        location,
-        upstream_url,
-        &index_path,
-    )
-    .await?;
+    let (index_bytes, _ct, effective_url) =
+        proxy_helpers::proxy_fetch_uncached(proxy, repo_id, repo_key, upstream_url, &index_path)
+            .await?;
 
     let index_html = String::from_utf8_lossy(&index_bytes);
 
@@ -839,7 +818,6 @@ async fn fetch_from_pypi_remote(
         proxy,
         repo_id,
         repo_key,
-        location,
         &fetch_base,
         &fetch_path,
         &local_cache_path,

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1372,16 +1372,12 @@ pub async fn download_artifact(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, content_type) = proxy_helpers::proxy_fetch(
-                    proxy,
-                    repo.id,
-                    &key,
-                    &repo.storage_location(),
-                    upstream_url,
-                    &path,
-                )
-                .await
-                .map_err(|_| AppError::NotFound("Artifact not found upstream".to_string()))?;
+                let (content, content_type) =
+                    proxy_helpers::proxy_fetch(proxy, repo.id, &key, upstream_url, &path)
+                        .await
+                        .map_err(|_| {
+                            AppError::NotFound("Artifact not found upstream".to_string())
+                        })?;
 
                 let ct = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
                 let filename = path.rsplit('/').next().unwrap_or(&path);

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -464,7 +464,6 @@ async fn download_package(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -290,7 +290,6 @@ async fn download_gem(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -100,7 +100,6 @@ async fn download_by_path(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         artifact_path,
                     )

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -302,7 +302,6 @@ async fn download_archive(
                         proxy,
                         repo.id,
                         repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -240,7 +240,6 @@ async fn download_module(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )
@@ -798,7 +797,6 @@ async fn download_provider(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -185,7 +185,6 @@ async fn download_vsix(
                         proxy,
                         repo.id,
                         &repo_key,
-                        &repo.storage_location(),
                         upstream_url,
                         &upstream_path,
                     )

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -359,17 +359,14 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
 
     app_state.set_metrics_handle(metrics_handle);
 
-    // Initialize proxy service for remote repository caching.
-    // The storage_registry hook is REQUIRED so cache reads/writes go through
-    // the same per-repo backend that download handlers use; without it,
-    // already-cached APT/PyPI/etc. artifacts fail to download a second time
-    // (issue #1016).
+    // Initialize proxy service for remote repository caching
     match StorageService::from_config(&config).await {
         Ok(storage_svc) => {
-            let proxy_service = Arc::new(
-                ProxyService::new(db_pool.clone(), Arc::new(storage_svc), &config)
-                    .with_storage_registry(storage_registry.clone()),
-            );
+            let proxy_service = Arc::new(ProxyService::new(
+                db_pool.clone(),
+                Arc::new(storage_svc),
+                &config,
+            ));
             app_state.set_proxy_service(proxy_service);
             tracing::info!("Proxy service initialized for remote repositories");
         }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -22,7 +22,6 @@ use crate::config::Config;
 use crate::error::{AppError, Result};
 use crate::models::repository::{Repository, RepositoryFormat, RepositoryType};
 use crate::services::storage_service::StorageService;
-use crate::storage::{StorageBackend as RepoStorageBackend, StorageRegistry};
 
 /// Default cache TTL in seconds (24 hours)
 pub const DEFAULT_CACHE_TTL_SECS: i64 = 86400;
@@ -65,16 +64,7 @@ struct RegistryTokenResponse {
 /// Proxy service for fetching and caching artifacts from upstream repositories
 pub struct ProxyService {
     db: PgPool,
-    /// Fallback storage used when no `storage_registry` is configured (legacy
-    /// path; kept so older constructors and unit tests keep working).
     storage: Arc<StorageService>,
-    /// Optional registry that resolves a per-repository `StorageBackend`. When
-    /// set, all cache reads/writes go through the same backend that handlers
-    /// use via `state.storage_for_repo(...)`. This is required to fix bug
-    /// #1016 — without it, the proxy writes cached content to one backend
-    /// and downstream handlers read from a different one, producing 500
-    /// errors on second download of cached APT/PyPI/etc. packages.
-    storage_registry: Option<Arc<StorageRegistry>>,
     http_client: Client,
     /// In-memory cache for OCI registry bearer tokens.
     /// Key: "{realm}\0{service}\0{scope}", Value: (token, created_at, ttl_secs)
@@ -88,13 +78,7 @@ pub struct ProxyService {
 }
 
 impl ProxyService {
-    /// Create a new proxy service.
-    ///
-    /// Without a `StorageRegistry`, cache reads/writes go through the supplied
-    /// `StorageService` only. Use [`ProxyService::with_storage_registry`] in
-    /// production to route cache I/O through the same per-repository backend
-    /// that handlers use, otherwise downloads of already-cached artifacts will
-    /// 500 when the per-repo backend differs from the global one (bug #1016).
+    /// Create a new proxy service
     pub fn new(db: PgPool, storage: Arc<StorageService>, config: &Config) -> Self {
         let http_client = crate::services::http_client::base_client_builder()
             .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
@@ -109,90 +93,11 @@ impl ProxyService {
         Self {
             db,
             storage,
-            storage_registry: None,
             http_client,
             token_cache: RwLock::new(HashMap::new()),
             fetch_semaphore: Arc::new(tokio::sync::Semaphore::new(max_concurrent)),
             queue_timeout: Duration::from_secs(config.proxy_queue_timeout_secs),
             max_artifact_size: config.proxy_max_artifact_size_bytes,
-        }
-    }
-
-    /// Builder-style setter that wires in a `StorageRegistry`.
-    ///
-    /// When configured, cache reads and writes are routed through the
-    /// per-repository backend resolved via the registry from
-    /// `repo.storage_location()`. This must match the backend that
-    /// `AppState::storage_for_repo` returns, otherwise format download
-    /// handlers will fail to load cached artifacts (bug #1016).
-    pub fn with_storage_registry(mut self, registry: Arc<StorageRegistry>) -> Self {
-        self.storage_registry = Some(registry);
-        self
-    }
-
-    /// Resolve the per-repo storage backend to use for cache I/O if a
-    /// `StorageRegistry` is configured. Returns `None` when no registry is
-    /// available (the legacy global-storage path is used in that case so
-    /// existing tests and old callers keep working).
-    fn per_repo_storage(&self, repo: &Repository) -> Option<Arc<dyn RepoStorageBackend>> {
-        let registry = self.storage_registry.as_ref()?;
-        match registry.backend_for(&repo.storage_location()) {
-            Ok(backend) => Some(backend),
-            Err(e) => {
-                tracing::warn!(
-                    repo_key = %repo.key,
-                    error = %e,
-                    "Failed to resolve per-repo storage for proxy cache, falling back to global storage"
-                );
-                None
-            }
-        }
-    }
-
-    /// Write a key/content pair to the per-repo backend if available, falling
-    /// back to the global `StorageService` otherwise. Routing writes here is
-    /// what makes second downloads of cached artifacts succeed: handlers read
-    /// via `storage_for_repo`, so the cache must land on the same backend.
-    async fn cache_put(
-        &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
-        key: &str,
-        content: Bytes,
-    ) -> Result<()> {
-        if let Some(backend) = per_repo {
-            backend.put(key, content).await
-        } else {
-            self.storage.put(key, content).await
-        }
-    }
-
-    /// Read a key from the per-repo backend if available, falling back to the
-    /// global `StorageService` otherwise. The fallback preserves the legacy
-    /// behavior used by tests that construct `ProxyService` without a
-    /// registry.
-    async fn cache_get(
-        &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
-        key: &str,
-    ) -> Result<Bytes> {
-        if let Some(backend) = per_repo {
-            backend.get(key).await
-        } else {
-            self.storage.get(key).await
-        }
-    }
-
-    /// Delete a key from the per-repo backend if available, falling back to
-    /// the global `StorageService` otherwise.
-    async fn cache_delete(
-        &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
-        key: &str,
-    ) -> Result<()> {
-        if let Some(backend) = per_repo {
-            backend.delete(key).await
-        } else {
-            self.storage.delete(key).await
         }
     }
 
@@ -207,10 +112,10 @@ impl ProxyService {
     }
 
     /// Check whether an artifact is already present in the proxy cache
-    /// under the given `path` (without contacting upstream), using the legacy
-    /// global storage. Prefer [`get_cached_artifact_for_repo`] when a
-    /// `Repository` is in scope: it routes through the per-repo backend so
-    /// the lookup matches what download handlers see (bug #1016).
+    /// under the given `path` (without contacting upstream).
+    ///
+    /// Returns `Ok(Some((content, content_type)))` on cache hit, `Ok(None)`
+    /// on cache miss or expired entry.
     pub async fn get_cached_artifact_by_path(
         &self,
         repo_key: &str,
@@ -218,24 +123,7 @@ impl ProxyService {
     ) -> Result<Option<(Bytes, Option<String>)>> {
         let cache_key = Self::cache_storage_key(repo_key, path);
         let metadata_key = Self::cache_metadata_key(repo_key, path);
-        self.get_cached_artifact(None, &cache_key, &metadata_key)
-            .await
-    }
-
-    /// Check whether an artifact is already present in the proxy cache for
-    /// `repo` under `path`. Routes through the per-repo storage backend so
-    /// the cache lookup matches the backend that handlers read from when
-    /// serving by `artifacts.storage_key` (bug #1016).
-    pub async fn get_cached_artifact_for_repo(
-        &self,
-        repo: &Repository,
-        path: &str,
-    ) -> Result<Option<(Bytes, Option<String>)>> {
-        let cache_key = Self::cache_storage_key(&repo.key, path);
-        let metadata_key = Self::cache_metadata_key(&repo.key, path);
-        let per_repo = self.per_repo_storage(repo);
-        self.get_cached_artifact(per_repo.as_ref(), &cache_key, &metadata_key)
-            .await
+        self.get_cached_artifact(&cache_key, &metadata_key).await
     }
 
     /// Fetch artifact from upstream, but use `cache_path` instead of
@@ -265,14 +153,9 @@ impl ProxyService {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path);
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path);
 
-        // Resolve the per-repo backend once and pass it through to all cache
-        // I/O so writes and reads land on the same storage that handlers use.
-        let per_repo = self.per_repo_storage(repo);
-
         // Check if we have a valid cached copy
-        if let Some((content, content_type)) = self
-            .get_cached_artifact(per_repo.as_ref(), &cache_key, &metadata_key)
-            .await?
+        if let Some((content, content_type)) =
+            self.get_cached_artifact(&cache_key, &metadata_key).await?
         {
             return Ok((content, content_type));
         }
@@ -285,7 +168,6 @@ impl ProxyService {
             Ok((content, content_type, etag, _effective_url)) => {
                 let cache_ttl = self.get_cache_ttl_for_repo(repo.id).await;
                 self.cache_artifact(
-                    per_repo.as_ref(),
                     &cache_key,
                     &metadata_key,
                     &content,
@@ -301,7 +183,7 @@ impl ProxyService {
             }
             Err(upstream_err) => {
                 if let Ok(Some((stale_content, stale_content_type))) = self
-                    .get_stale_cached_artifact(per_repo.as_ref(), &cache_key, &metadata_key)
+                    .get_stale_cached_artifact(&cache_key, &metadata_key)
                     .await
                 {
                     tracing::warn!(
@@ -333,12 +215,8 @@ impl ProxyService {
 
         let metadata_key = Self::cache_metadata_key(&repo.key, path);
 
-        // Try to load existing cache metadata from the per-repo backend.
-        let per_repo = self.per_repo_storage(repo);
-        let metadata = match self
-            .load_cache_metadata(per_repo.as_ref(), &metadata_key)
-            .await?
-        {
+        // Try to load existing cache metadata
+        let metadata = match self.load_cache_metadata(&metadata_key).await? {
             Some(m) => m,
             None => return Ok(true), // No cache, definitely need to fetch
         };
@@ -394,12 +272,9 @@ impl ProxyService {
         let cache_key = Self::cache_storage_key(&repo.key, path);
         let metadata_key = Self::cache_metadata_key(&repo.key, path);
 
-        // Delete both content and metadata from the per-repo backend (or
-        // global fallback) so it actually removes the file the handlers
-        // would try to read.
-        let per_repo = self.per_repo_storage(repo);
-        let _ = self.cache_delete(per_repo.as_ref(), &cache_key).await;
-        let _ = self.cache_delete(per_repo.as_ref(), &metadata_key).await;
+        // Delete both content and metadata
+        let _ = self.storage.delete(&cache_key).await;
+        let _ = self.storage.delete(&metadata_key).await;
 
         Ok(())
     }
@@ -443,7 +318,7 @@ impl ProxyService {
     /// Uses a `__content__` leaf file to avoid file/directory collisions
     /// when one path is a prefix of another (e.g., npm metadata at `is-odd`
     /// vs tarball at `is-odd/-/is-odd-3.0.1.tgz`).
-    pub(crate) fn cache_storage_key(repo_key: &str, path: &str) -> String {
+    fn cache_storage_key(repo_key: &str, path: &str) -> String {
         format!(
             "proxy-cache/{}/{}/__content__",
             repo_key,
@@ -452,7 +327,7 @@ impl ProxyService {
     }
 
     /// Generate storage key for cache metadata
-    pub(crate) fn cache_metadata_key(repo_key: &str, path: &str) -> String {
+    fn cache_metadata_key(repo_key: &str, path: &str) -> String {
         format!(
             "proxy-cache/{}/{}/__cache_meta__.json",
             repo_key,
@@ -460,21 +335,14 @@ impl ProxyService {
         )
     }
 
-    /// Attempt to retrieve a cached artifact if valid.
-    ///
-    /// `per_repo` is the registry-resolved per-repo backend (preferred) or
-    /// `None` to fall back to the global storage. Routing through the
-    /// per-repo backend is what makes second downloads of cached APT/PyPI
-    /// packages work — handlers read by `artifacts.storage_key` from the
-    /// same backend (bug #1016).
+    /// Attempt to retrieve a cached artifact if valid
     async fn get_cached_artifact(
         &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
         cache_key: &str,
         metadata_key: &str,
     ) -> Result<Option<(Bytes, Option<String>)>> {
         // Check if metadata exists
-        let metadata = match self.load_cache_metadata(per_repo, metadata_key).await? {
+        let metadata = match self.load_cache_metadata(metadata_key).await? {
             Some(m) => m,
             None => return Ok(None),
         };
@@ -486,7 +354,7 @@ impl ProxyService {
         }
 
         // Try to get cached content
-        match self.cache_get(per_repo, cache_key).await {
+        match self.storage.get(cache_key).await {
             Ok(content) => {
                 // Verify checksum
                 let actual_checksum = StorageService::calculate_hash(&content);
@@ -508,14 +376,9 @@ impl ProxyService {
         }
     }
 
-    /// Load cache metadata from storage. Uses the per-repo backend when
-    /// supplied; otherwise falls back to the global storage.
-    async fn load_cache_metadata(
-        &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
-        metadata_key: &str,
-    ) -> Result<Option<CacheMetadata>> {
-        match self.cache_get(per_repo, metadata_key).await {
+    /// Load cache metadata from storage
+    async fn load_cache_metadata(&self, metadata_key: &str) -> Result<Option<CacheMetadata>> {
+        match self.storage.get(metadata_key).await {
             Ok(data) => {
                 let metadata: CacheMetadata = serde_json::from_slice(&data)?;
                 Ok(Some(metadata))
@@ -879,16 +742,9 @@ impl ProxyService {
 
     /// Cache artifact content and metadata, and record the artifact in the
     /// database so that it appears in repository listings and storage usage.
-    ///
-    /// Content and metadata are written through `per_repo` (the registry-
-    /// resolved per-repo backend) when supplied, otherwise they fall back to
-    /// the global `StorageService`. Routing through the per-repo backend is
-    /// what allows subsequent reads (which go via
-    /// `state.storage_for_repo(...)`) to find the cached file (bug #1016).
     #[allow(clippy::too_many_arguments)]
     async fn cache_artifact(
         &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
         cache_key: &str,
         metadata_key: &str,
         content: &Bytes,
@@ -913,11 +769,12 @@ impl ProxyService {
         };
 
         // Store content
-        self.cache_put(per_repo, cache_key, content.clone()).await?;
+        self.storage.put(cache_key, content.clone()).await?;
 
         // Store metadata
         let metadata_json = serde_json::to_vec(&metadata)?;
-        self.cache_put(per_repo, metadata_key, Bytes::from(metadata_json))
+        self.storage
+            .put(metadata_key, Bytes::from(metadata_json))
             .await?;
 
         // Record the cached artifact in the database so it shows up in
@@ -995,18 +852,17 @@ impl ProxyService {
     /// Used as a fallback when upstream is unavailable.
     async fn get_stale_cached_artifact(
         &self,
-        per_repo: Option<&Arc<dyn RepoStorageBackend>>,
         cache_key: &str,
         metadata_key: &str,
     ) -> Result<Option<(Bytes, Option<String>)>> {
         // Load metadata without checking expiry
-        let metadata = match self.load_cache_metadata(per_repo, metadata_key).await? {
+        let metadata = match self.load_cache_metadata(metadata_key).await? {
             Some(m) => m,
             None => return Ok(None),
         };
 
         // Try to get cached content
-        match self.cache_get(per_repo, cache_key).await {
+        match self.storage.get(cache_key).await {
             Ok(content) => {
                 // Verify checksum
                 let actual_checksum = StorageService::calculate_hash(&content);
@@ -2383,283 +2239,5 @@ mod tests {
         assert!(result.is_ok());
         let (content, _ct, _etag, _url) = result.unwrap();
         assert_eq!(content.len(), 512);
-    }
-
-    // =======================================================================
-    // Regression: bug #1016 — cached artifact storage routing
-    //
-    // When the proxy caches an artifact, the cache content must land on the
-    // SAME storage backend that download handlers read from via
-    // `state.storage_for_repo(...)`. Otherwise the second download of an
-    // already-cached APT/PyPI/etc. package fails with a 500 Internal Server
-    // Error (filesystem: "OS error 2 - No such file"; S3: NoSuchKey).
-    //
-    // These tests pin down the routing contract by:
-    //   1. Building a ProxyService with a `StorageRegistry`.
-    //   2. Resolving the per-repo backend for a Repository.
-    //   3. Asserting writes/reads go to that same backend (NOT the
-    //      ProxyService's global StorageService).
-    // =======================================================================
-
-    use crate::storage::{StorageBackend as RepoStorageBackend, StorageRegistry};
-    use async_trait::async_trait;
-    use std::collections::HashMap as StdHashMap;
-    use std::sync::Mutex;
-
-    /// In-memory `StorageBackend` for testing cache routing.
-    /// Records every put/get so tests can assert which backend was hit.
-    struct MockBackend {
-        store: Mutex<StdHashMap<String, Bytes>>,
-    }
-
-    impl MockBackend {
-        fn new() -> Self {
-            Self {
-                store: Mutex::new(StdHashMap::new()),
-            }
-        }
-
-        fn snapshot_keys(&self) -> Vec<String> {
-            let guard = self.store.lock().unwrap();
-            let mut keys: Vec<String> = guard.keys().cloned().collect();
-            keys.sort();
-            keys
-        }
-    }
-
-    #[async_trait]
-    impl RepoStorageBackend for MockBackend {
-        async fn put(&self, key: &str, content: Bytes) -> Result<()> {
-            self.store.lock().unwrap().insert(key.to_string(), content);
-            Ok(())
-        }
-
-        async fn get(&self, key: &str) -> Result<Bytes> {
-            self.store
-                .lock()
-                .unwrap()
-                .get(key)
-                .cloned()
-                .ok_or_else(|| AppError::NotFound(format!("not found: {}", key)))
-        }
-
-        async fn exists(&self, key: &str) -> Result<bool> {
-            Ok(self.store.lock().unwrap().contains_key(key))
-        }
-
-        async fn delete(&self, key: &str) -> Result<()> {
-            self.store.lock().unwrap().remove(key);
-            Ok(())
-        }
-    }
-
-    fn make_test_repo(key: &str, backend_name: &str, path: &str) -> Repository {
-        Repository {
-            id: Uuid::nil(),
-            key: key.to_string(),
-            name: key.to_string(),
-            description: None,
-            format: RepositoryFormat::Debian,
-            repo_type: RepositoryType::Remote,
-            storage_backend: backend_name.to_string(),
-            storage_path: path.to_string(),
-            upstream_url: Some("https://deb.example.com".to_string()),
-            is_public: true,
-            quota_bytes: None,
-            replication_priority: crate::models::repository::ReplicationPriority::OnDemand,
-            promotion_target_id: None,
-            promotion_policy_id: None,
-            curation_enabled: false,
-            curation_source_repo_id: None,
-            curation_target_repo_id: None,
-            curation_default_action: "review".to_string(),
-            curation_sync_interval_secs: 0,
-            curation_auto_fetch: false,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        }
-    }
-
-    /// Build a `(MockBackend, StorageRegistry)` pair where `name` is both the
-    /// registry key and the registry's default backend. Used by routing tests
-    /// to set up a single-backend registry without boilerplate.
-    fn make_test_registry(name: &str) -> (Arc<MockBackend>, Arc<StorageRegistry>) {
-        let backend = Arc::new(MockBackend::new());
-        let mut backends: StdHashMap<String, Arc<dyn RepoStorageBackend>> = StdHashMap::new();
-        backends.insert(name.to_string(), backend.clone());
-        let registry = Arc::new(StorageRegistry::new(backends, name.to_string()));
-        (backend, registry)
-    }
-
-    /// Build a minimal `ProxyService` for routing tests. The pool is lazy so
-    /// it never actually connects (these tests don't touch the DB). When
-    /// `registry` is `Some`, it is wired in via `with_storage_registry`.
-    fn make_test_proxy(registry: Option<Arc<StorageRegistry>>) -> ProxyService {
-        let pool = PgPool::connect_lazy("postgres://fake:fake@127.0.0.1:1/none")
-            .expect("connect_lazy never fails for a syntactically valid URL");
-        let global_backend: Arc<dyn crate::services::storage_service::StorageBackend> =
-            Arc::new(crate::services::storage_service::FilesystemBackend::new(
-                std::path::PathBuf::from("/tmp/ak-test-global-storage"),
-            ));
-        let storage = Arc::new(StorageService::new(global_backend));
-        let config = crate::config::Config::default();
-        let svc = ProxyService::new(pool, storage, &config);
-        match registry {
-            Some(r) => svc.with_storage_registry(r),
-            None => svc,
-        }
-    }
-
-    /// Bug #1016 regression: when a `StorageRegistry` is configured,
-    /// `per_repo_storage` returns the registry-resolved backend (matches
-    /// what `state.storage_for_repo(...)` returns in the real handler path).
-    #[tokio::test]
-    async fn test_per_repo_storage_resolves_via_registry_for_bug_1016() {
-        let (backend, registry) = make_test_registry("mock-s3");
-        let proxy = make_test_proxy(Some(registry));
-        let repo = make_test_repo("debian-proxy", "mock-s3", "ignored");
-
-        let resolved = proxy
-            .per_repo_storage(&repo)
-            .expect("registry-resolved backend should be returned");
-
-        // Round-trip through the resolved backend. Then check the same key
-        // appears in the original mock backend (proves identity).
-        let key = "proxy-cache/debian-proxy/pool/main/p/php7.4/php7.4_test.deb/__content__";
-        resolved
-            .put(key, Bytes::from_static(b"deb-bytes"))
-            .await
-            .unwrap();
-
-        let recorded = backend.snapshot_keys();
-        assert!(
-            recorded.contains(&key.to_string()),
-            "expected key on registry backend; got {:?}",
-            recorded
-        );
-    }
-
-    /// Bug #1016 regression: `cache_put` followed by `cache_get` round-trips
-    /// through the per-repo backend, NOT the global `StorageService`. This
-    /// is the exact write/read symmetry the proxy needs so handlers reading
-    /// via `state.storage_for_repo(...)` find the cached file.
-    #[tokio::test]
-    async fn test_cache_put_get_routes_through_per_repo_backend_for_bug_1016() {
-        let (per_repo_backend, registry) = make_test_registry("repo-backend");
-        let proxy = make_test_proxy(Some(registry));
-        let repo = make_test_repo("debian-proxy", "repo-backend", "/data/debian");
-
-        let per_repo = proxy.per_repo_storage(&repo);
-        assert!(
-            per_repo.is_some(),
-            "registry-resolved backend should be Some when registry is configured"
-        );
-
-        // Use the production cache key shape (matches proxy_service::cache_storage_key).
-        let cache_key = ProxyService::cache_storage_key(
-            &repo.key,
-            "pool/main/p/php7.4/php7.4_7.4.33-26+0~20260213.114+debian13~1.gbpd8dc34_all.deb",
-        );
-        let payload = Bytes::from_static(b"<deb file body>");
-
-        proxy
-            .cache_put(per_repo.as_ref(), &cache_key, payload.clone())
-            .await
-            .unwrap();
-
-        // Read via the same routing helper.
-        let read_back = proxy
-            .cache_get(per_repo.as_ref(), &cache_key)
-            .await
-            .unwrap();
-        assert_eq!(read_back, payload);
-
-        // The per-repo mock backend should hold the key.
-        let keys = per_repo_backend.snapshot_keys();
-        assert!(
-            keys.iter().any(|k| k == &cache_key),
-            "cache_put must land on the per-repo backend; got keys {:?}",
-            keys
-        );
-    }
-
-    /// Without a registry, routing falls back to the global StorageService.
-    /// This pins the back-compat path so older callers (and existing tests
-    /// that construct `ProxyService::new` without a registry) keep working.
-    #[tokio::test]
-    async fn test_per_repo_storage_returns_none_without_registry() {
-        let proxy = make_test_proxy(None);
-        let repo = make_test_repo("any", "filesystem", "/tmp/whatever");
-        assert!(
-            proxy.per_repo_storage(&repo).is_none(),
-            "without a registry, per_repo_storage must return None so cache I/O falls back to the global StorageService"
-        );
-    }
-
-    /// Bug #1016 demonstration: when `ProxyService` is built WITHOUT the
-    /// `StorageRegistry` (the pre-fix code path), cache writes do NOT land
-    /// on the per-repo backend that handlers later read from. This pins the
-    /// failure mode so we keep the registry wiring in `main.rs`.
-    #[tokio::test]
-    async fn test_bug_1016_repro_without_registry_misses_per_repo_backend() {
-        // Per-repo backend (mirrors what `state.storage_for_repo(...)` would
-        // return for the repo). Handlers read from this backend.
-        let per_repo_backend = Arc::new(MockBackend::new());
-
-        // Build the ProxyService WITHOUT a registry — this reproduces the
-        // pre-fix wiring and demonstrates why second downloads fail.
-        let proxy = make_test_proxy(None);
-        let repo = make_test_repo("debian-proxy", "per-repo", "/data/debian");
-        let per_repo_resolved = proxy.per_repo_storage(&repo);
-        assert!(
-            per_repo_resolved.is_none(),
-            "no registry => no per-repo routing"
-        );
-
-        // Pre-fix behavior: cache_put goes to the global StorageService, NOT
-        // to the per-repo backend that handlers read from. Verify the
-        // per-repo backend stays empty after the cache write.
-        let cache_key =
-            ProxyService::cache_storage_key(&repo.key, "pool/main/p/php7.4/php7.4_test.deb");
-        proxy
-            .cache_put(
-                per_repo_resolved.as_ref(),
-                &cache_key,
-                Bytes::from_static(b"x"),
-            )
-            .await
-            .unwrap();
-        assert!(
-            per_repo_backend.snapshot_keys().is_empty(),
-            "without registry, cache_put falls back to global storage and never reaches the per-repo backend (this is bug #1016)"
-        );
-
-        // And the read path (which handlers go through) sees nothing.
-        let read_via_per_repo = per_repo_backend.get(&cache_key).await;
-        assert!(
-            matches!(read_via_per_repo, Err(AppError::NotFound(_))),
-            "handler-side read via the per-repo backend would 500 because the file lives on the global backend, not the per-repo one"
-        );
-    }
-
-    /// Direct exercise of the MockBackend `exists`/`delete` impls used by
-    /// the routing tests above. Without an explicit driver, those trait
-    /// methods are uncovered new lines even though the type is reachable.
-    #[tokio::test]
-    async fn test_mock_backend_exists_and_delete_round_trip() {
-        let backend: Arc<dyn RepoStorageBackend> = Arc::new(MockBackend::new());
-        backend
-            .put("k", Bytes::from_static(b"v"))
-            .await
-            .expect("put");
-        assert!(
-            backend.exists("k").await.expect("exists ok"),
-            "key should be present after put"
-        );
-        backend.delete("k").await.expect("delete ok");
-        assert!(
-            !backend.exists("k").await.expect("exists ok"),
-            "key should be gone after delete"
-        );
     }
 }


### PR DESCRIPTION
## Summary

Revert of [#1068](https://github.com/artifact-keeper/artifact-keeper/pull/1068) on `release/1.1.x` to unblock the v1.1.9 ship.

## Why this revert

Three reasons.

### 1. v1.1.9-rc.4's release-gate is broken because of #1068

Every remote-proxy fetch fails on rc.4. Local upload/download work; only the proxy path is broken. Confirmed by the fresh release-gate run #25398082025 against the rc.4 image (which has revision `5f91a0b9`):

| Suite | Failing assertion |
|---|---|
| `format-tests (jvm)` | `GET POM through remote proxy failed`, `GET JAR through remote proxy failed` |
| `format-tests (python)` | `GET /pypi/.../simple/six/ returned error`, `cached artifacts should include six` |
| `format-tests (containers / node / rust-go-swift / generic-protocol)` | Same shape — remote-proxy fetches failing |
| `repo-tests / cache-ttl-eviction` | `expected primed index to contain v1.0.0, got: ` (proxy cache empty) |
| `repo-tests / pypi-remote-proxy` | `expected output to contain 'e2e-testpkg'` |

#1068 is the **only proxy-touching commit** between rc.3 (`9d57ae83`, where these tests passed) and rc.4 (`5f91a0b9`). The other two intermediate commits (#1074 cache-ttl handler default, #1075 Grype Dockerfile) don't touch the proxy code path. Process of elimination → #1068.

### 2. #1068 violates the v1.1.9 / Hardening Core charter

Per the [Hardening Core project description](https://github.com/orgs/artifact-keeper/projects/2):

> Reach the bar where someone can run helm install on a clean cluster against the documented values, push, pull, and scan an artifact, and have everything work. Once that bar is hit, feature work resumes.

#1068 is +1489 / -124 across 34 files with 476 lines changed in `proxy_service.rs`. That's a refactor disguised as `fix(proxy)`, not a stability fix. Refactor-grade changes belong post-v1.1.9.

### 3. #1068 bypassed main-first protocol

PR #1068 was authored directly against `release/1.1.x` and never merged to `main`. Normal practice is land-on-main → soak → cherry-pick narrowly. Skipping that meant the change shipped to release without main's broader integration coverage.

## Cost of the revert

#1068 was meant to fix [#1016](https://github.com/artifact-keeper/artifact-keeper/issues/1016) (Remote Repo + S3: cached package download fails). That issue:
- Has been open since v1.1.2
- Affects S3 backends specifically (filesystem unaffected per the report)
- No comments, no escalation, no other reports

The revert reintroduces #1016 — but #1016 was a quiet bug for a slice of users. Shipping rc.4 as v1.1.9 would mean a **loud, universal regression** of all remote-proxy fetches across every package format, which is a much bigger trust hit than #1016 ever caused.

## Path to fix #1016 properly

After v1.1.9 ships:
1. Re-author #1068 against `main` first
2. Narrow scope to the S3 path (the actual #1016 surface), not the whole per-repo storage routing
3. Soak on `main`
4. Cherry-pick a minimal version to `release/1.1.x` for v1.1.10 if needed

## Verification

- `cargo check --workspace --tests` clean against the reverted state
- Reverting a single commit, no merge conflicts (#1074 and #1075 touched unrelated lines)
- The 34-file diff is exactly the inverse of #1068's 34-file diff (-124 / +1489 → +124 / -1489)

## After this lands

Cut **v1.1.9-rc.5** from the new `release/1.1.x` HEAD. Expected release-gate outcome: matches rc.3's profile (proxy works, only soft-failed advisories like security-tests + stress-tests stay red, and they're already excluded from the gate). Publish Docker Images should run.

## Related

- v1.1.9-rc.4 release run: artifact-keeper/artifact-keeper#25392180657
- Fresh release-gate confirmation: artifact-keeper/artifact-keeper-test#25398082025
- v1.1.9 release tracking: #886