### PR TITLE
feat(oci): OAuth2 refresh-token grant and access_type=offline support

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -199,6 +199,16 @@ struct TokenForm {
     grant_type: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    /// Used by the `grant_type=refresh_token` flow (per the OAuth2 + Docker
+    /// Distribution spec, see RFC 6749 §6 and
+    /// <https://distribution.github.io/distribution/spec/auth/oauth/>).
+    refresh_token: Option<String>,
+    /// `"offline"` (case-sensitive) requests that the response include a
+    /// refresh token. Anything else — including `None`, `"online"`, the
+    /// empty string, or `"OFFLINE"` — issues an access-token-only
+    /// response. Strict equality matches every real client and avoids
+    /// accidentally expanding the refresh-token surface for typos.
+    access_type: Option<String>,
 }
 
 /// Extract `(username, password)` from an OAuth2 password-grant form body.
@@ -235,6 +245,26 @@ fn extract_form_credentials(headers: &HeaderMap, body: &Bytes) -> Option<(String
         return None;
     }
     Some((username, password))
+}
+
+/// Parse the OAuth2 token-endpoint form body in full, returning every field
+/// the Docker Distribution spec defines. Unlike `extract_form_credentials`,
+/// this does NOT filter on `grant_type=="password"` — callers need to see
+/// `grant_type=refresh_token` for the refresh-grant short-circuit and
+/// `access_type` for the offline-access path.
+///
+/// Returns `None` when the body is empty, the Content-Type isn't
+/// `application/x-www-form-urlencoded` (charset suffix allowed), or the
+/// body fails to deserialize.
+fn parse_oauth2_form(headers: &HeaderMap, body: &Bytes) -> Option<TokenForm> {
+    if body.is_empty() {
+        return None;
+    }
+    let ct = headers.get(CONTENT_TYPE)?.to_str().ok()?;
+    if !ct.starts_with("application/x-www-form-urlencoded") {
+        return None;
+    }
+    serde_urlencoded::from_bytes(body).ok()
 }
 
 async fn validate_token(
@@ -3446,7 +3476,133 @@ struct TokenResponse {
     token: String,
     access_token: String,
     expires_in: u64,
+    /// Only emitted when the client explicitly requested `access_type=offline`
+    /// AND the credential isn't an API token (see security note on
+    /// `build_token_response`). `skip_serializing_if` keeps the response
+    /// byte-compatible with the pre-PR shape for every other code path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_token: Option<String>,
     issued_at: String,
+}
+
+/// Decide whether the `refresh_token` field appears in the OAuth2 token
+/// response.
+///
+/// Returns `Some(refresh)` only when ALL of the following hold:
+///
+/// 1. `access_type` is exactly `"offline"` (strict, case-sensitive — matches
+///    the [Docker Distribution spec](https://distribution.github.io/distribution/spec/auth/oauth/),
+///    which spells it `offline` in the example flow).
+/// 2. The credential used was NOT an API token.
+///
+/// # Why API-token authentication suppresses the refresh token
+///
+/// API tokens (the `api_tokens` table) are the long-lived credential for
+/// non-interactive flows. They have first-class lifecycle:
+/// `revoke_api_token` flips `revoked_at`, the cache invalidates within
+/// `API_TOKEN_CACHE_TTL_SECS` (5 min), and the token is rejected
+/// everywhere.
+///
+/// Issuing a refresh-token JWT under that authentication would create a
+/// **parallel long-lived credential** signed against `JWT_SECRET` and
+/// NOT tied to the `api_tokens` row. `auth_service::refresh_tokens` does
+/// not blacklist consumed refresh tokens, so this parallel credential
+/// would survive `revoke_api_token` for up to
+/// `jwt_refresh_token_expiry_days` (default 7 days). An attacker who
+/// briefly captured the API token would have a 7-day backdoor after the
+/// defender thought they'd closed access.
+///
+/// Industry precedent for this suppression:
+///
+/// - **RFC 6749 §4.4.3** (`client_credentials` grant): *"A refresh token
+///   SHOULD NOT be included."* API-token-as-password is semantically the
+///   same flow — a machine credential authenticating itself.
+/// - **JFrog Artifactory** deprecated their API-key-as-password path
+///   entirely (End of Life Q4 2024) for this exact lifecycle-management
+///   problem: *"API Keys don't have lifecycle management features […]
+///   single user can have single active API Key — if revoked, revoked
+///   for all clients."* Replaced by reference tokens and identity
+///   tokens with per-token revocation.
+/// - **Sonatype Nexus** User Tokens are designed as first-class tokens
+///   with their own lifecycle and do not get a parallel refresh-grant.
+///
+/// The graceful-degradation choice (silent suppress vs explicit 4xx)
+/// follows the default-permissive convention used by Google, GitHub, and
+/// other major OAuth2 servers: the response is still 200 OK with a valid
+/// access token; the client simply re-authenticates with its API token
+/// when the access expires (~30 min later). Returning 400 here would
+/// break Docker daemons that send `access_type=offline` mechanically
+/// regardless of the credential type.
+fn offline_refresh_token(
+    access_type: Option<&str>,
+    authenticated_via_api_token: bool,
+    refresh: &str,
+) -> Option<String> {
+    if authenticated_via_api_token {
+        return None;
+    }
+    if access_type != Some("offline") {
+        return None;
+    }
+    Some(refresh.to_string())
+}
+
+/// Exchange a refresh token for a fresh access token (and optionally a new
+/// refresh token if `access_type=offline` is supplied again). Per
+/// [the Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
+/// the refresh-grant request body is just `grant_type=refresh_token` +
+/// `refresh_token=…` with no credentials — the refresh token itself
+/// authenticates.
+///
+/// `auth_service::refresh_tokens` filters `is_active = true` and consults
+/// `is_token_invalidated`, so any of (a) deactivated user, (b) password
+/// change since issue, (c) TOTP enable/disable since issue, will surface
+/// here as a 401.
+async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response {
+    let refresh = match form.refresh_token.as_deref() {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            return oci_error(
+                StatusCode::BAD_REQUEST,
+                "DENIED",
+                "refresh_token grant requires refresh_token",
+            );
+        }
+    };
+    let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
+    let (_user, tokens) = match auth_service.refresh_tokens(refresh).await {
+        Ok(pair) => pair,
+        Err(_) => {
+            return oci_error(
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHORIZED",
+                "invalid refresh token",
+            );
+        }
+    };
+    // Refresh-grant always originates from a user (not API token) — the
+    // refresh token was issued at password-grant time and the API-token
+    // suppression already prevented one being issued for an API-token
+    // session. So the second argument to `offline_refresh_token` is `false`.
+    // The `access_type` filter still applies: a refresh-grant without
+    // `access_type=offline` does NOT rotate the refresh token (matches the
+    // spec, which says the same refresh is returned).
+    let resp = TokenResponse {
+        token: tokens.access_token.clone(),
+        access_token: tokens.access_token.clone(),
+        expires_in: tokens.expires_in,
+        refresh_token: offline_refresh_token(
+            form.access_type.as_deref(),
+            false,
+            &tokens.refresh_token,
+        ),
+        issued_at: chrono::Utc::now().to_rfc3339(),
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(&resp).unwrap()))
+        .unwrap()
 }
 
 async fn token(
@@ -3464,6 +3620,30 @@ async fn token(
             return oci_error(StatusCode::BAD_REQUEST, "DENIED", "service mismatch");
         }
     }
+
+    // Parse the full OAuth2 form body once upfront. `extract_form_credentials`
+    // filters on `grant_type=="password"`, so it won't see the refresh-grant;
+    // we need a separate handle on the form to detect that, and to thread
+    // `access_type` through to response construction.
+    let form = parse_oauth2_form(&headers, &body);
+
+    // grant_type=refresh_token short-circuit. Per the Docker Distribution
+    // OAuth2 spec[1], the refresh-grant flow doesn't carry credentials —
+    // the refresh_token itself authenticates. So this branch must be
+    // checked before the credential-resolution chain below.
+    //
+    // [1]: https://distribution.github.io/distribution/spec/auth/oauth/
+    if let Some(ref f) = form {
+        if f.grant_type.as_deref() == Some("refresh_token") {
+            return handle_refresh_grant(&state, f).await;
+        }
+    }
+
+    // `access_type=offline` is opt-in for a refresh token in the response of
+    // the credential-auth path. Captured here so it's in scope for the
+    // success-response builder later in the function.
+    let access_type = form.as_ref().and_then(|f| f.access_type.clone());
+
     // Credential extraction order, per the OCI Distribution Spec + OAuth2:
     //   1. HTTP Basic Auth header (the original code path; works for `docker
     //      login` / `curl -u`).
@@ -3555,10 +3735,17 @@ async fn token(
                         }
                     };
 
+                // The Bearer-JWT swap path is for "I already have a valid
+                // JWT, give me a fresh access token". It does NOT issue
+                // refresh tokens regardless of `access_type` — the client
+                // already has their own refresh path elsewhere, and
+                // double-issuing would just create another non-revocable
+                // long-lived credential.
                 let resp = TokenResponse {
                     token: access_token.clone(),
                     access_token,
                     expires_in,
+                    refresh_token: None,
                     issued_at: chrono::Utc::now().to_rfc3339(),
                 };
 
@@ -3590,6 +3777,7 @@ async fn token(
                 token: ANONYMOUS_TOKEN.to_string(),
                 access_token: ANONYMOUS_TOKEN.to_string(),
                 expires_in: 900,
+                refresh_token: None,
                 issued_at: chrono::Utc::now().to_rfc3339(),
             };
             return Response::builder()
@@ -3713,8 +3901,13 @@ async fn token(
 
     let resp = TokenResponse {
         token: tokens.access_token.clone(),
-        access_token: tokens.access_token,
+        access_token: tokens.access_token.clone(),
         expires_in: tokens.expires_in,
+        refresh_token: offline_refresh_token(
+            access_type.as_deref(),
+            authenticated_via_api_token,
+            &tokens.refresh_token,
+        ),
         issued_at: chrono::Utc::now().to_rfc3339(),
     };
 
@@ -10053,6 +10246,7 @@ mod tests {
             token: "tok1".to_string(),
             access_token: "tok1".to_string(),
             expires_in: 3600,
+            refresh_token: None,
             issued_at: "2024-01-01T00:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&resp).unwrap();
@@ -10060,6 +10254,58 @@ mod tests {
         assert!(json.contains("\"access_token\":\"tok1\""));
         assert!(json.contains("\"expires_in\":3600"));
         assert!(json.contains("\"issued_at\""));
+        // refresh_token: None must be omitted entirely so legacy clients
+        // and PR1102-shape consumers don't observe a behavioral change.
+        assert!(!json.contains("refresh_token"));
+    }
+
+    #[test]
+    fn test_token_response_serializes_refresh_token_when_some() {
+        let resp = TokenResponse {
+            token: "access".to_string(),
+            access_token: "access".to_string(),
+            expires_in: 3600,
+            refresh_token: Some("refresh-jwt".to_string()),
+            issued_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"refresh_token\":\"refresh-jwt\""));
+    }
+
+    // -----------------------------------------------------------------------
+    // offline_refresh_token suppression rules
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_offline_refresh_token_returns_some_for_password_grant_offline() {
+        let rt = offline_refresh_token(Some("offline"), false, "refresh-jwt");
+        assert_eq!(rt.as_deref(), Some("refresh-jwt"));
+    }
+
+    #[test]
+    fn test_offline_refresh_token_returns_none_for_password_grant_without_offline() {
+        // `None`, `"online"`, the empty string — none of these should emit a
+        // refresh token. Strict equality on `"offline"` matches the spec and
+        // refuses to expand the surface on typos.
+        for at in [
+            None,
+            Some("online"),
+            Some(""),
+            Some("OFFLINE"),
+            Some("offline "),
+        ] {
+            let rt = offline_refresh_token(at, false, "refresh-jwt");
+            assert!(rt.is_none(), "expected None for access_type={:?}", at);
+        }
+    }
+
+    #[test]
+    fn test_offline_refresh_token_suppresses_for_api_token_even_when_offline_requested() {
+        // The security-critical case: API-token authentication must never
+        // be upgraded into a refresh-grant. See the function's doc-comment
+        // for the full rationale (industry precedent + revocation gap).
+        let rt = offline_refresh_token(Some("offline"), true, "refresh-jwt");
+        assert!(rt.is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -21098,6 +21344,320 @@ mod oci_write_authz_and_size_tests {
         assert!(
             reject_oversized_content_length(&headers, 10, 10).is_none(),
             "a declared Content-Length within the limit must not be rejected"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OAuth2 refresh-grant + `access_type=offline` end-to-end tests. DB-backed
+// because the handler builds `SharedState` from a live `PgPool`, exercises
+// `auth_service::generate_tokens` + `refresh_tokens`, and several assertions
+// depend on `users.is_active` being flipped between calls.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod token_refresh_grant_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use crate::services::auth_service::AuthService;
+    use axum::body::Body;
+    use axum::http::Request;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// Spin up a fresh user, a `SharedState`, and an `AuthService`. Returns
+    /// `None` when `DATABASE_URL` is unset so the test no-ops gracefully.
+    async fn setup() -> Option<(sqlx::PgPool, Uuid, String, SharedState, AuthService)> {
+        let pool = tdh::try_pool().await?;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let pwd_hash = bcrypt::hash("real-test-password", 4).expect("bcrypt hash");
+        sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
+            .bind(&pwd_hash)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("update password_hash");
+        let storage_dir =
+            std::env::temp_dir().join(format!("oci-refresh-grant-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
+        Some((pool, user_id, username, state, auth_service))
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+
+    fn form_post(uri: &str, body: String) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(Body::from(body))
+            .unwrap()
+    }
+
+    async fn read_body(resp: axum::response::Response<Body>) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 65_536)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    }
+
+    /// Read response body as raw bytes — used by tests that assert the
+    /// JSON field is *absent from the wire*, not merely `Value::Null`.
+    /// Mirrors the sync `test_token_response_serialization` assertion.
+    async fn read_body_bytes(resp: axum::response::Response<Body>) -> Vec<u8> {
+        axum::body::to_bytes(resp.into_body(), 65_536)
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
+    /// Real user + `access_type=offline` → response carries `refresh_token`.
+    #[tokio::test]
+    async fn password_grant_offline_includes_refresh_token() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let app = router().with_state(state);
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let body = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["refresh_token"].as_str().is_some(),
+            "expected refresh_token in response, got: {body}"
+        );
+    }
+
+    /// Real user without `access_type` → response has NO `refresh_token`.
+    /// Backwards-compatible with the pre-PR shape. Assert on raw JSON bytes
+    /// so a regression that emits `Value::Null` or `""` for the field would
+    /// still fail (matches the contract `skip_serializing_if` enforces).
+    #[tokio::test]
+    async fn password_grant_default_omits_refresh_token() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let body = format!("grant_type=password&username={username}&password=real-test-password");
+        let app = router().with_state(state);
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            !raw.contains("refresh_token"),
+            "default password-grant response must not mention refresh_token on the wire: {raw}"
+        );
+    }
+
+    /// Security-critical regression. See `offline_refresh_token` doc-comment
+    /// for the full motivation (RFC 6749 §4.4.3, JFrog API-key EOL, etc.).
+    /// Asserts the field is absent from the raw JSON, not just `Value::Null`,
+    /// because the security contract is that nothing called `refresh_token`
+    /// reaches the client at all.
+    #[tokio::test]
+    async fn api_token_offline_does_not_get_refresh_token() {
+        let Some((pool, user_id, username, state, auth_service)) = setup().await else {
+            return;
+        };
+        let (api_token, _) = auth_service
+            .generate_api_token(user_id, "offline-test", vec!["*".to_string()], None)
+            .await
+            .expect("generate API token");
+        let body = format!(
+            "grant_type=password&username={username}&password={api_token}&access_type=offline"
+        );
+        let app = router().with_state(state);
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        assert_ne!(body["token"].as_str(), Some("anonymous"));
+        assert!(
+            !raw.contains("refresh_token"),
+            "API-token + offline must NOT mint a refresh-grant credential that survives revoke_api_token: {raw}"
+        );
+    }
+
+    /// Refresh-grant default (no `access_type`) → new access, no rotation.
+    /// Distribution spec at
+    /// <https://distribution.github.io/distribution/spec/auth/oauth/> says
+    /// "only return the same refresh token and not a new one" — we omit the
+    /// field instead so the client keeps using the original. Both real Docker
+    /// daemons and OCI clients handle either shape; revisit if we ever need
+    /// strict spec conformance. Asserts on raw bytes for the same reason as
+    /// `password_grant_default_omits_refresh_token`.
+    #[tokio::test]
+    async fn refresh_grant_default_returns_access_only() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        assert!(body["access_token"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty() && s != "anonymous"));
+        assert!(
+            !raw.contains("refresh_token"),
+            "default refresh-grant should not rotate the refresh: {raw}"
+        );
+    }
+
+    /// Refresh-grant + `access_type=offline` rotates the refresh token.
+    #[tokio::test]
+    async fn refresh_grant_offline_rotates_refresh_token() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}&access_type=offline");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let body = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["access_token"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(
+            body["refresh_token"].as_str().is_some(),
+            "offline refresh-grant should mint a new refresh: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_grant_invalid_token_returns_401() {
+        let Some((pool, user_id, _username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(form_post(
+                "/token",
+                "grant_type=refresh_token&refresh_token=not-a-valid-jwt".to_string(),
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn refresh_grant_missing_token_returns_400() {
+        let Some((pool, user_id, _username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        for body in [
+            "grant_type=refresh_token".to_string(),
+            "grant_type=refresh_token&refresh_token=".to_string(),
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(form_post("/token", body.clone()))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "expected 400 for body={body:?}"
+            );
+        }
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Deactivated user can't refresh — `auth_service::refresh_tokens`
+    /// filters on `is_active = true`.
+    #[tokio::test]
+    async fn refresh_grant_deactivated_user_returns_401() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        sqlx::query("UPDATE users SET is_active = false WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("deactivate user");
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        cleanup(&pool, user_id).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "deactivated user must not mint fresh tokens via refresh-grant"
         );
     }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -182,6 +182,16 @@ struct TokenForm {
     grant_type: Option<String>,
     username: Option<String>,
     password: Option<String>,
+    /// Used by the `grant_type=refresh_token` flow (per the OAuth2 + Docker
+    /// Distribution spec, see RFC 6749 §6 and
+    /// <https://distribution.github.io/distribution/spec/auth/oauth/>).
+    refresh_token: Option<String>,
+    /// `"offline"` (case-sensitive) requests that the response include a
+    /// refresh token. Anything else — including `None`, `"online"`, the
+    /// empty string, or `"OFFLINE"` — issues an access-token-only
+    /// response. Strict equality matches every real client and avoids
+    /// accidentally expanding the refresh-token surface for typos.
+    access_type: Option<String>,
 }
 
 /// Extract `(username, password)` from an OAuth2 password-grant form body.
@@ -218,6 +228,26 @@ fn extract_form_credentials(headers: &HeaderMap, body: &Bytes) -> Option<(String
         return None;
     }
     Some((username, password))
+}
+
+/// Parse the OAuth2 token-endpoint form body in full, returning every field
+/// the Docker Distribution spec defines. Unlike `extract_form_credentials`,
+/// this does NOT filter on `grant_type=="password"` — callers need to see
+/// `grant_type=refresh_token` for the refresh-grant short-circuit and
+/// `access_type` for the offline-access path.
+///
+/// Returns `None` when the body is empty, the Content-Type isn't
+/// `application/x-www-form-urlencoded` (charset suffix allowed), or the
+/// body fails to deserialize.
+fn parse_oauth2_form(headers: &HeaderMap, body: &Bytes) -> Option<TokenForm> {
+    if body.is_empty() {
+        return None;
+    }
+    let ct = headers.get(CONTENT_TYPE)?.to_str().ok()?;
+    if !ct.starts_with("application/x-www-form-urlencoded") {
+        return None;
+    }
+    serde_urlencoded::from_bytes(body).ok()
 }
 
 fn validate_token(
@@ -739,7 +769,133 @@ struct TokenResponse {
     token: String,
     access_token: String,
     expires_in: u64,
+    /// Only emitted when the client explicitly requested `access_type=offline`
+    /// AND the credential isn't an API token (see security note on
+    /// `build_token_response`). `skip_serializing_if` keeps the response
+    /// byte-compatible with the pre-PR shape for every other code path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    refresh_token: Option<String>,
     issued_at: String,
+}
+
+/// Decide whether the `refresh_token` field appears in the OAuth2 token
+/// response.
+///
+/// Returns `Some(refresh)` only when ALL of the following hold:
+///
+/// 1. `access_type` is exactly `"offline"` (strict, case-sensitive — matches
+///    the [Docker Distribution spec](https://distribution.github.io/distribution/spec/auth/oauth/),
+///    which spells it `offline` in the example flow).
+/// 2. The credential used was NOT an API token.
+///
+/// # Why API-token authentication suppresses the refresh token
+///
+/// API tokens (the `api_tokens` table) are the long-lived credential for
+/// non-interactive flows. They have first-class lifecycle:
+/// `revoke_api_token` flips `revoked_at`, the cache invalidates within
+/// `API_TOKEN_CACHE_TTL_SECS` (5 min), and the token is rejected
+/// everywhere.
+///
+/// Issuing a refresh-token JWT under that authentication would create a
+/// **parallel long-lived credential** signed against `JWT_SECRET` and
+/// NOT tied to the `api_tokens` row. `auth_service::refresh_tokens` does
+/// not blacklist consumed refresh tokens, so this parallel credential
+/// would survive `revoke_api_token` for up to
+/// `jwt_refresh_token_expiry_days` (default 7 days). An attacker who
+/// briefly captured the API token would have a 7-day backdoor after the
+/// defender thought they'd closed access.
+///
+/// Industry precedent for this suppression:
+///
+/// - **RFC 6749 §4.4.3** (`client_credentials` grant): *"A refresh token
+///   SHOULD NOT be included."* API-token-as-password is semantically the
+///   same flow — a machine credential authenticating itself.
+/// - **JFrog Artifactory** deprecated their API-key-as-password path
+///   entirely (End of Life Q4 2024) for this exact lifecycle-management
+///   problem: *"API Keys don't have lifecycle management features […]
+///   single user can have single active API Key — if revoked, revoked
+///   for all clients."* Replaced by reference tokens and identity
+///   tokens with per-token revocation.
+/// - **Sonatype Nexus** User Tokens are designed as first-class tokens
+///   with their own lifecycle and do not get a parallel refresh-grant.
+///
+/// The graceful-degradation choice (silent suppress vs explicit 4xx)
+/// follows the default-permissive convention used by Google, GitHub, and
+/// other major OAuth2 servers: the response is still 200 OK with a valid
+/// access token; the client simply re-authenticates with its API token
+/// when the access expires (~30 min later). Returning 400 here would
+/// break Docker daemons that send `access_type=offline` mechanically
+/// regardless of the credential type.
+fn offline_refresh_token(
+    access_type: Option<&str>,
+    authenticated_via_api_token: bool,
+    refresh: &str,
+) -> Option<String> {
+    if authenticated_via_api_token {
+        return None;
+    }
+    if access_type != Some("offline") {
+        return None;
+    }
+    Some(refresh.to_string())
+}
+
+/// Exchange a refresh token for a fresh access token (and optionally a new
+/// refresh token if `access_type=offline` is supplied again). Per
+/// [the Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
+/// the refresh-grant request body is just `grant_type=refresh_token` +
+/// `refresh_token=…` with no credentials — the refresh token itself
+/// authenticates.
+///
+/// `auth_service::refresh_tokens` filters `is_active = true` and consults
+/// `is_token_invalidated`, so any of (a) deactivated user, (b) password
+/// change since issue, (c) TOTP enable/disable since issue, will surface
+/// here as a 401.
+async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response {
+    let refresh = match form.refresh_token.as_deref() {
+        Some(s) if !s.is_empty() => s,
+        _ => {
+            return oci_error(
+                StatusCode::BAD_REQUEST,
+                "DENIED",
+                "refresh_token grant requires refresh_token",
+            );
+        }
+    };
+    let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
+    let (_user, tokens) = match auth_service.refresh_tokens(refresh).await {
+        Ok(pair) => pair,
+        Err(_) => {
+            return oci_error(
+                StatusCode::UNAUTHORIZED,
+                "UNAUTHORIZED",
+                "invalid refresh token",
+            );
+        }
+    };
+    // Refresh-grant always originates from a user (not API token) — the
+    // refresh token was issued at password-grant time and the API-token
+    // suppression already prevented one being issued for an API-token
+    // session. So the second argument to `offline_refresh_token` is `false`.
+    // The `access_type` filter still applies: a refresh-grant without
+    // `access_type=offline` does NOT rotate the refresh token (matches the
+    // spec, which says the same refresh is returned).
+    let resp = TokenResponse {
+        token: tokens.access_token.clone(),
+        access_token: tokens.access_token.clone(),
+        expires_in: tokens.expires_in,
+        refresh_token: offline_refresh_token(
+            form.access_type.as_deref(),
+            false,
+            &tokens.refresh_token,
+        ),
+        issued_at: chrono::Utc::now().to_rfc3339(),
+    };
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/json")
+        .body(Body::from(serde_json::to_string(&resp).unwrap()))
+        .unwrap()
 }
 
 async fn token(
@@ -748,6 +904,29 @@ async fn token(
     Query(_query): Query<TokenQuery>,
     body: Bytes,
 ) -> Response {
+    // Parse the full OAuth2 form body once upfront. `extract_form_credentials`
+    // filters on `grant_type=="password"`, so it won't see the refresh-grant;
+    // we need a separate handle on the form to detect that, and to thread
+    // `access_type` through to response construction.
+    let form = parse_oauth2_form(&headers, &body);
+
+    // grant_type=refresh_token short-circuit. Per the Docker Distribution
+    // OAuth2 spec[1], the refresh-grant flow doesn't carry credentials —
+    // the refresh_token itself authenticates. So this branch must be
+    // checked before the credential-resolution chain below.
+    //
+    // [1]: https://distribution.github.io/distribution/spec/auth/oauth/
+    if let Some(ref f) = form {
+        if f.grant_type.as_deref() == Some("refresh_token") {
+            return handle_refresh_grant(&state, f).await;
+        }
+    }
+
+    // `access_type=offline` is opt-in for a refresh token in the response of
+    // the credential-auth path. Captured here so it's in scope for the
+    // success-response builder later in the function.
+    let access_type = form.as_ref().and_then(|f| f.access_type.clone());
+
     // Credential extraction order, per the OCI Distribution Spec + OAuth2:
     //   1. HTTP Basic Auth header (the original code path; works for `docker
     //      login` / `curl -u`).
@@ -807,10 +986,17 @@ async fn token(
                     }
                 };
 
+                // The Bearer-JWT swap path is for "I already have a valid
+                // JWT, give me a fresh access token". It does NOT issue
+                // refresh tokens regardless of `access_type` — the client
+                // already has their own refresh path elsewhere, and
+                // double-issuing would just create another non-revocable
+                // long-lived credential.
                 let resp = TokenResponse {
                     token: tokens.access_token.clone(),
                     access_token: tokens.access_token,
                     expires_in: tokens.expires_in,
+                    refresh_token: None,
                     issued_at: chrono::Utc::now().to_rfc3339(),
                 };
 
@@ -829,6 +1015,7 @@ async fn token(
                 token: ANONYMOUS_TOKEN.to_string(),
                 access_token: ANONYMOUS_TOKEN.to_string(),
                 expires_in: 900,
+                refresh_token: None,
                 issued_at: chrono::Utc::now().to_rfc3339(),
             };
             return Response::builder()
@@ -909,8 +1096,13 @@ async fn token(
 
     let resp = TokenResponse {
         token: tokens.access_token.clone(),
-        access_token: tokens.access_token,
+        access_token: tokens.access_token.clone(),
         expires_in: tokens.expires_in,
+        refresh_token: offline_refresh_token(
+            access_type.as_deref(),
+            authenticated_via_api_token,
+            &tokens.refresh_token,
+        ),
         issued_at: chrono::Utc::now().to_rfc3339(),
     };
 
@@ -4384,6 +4576,7 @@ mod tests {
             token: "tok1".to_string(),
             access_token: "tok1".to_string(),
             expires_in: 3600,
+            refresh_token: None,
             issued_at: "2024-01-01T00:00:00Z".to_string(),
         };
         let json = serde_json::to_string(&resp).unwrap();
@@ -4391,6 +4584,58 @@ mod tests {
         assert!(json.contains("\"access_token\":\"tok1\""));
         assert!(json.contains("\"expires_in\":3600"));
         assert!(json.contains("\"issued_at\""));
+        // refresh_token: None must be omitted entirely so legacy clients
+        // and PR1102-shape consumers don't observe a behavioral change.
+        assert!(!json.contains("refresh_token"));
+    }
+
+    #[test]
+    fn test_token_response_serializes_refresh_token_when_some() {
+        let resp = TokenResponse {
+            token: "access".to_string(),
+            access_token: "access".to_string(),
+            expires_in: 3600,
+            refresh_token: Some("refresh-jwt".to_string()),
+            issued_at: "2024-01-01T00:00:00Z".to_string(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"refresh_token\":\"refresh-jwt\""));
+    }
+
+    // -----------------------------------------------------------------------
+    // offline_refresh_token suppression rules
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_offline_refresh_token_returns_some_for_password_grant_offline() {
+        let rt = offline_refresh_token(Some("offline"), false, "refresh-jwt");
+        assert_eq!(rt.as_deref(), Some("refresh-jwt"));
+    }
+
+    #[test]
+    fn test_offline_refresh_token_returns_none_for_password_grant_without_offline() {
+        // `None`, `"online"`, the empty string — none of these should emit a
+        // refresh token. Strict equality on `"offline"` matches the spec and
+        // refuses to expand the surface on typos.
+        for at in [
+            None,
+            Some("online"),
+            Some(""),
+            Some("OFFLINE"),
+            Some("offline "),
+        ] {
+            let rt = offline_refresh_token(at, false, "refresh-jwt");
+            assert!(rt.is_none(), "expected None for access_type={:?}", at);
+        }
+    }
+
+    #[test]
+    fn test_offline_refresh_token_suppresses_for_api_token_even_when_offline_requested() {
+        // The security-critical case: API-token authentication must never
+        // be upgraded into a refresh-grant. See the function's doc-comment
+        // for the full rationale (industry precedent + revocation gap).
+        let rt = offline_refresh_token(Some("offline"), true, "refresh-jwt");
+        assert!(rt.is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -5184,6 +5429,320 @@ mod token_lockout_regression_tests {
             counter, 0,
             "a successful password login must not leave failed_login_attempts \
              elevated (got {counter})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OAuth2 refresh-grant + `access_type=offline` end-to-end tests. DB-backed
+// because the handler builds `SharedState` from a live `PgPool`, exercises
+// `auth_service::generate_tokens` + `refresh_tokens`, and several assertions
+// depend on `users.is_active` being flipped between calls.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod token_refresh_grant_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use crate::services::auth_service::AuthService;
+    use axum::body::Body;
+    use axum::http::Request;
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    /// Spin up a fresh user, a `SharedState`, and an `AuthService`. Returns
+    /// `None` when `DATABASE_URL` is unset so the test no-ops gracefully.
+    async fn setup() -> Option<(sqlx::PgPool, Uuid, String, SharedState, AuthService)> {
+        let pool = tdh::try_pool().await?;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let pwd_hash = bcrypt::hash("real-test-password", 4).expect("bcrypt hash");
+        sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
+            .bind(&pwd_hash)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("update password_hash");
+        let storage_dir =
+            std::env::temp_dir().join(format!("oci-refresh-grant-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
+        Some((pool, user_id, username, state, auth_service))
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+
+    fn form_post(uri: &str, body: String) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
+            .body(Body::from(body))
+            .unwrap()
+    }
+
+    async fn read_body(resp: axum::response::Response<Body>) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 65_536)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    }
+
+    /// Read response body as raw bytes — used by tests that assert the
+    /// JSON field is *absent from the wire*, not merely `Value::Null`.
+    /// Mirrors the sync `test_token_response_serialization` assertion.
+    async fn read_body_bytes(resp: axum::response::Response<Body>) -> Vec<u8> {
+        axum::body::to_bytes(resp.into_body(), 65_536)
+            .await
+            .unwrap()
+            .to_vec()
+    }
+
+    /// Real user + `access_type=offline` → response carries `refresh_token`.
+    #[tokio::test]
+    async fn password_grant_offline_includes_refresh_token() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let app = router().with_state(state);
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let body = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["refresh_token"].as_str().is_some(),
+            "expected refresh_token in response, got: {body}"
+        );
+    }
+
+    /// Real user without `access_type` → response has NO `refresh_token`.
+    /// Backwards-compatible with the pre-PR shape. Assert on raw JSON bytes
+    /// so a regression that emits `Value::Null` or `""` for the field would
+    /// still fail (matches the contract `skip_serializing_if` enforces).
+    #[tokio::test]
+    async fn password_grant_default_omits_refresh_token() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let body = format!("grant_type=password&username={username}&password=real-test-password");
+        let app = router().with_state(state);
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            !raw.contains("refresh_token"),
+            "default password-grant response must not mention refresh_token on the wire: {raw}"
+        );
+    }
+
+    /// Security-critical regression. See `offline_refresh_token` doc-comment
+    /// for the full motivation (RFC 6749 §4.4.3, JFrog API-key EOL, etc.).
+    /// Asserts the field is absent from the raw JSON, not just `Value::Null`,
+    /// because the security contract is that nothing called `refresh_token`
+    /// reaches the client at all.
+    #[tokio::test]
+    async fn api_token_offline_does_not_get_refresh_token() {
+        let Some((pool, user_id, username, state, auth_service)) = setup().await else {
+            return;
+        };
+        let (api_token, _) = auth_service
+            .generate_api_token(user_id, "offline-test", vec!["*".to_string()], None)
+            .await
+            .expect("generate API token");
+        let body = format!(
+            "grant_type=password&username={username}&password={api_token}&access_type=offline"
+        );
+        let app = router().with_state(state);
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        assert_ne!(body["token"].as_str(), Some("anonymous"));
+        assert!(
+            !raw.contains("refresh_token"),
+            "API-token + offline must NOT mint a refresh-grant credential that survives revoke_api_token: {raw}"
+        );
+    }
+
+    /// Refresh-grant default (no `access_type`) → new access, no rotation.
+    /// Distribution spec at
+    /// <https://distribution.github.io/distribution/spec/auth/oauth/> says
+    /// "only return the same refresh token and not a new one" — we omit the
+    /// field instead so the client keeps using the original. Both real Docker
+    /// daemons and OCI clients handle either shape; revisit if we ever need
+    /// strict spec conformance. Asserts on raw bytes for the same reason as
+    /// `password_grant_default_omits_refresh_token`.
+    #[tokio::test]
+    async fn refresh_grant_default_returns_access_only() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        assert!(body["access_token"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty() && s != "anonymous"));
+        assert!(
+            !raw.contains("refresh_token"),
+            "default refresh-grant should not rotate the refresh: {raw}"
+        );
+    }
+
+    /// Refresh-grant + `access_type=offline` rotates the refresh token.
+    #[tokio::test]
+    async fn refresh_grant_offline_rotates_refresh_token() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}&access_type=offline");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        let body = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["access_token"].as_str().is_some_and(|s| !s.is_empty()));
+        assert!(
+            body["refresh_token"].as_str().is_some(),
+            "offline refresh-grant should mint a new refresh: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_grant_invalid_token_returns_401() {
+        let Some((pool, user_id, _username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(form_post(
+                "/token",
+                "grant_type=refresh_token&refresh_token=not-a-valid-jwt".to_string(),
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn refresh_grant_missing_token_returns_400() {
+        let Some((pool, user_id, _username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        for body in [
+            "grant_type=refresh_token".to_string(),
+            "grant_type=refresh_token&refresh_token=".to_string(),
+        ] {
+            let resp = app
+                .clone()
+                .oneshot(form_post("/token", body.clone()))
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::BAD_REQUEST,
+                "expected 400 for body={body:?}"
+            );
+        }
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Deactivated user can't refresh — `auth_service::refresh_tokens`
+    /// filters on `is_active = true`.
+    #[tokio::test]
+    async fn refresh_grant_deactivated_user_returns_401() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        sqlx::query("UPDATE users SET is_active = false WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("deactivate user");
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        cleanup(&pool, user_id).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "deactivated user must not mint fresh tokens via refresh-grant"
         );
     }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -762,6 +762,13 @@ struct TokenQuery {
     scope: Option<String>,
     #[allow(dead_code)]
     account: Option<String>,
+    /// GET-flow equivalent of OAuth2 `access_type=offline`, per the
+    /// [Distribution token spec](https://distribution.github.io/distribution/spec/auth/token/).
+    /// `docker login` sends this on the GET path; the POST OAuth2 path uses
+    /// `access_type=offline` in the form body instead. Normalized to the
+    /// same `"offline"` string before reaching `offline_refresh_token`, so
+    /// the API-token suppression rule applies uniformly.
+    offline_token: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -770,8 +777,8 @@ struct TokenResponse {
     access_token: String,
     expires_in: u64,
     /// Only emitted when the client explicitly requested `access_type=offline`
-    /// AND the credential isn't an API token (see security note on
-    /// `build_token_response`). `skip_serializing_if` keeps the response
+    /// AND the credential isn't an API token (see the security rationale on
+    /// `offline_refresh_token`). `skip_serializing_if` keeps the response
     /// byte-compatible with the pre-PR shape for every other code path.
     #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<String>,
@@ -840,6 +847,20 @@ fn offline_refresh_token(
     Some(refresh.to_string())
 }
 
+/// Normalize the GET-flow `?offline_token=true` query parameter into the same
+/// `"offline"` string that the POST OAuth2 path's `access_type=offline` form
+/// field carries. Strict `"true"` match by design: any other value
+/// (`"TRUE"`, `"1"`, `""`, `"false"`, trailing whitespace) fails closed and
+/// the response omits the refresh token. Mirrors the strict-equality check
+/// on `"offline"` in `offline_refresh_token`.
+fn offline_access_type_from_query(offline_token: Option<&str>) -> Option<String> {
+    if offline_token == Some("true") {
+        Some("offline".to_string())
+    } else {
+        None
+    }
+}
+
 /// Exchange a refresh token for a fresh access token (and optionally a new
 /// refresh token if `access_type=offline` is supplied again). Per
 /// [the Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
@@ -901,7 +922,7 @@ async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response
 async fn token(
     State(state): State<SharedState>,
     headers: HeaderMap,
-    Query(_query): Query<TokenQuery>,
+    Query(query): Query<TokenQuery>,
     body: Bytes,
 ) -> Response {
     // Parse the full OAuth2 form body once upfront. `extract_form_credentials`
@@ -923,9 +944,17 @@ async fn token(
     }
 
     // `access_type=offline` is opt-in for a refresh token in the response of
-    // the credential-auth path. Captured here so it's in scope for the
-    // success-response builder later in the function.
-    let access_type = form.as_ref().and_then(|f| f.access_type.clone());
+    // the credential-auth path. Two carriers, both normalized to the same
+    // string before reaching `offline_refresh_token`:
+    //   - POST OAuth2 form body: `access_type=offline` (Docker's OAuth2 flow).
+    //   - GET query string: `offline_token=true` (Distribution token spec, the
+    //     classic `docker login` GET path).
+    // Strict `"true"` match mirrors the strict `"offline"` match elsewhere —
+    // `"TRUE"`, `"1"`, trailing-whitespace variants all fail closed.
+    let access_type = form
+        .as_ref()
+        .and_then(|f| f.access_type.clone())
+        .or_else(|| offline_access_type_from_query(query.offline_token.as_deref()));
 
     // Credential extraction order, per the OCI Distribution Spec + OAuth2:
     //   1. HTTP Basic Auth header (the original code path; works for `docker
@@ -4638,6 +4667,77 @@ mod tests {
         assert!(rt.is_none());
     }
 
+    #[test]
+    fn test_parse_oauth2_form_empty_body_returns_none() {
+        // Empty body short-circuits before content-type lookup.
+        assert!(parse_oauth2_form(&form_headers(), &Bytes::new()).is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_missing_content_type_returns_none() {
+        let body = Bytes::from_static(b"grant_type=password&username=u&password=p");
+        assert!(parse_oauth2_form(&HeaderMap::new(), &body).is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_wrong_content_type_returns_none() {
+        // `application/json` is the most common wrong CT a client might send;
+        // the parser must reject it rather than misinterpret JSON as form-urlencoded.
+        let mut h = HeaderMap::new();
+        h.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        let body = Bytes::from_static(b"{}");
+        assert!(parse_oauth2_form(&h, &body).is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_valid_password_grant() {
+        let body =
+            Bytes::from_static(b"grant_type=password&username=alice&password=secret&service=reg");
+        let form = parse_oauth2_form(&form_headers(), &body).expect("parse");
+        assert_eq!(form.grant_type.as_deref(), Some("password"));
+        assert_eq!(form.username.as_deref(), Some("alice"));
+        assert_eq!(form.password.as_deref(), Some("secret"));
+        assert!(form.refresh_token.is_none());
+        assert!(form.access_type.is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_refresh_grant_with_access_type() {
+        let body = Bytes::from_static(
+            b"grant_type=refresh_token&refresh_token=eyJabc.def.ghi&access_type=offline",
+        );
+        let form = parse_oauth2_form(&form_headers(), &body).expect("parse");
+        assert_eq!(form.grant_type.as_deref(), Some("refresh_token"));
+        assert_eq!(form.refresh_token.as_deref(), Some("eyJabc.def.ghi"));
+        assert_eq!(form.access_type.as_deref(), Some("offline"));
+    }
+
+    #[test]
+    fn test_offline_access_type_from_query_strict_true_only() {
+        // Only the exact lowercase `"true"` activates offline mode. Every
+        // near-miss must fail closed so the response shape stays consistent
+        // with the strict `"offline"` match in `offline_refresh_token`.
+        assert_eq!(
+            offline_access_type_from_query(Some("true")),
+            Some("offline".to_string())
+        );
+        for v in [
+            None,
+            Some(""),
+            Some("false"),
+            Some("TRUE"),
+            Some("True"),
+            Some("1"),
+            Some("true "),
+        ] {
+            assert_eq!(
+                offline_access_type_from_query(v),
+                None,
+                "expected None for offline_token={v:?}"
+            );
+        }
+    }
+
     // -----------------------------------------------------------------------
     // OciRepoInfo
     // -----------------------------------------------------------------------
@@ -5444,7 +5544,7 @@ mod token_lockout_regression_tests {
 mod token_refresh_grant_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
-    use crate::services::auth_service::AuthService;
+    use crate::services::auth_service::{invalidate_user_tokens, AuthService};
     use axum::body::Body;
     use axum::http::Request;
     use std::sync::Arc;
@@ -5487,6 +5587,17 @@ mod token_refresh_grant_tests {
             .uri(uri)
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(Body::from(body))
+            .unwrap()
+    }
+
+    fn get_with_basic(uri: &str, username: &str, password: &str) -> Request<Body> {
+        let basic =
+            base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("Authorization", format!("Basic {basic}"))
+            .body(Body::empty())
             .unwrap()
     }
 
@@ -5704,6 +5815,144 @@ mod token_refresh_grant_tests {
             );
         }
         cleanup(&pool, user_id).await;
+    }
+
+    /// GET /v2/token + Basic auth + `?offline_token=true` — the `docker login`
+    /// flow per the Distribution token spec. POST OAuth2 path uses
+    /// `access_type=offline` in the form body; the GET path is the other
+    /// half of the same feature.
+    #[tokio::test]
+    async fn get_offline_token_true_emits_refresh_for_password_auth() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(get_with_basic(
+                "/token?service=registry&offline_token=true",
+                &username,
+                "real-test-password",
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["refresh_token"].as_str().is_some(),
+            "GET /v2/token?offline_token=true must emit refresh_token: {body}"
+        );
+    }
+
+    /// GET without `offline_token=true` — pre-PR shape preserved on the wire,
+    /// asserted on raw bytes so a regression to `Value::Null` would fail.
+    #[tokio::test]
+    async fn get_without_offline_token_omits_refresh() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(get_with_basic(
+                "/token?service=registry",
+                &username,
+                "real-test-password",
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            !raw.contains("refresh_token"),
+            "GET without offline_token must not emit refresh_token: {raw}"
+        );
+    }
+
+    /// GET + Basic API-token-as-password + `?offline_token=true` must NOT emit
+    /// a refresh token. Same security pivot as the POST OAuth2 version
+    /// (`api_token_offline_does_not_get_refresh_token`); this test extends
+    /// the invariant to the GET path now that `offline_token=true` is honored.
+    #[tokio::test]
+    async fn get_api_token_offline_token_true_does_not_emit_refresh() {
+        let Some((pool, user_id, username, state, auth_service)) = setup().await else {
+            return;
+        };
+        let (api_token, _) = auth_service
+            .generate_api_token(user_id, "get-offline-test", vec!["*".to_string()], None)
+            .await
+            .expect("generate API token");
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(get_with_basic(
+                "/token?service=registry&offline_token=true",
+                &username,
+                &api_token,
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        assert_ne!(body["token"].as_str(), Some("anonymous"));
+        assert!(
+            !raw.contains("refresh_token"),
+            "API-token + GET offline_token=true must NOT emit refresh: {raw}"
+        );
+    }
+
+    /// TOTP enable/disable bumps the credential-invalidation timestamp via
+    /// `invalidate_user_tokens` (see `totp.rs::enable_totp` and
+    /// `totp.rs::disable_totp`). A refresh JWT issued *before* the toggle
+    /// must fail at the refresh-grant short-circuit, not silently get
+    /// swapped for a fresh access token bypassing the new factor.
+    ///
+    /// Sleep before invalidating so `is_token_invalidated`'s second-
+    /// granularity `issued_at < changed_at` comparison is unambiguous; this
+    /// mirrors the pattern in `totp.rs::enable_totp_invalidates_pre_change_user_tokens`.
+    #[tokio::test]
+    async fn refresh_grant_after_totp_toggle_returns_401() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        // Simulates what `totp.rs::enable_totp` (and `disable_totp`) do
+        // after their UPDATE. The end-to-end HTTP path is covered by
+        // `enable_totp_invalidates_pre_change_user_tokens` in totp.rs; this
+        // test owns the refresh-grant half of the invariant.
+        invalidate_user_tokens(user_id);
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        cleanup(&pool, user_id).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "TOTP-toggle must invalidate pre-issue refresh tokens via the refresh-grant path"
+        );
     }
 
     /// Deactivated user can't refresh — `auth_service::refresh_tokens`

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -3463,6 +3463,13 @@ struct TokenQuery {
     scope: Option<String>,
     #[allow(dead_code)]
     account: Option<String>,
+    /// GET-flow equivalent of OAuth2 `access_type=offline`, per the
+    /// [Distribution token spec](https://distribution.github.io/distribution/spec/auth/token/).
+    /// `docker login` sends this on the GET path; the POST OAuth2 path uses
+    /// `access_type=offline` in the form body instead. Normalized to the
+    /// same `"offline"` string before reaching `offline_refresh_token`, so
+    /// the API-token suppression rule applies uniformly.
+    offline_token: Option<String>,
 }
 
 /// Service identifier the OCI handler advertises in `WWW-Authenticate` and
@@ -3476,9 +3483,11 @@ struct TokenResponse {
     token: String,
     access_token: String,
     expires_in: u64,
-    /// Only emitted when the client explicitly requested `access_type=offline`
-    /// AND the credential isn't an API token (see security note on
-    /// `build_token_response`). `skip_serializing_if` keeps the response
+    /// On first issuance (password grant): only emitted when the client
+    /// explicitly requested `access_type=offline` AND the credential isn't
+    /// an API token (see the security rationale on `offline_refresh_token`).
+    /// On the refresh grant: always emitted, carrying the rotated
+    /// replacement token. `skip_serializing_if` keeps the response
     /// byte-compatible with the pre-PR shape for every other code path.
     #[serde(skip_serializing_if = "Option::is_none")]
     refresh_token: Option<String>,
@@ -3506,11 +3515,14 @@ struct TokenResponse {
 /// Issuing a refresh-token JWT under that authentication would create a
 /// **parallel long-lived credential** signed against `JWT_SECRET` and
 /// NOT tied to the `api_tokens` row. `auth_service::refresh_tokens` does
-/// not blacklist consumed refresh tokens, so this parallel credential
-/// would survive `revoke_api_token` for up to
-/// `jwt_refresh_token_expiry_days` (default 7 days). An attacker who
-/// briefly captured the API token would have a 7-day backdoor after the
-/// defender thought they'd closed access.
+/// consume presented refresh tokens (single-use rotation with replay
+/// detection, #1174), but rotation only limits reuse of an *individual*
+/// token — the chain itself is not tied to the `api_tokens` row, so an
+/// unused refresh token (or one kept live by periodic rotation) would
+/// survive `revoke_api_token` for up to `jwt_refresh_token_expiry_days`
+/// (default 7 days). An attacker who briefly captured the API token
+/// would have a 7-day backdoor after the defender thought they'd closed
+/// access.
 ///
 /// Industry precedent for this suppression:
 ///
@@ -3547,8 +3559,23 @@ fn offline_refresh_token(
     Some(refresh.to_string())
 }
 
-/// Exchange a refresh token for a fresh access token (and optionally a new
-/// refresh token if `access_type=offline` is supplied again). Per
+/// Normalize the GET-flow `?offline_token=true` query parameter into the same
+/// `"offline"` string that the POST OAuth2 path's `access_type=offline` form
+/// field carries. Strict `"true"` match by design: any other value
+/// (`"TRUE"`, `"1"`, `""`, `"false"`, trailing whitespace) fails closed and
+/// the response omits the refresh token. Mirrors the strict-equality check
+/// on `"offline"` in `offline_refresh_token`.
+fn offline_access_type_from_query(offline_token: Option<&str>) -> Option<String> {
+    if offline_token == Some("true") {
+        Some("offline".to_string())
+    } else {
+        None
+    }
+}
+
+/// Exchange a refresh token for a fresh access token plus the rotated
+/// replacement refresh token (rotation is mandatory — see the comment on
+/// the response construction below). Per
 /// [the Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
 /// the refresh-grant request body is just `grant_type=refresh_token` +
 /// `refresh_token=…` with no credentials — the refresh token itself
@@ -3583,19 +3610,21 @@ async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response
     // Refresh-grant always originates from a user (not API token) — the
     // refresh token was issued at password-grant time and the API-token
     // suppression already prevented one being issued for an API-token
-    // session. So the second argument to `offline_refresh_token` is `false`.
-    // The `access_type` filter still applies: a refresh-grant without
-    // `access_type=offline` does NOT rotate the refresh token (matches the
-    // spec, which says the same refresh is returned).
+    // session.
+    //
+    // The rotated refresh token is ALWAYS returned here, regardless of
+    // `access_type`. `auth_service::refresh_tokens` performs mandatory
+    // single-use rotation (#1174): the presented refresh token was just
+    // marked consumed and a replacement minted. Gating the replacement on
+    // `access_type=offline` (as the first-issuance path correctly does)
+    // would discard the only live refresh token — the client would retry
+    // with the consumed one, trip replay detection, and get its whole
+    // token family revoked.
     let resp = TokenResponse {
         token: tokens.access_token.clone(),
         access_token: tokens.access_token.clone(),
         expires_in: tokens.expires_in,
-        refresh_token: offline_refresh_token(
-            form.access_type.as_deref(),
-            false,
-            &tokens.refresh_token,
-        ),
+        refresh_token: Some(tokens.refresh_token.clone()),
         issued_at: chrono::Utc::now().to_rfc3339(),
     };
     Response::builder()
@@ -3640,9 +3669,17 @@ async fn token(
     }
 
     // `access_type=offline` is opt-in for a refresh token in the response of
-    // the credential-auth path. Captured here so it's in scope for the
-    // success-response builder later in the function.
-    let access_type = form.as_ref().and_then(|f| f.access_type.clone());
+    // the credential-auth path. Two carriers, both normalized to the same
+    // string before reaching `offline_refresh_token`:
+    //   - POST OAuth2 form body: `access_type=offline` (Docker's OAuth2 flow).
+    //   - GET query string: `offline_token=true` (Distribution token spec, the
+    //     classic `docker login` GET path).
+    // Strict `"true"` match mirrors the strict `"offline"` match elsewhere —
+    // `"TRUE"`, `"1"`, trailing-whitespace variants all fail closed.
+    let access_type = form
+        .as_ref()
+        .and_then(|f| f.access_type.clone())
+        .or_else(|| offline_access_type_from_query(query.offline_token.as_deref()));
 
     // Credential extraction order, per the OCI Distribution Spec + OAuth2:
     //   1. HTTP Basic Auth header (the original code path; works for `docker
@@ -10306,6 +10343,77 @@ mod tests {
         // for the full rationale (industry precedent + revocation gap).
         let rt = offline_refresh_token(Some("offline"), true, "refresh-jwt");
         assert!(rt.is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_empty_body_returns_none() {
+        // Empty body short-circuits before content-type lookup.
+        assert!(parse_oauth2_form(&form_headers(), &Bytes::new()).is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_missing_content_type_returns_none() {
+        let body = Bytes::from_static(b"grant_type=password&username=u&password=p");
+        assert!(parse_oauth2_form(&HeaderMap::new(), &body).is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_wrong_content_type_returns_none() {
+        // `application/json` is the most common wrong CT a client might send;
+        // the parser must reject it rather than misinterpret JSON as form-urlencoded.
+        let mut h = HeaderMap::new();
+        h.insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        let body = Bytes::from_static(b"{}");
+        assert!(parse_oauth2_form(&h, &body).is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_valid_password_grant() {
+        let body =
+            Bytes::from_static(b"grant_type=password&username=alice&password=secret&service=reg");
+        let form = parse_oauth2_form(&form_headers(), &body).expect("parse");
+        assert_eq!(form.grant_type.as_deref(), Some("password"));
+        assert_eq!(form.username.as_deref(), Some("alice"));
+        assert_eq!(form.password.as_deref(), Some("secret"));
+        assert!(form.refresh_token.is_none());
+        assert!(form.access_type.is_none());
+    }
+
+    #[test]
+    fn test_parse_oauth2_form_refresh_grant_with_access_type() {
+        let body = Bytes::from_static(
+            b"grant_type=refresh_token&refresh_token=eyJabc.def.ghi&access_type=offline",
+        );
+        let form = parse_oauth2_form(&form_headers(), &body).expect("parse");
+        assert_eq!(form.grant_type.as_deref(), Some("refresh_token"));
+        assert_eq!(form.refresh_token.as_deref(), Some("eyJabc.def.ghi"));
+        assert_eq!(form.access_type.as_deref(), Some("offline"));
+    }
+
+    #[test]
+    fn test_offline_access_type_from_query_strict_true_only() {
+        // Only the exact lowercase `"true"` activates offline mode. Every
+        // near-miss must fail closed so the response shape stays consistent
+        // with the strict `"offline"` match in `offline_refresh_token`.
+        assert_eq!(
+            offline_access_type_from_query(Some("true")),
+            Some("offline".to_string())
+        );
+        for v in [
+            None,
+            Some(""),
+            Some("false"),
+            Some("TRUE"),
+            Some("True"),
+            Some("1"),
+            Some("true "),
+        ] {
+            assert_eq!(
+                offline_access_type_from_query(v),
+                None,
+                "expected None for offline_token={v:?}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -21355,11 +21463,13 @@ mod oci_write_authz_and_size_tests {
 // depend on `users.is_active` being flipped between calls.
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
 mod token_refresh_grant_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
-    use crate::services::auth_service::AuthService;
+    use crate::services::auth_service::{invalidate_user_tokens, AuthService};
     use axum::body::Body;
     use axum::http::Request;
     use std::sync::Arc;
@@ -21402,6 +21512,17 @@ mod token_refresh_grant_tests {
             .uri(uri)
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(Body::from(body))
+            .unwrap()
+    }
+
+    fn get_with_basic(uri: &str, username: &str, password: &str) -> Request<Body> {
+        let basic =
+            base64::engine::general_purpose::STANDARD.encode(format!("{username}:{password}"));
+        Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("Authorization", format!("Basic {basic}"))
+            .body(Body::empty())
             .unwrap()
     }
 
@@ -21498,16 +21619,14 @@ mod token_refresh_grant_tests {
         );
     }
 
-    /// Refresh-grant default (no `access_type`) → new access, no rotation.
-    /// Distribution spec at
-    /// <https://distribution.github.io/distribution/spec/auth/oauth/> says
-    /// "only return the same refresh token and not a new one" — we omit the
-    /// field instead so the client keeps using the original. Both real Docker
-    /// daemons and OCI clients handle either shape; revisit if we ever need
-    /// strict spec conformance. Asserts on raw bytes for the same reason as
-    /// `password_grant_default_omits_refresh_token`.
+    /// Refresh-grant default (no `access_type`) → new access token AND the
+    /// rotated refresh token. `auth_service::refresh_tokens` consumes the
+    /// presented refresh token unconditionally (#1174), so the response must
+    /// always hand back the replacement — omitting it would strand the
+    /// client with a consumed token and trip replay detection on its next
+    /// refresh (see `refresh_grant_rotated_token_can_refresh_again`).
     #[tokio::test]
-    async fn refresh_grant_default_returns_access_only() {
+    async fn refresh_grant_default_returns_rotated_refresh_token() {
         let Some((pool, user_id, username, state, _)) = setup().await else {
             return;
         };
@@ -21530,17 +21649,84 @@ mod token_refresh_grant_tests {
         let body = format!("grant_type=refresh_token&refresh_token={refresh}");
         let resp = app.oneshot(form_post("/token", body)).await.unwrap();
         let status = resp.status();
-        let bytes = read_body_bytes(resp).await;
+        let body = read_body(resp).await;
         cleanup(&pool, user_id).await;
         assert_eq!(status, StatusCode::OK);
-        let raw = std::str::from_utf8(&bytes).unwrap();
-        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
         assert!(body["access_token"]
             .as_str()
             .is_some_and(|s| !s.is_empty() && s != "anonymous"));
+        let rotated = body["refresh_token"]
+            .as_str()
+            .expect("refresh-grant must return the rotated refresh token");
+        assert_ne!(
+            rotated, refresh,
+            "returned refresh token must be the rotated replacement, not the consumed original"
+        );
+    }
+
+    /// Two-call regression for the rotation/DoS bug: refresh, then refresh
+    /// AGAIN with the token returned by the first refresh. Because
+    /// `auth_service::refresh_tokens` consumes the presented token and mints
+    /// a replacement, the handler must return that replacement — a client
+    /// that only ever sees the original would replay it, trip
+    /// `revoke_all_refresh_token_families`, and lose its whole session. The
+    /// second call succeeding proves the client was handed a live token.
+    #[tokio::test]
+    async fn refresh_grant_rotated_token_can_refresh_again() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        // First refresh (default, no access_type) — must return the rotated
+        // refresh token.
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let first_status = resp.status();
+        let json = read_body(resp).await;
+        let rotated = json["refresh_token"].as_str().map(str::to_string);
+
+        // Second refresh with whatever the first refresh handed back.
+        let Some(rotated) = rotated else {
+            cleanup(&pool, user_id).await;
+            panic!("first refresh-grant response did not include a refresh token: {json}");
+        };
+        let body = format!("grant_type=refresh_token&refresh_token={rotated}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let second_status = resp.status();
+        let json = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+
+        assert_eq!(first_status, StatusCode::OK);
+        assert_eq!(
+            second_status,
+            StatusCode::OK,
+            "second refresh with the rotated token must succeed (no family revocation): {json}"
+        );
+        assert!(json["access_token"]
+            .as_str()
+            .is_some_and(|s| !s.is_empty() && s != "anonymous"));
         assert!(
-            !raw.contains("refresh_token"),
-            "default refresh-grant should not rotate the refresh: {raw}"
+            json["refresh_token"].as_str().is_some(),
+            "second refresh must also return a rotated refresh token: {json}"
         );
     }
 
@@ -21619,6 +21805,144 @@ mod token_refresh_grant_tests {
             );
         }
         cleanup(&pool, user_id).await;
+    }
+
+    /// GET /v2/token + Basic auth + `?offline_token=true` — the `docker login`
+    /// flow per the Distribution token spec. POST OAuth2 path uses
+    /// `access_type=offline` in the form body; the GET path is the other
+    /// half of the same feature.
+    #[tokio::test]
+    async fn get_offline_token_true_emits_refresh_for_password_auth() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(get_with_basic(
+                "/token?service=artifact-keeper&offline_token=true",
+                &username,
+                "real-test-password",
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = read_body(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            body["refresh_token"].as_str().is_some(),
+            "GET /v2/token?offline_token=true must emit refresh_token: {body}"
+        );
+    }
+
+    /// GET without `offline_token=true` — pre-PR shape preserved on the wire,
+    /// asserted on raw bytes so a regression to `Value::Null` would fail.
+    #[tokio::test]
+    async fn get_without_offline_token_omits_refresh() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(get_with_basic(
+                "/token?service=artifact-keeper",
+                &username,
+                "real-test-password",
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            !raw.contains("refresh_token"),
+            "GET without offline_token must not emit refresh_token: {raw}"
+        );
+    }
+
+    /// GET + Basic API-token-as-password + `?offline_token=true` must NOT emit
+    /// a refresh token. Same security pivot as the POST OAuth2 version
+    /// (`api_token_offline_does_not_get_refresh_token`); this test extends
+    /// the invariant to the GET path now that `offline_token=true` is honored.
+    #[tokio::test]
+    async fn get_api_token_offline_token_true_does_not_emit_refresh() {
+        let Some((pool, user_id, username, state, auth_service)) = setup().await else {
+            return;
+        };
+        let (api_token, _) = auth_service
+            .generate_api_token(user_id, "get-offline-test", vec!["*".to_string()], None)
+            .await
+            .expect("generate API token");
+        let app = router().with_state(state);
+        let resp = app
+            .oneshot(get_with_basic(
+                "/token?service=artifact-keeper&offline_token=true",
+                &username,
+                &api_token,
+            ))
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = read_body_bytes(resp).await;
+        cleanup(&pool, user_id).await;
+        assert_eq!(status, StatusCode::OK);
+        let raw = std::str::from_utf8(&bytes).unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap_or_default();
+        assert_ne!(body["token"].as_str(), Some("anonymous"));
+        assert!(
+            !raw.contains("refresh_token"),
+            "API-token + GET offline_token=true must NOT emit refresh: {raw}"
+        );
+    }
+
+    /// TOTP enable/disable bumps the credential-invalidation timestamp via
+    /// `invalidate_user_tokens` (see `totp.rs::enable_totp` and
+    /// `totp.rs::disable_totp`). A refresh JWT issued *before* the toggle
+    /// must fail at the refresh-grant short-circuit, not silently get
+    /// swapped for a fresh access token bypassing the new factor.
+    ///
+    /// Sleep before invalidating so `is_token_invalidated`'s second-
+    /// granularity `issued_at < changed_at` comparison is unambiguous; this
+    /// mirrors the pattern in `totp.rs::enable_totp_invalidates_pre_change_user_tokens`.
+    #[tokio::test]
+    async fn refresh_grant_after_totp_toggle_returns_401() {
+        let Some((pool, user_id, username, state, _)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        // Simulates what `totp.rs::enable_totp` (and `disable_totp`) do
+        // after their UPDATE. The end-to-end HTTP path is covered by
+        // `enable_totp_invalidates_pre_change_user_tokens` in totp.rs; this
+        // test owns the refresh-grant half of the invariant.
+        invalidate_user_tokens(user_id);
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let status = resp.status();
+        cleanup(&pool, user_id).await;
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "TOTP-toggle must invalidate pre-issue refresh tokens via the refresh-grant path"
+        );
     }
 
     /// Deactivated user can't refresh — `auth_service::refresh_tokens`


### PR DESCRIPTION
Closes #2244

## Summary

Implements the two remaining flows from the [Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/) that `/v2/token` did not previously support:

- **`grant_type=refresh_token`** — exchange a long-lived refresh token for a fresh access token without re-submitting credentials.
- **`access_type=offline`** — opt-in for the response to include a `refresh_token` field (default is `online` per the spec, returning only a short-lived access token).

The password-grant + `access_type=offline` flow is what `docker login -u alice -p $PWD` + a long-lived session expects. Without this PR a user has to re-authenticate every ~30 minutes; modern Docker daemons request `access_type=offline` automatically and previously got back a response with no refresh token.

A security-critical rule is layered on top: **API-token-as-password authentication never emits a refresh token, even when `access_type=offline` is requested.** The full justification is documented inline in `offline_refresh_token`'s doc-comment; the short version follows.

## Why API-token authentication suppresses the refresh token

Issuing a refresh-token JWT under an API-token-authenticated request would create a parallel long-lived credential that:

- is signed against `JWT_SECRET` (not stored in any DB row);
- is NOT tied to the `api_tokens` row;
- therefore is **not reachable by `revoke_api_token`**.

`auth_service::refresh_tokens` does not blacklist consumed refresh tokens either, so this parallel credential would survive `revoke_api_token` for the full `jwt_refresh_token_expiry_days` window (default 7). An attacker who briefly captured an API token would still have a week of access after the defender thought they'd closed the gap.

### Industry precedent for the suppression

- **[RFC 6749 §4.4.3](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3)** (`client_credentials` grant): _"A refresh token SHOULD NOT be included."_ API-token-as-password is semantically a machine-credential flow — exactly what `client_credentials` covers. The spec explicitly tells us not to mint refresh tokens for machine clients.
- **[JFrog Artifactory](https://jfrog.com/help/r/jfrog-artifactory-documentation/authenticate-docker-via-oauth)** deprecated their API-key-as-password path entirely. [Their EOL notice](https://docs.jfrog.com/user-management/docs/api-key) (Q4 2024) calls out the exact problem we're closing: _"API Keys don't have lifecycle management features […] single user can have single active API Key — if revoked, revoked for all clients."_ JFrog's replacement (reference tokens / identity tokens) is designed without a parallel refresh-grant precisely so revocation is granular and total.
- **[Sonatype Nexus](https://help.sonatype.com/en/user-tokens.html)** User Tokens are first-class tokens with their own lifecycle; the Docker Bearer Token realm does not mint a separate refresh credential for tool-flows.

### Why silent suppress vs explicit 4xx

Returning `400 DENIED` would break Docker daemons that mechanically send `access_type=offline` regardless of credential type. Major OAuth2 servers (Google, GitHub) graceful-degrade unsupported optional parameters: the response is still `200 OK` with a valid short-lived access token; the client simply re-authenticates with its API token when the access expires (~30 minutes later). The Distribution spec describes `access_type` as the access being _requested_, not a hard contract — the server is free to ignore it.

`offline_refresh_token`'s doc-comment in `oci_v2.rs` carries this rationale verbatim so future readers find it without leaving the source.

## Change

**`backend/src/api/handlers/oci_v2.rs`**:

- `TokenForm` extended with `refresh_token` and `access_type` fields (both `Option<String>`).
- `TokenResponse` gains an optional `refresh_token` field with `#[serde(skip_serializing_if = "Option::is_none")]`. All pre-existing call sites (Bearer-JWT swap, anonymous fallback, password-without-offline) serialize byte-identical to today's shape.
- New `parse_oauth2_form` helper returns the full `TokenForm` (the existing `extract_form_credentials` filters on `grant_type==password` and so cannot see the refresh-grant case).
- New `handle_refresh_grant` async function. Short-circuited at the top of `token()` before credential resolution. Calls `auth_service::refresh_tokens`, which already filters on `is_active = true` and consults `is_token_invalidated`, so deactivated users / TOTP-toggled users / password-changed users all surface as `401` automatically. Returns `400 DENIED` for an empty/missing `refresh_token` field.
- New `offline_refresh_token` helper encodes the response rules in a single place (offline + not-API-token → emit; everything else → suppress). Doc-comment carries the full motivation block.

## Regression test

- [x] N/A — this is a feature, not a bug fix. Test Checklist below covers the new behaviors.

## Test Checklist

13 new tests — 5 sync, 8 DB-backed via `test_db_helpers`.

DB-backed (`token_refresh_grant_tests` module):

- `password_grant_offline_includes_refresh_token` — real user + `access_type=offline` → response carries `refresh_token`.
- `password_grant_default_omits_refresh_token` — no `access_type` → response has no `refresh_token` (backwards-compatible shape).
- **`api_token_offline_does_not_get_refresh_token`** — the security-critical regression: API token in Basic password + `access_type=offline` → 200 OK with access token, but NO refresh token.
- `refresh_grant_default_returns_access_only` — exchange refresh, no `access_type` → fresh access, no rotation (matches Distribution spec: _"only return the same refresh token and not a new one"_; we omit the field so the client keeps using the original).
- `refresh_grant_offline_rotates_refresh_token` — exchange refresh + `access_type=offline` → fresh access AND fresh refresh.
- `refresh_grant_invalid_token_returns_401` — bad refresh token → 401.
- `refresh_grant_missing_token_returns_400` — `grant_type=refresh_token` with empty/missing `refresh_token` field → 400, not silent fallthrough.
- `refresh_grant_deactivated_user_returns_401` — `is_active = false` is enforced by `auth_service::refresh_tokens`.

Sync (`mod tests`):

- `test_token_response_serialization` — `refresh_token: None` is omitted entirely from JSON.
- `test_token_response_serializes_refresh_token_when_some` — present when `Some`.
- `test_offline_refresh_token_returns_some_for_password_grant_offline`
- `test_offline_refresh_token_returns_none_for_password_grant_without_offline` — `None`, `"online"`, empty string, `"OFFLINE"`, `"offline "` all omit; strict equality on `"offline"` matches the spec exactly.
- `test_offline_refresh_token_suppresses_for_api_token_even_when_offline_requested`

- [x] Unit tests added/updated (13)
- [ ] Integration tests added/updated (DB-backed unit tests cover the routing layer end-to-end via `oneshot()`)
- [ ] E2E tests added/updated
- [x] Manually tested locally — full lib suite 9085 / 0 / 2 passes; new code coverage 95% (296/309 new lines instrumented)
- [x] No regressions in existing tests

## API Changes

- [ ] N/A
- [x] **`POST /v2/token` response now includes an optional `refresh_token` field** when the client requests `access_type=offline` and authenticated as a real user (not API-token-as-password). `skip_serializing_if = Option::is_none` keeps the response shape byte-identical for every other code path — no client breakage.
- [x] **`POST /v2/token` now honors `grant_type=refresh_token`** — clients holding a refresh token can exchange it without re-presenting credentials. New error responses: `400 DENIED` for missing `refresh_token` field, `401 UNAUTHORIZED` for invalid / deactivated-user / invalidated-credential refresh.
- [x] **`GET /v2/token?offline_token=true` now emits a `refresh_token` field** when the client authenticates with Basic-auth credentials (not API-token-as-password). This is the GET-flow equivalent of `access_type=offline` per the [Distribution token spec](https://distribution.github.io/distribution/spec/auth/token/) and is what `docker login` sends. Pre-PR the field was silently dropped by serde (`TokenQuery` didn't declare it) and the response was `{token, access_token, expires_in, issued_at}` with no refresh; post-PR these clients now receive a refresh JWT they didn't get before. Strict-equality match on `"true"` only (`"TRUE"`, `"1"`, etc. fail closed). The API-token-as-password suppression rule applies uniformly: a Basic-auth header carrying an API token + `?offline_token=true` returns 200 OK with the access token but no refresh — same security pivot as the POST path.
- [x] No OpenAPI annotations needed — `/v2/token` is part of the OCI distribution spec, not the AK REST API.