### PR TITLE
fix (debian/apt) Use real OpenPGP signatures for Debian repository metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+ "zeroize",
+]
+
+[[package]]
 name = "artifact-keeper-backend"
 version = "1.1.2"
 dependencies = [
@@ -199,9 +212,11 @@ dependencies = [
  "opentelemetry-http",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "pgp",
  "prost",
  "prost-types",
  "quick-xml",
+ "rand 0.8.5",
  "rand 0.9.2",
  "regex",
  "reqwest 0.13.2",
@@ -748,6 +763,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
 name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,6 +824,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "buffer-redux"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "431a9cc8d7efa49bc326729264537f5e60affce816c66edf434350778c9f4f54"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -848,6 +888,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
 dependencies = [
  "libbz2-rs-sys",
+]
+
+[[package]]
+name = "camellia"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
+dependencies = [
+ "byteorder",
+ "cipher",
 ]
 
 [[package]]
@@ -929,6 +979,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast5"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b07d673db1ccf000e90f54b819db9e75a8348d6eb056e9b8ab53231b7a9911"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cbc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +1013,15 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "cfg-if"
@@ -1041,6 +1109,17 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmac"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
+dependencies = [
+ "cipher",
+ "dbl",
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "cmake"
@@ -1349,6 +1428,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc24"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd121741cf3eb82c08dd3023eb55bf2665e5f60ec20f89760cf836ae4562e6a0"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,7 +1556,7 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1555,6 +1640,15 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dbl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2735a791158376708f9347fe8faba9667589d82427ef3aed6794a8981de3d9"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1677,6 +1771,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1896,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "eax"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9954fabd903b82b9d7a68f65f97dc96dd9ad368e40ccc907a7c19d53e6bfac28"
+dependencies = [
+ "aead",
+ "cipher",
+ "cmac",
+ "ctr",
+ "subtle",
+]
+
+[[package]]
 name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,6 +1945,17 @@ dependencies = [
  "sha2 0.10.9",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ed448-goldilocks"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87b5fa9e9e3dd5fe1369f380acd3dcdfa766dbd0a1cd5b048fb40e38a6a78e79"
+dependencies = [
+ "fiat-crypto 0.1.20",
+ "hex",
+ "subtle",
 ]
 
 [[package]]
@@ -1913,7 +2052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2030,6 +2169,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "fiat-crypto"
@@ -2673,7 +2818,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2791,6 +2936,15 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idea"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075557004419d7f2031b8bb7f44bb43e55a83ca7b63076a8fb8fe75753836477"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "ident_case"
@@ -2913,6 +3067,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "iter-read"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071ed4cc1afd86650602c7b11aa2e1ce30762a1c27193201cb5cee9c6ebb1294"
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +3173,20 @@ dependencies = [
  "serde_json",
  "signature 2.2.0",
  "simple_asn1",
+]
+
+[[package]]
+name = "k256"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+dependencies = [
+ "cfg-if",
+ "ecdsa",
+ "elliptic-curve",
+ "once_cell",
+ "sha2 0.10.9",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3661,6 +3835,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3904,18 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "ocb3"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c196e0276c471c843dd5777e7543a36a298a4be942a2a688d8111cd43390dedb"
+dependencies = [
+ "aead",
+ "cipher",
+ "ctr",
+ "subtle",
 ]
 
 [[package]]
@@ -3958,6 +4166,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,6 +4225,73 @@ checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
  "indexmap 2.13.0",
+]
+
+[[package]]
+name = "pgp"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1877a97fd422433220ad272eb008ec55691944b1200e9eb204e3cb2cb69d34e9"
+dependencies = [
+ "aes",
+ "aes-gcm",
+ "aes-kw",
+ "argon2",
+ "base64",
+ "bitfield",
+ "block-padding",
+ "blowfish",
+ "bstr",
+ "buffer-redux",
+ "byteorder",
+ "camellia",
+ "cast5",
+ "cfb-mode",
+ "chrono",
+ "cipher",
+ "const-oid 0.9.6",
+ "crc24",
+ "curve25519-dalek",
+ "derive_builder",
+ "derive_more",
+ "des",
+ "digest 0.10.7",
+ "dsa",
+ "eax",
+ "ecdsa",
+ "ed25519-dalek",
+ "elliptic-curve",
+ "flate2",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "idea",
+ "iter-read",
+ "k256",
+ "log",
+ "md-5",
+ "nom 7.1.3",
+ "num-bigint-dig",
+ "num-traits",
+ "num_enum",
+ "ocb3",
+ "p256",
+ "p384",
+ "p521",
+ "rand 0.8.5",
+ "ripemd",
+ "rsa",
+ "sha1",
+ "sha1-checked",
+ "sha2 0.10.9",
+ "sha3 0.10.8",
+ "signature 2.2.0",
+ "smallvec",
+ "thiserror 1.0.69",
+ "twofish",
+ "x25519-dalek",
+ "x448",
+ "zeroize",
 ]
 
 [[package]]
@@ -4199,6 +4485,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4346,7 +4641,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4384,9 +4679,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4467,6 +4762,12 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -4896,7 +5197,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4964,7 +5265,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5246,6 +5547,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest 0.10.7",
+ "sha1",
+ "zeroize",
 ]
 
 [[package]]
@@ -5764,7 +6076,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6025,8 +6337,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -6039,6 +6351,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6047,9 +6368,30 @@ dependencies = [
  "indexmap 2.13.0",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -6318,6 +6660,15 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twofish"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78e83a30223c757c3947cd144a31014ff04298d8719ae10d03c31c0448c8013"
+dependencies = [
+ "cipher",
+]
 
 [[package]]
 name = "typed-path"
@@ -7233,7 +7584,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7650,6 +8001,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winx"
 version = "0.36.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7816,6 +8176,17 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "x448"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cd07d4fae29e07089dbcacf7077cd52dce7760125ca9a4dd5a35ca603ffebb"
+dependencies = [
+ "ed448-goldilocks",
+ "hex",
+ "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -104,6 +104,8 @@ async-trait = "0.1"
 async-stream = "0.3"
 hex = "0.4"
 rand = "0.9"
+rand08 = { package = "rand", version = "0.8" }
+pgp = "0.14.2"
 
 # Format parsing
 quick-xml = { version = "0.39", features = ["serialize"] }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -26,7 +26,6 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Extension;
 use axum::Router;
-use base64::Engine;
 use bytes::Bytes;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -315,50 +314,6 @@ async fn generate_release_content(
     );
 
     Ok(release)
-}
-
-// ---------------------------------------------------------------------------
-// PGP armor helpers
-// ---------------------------------------------------------------------------
-
-/// Wrap a raw signature in PGP detached signature armor format.
-fn pgp_armor_signature(signature: &[u8]) -> String {
-    let b64 = base64::engine::general_purpose::STANDARD.encode(signature);
-    // Wrap base64 at 76 characters per line (PGP convention)
-    let wrapped: Vec<&str> = b64
-        .as_bytes()
-        .chunks(76)
-        .map(|c| std::str::from_utf8(c).unwrap_or(""))
-        .collect();
-    format!(
-        "-----BEGIN PGP SIGNATURE-----\n\
-         \n\
-         {}\n\
-         -----END PGP SIGNATURE-----\n",
-        wrapped.join("\n"),
-    )
-}
-
-/// Produce a GPG-style clearsigned document from content and signature.
-fn pgp_clearsign(content: &str, signature: &[u8]) -> String {
-    let b64 = base64::engine::general_purpose::STANDARD.encode(signature);
-    let wrapped: Vec<&str> = b64
-        .as_bytes()
-        .chunks(76)
-        .map(|c| std::str::from_utf8(c).unwrap_or(""))
-        .collect();
-    format!(
-        "-----BEGIN PGP SIGNED MESSAGE-----\n\
-         Hash: SHA256\n\
-         \n\
-         {content}\
-         -----BEGIN PGP SIGNATURE-----\n\
-         \n\
-         {sig}\n\
-         -----END PGP SIGNATURE-----\n",
-        content = content,
-        sig = wrapped.join("\n"),
-    )
 }
 
 // ---------------------------------------------------------------------------
@@ -682,15 +637,17 @@ async fn in_release_file(
     let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
-    let signature = signing_svc
-        .sign_data(repo.id, release.as_bytes())
+    let body = signing_svc
+        .sign_openpgp_cleartext(repo.id, &release)
         .await
-        .unwrap_or(None);
-
-    let body = match signature {
-        Some(sig) => pgp_clearsign(&release, &sig),
-        None => release,
-    };
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to sign InRelease: {}", e),
+            )
+                .into_response()
+        })?
+        .unwrap_or(release);
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -719,19 +676,22 @@ async fn release_gpg(
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
     let signature = signing_svc
-        .sign_data(repo.id, release.as_bytes())
+        .sign_openpgp_detached(repo.id, release.as_bytes())
         .await
-        .unwrap_or(None);
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to sign Release.gpg: {}", e),
+            )
+                .into_response()
+        })?;
 
     match signature {
-        Some(sig) => {
-            let armored = pgp_armor_signature(&sig);
-            Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(CONTENT_TYPE, "application/pgp-signature")
-                .body(Body::from(armored))
-                .unwrap())
-        }
+        Some(armored) => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "application/pgp-signature")
+            .body(Body::from(armored))
+            .unwrap()),
         None => Err((
             StatusCode::NOT_FOUND,
             "No signing key configured for this repository",
@@ -1915,59 +1875,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // pgp_armor_signature
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_pgp_armor_signature_basic() {
-        let sig_data = b"test signature data";
-        let armored = pgp_armor_signature(sig_data);
-        assert!(armored.starts_with("-----BEGIN PGP SIGNATURE-----\n"));
-        assert!(armored.ends_with("-----END PGP SIGNATURE-----\n"));
-        let b64 = base64::engine::general_purpose::STANDARD.encode(sig_data);
-        assert!(armored.contains(&b64));
-    }
-
-    #[test]
-    fn test_pgp_armor_signature_empty() {
-        let armored = pgp_armor_signature(b"");
-        assert!(armored.contains("-----BEGIN PGP SIGNATURE-----"));
-        assert!(armored.contains("-----END PGP SIGNATURE-----"));
-    }
-
-    #[test]
-    fn test_pgp_armor_signature_long_data_wraps() {
-        let sig_data = vec![0u8; 100];
-        let armored = pgp_armor_signature(&sig_data);
-        assert!(armored.starts_with("-----BEGIN PGP SIGNATURE-----\n"));
-        assert!(armored.ends_with("-----END PGP SIGNATURE-----\n"));
-    }
-
-    // -----------------------------------------------------------------------
-    // pgp_clearsign
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_pgp_clearsign_basic() {
-        let content = "Origin: artifact-keeper\nSuite: stable\n";
-        let sig_data = b"signature";
-        let result = pgp_clearsign(content, sig_data);
-        assert!(result.starts_with("-----BEGIN PGP SIGNED MESSAGE-----\n"));
-        assert!(result.contains("Hash: SHA256\n"));
-        assert!(result.contains(content));
-        assert!(result.contains("-----BEGIN PGP SIGNATURE-----\n"));
-        assert!(result.contains("-----END PGP SIGNATURE-----\n"));
-    }
-
-    #[test]
-    fn test_pgp_clearsign_preserves_content() {
-        let content = "Line 1\nLine 2\nLine 3\n";
-        let sig = b"sig";
-        let result = pgp_clearsign(content, sig);
-        assert!(result.contains("Line 1\nLine 2\nLine 3\n"));
-    }
-
-    // -----------------------------------------------------------------------
     // Upstream path construction for APT remote proxy (#674)
     // -----------------------------------------------------------------------
 
@@ -2332,5 +2239,123 @@ mod tests {
         let mut decompressed = Vec::new();
         decoder.read_to_end(&mut decompressed).unwrap();
         assert_eq!(decompressed, text.as_bytes());
+    }
+
+    // -----------------------------------------------------------------------
+    // Pure helpers added alongside the OpenPGP signing flow (#1236). These
+    // are the path-shape parsers and string builders that the Debian
+    // handlers exercise before they touch the DB or storage; locking them
+    // down keeps the per-PR coverage gate above the 70% floor and pins
+    // exact behavior so a future refactor of the dists/* route shape (or
+    // the `binary-{arch}` segment convention) shows up as a test break.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_deb_filename_standard() {
+        let info = parse_deb_filename("hello_2.10-2_amd64.deb").expect("standard shape parses");
+        assert_eq!(info.name, "hello");
+        assert_eq!(info.version, "2.10-2");
+        assert_eq!(info.arch, "amd64");
+    }
+
+    #[test]
+    fn test_parse_deb_filename_missing_deb_suffix() {
+        // No .deb suffix at all -- strip_suffix returns None.
+        assert!(parse_deb_filename("hello_2.10-2_amd64").is_none());
+    }
+
+    #[test]
+    fn test_parse_deb_filename_only_two_segments() {
+        // Two underscores would be required; this has one.
+        assert!(parse_deb_filename("hello_amd64.deb").is_none());
+    }
+
+    #[test]
+    fn test_parse_deb_filename_version_may_contain_underscores() {
+        // splitn(3) caps at three pieces, so any extra underscores in
+        // segment 3 become part of the `arch` field. This pins the
+        // splitn behaviour so a future refactor that bumps the split
+        // depth shows up as an explicit test break.
+        let info = parse_deb_filename("pkg_1.0_amd64_extra.deb").expect("splitn yields 3 segments");
+        assert_eq!(info.name, "pkg");
+        assert_eq!(info.version, "1.0");
+        assert_eq!(info.arch, "amd64_extra");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_present() {
+        assert_eq!(strip_binary_arch_prefix("binary-amd64"), "amd64");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_absent() {
+        // Without the binary- prefix the input is returned unchanged.
+        assert_eq!(strip_binary_arch_prefix("amd64"), "amd64");
+    }
+
+    #[test]
+    fn test_strip_binary_arch_prefix_only_prefix() {
+        // Edge case: the prefix is the entire input.
+        assert_eq!(strip_binary_arch_prefix("binary-"), "");
+    }
+
+    #[test]
+    fn test_packages_index_suffix_plain() {
+        assert_eq!(
+            packages_index_suffix("main", "binary-amd64", ""),
+            "main/binary-amd64/Packages"
+        );
+    }
+
+    #[test]
+    fn test_packages_index_suffix_compressed() {
+        assert_eq!(
+            packages_index_suffix("main", "binary-amd64", "gz"),
+            "main/binary-amd64/Packages.gz"
+        );
+        assert_eq!(
+            packages_index_suffix("contrib", "binary-arm64", "xz"),
+            "contrib/binary-arm64/Packages.xz"
+        );
+    }
+
+    #[test]
+    fn test_parse_packages_request_wrong_segment_count() {
+        // Two segments -- caller should fall through to the upstream
+        // proxy, not handle it as a Packages request.
+        assert!(parse_packages_request("main/Packages").is_none());
+        // Four segments.
+        assert!(parse_packages_request("main/binary-amd64/extra/Packages").is_none());
+    }
+
+    #[test]
+    fn test_parse_packages_request_missing_binary_prefix() {
+        // Middle segment must start with "binary-"; "src-" is a real
+        // Debian segment but is not handled here.
+        assert!(parse_packages_request("main/src-amd64/Sources").is_none());
+        assert!(parse_packages_request("main/amd64/Packages").is_none());
+    }
+
+    #[test]
+    fn test_parse_packages_request_unknown_extension() {
+        // Anything other than Packages / Packages.gz / Packages.xz
+        // is None so the caller proxies to upstream.
+        assert!(parse_packages_request("main/binary-amd64/Packages.bz2").is_none());
+        assert!(parse_packages_request("main/binary-amd64/Release").is_none());
+    }
+
+    #[test]
+    fn test_release_invalidation_payload_changed() {
+        // Non-empty bytes + changed -> Some(snippet) so the caller emits
+        // a webhook payload. Empty bytes still returns Some but with the
+        // empty string.
+        let payload = release_invalidation_payload(true, b"foo bar baz");
+        assert!(payload.is_some());
+    }
+
+    #[test]
+    fn test_release_invalidation_payload_unchanged_is_none() {
+        // changed = false -> None; no webhook fires.
+        assert!(release_invalidation_payload(false, b"any content").is_none());
     }
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -35,8 +35,9 @@ use tracing::info;
 
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
-use crate::api::SharedState;
+use crate::api::{SharedState, SIGNED_RELEASE_CACHE_MAX_ENTRIES};
 use crate::models::repository::RepositoryType;
+use crate::models::signing_key::SigningKey;
 use crate::services::signing_service::SigningService;
 
 // ---------------------------------------------------------------------------
@@ -441,6 +442,10 @@ impl<'a> DebianProxy<'a> {
             proxy
                 .invalidate_dist_packages_cache(self.repo_key, self.distribution, text)
                 .await;
+            // Drop any signed-Release entries for this dist; the next
+            // InRelease / Release.gpg fetch will re-sign against the new
+            // content (#1236).
+            signed_release_cache_invalidate(self.state, self.repo_key, self.distribution).await;
         }
 
         Err(build_dists_response(content, upstream_ct, content_type))
@@ -489,6 +494,130 @@ fn release_invalidation_payload(changed: bool, content: &[u8]) -> Option<&str> {
         return None;
     }
     std::str::from_utf8(content).ok()
+}
+
+// ---------------------------------------------------------------------------
+// Signed-Release cache helpers (#1236)
+//
+// `apt update` polls InRelease and Release.gpg on every refresh; OpenPGP
+// signing is multi-millisecond CPU work, so we cache the signed bytes keyed
+// by SHA-256(unsigned Release || key fingerprint). The fingerprint is in the
+// key so that a key rotation naturally invalidates the prior signature, and
+// the content prefix means any Release flip rotates the key without needing
+// an explicit invalidation pass — though we also evict eagerly from the
+// change-detect path to keep the cache from growing unboundedly.
+// ---------------------------------------------------------------------------
+
+/// Variant tag included in cache keys so InRelease and Release.gpg cannot
+/// collide even when they sign the same unsigned content with the same key.
+#[derive(Clone, Copy)]
+enum SignedReleaseVariant {
+    InRelease,
+    ReleaseGpg,
+}
+
+impl SignedReleaseVariant {
+    fn as_str(self) -> &'static str {
+        match self {
+            SignedReleaseVariant::InRelease => "InRelease",
+            SignedReleaseVariant::ReleaseGpg => "Release.gpg",
+        }
+    }
+}
+
+/// Compute the cache key for a signed Release artifact. The fingerprint
+/// argument is the active signing key fingerprint (hex); when absent (no key
+/// configured) the caller should be returning 404 anyway and never call this.
+fn signed_release_cache_key(
+    variant: SignedReleaseVariant,
+    unsigned_release: &str,
+    key_fingerprint: &str,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(variant.as_str().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(key_fingerprint.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(unsigned_release.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+/// Look up a previously-signed Release artifact in the in-process cache.
+async fn signed_release_cache_get(state: &SharedState, cache_key: &str) -> Option<Bytes> {
+    let cache = state.signed_release_cache.read().await;
+    cache.get(cache_key).cloned()
+}
+
+/// Insert a freshly-signed Release artifact into the cache and update the
+/// `(repo_key, distribution)` reverse index used for targeted invalidation.
+/// A soft cap on total entries (`SIGNED_RELEASE_CACHE_MAX_ENTRIES`) bounds
+/// worst-case memory; once exceeded the entire cache is dropped, which is
+/// safe because every entry is reconstructible from its sign input.
+async fn signed_release_cache_put(
+    state: &SharedState,
+    repo_key: &str,
+    distribution: &str,
+    cache_key: String,
+    bytes: Bytes,
+) {
+    let mut cache = state.signed_release_cache.write().await;
+    if cache.len() >= SIGNED_RELEASE_CACHE_MAX_ENTRIES {
+        cache.clear();
+        let mut idx = state.signed_release_cache_index.write().await;
+        idx.clear();
+    }
+    cache.insert(cache_key.clone(), bytes);
+    drop(cache);
+
+    let mut idx = state.signed_release_cache_index.write().await;
+    let entry = idx
+        .entry((repo_key.to_string(), distribution.to_string()))
+        .or_default();
+    if !entry.contains(&cache_key) {
+        entry.push(cache_key);
+    }
+}
+
+/// Evict all signed-Release entries belonging to the given
+/// `(repo_key, distribution)`. Called from the change-detection paths so
+/// that an upstream Release flip drops the matching signed copies in
+/// lock-step with the sibling-Packages eviction in `proxy_service`.
+async fn signed_release_cache_invalidate(state: &SharedState, repo_key: &str, distribution: &str) {
+    let key = (repo_key.to_string(), distribution.to_string());
+    let drained = {
+        let mut idx = state.signed_release_cache_index.write().await;
+        idx.remove(&key).unwrap_or_default()
+    };
+    if drained.is_empty() {
+        return;
+    }
+    let mut cache = state.signed_release_cache.write().await;
+    for cache_key in drained {
+        cache.remove(&cache_key);
+    }
+}
+
+/// Resolve the active signing key for a repository, returning a 404 when
+/// none is configured. We refuse to silently fall through to unsigned
+/// `InRelease` (#1236): clients trust the signature, so absence of a key
+/// is a configuration error the operator needs to see, not a soft fallback.
+async fn require_active_signing_key(
+    signing_svc: &SigningService,
+    repo_id: uuid::Uuid,
+) -> Result<SigningKey, Response> {
+    match signing_svc.get_active_key_for_repo(repo_id).await {
+        Ok(Some(k)) => Ok(k),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            "No signing key configured for this repository",
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to load signing key: {}", e),
+        )
+            .into_response()),
+    }
 }
 
 /// Iterate the virtual repo's Remote members for `upstream_path` and
@@ -559,6 +688,7 @@ async fn try_virtual_dists_detecting_change(
                     proxy
                         .invalidate_dist_packages_cache(&member.key, distribution, text)
                         .await;
+                    signed_release_cache_invalidate(state, &member.key, distribution).await;
                 }
                 return Ok(Some(build_dists_response(
                     content,
@@ -637,21 +767,40 @@ async fn in_release_file(
     let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
-    let body = signing_svc
-        .sign_openpgp_cleartext(repo.id, &release)
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to sign InRelease: {}", e),
-            )
-                .into_response()
-        })?
-        .unwrap_or(release);
+    // Resolve the signing key up front so we can both (a) return 404 when
+    // none is configured and (b) include the fingerprint in the cache key.
+    // The previous `.unwrap_or(release)` fallback silently served unsigned
+    // bytes, which is a security footgun (#1236 review).
+    let key = require_active_signing_key(&signing_svc, repo.id).await?;
+    let fingerprint = key.fingerprint.as_deref().unwrap_or("unknown");
+    let cache_key =
+        signed_release_cache_key(SignedReleaseVariant::InRelease, &release, fingerprint);
+
+    let body = if let Some(cached) = signed_release_cache_get(&state, &cache_key).await {
+        cached
+    } else {
+        let armored = signing_svc
+            .sign_openpgp_cleartext_with_key(&key, &release)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to sign InRelease: {}", e),
+                )
+                    .into_response()
+            })?;
+        // Best-effort `last_used_at` stamp; we don't fail the request if the
+        // audit update errors (the sign already succeeded).
+        let _ = signing_svc.mark_key_used(key.id).await;
+        let bytes = Bytes::from(armored.into_bytes());
+        signed_release_cache_put(&state, &repo_key, &distribution, cache_key, bytes.clone()).await;
+        bytes
+    };
 
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+        .header(CONTENT_LENGTH, body.len().to_string())
         .body(Body::from(body))
         .unwrap())
 }
@@ -675,29 +824,36 @@ async fn release_gpg(
     let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
-    let signature = signing_svc
-        .sign_openpgp_detached(repo.id, release.as_bytes())
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to sign Release.gpg: {}", e),
-            )
-                .into_response()
-        })?;
+    let key = require_active_signing_key(&signing_svc, repo.id).await?;
+    let fingerprint = key.fingerprint.as_deref().unwrap_or("unknown");
+    let cache_key =
+        signed_release_cache_key(SignedReleaseVariant::ReleaseGpg, &release, fingerprint);
 
-    match signature {
-        Some(armored) => Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "application/pgp-signature")
-            .body(Body::from(armored))
-            .unwrap()),
-        None => Err((
-            StatusCode::NOT_FOUND,
-            "No signing key configured for this repository",
-        )
-            .into_response()),
-    }
+    let body = if let Some(cached) = signed_release_cache_get(&state, &cache_key).await {
+        cached
+    } else {
+        let armored = signing_svc
+            .sign_openpgp_detached_with_key(&key, release.as_bytes())
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to sign Release.gpg: {}", e),
+                )
+                    .into_response()
+            })?;
+        let _ = signing_svc.mark_key_used(key.id).await;
+        let bytes = Bytes::from(armored.into_bytes());
+        signed_release_cache_put(&state, &repo_key, &distribution, cache_key, bytes.clone()).await;
+        bytes
+    };
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/pgp-signature")
+        .header(CONTENT_LENGTH, body.len().to_string())
+        .body(Body::from(body))
+        .unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -2357,5 +2513,47 @@ mod tests {
     fn test_release_invalidation_payload_unchanged_is_none() {
         // changed = false -> None; no webhook fires.
         assert!(release_invalidation_payload(false, b"any content").is_none());
+    }
+
+    // ---------------------------------------------------------------------
+    // signed_release_cache_key (#1236)
+    //
+    // The cache key must be stable for a given (variant, content, key
+    // fingerprint) triple and must differ for InRelease vs Release.gpg
+    // and across key rotations, so a key rotation cannot accidentally
+    // serve a stale signature from a previous fingerprint.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_signed_release_cache_key_is_deterministic() {
+        let a = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "abcd");
+        let b = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "abcd");
+        assert_eq!(a, b);
+        // SHA-256 hex = 64 chars.
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn test_signed_release_cache_key_variant_namespaces_collide_safely() {
+        let a = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "abcd");
+        let b = signed_release_cache_key(SignedReleaseVariant::ReleaseGpg, "Release\n", "abcd");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_signed_release_cache_key_content_change_rotates_key() {
+        let a = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "abcd");
+        let b =
+            signed_release_cache_key(SignedReleaseVariant::InRelease, "Release-changed\n", "abcd");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_signed_release_cache_key_fingerprint_change_rotates_key() {
+        // A signing-key rotation must rotate the cache key so we never
+        // serve a signature produced by a deactivated key.
+        let a = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "abcd");
+        let b = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "ef01");
+        assert_ne!(a, b);
     }
 }

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -68,6 +68,33 @@ pub type RepoCache = Arc<RwLock<HashMap<String, (CachedRepo, Instant)>>>;
 /// Key: `"{repo_key}:{crate_name_lowercase}"`. Value: raw response bytes + insertion time.
 pub type IndexCache = Arc<RwLock<HashMap<String, (Bytes, Instant)>>>;
 
+/// Thread-safe in-process cache for signed APT Release artifacts
+/// (`InRelease` and `Release.gpg`). Key: hex-encoded SHA-256 of
+/// `(unsigned Release content || signing key fingerprint)`. Value: the
+/// armored signed bytes.
+///
+/// OpenPGP signing of the Release file is CPU-bound (multi-millisecond per
+/// hit on RSA-4096) and `apt update` requests both InRelease and Release.gpg
+/// on every refresh. Caching by content hash means the signature is reused
+/// across requests until the underlying Release content actually changes,
+/// at which point the cache key naturally rotates. The `(repo_key,
+/// distribution) -> set of cache keys` reverse index lets the change-detect
+/// path purge stale entries when an upstream Release flip is detected
+/// (mirroring how sibling Packages caches are invalidated for #1147).
+pub type SignedReleaseCache = Arc<RwLock<HashMap<String, Bytes>>>;
+
+/// Reverse index from (repo_key, distribution) to the set of cache keys
+/// installed under that scope. Lets the change-detect path drop just the
+/// signed-Release entries that belong to the changed distribution without
+/// scanning the entire cache.
+pub type SignedReleaseCacheIndex = Arc<RwLock<HashMap<(String, String), Vec<String>>>>;
+
+/// Soft cap on the signed-Release cache. Each distribution typically holds
+/// at most two entries (InRelease + Release.gpg) per active fingerprint, so
+/// 1024 is comfortably above the working-set size for a busy registry while
+/// still bounding worst-case memory if the cache ever grows pathologically.
+pub const SIGNED_RELEASE_CACHE_MAX_ENTRIES: usize = 1024;
+
 /// Application state shared across handlers
 #[derive(Clone)]
 pub struct AppState {
@@ -95,6 +122,14 @@ pub struct AppState {
     /// `"{repo_key}:{crate_name_lowercase}"`. Eliminates storage I/O and
     /// SHA-256 re-verification on every warm index request.
     pub index_cache: IndexCache,
+    /// In-process cache of signed APT `InRelease` / `Release.gpg` payloads,
+    /// keyed by `SHA-256(unsigned Release || key fingerprint)`. Avoids
+    /// re-signing on every `apt update` poll (#1236).
+    pub signed_release_cache: SignedReleaseCache,
+    /// Reverse index for `signed_release_cache` so the change-detect path
+    /// can evict just the entries belonging to a specific
+    /// `(repo_key, distribution)` when the underlying Release flips.
+    pub signed_release_cache_index: SignedReleaseCacheIndex,
     /// Concurrency cap for bcrypt-bound auth work (login, password verify,
     /// API token verify). `None` when `auth_max_concurrency == 0`, in which
     /// case auth runs without a process-wide cap (legacy behaviour).
@@ -156,6 +191,8 @@ impl AppState {
             event_bus: Arc::new(EventBus::new(1024)),
             repo_cache: Arc::new(RwLock::new(HashMap::new())),
             index_cache: Arc::new(RwLock::new(HashMap::new())),
+            signed_release_cache: Arc::new(RwLock::new(HashMap::new())),
+            signed_release_cache_index: Arc::new(RwLock::new(HashMap::new())),
             auth_semaphore,
         }
     }
@@ -196,6 +233,8 @@ impl AppState {
             event_bus: Arc::new(EventBus::new(1024)),
             repo_cache: Arc::new(RwLock::new(HashMap::new())),
             index_cache: Arc::new(RwLock::new(HashMap::new())),
+            signed_release_cache: Arc::new(RwLock::new(HashMap::new())),
+            signed_release_cache_index: Arc::new(RwLock::new(HashMap::new())),
             auth_semaphore,
         }
     }

--- a/backend/src/services/signing_service.rs
+++ b/backend/src/services/signing_service.rs
@@ -6,7 +6,15 @@
 use crate::error::{AppError, Result};
 use crate::models::signing_key::{RepositorySigningConfig, SigningKey, SigningKeyPublic};
 use crate::services::encryption::CredentialEncryption;
-use chrono::Utc;
+use chrono::{SubsecRound, Utc};
+use pgp::composed::cleartext::CleartextSignedMessage;
+use pgp::composed::key::{KeyType, SecretKeyParamsBuilder};
+use pgp::composed::{Deserializable, SignedPublicKey, StandaloneSignature};
+use pgp::crypto::hash::HashAlgorithm;
+use pgp::crypto::public_key::PublicKeyAlgorithm;
+use pgp::packet::{SignatureConfig, SignatureType, Subpacket, SubpacketData};
+use pgp::types::{KeyVersion, PublicKeyTrait};
+use pgp::ArmorOptions;
 use rsa::pkcs1v15::SigningKey as RsaSigningKey;
 use rsa::pkcs8::{DecodePrivateKey, EncodePrivateKey, EncodePublicKey};
 use rsa::signature::{SignatureEncoding, Signer};
@@ -29,6 +37,23 @@ pub(crate) fn algorithm_to_bits(algorithm: &str) -> std::result::Result<usize, S
             "Unsupported algorithm: {}. Use rsa2048 or rsa4096.",
             other
         )),
+    }
+}
+
+fn algorithm_to_bits_u32(algorithm: &str) -> std::result::Result<u32, String> {
+    algorithm_to_bits(algorithm).and_then(|bits| {
+        u32::try_from(bits).map_err(|_| format!("Unsupported RSA key size: {}", bits))
+    })
+}
+
+fn pgp_user_id(uid_name: Option<&str>, uid_email: Option<&str>, fallback_name: &str) -> String {
+    match (uid_name, uid_email) {
+        (Some(name), Some(email)) if !name.is_empty() && !email.is_empty() => {
+            format!("{} <{}>", name, email)
+        }
+        (Some(name), _) if !name.is_empty() => name.to_string(),
+        (_, Some(email)) if !email.is_empty() => format!("{} <{}>", fallback_name, email),
+        _ => fallback_name.to_string(),
     }
 }
 
@@ -73,45 +98,15 @@ impl SigningService {
         }
     }
 
-    /// Generate a new RSA key pair and store it.
+    /// Generate a new signing key pair and store it.
     pub async fn create_key(&self, req: CreateKeyRequest) -> Result<SigningKeyPublic> {
-        let bits = algorithm_to_bits(&req.algorithm).map_err(AppError::Validation)?;
-
-        // Generate RSA key pair (use OsRng from rsa's rand_core to avoid version mismatch)
-        let mut rng = rsa::rand_core::OsRng;
-        let private_key = RsaPrivateKey::new(&mut rng, bits)
-            .map_err(|e| AppError::Internal(format!("Failed to generate RSA key: {}", e)))?;
-        let public_key = RsaPublicKey::from(&private_key);
-
-        // Serialize keys
-        let public_pem = public_key
-            .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
-            .map_err(|e| AppError::Internal(format!("Failed to encode public key: {}", e)))?;
-
-        let private_pem = private_key
-            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
-            .map_err(|e| AppError::Internal(format!("Failed to encode private key: {}", e)))?;
-
-        // Encrypt private key
-        let private_bytes = private_pem.as_bytes();
-        let private_enc = self.encryption.encrypt(private_bytes);
-
-        // Compute fingerprint (SHA-256 of DER-encoded public key)
-        let public_der = public_key
-            .to_public_key_der()
-            .map_err(|e| AppError::Internal(format!("Failed to encode public key DER: {}", e)))?;
-        let fingerprint = compute_fingerprint(public_der.as_ref());
-        let key_id = derive_key_id(&fingerprint);
-
-        // Build GPG-style armored public key if key_type is gpg
-        let public_key_out = if req.key_type == "gpg" {
-            // For GPG consumers, wrap the RSA public key in a GPG-compatible format.
-            // We use raw PEM for now — real GPG armoring would need pgp crate.
-            // Consumers that need actual GPG packets should import via gpg --import.
-            public_pem.clone()
+        let (public_key_out, private_key_material, fingerprint, key_id) = if req.key_type == "gpg" {
+            self.generate_openpgp_key(&req)?
         } else {
-            public_pem.clone()
+            self.generate_rsa_key(&req.algorithm)?
         };
+
+        let private_enc = self.encryption.encrypt(private_key_material.as_bytes());
 
         let id = Uuid::new_v4();
         let now = Utc::now();
@@ -160,6 +155,75 @@ impl SigningService {
             created_at: now,
             last_used_at: None,
         })
+    }
+
+    fn generate_rsa_key(&self, algorithm: &str) -> Result<(String, String, String, String)> {
+        let bits = algorithm_to_bits(algorithm).map_err(AppError::Validation)?;
+
+        let mut rng = rsa::rand_core::OsRng;
+        let private_key = RsaPrivateKey::new(&mut rng, bits)
+            .map_err(|e| AppError::Internal(format!("Failed to generate RSA key: {}", e)))?;
+        let public_key = RsaPublicKey::from(&private_key);
+
+        let public_pem = public_key
+            .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
+            .map_err(|e| AppError::Internal(format!("Failed to encode public key: {}", e)))?;
+        let private_pem = private_key
+            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+            .map_err(|e| AppError::Internal(format!("Failed to encode private key: {}", e)))?
+            .to_string();
+
+        let public_der = public_key
+            .to_public_key_der()
+            .map_err(|e| AppError::Internal(format!("Failed to encode public key DER: {}", e)))?;
+        let fingerprint = compute_fingerprint(public_der.as_ref());
+        let key_id = derive_key_id(&fingerprint);
+
+        Ok((public_pem, private_pem, fingerprint, key_id))
+    }
+
+    fn generate_openpgp_key(
+        &self,
+        req: &CreateKeyRequest,
+    ) -> Result<(String, String, String, String)> {
+        let bits = algorithm_to_bits_u32(&req.algorithm).map_err(AppError::Validation)?;
+        let user_id = pgp_user_id(req.uid_name.as_deref(), req.uid_email.as_deref(), &req.name);
+
+        let mut key_params = SecretKeyParamsBuilder::default();
+        key_params
+            .version(KeyVersion::V4)
+            .key_type(KeyType::Rsa(bits))
+            .can_certify(true)
+            .can_sign(true)
+            .primary_user_id(user_id)
+            .passphrase(None);
+
+        let mut rng = rand08::rngs::OsRng;
+        let secret_key = key_params
+            .build()
+            .map_err(|e| AppError::Internal(format!("Failed to build OpenPGP key params: {}", e)))?
+            .generate(rng)
+            .map_err(|e| AppError::Internal(format!("Failed to generate OpenPGP key: {}", e)))?;
+        let signed_secret_key = secret_key
+            .sign(&mut rng, String::new)
+            .map_err(|e| AppError::Internal(format!("Failed to certify OpenPGP key: {}", e)))?;
+        let public_key = SignedPublicKey::from(signed_secret_key.clone());
+
+        let public_armored = public_key
+            .to_armored_string(ArmorOptions::default())
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to armor OpenPGP public key: {}", e))
+            })?;
+        let private_armored = signed_secret_key
+            .to_armored_string(ArmorOptions::default())
+            .map_err(|e| {
+                AppError::Internal(format!("Failed to armor OpenPGP private key: {}", e))
+            })?;
+
+        let fingerprint = hex::encode(public_key.fingerprint().as_bytes());
+        let key_id = hex::encode(public_key.key_id().as_ref());
+
+        Ok((public_armored, private_armored, fingerprint, key_id))
     }
 
     /// Get a signing key by ID (public info only).
@@ -242,6 +306,10 @@ impl SigningService {
         Ok(())
     }
 
+    async fn active_key_or_none(&self, repo_id: Uuid) -> Result<Option<SigningKey>> {
+        self.get_active_key_for_repo(repo_id).await
+    }
+
     /// Sign data with the repository's active signing key (RSA PKCS#1 v1.5 SHA-256).
     pub async fn sign_data(&self, repo_id: Uuid, data: &[u8]) -> Result<Option<Vec<u8>>> {
         let key = match self.get_active_key_for_repo(repo_id).await? {
@@ -282,7 +350,108 @@ impl SigningService {
         Ok(signature.to_bytes().to_vec())
     }
 
-    /// Get the public key in PEM format for a repository.
+    /// Create an ASCII-armored detached OpenPGP signature for repository metadata.
+    pub async fn sign_openpgp_detached(
+        &self,
+        repo_id: Uuid,
+        data: &[u8],
+    ) -> Result<Option<String>> {
+        let key = match self.active_key_or_none(repo_id).await? {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+        let armored = self.sign_openpgp_detached_with_key(&key, data)?;
+        self.mark_key_used(key.id).await?;
+        Ok(Some(armored))
+    }
+
+    /// Create an OpenPGP cleartext signed message for repository metadata.
+    pub async fn sign_openpgp_cleartext(
+        &self,
+        repo_id: Uuid,
+        text: &str,
+    ) -> Result<Option<String>> {
+        let key = match self.active_key_or_none(repo_id).await? {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+        let armored = self.sign_openpgp_cleartext_with_key(&key, text)?;
+        self.mark_key_used(key.id).await?;
+        Ok(Some(armored))
+    }
+
+    fn load_openpgp_secret_key(&self, key: &SigningKey) -> Result<pgp::SignedSecretKey> {
+        if key.key_type != "gpg" {
+            return Err(AppError::Validation(
+                "OpenPGP signatures require a signing key with key_type='gpg'".to_string(),
+            ));
+        }
+
+        let private_key = self
+            .encryption
+            .decrypt(&key.private_key_enc)
+            .map_err(|e| AppError::Internal(format!("Failed to decrypt private key: {}", e)))?;
+        let private_key = std::str::from_utf8(&private_key)
+            .map_err(|e| AppError::Internal(format!("Invalid UTF-8 in OpenPGP key: {}", e)))?;
+
+        let (secret_key, _) = pgp::SignedSecretKey::from_string(private_key).map_err(|e| {
+            AppError::Internal(format!(
+                "Failed to parse OpenPGP private key. Existing key may be a legacy PEM key; rotate or recreate it: {}",
+                e
+            ))
+        })?;
+        Ok(secret_key)
+    }
+
+    fn sign_openpgp_detached_with_key(&self, key: &SigningKey, data: &[u8]) -> Result<String> {
+        let secret_key = self.load_openpgp_secret_key(key)?;
+        let mut config = SignatureConfig::v4(
+            SignatureType::Binary,
+            PublicKeyAlgorithm::RSA,
+            HashAlgorithm::SHA2_256,
+        );
+        config.hashed_subpackets = vec![
+            Subpacket::regular(SubpacketData::IssuerFingerprint(secret_key.fingerprint())),
+            Subpacket::regular(SubpacketData::SignatureCreationTime(
+                chrono::Utc::now().trunc_subsecs(0),
+            )),
+        ];
+        config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+            secret_key.key_id(),
+        ))];
+
+        let signature = config
+            .sign(&secret_key, String::new, data)
+            .map_err(|e| AppError::Internal(format!("Failed to sign OpenPGP data: {}", e)))?;
+        StandaloneSignature::new(signature)
+            .to_armored_string(ArmorOptions::default())
+            .map_err(|e| AppError::Internal(format!("Failed to armor OpenPGP signature: {}", e)))
+    }
+
+    fn sign_openpgp_cleartext_with_key(&self, key: &SigningKey, text: &str) -> Result<String> {
+        let secret_key = self.load_openpgp_secret_key(key)?;
+        let rng = rand08::rngs::OsRng;
+        CleartextSignedMessage::sign(rng, text, &secret_key, String::new)
+            .and_then(|msg| msg.to_armored_string(ArmorOptions::default()))
+            .map_err(|e| {
+                AppError::Internal(format!(
+                    "Failed to create OpenPGP cleartext signature: {}",
+                    e
+                ))
+            })
+    }
+
+    async fn mark_key_used(&self, key_id: Uuid) -> Result<()> {
+        sqlx::query!(
+            "UPDATE signing_keys SET last_used_at = NOW() WHERE id = $1",
+            key_id,
+        )
+        .execute(&self.db)
+        .await?;
+        Ok(())
+    }
+
+    /// Get the public key in PEM or ASCII-armored OpenPGP format for a repository.
     pub async fn get_repo_public_key(&self, repo_id: Uuid) -> Result<Option<String>> {
         let key = self.get_active_key_for_repo(repo_id).await?;
         Ok(key.map(|k| k.public_key_pem))
@@ -475,6 +644,71 @@ mod tests {
             rotated_from: None,
             last_used_at: None,
         }
+    }
+
+    fn generate_test_openpgp_signing_key(passphrase: &str) -> SigningKey {
+        let service = SigningService {
+            db: PgPool::connect_lazy("postgresql://example.invalid/test").unwrap(),
+            encryption: CredentialEncryption::from_passphrase(passphrase),
+        };
+        let req = CreateKeyRequest {
+            repository_id: None,
+            name: "test-openpgp-key".to_string(),
+            key_type: "gpg".to_string(),
+            algorithm: "rsa2048".to_string(),
+            uid_name: Some("Test User".to_string()),
+            uid_email: Some("test@example.com".to_string()),
+            created_by: None,
+        };
+        let (public_key_pem, private_key_material, fingerprint, key_id) =
+            service.generate_openpgp_key(&req).unwrap();
+        let now = Utc::now();
+        SigningKey {
+            id: Uuid::new_v4(),
+            repository_id: None,
+            name: req.name,
+            key_type: req.key_type,
+            fingerprint: Some(fingerprint),
+            key_id: Some(key_id),
+            public_key_pem,
+            private_key_enc: service.encryption.encrypt(private_key_material.as_bytes()),
+            algorithm: req.algorithm,
+            uid_name: req.uid_name,
+            uid_email: req.uid_email,
+            expires_at: None,
+            is_active: true,
+            created_at: now,
+            created_by: None,
+            rotated_from: None,
+            last_used_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_openpgp_key_and_signatures_are_parseable_and_verifiable() {
+        let passphrase = "openpgp-test-passphrase";
+        let key = generate_test_openpgp_signing_key(passphrase);
+        assert!(key
+            .public_key_pem
+            .starts_with("-----BEGIN PGP PUBLIC KEY BLOCK-----"));
+
+        let service = SigningService {
+            db: PgPool::connect_lazy("postgresql://example.invalid/test").unwrap(),
+            encryption: CredentialEncryption::from_passphrase(passphrase),
+        };
+        let (public_key, _) = pgp::SignedPublicKey::from_string(&key.public_key_pem).unwrap();
+        public_key.verify().unwrap();
+
+        let data = b"Origin: artifact-keeper\nSuite: stable\n";
+        let detached = service.sign_openpgp_detached_with_key(&key, data).unwrap();
+        let (signature, _) = StandaloneSignature::from_string(&detached).unwrap();
+        signature.verify(&public_key, data).unwrap();
+
+        let cleartext = service
+            .sign_openpgp_cleartext_with_key(&key, std::str::from_utf8(data).unwrap())
+            .unwrap();
+        let (message, _) = CleartextSignedMessage::from_string(&cleartext).unwrap();
+        message.verify(&public_key).unwrap();
     }
 
     // -----------------------------------------------------------------------
@@ -1040,6 +1274,125 @@ mod tests {
         assert!(
             !enc_str.contains("BEGIN PRIVATE KEY"),
             "Private key should not be stored as plaintext PEM"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Pure helpers (algorithm_to_bits_u32, pgp_user_id, derive_key_id,
+    // build_rotated_key_name). These are the small free functions that the
+    // OpenPGP signing path (#1236) pulls into the call chain; they each
+    // have a couple of branches that the round-trip / property tests above
+    // don't exercise directly. Locking them down keeps the new-code
+    // coverage gate above the 70% floor and pins the precise behavior
+    // each branch is responsible for so a future refactor can't silently
+    // change what gets put into a generated key's user-id or what shape
+    // the rotated-key name takes.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_algorithm_to_bits_u32_rsa2048() {
+        assert_eq!(algorithm_to_bits_u32("rsa2048").unwrap(), 2048u32);
+    }
+
+    #[test]
+    fn test_algorithm_to_bits_u32_rsa4096() {
+        assert_eq!(algorithm_to_bits_u32("rsa4096").unwrap(), 4096u32);
+    }
+
+    #[test]
+    fn test_algorithm_to_bits_u32_unsupported() {
+        let err = algorithm_to_bits_u32("ed25519").unwrap_err();
+        assert!(
+            err.contains("Unsupported algorithm"),
+            "expected unsupported-algorithm error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_pgp_user_id_name_and_email() {
+        let uid = pgp_user_id(Some("Alice"), Some("alice@example.com"), "fallback");
+        assert_eq!(uid, "Alice <alice@example.com>");
+    }
+
+    #[test]
+    fn test_pgp_user_id_name_only() {
+        let uid = pgp_user_id(Some("Alice"), None, "fallback");
+        assert_eq!(uid, "Alice");
+    }
+
+    #[test]
+    fn test_pgp_user_id_name_only_empty_email() {
+        // The non-empty name should win over an empty email argument.
+        let uid = pgp_user_id(Some("Alice"), Some(""), "fallback");
+        assert_eq!(uid, "Alice");
+    }
+
+    #[test]
+    fn test_pgp_user_id_email_only_uses_fallback_name() {
+        let uid = pgp_user_id(None, Some("alice@example.com"), "fallback");
+        assert_eq!(uid, "fallback <alice@example.com>");
+    }
+
+    #[test]
+    fn test_pgp_user_id_empty_name_with_email_uses_fallback_name() {
+        // Empty name still falls back even when email is set, since the
+        // (Some(name), _) branch requires !name.is_empty().
+        let uid = pgp_user_id(Some(""), Some("alice@example.com"), "fallback");
+        assert_eq!(uid, "fallback <alice@example.com>");
+    }
+
+    #[test]
+    fn test_pgp_user_id_neither_present() {
+        let uid = pgp_user_id(None, None, "fallback");
+        assert_eq!(uid, "fallback");
+    }
+
+    #[test]
+    fn test_pgp_user_id_both_empty_falls_back() {
+        // Pathological case: empty strings on both sides. Should still
+        // produce the fallback rather than "<>" or "name <>".
+        let uid = pgp_user_id(Some(""), Some(""), "fallback");
+        assert_eq!(uid, "fallback");
+    }
+
+    #[test]
+    fn test_derive_key_id_normal_fingerprint() {
+        // A 40-hex-char SHA-1-style fingerprint: last 16 hex chars become
+        // the short key id.
+        let fp = "0123456789abcdef0123456789abcdef01234567";
+        assert_eq!(derive_key_id(fp), "89abcdef01234567");
+    }
+
+    #[test]
+    fn test_derive_key_id_short_fingerprint_returns_whole_string() {
+        // saturating_sub: fingerprints shorter than 16 chars should not
+        // panic; the whole string is the key id.
+        let fp = "abc123";
+        assert_eq!(derive_key_id(fp), "abc123");
+    }
+
+    #[test]
+    fn test_derive_key_id_empty_fingerprint() {
+        assert_eq!(derive_key_id(""), "");
+    }
+
+    #[test]
+    fn test_build_rotated_key_name_appends_suffix() {
+        assert_eq!(
+            build_rotated_key_name("debian-stable"),
+            "debian-stable (rotated)"
+        );
+    }
+
+    #[test]
+    fn test_build_rotated_key_name_already_rotated_still_appends() {
+        // We always append, even on an already-rotated name. Pin this so
+        // a future "smart rename" refactor that changes the shape (e.g.,
+        // appending "(rotated 2)") shows up as an explicit test break
+        // and forces an explicit decision.
+        assert_eq!(
+            build_rotated_key_name("debian-stable (rotated)"),
+            "debian-stable (rotated) (rotated)"
         );
     }
 }

--- a/backend/src/services/signing_service.rs
+++ b/backend/src/services/signing_service.rs
@@ -73,6 +73,124 @@ pub(crate) fn build_rotated_key_name(original_name: &str) -> String {
     format!("{} (rotated)", original_name)
 }
 
+// ---------------------------------------------------------------------------
+// CPU-bound rPGP helpers
+//
+// These are pure functions with no I/O or DB access, intended to be invoked
+// from `tokio::task::spawn_blocking` (#1236 review). RSA key generation can
+// take hundreds of milliseconds to multiple seconds, and OpenPGP signing is
+// also non-trivial CPU work. Running them inline on a tokio runtime worker
+// stalls the rest of the HTTP server.
+// ---------------------------------------------------------------------------
+
+/// Parameters describing an OpenPGP key to generate. Owns its data so it can
+/// cross a `spawn_blocking` boundary.
+struct OpenPgpKeyParams {
+    bits: u32,
+    user_id: String,
+}
+
+/// Generate an OpenPGP RSA key pair and return
+/// (armored_public, armored_private, fingerprint_hex, key_id_hex).
+///
+/// CPU-bound. Call from within `spawn_blocking`.
+fn generate_openpgp_key_blocking(
+    params: OpenPgpKeyParams,
+) -> Result<(String, String, String, String)> {
+    let mut key_params = SecretKeyParamsBuilder::default();
+    key_params
+        .version(KeyVersion::V4)
+        .key_type(KeyType::Rsa(params.bits))
+        .can_certify(true)
+        .can_sign(true)
+        .primary_user_id(params.user_id)
+        .passphrase(None);
+
+    let mut rng = rand08::rngs::OsRng;
+    let secret_key = key_params
+        .build()
+        .map_err(|e| AppError::Internal(format!("Failed to build OpenPGP key params: {}", e)))?
+        .generate(rng)
+        .map_err(|e| AppError::Internal(format!("Failed to generate OpenPGP key: {}", e)))?;
+    let signed_secret_key = secret_key
+        .sign(&mut rng, String::new)
+        .map_err(|e| AppError::Internal(format!("Failed to certify OpenPGP key: {}", e)))?;
+    let public_key = SignedPublicKey::from(signed_secret_key.clone());
+
+    let public_armored = public_key
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|e| AppError::Internal(format!("Failed to armor OpenPGP public key: {}", e)))?;
+    let private_armored = signed_secret_key
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|e| AppError::Internal(format!("Failed to armor OpenPGP private key: {}", e)))?;
+
+    let fingerprint = hex::encode(public_key.fingerprint().as_bytes());
+    let key_id = hex::encode(public_key.key_id().as_ref());
+
+    Ok((public_armored, private_armored, fingerprint, key_id))
+}
+
+/// Create an ASCII-armored detached OpenPGP signature.
+///
+/// CPU-bound. Call from within `spawn_blocking`.
+fn sign_openpgp_detached_blocking(
+    secret_key: pgp::SignedSecretKey,
+    data: Vec<u8>,
+) -> Result<String> {
+    let mut config = SignatureConfig::v4(
+        SignatureType::Binary,
+        PublicKeyAlgorithm::RSA,
+        HashAlgorithm::SHA2_256,
+    );
+    config.hashed_subpackets = vec![
+        Subpacket::regular(SubpacketData::IssuerFingerprint(secret_key.fingerprint())),
+        Subpacket::regular(SubpacketData::SignatureCreationTime(
+            chrono::Utc::now().trunc_subsecs(0),
+        )),
+    ];
+    config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
+        secret_key.key_id(),
+    ))];
+
+    let signature = config
+        .sign(&secret_key, String::new, &data[..])
+        .map_err(|e| AppError::Internal(format!("Failed to sign OpenPGP data: {}", e)))?;
+    StandaloneSignature::new(signature)
+        .to_armored_string(ArmorOptions::default())
+        .map_err(|e| AppError::Internal(format!("Failed to armor OpenPGP signature: {}", e)))
+}
+
+/// Create an OpenPGP cleartext signed message.
+///
+/// CPU-bound. Call from within `spawn_blocking`.
+fn sign_openpgp_cleartext_blocking(
+    secret_key: pgp::SignedSecretKey,
+    text: String,
+) -> Result<String> {
+    let rng = rand08::rngs::OsRng;
+    CleartextSignedMessage::sign(rng, &text, &secret_key, String::new)
+        .and_then(|msg| msg.to_armored_string(ArmorOptions::default()))
+        .map_err(|e| {
+            AppError::Internal(format!(
+                "Failed to create OpenPGP cleartext signature: {}",
+                e
+            ))
+        })
+}
+
+/// Helper to dispatch a CPU-bound crypto closure to the blocking pool and
+/// convert a panic into an `AppError::Internal`. Centralizes the
+/// `spawn_blocking` join-error handling so callers stay readable.
+async fn run_blocking<F, T>(label: &'static str, f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .map_err(|e| AppError::Internal(format!("{label} task panicked: {e}")))?
+}
+
 /// Service for managing signing keys and signing operations.
 pub struct SigningService {
     db: PgPool,
@@ -101,9 +219,9 @@ impl SigningService {
     /// Generate a new signing key pair and store it.
     pub async fn create_key(&self, req: CreateKeyRequest) -> Result<SigningKeyPublic> {
         let (public_key_out, private_key_material, fingerprint, key_id) = if req.key_type == "gpg" {
-            self.generate_openpgp_key(&req)?
+            self.generate_openpgp_key(&req).await?
         } else {
-            self.generate_rsa_key(&req.algorithm)?
+            self.generate_rsa_key(&req.algorithm).await?
         };
 
         let private_enc = self.encryption.encrypt(private_key_material.as_bytes());
@@ -157,73 +275,51 @@ impl SigningService {
         })
     }
 
-    fn generate_rsa_key(&self, algorithm: &str) -> Result<(String, String, String, String)> {
+    async fn generate_rsa_key(&self, algorithm: &str) -> Result<(String, String, String, String)> {
         let bits = algorithm_to_bits(algorithm).map_err(AppError::Validation)?;
 
-        let mut rng = rsa::rand_core::OsRng;
-        let private_key = RsaPrivateKey::new(&mut rng, bits)
-            .map_err(|e| AppError::Internal(format!("Failed to generate RSA key: {}", e)))?;
-        let public_key = RsaPublicKey::from(&private_key);
+        // RSA-4096 key generation is CPU-bound and can take multiple seconds
+        // under load. Run on the blocking pool so the async runtime stays free
+        // to service other requests.
+        run_blocking("rsa_keygen", move || {
+            let mut rng = rsa::rand_core::OsRng;
+            let private_key = RsaPrivateKey::new(&mut rng, bits)
+                .map_err(|e| AppError::Internal(format!("Failed to generate RSA key: {}", e)))?;
+            let public_key = RsaPublicKey::from(&private_key);
 
-        let public_pem = public_key
-            .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
-            .map_err(|e| AppError::Internal(format!("Failed to encode public key: {}", e)))?;
-        let private_pem = private_key
-            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
-            .map_err(|e| AppError::Internal(format!("Failed to encode private key: {}", e)))?
-            .to_string();
+            let public_pem = public_key
+                .to_public_key_pem(rsa::pkcs8::LineEnding::LF)
+                .map_err(|e| AppError::Internal(format!("Failed to encode public key: {}", e)))?;
+            let private_pem = private_key
+                .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+                .map_err(|e| AppError::Internal(format!("Failed to encode private key: {}", e)))?
+                .to_string();
 
-        let public_der = public_key
-            .to_public_key_der()
-            .map_err(|e| AppError::Internal(format!("Failed to encode public key DER: {}", e)))?;
-        let fingerprint = compute_fingerprint(public_der.as_ref());
-        let key_id = derive_key_id(&fingerprint);
+            let public_der = public_key.to_public_key_der().map_err(|e| {
+                AppError::Internal(format!("Failed to encode public key DER: {}", e))
+            })?;
+            let fingerprint = compute_fingerprint(public_der.as_ref());
+            let key_id = derive_key_id(&fingerprint);
 
-        Ok((public_pem, private_pem, fingerprint, key_id))
+            Ok((public_pem, private_pem, fingerprint, key_id))
+        })
+        .await
     }
 
-    fn generate_openpgp_key(
+    async fn generate_openpgp_key(
         &self,
         req: &CreateKeyRequest,
     ) -> Result<(String, String, String, String)> {
         let bits = algorithm_to_bits_u32(&req.algorithm).map_err(AppError::Validation)?;
         let user_id = pgp_user_id(req.uid_name.as_deref(), req.uid_email.as_deref(), &req.name);
 
-        let mut key_params = SecretKeyParamsBuilder::default();
-        key_params
-            .version(KeyVersion::V4)
-            .key_type(KeyType::Rsa(bits))
-            .can_certify(true)
-            .can_sign(true)
-            .primary_user_id(user_id)
-            .passphrase(None);
-
-        let mut rng = rand08::rngs::OsRng;
-        let secret_key = key_params
-            .build()
-            .map_err(|e| AppError::Internal(format!("Failed to build OpenPGP key params: {}", e)))?
-            .generate(rng)
-            .map_err(|e| AppError::Internal(format!("Failed to generate OpenPGP key: {}", e)))?;
-        let signed_secret_key = secret_key
-            .sign(&mut rng, String::new)
-            .map_err(|e| AppError::Internal(format!("Failed to certify OpenPGP key: {}", e)))?;
-        let public_key = SignedPublicKey::from(signed_secret_key.clone());
-
-        let public_armored = public_key
-            .to_armored_string(ArmorOptions::default())
-            .map_err(|e| {
-                AppError::Internal(format!("Failed to armor OpenPGP public key: {}", e))
-            })?;
-        let private_armored = signed_secret_key
-            .to_armored_string(ArmorOptions::default())
-            .map_err(|e| {
-                AppError::Internal(format!("Failed to armor OpenPGP private key: {}", e))
-            })?;
-
-        let fingerprint = hex::encode(public_key.fingerprint().as_bytes());
-        let key_id = hex::encode(public_key.key_id().as_ref());
-
-        Ok((public_armored, private_armored, fingerprint, key_id))
+        // Building and signing an RSA-4096 OpenPGP key is CPU-bound and can
+        // take multiple seconds. Run on the blocking pool (#1236 review).
+        let params = OpenPgpKeyParams { bits, user_id };
+        run_blocking("openpgp_keygen", move || {
+            generate_openpgp_key_blocking(params)
+        })
+        .await
     }
 
     /// Get a signing key by ID (public info only).
@@ -360,7 +456,7 @@ impl SigningService {
             Some(k) => k,
             None => return Ok(None),
         };
-        let armored = self.sign_openpgp_detached_with_key(&key, data)?;
+        let armored = self.sign_openpgp_detached_with_key(&key, data).await?;
         self.mark_key_used(key.id).await?;
         Ok(Some(armored))
     }
@@ -375,7 +471,7 @@ impl SigningService {
             Some(k) => k,
             None => return Ok(None),
         };
-        let armored = self.sign_openpgp_cleartext_with_key(&key, text)?;
+        let armored = self.sign_openpgp_cleartext_with_key(&key, text).await?;
         self.mark_key_used(key.id).await?;
         Ok(Some(armored))
     }
@@ -403,45 +499,46 @@ impl SigningService {
         Ok(secret_key)
     }
 
-    fn sign_openpgp_detached_with_key(&self, key: &SigningKey, data: &[u8]) -> Result<String> {
+    /// Sign `data` with `key` and return an ASCII-armored detached OpenPGP
+    /// signature. Exposed publicly (in addition to `sign_openpgp_detached`)
+    /// so callers that already hold the active `SigningKey` — e.g. handlers
+    /// checking a content-keyed signed-Release cache — can avoid a second
+    /// DB lookup per request (#1236).
+    pub async fn sign_openpgp_detached_with_key(
+        &self,
+        key: &SigningKey,
+        data: &[u8],
+    ) -> Result<String> {
+        // Decrypt + parse on the runtime: cheap relative to the signing work
+        // itself, and lets us avoid cloning the encryption state across the
+        // spawn_blocking boundary.
         let secret_key = self.load_openpgp_secret_key(key)?;
-        let mut config = SignatureConfig::v4(
-            SignatureType::Binary,
-            PublicKeyAlgorithm::RSA,
-            HashAlgorithm::SHA2_256,
-        );
-        config.hashed_subpackets = vec![
-            Subpacket::regular(SubpacketData::IssuerFingerprint(secret_key.fingerprint())),
-            Subpacket::regular(SubpacketData::SignatureCreationTime(
-                chrono::Utc::now().trunc_subsecs(0),
-            )),
-        ];
-        config.unhashed_subpackets = vec![Subpacket::regular(SubpacketData::Issuer(
-            secret_key.key_id(),
-        ))];
-
-        let signature = config
-            .sign(&secret_key, String::new, data)
-            .map_err(|e| AppError::Internal(format!("Failed to sign OpenPGP data: {}", e)))?;
-        StandaloneSignature::new(signature)
-            .to_armored_string(ArmorOptions::default())
-            .map_err(|e| AppError::Internal(format!("Failed to armor OpenPGP signature: {}", e)))
+        let data_owned = data.to_vec();
+        run_blocking("openpgp_sign_detached", move || {
+            sign_openpgp_detached_blocking(secret_key, data_owned)
+        })
+        .await
     }
 
-    fn sign_openpgp_cleartext_with_key(&self, key: &SigningKey, text: &str) -> Result<String> {
+    /// Sign `text` with `key` and return an ASCII-armored cleartext
+    /// signed message. See [`Self::sign_openpgp_detached_with_key`] for
+    /// the rationale on the public surface.
+    pub async fn sign_openpgp_cleartext_with_key(
+        &self,
+        key: &SigningKey,
+        text: &str,
+    ) -> Result<String> {
         let secret_key = self.load_openpgp_secret_key(key)?;
-        let rng = rand08::rngs::OsRng;
-        CleartextSignedMessage::sign(rng, text, &secret_key, String::new)
-            .and_then(|msg| msg.to_armored_string(ArmorOptions::default()))
-            .map_err(|e| {
-                AppError::Internal(format!(
-                    "Failed to create OpenPGP cleartext signature: {}",
-                    e
-                ))
-            })
+        let text_owned = text.to_string();
+        run_blocking("openpgp_sign_cleartext", move || {
+            sign_openpgp_cleartext_blocking(secret_key, text_owned)
+        })
+        .await
     }
 
-    async fn mark_key_used(&self, key_id: Uuid) -> Result<()> {
+    /// Stamp the `last_used_at` column for `key_id`. Public so callers
+    /// that sign through the `_with_key` path can still record usage.
+    pub async fn mark_key_used(&self, key_id: Uuid) -> Result<()> {
         sqlx::query!(
             "UPDATE signing_keys SET last_used_at = NOW() WHERE id = $1",
             key_id,
@@ -646,7 +743,7 @@ mod tests {
         }
     }
 
-    fn generate_test_openpgp_signing_key(passphrase: &str) -> SigningKey {
+    async fn generate_test_openpgp_signing_key(passphrase: &str) -> SigningKey {
         let service = SigningService {
             db: PgPool::connect_lazy("postgresql://example.invalid/test").unwrap(),
             encryption: CredentialEncryption::from_passphrase(passphrase),
@@ -661,7 +758,7 @@ mod tests {
             created_by: None,
         };
         let (public_key_pem, private_key_material, fingerprint, key_id) =
-            service.generate_openpgp_key(&req).unwrap();
+            service.generate_openpgp_key(&req).await.unwrap();
         let now = Utc::now();
         SigningKey {
             id: Uuid::new_v4(),
@@ -687,7 +784,7 @@ mod tests {
     #[tokio::test]
     async fn test_openpgp_key_and_signatures_are_parseable_and_verifiable() {
         let passphrase = "openpgp-test-passphrase";
-        let key = generate_test_openpgp_signing_key(passphrase);
+        let key = generate_test_openpgp_signing_key(passphrase).await;
         assert!(key
             .public_key_pem
             .starts_with("-----BEGIN PGP PUBLIC KEY BLOCK-----"));
@@ -700,12 +797,16 @@ mod tests {
         public_key.verify().unwrap();
 
         let data = b"Origin: artifact-keeper\nSuite: stable\n";
-        let detached = service.sign_openpgp_detached_with_key(&key, data).unwrap();
+        let detached = service
+            .sign_openpgp_detached_with_key(&key, data)
+            .await
+            .unwrap();
         let (signature, _) = StandaloneSignature::from_string(&detached).unwrap();
         signature.verify(&public_key, data).unwrap();
 
         let cleartext = service
             .sign_openpgp_cleartext_with_key(&key, std::str::from_utf8(data).unwrap())
+            .await
             .unwrap();
         let (message, _) = CleartextSignedMessage::from_string(&cleartext).unwrap();
         message.verify(&public_key).unwrap();

--- a/scripts/e2e-syspkg/lib.sh
+++ b/scripts/e2e-syspkg/lib.sh
@@ -63,15 +63,18 @@ for r in repos:
     fi
 }
 
-# Create a signing key for a repo: api_create_signing_key
-# Uses $REPO_ID, exports $SIGNING_KEY_ID
+# Create a signing key for a repo: api_create_signing_key [key_type]
+# Uses $REPO_ID, exports $SIGNING_KEY_ID. key_type defaults to rsa for
+# existing system-package tests; Debian passes gpg so apt receives real
+# OpenPGP Release metadata signatures.
 api_create_signing_key() {
-    log "Creating RSA-4096 signing key for repo $REPO_ID..."
+    local key_type="${1:-rsa}"
+    log "Creating $key_type RSA-4096 signing key for repo $REPO_ID..."
     local resp
     resp=$(curl -sf -X POST "$BACKEND_URL/api/v1/signing/keys" \
         -H "Authorization: Bearer $TOKEN" \
         -H 'Content-Type: application/json' \
-        -d "{\"name\":\"e2e-signing-key\",\"key_type\":\"rsa\",\"algorithm\":\"rsa4096\",\"repository_id\":\"$REPO_ID\"}")
+        -d "{\"name\":\"e2e-signing-key\",\"key_type\":\"$key_type\",\"algorithm\":\"rsa4096\",\"repository_id\":\"$REPO_ID\"}")
     SIGNING_KEY_ID=$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin)['id'])" 2>/dev/null) \
         || SIGNING_KEY_ID=$(echo "$resp" | sed -n 's/.*"id":"\([^"]*\)".*/\1/p')
     [ -n "$SIGNING_KEY_ID" ] || fail "Failed to create signing key"
@@ -92,11 +95,11 @@ api_configure_signing() {
 }
 
 # Full setup: login + create repo + create key + configure signing
-# Usage: setup_signed_repo <repo_key> <format>
+# Usage: setup_signed_repo <repo_key> <format> [key_type]
 setup_signed_repo() {
     api_login
     api_create_repo "$1" "$2"
-    api_create_signing_key
+    api_create_signing_key "${3:-rsa}"
     api_configure_signing
 }
 

--- a/scripts/e2e-syspkg/test-debian.sh
+++ b/scripts/e2e-syspkg/test-debian.sh
@@ -16,7 +16,7 @@ apt-get update -qq > /dev/null
 apt-get install -y -qq build-essential devscripts dpkg-dev curl gnupg python3 > /dev/null 2>&1
 
 # --- Setup repo + signing ---
-setup_signed_repo "$REPO_KEY" "debian"
+setup_signed_repo "$REPO_KEY" "debian" "gpg"
 
 # --- Build .deb package ---
 log "Building Debian package..."
@@ -98,25 +98,17 @@ log "Downloading public key..."
 curl -sf "$BACKEND_URL/debian/$REPO_KEY/dists/stable/gpg-key.asc" > /tmp/repo-key.asc
 [ -s /tmp/repo-key.asc ] || fail "Empty public key"
 
-log "Public key downloaded (RSA PEM format)"
-# Note: Our signing uses RSA PKCS#1v15, not OpenPGP format.
-# Real GPG verification would need pgp crate in backend.
-# We validate the signature endpoints exist and use [trusted=yes] for apt.
+grep -q "BEGIN PGP PUBLIC KEY BLOCK" /tmp/repo-key.asc || fail "Public key is not OpenPGP armored"
+install -d -m 0755 /etc/apt/keyrings
+gpg --dearmor -o /etc/apt/keyrings/e2e-registry.gpg /tmp/repo-key.asc
 
-log "Adding apt source (trusted mode)..."
-echo "deb [trusted=yes] $BACKEND_URL/debian/$REPO_KEY stable main" \
+log "Adding apt source (signed-by mode)..."
+echo "deb [signed-by=/etc/apt/keyrings/e2e-registry.gpg] $BACKEND_URL/debian/$REPO_KEY stable main" \
     > /etc/apt/sources.list.d/e2e-registry.list
-
-# Allow insecure repos since our signing uses RSA not OpenPGP
-cat > /etc/apt/apt.conf.d/99e2e-insecure << 'APTCONF'
-Acquire::AllowInsecureRepositories "true";
-Acquire::AllowDowngradeToInsecureRepositories "true";
-APT::Get::AllowUnauthenticated "true";
-APTCONF
 
 # --- apt-get update + install ---
 log "Running apt-get update..."
-apt-get update 2>&1 | tail -10 || log "apt update had warnings (expected with RSA-only signatures)"
+apt-get update 2>&1 | tail -10
 
 log "Installing $PKG_NAME..."
 apt-get install -y -qq "$PKG_NAME" 2>&1 || {


### PR DESCRIPTION
Closes #1307

## Summary

Fix Debian/APT repository signing so `InRelease`, `Release.gpg`, and `gpg-key.asc` contain valid OpenPGP material that `apt`/`sqv` can verify.

Previously, `key_type: "gpg"` generated a plain RSA PEM key pair and Debian metadata signing wrapped raw RSA signature bytes in `-----BEGIN PGP SIGNATURE-----` ASCII armor. That produced PGP-looking output, but not valid OpenPGP packets. `apt update` rejected signed Debian repositories with errors like:

`Malformed packet: Malformed CTB`

This PR changes the Debian signing path to:

- generate real OpenPGP key material for `key_type: "gpg"` using `pgp`/rPGP
- store ASCII-armored OpenPGP public/secret keys for GPG signing keys
- emit a real OpenPGP cleartext-signed `InRelease`
- emit a real OpenPGP detached `Release.gpg`
- keep existing raw RSA `sign_data()` behavior for other formats that already use it
- update Debian E2E setup to use `signed-by=` instead of `[trusted=yes]`

The public Debian key endpoint now returns:

`-----BEGIN PGP PUBLIC KEY BLOCK-----`

instead of a plain PEM:

`-----BEGIN PUBLIC KEY-----`

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Regression coverage:

- Added/updated unit coverage for OpenPGP key generation and signing:
  - verifies generated GPG keys are parseable OpenPGP public keys
  - verifies detached signatures parse and verify against the generated key
  - verifies cleartext signatures parse and verify against the generated key
- Updated Debian E2E script to import `gpg-key.asc` with `gpg --dearmor` and configure apt with `signed-by=`, instead of bypassing signature validation with `[trusted=yes]`.

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local/manual validation performed:

- `cargo fmt --check`
- `cargo test -p artifact-keeper-backend --lib -q`
- `cargo test -p artifact-keeper-backend debian::tests --lib`
- `cargo test -p artifact-keeper-backend signing_service::tests::test_openpgp_key_and_signatures_are_parseable_and_verifiable --lib`
- `cargo clippy -p artifact-keeper-backend --lib -- -D warnings -A unused-assignments`

Manual end-to-end validation against a test deployment:

- built and deployed a test backend image with this patch
- created a new Debian repository
- configured repository signing with a newly generated `gpg` key
- confirmed `gpg-key.asc` returns `-----BEGIN PGP PUBLIC KEY BLOCK-----`
- confirmed `apt update` accepts the repository without `[trusted=yes]`
- uploaded deb package through the Debian endpoint
- confirmed `apt-cache policy <package name>` sees the package
- confirmed `apt install <package name>` downloads and installs from Artifact Keeper

Note: plain `cargo clippy -p artifact-keeper-backend --lib -- -D warnings` currently fails on an existing unrelated `unused_assignments` warning in `backend/src/api/handlers/promotion.rs`. The clippy command above allows that pre-existing warning so this PR’s changes can still be linted.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes