### PR TITLE
fix(migration): improve JFrog 7.38.10 cache-artifact migration reliability

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -1316,6 +1316,7 @@ async fn handle_head_blob(
                 }
             };
             if storage.exists(&b.storage_key).await.unwrap_or(false) {
+                tracing::debug!(repo = %repo.key, digest = %digest, storage_key = %b.storage_key, "HEAD blob: serving from migrated oci_blobs (CAS hit)");
                 return Response::builder()
                     .status(StatusCode::OK)
                     .header("Docker-Content-Digest", digest)
@@ -1324,8 +1325,11 @@ async fn handle_head_blob(
                     .body(Body::empty())
                     .unwrap();
             }
+            tracing::warn!(repo = %repo.key, digest = %digest, storage_key = %b.storage_key, "HEAD blob: oci_blobs row found but storage file missing - will proxy from upstream");
         }
-        Ok(None) => {}
+        Ok(None) => {
+            tracing::debug!(repo = %repo.key, digest = %digest, "HEAD blob: no oci_blobs row - will proxy from upstream");
+        }
         Err(e) => {
             warn!("DB error checking blob: {}", e);
         }
@@ -1390,6 +1394,7 @@ async fn handle_get_blob(
             };
             match storage.get(&b.storage_key).await {
                 Ok(data) => {
+                    tracing::debug!(repo = %repo.key, digest = %digest, storage_key = %b.storage_key, "GET blob: serving from migrated oci_blobs (CAS hit)");
                     return Response::builder()
                         .status(StatusCode::OK)
                         .header("Docker-Content-Digest", digest)
@@ -1399,11 +1404,13 @@ async fn handle_get_blob(
                         .unwrap();
                 }
                 Err(e) => {
-                    warn!("Storage error reading blob {}: {}", digest, e);
+                    warn!(repo = %repo.key, digest = %digest, storage_key = %b.storage_key, "GET blob: oci_blobs row found but storage.get failed - will proxy from upstream: {}", e);
                 }
             }
         }
-        Ok(None) => {}
+        Ok(None) => {
+            tracing::debug!(repo = %repo.key, digest = %digest, "GET blob: no oci_blobs row - will proxy from upstream");
+        }
         Err(e) => {
             warn!("DB error reading blob: {}", e);
         }
@@ -1976,6 +1983,7 @@ async fn handle_get_manifest(
         let manifest_key = manifest_storage_key(&manifest_digest);
 
         if let Ok(data) = storage.get(&manifest_key).await {
+            tracing::debug!(repo = %repo.key, image = %repo.image, reference = %reference, digest = %manifest_digest, "GET manifest: serving from migrated oci_tags (local hit)");
             return Response::builder()
                 .status(StatusCode::OK)
                 .header("Docker-Content-Digest", &manifest_digest)
@@ -1984,6 +1992,9 @@ async fn handle_get_manifest(
                 .body(Body::from(data))
                 .unwrap();
         }
+        tracing::warn!(repo = %repo.key, image = %repo.image, reference = %reference, digest = %manifest_digest, manifest_key = %manifest_key, "GET manifest: oci_tags row found but storage file missing - will proxy from upstream");
+    } else {
+        tracing::debug!(repo = %repo.key, image = %repo.image, reference = %reference, "GET manifest: no oci_tags row - will proxy from upstream");
     }
 
     // For remote repos, try fetching manifest from upstream. Forward the

--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -601,7 +601,10 @@ impl ArtifactoryClient {
         );
 
         let fallback_request = self.auth_request(self.client.get(download_uri));
-        fallback_request.send().await.map_err(ArtifactoryError::from)
+        fallback_request
+            .send()
+            .await
+            .map_err(ArtifactoryError::from)
     }
 
     /// Get artifact properties

--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -3,6 +3,8 @@
 //! This module provides a client for interacting with JFrog Artifactory's REST API
 //! to fetch repositories, artifacts, users, groups, and permissions for migration.
 
+use futures::stream::BoxStream;
+use futures::StreamExt;
 use reqwest::{Client, RequestBuilder};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -565,6 +567,43 @@ impl ArtifactoryClient {
             .await
     }
 
+    async fn download_response_with_fallback(
+        &self,
+        repo_key: &str,
+        path: &str,
+    ) -> Result<reqwest::Response, ArtifactoryError> {
+        let raw_url = format!("{}/{}/{}", self.config.base_url, repo_key, path);
+        let request = self.auth_request(self.client.get(&raw_url));
+        let response = request.send().await?;
+
+        if response.status().as_u16() != 404 {
+            return Ok(response);
+        }
+
+        let storage_info = match self.get_storage_info(repo_key, path).await {
+            Ok(info) => info,
+            Err(_) => return Ok(response),
+        };
+
+        let Some(download_uri) = storage_info.download_uri else {
+            return Ok(response);
+        };
+
+        if download_uri == raw_url {
+            return Ok(response);
+        }
+
+        tracing::debug!(
+            repo = %repo_key,
+            path = %path,
+            download_uri = %download_uri,
+            "Direct artifact download returned 404; retrying with Artifactory storage downloadUri"
+        );
+
+        let fallback_request = self.auth_request(self.client.get(download_uri));
+        fallback_request.send().await.map_err(ArtifactoryError::from)
+    }
+
     /// Get artifact properties
     pub async fn get_properties(
         &self,
@@ -581,14 +620,40 @@ impl ArtifactoryClient {
         repo_key: &str,
         path: &str,
     ) -> Result<bytes::Bytes, ArtifactoryError> {
-        let url = format!("{}/{}/{}", self.config.base_url, repo_key, path);
-        let request = self.auth_request(self.client.get(&url));
-
-        let response = request.send().await?;
+        let response = self.download_response_with_fallback(repo_key, path).await?;
         let status = response.status();
 
         if status.is_success() {
             Ok(response.bytes().await?)
+        } else if status.as_u16() == 404 {
+            Err(ArtifactoryError::NotFound(format!(
+                "Artifact not found: {}/{}",
+                repo_key, path
+            )))
+        } else {
+            Err(ArtifactoryError::ApiError {
+                status: status.as_u16(),
+                message: "Failed to download artifact".into(),
+            })
+        }
+    }
+
+    /// Download artifact as streaming chunks to avoid loading large payloads
+    /// fully into memory.
+    pub async fn download_artifact_stream(
+        &self,
+        repo_key: &str,
+        path: &str,
+    ) -> Result<BoxStream<'static, Result<bytes::Bytes, ArtifactoryError>>, ArtifactoryError> {
+        let response = self.download_response_with_fallback(repo_key, path).await?;
+        let status = response.status();
+
+        if status.is_success() {
+            let stream = response
+                .bytes_stream()
+                .map(|chunk| chunk.map_err(ArtifactoryError::from))
+                .boxed();
+            Ok(stream)
         } else if status.as_u16() == 404 {
             Err(ArtifactoryError::NotFound(format!(
                 "Artifact not found: {}/{}",

--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -3,8 +3,6 @@
 //! This module provides a client for interacting with JFrog Artifactory's REST API
 //! to fetch repositories, artifacts, users, groups, and permissions for migration.
 
-use futures::stream::BoxStream;
-use futures::StreamExt;
 use reqwest::{Client, RequestBuilder};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -628,35 +626,6 @@ impl ArtifactoryClient {
 
         if status.is_success() {
             Ok(response.bytes().await?)
-        } else if status.as_u16() == 404 {
-            Err(ArtifactoryError::NotFound(format!(
-                "Artifact not found: {}/{}",
-                repo_key, path
-            )))
-        } else {
-            Err(ArtifactoryError::ApiError {
-                status: status.as_u16(),
-                message: "Failed to download artifact".into(),
-            })
-        }
-    }
-
-    /// Download artifact as streaming chunks to avoid loading large payloads
-    /// fully into memory.
-    pub async fn download_artifact_stream(
-        &self,
-        repo_key: &str,
-        path: &str,
-    ) -> Result<BoxStream<'static, Result<bytes::Bytes, ArtifactoryError>>, ArtifactoryError> {
-        let response = self.download_response_with_fallback(repo_key, path).await?;
-        let status = response.status();
-
-        if status.is_success() {
-            let stream = response
-                .bytes_stream()
-                .map(|chunk| chunk.map_err(ArtifactoryError::from))
-                .boxed();
-            Ok(stream)
         } else if status.as_u16() == 404 {
             Err(ArtifactoryError::NotFound(format!(
                 "Artifact not found: {}/{}",

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -488,9 +488,7 @@ impl MigrationWorker {
                     .await?;
 
                 // Log debug info for Docker manifests (especially helpful if they fail due to repo not being offline)
-                let is_docker_manifest = artifact_path.contains("/sha256__")
-                    && (artifact_path.ends_with("/manifest.json") || artifact_path.ends_with("/list.manifest.json"));
-                if is_docker_manifest {
+                if is_docker_manifest_path(&artifact_path) {
                     tracing::debug!(
                         repo = %repo_key,
                         path = %artifact_path,
@@ -645,12 +643,8 @@ impl MigrationWorker {
 
                 // Skip only when source reports not found right now.
                 // This keeps items eligible for future migration runs when cache entries become available.
-                if err_msg.contains("Artifact not found")
-                    && should_skip_cache_only_artifact(repo_key, artifact_path)
-                {
-                    let skip_reason = format!(
-                        "{err_msg} | Cache metadata/index artifact is currently unavailable from source. Skipped for this run only; rerun migration when source cache entry becomes available."
-                    );
+                if should_skip_failed_cache_artifact(&err_msg, repo_key, artifact_path) {
+                    let skip_reason = build_cache_skip_reason(&err_msg);
 
                     tracing::info!(
                         item_id = %item_id,
@@ -664,9 +658,7 @@ impl MigrationWorker {
                         .await?;
                     *skipped += 1;
                 } else {
-                    self.migration_service
-                        .fail_item(item_id, &err_msg)
-                        .await?;
+                    self.migration_service.fail_item(item_id, &err_msg).await?;
                     *failed += 1;
                 }
             }
@@ -727,7 +719,6 @@ impl MigrationWorker {
             actual.calculated_sha1.as_deref(),
         )
     }
-
 
     /// Send a progress update through the channel, if one is configured
     #[allow(clippy::too_many_arguments)]
@@ -1624,6 +1615,18 @@ pub(crate) fn build_source_path(repo_key: &str, artifact_path: &str) -> String {
     format!("{}/{}", repo_key, artifact_path)
 }
 
+/// Detect Docker/OCI manifest paths laid out by Artifactory's filesystem
+/// layout (`.../sha256__<digest>/manifest.json` or `.../list.manifest.json`).
+///
+/// Used purely for logging context when initiating a download attempt of a
+/// manifest, since manifest downloads require the source repo to be offline
+/// for Artifactory to surface them via the storage API.
+fn is_docker_manifest_path(artifact_path: &str) -> bool {
+    artifact_path.contains("/sha256__")
+        && (artifact_path.ends_with("/manifest.json")
+            || artifact_path.ends_with("/list.manifest.json"))
+}
+
 /// Detect cache-only artifacts from Artifactory remote cache repositories.
 ///
 /// These are metadata/index files that exist in AQL but cannot be downloaded via HTTP
@@ -1639,17 +1642,18 @@ fn should_skip_cache_only_artifact(repo_key: &str, artifact_path: &str) -> bool 
     let path_lower = artifact_path.to_lowercase();
 
     // Docker/OCI: skip cache metadata manifests, not blob payloads.
-    if repo_lower.contains("docker") || repo_lower.contains("oci") {
-        if path_lower.contains("sha256__")
-            && (path_lower.ends_with("/manifest.json")
-                || path_lower.ends_with("/list.manifest.json"))
-        {
-            return true;
-        }
+    if (repo_lower.contains("docker") || repo_lower.contains("oci"))
+        && path_lower.contains("sha256__")
+        && (path_lower.ends_with("/manifest.json") || path_lower.ends_with("/list.manifest.json"))
+    {
+        return true;
     }
 
     // PyPI cache: simple index HTML files
-    if repo_lower.contains("pypi") && path_lower.starts_with(".pypi/") && path_lower.ends_with(".html") {
+    if repo_lower.contains("pypi")
+        && path_lower.starts_with(".pypi/")
+        && path_lower.ends_with(".html")
+    {
         return true;
     }
 
@@ -1670,16 +1674,39 @@ fn should_skip_cache_only_artifact(repo_key: &str, artifact_path: &str) -> bool 
         || path_lower.ends_with("contents.gz")
         || path_lower.ends_with("contents");
 
-    if is_deb_metadata && (repo_lower.contains("debian")
-        || repo_lower.contains("apt")
-        || repo_lower.contains("ubuntu")
-        || repo_lower.contains("bazel")) {
+    if is_deb_metadata
+        && (repo_lower.contains("debian")
+            || repo_lower.contains("apt")
+            || repo_lower.contains("ubuntu")
+            || repo_lower.contains("bazel"))
+    {
         return true;
     }
 
     false
 }
 
+/// Decide whether a failed transfer should be marked as skipped (versus
+/// failed) so the item stays eligible for a future migration run.
+///
+/// The combined predicate is intentionally narrow: only when the source
+/// reports the artifact as currently missing AND the (repo, path) pair
+/// matches the known cache-only metadata layout. Anything else surfaces
+/// as a hard failure so genuine outages stay visible.
+fn should_skip_failed_cache_artifact(err_msg: &str, repo_key: &str, artifact_path: &str) -> bool {
+    err_msg.contains("Artifact not found")
+        && should_skip_cache_only_artifact(repo_key, artifact_path)
+}
+
+/// Build the user-facing reason string recorded on migration items that
+/// were skipped because their cache entry is currently unavailable.
+fn build_cache_skip_reason(err_msg: &str) -> String {
+    format!(
+        "{err_msg} | Cache metadata/index artifact is currently unavailable from source. Skipped for this run only; rerun migration when source cache entry becomes available."
+    )
+}
+
+#[allow(dead_code)] // Helper retained for upcoming Artifactory remote-cache resolution path; covered by unit tests.
 fn resolve_source_repo_key_from_listing(
     repositories: &[crate::services::artifactory_client::RepositoryListItem],
     target_repo_key: &str,
@@ -1710,7 +1737,10 @@ pub(crate) fn extract_name_from_path(artifact_path: &str) -> &str {
 mod tests {
     use super::*;
 
-    fn repo_item(key: &str, repo_type: &str) -> crate::services::artifactory_client::RepositoryListItem {
+    fn repo_item(
+        key: &str,
+        repo_type: &str,
+    ) -> crate::services::artifactory_client::RepositoryListItem {
         crate::services::artifactory_client::RepositoryListItem {
             key: key.to_string(),
             repo_type: repo_type.to_string(),
@@ -1851,24 +1881,48 @@ mod tests {
     #[test]
     fn test_should_skip_cache_only_artifact_pypi() {
         // PyPI cache HTML index files
-        assert!(should_skip_cache_only_artifact("pypi-remote-cache", ".pypi/invoke.html"));
-        assert!(should_skip_cache_only_artifact("pypi-cache", ".pypi/ipaddress.html"));
+        assert!(should_skip_cache_only_artifact(
+            "pypi-remote-cache",
+            ".pypi/invoke.html"
+        ));
+        assert!(should_skip_cache_only_artifact(
+            "pypi-cache",
+            ".pypi/ipaddress.html"
+        ));
     }
 
     #[test]
     fn test_should_skip_cache_only_artifact_cargo() {
         // Cargo auto-generated config
-        assert!(should_skip_cache_only_artifact("cargo-remote-cache", "config.json"));
-        assert!(should_skip_cache_only_artifact("cargo-cache", "1/registry/config.json"));
+        assert!(should_skip_cache_only_artifact(
+            "cargo-remote-cache",
+            "config.json"
+        ));
+        assert!(should_skip_cache_only_artifact(
+            "cargo-cache",
+            "1/registry/config.json"
+        ));
     }
 
     #[test]
     fn test_should_skip_cache_only_artifact_debian_metadata() {
         // Debian/Apt/Ubuntu repository metadata
-        assert!(should_skip_cache_only_artifact("debian-cache", "dists/focal/Release"));
-        assert!(should_skip_cache_only_artifact("ubuntu-cache", "dists/jammy/InRelease"));
-        assert!(should_skip_cache_only_artifact("apt-cache", "dists/bullseye/Packages.gz"));
-        assert!(should_skip_cache_only_artifact("bazel-cache", "dists/Contents.gz"));
+        assert!(should_skip_cache_only_artifact(
+            "debian-cache",
+            "dists/focal/Release"
+        ));
+        assert!(should_skip_cache_only_artifact(
+            "ubuntu-cache",
+            "dists/jammy/InRelease"
+        ));
+        assert!(should_skip_cache_only_artifact(
+            "apt-cache",
+            "dists/bullseye/Packages.gz"
+        ));
+        assert!(should_skip_cache_only_artifact(
+            "bazel-cache",
+            "dists/Contents.gz"
+        ));
     }
 
     #[test]
@@ -1892,11 +1946,7 @@ mod tests {
     fn test_resolve_source_repo_key_prefers_hidden_remote_cache_repo() {
         let repositories = vec![repo_item("docker-remote", "REMOTE")];
 
-        let resolved = resolve_source_repo_key_from_listing(
-            &repositories,
-            "docker-remote",
-            true,
-        );
+        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", true);
 
         assert_eq!(resolved, "docker-remote-cache");
     }
@@ -1905,11 +1955,7 @@ mod tests {
     fn test_resolve_source_repo_key_uses_target_for_non_remote_repo() {
         let repositories = vec![repo_item("docker-local", "LOCAL")];
 
-        let resolved = resolve_source_repo_key_from_listing(
-            &repositories,
-            "docker-local",
-            true,
-        );
+        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-local", true);
 
         assert_eq!(resolved, "docker-local");
     }
@@ -1918,13 +1964,238 @@ mod tests {
     fn test_resolve_source_repo_key_uses_target_when_repo_missing() {
         let repositories = vec![repo_item("some-other-repo", "REMOTE")];
 
-        let resolved = resolve_source_repo_key_from_listing(
-            &repositories,
-            "docker-remote",
-            true,
-        );
+        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", true);
 
         assert_eq!(resolved, "docker-remote");
+    }
+
+    #[test]
+    fn test_resolve_source_repo_key_returns_target_when_cached_remote_disabled() {
+        // include_cached_remote = false short-circuits the lookup regardless of
+        // whether the repo exists and regardless of its type.
+        let repositories = vec![repo_item("docker-remote", "REMOTE")];
+
+        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", false);
+
+        assert_eq!(resolved, "docker-remote");
+    }
+
+    #[test]
+    fn test_resolve_source_repo_key_returns_target_when_cached_remote_disabled_and_missing() {
+        // include_cached_remote = false also short-circuits when no listing entry
+        // is found, exercising the early-return branch before the .find() call.
+        let resolved = resolve_source_repo_key_from_listing(&[], "docker-remote", false);
+
+        assert_eq!(resolved, "docker-remote");
+    }
+
+    #[test]
+    fn test_resolve_source_repo_key_matches_remote_case_insensitively() {
+        // The remote-type comparison is case-insensitive (some Artifactory
+        // versions report "remote" rather than "REMOTE").
+        let repositories = vec![repo_item("docker-remote", "remote")];
+
+        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", true);
+
+        assert_eq!(resolved, "docker-remote-cache");
+    }
+
+    // -----------------------------------------------------------------------
+    // is_docker_manifest_path
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_docker_manifest_path_detects_single_arch_manifest() {
+        assert!(is_docker_manifest_path(
+            "library/nginx/sha256__abc123/manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_is_docker_manifest_path_detects_multi_arch_list_manifest() {
+        assert!(is_docker_manifest_path(
+            "library/nginx/sha256__abc123/list.manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_is_docker_manifest_path_rejects_layer_payload() {
+        // sha256__ subdirectory but not a manifest filename
+        assert!(!is_docker_manifest_path(
+            "library/nginx/sha256__abc123/layer.tar"
+        ));
+    }
+
+    #[test]
+    fn test_is_docker_manifest_path_rejects_manifest_without_sha256_prefix() {
+        // manifest.json filename but no sha256__ marker upstream
+        assert!(!is_docker_manifest_path(
+            "library/nginx/latest/manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_is_docker_manifest_path_rejects_empty_path() {
+        assert!(!is_docker_manifest_path(""));
+    }
+
+    // -----------------------------------------------------------------------
+    // should_skip_failed_cache_artifact + build_cache_skip_reason
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_should_skip_failed_cache_artifact_matches_not_found_for_cache_metadata() {
+        // Real-world error string from Artifactory client wrapping a 404
+        let err = "Artifact not found: docker-remote-cache/library/nginx/sha256__abc/manifest.json";
+        assert!(should_skip_failed_cache_artifact(
+            err,
+            "docker-remote-cache",
+            "library/nginx/sha256__abc/manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_failed_cache_artifact_rejects_not_found_for_real_payload() {
+        // A 404 on an actual package payload is a real failure, not a cache skip
+        let err = "Artifact not found: pypi-remote-cache/wheel-0.46.2-py3-none-any.whl";
+        assert!(!should_skip_failed_cache_artifact(
+            err,
+            "pypi-remote-cache",
+            "wheel-0.46.2-py3-none-any.whl"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_failed_cache_artifact_rejects_non_not_found_errors() {
+        // Connection errors, 500s, etc. must surface as failures even on
+        // cache-metadata paths so genuine outages stay visible.
+        let err = "Connection refused while contacting source registry";
+        assert!(!should_skip_failed_cache_artifact(
+            err,
+            "docker-remote-cache",
+            "library/nginx/sha256__abc/manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_build_cache_skip_reason_preserves_underlying_error_message() {
+        let reason = build_cache_skip_reason("Artifact not found: foo/bar.json");
+        assert!(reason.starts_with("Artifact not found: foo/bar.json"));
+        assert!(reason.contains("currently unavailable from source"));
+        assert!(reason.contains("rerun migration"));
+    }
+
+    // -----------------------------------------------------------------------
+    // should_skip_cache_only_artifact - additional branch coverage
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_docker_rejects_non_manifest_filenames() {
+        // Docker/OCI repo but path does not match the manifest filename
+        // pattern: must not be skipped (it is a real blob/payload).
+        assert!(!should_skip_cache_only_artifact(
+            "docker-remote-cache",
+            "library/nginx/sha256__abc/config.json"
+        ));
+        assert!(!should_skip_cache_only_artifact(
+            "oci-remote-cache",
+            "library/nginx/sha256__abc/blob.bin"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_docker_rejects_manifest_without_sha256_marker() {
+        // manifest.json filename but no sha256__ in the path: not a cache
+        // manifest, must not be skipped.
+        assert!(!should_skip_cache_only_artifact(
+            "docker-remote-cache",
+            "library/nginx/manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_pypi_rejects_non_html() {
+        // PyPI repo but the path is not an .html index file
+        assert!(!should_skip_cache_only_artifact(
+            "pypi-remote-cache",
+            ".pypi/wheel-0.46.2-py3-none-any.whl"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_pypi_rejects_html_outside_pypi_prefix() {
+        // .html file but not inside the `.pypi/` cache directory
+        assert!(!should_skip_cache_only_artifact(
+            "pypi-remote-cache",
+            "docs/index.html"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_cargo_rejects_non_config_files() {
+        // Cargo repo but file is not config.json
+        assert!(!should_skip_cache_only_artifact(
+            "cargo-remote-cache",
+            "1/r/registry.crate"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_debian_metadata_requires_known_repo_family() {
+        // Debian-style metadata filename but the repo key does not look like
+        // a debian/apt/ubuntu/bazel repo: must not be skipped.
+        assert!(!should_skip_cache_only_artifact(
+            "generic-remote-cache",
+            "dists/focal/Release"
+        ));
+        assert!(!should_skip_cache_only_artifact(
+            "maven-remote-cache",
+            "dists/focal/Packages.gz"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_debian_metadata_covers_each_variant() {
+        // Walk every debian-metadata file extension the helper recognises so
+        // each branch of the `is_deb_metadata` chain is exercised.
+        let variants = [
+            "dists/focal/Release",
+            "dists/focal/Release.gpg",
+            "dists/focal/InRelease",
+            "dists/focal/main/binary-amd64/Packages.gz",
+            "dists/focal/main/binary-amd64/Packages.bz2",
+            "dists/focal/main/binary-amd64/Packages.xz",
+            "dists/focal/main/binary-amd64/Packages",
+            "dists/focal/main/binary-amd64/Packages.dir",
+            "dists/focal/Contents.gz",
+            "dists/focal/Contents",
+        ];
+        for path in variants {
+            assert!(
+                should_skip_cache_only_artifact("debian-remote-cache", path),
+                "expected debian metadata variant to be skippable: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_unknown_repo_unknown_path_returns_false() {
+        // Exercises the trailing `false` branch: no Docker/OCI, no PyPI,
+        // no Cargo, no debian-family rule applies.
+        assert!(!should_skip_cache_only_artifact(
+            "maven-remote-cache",
+            "com/example/lib/1.0/lib-1.0.jar"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_is_repo_key_case_insensitive() {
+        // The helper lowercases the repo key, so mixed-case keys still
+        // route into the docker branch.
+        assert!(should_skip_cache_only_artifact(
+            "Docker-Remote-Cache",
+            "library/nginx/sha256__abc/manifest.json"
+        ));
     }
 
     #[test]

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -1706,26 +1706,6 @@ fn build_cache_skip_reason(err_msg: &str) -> String {
     )
 }
 
-#[allow(dead_code)] // Helper retained for upcoming Artifactory remote-cache resolution path; covered by unit tests.
-fn resolve_source_repo_key_from_listing(
-    repositories: &[crate::services::artifactory_client::RepositoryListItem],
-    target_repo_key: &str,
-    include_cached_remote: bool,
-) -> String {
-    if !include_cached_remote {
-        return target_repo_key.to_string();
-    }
-
-    let Some(target_repo) = repositories.iter().find(|repo| repo.key == target_repo_key) else {
-        return target_repo_key.to_string();
-    };
-
-    if !target_repo.repo_type.eq_ignore_ascii_case("remote") {
-        return target_repo_key.to_string();
-    }
-
-    format!("{}-cache", target_repo_key)
-}
 /// Extract the file name from an artifact path.
 /// Returns the portion after the last '/' separator, or the entire
 /// string if no separator is present.
@@ -1736,19 +1716,6 @@ pub(crate) fn extract_name_from_path(artifact_path: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    fn repo_item(
-        key: &str,
-        repo_type: &str,
-    ) -> crate::services::artifactory_client::RepositoryListItem {
-        crate::services::artifactory_client::RepositoryListItem {
-            key: key.to_string(),
-            repo_type: repo_type.to_string(),
-            package_type: String::new(),
-            url: None,
-            description: None,
-        }
-    }
 
     #[test]
     fn test_conflict_resolution_from_str() {
@@ -1940,64 +1907,6 @@ mod tests {
             "cargo-cache",
             "requests/requests-2.28.0-py3-none-any.whl"
         ));
-    }
-
-    #[test]
-    fn test_resolve_source_repo_key_prefers_hidden_remote_cache_repo() {
-        let repositories = vec![repo_item("docker-remote", "REMOTE")];
-
-        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", true);
-
-        assert_eq!(resolved, "docker-remote-cache");
-    }
-
-    #[test]
-    fn test_resolve_source_repo_key_uses_target_for_non_remote_repo() {
-        let repositories = vec![repo_item("docker-local", "LOCAL")];
-
-        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-local", true);
-
-        assert_eq!(resolved, "docker-local");
-    }
-
-    #[test]
-    fn test_resolve_source_repo_key_uses_target_when_repo_missing() {
-        let repositories = vec![repo_item("some-other-repo", "REMOTE")];
-
-        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", true);
-
-        assert_eq!(resolved, "docker-remote");
-    }
-
-    #[test]
-    fn test_resolve_source_repo_key_returns_target_when_cached_remote_disabled() {
-        // include_cached_remote = false short-circuits the lookup regardless of
-        // whether the repo exists and regardless of its type.
-        let repositories = vec![repo_item("docker-remote", "REMOTE")];
-
-        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", false);
-
-        assert_eq!(resolved, "docker-remote");
-    }
-
-    #[test]
-    fn test_resolve_source_repo_key_returns_target_when_cached_remote_disabled_and_missing() {
-        // include_cached_remote = false also short-circuits when no listing entry
-        // is found, exercising the early-return branch before the .find() call.
-        let resolved = resolve_source_repo_key_from_listing(&[], "docker-remote", false);
-
-        assert_eq!(resolved, "docker-remote");
-    }
-
-    #[test]
-    fn test_resolve_source_repo_key_matches_remote_case_insensitively() {
-        // The remote-type comparison is case-insensitive (some Artifactory
-        // versions report "remote" rather than "REMOTE").
-        let repositories = vec![repo_item("docker-remote", "remote")];
-
-        let resolved = resolve_source_repo_key_from_listing(&repositories, "docker-remote", true);
-
-        assert_eq!(resolved, "docker-remote-cache");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -455,6 +455,27 @@ impl MigrationWorker {
                     continue;
                 }
 
+                // Check for duplicates in the artifacts table (cross-job support)
+                // This is checked BEFORE creating migration_item so we avoid tracking
+                // duplicates that already exist, which makes delta migrations work
+                let should_skip_duplicate = self
+                    .check_artifact_duplicate(
+                        &source_path,
+                        item_checksum.as_deref(),
+                        conflict_resolution,
+                    )
+                    .await?;
+
+                if should_skip_duplicate {
+                    tracing::debug!(
+                        repo = %repo_key,
+                        path = %artifact_path,
+                        "Skipping duplicate artifact (already exists with matching checksum)"
+                    );
+                    *skipped += 1;
+                    continue;
+                }
+
                 // Add migration item to database (or get existing one on resume)
                 let item_id = self
                     .add_migration_item(
@@ -465,6 +486,17 @@ impl MigrationWorker {
                         item_checksum.as_deref(),
                     )
                     .await?;
+
+                // Log debug info for Docker manifests (especially helpful if they fail due to repo not being offline)
+                let is_docker_manifest = artifact_path.contains("/sha256__")
+                    && (artifact_path.ends_with("/manifest.json") || artifact_path.ends_with("/list.manifest.json"));
+                if is_docker_manifest {
+                    tracing::debug!(
+                        repo = %repo_key,
+                        path = %artifact_path,
+                        "Attempting download of Docker manifest (requires source repo to be offline)"
+                    );
+                }
 
                 self.process_single_artifact(
                     item_id,
@@ -609,10 +641,34 @@ impl MigrationWorker {
                 .await?;
             }
             Err(e) => {
-                self.migration_service
-                    .fail_item(item_id, &e.to_string())
-                    .await?;
-                *failed += 1;
+                let err_msg = e.to_string();
+
+                // Skip only when source reports not found right now.
+                // This keeps items eligible for future migration runs when cache entries become available.
+                if err_msg.contains("Artifact not found")
+                    && should_skip_cache_only_artifact(repo_key, artifact_path)
+                {
+                    let skip_reason = format!(
+                        "{err_msg} | Cache metadata/index artifact is currently unavailable from source. Skipped for this run only; rerun migration when source cache entry becomes available."
+                    );
+
+                    tracing::info!(
+                        item_id = %item_id,
+                        repo = %repo_key,
+                        path = %artifact_path,
+                        "Cache metadata/index artifact currently unavailable from source; skipping for this run and eligible on future runs"
+                    );
+
+                    self.migration_service
+                        .skip_item(item_id, &skip_reason)
+                        .await?;
+                    *skipped += 1;
+                } else {
+                    self.migration_service
+                        .fail_item(item_id, &err_msg)
+                        .await?;
+                    *failed += 1;
+                }
             }
         }
 
@@ -671,6 +727,7 @@ impl MigrationWorker {
             actual.calculated_sha1.as_deref(),
         )
     }
+
 
     /// Send a progress update through the channel, if one is configured
     #[allow(clippy::too_many_arguments)]
@@ -1567,6 +1624,81 @@ pub(crate) fn build_source_path(repo_key: &str, artifact_path: &str) -> String {
     format!("{}/{}", repo_key, artifact_path)
 }
 
+/// Detect cache-only artifacts from Artifactory remote cache repositories.
+///
+/// These are metadata/index files that exist in AQL but cannot be downloaded via HTTP
+/// because they are:
+/// 1. Dynamically generated during cache revalidation
+/// 2. Index files (e.g., Debian Release files, Cargo config, PyPI index pages)
+/// 3. Expired cache entries that cannot be revalidated with upstream
+///
+/// Skipping these prevents failed migration items while preserving actual downloadable
+/// artifacts (packages, blobs, tarballs, etc.)
+fn should_skip_cache_only_artifact(repo_key: &str, artifact_path: &str) -> bool {
+    let repo_lower = repo_key.to_lowercase();
+    let path_lower = artifact_path.to_lowercase();
+
+    // Docker/OCI: skip cache metadata manifests, not blob payloads.
+    if repo_lower.contains("docker") || repo_lower.contains("oci") {
+        if path_lower.contains("sha256__")
+            && (path_lower.ends_with("/manifest.json")
+                || path_lower.ends_with("/list.manifest.json"))
+        {
+            return true;
+        }
+    }
+
+    // PyPI cache: simple index HTML files
+    if repo_lower.contains("pypi") && path_lower.starts_with(".pypi/") && path_lower.ends_with(".html") {
+        return true;
+    }
+
+    // Cargo cache: auto-generated config.json
+    if repo_lower.contains("cargo") && artifact_path.ends_with("config.json") {
+        return true;
+    }
+
+    // Debian/Apt/Ubuntu repository metadata and package indices
+    let is_deb_metadata = path_lower.ends_with("release")
+        || path_lower.ends_with("release.gpg")
+        || path_lower.ends_with("inrelease")
+        || path_lower.ends_with("packages.gz")
+        || path_lower.ends_with("packages.bz2")
+        || path_lower.ends_with("packages.xz")
+        || path_lower.ends_with("packages")
+        || path_lower.ends_with("packages.dir")
+        || path_lower.ends_with("contents.gz")
+        || path_lower.ends_with("contents");
+
+    if is_deb_metadata && (repo_lower.contains("debian")
+        || repo_lower.contains("apt")
+        || repo_lower.contains("ubuntu")
+        || repo_lower.contains("bazel")) {
+        return true;
+    }
+
+    false
+}
+
+fn resolve_source_repo_key_from_listing(
+    repositories: &[crate::services::artifactory_client::RepositoryListItem],
+    target_repo_key: &str,
+    include_cached_remote: bool,
+) -> String {
+    if !include_cached_remote {
+        return target_repo_key.to_string();
+    }
+
+    let Some(target_repo) = repositories.iter().find(|repo| repo.key == target_repo_key) else {
+        return target_repo_key.to_string();
+    };
+
+    if !target_repo.repo_type.eq_ignore_ascii_case("remote") {
+        return target_repo_key.to_string();
+    }
+
+    format!("{}-cache", target_repo_key)
+}
 /// Extract the file name from an artifact path.
 /// Returns the portion after the last '/' separator, or the entire
 /// string if no separator is present.
@@ -1577,6 +1709,16 @@ pub(crate) fn extract_name_from_path(artifact_path: &str) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn repo_item(key: &str, repo_type: &str) -> crate::services::artifactory_client::RepositoryListItem {
+        crate::services::artifactory_client::RepositoryListItem {
+            key: key.to_string(),
+            repo_type: repo_type.to_string(),
+            package_type: String::new(),
+            url: None,
+            description: None,
+        }
+    }
 
     #[test]
     fn test_conflict_resolution_from_str() {
@@ -1691,6 +1833,98 @@ mod tests {
         let config = WorkerConfig::default();
         assert!(config.batch_size >= 100);
         assert!(config.batch_size <= 10_000);
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_docker() {
+        // Docker/OCI cache paths with sha256__
+        assert!(should_skip_cache_only_artifact(
+            "docker-remote-cache",
+            "anchore/grype/sha256__1a58983ca4abb6bd0b0ae9f171541ff67d8f6a15bfcc49203ab97f9d01d3294e/manifest.json"
+        ));
+        assert!(should_skip_cache_only_artifact(
+            "oci-cache",
+            "library/nginx/sha256__52e3/list.manifest.json"
+        ));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_pypi() {
+        // PyPI cache HTML index files
+        assert!(should_skip_cache_only_artifact("pypi-remote-cache", ".pypi/invoke.html"));
+        assert!(should_skip_cache_only_artifact("pypi-cache", ".pypi/ipaddress.html"));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_cargo() {
+        // Cargo auto-generated config
+        assert!(should_skip_cache_only_artifact("cargo-remote-cache", "config.json"));
+        assert!(should_skip_cache_only_artifact("cargo-cache", "1/registry/config.json"));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_debian_metadata() {
+        // Debian/Apt/Ubuntu repository metadata
+        assert!(should_skip_cache_only_artifact("debian-cache", "dists/focal/Release"));
+        assert!(should_skip_cache_only_artifact("ubuntu-cache", "dists/jammy/InRelease"));
+        assert!(should_skip_cache_only_artifact("apt-cache", "dists/bullseye/Packages.gz"));
+        assert!(should_skip_cache_only_artifact("bazel-cache", "dists/Contents.gz"));
+    }
+
+    #[test]
+    fn test_should_skip_cache_only_artifact_allows_real_packages() {
+        // Non-cache artifacts should not be skipped
+        assert!(!should_skip_cache_only_artifact(
+            "pypi-cache",
+            "13/2c/5e079cefe955ae58e5a052fe037c850ce493eb7269dedeb960237e78fb0f/wheel-0.46.2-py3-none-any.whl"
+        ));
+        assert!(!should_skip_cache_only_artifact(
+            "docker-cache",
+            "library/nginx/sha256__52e3/layer.tar"
+        ));
+        assert!(!should_skip_cache_only_artifact(
+            "cargo-cache",
+            "requests/requests-2.28.0-py3-none-any.whl"
+        ));
+    }
+
+    #[test]
+    fn test_resolve_source_repo_key_prefers_hidden_remote_cache_repo() {
+        let repositories = vec![repo_item("docker-remote", "REMOTE")];
+
+        let resolved = resolve_source_repo_key_from_listing(
+            &repositories,
+            "docker-remote",
+            true,
+        );
+
+        assert_eq!(resolved, "docker-remote-cache");
+    }
+
+    #[test]
+    fn test_resolve_source_repo_key_uses_target_for_non_remote_repo() {
+        let repositories = vec![repo_item("docker-local", "LOCAL")];
+
+        let resolved = resolve_source_repo_key_from_listing(
+            &repositories,
+            "docker-local",
+            true,
+        );
+
+        assert_eq!(resolved, "docker-local");
+    }
+
+    #[test]
+    fn test_resolve_source_repo_key_uses_target_when_repo_missing() {
+        let repositories = vec![repo_item("some-other-repo", "REMOTE")];
+
+        let resolved = resolve_source_repo_key_from_listing(
+            &repositories,
+            "docker-remote",
+            true,
+        );
+
+        assert_eq!(resolved, "docker-remote");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1299

## Summary
Forward-port migration reliability fixes originally validated on local setup for migrations from JFrog Artifactory 7.38.10 to Artifact Keeper 1.1.6, adapted to current main.

This PR includes:
- Artifactory download fallback using storage `downloadUri`
- Retry-oriented cache skip handling for currently unavailable cache metadata
- Docker and OCI migration reliability updates for offline and cache-backed manifest paths
- Cache-only skip heuristic refinement so real layer payloads are not skipped

This PR intentionally avoids environment-specific configuration and keeps scope limited to migration reliability paths.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds or updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

Regression coverage:
- Updated unit-test-covered migration-worker cache-only behavior and validated:
  - `services::migration_worker::tests::test_should_skip_cache_only_artifact_allows_real_packages`

## Test Checklist
- [x] Unit tests added or updated
- [ ] Integration tests added or updated (if applicable)
- [ ] E2E tests added or updated (if applicable)
- [x] Manually tested locally
- [ ] No regressions in existing tests

Local validation notes:
- Full `cargo test --workspace --lib` run completed in Windows MSVC + SDK + protoc environment.
- Result: `9596 passed`, `4 failed`, `2 ignored`.
- Remaining failed tests appear pre-existing and out of scope for this PR:
  - `services::incus_scanner::tests::test_run_command_failure_nonzero_exit`
  - `services::incus_scanner::tests::test_run_command_success`
  - `services::incus_scanner::tests::test_run_command_with_args`
  - `services::upload_service::tests::test_temp_file_path_with_trailing_slash_storage`

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes