### PR TITLE
fix(auth): block non-admins from granting admin-class scopes on token issuance

### DIFF
--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -362,12 +362,13 @@ pub async fn create_api_token(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateApiTokenRequest>,
 ) -> Result<Json<CreateApiTokenResponse>> {
-    // Non-admin users cannot request the "admin" scope
-    if !auth.is_admin && payload.scopes.iter().any(|s| s == "admin") {
-        return Err(AppError::Authorization(
-            "Only administrators can create tokens with the 'admin' scope".to_string(),
-        ));
-    }
+    // Refuse admin-class scopes from non-admin callers. The legacy check
+    // only blocked the literal "admin" scope, leaving non-admins able to
+    // mint `*`, `delete:artifacts`, `delete:repositories`, and
+    // `write:users` via this endpoint. See
+    // `token_service::ADMIN_ONLY_SCOPES` for the policy list and rationale.
+    crate::services::token_service::enforce_admin_only_scopes(&payload.scopes, auth.is_admin)
+        .map_err(AppError::Authorization)?;
 
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
 
@@ -1233,5 +1234,161 @@ mod tests {
         // touches only segment 2 (the package name).
         let got = validate_and_normalize_resource_path("/pypi/MyRepo/Django").unwrap();
         assert_eq!(got, "/pypi/MyRepo/django");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Admin-only token-scope enforcement tests (auth::create_api_token)
+//
+// Sibling of `users::admin_scope_policy_tests` and the repo-tokens
+// endpoint tests. The same policy must apply to
+// `POST /api/v1/auth/tokens`, otherwise any logged-in user can pivot
+// here to mint a token with `*` / `admin` / `delete:artifacts` /
+// `delete:repositories` / `write:users` and bypass every scope-only
+// authorization gate.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod admin_scope_policy_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use axum::Extension as AxumExtension;
+    use serde_json::json;
+
+    /// Build the auth router with a bare `Extension<AuthExtension>` layer
+    /// (the shape this handler's extractor expects).
+    fn build_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+        protected_router()
+            .with_state(state)
+            .layer(AxumExtension::<AuthExtension>(auth))
+    }
+
+    async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String)> {
+        let pool = tdh::try_pool().await?;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        Some((pool, state, user_id, username))
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+
+    /// Each ADMIN_ONLY_SCOPES entry submitted alone by a non-admin must
+    /// be refused at the handler. Iterates so a future addition to the
+    /// policy list is automatically covered.
+    #[tokio::test]
+    async fn non_admin_cannot_mint_admin_only_scopes_on_auth_tokens_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username); // is_admin: false
+
+        for admin_scope in crate::services::token_service::ADMIN_ONLY_SCOPES {
+            let app = build_app(state.clone(), auth.clone());
+            let body = json!({
+                "name": format!("probe-{}", admin_scope),
+                "scopes": [admin_scope],
+                "expires_in_days": 30_i64,
+            })
+            .to_string();
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri("/tokens")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap();
+            let (status, body_bytes) = tdh::send(app, req).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin minting auth token with admin-class scope {:?} MUST 403; got {} body: {}",
+                admin_scope,
+                status,
+                String::from_utf8_lossy(&body_bytes),
+            );
+        }
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// A non-admin must not smuggle an admin-only scope through this
+    /// endpoint by burying it in a list of otherwise-safe scopes.
+    #[tokio::test]
+    async fn non_admin_cannot_smuggle_admin_scope_in_a_mixed_list_auth_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username);
+        let app = build_app(state, auth);
+
+        let body = json!({
+            "name": "smuggle-attempt",
+            "scopes": ["read:artifacts", "write:artifacts", "delete:repositories"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "non-admin smuggling 'delete:repositories' on /auth/tokens MUST 403"
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Admin callers retain the ability to grant the entire policy
+    /// surface via this endpoint. Pinning this prevents the policy from
+    /// accidentally locking out legitimate admin token issuance.
+    #[tokio::test]
+    async fn admin_can_mint_admin_only_scopes_on_auth_tokens_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_admin = true;
+        let app = build_app(state, auth);
+
+        let body = json!({
+            "name": "admin-token",
+            "scopes": ["*"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "admin minting a wildcard auth token MUST succeed; got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body_bytes),
+        );
+
+        cleanup(&pool, user_id).await;
     }
 }

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -73,8 +73,19 @@ async fn create_access_token(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateAccessTokenRequest>,
 ) -> Result<Json<ApiTokenCreatedResponse>> {
-    let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let scopes = payload.scopes.unwrap_or_else(|| vec!["read".to_string()]);
+
+    // Refuse admin-class scopes from non-admin callers. Without this
+    // check, any logged-in user can mint a token with `*` or `admin`
+    // and bypass every scope-only authorization gate via
+    // `scopes_grant_access` (which short-circuits on those two values).
+    // Other admin-only scopes (`delete:artifacts`, `delete:repositories`,
+    // `write:users`) cover destructive/admin-class operations — see
+    // `token_service::ADMIN_ONLY_SCOPES`.
+    crate::services::token_service::enforce_admin_only_scopes(&scopes, auth.is_admin)
+        .map_err(crate::error::AppError::Authorization)?;
+
+    let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let (token, token_id) = auth_service
         .generate_api_token(auth.user_id, &payload.name, scopes, payload.expires_in_days)
         .await?;

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -115,6 +115,34 @@ fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     Ok(auth)
 }
 
+/// Authorize the caller for a repo-tokens endpoint and resolve the target
+/// repository. Returns the validated `(auth, repo)` pair on success.
+///
+/// This collapses the three-step pre-amble shared by every handler in this
+/// module: `require_repo_write`, `RepositoryService::get_by_key`, and the
+/// per-caller `can_access_repo` visibility check. The `NotFound` (rather
+/// than `Forbidden`) response on visibility failure is intentional: it
+/// prevents an unauthorized caller from probing repository existence.
+async fn authorize_repo_for_tokens(
+    state: &SharedState,
+    auth: Option<AuthExtension>,
+    key: &str,
+) -> Result<(AuthExtension, crate::models::repository::Repository)> {
+    let auth = require_repo_write(auth)?;
+
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(key).await?;
+
+    if !auth.can_access_repo(repo.id) {
+        return Err(AppError::NotFound(format!(
+            "Repository '{}' not found",
+            key
+        )));
+    }
+
+    Ok((auth, repo))
+}
+
 // ---------------------------------------------------------------------------
 // Row types for unchecked queries
 // ---------------------------------------------------------------------------
@@ -158,17 +186,7 @@ pub async fn list_repo_tokens(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
 ) -> Result<Json<RepoTokenListResponse>> {
-    let auth = require_repo_write(auth)?;
-
-    let repo_service = RepositoryService::new(state.db.clone());
-    let repo = repo_service.get_by_key(&key).await?;
-
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (_auth, repo) = authorize_repo_for_tokens(&state, auth, &key).await?;
 
     let rows: Vec<TokenRow> = sqlx::query_as(
         r#"
@@ -241,17 +259,7 @@ pub async fn create_repo_token(
     Path(key): Path<String>,
     Json(payload): Json<CreateRepoTokenRequest>,
 ) -> Result<Json<CreateRepoTokenResponse>> {
-    let auth = require_repo_write(auth)?;
-
-    let repo_service = RepositoryService::new(state.db.clone());
-    let repo = repo_service.get_by_key(&key).await?;
-
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (auth, repo) = authorize_repo_for_tokens(&state, auth, &key).await?;
 
     // Validate inputs
     validate_scopes_pure(&payload.scopes).map_err(AppError::Validation)?;
@@ -330,17 +338,7 @@ pub async fn get_repo_token(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, token_id)): Path<(String, Uuid)>,
 ) -> Result<Json<RepoTokenResponse>> {
-    let auth = require_repo_write(auth)?;
-
-    let repo_service = RepositoryService::new(state.db.clone());
-    let repo = repo_service.get_by_key(&key).await?;
-
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (_auth, repo) = authorize_repo_for_tokens(&state, auth, &key).await?;
 
     let row: TokenRow = sqlx::query_as(
         r#"
@@ -409,17 +407,7 @@ pub async fn revoke_repo_token(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, token_id)): Path<(String, Uuid)>,
 ) -> Result<axum::http::StatusCode> {
-    let auth = require_repo_write(auth)?;
-
-    let repo_service = RepositoryService::new(state.db.clone());
-    let repo = repo_service.get_by_key(&key).await?;
-
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (_auth, repo) = authorize_repo_for_tokens(&state, auth, &key).await?;
 
     // Verify the token belongs to this repository
     let exists: Option<(Uuid,)> = sqlx::query_as(
@@ -823,6 +811,24 @@ mod admin_scope_policy_tests {
             .await;
     }
 
+    /// Build a `POST /{repo_key}/tokens` request with the given token name
+    /// and scopes. Centralizing this avoids repeating the Request::builder
+    /// chain across every admin-scope policy test.
+    fn post_repo_token_request(repo_key: &str, name: &str, scopes: &[&str]) -> Request<Body> {
+        let body = json!({
+            "name": name,
+            "scopes": scopes,
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", repo_key))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap()
+    }
+
     /// Each ADMIN_ONLY_SCOPES entry, submitted alone by a non-admin with
     /// the delegatable `write:repositories` scope, must be refused at the
     /// handler. Iterating means a future addition to the policy list is
@@ -840,18 +846,11 @@ mod admin_scope_policy_tests {
 
         for admin_scope in crate::services::token_service::ADMIN_ONLY_SCOPES {
             let app = build_app(state.clone(), auth.clone());
-            let body = json!({
-                "name": format!("probe-{}", admin_scope),
-                "scopes": [admin_scope],
-                "expires_in_days": 30_i64,
-            })
-            .to_string();
-            let req = Request::builder()
-                .method(Method::POST)
-                .uri(format!("/{}/tokens", repo_key))
-                .header("content-type", "application/json")
-                .body(Body::from(body))
-                .unwrap();
+            let req = post_repo_token_request(
+                &repo_key,
+                &format!("probe-{}", admin_scope),
+                &[admin_scope],
+            );
             let (status, body_bytes) = tdh::send(app, req).await;
 
             assert_eq!(
@@ -879,18 +878,11 @@ mod admin_scope_policy_tests {
         auth.scopes = Some(vec!["write:repositories".to_string()]);
         let app = build_app(state, auth);
 
-        let body = json!({
-            "name": "smuggle-attempt",
-            "scopes": ["read:artifacts", "write:artifacts", "*"],
-            "expires_in_days": 30_i64,
-        })
-        .to_string();
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri(format!("/{}/tokens", repo_key))
-            .header("content-type", "application/json")
-            .body(Body::from(body))
-            .unwrap();
+        let req = post_repo_token_request(
+            &repo_key,
+            "smuggle-attempt",
+            &["read:artifacts", "write:artifacts", "*"],
+        );
         let (status, _) = tdh::send(app, req).await;
 
         assert_eq!(
@@ -914,18 +906,7 @@ mod admin_scope_policy_tests {
         auth.is_admin = true;
         let app = build_app(state, auth);
 
-        let body = json!({
-            "name": "admin-repo-token",
-            "scopes": ["delete:artifacts"],
-            "expires_in_days": 30_i64,
-        })
-        .to_string();
-        let req = Request::builder()
-            .method(Method::POST)
-            .uri(format!("/{}/tokens", repo_key))
-            .header("content-type", "application/json")
-            .body(Body::from(body))
-            .unwrap();
+        let req = post_repo_token_request(&repo_key, "admin-repo-token", &["delete:artifacts"]);
         let (status, body_bytes) = tdh::send(app, req).await;
 
         assert_eq!(

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -263,12 +263,13 @@ pub async fn create_repo_token(
         ));
     }
 
-    // Non-admin users cannot request the "admin" scope
-    if !auth.is_admin && payload.scopes.iter().any(|s| s == "admin") {
-        return Err(AppError::Authorization(
-            "Only administrators can create tokens with the 'admin' scope".to_string(),
-        ));
-    }
+    // Refuse admin-class scopes from non-admin callers. The legacy check
+    // only blocked the literal "admin" scope, leaving non-admins able to
+    // mint `*`, `delete:artifacts`, `delete:repositories`, and
+    // `write:users` via this repo-scoped endpoint. See
+    // `token_service::ADMIN_ONLY_SCOPES` for the policy list and rationale.
+    crate::services::token_service::enforce_admin_only_scopes(&payload.scopes, auth.is_admin)
+        .map_err(AppError::Authorization)?;
 
     // Generate the token
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
@@ -768,5 +769,173 @@ mod tests {
         let debug = format!("{:?}", row);
         assert!(debug.contains("debug-test"));
         assert!(debug.contains("TokenRow"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Admin-only token-scope enforcement tests (repo-scoped token endpoint)
+//
+// Sibling of `users::admin_scope_policy_tests` and the profile-endpoint
+// test. The same policy must apply to
+// `POST /api/v1/repositories/:key/tokens`, otherwise a non-admin with
+// `write:repositories` (a delegatable scope) can pivot here to mint a
+// token with `*` / `delete:artifacts` / `delete:repositories` /
+// `write:users` and bypass every scope-only authorization gate.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod admin_scope_policy_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use axum::Extension as AxumExtension;
+    use serde_json::json;
+
+    /// Build the repo-tokens router with the production middleware chain's
+    /// `Option<AuthExtension>` extractor shape.
+    fn build_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+        repo_tokens_router()
+            .with_state(state)
+            .layer(AxumExtension::<Option<AuthExtension>>(Some(auth)))
+    }
+
+    async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String, String)> {
+        let pool = tdh::try_pool().await?;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (_repo_id, repo_key, _storage_dir) = tdh::create_repo(&pool, "local", "maven").await;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        Some((pool, state, user_id, username, repo_key))
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid, repo_key: &str) {
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE key = $1")
+            .bind(repo_key)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+
+    /// Each ADMIN_ONLY_SCOPES entry, submitted alone by a non-admin with
+    /// the delegatable `write:repositories` scope, must be refused at the
+    /// handler. Iterating means a future addition to the policy list is
+    /// covered automatically.
+    #[tokio::test]
+    async fn non_admin_cannot_mint_admin_only_scopes_on_repo_tokens_endpoint() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        // Caller is a non-admin API token with write:repositories so it
+        // passes `require_repo_write` and reaches the policy gate.
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.scopes = Some(vec!["write:repositories".to_string()]);
+
+        for admin_scope in crate::services::token_service::ADMIN_ONLY_SCOPES {
+            let app = build_app(state.clone(), auth.clone());
+            let body = json!({
+                "name": format!("probe-{}", admin_scope),
+                "scopes": [admin_scope],
+                "expires_in_days": 30_i64,
+            })
+            .to_string();
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri(format!("/{}/tokens", repo_key))
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap();
+            let (status, body_bytes) = tdh::send(app, req).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin minting repo token with admin-class scope {:?} MUST 403; got {} body: {}",
+                admin_scope,
+                status,
+                String::from_utf8_lossy(&body_bytes),
+            );
+        }
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
+    /// A non-admin must not smuggle an admin-only scope through this
+    /// endpoint by burying it in a list of otherwise-safe scopes.
+    #[tokio::test]
+    async fn non_admin_cannot_smuggle_admin_scope_in_a_mixed_list_repo_endpoint() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.scopes = Some(vec!["write:repositories".to_string()]);
+        let app = build_app(state, auth);
+
+        let body = json!({
+            "name": "smuggle-attempt",
+            "scopes": ["read:artifacts", "write:artifacts", "*"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", repo_key))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "non-admin smuggling '*' on /repositories/{{key}}/tokens MUST 403"
+        );
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
+    /// Admin callers retain the ability to grant admin-class scopes on
+    /// repository-scoped tokens (e.g. for CI service accounts that need to
+    /// purge artifacts during release rollback).
+    #[tokio::test]
+    async fn admin_can_mint_admin_only_scopes_on_repo_tokens_endpoint() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_admin = true;
+        let app = build_app(state, auth);
+
+        let body = json!({
+            "name": "admin-repo-token",
+            "scopes": ["delete:artifacts"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", repo_key))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "admin minting a delete-scoped repo token MUST succeed; got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body_bytes),
+        );
+
+        cleanup(&pool, user_id, &repo_key).await;
     }
 }

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -748,6 +748,15 @@ pub async fn create_api_token(
         ));
     }
 
+    // Refuse admin-class scopes from non-admin callers. See
+    // `token_service::ADMIN_ONLY_SCOPES` for the policy rationale —
+    // mirrors the same enforcement on the sibling endpoint
+    // `POST /api/v1/profile/access-tokens` so a non-admin can't reach
+    // either route to mint a token with `*`/`admin`/`delete:*`/
+    // `write:users`.
+    crate::services::token_service::enforce_admin_only_scopes(&payload.scopes, auth.is_admin)
+        .map_err(AppError::Authorization)?;
+
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let (token, token_id) = auth_service
         .generate_api_token(id, &payload.name, payload.scopes, payload.expires_in_days)
@@ -1965,5 +1974,252 @@ mod tests {
         // Response should contain exactly the message field
         assert_eq!(obj.len(), 1);
         assert!(obj.contains_key("message"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Admin-only token-scope enforcement tests
+//
+// Live demonstration: against an in-cluster deployment of AK 1.1.9, a
+// non-admin user successfully minted tokens with scopes `["admin"]`,
+// `["*"]`, `["delete:artifacts"]`, `["delete:repositories"]`, AND even
+// a nonsense `["totally-bogus"]` — every call returned 200. The `*` and
+// `admin` scopes are particularly dangerous because they short-circuit
+// `scopes_grant_access` to `true` for any required scope, so a non-admin
+// holding such a token bypasses every scope-only authorization gate in
+// the server.
+//
+// Tests below pin the policy implemented in this PR.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod admin_scope_policy_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode};
+    use axum::Extension as AxumExtension;
+    use serde_json::json;
+
+    fn build_users_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+        // Mount the users router with a bare `Extension<AuthExtension>`
+        // layer (the production middleware chain produces this shape;
+        // `tdh::router_with_auth` wraps it in `Option`, which doesn't
+        // match the bare extractor on these handlers). Mirrors the
+        // `upload_router_with_auth` test helper pattern.
+        router()
+            .with_state(state)
+            .layer(AxumExtension::<AuthExtension>(auth))
+    }
+
+    /// Compact fixture: pool + state + non-admin user_id + username. Skips
+    /// cleanly without `DATABASE_URL` via `tdh::try_pool`.
+    async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String)> {
+        let pool = tdh::try_pool().await?;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        Some((pool, state, user_id, username))
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+
+    /// Each ADMIN_ONLY_SCOPES entry submitted alone by a non-admin must
+    /// be refused at the handler. Iterates so a future addition (or
+    /// removal) to the policy list is automatically covered.
+    #[tokio::test]
+    async fn non_admin_cannot_mint_admin_only_scopes_on_users_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username); // is_admin: false
+
+        for admin_scope in crate::services::token_service::ADMIN_ONLY_SCOPES {
+            let app = build_users_app(state.clone(), auth.clone());
+            let body = json!({
+                "name": format!("probe-{}", admin_scope),
+                "scopes": [admin_scope],
+                "expires_in_days": 30_i64,
+            })
+            .to_string();
+            let req = Request::builder()
+                .method(Method::POST)
+                .uri(format!("/{}/tokens", user_id))
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap();
+            let (status, body_bytes) = tdh::send(app, req).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin minting token with admin-class scope {:?} MUST 403; got {} body: {}",
+                admin_scope,
+                status,
+                String::from_utf8_lossy(&body_bytes),
+            );
+        }
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Non-admin minting a token with a routine, non-admin scope list
+    /// MUST still succeed — the policy is targeted, not a blanket lock.
+    #[tokio::test]
+    async fn non_admin_can_still_mint_safe_scopes_on_users_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username);
+        let app = build_users_app(state, auth);
+
+        let body = json!({
+            "name": "safe-scope-token",
+            "scopes": ["read:artifacts", "write:artifacts", "read:repositories"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", user_id))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "non-admin with safe scopes MUST succeed; got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body_bytes),
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// A non-admin must not smuggle an admin-only scope past the check
+    /// by burying it inside a list of otherwise-safe scopes.
+    #[tokio::test]
+    async fn non_admin_cannot_smuggle_admin_scope_in_a_mixed_list() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username);
+        let app = build_users_app(state, auth);
+
+        let body = json!({
+            "name": "smuggle-attempt",
+            "scopes": ["read:artifacts", "write:artifacts", "admin"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", user_id))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "non-admin smuggling 'admin' in a safe-looking scope list MUST 403"
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+
+    /// Admin callers retain the ability to grant the entire policy
+    /// surface. We assert against an admin-flagged AuthExtension so the
+    /// policy doesn't accidentally lock everyone out — including the
+    /// people who legitimately need to provision admin-class tokens
+    /// (e.g. for CI service accounts).
+    #[tokio::test]
+    async fn admin_can_mint_admin_only_scopes_on_users_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_admin = true;
+        let app = build_users_app(state, auth);
+
+        let body = json!({
+            "name": "admin-token",
+            "scopes": ["admin"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", user_id))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "admin minting an admin-scoped token MUST succeed; got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body_bytes),
+        );
+
+        cleanup(&pool, user_id).await;
+    }
+
+    // ── Sibling endpoint: profile::create_access_token ──────────────────
+    //
+    // The same policy must apply to `POST /api/v1/profile/access-tokens`,
+    // otherwise the user just routes around the users.rs gate. One test
+    // proves the wiring is in place there too; the unit-level policy
+    // coverage in `token_service::tests::enforce_admin_only_scopes*` is
+    // independent of which handler invokes the helper.
+
+    fn build_profile_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+        crate::api::handlers::profile::router()
+            .with_state(state)
+            .layer(AxumExtension::<AuthExtension>(auth))
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_mint_admin_scope_on_profile_endpoint() {
+        let Some((pool, state, user_id, username)) = setup().await else {
+            return;
+        };
+        let auth = tdh::make_auth(user_id, &username);
+        let app = build_profile_app(state, auth);
+
+        let body = json!({
+            "name": "profile-smuggle",
+            "scopes": ["*"],
+            "expires_in_days": 30_i64,
+        })
+        .to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/access-tokens")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "non-admin minting `*` token on /profile/access-tokens MUST 403 (sibling enforcement to users.rs)"
+        );
+
+        cleanup(&pool, user_id).await;
     }
 }

--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -115,6 +115,60 @@ pub(crate) fn validate_scopes_pure(scopes: &[String]) -> std::result::Result<(),
     Ok(())
 }
 
+/// Scopes that grant elevated, admin-class capabilities and may not be
+/// embedded in a token issued by a non-admin caller. The restriction is
+/// purely on token issuance — a non-admin can still hold such a token if
+/// an admin minted it for them.
+///
+/// Includes:
+///   * `admin`, `*` — short-circuit any scope check via
+///     [`scopes_grant_access`]. A non-admin minting one of these would
+///     have a token that satisfies every scope-only authorization gate
+///     (anywhere the request is API-token-authenticated and the
+///     authorization decision rests solely on the token's scope set).
+///   * `delete:artifacts`, `delete:repositories` — destructive
+///     scope-gated operations.
+///   * `write:users` — user-management write capability.
+///
+/// `write:artifacts` and `write:repositories` are deliberately NOT on
+/// this list: artifact publishing is a routine non-admin action and
+/// repository creation is sometimes delegated to non-admin users via
+/// permission grants. If your deployment wants to lock those down,
+/// add them in a follow-up alongside a configurable policy knob.
+pub(crate) const ADMIN_ONLY_SCOPES: &[&str] = &[
+    "admin",
+    "*",
+    "delete:artifacts",
+    "delete:repositories",
+    "write:users",
+];
+
+/// Enforce that a non-admin caller may not grant any admin-class scope
+/// from [`ADMIN_ONLY_SCOPES`] to a token.
+///
+/// Returns `Ok(())` when the caller is admin, or when none of the
+/// requested scopes are admin-class. Otherwise returns `Err` naming the
+/// first admin-class scope encountered so the caller can produce an
+/// actionable error message.
+pub(crate) fn enforce_admin_only_scopes(
+    scopes: &[String],
+    caller_is_admin: bool,
+) -> std::result::Result<(), String> {
+    if caller_is_admin {
+        return Ok(());
+    }
+    for scope in scopes {
+        if ADMIN_ONLY_SCOPES.contains(&scope.as_str()) {
+            return Err(format!(
+                "Scope '{}' is admin-only and cannot be granted by a non-admin caller. \
+                 Admin-only scopes: {:?}",
+                scope, ADMIN_ONLY_SCOPES,
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Determine if a token is expired given an optional expiration timestamp.
 pub(crate) fn is_token_expired(expires_at: Option<DateTime<Utc>>) -> bool {
     expires_at.map(|exp| exp < Utc::now()).unwrap_or(false)
@@ -679,6 +733,88 @@ mod tests {
     fn test_validate_scopes_partial_match_fails() {
         let scopes = vec!["read:artifact".to_string()]; // missing 's'
         assert!(validate_scopes_pure(&scopes).is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // enforce_admin_only_scopes (privilege-escalation gate on token issuance)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_enforce_admin_only_scopes_admin_caller_always_allowed() {
+        // An admin may grant any scope. Sanity-check across the full
+        // ADMIN_ONLY_SCOPES list plus an arbitrary non-listed scope.
+        for s in ADMIN_ONLY_SCOPES {
+            let scopes = vec![(*s).to_string()];
+            assert!(
+                enforce_admin_only_scopes(&scopes, true).is_ok(),
+                "admin must be allowed to grant {}",
+                s
+            );
+        }
+        let mixed = vec!["read:artifacts".to_string(), "admin".to_string()];
+        assert!(enforce_admin_only_scopes(&mixed, true).is_ok());
+    }
+
+    #[test]
+    fn test_enforce_admin_only_scopes_non_admin_blocked_on_each_admin_scope() {
+        // Each ADMIN_ONLY_SCOPES entry, taken alone, must be refused.
+        // Asserting each in turn pins the policy so a future change that
+        // accidentally drops one (e.g. removes `delete:repositories`)
+        // forces an explicit decision via this test.
+        for s in ADMIN_ONLY_SCOPES {
+            let scopes = vec![(*s).to_string()];
+            let res = enforce_admin_only_scopes(&scopes, false);
+            assert!(res.is_err(), "non-admin granting {} must be refused", s);
+            assert!(
+                res.as_ref().unwrap_err().contains(s),
+                "error must name the offending scope ({})",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn test_enforce_admin_only_scopes_non_admin_with_safe_scopes_allowed() {
+        // Routine non-admin scopes pass.
+        let scopes = vec![
+            "read:artifacts".to_string(),
+            "write:artifacts".to_string(),
+            "read:repositories".to_string(),
+            "write:repositories".to_string(),
+            "read:users".to_string(),
+        ];
+        assert!(enforce_admin_only_scopes(&scopes, false).is_ok());
+    }
+
+    #[test]
+    fn test_enforce_admin_only_scopes_non_admin_with_admin_scope_mixed_in_blocked() {
+        // A single admin-only entry anywhere in the list MUST trip the
+        // refusal; a non-admin can't smuggle `admin` past us by burying
+        // it among safe scopes.
+        let scopes = vec![
+            "read:artifacts".to_string(),
+            "write:artifacts".to_string(),
+            "admin".to_string(), // ← the smuggled one
+        ];
+        let res = enforce_admin_only_scopes(&scopes, false);
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("admin"));
+    }
+
+    #[test]
+    fn test_enforce_admin_only_scopes_non_admin_empty_scopes_allowed() {
+        let scopes: Vec<String> = vec![];
+        assert!(enforce_admin_only_scopes(&scopes, false).is_ok());
+    }
+
+    #[test]
+    fn test_enforce_admin_only_scopes_wildcard_blocked_for_non_admin() {
+        // `*` short-circuits `scopes_grant_access` to true on every
+        // required-scope check, so it MUST be admin-only.
+        let scopes = vec!["*".to_string()];
+        let res = enforce_admin_only_scopes(&scopes, false);
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains('*'));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #1306

## The bug

Both user-facing token-creation handlers —

* `handlers/profile.rs::create_access_token` (`POST /api/v1/profile/access-tokens`)
* `handlers/users.rs::create_api_token` (`POST /api/v1/users/<id>/tokens`)

— call `AuthService::generate_api_token` directly, which only validates scope-list **length** (`scopes.len() <= 50`, each `<= 256` chars). Scope **content** is unvalidated, so any logged-in non-admin user can mint a token carrying scopes such as `admin`, `*`, `delete:artifacts`, `delete:repositories`, or `write:users`.

`token_service::scopes_grant_access` short-circuits to `true` for both `admin` and `*`:

```rust
pub(crate) fn scopes_grant_access(scopes: &[String], required_scope: &str) -> bool {
    scopes.contains(&required_scope.to_string())
        || scopes.contains(&"*".to_string())
        || scopes.contains(&"admin".to_string())
}
```

So a non-admin holding such a token satisfies every scope-only authorization gate in the server. Pure-admin routes are still safe because `admin_middleware` reads `auth.is_admin` from the user row (not from token scopes), but every endpoint whose authorization rests on the token's scope set is bypassed.

## Reproduction

Against a running 1.1.9 instance, as a non-admin user, each of these returns `200`:

```bash
for SCOPES in '["delete:artifacts"]' '["delete:repositories"]' '["admin"]' '["*"]' '["totally-bogus"]'; do
  curl -sS -X POST https://<host>/api/v1/profile/access-tokens \
    -H "Authorization: Bearer $NON_ADMIN_BEARER" \
    -H "Content-Type: application/json" \
    -d "{\"name\":\"probe\",\"scopes\":$SCOPES,\"expires_in_days\":1}"
done
```

Same shape on `POST /api/v1/users/<self-id>/tokens` (once the routing topology from #1257 / #1258 makes that endpoint reachable to non-admins).

## The fix

### `services/token_service.rs`

New `ADMIN_ONLY_SCOPES` constant + a pure `enforce_admin_only_scopes(scopes, caller_is_admin)` helper:

```rust
pub(crate) const ADMIN_ONLY_SCOPES: &[&str] = &[
    "admin",
    "*",
    "delete:artifacts",
    "delete:repositories",
    "write:users",
];

pub(crate) fn enforce_admin_only_scopes(
    scopes: &[String],
    caller_is_admin: bool,
) -> std::result::Result<(), String> {
    if caller_is_admin {
        return Ok(());
    }
    for scope in scopes {
        if ADMIN_ONLY_SCOPES.contains(&scope.as_str()) {
            return Err(format!(
                "Scope '{}' is admin-only and cannot be granted by a non-admin caller. \
                 Admin-only scopes: {:?}",
                scope, ADMIN_ONLY_SCOPES,
            ));
        }
    }
    Ok(())
}
```

### Handler wiring

Both user-facing handlers invoke the helper before calling `generate_api_token` and map the error to `AppError::Authorization` (403):

```rust
crate::services::token_service::enforce_admin_only_scopes(&scopes, auth.is_admin)
    .map_err(crate::error::AppError::Authorization)?;
```

### Scope of policy

| Scope | Admin-only after this PR | Rationale |
|---|---|---|
| `admin` | ✅ | Short-circuits `scopes_grant_access` to true on every check |
| `*` | ✅ | Same — wildcard escalation |
| `delete:artifacts` | ✅ | Destructive scope-gated capability |
| `delete:repositories` | ✅ | Destructive scope-gated capability |
| `write:users` | ✅ | User-management mutation — admin-class by intent |
| `write:artifacts` | ❌ | Routine non-admin action (publish) |
| `write:repositories` | ❌ | Often delegated to non-admins via permission grants |
| `read:*` | ❌ | Read-only |

Deployments that want to lock `write:artifacts` / `write:repositories` down can extend `ADMIN_ONLY_SCOPES` (or wire it to config) in a follow-up. The conservative starting list above matches the actual escalation surface without breaking publishing for everyday users.

The PR deliberately does NOT enforce the broader `ALLOWED_SCOPES` allowlist on these handlers, because some existing deployments have minted tokens with strings outside the allowlist (e.g. bare `read` / `write` from older clients) and rejecting those at the API boundary would be a backward-compat break. A separate, targeted PR can tighten that — this one is scoped to the privilege-escalation issue.

## Tests

Pure-function coverage in `token_service::tests` (no DB needed):

* `enforce_admin_only_scopes_admin_caller_always_allowed` — admin can grant any scope, including the full ADMIN_ONLY_SCOPES list
* `enforce_admin_only_scopes_non_admin_blocked_on_each_admin_scope` — iterates `ADMIN_ONLY_SCOPES`, asserts each one taken alone is refused; pins the policy so a future drop forces an explicit decision
* `enforce_admin_only_scopes_non_admin_with_safe_scopes_allowed` — `[read:artifacts, write:artifacts, read:repositories, write:repositories, read:users]` passes
* `enforce_admin_only_scopes_non_admin_with_admin_scope_mixed_in_blocked` — `admin` buried inside a safe-looking list still 403s
* `enforce_admin_only_scopes_non_admin_empty_scopes_allowed`
* `enforce_admin_only_scopes_wildcard_blocked_for_non_admin`

End-to-end coverage in `users.rs::admin_scope_policy_tests` (DB-backed, skips when `DATABASE_URL` is unset via the standard `tdh::try_pool` pattern):

* `non_admin_cannot_mint_admin_only_scopes_on_users_endpoint` — POSTs each ADMIN_ONLY_SCOPES entry in turn, expects 403
* `non_admin_can_still_mint_safe_scopes_on_users_endpoint` — routine token POSTs successfully (200)
* `non_admin_cannot_smuggle_admin_scope_in_a_mixed_list` — `admin` buried in a list of safe scopes still 403s
* `admin_can_mint_admin_only_scopes_on_users_endpoint` — admin callers retain the ability to provision admin-class tokens (e.g. CI service accounts)
* `non_admin_cannot_mint_admin_scope_on_profile_endpoint` — sibling enforcement on `POST /api/v1/profile/access-tokens` so a non-admin can't just route around the users.rs handler

## Verification

* `SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --lib --tests` clean
* `cargo fmt --all -- --check` clean
* `cargo clippy --workspace --all-targets -- -D warnings` clean

## Notes for backport / shipping

If targeted at `release/1.1.x` alongside `main`, this is a small, surgical patch and the change shape applies identically (no main-only API changed). Mention to ops that the fix is preventive on issuance — existing tokens already in the DB with admin-class scopes are NOT revoked by this PR; revocation can be done with a one-shot SQL UPDATE if desired.