### PR TITLE
fix: update and improve docker-compose files

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,4 +16,14 @@ ignore = [
     # wasmtime advisories from the 2026-04-09 batch (RUSTSEC-2026-0086,
     # 0088, 0089, 0094, 0095, 0096) are resolved by the wasmtime 24 -> 36.0.7
     # upgrade tracked in issue #691. No wasmtime ignores needed.
+
+    # rand unsoundness: aliased mutable references when both `log` and
+    # `thread_rng` features are enabled and a custom logger reentrantly calls
+    # rand::rng() during reseed. Reaches us only via transitive deps
+    # (totp-rs, quinn-proto, object_store) that pin pre-fix rand versions
+    # (0.8.5, 0.9.2, 0.10.0; fixed in 0.8.6 / 0.9.3 / 0.10.1). We do not
+    # enable the `log` feature on `rand`, and our loggers do not call
+    # rand::rng(), so the unsound code path is unreachable from artifact-keeper.
+    # Re-evaluate once upstream deps bump their rand pins.
+    "RUSTSEC-2026-0097",
 ]

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -90,7 +90,7 @@ services:
     restart: unless-stopped
 
   dependency-track-apiserver:
-    image: dependencytrack/apiserver:4.11.4
+    image: dependencytrack/apiserver:4.14.2
     container_name: artifact-keeper-dev-dtrack-api
     depends_on:
       postgres:
@@ -115,16 +115,10 @@ services:
       - dev_dtrack_data:/data
     ports:
       - "8092:8080"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/api/version"]
-      interval: 30s
-      timeout: 10s
-      start_period: 60s
-      retries: 5
     restart: unless-stopped
 
   jaeger:
-    image: jaegertracing/all-in-one:1.62
+    image: jaegertracing/all-in-one:1.62.0
     container_name: artifact-keeper-dev-jaeger
     environment:
       COLLECTOR_OTLP_ENABLED: "true"
@@ -147,6 +141,8 @@ services:
       - dev_shared_config:/shared
     entrypoint: ["/bin/sh", "/init-dtrack.sh"]
     restart: "no"
+    healthcheck:
+      disable: true
 
   # Backend with hot-reload using cargo-watch
   backend:
@@ -227,17 +223,24 @@ services:
     ports:
       - "8080:8080"
       - "9090:9090"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:8080/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+      start_period: 120s
     restart: unless-stopped
 
   # Web frontend with hot-reload using next dev
   # Set WEB_PATH env var if artifact-keeper-web is not at ../artifact-keeper-web
   web:
     build:
-      context: ${WEB_PATH:-/Users/khan/artifact-keeper-web}
+      context: ${WEB_PATH:-../artifact-keeper-web}
       dockerfile: Dockerfile.dev
     container_name: artifact-keeper-dev-web
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     environment:
       NEXT_PUBLIC_API_URL: http://localhost:8080
       BACKEND_URL: http://backend:8080
@@ -245,13 +248,13 @@ services:
       WATCHPACK_POLLING: "true"
     volumes:
       # Mount source code for hot-reload
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/src:/app/src:cached
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/public:/app/public:cached
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/next.config.ts:/app/next.config.ts:cached
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/tailwind.config.ts:/app/tailwind.config.ts:cached
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/tsconfig.json:/app/tsconfig.json:cached
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/components.json:/app/components.json:cached
-      - ${WEB_PATH:-/Users/khan/artifact-keeper-web}/postcss.config.mjs:/app/postcss.config.mjs:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/src:/app/src:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/public:/app/public:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/next.config.ts:/app/next.config.ts:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/tailwind.config.ts:/app/tailwind.config.ts:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/tsconfig.json:/app/tsconfig.json:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/components.json:/app/components.json:cached
+      - ${WEB_PATH:-../artifact-keeper-web}/postcss.config.mjs:/app/postcss.config.mjs:cached
       # Exclude node_modules (use container's own)
       - dev_web_node_modules:/app/node_modules
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   # In production, replace this with certs issued by your internal CA or use a
   # managed database service that handles TLS for you.
   pg-certs:
-    image: alpine:3.20
+    image: alpine:3.23
     container_name: artifact-keeper-pg-certs
     entrypoint: ["/bin/sh", "-c"]
     command:
@@ -118,6 +118,8 @@ services:
       - shared_config:/shared
     entrypoint: ["/bin/sh", "/init-dtrack.sh"]
     restart: "no"
+    healthcheck:
+      disable: true
 
   # ---------------------------------------------------------------------------
   # Backend API server
