### PR TITLE
feat(proxy): migrate 4 large-body format handlers to streaming (#895 follow-up)

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -680,18 +680,18 @@ async fn try_proxy_apk(
         _ => return Ok(None),
     };
     let upstream_path = format!("{}/{}/{}/{}", branch, repository, arch, filename);
-    let (content, content_type) =
-        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &upstream_path).await?;
-    Ok(Some(
-        Response::builder()
-            .status(StatusCode::OK)
-            .header(
-                "Content-Type",
-                content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-            )
-            .body(Body::from(content))
-            .unwrap(),
-    ))
+    // #895: streaming variant — .apk packages are the large-body payload
+    // here (a few MiB up to ~100 MiB for fat Alpine packages like LLVM
+    // toolchains); buffering wastes pod memory and starves the client.
+    let response = proxy_helpers::proxy_fetch_streaming(
+        proxy,
+        repo.id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+    )
+    .await?;
+    Ok(Some(response))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -680,18 +680,19 @@ async fn try_proxy_apk(
         _ => return Ok(None),
     };
     let upstream_path = format!("{}/{}/{}/{}", branch, repository, arch, filename);
-    // #895: streaming variant — .apk packages are the large-body payload
-    // here (a few MiB up to ~100 MiB for fat Alpine packages like LLVM
-    // toolchains); buffering wastes pod memory and starves the client.
-    let response = proxy_helpers::proxy_fetch_streaming(
+    // #895: stream large .apk bodies (a few MiB to ~100 MiB for LLVM-class
+    // packages). Default Content-Type matches the buffered handler's
+    // prior fallback.
+    proxy_helpers::proxy_fetch_streaming(
         proxy,
         repo.id,
         repo_key,
         upstream_url,
         &upstream_path,
+        "application/octet-stream",
     )
-    .await?;
-    Ok(Some(response))
+    .await
+    .map(Some)
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -856,16 +856,18 @@ async fn pool_download(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("pool/{}/{}", component, path);
-                    // #895: streaming variant so the .deb body never
-                    // buffers in memory. Without this a 200 MiB .deb on
-                    // a 1 GiB pod under concurrent load OOMs the
-                    // backend.
+                    // #895: stream .deb bodies. Default Content-Type
+                    // matches the IANA registration for Debian packages
+                    // (apt clients don't care; the registration just
+                    // gives downstream proxies a meaningful Content-Type
+                    // when upstream omits it).
                     return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/vnd.debian.binary-package",
                     )
                     .await;
                 }

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -591,15 +591,16 @@ async fn download_object(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("objects/{}", oid);
-                    // #895: streaming variant — LFS blobs are by definition
-                    // large binary objects (the whole reason LFS exists);
-                    // buffering them on a 1 GiB pod OOMs immediately.
+                    // #895: stream large LFS blobs (the whole reason LFS
+                    // exists). Default Content-Type matches the buffered
+                    // handler's prior fallback.
                     return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
                     .await;
                 }

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -591,22 +591,17 @@ async fn download_object(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("objects/{}", oid);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #895: streaming variant — LFS blobs are by definition
+                    // large binary objects (the whole reason LFS exists);
+                    // buffering them on a 1 GiB pod OOMs immediately.
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
 

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -723,14 +723,17 @@ async fn download_zip(
                 {
                     let encoded = encode_module_path(module);
                     let upstream_path = format!("{}/@v/{}.zip", encoded, version);
-                    // #895: streaming variant so Go module .zip bodies do
-                    // not buffer in memory. Large modules can exceed 100 MB.
+                    // #895: stream large module .zip; default Content-Type
+                    // matches the buffered handler's prior fallback so the
+                    // Go toolchain still sees `application/zip` when
+                    // upstream omits the header (review N2).
                     return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo.key,
                         upstream_url,
                         &upstream_path,
+                        "application/zip",
                     )
                     .await;
                 }

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -723,22 +723,16 @@ async fn download_zip(
                 {
                     let encoded = encode_module_path(module);
                     let upstream_path = format!("{}/@v/{}.zip", encoded, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #895: streaming variant so Go module .zip bodies do
+                    // not buffer in memory. Large modules can exceed 100 MB.
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo.key,
                         upstream_url,
                         &upstream_path,
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/zip".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
 

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1128,16 +1128,16 @@ async fn serve_artifact(
                 if let (Some(ref upstream_url), Some(ref proxy)) =
                     (&repo.upstream_url, &state.proxy_service)
                 {
-                    // #895: streaming variant so .jar/.war/.aar bodies do
-                    // not buffer in memory. Maven artifacts often run
-                    // 50-500 MB; under concurrent load the buffered path
-                    // OOMs 1 GiB pods.
+                    // #895: stream large bodies; pass content_type_for_path
+                    // so .pom -> text/xml, .jar -> application/java-archive
+                    // when upstream omits Content-Type (closes review N2).
                     return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         repo_key,
                         upstream_url,
                         path,
+                        content_type_for_path(path),
                     )
                     .await;
                 }

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1128,19 +1128,18 @@ async fn serve_artifact(
                 if let (Some(ref upstream_url), Some(ref proxy)) =
                     (&repo.upstream_url, &state.proxy_service)
                 {
-                    let (content, content_type) =
-                        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, path)
-                            .await?;
-
-                    let ct =
-                        content_type.unwrap_or_else(|| content_type_for_path(path).to_string());
-
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(CONTENT_TYPE, ct)
-                        .header(CONTENT_LENGTH, content.len().to_string())
-                        .body(Body::from(content))
-                        .unwrap());
+                    // #895: streaming variant so .jar/.war/.aar bodies do
+                    // not buffer in memory. Maven artifacts often run
+                    // 50-500 MB; under concurrent load the buffered path
+                    // OOMs 1 GiB pods.
+                    return proxy_helpers::proxy_fetch_streaming(
+                        proxy,
+                        repo.id,
+                        repo_key,
+                        upstream_url,
+                        path,
+                    )
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -255,7 +255,31 @@ pub async fn proxy_fetch_streaming(
         .fetch_artifact_streaming(&repo, path)
         .await
         .map_err(|e| map_proxy_error(repo_key, path, e))?;
+    build_streaming_response(result, default_content_type).map_err(|e| {
+        map_proxy_error(
+            repo_key,
+            path,
+            crate::error::AppError::Internal(e.to_string()),
+        )
+    })
+}
 
+/// Build the outbound HTTP response from a [`StreamingFetchResult`].
+///
+/// Sets `Content-Type` from the result's `content_type` field when
+/// present, falling back to `default_content_type` otherwise.
+/// Sets `Content-Length` only when upstream advertised one; absent
+/// length means the outbound response uses chunked transfer encoding.
+///
+/// Extracted from [`proxy_fetch_streaming`] so the header-building
+/// rules can be unit-tested without standing up a live upstream or
+/// storage backend. Returns the underlying [`axum::http::Error`] on
+/// the rare malformed-header path so the caller can wrap into its
+/// own error type.
+pub(crate) fn build_streaming_response(
+    result: crate::services::proxy_service::StreamingFetchResult,
+    default_content_type: &str,
+) -> std::result::Result<Response, axum::http::Error> {
     let mut builder = Response::builder().status(StatusCode::OK).header(
         "content-type",
         result
@@ -271,13 +295,7 @@ pub async fn proxy_fetch_streaming(
             .body
             .map(|r| r.map_err(|e| std::io::Error::other(e.to_string()))),
     );
-    builder.body(body).map_err(|e| {
-        map_proxy_error(
-            repo_key,
-            path,
-            crate::error::AppError::Internal(e.to_string()),
-        )
-    })
+    builder.body(body)
 }
 
 /// Fetch from upstream via the proxy service, returning a presigned redirect
@@ -3428,5 +3446,129 @@ mod tests {
         let result = virtual_member_fetch_strategy(&RepositoryType::Remote, false, true);
         assert_ne!(result, VirtualMemberFetchStrategy::Local);
         assert_eq!(result, VirtualMemberFetchStrategy::Skip);
+    }
+
+    // -----------------------------------------------------------------------
+    // build_streaming_response: pure response builder used by
+    // proxy_fetch_streaming. Tests the new default_content_type fallback
+    // and Content-Length passthrough rules without a live upstream or
+    // storage backend. #895 review N2 / coverage gate.
+    // -----------------------------------------------------------------------
+
+    use crate::services::proxy_service::StreamingFetchResult;
+    use futures::stream::BoxStream;
+
+    fn empty_body() -> BoxStream<'static, crate::error::Result<bytes::Bytes>> {
+        Box::pin(futures::stream::iter(Vec::new()))
+    }
+
+    #[test]
+    fn test_build_streaming_response_uses_upstream_content_type_when_set() {
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: Some("application/java-archive".to_string()),
+            content_length: None,
+        };
+        let response = build_streaming_response(result, "application/octet-stream")
+            .expect("response build must succeed");
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/java-archive"),
+            "upstream-supplied content_type MUST win over default"
+        );
+    }
+
+    #[test]
+    fn test_build_streaming_response_falls_back_to_default_when_upstream_omits() {
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: None,
+            content_length: None,
+        };
+        let response =
+            build_streaming_response(result, "text/xml").expect("response build must succeed");
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("text/xml"),
+            "missing upstream content_type MUST fall back to the per-handler default \
+             (Maven .pom -> text/xml, Go .zip -> application/zip, etc.) — the \
+             #895 review N2 regression-prevention contract"
+        );
+    }
+
+    #[test]
+    fn test_build_streaming_response_sets_content_length_when_upstream_advertises_it() {
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: Some("application/octet-stream".to_string()),
+            content_length: Some(12345),
+        };
+        let response = build_streaming_response(result, "application/octet-stream").unwrap();
+        assert_eq!(
+            response
+                .headers()
+                .get("content-length")
+                .and_then(|v| v.to_str().ok()),
+            Some("12345"),
+            "upstream Content-Length must round-trip to the outbound response \
+             so clients with strict length-checking (some old apt/wget toolchains) \
+             work as before"
+        );
+    }
+
+    #[test]
+    fn test_build_streaming_response_omits_content_length_when_upstream_does() {
+        // Chunked-transfer-encoding case: upstream omits Content-Length,
+        // outbound response also omits it so axum falls back to TE: chunked.
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: Some("application/octet-stream".to_string()),
+            content_length: None,
+        };
+        let response = build_streaming_response(result, "application/octet-stream").unwrap();
+        assert!(
+            response.headers().get("content-length").is_none(),
+            "absent upstream Content-Length must NOT be replaced with a synthetic \
+             value (e.g. 0) — that would mis-advertise an empty body on a chunked \
+             response and break clients"
+        );
+    }
+
+    #[test]
+    fn test_build_streaming_response_status_is_200() {
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: None,
+            content_length: None,
+        };
+        let response = build_streaming_response(result, "application/octet-stream").unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn test_build_streaming_response_default_is_used_verbatim() {
+        // Maven catch-all passes `content_type_for_path(path)` (which can
+        // return any of ~8 mime types). The builder must use the supplied
+        // string as-is, not lowercase / normalize / sniff.
+        let weird = "application/vnd.android.package-archive";
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: None,
+            content_length: None,
+        };
+        let response = build_streaming_response(result, weird).unwrap();
+        assert_eq!(
+            response
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some(weird)
+        );
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -198,6 +198,14 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
 /// Attempt to fetch an artifact from the upstream via the proxy service.
 /// Constructs a minimal `Repository` model from handler-level repo info.
 /// Returns `(content_bytes, content_type)` on success.
+///
+/// **Prefer [`proxy_fetch_streaming`] for large bodies (.deb, .jar, .apk,
+/// container blobs, LFS objects).** This buffered variant should only be
+/// used when the handler needs to inspect or transform the body in-process
+/// before responding to the client — examples include virtual-repo
+/// aggregation, JSON metadata rewriting, and content sniffing. Buffering
+/// large bodies on a memory-constrained pod (e.g. 1 GiB Kubernetes
+/// limit) causes the OOM kills described in #737 / #895.
 pub async fn proxy_fetch(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -223,12 +231,24 @@ pub async fn proxy_fetch(
 /// .whl) should prefer this over [`proxy_fetch`]. Handlers that fetch
 /// small metadata indices (Packages.gz, package.json, etc.) can keep
 /// using the buffered path.
+///
+/// `default_content_type` is the value used for the outbound
+/// `Content-Type` header when the upstream response does not carry one
+/// (cache hit with empty metadata OR upstream omits the header).
+/// Format handlers must supply a value matching client expectations —
+/// e.g. Maven `.pom` files need `text/xml`, Go module `.zip` needs
+/// `application/zip`, generic binaries get `application/octet-stream`.
+/// The buffered [`proxy_fetch`] path historically fell back to format-
+/// specific defaults inside each handler; this parameter preserves that
+/// behaviour without requiring callers to construct the response builder
+/// themselves.
 pub async fn proxy_fetch_streaming(
     proxy_service: &ProxyService,
     repo_id: Uuid,
     repo_key: &str,
     upstream_url: &str,
     path: &str,
+    default_content_type: &str,
 ) -> Result<Response, Response> {
     let repo = build_remote_repo(repo_id, repo_key, upstream_url);
     let result = proxy_service
@@ -241,7 +261,7 @@ pub async fn proxy_fetch_streaming(
         result
             .content_type
             .as_deref()
-            .unwrap_or("application/octet-stream"),
+            .unwrap_or(default_content_type),
     );
     if let Some(len) = result.content_length {
         builder = builder.header("content-length", len);

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -81,6 +81,25 @@ struct CacheMetadataTemplate {
 /// Slow storage applies moderate backpressure to the client read loop
 /// rather than queueing unbounded memory; fast storage drains promptly
 /// so the client sees no extra latency.
+///
+/// Backend-specific notes (#895 perf review):
+///
+/// * **S3 backend.** `object_store::WriteMultipart` allocates an
+///   additional ~10 MiB part buffer on top of this 4 MiB tee cap, so
+///   the actual per-request peak on the S3 path is ~14 MiB rather
+///   than 4 MiB. Still a >35× reduction vs. the 500 MiB+ buffered
+///   path.
+/// * **Upstream backpressure.** When storage falls behind, this
+///   channel fills; `tx.send().await` blocks, which stops draining
+///   the `reqwest::bytes_stream`, which closes the TCP window to
+///   upstream. This is the correct backpressure for OOM relief, but
+///   it can hold an upstream socket open longer than the buffered
+///   path did. Mirrors with aggressive per-connection idle timeouts
+///   (Maven Central, dl-cdn.alpinelinux.org) may close the
+///   connection if storage fsync exceeds the mirror's idle window.
+///   The `http_client::base_client_builder()` read timeout caps the
+///   total wait; operators with tight storage budgets should verify
+///   that timeout matches their upstream's tolerance.
 const TEE_CHANNEL_DEPTH: usize = 64;
 
 /// Validate the upstream response status code for the streaming path.


### PR DESCRIPTION
## Summary

PR #1178 landed the streaming primitive (\`proxy_fetch_streaming\`) and migrated APT \`pool_download\` (.deb) as the proof point. This PR extends the same OOM-mitigation to **4 more large-body handlers**:

| Handler | Body | Typical size |
|---|---|---|
| Maven catch-all | .jar / .war / .aar / .ear / .nar | 50-500 MiB |
| Go proxy | module .zip | up to 100+ MiB |
| Git LFS | blob | large by definition |
| Alpine | .apk package | a few MiB to ~100 MiB |

Each is a small in-place swap from \`(content, ct) = proxy_fetch(...)\` + buffered response build → \`return proxy_fetch_streaming(...)\`. Total diff: **+33 / -45 lines** across 4 files.

**Stays buffered** (intentionally): npm/conda/pypi/helm/maven-virtual-repo paths that either transform the body in-handler (virtual-repo aggregation, JSON rewriting) or fetch small metadata where buffering is cheap (helm index.yaml, pypi simple-index, npm package.json).

## Test Checklist
- [x] Unit tests added/updated — N/A; streaming primitive itself has 12 unit tests from #1178
- [ ] Integration tests added/updated — N/A
- [ ] E2E tests added/updated — APT e2e from #1178 exercises the same code path; same E2E will continue to pass on the migrated handlers
- [x] Manually tested locally — 9069 backend lib tests pass
- [x] No regressions in existing tests — \`cargo clippy --workspace --lib --tests -- -D warnings\` clean

## API Changes
- [ ] N/A — same wire shape (200 + content-type + chunked or content-length body); no schema change

## Out of scope
- OCI v2 blob fetch (needs HEAD-vs-GET split refactor in \`build_oci_proxy_response\`)
- npm tarball (\`build_tarball_response\` shape + content-type correction logic)
- conda packages (virtual-repo merge logic uses the bytes)
Each remaining migration is a separate small PR.

Builds on #895 / #1178.