### PR TITLE
chore(release): bump workspace version to 1.2.0-rc.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0-rc.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"


### PR DESCRIPTION
## Summary

Bumps `[workspace.package].version` from `1.1.2` to `1.2.0-rc.1`. This is the unblocking step for v1.2.0-rc.1; everything that's been merged to main since `v1.1.9` is feature-gated in release-gate tests via `/health.version`, and pre-bump that endpoint reports `1.1.2` (the literal workspace version) on every main build.

## Why now (the unlock)

Release-gate run [`26107615074`](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26107615074) on commit `6c990778` reported 17 failed gates. The failure mode is `feature_flag_enabled()` in `tests/lib/common.sh` reading `/health.version`, getting `"1.1.2"`, and skipping every feature added since 1.1.2 — even though main has all of them. `RELEASE_GATE=1` converts the skips to hard fails:

```
SKIP: feature 'download_ticket_consumer' requires backend >= 1.1.9, running 1.1.2
SKIP: feature 'refresh_token_rotation' requires backend >= 1.1.9, running 1.1.2
SKIP: feature 'user_deactivation_token_flush' requires backend >= 1.1.9, running 1.1.2
```

Triage doc at [`/tmp/ak-goal/v1.2.0-gate-triage.md`](https://github.com/artifact-keeper/artifact-keeper-test/blob/main/docs/triage-2026-05-17-epic-coverage.md) found **0 real backend bugs** in the 13 failing gates from the prior run — it's the version pin alone.

## What this PR does

One line change:

```diff
 [workspace.package]
-version = "1.1.2"
+version = "1.2.0-rc.1"
```

## After merge

1. `Docker Publish` workflow fires on main; rebuilds `ghcr.io/artifact-keeper/artifact-keeper-backend:dev` with the new version string baked in
2. Re-trigger release-gate against `dev` — expect ~10 of the prior failures to clear naturally
3. Address residual failures via [#187](https://github.com/artifact-keeper/artifact-keeper-test/pull/187) (lifecycle `auth_type` + webhook private-IP) and any documented skips
4. Tag `v1.2.0-rc.1` to release

## Test Checklist

- [x] `cargo fmt --check` passes (Cargo.toml-only change, fmt doesn't touch it)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — N/A for version string
- [x] `cargo check --workspace` — clean (1m02s locally)
- [x] No `--no-verify` / `--admin` bypasses

## API Changes

None — purely version-string change. Compatible with all consumers.

## Refs

- artifact-keeper-test [`#187`](https://github.com/artifact-keeper/artifact-keeper-test/pull/187) — companion test-side fixes (lifecycle migration `auth_type`, webhook private-IP)
- artifact-keeper-test release-gate runs [`26008441321`](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26008441321), [`26107615074`](https://github.com/artifact-keeper/artifact-keeper-test/actions/runs/26107615074)
- Customer report [#1263](https://github.com/artifact-keeper/artifact-keeper/issues/1263) (PyPI proxy slow-path) — already addressed by #1178 + #1181 + #1203 which are on this branch