### PR TITLE
fix(setup): make admin password retrieval instructions runtime-agnostic

### DIFF
--- a/backend/src/api/middleware/setup.rs
+++ b/backend/src/api/middleware/setup.rs
@@ -54,7 +54,9 @@ pub async fn setup_guard(
             "error": "SETUP_REQUIRED",
             "message": "Initial setup is required. Change the admin password to unlock the API.",
             "instructions": [
-                "1. Read the generated password: docker exec artifact-keeper-backend cat /data/storage/admin.password && echo",
+                "1. Read the generated password by exec'ing into the artifact-keeper backend container and running: cat /data/storage/admin.password",
+                "   - Docker:     docker exec artifact-keeper-backend cat /data/storage/admin.password && echo",
+                "   - Kubernetes: kubectl exec deploy/artifact-keeper-backend -- cat /data/storage/admin.password",
                 "2. Login: POST /api/v1/auth/login with {\"username\":\"admin\",\"password\":\"<from-file>\"}",
                 "3. Change password: POST /api/v1/users/<id>/password with {\"new_password\":\"<your-password>\"}",
                 "4. The API will unlock automatically after the password is changed.",

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1512,7 +1512,9 @@ fn log_admin_setup_banner(password_file: &std::path::Path, password: Option<&str
         {}\
         \n\
           File:      {}\n\
-          Read it:   docker exec artifact-keeper-backend cat {}\n\
+          Read it by exec'ing into the artifact-keeper backend container:\n\
+            Docker:      docker exec artifact-keeper-backend cat {}\n\
+            Kubernetes:  kubectl exec deploy/artifact-keeper-backend -- cat {}\n\
         \n\
           The API is LOCKED until you change this password.\n\
           Open the web UI and log in -- you will be redirected to\n\
@@ -1524,6 +1526,7 @@ fn log_admin_setup_banner(password_file: &std::path::Path, password: Option<&str
         \n\
         ===========================================================",
         password_line,
+        password_file.display(),
         password_file.display(),
         password_file.display(),
     );


### PR DESCRIPTION
Closes #1302

## Summary

The initial-setup banner and the `SETUP_REQUIRED` API error both hardcoded `docker exec artifact-keeper-backend cat /data/storage/admin.password`. Operators running artifact-keeper on Kubernetes (e.g., via the official Helm chart) cannot copy-paste that command — `docker` does not see the pod. They have to translate to `kubectl exec deploy/artifact-keeper-backend -- ...` on the fly, which is friction on the bigger the cluster, and a foot-gun for operators who hit `SETUP_REQUIRED` via an API client rather than reading the startup log.

This PR surfaces both invocations side-by-side at both call sites so the instructions are immediately useful regardless of runtime:

- Docker:     `docker exec artifact-keeper-backend cat <file>`
- Kubernetes: `kubectl exec deploy/artifact-keeper-backend -- cat <file>`

No runtime detection (`KUBERNETES_SERVICE_HOST` probing, etc.) is performed — listing both keeps the message correct in environments we don't probe (Podman, Nomad, bare-metal `nsenter`, etc.) and avoids a code path that's awkward to unit-test.

Affected files:
- `backend/src/api/middleware/setup.rs` — JSON `SETUP_REQUIRED` response
- `backend/src/main.rs` — `log_admin_setup_banner` startup log

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

<!--
Honest disclosure: this PR is a `fix/*` (the wrong-for-K8s instructions
are a bug), but neither checkbox quite fits. A regression test that pins
the new operator-facing copy verbatim would be brittle (any future
wording polish triggers a CI failure for no real reason), and no existing
test asserts the old text (verified with `rg "Read the generated password|Read it:|docker exec artifact" --type rust`).

If reviewers want one, the least-brittle shape would be a smoke test
that asserts the rendered messages CONTAIN both `docker exec` and `kubectl exec`
markers — i.e. asserting the *intent* (both runtimes documented) rather
than the literal text. Happy to add that; flagging the trade-off before
writing one.
-->

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (verified the new banner via `cargo build` and reviewed both call sites)
- [x] No regressions in existing tests (`cargo test --workspace --lib` → 9586 passed, 0 failed)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (the JSON shape of `SETUP_REQUIRED` 403 is unchanged; only human-readable strings in `instructions[]` changed)