### PR TITLE
fix(migration): correct column names + required NOT NULL columns in MigrationService

### DIFF
--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -311,7 +311,7 @@ impl MigrationService {
         // Check if repository with same key exists
         let existing: Option<(String, String)> = sqlx::query_as(
             r#"
-            SELECT repository_type, format
+            SELECT repo_type::text, format::text
             FROM repositories
             WHERE key = $1
             "#,
@@ -387,23 +387,24 @@ impl MigrationService {
 
         let repo_type = config.repo_type.to_artifact_keeper();
 
+        // The repositories table schema has no `metadata`, `display_name`, or
+        // `repository_type` columns. The corresponding columns are `name` and
+        // `repo_type`, and `storage_path` is NOT NULL — so the INSERT must
+        // supply it. We default storage_path to the repository key, matching
+        // how local repos are typically named by the storage backend.
         let repo_id: (Uuid,) = sqlx::query_as(
             r#"
-            INSERT INTO repositories (key, display_name, repository_type, format, description, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6)
+            INSERT INTO repositories (key, name, description, format, repo_type, storage_path)
+            VALUES ($1, $2, $3, $4::repository_format, $5::repository_type, $6)
             RETURNING id
             "#,
         )
         .bind(&config.target_key)
-        .bind(&config.target_key) // display_name same as key
-        .bind(repo_type)
-        .bind(&format)
+        .bind(&config.target_key) // name same as key for auto-provisioned repos
         .bind(&config.description)
-        .bind(serde_json::json!({
-            "migrated_from": "artifactory",
-            "source_key": config.source_key,
-            "original_package_type": config.package_type,
-        }))
+        .bind(&format)
+        .bind(repo_type)
+        .bind(&config.target_key) // storage_path defaults to key
         .fetch_one(&self.db)
         .await?;
 


### PR DESCRIPTION
Closes #1305

## Summary

`MigrationService::check_repository_conflict` and `MigrationService::create_repository` reference columns on the `repositories` table that don't exist on the actual schema. The queries have been latent since the original artifactory-migration PR (#17) because nothing in the worker called these helpers — they sat as dead code. After destination-repo auto-provisioning was wired into `migration_worker::process_job` (#1017), every migration job where the target repository already exists in AK now fails at the very first SELECT with:

```
Database error: error returned from database:
column "repository_type" does not exist
```

The bug only fires on Artifact Keeper releases that include the new worker pre-pass (1.2.0-rc.1 and later); older releases never reached this code path, which is why CI integration didn't catch it.

## Two distinct issues fixed

### 1. `check_repository_conflict` SELECT (was `migration_service.rs:312-321`)

```sql
SELECT repository_type, format
FROM repositories
WHERE key = $1
```

- `repository_type` is the **enum type name**, not the column name. The column is `repo_type` (per `003_repositories.sql:16`).
- `repo_type` and `format` are both ENUMs, so decoding into `(String, String)` needs explicit `::text` casts; otherwise sqlx returns a runtime decode error.

After the fix:

```sql
SELECT repo_type::text, format::text
FROM repositories
WHERE key = $1
```

### 2. `create_repository` INSERT (was `migration_service.rs:390-408`)

```sql
INSERT INTO repositories (key, display_name, repository_type, format, description, metadata)
VALUES ($1, $2, $3, $4, $5, $6)
```

Three of the six columns don't exist on the actual `repositories` schema:

| Used | Actual |
|---|---|
| `display_name` | `name` |
| `repository_type` | `repo_type` |
| `metadata` | *(no such column on this table)* |

Two more problems:
- `storage_path` is `NOT NULL` with no DEFAULT (`003_repositories.sql:21`) but the INSERT never supplied a value. Even with the column names corrected, the INSERT would fail with a NOT NULL constraint violation.
- The `serde_json::json!({...})` payload was bound to a non-existent column and silently dropped on the wire.

After the fix:

```sql
INSERT INTO repositories (key, name, description, format, repo_type, storage_path)
VALUES ($1, $2, $3, $4::repository_format, $5::repository_type, $6)
RETURNING id
```

- `name` and `storage_path` both default to the migration's target key for auto-provisioned repos, matching the convention of "key as the canonical identifier for locally-stored repos".
- The migration provenance that the dropped `metadata` payload tried to encode is already recorded in the `migrations` table's `config.include_repos` and source connection — no information loss.

## Reproducer (against any AK 1.2.0-rc.1 deployment)

1. Pre-create a repository, e.g. `pypi-local`, via the normal `POST /api/v1/repositories` API.
2. Add an Artifactory source connection that has a repository with the same key.
3. POST a migration with `include_repos: ["pypi-local"]`, then POST `/start`.

Expected: the worker recognizes the existing AK repository and proceeds to artifact transfer (auto-create not needed).
Observed without this fix: the migration job flips to `failed` in ~200 ms with the column-not-found error above; `total_items=0`.

## Why no tests catch this today

`migration_service.rs`'s existing unit tests are all pure (no DB). The queries fixed here were dead until the worker started invoking them — no integration test exercises `check_repository_conflict` / `create_repository` end-to-end against a real Postgres schema. A follow-up adding DB-backed regression tests for these helpers is worth doing; this PR keeps scope to the schema corrections so the fix can ship quickly.

## Local verification

```
$ SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --tests
    Finished `dev` profile target(s)

$ cargo fmt --all -- --check
    (clean)

$ SQLX_OFFLINE=true cargo clippy -p artifact-keeper-backend --lib --no-deps -- -D warnings
    Finished `dev` profile target(s)

$ SQLX_OFFLINE=true cargo test -p artifact-keeper-backend --lib migration_service
    test result: ok. 81 passed; 0 failed
```