### PR TITLE
fix(scanner): gate Grype out of OCI image scans (closes #966)

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -155,6 +155,17 @@ impl Scanner for GrypeScanner {
         "grype"
     }
 
+    /// Grype currently runs `grype dir:<workspace>` which scans whatever
+    /// bytes the artifact's content body holds. For OCI / Docker image
+    /// manifests the body is the manifest JSON, not the layer blobs that
+    /// hold the installed packages, so the scan returns 0 findings while
+    /// ImageScanner (Trivy server mode against the registry) finds
+    /// hundreds (#966). Gate OCI artifacts out until Grype can scan
+    /// images via `registry:` mode (follow-up #1160).
+    fn is_applicable(&self, artifact: &Artifact) -> bool {
+        !crate::services::scanner_service::is_oci_image_artifact(artifact)
+    }
+
     /// Probe `grype --version` once and cache the parsed version string.
     /// Returns `None` if the binary is missing or its output cannot be
     /// parsed.
@@ -214,6 +225,71 @@ mod tests {
 
     fn make_artifact(name: &str, content_type: &str) -> Artifact {
         make_test_artifact(name, content_type, &format!("test/{}", name))
+    }
+
+    // -----------------------------------------------------------------------
+    // is_applicable: #966 gate. Grype's dir-scan mode returns 0 findings
+    // against an OCI manifest JSON because it can't see the layer blobs;
+    // ImageScanner (Trivy) is authoritative for container images today.
+    // Follow-up #1160 tracks the proper Grype-on-OCI-via-registry work.
+    // -----------------------------------------------------------------------
+
+    fn grype() -> GrypeScanner {
+        GrypeScanner::new("/tmp/grype-applicability-test".to_string())
+    }
+
+    #[test]
+    fn test_is_applicable_rejects_oci_image_manifest() {
+        let a = make_test_artifact(
+            "nginx",
+            "application/vnd.oci.image.manifest.v1+json",
+            "v2/library/nginx/manifests/latest",
+        );
+        assert!(
+            !grype().is_applicable(&a),
+            "OCI image manifests must NOT route to Grype (#966); ImageScanner \
+             handles them via Trivy server mode"
+        );
+    }
+
+    #[test]
+    fn test_is_applicable_rejects_docker_distribution_manifest() {
+        let a = make_test_artifact(
+            "redis",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "v2/library/redis/manifests/latest",
+        );
+        assert!(!grype().is_applicable(&a));
+    }
+
+    #[test]
+    fn test_is_applicable_rejects_path_with_manifests_segment() {
+        // Path-based detection catches OCI artifacts that lack the OCI
+        // content_type, which can happen for some proxy upstream variants.
+        let a = make_test_artifact("foo", "application/octet-stream", "v2/foo/manifests/v1");
+        assert!(!grype().is_applicable(&a));
+    }
+
+    #[test]
+    fn test_is_applicable_accepts_npm_tarball() {
+        // The happy path: Grype's existing fs scan does work on lockfiles,
+        // SBOMs, language-pkg targets — keep those routing to Grype.
+        let a = make_test_artifact(
+            "body-parser-1.20.1.tgz",
+            "application/gzip",
+            "npm/body-parser/-/body-parser-1.20.1.tgz",
+        );
+        assert!(grype().is_applicable(&a));
+    }
+
+    #[test]
+    fn test_is_applicable_accepts_pypi_wheel() {
+        let a = make_test_artifact(
+            "requests-2.31.0.whl",
+            "application/zip",
+            "pypi/requests/2.31.0/requests-2.31.0-py3-none-any.whl",
+        );
+        assert!(grype().is_applicable(&a));
     }
 
     #[test]

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -107,13 +107,11 @@ impl ImageScanner {
         }
     }
 
-    /// Check if this artifact is an OCI/Docker image manifest.
+    /// Check if this artifact is an OCI/Docker image manifest. Thin wrapper
+    /// around the shared [`crate::services::scanner_service::is_oci_image_artifact`]
+    /// helper so the predicate has one source of truth.
     fn is_container_image(artifact: &Artifact) -> bool {
-        let ct = &artifact.content_type;
-        ct.contains("vnd.oci.image")
-            || ct.contains("vnd.docker.distribution")
-            || ct.contains("vnd.docker.container")
-            || artifact.path.contains("/manifests/")
+        crate::services::scanner_service::is_oci_image_artifact(artifact)
     }
 
     /// Extract an image reference from the artifact path.

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -75,6 +75,28 @@ fn format_to_purl_type(format: &str) -> &'static str {
     }
 }
 
+/// True when the artifact is an OCI / Docker container image manifest.
+///
+/// Used to gate scanner applicability: `ImageScanner` (Trivy server-mode
+/// against the registry) handles these; `TrivyFsScanner` and
+/// `GrypeScanner` reject them because their `dir:<workspace>` invocation
+/// sees only the manifest JSON, not the layer blobs that hold the
+/// installed packages (#961, #966).
+///
+/// Predicate matches against either:
+/// - content type contains `vnd.oci.image` / `vnd.docker.distribution`
+///   / `vnd.docker.container`
+/// - artifact path contains `/manifests/` — catches proxy upstream
+///   variants that serve manifests without setting the canonical
+///   content type
+pub fn is_oci_image_artifact(artifact: &Artifact) -> bool {
+    let ct = &artifact.content_type;
+    ct.contains("vnd.oci.image")
+        || ct.contains("vnd.docker.distribution")
+        || ct.contains("vnd.docker.container")
+        || artifact.path.contains("/manifests/")
+}
+
 /// SQL CTE that pins each `(artifact_id, scan_type)` pair to its single most-
 /// recently-completed scan_result row. Bind `$1 = artifact_id` and follow
 /// with `SELECT ... FROM <table> WHERE <table>.scan_result_id IN
@@ -3032,6 +3054,96 @@ mod tests {
             VERSION_CACHE_MISS_TTL <= Duration::from_secs(300),
             "miss TTL must be short enough that the column populates promptly after a fix"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // is_oci_image_artifact: shared predicate used by all 3 scanners'
+    // is_applicable impls. Centralizes the duplicated content-type +
+    // /manifests/ path check that was previously inline in each scanner.
+    // (#966 cleanup + jscpd duplication-gate fix.)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_oci_image_artifact_matches_vnd_oci() {
+        let a = test_helpers::make_test_artifact(
+            "nginx",
+            "application/vnd.oci.image.manifest.v1+json",
+            "v2/library/nginx/manifests/latest",
+        );
+        assert!(is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_matches_docker_distribution() {
+        let a = test_helpers::make_test_artifact(
+            "redis",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "v2/library/redis/manifests/latest",
+        );
+        assert!(is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_matches_docker_container() {
+        let a = test_helpers::make_test_artifact(
+            "busybox",
+            "application/vnd.docker.container.image.v1+json",
+            "v2/library/busybox/blobs/sha256:abc",
+        );
+        assert!(is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_matches_path_manifest_segment() {
+        // Path-based detection catches proxy variants that omit the
+        // canonical OCI content type but still serve manifests under
+        // the v2/.../manifests/ convention.
+        let a = test_helpers::make_test_artifact(
+            "foo",
+            "application/octet-stream",
+            "v2/foo/manifests/v1",
+        );
+        assert!(is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_rejects_npm_tarball() {
+        let a = test_helpers::make_test_artifact(
+            "body-parser-1.20.1.tgz",
+            "application/gzip",
+            "npm/body-parser/-/body-parser-1.20.1.tgz",
+        );
+        assert!(!is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_rejects_pypi_wheel() {
+        let a = test_helpers::make_test_artifact(
+            "requests-2.31.0-py3-none-any.whl",
+            "application/zip",
+            "pypi/requests/2.31.0/requests-2.31.0-py3-none-any.whl",
+        );
+        assert!(!is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_rejects_maven_jar() {
+        let a = test_helpers::make_test_artifact(
+            "log4j-core-2.17.1.jar",
+            "application/java-archive",
+            "maven/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar",
+        );
+        assert!(!is_oci_image_artifact(&a));
+    }
+
+    #[test]
+    fn test_is_oci_image_artifact_rejects_empty_content_type_with_safe_path() {
+        // Defensive: an unset content type combined with a non-manifest
+        // path must NOT trip the gate (avoids false-positive that
+        // would deny scanners on uploads that haven't yet had their
+        // content type sniffed).
+        let a = test_helpers::make_test_artifact("foo", "", "generic/foo");
+        assert!(!is_oci_image_artifact(&a));
     }
 
     #[test]

--- a/backend/src/services/trivy_fs_scanner.rs
+++ b/backend/src/services/trivy_fs_scanner.rs
@@ -39,13 +39,8 @@ impl TrivyFsScanner {
     /// Container image manifests are handled by `ImageScanner`; everything
     /// else that looks like a scannable package is handled here.
     pub fn is_applicable(artifact: &Artifact) -> bool {
-        let ct = &artifact.content_type;
         // Skip OCI / Docker image manifests — those belong to ImageScanner.
-        if ct.contains("vnd.oci.image")
-            || ct.contains("vnd.docker.distribution")
-            || ct.contains("vnd.docker.container")
-            || artifact.path.contains("/manifests/")
-        {
+        if crate::services::scanner_service::is_oci_image_artifact(artifact) {
             return false;
         }
 


### PR DESCRIPTION
## Summary

Grype's current invocation is \`grype dir:<workspace>\` against the artifact's raw bytes. For OCI / Docker image manifests those bytes are the manifest JSON — a metadata file listing layer digests, not the actual image layers. Grype walks the JSON, finds no installed packages, and returns 0 findings. Trivy (via ImageScanner in server mode against the registry) actually pulls the layers and finds 200+ CVEs on common base images.

The mismatch was reported in #966 as \`nginx:latest\` showing 0 (Grype) vs 201 (Trivy) findings on the same image. Until Grype gains \`registry:<image-ref>\` invocation (proper fix tracked in #1160), gate OCI artifacts out via the new \`Scanner::is_applicable\` trait method introduced in #1162.

The predicate mirrors \`ImageScanner::is_container_image\`: rejects \`vnd.oci.image\`, \`vnd.docker.distribution\`, \`vnd.docker.container\` content types, OR path containing \`/manifests/\` (catches proxy variants that omit the canonical content type).

## Test Checklist
- [x] Unit tests added/updated — 5 new \`test_is_applicable_*\` tests in grype_scanner covering rejected (OCI/Docker/path-based) and accepted (npm tarball, PyPI wheel) cases.
- [ ] Integration tests added/updated (if applicable) — N/A; the orchestrator-level gate is exercised by #1162's tests.
- [ ] E2E tests added/updated (if applicable) — follow-up #1160 will need an E2E once Grype gets proper registry-mode scanning.
- [x] Manually tested locally — 9062 lib tests pass.
- [x] No regressions in existing tests — full lib green; clippy clean with \`-D warnings\`.

## API Changes
- [ ] N/A - no API changes.

Closes #966.