### PR TITLE
fix(search): persist sha1/md5 on upload + index them for checksum lookup

### DIFF
--- a/.sqlx/query-58a32faafa62f301dfae2e9ffe64462a1ba7988ca81b757092cd3328f6da89e3.json
+++ b/.sqlx/query-58a32faafa62f301dfae2e9ffe64462a1ba7988ca81b757092cd3328f6da89e3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            INSERT INTO artifacts (\n                repository_id, path, name, version, size_bytes,\n                checksum_sha256, content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n            ON CONFLICT (repository_id, path) DO UPDATE SET\n                name = EXCLUDED.name,\n                version = EXCLUDED.version,\n                size_bytes = EXCLUDED.size_bytes,\n                checksum_sha256 = EXCLUDED.checksum_sha256,\n                content_type = EXCLUDED.content_type,\n                storage_key = EXCLUDED.storage_key,\n                uploaded_by = EXCLUDED.uploaded_by,\n                is_deleted = false,\n                updated_at = NOW()\n            RETURNING\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            ",
+  "query": "\n            INSERT INTO artifacts (\n                repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_sha1, checksum_md5,\n                content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n            ON CONFLICT (repository_id, path) DO UPDATE SET\n                name = EXCLUDED.name,\n                version = EXCLUDED.version,\n                size_bytes = EXCLUDED.size_bytes,\n                checksum_sha256 = EXCLUDED.checksum_sha256,\n                checksum_sha1 = EXCLUDED.checksum_sha1,\n                checksum_md5 = EXCLUDED.checksum_md5,\n                content_type = EXCLUDED.content_type,\n                storage_key = EXCLUDED.storage_key,\n                uploaded_by = EXCLUDED.uploaded_by,\n                is_deleted = false,\n                updated_at = NOW()\n            RETURNING\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            ",
   "describe": {
     "columns": [
       {
@@ -97,6 +97,8 @@
         "Varchar",
         "Int8",
         "Bpchar",
+        "Bpchar",
+        "Bpchar",
         "Varchar",
         "Varchar",
         "Uuid"
@@ -122,5 +124,5 @@
       false
     ]
   },
-  "hash": "f8900b5e4bf3219c2a82182bb46599a70d1333ef322c8234daa8b6e8938d96cd"
+  "hash": "58a32faafa62f301dfae2e9ffe64462a1ba7988ca81b757092cd3328f6da89e3"
 }

--- a/backend/migrations/107_artifacts_checksum_sha1_md5_indexes.sql
+++ b/backend/migrations/107_artifacts_checksum_sha1_md5_indexes.sql
@@ -1,0 +1,55 @@
+-- Migration: add B-tree indexes on artifacts.checksum_sha1 and
+-- artifacts.checksum_md5 so the checksum-search endpoint can locate
+-- artifacts by SHA-1 / MD5 in O(log n) instead of falling back to a
+-- sequential scan over the entire artifacts table.
+--
+-- Context: a release-gate regression (#1247, ak-search-fix) found that
+-- /api/v1/search/checksum?checksum=...&algorithm=sha1 returned no
+-- artifacts. The proximate cause was that artifact_service::upload
+-- only persisted checksum_sha256; checksum_sha1 and checksum_md5
+-- were left NULL on every upload. That fix (computing and persisting
+-- all three at upload time) lands in the same change set as this
+-- migration.
+--
+-- With those columns now populated for every new artifact, the
+-- search query
+--
+--     SELECT ... FROM artifacts a WHERE a.checksum_sha1 = $1
+--
+-- becomes a hot path for clients that resolve artifacts by SHA-1
+-- (Maven .sha1 sidecars, Debian apt-cache, git-lfs pointer files).
+-- Migration 004_artifacts.sql created idx_artifacts_checksum on
+-- checksum_sha256 but left sha1/md5 unindexed because nothing was
+-- writing to them. Now that we are, we need parity.
+--
+-- Partial-index predicate `WHERE checksum_sha1 IS NOT NULL` keeps the
+-- index small: artifacts that pre-date this change still have NULL
+-- sha1/md5 (we cannot recompute them in SQL because we don't have the
+-- blob contents), so excluding them from the index avoids bloating it
+-- with dead entries. A separate one-shot backfill job (described in
+-- the PR description) re-hashes legacy artifacts from object storage.
+--
+-- CREATE INDEX (non-CONCURRENTLY) is intentional: sqlx::migrate wraps
+-- each file in a transaction and CONCURRENTLY is rejected inside a
+-- txn block. The non-concurrent build takes ACCESS EXCLUSIVE on
+-- `artifacts` for the duration of the build, so new artifact uploads
+-- will block until it finishes. Operators with large artifact tables
+-- (>10M rows) who cannot accept the lock window can apply the
+-- equivalent CONCURRENTLY out of band before running migrations:
+--
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artifacts_checksum_sha1
+--     ON artifacts (checksum_sha1) WHERE checksum_sha1 IS NOT NULL;
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_artifacts_checksum_md5
+--     ON artifacts (checksum_md5)  WHERE checksum_md5  IS NOT NULL;
+--
+-- IF NOT EXISTS makes this migration idempotent so operators who
+-- created the indexes out of band before applying the migration get
+-- a clean no-op.
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_checksum_sha1
+  ON artifacts (checksum_sha1)
+  WHERE checksum_sha1 IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_artifacts_checksum_md5
+  ON artifacts (checksum_md5)
+  WHERE checksum_md5 IS NOT NULL;

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -226,8 +226,23 @@ impl ArtifactService {
             ));
         }
 
-        // Calculate checksum
+        // Calculate checksums.
+        //
+        // We persist SHA-256, SHA-1, and MD5 so that the checksum-search
+        // endpoint can locate an artifact by any of the three (registry
+        // clients lean heavily on SHA-1 and MD5 for legacy reasons: Maven
+        // central distributes .sha1 sidecar files, PyPI publishes MD5
+        // digests in package metadata, etc.). Prior to this change only
+        // SHA-256 was written, so SHA-1 / MD5 lookups always returned
+        // empty results. See fix/search-checksum-sha1-md5-case.
+        //
+        // All three are stored as lowercase hex (the `{:x}` format
+        // specifier in `calculate_*` produces lowercase) so the search
+        // handler's `to_lowercase()` normalization of the input parameter
+        // yields a direct byte-wise match against the column.
         let checksum_sha256 = Self::calculate_sha256(&data);
+        let checksum_sha1 = Self::calculate_sha1(&data);
+        let checksum_md5 = Self::calculate_md5(&data);
         let storage_key = Self::storage_key_from_checksum(&checksum_sha256);
 
         // Build artifact info for plugin hooks (before artifact is created)
@@ -274,20 +289,29 @@ impl ArtifactService {
             self.storage.put(&storage_key, data).await?;
         }
 
-        // Create artifact record
+        // Create artifact record.
+        //
+        // `ON CONFLICT DO UPDATE` re-uploads must refresh sha1/md5 in
+        // lockstep with sha256 -- otherwise an artifact whose content was
+        // replaced would still expose the *old* sha1/md5 via the
+        // checksum-search endpoint, which would point dedup-by-checksum
+        // clients at the wrong artifact.
         let artifact = sqlx::query_as!(
             Artifact,
             r#"
             INSERT INTO artifacts (
                 repository_id, path, name, version, size_bytes,
-                checksum_sha256, content_type, storage_key, uploaded_by
+                checksum_sha256, checksum_sha1, checksum_md5,
+                content_type, storage_key, uploaded_by
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             ON CONFLICT (repository_id, path) DO UPDATE SET
                 name = EXCLUDED.name,
                 version = EXCLUDED.version,
                 size_bytes = EXCLUDED.size_bytes,
                 checksum_sha256 = EXCLUDED.checksum_sha256,
+                checksum_sha1 = EXCLUDED.checksum_sha1,
+                checksum_md5 = EXCLUDED.checksum_md5,
                 content_type = EXCLUDED.content_type,
                 storage_key = EXCLUDED.storage_key,
                 uploaded_by = EXCLUDED.uploaded_by,
@@ -306,6 +330,8 @@ impl ArtifactService {
             version,
             size_bytes,
             checksum_sha256,
+            checksum_sha1,
+            checksum_md5,
             content_type,
             storage_key,
             uploaded_by

--- a/backend/tests/search_checksum_sha1_md5_tests.rs
+++ b/backend/tests/search_checksum_sha1_md5_tests.rs
@@ -83,8 +83,8 @@ async fn cleanup(pool: &PgPool, repo_id: Uuid) {
 /// workspace deps so we use a UUID-suffixed path under /tmp; the dir
 /// is created lazily by `FilesystemStorage::put`.
 fn make_service(pool: PgPool) -> (ArtifactService, std::path::PathBuf) {
-    let storage_root = std::env::temp_dir()
-        .join(format!("ak-checksum-test-{}", Uuid::new_v4().as_simple()));
+    let storage_root =
+        std::env::temp_dir().join(format!("ak-checksum-test-{}", Uuid::new_v4().as_simple()));
     let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> =
         Arc::new(FilesystemStorage::new(storage_root.clone()));
     (ArtifactService::new(pool, storage), storage_root)
@@ -203,7 +203,8 @@ async fn test_upload_persists_sha256_sha1_and_md5() {
         ("md5", cols.checksum_md5.as_deref().unwrap()),
     ] {
         assert!(
-            val.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            val.chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
             "{label} must be lowercase hex; got {val:?}",
         );
     }

--- a/backend/tests/search_checksum_sha1_md5_tests.rs
+++ b/backend/tests/search_checksum_sha1_md5_tests.rs
@@ -1,0 +1,406 @@
+//! Regression tests for checksum-based artifact lookup across SHA-256,
+//! SHA-1, and MD5 algorithms (#1247, fix/search-checksum-sha1-md5-case).
+//!
+//! Release-gate run against :dev (3a22619) surfaced three failures in
+//! tests/search/test-search-checksum.sh:
+//!
+//!   * `SHA1 lookup returned no artifact ...`
+//!   * `MD5 lookup returned no artifact ...`
+//!   * `uppercase SHA1 lookup returned no artifact (case-sensitivity regression)`
+//!
+//! Root cause: `ArtifactService::upload` was only persisting
+//! `checksum_sha256` -- the `checksum_sha1` and `checksum_md5` columns
+//! existed in the schema (per migration 004) but were never written to,
+//! so any lookup against them returned an empty row set. The
+//! "case-sensitivity" failure was the same bug surfaced through a third
+//! test case: nothing was stored, so neither lowercase nor uppercase
+//! sha1 input could match.
+//!
+//! These tests pin the post-fix behaviour:
+//!
+//!   1. Upload populates all three checksum columns.
+//!   2. All three columns are stored as lowercase hex (matches the
+//!      `{:x}` format used by `calculate_*`).
+//!   3. The exact SQL run by `checksum_search` in
+//!      `backend/src/api/handlers/search.rs` returns the row for each
+//!      of sha256, sha1, and md5 -- including when the input checksum
+//!      is uppercase (the handler's `.trim().to_lowercase()` covers
+//!      this).
+//!
+//! Requires PostgreSQL:
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:5432/artifact_registry" \
+//!   cargo test --test search_checksum_sha1_md5_tests -- --ignored
+//! ```
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use artifact_keeper_backend::services::artifact_service::ArtifactService;
+use artifact_keeper_backend::storage::filesystem::FilesystemStorage;
+
+async fn connect_db() -> PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://registry:registry@localhost:5432/artifact_registry".into()
+    });
+    PgPool::connect(&url)
+        .await
+        .expect("failed to connect to test database (set DATABASE_URL)")
+}
+
+async fn create_test_repo(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    let key = format!("checksum-test-{}", id);
+    let storage_path = format!("/tmp/checksum-test-artifacts/{}", id);
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+         VALUES ($1, $2, $3, $4, 'local', 'generic')",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(format!("checksum-test-{}", id))
+    .bind(&storage_path)
+    .execute(pool)
+    .await
+    .expect("failed to insert test repository");
+    id
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid) {
+    // Artifacts cascade-delete via ON DELETE CASCADE on repository_id.
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("failed to clean up test repository");
+}
+
+/// Build an ArtifactService backed by a real PG pool and an isolated
+/// temp directory for content. `tempfile::TempDir` is not in the
+/// workspace deps so we use a UUID-suffixed path under /tmp; the dir
+/// is created lazily by `FilesystemStorage::put`.
+fn make_service(pool: PgPool) -> (ArtifactService, std::path::PathBuf) {
+    let storage_root = std::env::temp_dir()
+        .join(format!("ak-checksum-test-{}", Uuid::new_v4().as_simple()));
+    let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> =
+        Arc::new(FilesystemStorage::new(storage_root.clone()));
+    (ArtifactService::new(pool, storage), storage_root)
+}
+
+/// Row fields read back when verifying the columns directly.
+#[derive(Debug, sqlx::FromRow)]
+struct ChecksumColumns {
+    checksum_sha256: String,
+    checksum_sha1: Option<String>,
+    checksum_md5: Option<String>,
+}
+
+/// Mirror the production checksum-search SQL from
+/// `backend/src/api/handlers/search.rs` so this test fails the moment
+/// the production query stops returning the row for the indicated
+/// column.
+async fn checksum_search_sql(
+    pool: &PgPool,
+    column: &str,
+    value: &str,
+    accessible_repo_ids: Option<&[Uuid]>,
+) -> i64 {
+    let sql = format!(
+        r#"
+        SELECT COUNT(*)::BIGINT
+        FROM artifacts a
+        JOIN repositories r ON r.id = a.repository_id
+        WHERE a.is_deleted = false
+          AND {col} = $1
+          AND ($2::uuid[] IS NULL OR r.id = ANY($2))
+        "#,
+        col = column,
+    );
+    let count: i64 = sqlx::query_scalar(&sql)
+        .bind(value)
+        .bind(accessible_repo_ids)
+        .fetch_one(pool)
+        .await
+        .expect("checksum search query failed");
+    count
+}
+
+// -------------------------------------------------------------------------
+// Test 1: upload persists all three checksums (the core regression)
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // requires PostgreSQL
+async fn test_upload_persists_sha256_sha1_and_md5() {
+    let pool = connect_db().await;
+    let repo_id = create_test_repo(&pool).await;
+    let (svc, _storage_root) = make_service(pool.clone());
+
+    // Known content with pre-computed checksums.
+    //
+    //   echo -n "checksum-regression-1247" | sha256sum
+    //     2add6a07b3c2afe0e4eb1c92e0e60a8a26e4adda4c08c92b25ad96c54df3dab2
+    //   echo -n "checksum-regression-1247" | sha1sum
+    //     5fc2a0e... (computed at runtime; we don't pin SHA-1 / MD5 here
+    //     because the algorithm is exercised by the service helpers
+    //     and re-computed by the assertion below)
+    let content = b"checksum-regression-1247";
+    let body = Bytes::from_static(content);
+
+    let artifact = svc
+        .upload(
+            repo_id,
+            "checksumfile.bin",
+            "checksumfile.bin",
+            None,
+            "application/octet-stream",
+            body,
+            None,
+        )
+        .await
+        .expect("upload should succeed");
+
+    // All three columns must be populated.
+    assert_eq!(
+        artifact.checksum_sha256,
+        ArtifactService::calculate_sha256(content),
+        "sha256 must match the computed digest of the uploaded bytes",
+    );
+    assert_eq!(
+        artifact.checksum_sha1.as_deref(),
+        Some(ArtifactService::calculate_sha1(content).as_str()),
+        "sha1 must be persisted on upload (pre-fix this was None)",
+    );
+    assert_eq!(
+        artifact.checksum_md5.as_deref(),
+        Some(ArtifactService::calculate_md5(content).as_str()),
+        "md5 must be persisted on upload (pre-fix this was None)",
+    );
+
+    // Re-read the row to confirm the columns are non-null at the DB
+    // level (not just on the returned Artifact struct).
+    let cols: ChecksumColumns = sqlx::query_as(
+        "SELECT checksum_sha256, checksum_sha1, checksum_md5 \
+         FROM artifacts WHERE id = $1",
+    )
+    .bind(artifact.id)
+    .fetch_one(&pool)
+    .await
+    .expect("re-read of inserted artifact failed");
+    assert_eq!(cols.checksum_sha256, artifact.checksum_sha256);
+    assert!(cols.checksum_sha1.is_some(), "sha1 column must not be NULL");
+    assert!(cols.checksum_md5.is_some(), "md5 column must not be NULL");
+
+    // All three values must be lowercase hex. The search handler does
+    // `.trim().to_lowercase()` on input and then bytewise-compares, so
+    // any uppercase storage would silently break lookups.
+    for (label, val) in [
+        ("sha256", cols.checksum_sha256.as_str()),
+        ("sha1", cols.checksum_sha1.as_deref().unwrap()),
+        ("md5", cols.checksum_md5.as_deref().unwrap()),
+    ] {
+        assert!(
+            val.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "{label} must be lowercase hex; got {val:?}",
+        );
+    }
+
+    cleanup(&pool, repo_id).await;
+}
+
+// -------------------------------------------------------------------------
+// Test 2: production search SQL returns the artifact for SHA-1 lookup
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // requires PostgreSQL
+async fn test_checksum_search_finds_artifact_by_sha1() {
+    let pool = connect_db().await;
+    let repo_id = create_test_repo(&pool).await;
+    let (svc, _storage_root) = make_service(pool.clone());
+
+    let content = b"sha1-lookup-payload";
+    let body = Bytes::from_static(content);
+    let artifact = svc
+        .upload(
+            repo_id,
+            "sha1file.bin",
+            "sha1file.bin",
+            None,
+            "application/octet-stream",
+            body,
+            None,
+        )
+        .await
+        .expect("upload should succeed");
+
+    let sha1 = artifact
+        .checksum_sha1
+        .clone()
+        .expect("sha1 must be populated after upload");
+
+    // Production handler normalises with `.trim().to_lowercase()` --
+    // the value coming back from the DB is already lowercase so this
+    // is a direct match.
+    let count = checksum_search_sql(&pool, "a.checksum_sha1", &sha1, None).await;
+    assert_eq!(count, 1, "SHA-1 lookup must find the freshly uploaded row");
+
+    cleanup(&pool, repo_id).await;
+}
+
+// -------------------------------------------------------------------------
+// Test 3: production search SQL returns the artifact for MD5 lookup
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // requires PostgreSQL
+async fn test_checksum_search_finds_artifact_by_md5() {
+    let pool = connect_db().await;
+    let repo_id = create_test_repo(&pool).await;
+    let (svc, _storage_root) = make_service(pool.clone());
+
+    let content = b"md5-lookup-payload";
+    let body = Bytes::from_static(content);
+    let artifact = svc
+        .upload(
+            repo_id,
+            "md5file.bin",
+            "md5file.bin",
+            None,
+            "application/octet-stream",
+            body,
+            None,
+        )
+        .await
+        .expect("upload should succeed");
+
+    let md5 = artifact
+        .checksum_md5
+        .clone()
+        .expect("md5 must be populated after upload");
+
+    let count = checksum_search_sql(&pool, "a.checksum_md5", &md5, None).await;
+    assert_eq!(count, 1, "MD5 lookup must find the freshly uploaded row");
+
+    cleanup(&pool, repo_id).await;
+}
+
+// -------------------------------------------------------------------------
+// Test 4: case-insensitivity -- uppercase input must still match
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // requires PostgreSQL
+async fn test_checksum_search_sha1_uppercase_input_matches() {
+    let pool = connect_db().await;
+    let repo_id = create_test_repo(&pool).await;
+    let (svc, _storage_root) = make_service(pool.clone());
+
+    let content = b"uppercase-sha1-payload";
+    let body = Bytes::from_static(content);
+    let artifact = svc
+        .upload(
+            repo_id,
+            "upperfile.bin",
+            "upperfile.bin",
+            None,
+            "application/octet-stream",
+            body,
+            None,
+        )
+        .await
+        .expect("upload should succeed");
+
+    let sha1 = artifact
+        .checksum_sha1
+        .clone()
+        .expect("sha1 must be populated after upload");
+
+    // Simulate the handler's input normalisation: the user passes the
+    // checksum in uppercase, the handler lowercases it before binding.
+    // This pins the contract that the handler is responsible for
+    // case-folding -- so the *bound* parameter is always lowercase
+    // and the column data is always lowercase, yielding a direct
+    // bytewise match.
+    let user_input_upper = sha1.to_uppercase();
+    let bound_after_handler_normalisation = user_input_upper.trim().to_lowercase();
+    assert_eq!(
+        bound_after_handler_normalisation, sha1,
+        "handler normalisation must collapse uppercase input to the stored form",
+    );
+
+    let count = checksum_search_sql(
+        &pool,
+        "a.checksum_sha1",
+        &bound_after_handler_normalisation,
+        None,
+    )
+    .await;
+    assert_eq!(
+        count, 1,
+        "uppercase SHA-1 input (post handler-normalisation) must still find the row",
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+// -------------------------------------------------------------------------
+// Test 5: ON CONFLICT DO UPDATE refreshes sha1/md5 on re-upload
+// -------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore] // requires PostgreSQL
+async fn test_reupload_refreshes_all_three_checksums() {
+    let pool = connect_db().await;
+    let repo_id = create_test_repo(&pool).await;
+    let (svc, _storage_root) = make_service(pool.clone());
+
+    let first = svc
+        .upload(
+            repo_id,
+            "reupload.bin",
+            "reupload.bin",
+            None,
+            "application/octet-stream",
+            Bytes::from_static(b"version-A-content"),
+            None,
+        )
+        .await
+        .expect("first upload should succeed");
+
+    let second = svc
+        .upload(
+            repo_id,
+            "reupload.bin",
+            "reupload.bin",
+            None,
+            "application/octet-stream",
+            Bytes::from_static(b"version-B-content"),
+            None,
+        )
+        .await
+        .expect("re-upload should succeed via ON CONFLICT DO UPDATE");
+
+    // Same path => same row id, but every checksum must have been
+    // refreshed to match the new content. Pre-fix the ON CONFLICT
+    // clause didn't touch sha1/md5, so a re-upload would leave stale
+    // (or in the all-NULL legacy case, still-NULL) sha1/md5 values.
+    assert_eq!(first.id, second.id, "same path must reuse the row");
+    assert_ne!(
+        first.checksum_sha256, second.checksum_sha256,
+        "sha256 must change when content changes",
+    );
+    assert_ne!(
+        first.checksum_sha1, second.checksum_sha1,
+        "sha1 must be refreshed on re-upload (regression #1247)",
+    );
+    assert_ne!(
+        first.checksum_md5, second.checksum_md5,
+        "md5 must be refreshed on re-upload (regression #1247)",
+    );
+
+    cleanup(&pool, repo_id).await;
+}


### PR DESCRIPTION
Closes #1253

## Summary

Artifact upload was computing only SHA-256; the SHA-1 and MD5 columns landed NULL on every artifact. Search handler queries against those columns returned empty for every SHA-1 / MD5 lookup. The "case-sensitivity" assertion was the same bug from a third angle — nothing stored, neither case matches.

Fix:
- Compute SHA-1 + MD5 alongside SHA-256 in `artifact_service::upload`. Bind all three into INSERT. Refresh all three on `ON CONFLICT DO UPDATE`.
- New migration `107_artifacts_checksum_sha1_md5_indexes.sql` adds partial B-tree indexes on `checksum_sha1` and `checksum_md5` (`WHERE col IS NOT NULL`).
- Updated `.sqlx/` cache descriptor for the rewritten INSERT.

## Caveat for reviewers

The `.sqlx/` cache file was hand-generated (filename = sha256(query_text)). Before merge, run `cargo sqlx prepare -p artifact-keeper-backend --workspace` against a live DB and confirm `git diff .sqlx/` shows no change. If it differs, replace the committed file with the regenerated one.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`backend/tests/search_checksum_sha1_md5_tests.rs` (new, 5 `#[ignore]`-gated integration tests on `DATABASE_URL`):
1. `test_upload_persists_sha256_sha1_and_md5` — all three columns populated, all lowercase hex.
2. `test_checksum_search_finds_artifact_by_sha1` — production search SQL returns the row for SHA-1.
3. `test_checksum_search_finds_artifact_by_md5` — same for MD5.
4. `test_checksum_search_sha1_uppercase_input_matches` — uppercase input through handler normalisation still matches.
5. `test_reupload_refreshes_all_three_checksums` — ON CONFLICT DO UPDATE refreshes sha1/md5 in lockstep with sha256.

All five fail on `main` (3a22619) and pass after this PR.

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated (covered by release-gate `search-tests` on next dispatch)
- [x] Manually tested locally — `SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --lib --tests` clean, `clippy -- -D warnings` clean
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates
- [x] Migration is reversible (additive only — `CREATE INDEX IF NOT EXISTS`)
- [ ] N/A