@@ -293,7 +295,7 @@ services:
   # the backend and remove these services if you do not need SBOM analysis.
   # https://dependencytrack.org/
   dependency-track-apiserver:
-    image: dependencytrack/apiserver:4.11.4
+    image: dependencytrack/apiserver:4.14.2
     container_name: artifact-keeper-dtrack-api
     depends_on:
       postgres:
@@ -322,12 +324,6 @@ services:
       - dtrack_data:/data
     ports:
       - "8092:8080"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/api/version"]
-      interval: 30s
-      timeout: 10s
-      start_period: 60s
-      retries: 5
     restart: unless-stopped
 
   # Dependency-Track native frontend (optional, for debugging/admin).
@@ -335,7 +331,7 @@ services:
   # useful for direct Dependency-Track access. Gated behind a profile:
   #   docker compose --profile dtrack-ui up
   dependency-track-frontend:
-    image: dependencytrack/frontend:4.11.4
+    image: dependencytrack/frontend:4.14.2
     container_name: artifact-keeper-dtrack-frontend
     profiles:
       - dtrack-ui  # Only starts with: docker compose --profile dtrack-ui up

--- a/docker/Dockerfile.backend.dev
+++ b/docker/Dockerfile.backend.dev
@@ -23,7 +23,10 @@ WORKDIR /app
 # Source and target will be mounted at runtime
 EXPOSE 8080 9090
 
-RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser
+RUN groupadd -r appuser && useradd -r -g appuser -d /app appuser \
+    && chown -R appuser:appuser /usr/local/cargo \
+    && mkdir -p /target /sccache \
+    && chown appuser:appuser /target /sccache /app
 USER appuser
 
 CMD ["cargo", "watch", "-x", "run --bin artifact-keeper"]

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -167,8 +167,9 @@ fi
 # Create a fresh API key. DT 4.x returns the unmasked secret in the
 # response body of this single call. There is no other way to retrieve it.
 echo "[dtrack-init] Generating new $DT_TEAM_NAME API key..."
-KEY_RESP=$(curl -sf -X POST "$DT_URL/api/v1/team/$TEAM_UUID/key" \
-  -H "Authorization: Bearer $TOKEN" || true)
+KEY_RESP=$(curl -sf -X PUT "$DT_URL/api/v1/team/$TEAM_UUID/key" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" || true)
 
 if [ -z "$KEY_RESP" ]; then
   echo "[dtrack-init] ERROR: POST /api/v1/team/$TEAM_UUID/key returned empty body" >&2
@@ -237,17 +238,16 @@ TMP_PUBLIC_ID_MARKER="$PUBLIC_ID_MARKER.tmp"
 chmod 600 "$TMP_PUBLIC_ID_MARKER"
 mv "$TMP_PUBLIC_ID_MARKER" "$PUBLIC_ID_MARKER"
 
-# Enable NVD API 2.0 mirroring (NIST retired legacy feeds; DTrack 4.10.0+ supports API 2.0)
-echo "[dtrack-init] Enabling NVD API 2.0 vulnerability source..."
+echo "[dtrack-init] Enabling NVD REST API 2.0 mirroring..."
 NVD_RESULT=$(curl -sf -o /dev/null -w "%{http_code}" \
   -X POST "$DT_URL/api/v1/configProperty" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"groupName":"vuln-source","propertyName":"nvd.feeds.url","propertyValue":"https://services.nvd.nist.gov/rest/json/cves/2.0"}')
+  -d '{"groupName":"vuln-source","propertyName":"nvd.api.enabled","propertyValue":"true"}')
 if [ "$NVD_RESULT" = "200" ]; then
-  echo "[dtrack-init] NVD API 2.0 source configured"
+  echo "[dtrack-init] NVD REST API 2.0 mirroring enabled"
 else
-  echo "[dtrack-init] WARNING: NVD config returned HTTP $NVD_RESULT (may already be set or unsupported)"
+  echo "[dtrack-init] WARNING: NVD API config returned HTTP $NVD_RESULT (may already be set)"
 fi
 
 # Drop a marker so operators can tell at a glance that bootstrap completed.

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -168,7 +168,8 @@ fi
 # response body of this single call. There is no other way to retrieve it.
 echo "[dtrack-init] Generating new $DT_TEAM_NAME API key..."
 KEY_RESP=$(curl -sf -X PUT "$DT_URL/api/v1/team/$TEAM_UUID/key" \
-  -H "Authorization: Bearer $TOKEN" || true)
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" || true)
 
 if [ -z "$KEY_RESP" ]; then
   echo "[dtrack-init] ERROR: PUT /api/v1/team/$TEAM_UUID/key returned empty body" >&2
@@ -237,17 +238,16 @@ TMP_PUBLIC_ID_MARKER="$PUBLIC_ID_MARKER.tmp"
 chmod 600 "$TMP_PUBLIC_ID_MARKER"
 mv "$TMP_PUBLIC_ID_MARKER" "$PUBLIC_ID_MARKER"
 
-# Enable NVD API 2.0 mirroring (NIST retired legacy feeds; DTrack 4.10.0+ supports API 2.0)
-echo "[dtrack-init] Enabling NVD API 2.0 vulnerability source..."
+echo "[dtrack-init] Enabling NVD REST API 2.0 mirroring..."
 NVD_RESULT=$(curl -sf -o /dev/null -w "%{http_code}" \
   -X POST "$DT_URL/api/v1/configProperty" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -d '{"groupName":"vuln-source","propertyName":"nvd.feeds.url","propertyValue":"https://services.nvd.nist.gov/rest/json/cves/2.0"}')
+  -d '{"groupName":"vuln-source","propertyName":"nvd.api.enabled","propertyValue":"true"}')
 if [ "$NVD_RESULT" = "200" ]; then
-  echo "[dtrack-init] NVD API 2.0 source configured"
+  echo "[dtrack-init] NVD REST API 2.0 mirroring enabled"
 else
-  echo "[dtrack-init] WARNING: NVD config returned HTTP $NVD_RESULT (may already be set or unsupported)"
+  echo "[dtrack-init] WARNING: NVD API config returned HTTP $NVD_RESULT (may already be set)"
 fi
 
 # Drop a marker so operators can tell at a glance that bootstrap completed.


### PR DESCRIPTION
Closes #1308

## Summary
Hi, I have updated the docker-compose manifests and the dependency track init script:
- Disable the builtin healthcheck from the dtrack-init container. It uses  the artifact-keeper-backend image which has a builtin healthcheck that will fail for the dtrack-init container. Since a healthcheck is unnecessary for an init container anyways, I removed it
- Update the alpine image creating the postgres certificates to 3.23
- Update Dependency Track apiserver to 4.12.2
	- The endpoint to generate a team API key now uses the PUT method and expects the content type `application/json`
	- The legacy file-based feed mirrors are [retired since late 2023](https://nvd.nist.gov/General/News/changes-to-feeds-and-apis) and some days ago the files were removed from their servers:
        ```
        $ curl -I https://services.nvd.nist.gov/rest/json/cves/2.0/json/cve/2.0/nvdcve-2.0-2019.meta
        HTTP/2 404 
        date: Thu, 14 May 2026 14:42:52 GMT
        [...]
        ```
		The alternative is to use  NVD REST API 2.0 mirroring by setting `nvd.api.enabled = true`. (See [here](https://docs.dependencytrack.org/datasources/nvd/))
	- I removed the healthcheck from the compose file since the `dependencytrack/apiserver` image has a [built-in healthcheck now](https://github.com/DependencyTrack/dependency-track/blob/dc1241c43f990f7df16442511cac3b9adeeefa3e/src/main/docker/Dockerfile#L101-L105)

I also tried updating the compose file for local development (`docker-compose.local-dev.yml`). It seems to me that this hasn't been used in a while but I still gave it a shot:
- Update Dependency Track as described above
- Removed the healthcheck of the dtrack-init container as described above
- Added a healthcheck for the backend so that the web frontend container only starts up once the backend is compiled successfully
- Removed the hardcoded username in `WEB_PATH`
- Changed the tag for the jaeger all-in-one container to `1.62.0` since `1.62` seemingly does not exist (anymore?)
- Fixed a permission issue in `Dockerfile.backend.dev`

Unfortunately I could not get the local dev compose to run because the backend did not compile (checked out `main` at 3170271c65e94e6d464fd9f8c6e774ff2c554391)

## Regression test (required for `fix/*` PRs)
<!--
Hardening Core (https://github.com/orgs/artifact-keeper/projects/2) requires
every bug-fix PR to land with a regression test that fails on `main` and
passes on this PR. Choose one that fits the bug:
  - unit test (closest to the buggy logic)
  - integration test (requires DB/storage/etc.)
  - end-to-end test in artifact-keeper-test (exercises the user flow)

For non-fix PRs (feat/, chore/, docs/, ci/, refactor/) check N/A.
Reviewers should not approve fix/* PRs without a checked box.
-->
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [ ] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes