### PR TITLE
fix: proxy generic streaming

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -6256,4 +6256,283 @@ mod tests {
              be simplified."
         );
     }
+
+    // ---------------------------------------------------------------------
+    // download_artifact: remote-repo streaming-fallback path (#1300 / PR #1294).
+    //
+    // The generic `/:key/download/*path` handler used to buffer the full
+    // upstream body into memory before responding, which OOM-killed pods
+    // serving multi-GB artifacts. PR #1294 migrated the remote-NotFound
+    // fallback arm to `proxy_helpers::proxy_fetch_streaming`. These tests
+    // pin that contract end-to-end:
+    //
+    //   1. wiremock stands in for the real upstream
+    //   2. an empty `artifacts` table forces `artifact_service.download`
+    //      to return NotFound, which routes execution into the new
+    //      `proxy_fetch_streaming(..)` block (lines 2159-2169)
+    //   3. assertions confirm the bytes round-trip and the streaming
+    //      Content-Type / Content-Length headers come from upstream
+    //
+    // Without these tests the new lines have no coverage in CI: every
+    // other download path the handler can take terminates before the
+    // remote-fallback arm. See PR #1294 review and the 70% new-code
+    // coverage gate in `.github/workflows/ci.yml` (`coverage` job).
+    // ---------------------------------------------------------------------
+
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    /// Update the `upstream_url` and `is_public` columns on a repository row.
+    /// Lets the test point a Remote repo at a wiremock server (which only
+    /// has a stable URL after `MockServer::start().await`) and skip auth
+    /// without needing a separate admin-user fixture.
+    async fn point_repo_at_upstream(pool: &sqlx::PgPool, repo_id: Uuid, upstream: &str) {
+        sqlx::query(
+            "UPDATE repositories \
+             SET upstream_url = $2, is_public = true \
+             WHERE id = $1",
+        )
+        .bind(repo_id)
+        .bind(upstream)
+        .execute(pool)
+        .await
+        .expect("update repo upstream_url");
+    }
+
+    #[tokio::test]
+    async fn test_download_artifact_remote_streams_upstream_body() {
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+
+        // Stand up the upstream and pin a single path.
+        let server = wiremock::MockServer::start().await;
+        let upstream_body: &[u8] = b"the-streamed-bytes-from-upstream";
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/foo/bar.tgz"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_bytes(upstream_body)
+                    .insert_header("content-type", "application/x-tar"),
+            )
+            .mount(&server)
+            .await;
+
+        point_repo_at_upstream(&fx.pool, fx.repo_id, &server.uri()).await;
+
+        // Build state with a real proxy_service so the streaming-fallback
+        // arm in `download_artifact` has somewhere to dispatch to.
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+
+        // Anonymous request: `is_public = true` makes require_visible pass
+        // without needing to thread an admin AuthExtension through.
+        let router = tdh::router_anon(download_router(), state);
+        let req = tdh::get(format!("/{}/download/foo/bar.tgz", fx.repo_key));
+        let (status, body) = tdh::send(router, req).await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "remote-NotFound branch must stream a 200 (not OOM on a buffered \
+             alloc, not 404 from the local-fetch arm)"
+        );
+        assert_eq!(
+            &body[..],
+            upstream_body,
+            "streamed body bytes must round-trip from wiremock through \
+             proxy_fetch_streaming and back to the caller"
+        );
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_download_artifact_remote_propagates_upstream_content_type() {
+        // The handler passes "application/octet-stream" as the
+        // `default_content_type` to `proxy_fetch_streaming`, but the
+        // upstream-supplied `content-type` must win when present. This
+        // pins the precedence rule alongside the body round-trip above.
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/some/file.bin"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_bytes(b"ctype-pinned".as_ref())
+                    .insert_header("content-type", "application/java-archive"),
+            )
+            .mount(&server)
+            .await;
+
+        point_repo_at_upstream(&fx.pool, fx.repo_id, &server.uri()).await;
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let router = tdh::router_anon(download_router(), state);
+        let req = tdh::get(format!("/{}/download/some/file.bin", fx.repo_key));
+        // Reach into the router directly so we can also inspect headers
+        // before draining the body into bytes.
+        use tower::ServiceExt;
+        let resp = router.oneshot(req).await.expect("oneshot");
+
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+        assert_eq!(
+            ct, "application/java-archive",
+            "upstream content-type must override the handler's \
+             `application/octet-stream` default fallback"
+        );
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 1024)
+            .await
+            .expect("body");
+        assert_eq!(&body_bytes[..], b"ctype-pinned");
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_download_artifact_remote_returns_default_content_type_when_upstream_omits_it() {
+        // When upstream doesn't set Content-Type, the handler's
+        // `application/octet-stream` default must be applied. This covers
+        // the `default_content_type` argument plumbed through #1294.
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/no/ctype.bin"))
+            .respond_with(
+                // No content-type header. wiremock will still emit a
+                // default `Content-Type: application/octet-stream` for
+                // raw byte bodies in some versions, but in this codebase
+                // we rely on the upstream metadata `content_type` field
+                // being None to exercise the default fallback.
+                wiremock::ResponseTemplate::new(200).set_body_bytes(b"no-upstream-ctype".as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        point_repo_at_upstream(&fx.pool, fx.repo_id, &server.uri()).await;
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let router = tdh::router_anon(download_router(), state);
+        let req = tdh::get(format!("/{}/download/no/ctype.bin", fx.repo_key));
+        let (status, body) = tdh::send(router, req).await;
+
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(
+            &body[..],
+            b"no-upstream-ctype",
+            "body bytes must still flow through even when upstream omits \
+             a Content-Type header"
+        );
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_download_artifact_remote_upstream_404_returns_error_response() {
+        // When upstream responds 404, `proxy_fetch_streaming` returns
+        // `Err(response)` which the handler unwraps via
+        // `.unwrap_or_else(|e| e).into_response()`. This pins that the
+        // error path produces a non-200 response (i.e. the unwrap_or_else
+        // arm in lines 2167-2168 is exercised, not just the happy path).
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+
+        let server = wiremock::MockServer::start().await;
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/gone/never.bin"))
+            .respond_with(wiremock::ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        point_repo_at_upstream(&fx.pool, fx.repo_id, &server.uri()).await;
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let router = tdh::router_anon(download_router(), state);
+        let req = tdh::get(format!("/{}/download/gone/never.bin", fx.repo_key));
+        let (status, _body) = tdh::send(router, req).await;
+
+        assert_ne!(
+            status,
+            axum::http::StatusCode::OK,
+            "an upstream 404 must NOT surface as a successful streamed body; \
+             the err-into-response shortcut on line 2168 must propagate the \
+             failure status"
+        );
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_download_artifact_remote_without_proxy_service_returns_not_found() {
+        // Belt-and-braces: with `proxy_service = None` the
+        // remote-NotFound arm falls through to `Err(NotFound)`, exercising
+        // the `else` branch right after the `proxy_fetch_streaming` call.
+        // Guards against a refactor that accidentally calls the streaming
+        // helper with an unwrap on a missing proxy service.
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+
+        // Mark public; do NOT install a proxy_service on the state.
+        point_repo_at_upstream(&fx.pool, fx.repo_id, "https://unused.example.test").await;
+        let state = tdh::build_state(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+
+        let router = tdh::router_anon(download_router(), state);
+        let req = tdh::get(format!("/{}/download/whatever.bin", fx.repo_key));
+        let (status, _body) = tdh::send(router, req).await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::NOT_FOUND,
+            "no proxy_service on the AppState must short-circuit to 404, \
+             not call into a streaming helper that does not exist"
+        );
+
+        fx.teardown().await;
+    }
+
+    // ---------------------------------------------------------------------
+    // Source-level pin: the remote-NotFound arm in `download_artifact` must
+    // call `proxy_helpers::proxy_fetch_streaming(` (#1294). Mirrors the
+    // five pins added in #1183 for the maven / goproxy / gitlfs / alpine /
+    // debian handlers. A silent revert to the buffered `proxy_fetch` helper
+    // would re-introduce the OOM regression closed by #895 and #1294.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_repositories_download_artifact_uses_streaming_helper_1294() {
+        let src = include_str!("repositories.rs");
+        assert!(
+            src.contains("proxy_helpers::proxy_fetch_streaming("),
+            "`repositories::download_artifact` MUST call \
+             `proxy_helpers::proxy_fetch_streaming(` for the remote \
+             upstream-fallback download (#1294). A revert to the buffered \
+             `proxy_fetch` helper would re-introduce the OOM regression \
+             closed by #895/#1294."
+        );
+    }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2156,7 +2156,7 @@ pub async fn download_artifact(
                 let fetch_path = routing_rules::apply_routing_rules(&path, &rules)
                     .unwrap_or_else(|| path.clone());
 
-                let response = proxy_helpers::proxy_fetch_streaming(
+                Ok(proxy_helpers::proxy_fetch_streaming(
                     proxy,
                     repo.id,
                     &key,
@@ -2165,8 +2165,8 @@ pub async fn download_artifact(
                     "application/octet-stream",
                 )
                 .await
-                .unwrap_or_else(|err_resp| err_resp);
-                Ok(response.into_response())
+                .unwrap_or_else(|e| e)
+                .into_response())
             } else {
                 Err(AppError::NotFound("Artifact not found".to_string()))
             }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2149,41 +2149,24 @@ pub async fn download_artifact(
         )
             .into_response()),
         Err(AppError::NotFound(_)) if repo.repo_type == RepositoryType::Remote => {
-            // Try proxy for remote repositories
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                // Apply routing rules to rewrite the path before upstream fetch
                 let rules = load_routing_rules(&state.db, repo.id).await;
                 let fetch_path = routing_rules::apply_routing_rules(&path, &rules)
                     .unwrap_or_else(|| path.clone());
 
-                let (content, content_type) =
-                    proxy_helpers::proxy_fetch(proxy, repo.id, &key, upstream_url, &fetch_path)
-                        .await
-                        .map_err(|_| {
-                            AppError::NotFound("Artifact not found upstream".to_string())
-                        })?;
-
-                let ct = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
-                let filename = path.rsplit('/').next().unwrap_or(&path);
-
-                Ok((
-                    [
-                        (header::CONTENT_TYPE, ct),
-                        (
-                            header::CONTENT_DISPOSITION,
-                            format!("attachment; filename=\"{}\"", filename),
-                        ),
-                        (header::CONTENT_LENGTH, content.len().to_string()),
-                        (
-                            header::HeaderName::from_static(X_ARTIFACT_STORAGE),
-                            "upstream".to_string(),
-                        ),
-                    ],
-                    content,
+                let response = proxy_helpers::proxy_fetch_streaming(
+                    proxy,
+                    repo.id,
+                    &key,
+                    upstream_url,
+                    &fetch_path,
+                    "application/octet-stream",
                 )
-                    .into_response())
+                .await
+                .unwrap_or_else(|err_resp| err_resp);
+                Ok(response.into_response())
             } else {
                 Err(AppError::NotFound("Artifact not found".to_string()))
             }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -494,7 +494,8 @@ impl ProxyService {
     /// Create a new proxy service
     pub fn new(db: PgPool, storage: Arc<StorageService>) -> Self {
         let http_client = crate::services::http_client::base_client_builder()
-            .timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
+            .connect_timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
+            .read_timeout(Duration::from_secs(HTTP_TIMEOUT_SECS))
             .user_agent("artifact-keeper-proxy/1.0")
             .build()
             .expect("Failed to create HTTP client");


### PR DESCRIPTION
Closes #1300

## Summary

fix(proxy): migrate generic /:key/download/*path to streaming
  
    Stream proxy fetch for remote repositories on the generic download
    route so multi-GiB upstream artifacts (cloud images, ISOs, etc.)
    aren't buffered in memory.
  
    The format-specific large-body handlers (Maven catch-all, Go module
    .zip, Git LFS blob, Alpine .apk) were migrated to
    `proxy_fetch_streaming` in #1181 (the #895 follow-up), and Debian
    .deb in #1178. The generic `/:key/download/*path` route on
    RepositoryService was missed, so GENERIC-format remote repos still
    OOM / time out on large downloads (a 2.5 GiB Ubuntu ISO surfaces
    as a 504 from the reverse proxy while the backend buffers the full
    response from upstream before serving the first byte).
  
    Same in-place swap pattern as #1181: replace `proxy_fetch` (returns
    Vec<u8>) + manual Response construction with `proxy_fetch_streaming`
    (returns a fully-constructed streaming Response).
    `proxy_fetch_streaming` returns `Result<Response, Response>` where
    both arms are fully-constructed axum responses; collapse to a single
    Response and lift into the outer `Result<impl IntoResponse,
    AppError>`.
  
    The migrated path drops the `Content-Disposition: attachment` and
    `X-Artifact-Storage: upstream` headers the buffered path set. The
    five already-streaming handlers (#1181, #1178) don't set these
    either; this keeps the pattern consistent.
  
fix(proxy): use read_timeout, not total timeout, on upstream client

    The proxy's upstream `reqwest::Client` was configured with
    `.timeout(HTTP_TIMEOUT_SECS)`, which is reqwest's TOTAL request
    timeout — including the time spent reading the response body. With
    HTTP_TIMEOUT_SECS=60 (unchanged here), the client force-closes any
    upstream connection after 60 s elapsed wall-clock, regardless of
    whether bytes are still flowing.
  
    For small-body upstream fetches (the buffered `proxy_fetch` path)
    this is invisible. For streaming fetches (`proxy_fetch_streaming`,
    introduced in #1178 / #1181, and now also used by the generic
    download route in the preceding commit), it caps every large
    download at 60 s wall-clock — a 2.5 GiB Ubuntu ISO at ~35 MB/s
    gets cleanly truncated to ~2.1 GB then the HTTP/2 stream RSTs
    with INTERNAL_ERROR.
  
    Switch to `connect_timeout` + `read_timeout`:
  
      - `connect_timeout` still caps connection establishment at 60 s.
      - `read_timeout` caps the *gap between bytes*, not total duration.
        A healthy upstream feeding bytes continuously runs as long as
        needed; a hung upstream (no data for 60 s) is still killed.
  
    Behavioral effects:
  
      - Small-body fetches: indistinguishable (complete in ms, well
        under any timeout).
      - Streaming fetches: no longer cut at 60 s wall-clock; idle
        upstreams still terminated via read_timeout.

    The `test_http_timeout_is_60_seconds` constant assertion still
    passes; the constant's role just moved from "total wall-clock cap"
    to "max inter-byte idle".


- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes