### PR TITLE
fix(migrations): raise statement_timeout/lock_timeout for the migration session

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -176,7 +176,23 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     } else {
         tracing::info!("Running database migrations...");
         repair_legacy_073_checksum(&db_pool).await?;
-        sqlx::migrate!("./migrations").run(&db_pool).await?;
+        // Some migrations (e.g. CREATE INDEX on a populated `artifacts` table
+        // or backfill UPDATEs) take longer than the per-query
+        // `statement_timeout` that operators commonly set on their Postgres
+        // parameter group as an app-query safeguard (10 s on AWS RDS for many
+        // tunings). Acquire a dedicated connection and raise the timeouts
+        // session-locally so the migration runner doesn't share fate with
+        // production query limits. The SET is per-session and is wiped when
+        // the connection is dropped — global limits for normal app queries
+        // are unaffected.
+        let mut conn = db_pool.acquire().await?;
+        sqlx::query("SET statement_timeout = '30min'")
+            .execute(&mut *conn)
+            .await?;
+        sqlx::query("SET lock_timeout = '5min'")
+            .execute(&mut *conn)
+            .await?;
+        sqlx::migrate!("./migrations").run(&mut *conn).await?;
         tracing::info!("Database migrations complete");
     }
 


### PR DESCRIPTION
Closes #1304

## Summary

`sqlx::migrate!().run(&db_pool)` inherits whatever per-query `statement_timeout` the migration session happens to get from the connecting client — usually whatever the operator's Postgres parameter group applies as a safeguard against runaway application queries (10 s on many AWS RDS tunings, 30 s common elsewhere).

That safeguard exists for a reason — runaway app queries should die — but it's the wrong ceiling for **schema-modifying migrations**, which legitimately run longer:

- `CREATE INDEX` on a populated table once the deployment has 10⁶+ rows. We just hit this on a `(repository_id, LOWER(name))` partial index against ~1.74M rows of `artifacts` — 10 s wasn't even close.
- `ALTER TABLE ADD COLUMN ... NOT NULL DEFAULT <non-constant>` (e.g. `gen_random_uuid()`) — Postgres rewrites every row.
- Backfill `UPDATE` statements bundled into migrations (`UPDATE artifacts SET … WHERE …`).
- Migrations that need `ACCESS EXCLUSIVE` while application pods hold shared locks on the same table — the migrator queues on the lock, then the global `statement_timeout` clock kills it before it's even started.

When the global timeout fires, the migration crashes mid-flight, the pod fails to boot, the operator sees `Migration(VersionMismatch)` or raw `statement timeout` errors on every restart, and there's no in-band recovery. The escape hatch today is a manual psql session with `SET statement_timeout = 0` followed by running the SQL by hand and inserting the `_sqlx_migrations` row with the canonical SHA-384 checksum — fragile, error-prone, requires deep familiarity with sqlx internals.

## The fix

Raising the parameter-group value globally is the wrong knob to turn; the value exists specifically to constrain runaway app queries. The right fix is for the migration session to be exempt.

This change acquires a dedicated connection from the pool just for the migration, raises both `statement_timeout` and `lock_timeout` to operationally-safe values (30 min and 5 min), and runs migrations against that connection:

```rust
let mut conn = db_pool.acquire().await?;
sqlx::query("SET statement_timeout = '30min'").execute(&mut *conn).await?;
sqlx::query("SET lock_timeout = '5min'").execute(&mut *conn).await?;
sqlx::migrate!("./migrations").run(&mut *conn).await?;
```

`SET` without `LOCAL` is session-local — it's wiped as soon as the connection is returned to the pool, so subsequent application traffic on other connections is unaffected. No change to the global app-query safeguard, no change to the parameter group, no infra-side coordination required.

## Knob choices

- **`statement_timeout = 30min`**: intentionally finite (not zero) so a genuinely-runaway migration still fails loudly rather than wedging the deployment indefinitely. 30 min is a reasonable upper bound for any single schema statement; anything longer should be split into smaller batches or run out-of-band.
- **`lock_timeout = 5min`**: separate knob that controls how long the migrator waits for `ACCESS EXCLUSIVE` before bailing. Enough to ride out brief pod-lock contention during a rolling restart (the new pod tries to migrate while the old pod is still serving + holding shared locks) but not so long that a stuck session pins the migration indefinitely.

Operators who need different values can still bypass via `SKIP_MIGRATIONS=true` and run migrations manually with whatever session settings they want.

## Why not make this configurable

I considered `MIGRATION_STATEMENT_TIMEOUT_SECS` / `MIGRATION_LOCK_TIMEOUT_SECS` env vars. The values chosen here are operationally safe upper bounds for almost every plausible migration — operators who need radically different values have a more fundamental problem (a migration that legitimately needs >30 min should be split, or run out-of-band). Erring on the side of fewer knobs to keep the migration surface area small.

## Verification

```
$ SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --tests
    Finished `dev` profile target(s)

$ cargo fmt --all -- --check
    (clean)

$ SQLX_OFFLINE=true cargo clippy -p artifact-keeper-backend --lib --no-deps -- -D warnings
    Finished `dev` profile target(s)
```

Behavioural test wasn't added because the failure mode requires (a) a Postgres with a small `statement_timeout` and (b) a populated table large enough for the migration to exceed it. Documenting in the migration runbook as the right path.

## Related context

Real-world incident this fix addresses: a deployment with `statement_timeout = 10s` on its Postgres parameter group hit migration 106 (`CREATE INDEX … ON artifacts (repository_id, LOWER(name)) WHERE is_deleted = false`) on a 1.74M-row `artifacts` table. The index build needed `ACCESS EXCLUSIVE` while a still-serving pod from the previous version held shared locks on the same table — the lock wait alone was hundreds of milliseconds, then the index build started, then `statement_timeout` killed it ~10 s in. Recovery required out-of-band `CREATE INDEX CONCURRENTLY` followed by a manual `INSERT INTO _sqlx_migrations` with the canonical sha384 checksum. With this fix the migration would have completed in ~30-60 s on its own.