### PR TITLE
feat(incus): accept .tar.zst as a unified-tarball image extension

### DIFF
--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -298,6 +298,8 @@ pub(crate) fn content_type_for_artifact(artifact_path: &str) -> &'static str {
         "application/x-xz"
     } else if artifact_path.ends_with(".tar.gz") {
         "application/gzip"
+    } else if artifact_path.ends_with(".tar.zst") {
+        "application/zstd"
     } else {
         "application/octet-stream"
     }
@@ -309,6 +311,8 @@ pub(crate) fn content_type_for_download(filename: &str) -> &'static str {
         "application/x-xz"
     } else if filename.ends_with(".tar.gz") {
         "application/gzip"
+    } else if filename.ends_with(".tar.zst") {
+        "application/zstd"
     } else if filename.ends_with(".json") {
         "application/json"
     } else {
@@ -326,6 +330,8 @@ pub(crate) fn simplestreams_ftype(filename: &str) -> &str {
         "incus.tar.xz"
     } else if filename.ends_with(".tar.gz") {
         "incus.tar.gz"
+    } else if filename.ends_with(".tar.zst") {
+        "incus.tar.zst"
     } else {
         filename
     }
@@ -1869,6 +1875,14 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_content_type_for_artifact_tar_zst() {
+        assert_eq!(
+            content_type_for_artifact("ubuntu/20240215/incus.tar.zst"),
+            "application/zstd"
+        );
+    }
+
     // -----------------------------------------------------------------------
     // content_type_for_download
     // -----------------------------------------------------------------------
@@ -1948,6 +1962,19 @@ mod tests {
     #[test]
     fn test_simplestreams_ftype_tar_gz() {
         assert_eq!(simplestreams_ftype("incus.tar.gz"), "incus.tar.gz");
+    }
+
+    #[test]
+    fn test_simplestreams_ftype_tar_zst() {
+        assert_eq!(simplestreams_ftype("incus.tar.zst"), "incus.tar.zst");
+    }
+
+    #[test]
+    fn test_content_type_for_download_tar_zst() {
+        assert_eq!(
+            content_type_for_download("incus.tar.zst"),
+            "application/zstd"
+        );
     }
 
     #[test]

--- a/backend/src/formats/incus.rs
+++ b/backend/src/formats/incus.rs
@@ -326,20 +326,34 @@ pub struct IncusImageMetadata {
 mod tests {
     use super::*;
 
+    /// Parse `path` and assert the resulting product/version/type. Shared by the
+    /// parse-path tests so each case is a single line instead of a repeated
+    /// three-assertion block.
+    fn assert_parsed(path: &str, product: &str, version: &str, file_type: IncusFileType) {
+        let info = IncusHandler::parse_path(path).unwrap();
+        assert_eq!(info.product, Some(product.to_string()));
+        assert_eq!(info.version, Some(version.to_string()));
+        assert_eq!(info.file_type, file_type);
+    }
+
     #[test]
     fn test_parse_unified_tarball_path() {
-        let info = IncusHandler::parse_path("ubuntu-noble/20240215/incus.tar.xz").unwrap();
-        assert_eq!(info.product, Some("ubuntu-noble".to_string()));
-        assert_eq!(info.version, Some("20240215".to_string()));
-        assert_eq!(info.file_type, IncusFileType::UnifiedTarball);
+        assert_parsed(
+            "ubuntu-noble/20240215/incus.tar.xz",
+            "ubuntu-noble",
+            "20240215",
+            IncusFileType::UnifiedTarball,
+        );
     }
 
     #[test]
     fn test_parse_metadata_tarball_path() {
-        let info = IncusHandler::parse_path("alpine-edge/20240301/metadata.tar.xz").unwrap();
-        assert_eq!(info.product, Some("alpine-edge".to_string()));
-        assert_eq!(info.version, Some("20240301".to_string()));
-        assert_eq!(info.file_type, IncusFileType::MetadataTarball);
+        assert_parsed(
+            "alpine-edge/20240301/metadata.tar.xz",
+            "alpine-edge",
+            "20240301",
+            IncusFileType::MetadataTarball,
+        );
     }
 
     #[test]
@@ -434,10 +448,12 @@ properties:
 
     #[test]
     fn test_parse_unified_tarball_zstd() {
-        let info = IncusHandler::parse_path("ubuntu-noble/20240215/incus.tar.zst").unwrap();
-        assert_eq!(info.product, Some("ubuntu-noble".to_string()));
-        assert_eq!(info.version, Some("20240215".to_string()));
-        assert_eq!(info.file_type, IncusFileType::UnifiedTarball);
+        assert_parsed(
+            "ubuntu-noble/20240215/incus.tar.zst",
+            "ubuntu-noble",
+            "20240215",
+            IncusFileType::UnifiedTarball,
+        );
     }
 
     #[test]
@@ -471,6 +487,37 @@ properties:
     async fn test_validate_invalid_path() {
         let handler = IncusHandler::new();
         assert!(handler.validate("bad-path", &Bytes::new()).await.is_err());
+    }
+
+    #[test]
+    fn test_extract_metadata_from_zstd_tarball() {
+        // Build a real zstd-compressed tar carrying metadata.yaml and assert the
+        // zstd magic-byte branch in extract_metadata_from_reader decompresses and
+        // parses it. This directly covers the new zstd decode path.
+        let yaml = b"architecture: aarch64\nproperties:\n  os: Debian\n  release: bookworm\n";
+
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(yaml.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "metadata.yaml", &yaml[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+
+        let compressed = zstd::encode_all(std::io::Cursor::new(tar_buf), 0).unwrap();
+        // Sanity-check the zstd magic so this test stays honest about which
+        // branch it exercises.
+        assert_eq!(&compressed[..4], &[0x28, 0xB5, 0x2F, 0xFD]);
+
+        let meta = IncusHandler::extract_metadata(&compressed).unwrap();
+        assert_eq!(meta.architecture, Some("aarch64".to_string()));
+        assert_eq!(meta.os, Some("Debian".to_string()));
+        assert_eq!(meta.release, Some("bookworm".to_string()));
     }
 
     #[tokio::test]

--- a/backend/src/formats/incus.rs
+++ b/backend/src/formats/incus.rs
@@ -62,17 +62,21 @@ impl IncusHandler {
     /// Classify an image filename into its type.
     fn classify_file(filename: &str) -> Result<IncusFileType> {
         match filename {
-            "incus.tar.xz" | "lxd.tar.xz" => Ok(IncusFileType::UnifiedTarball),
-            "metadata.tar.xz" | "meta.tar.xz" => Ok(IncusFileType::MetadataTarball),
+            "incus.tar.xz" | "incus.tar.gz" | "incus.tar.zst" | "lxd.tar.xz"
+            | "lxd.tar.gz" | "lxd.tar.zst" => Ok(IncusFileType::UnifiedTarball),
+            "metadata.tar.xz" | "metadata.tar.gz" | "metadata.tar.zst" | "meta.tar.xz"
+            | "meta.tar.gz" | "meta.tar.zst" => Ok(IncusFileType::MetadataTarball),
             "rootfs.squashfs" => Ok(IncusFileType::RootfsSquashfs),
             "rootfs.img" => Ok(IncusFileType::RootfsQcow2),
-            f if f.ends_with(".tar.xz") || f.ends_with(".tar.gz") => {
+            // `incus export --compression=zstd` is a native incus option and
+            // produces `.tar.zst`; accept it alongside xz and gzip.
+            f if f.ends_with(".tar.xz") || f.ends_with(".tar.gz") || f.ends_with(".tar.zst") => {
                 Ok(IncusFileType::UnifiedTarball)
             }
             f if f.ends_with(".squashfs") => Ok(IncusFileType::RootfsSquashfs),
             f if f.ends_with(".qcow2") || f.ends_with(".img") => Ok(IncusFileType::RootfsQcow2),
             _ => Err(AppError::Validation(format!(
-                "Unsupported Incus image file: {}. Expected .tar.xz, .squashfs, .qcow2, or .img",
+                "Unsupported Incus image file: {}. Expected .tar.xz, .tar.gz, .tar.zst, .squashfs, .qcow2, or .img",
                 filename
             ))),
         }
@@ -134,9 +138,14 @@ impl IncusHandler {
         // Chain the magic bytes back with the rest of the reader
         let full_reader = std::io::Cursor::new(magic[..n].to_vec()).chain(reader);
 
-        // Try xz first (magic: FD 37 7A 58 5A), then gzip
+        // Try xz first (FD 37 7A 58 5A), then zstd (28 B5 2F FD), then gzip.
         let decompressor: Box<dyn Read> = if magic.starts_with(&[0xFD, 0x37, 0x7A, 0x58, 0x5A]) {
             Box::new(xz2::read::XzDecoder::new(full_reader))
+        } else if magic.starts_with(&[0x28, 0xB5, 0x2F, 0xFD]) {
+            match zstd::Decoder::new(full_reader) {
+                Ok(d) => Box::new(d),
+                Err(_) => return None,
+            }
         } else {
             Box::new(GzDecoder::new(full_reader))
         };
@@ -420,6 +429,32 @@ properties:
     #[test]
     fn test_lxd_compat_tarball() {
         let info = IncusHandler::parse_path("product/v1/lxd.tar.xz").unwrap();
+        assert_eq!(info.file_type, IncusFileType::UnifiedTarball);
+    }
+
+    #[test]
+    fn test_parse_unified_tarball_zstd() {
+        let info = IncusHandler::parse_path("ubuntu-noble/20240215/incus.tar.zst").unwrap();
+        assert_eq!(info.product, Some("ubuntu-noble".to_string()));
+        assert_eq!(info.version, Some("20240215".to_string()));
+        assert_eq!(info.file_type, IncusFileType::UnifiedTarball);
+    }
+
+    #[test]
+    fn test_parse_unified_tarball_gzip() {
+        let info = IncusHandler::parse_path("ubuntu-noble/20240215/incus.tar.gz").unwrap();
+        assert_eq!(info.file_type, IncusFileType::UnifiedTarball);
+    }
+
+    #[test]
+    fn test_parse_metadata_tarball_zstd() {
+        let info = IncusHandler::parse_path("alpine-edge/20240301/metadata.tar.zst").unwrap();
+        assert_eq!(info.file_type, IncusFileType::MetadataTarball);
+    }
+
+    #[test]
+    fn test_lxd_compat_tarball_zstd() {
+        let info = IncusHandler::parse_path("product/v1/lxd.tar.zst").unwrap();
         assert_eq!(info.file_type, IncusFileType::UnifiedTarball);
     }
 

--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -395,29 +395,36 @@ impl IncusScanner {
         let tarball_path = dest.join("image.tar.xz");
         write_temp_file(&tarball_path, content, "tarball").await?;
 
-        // Detect compression: XZ magic bytes (0xFD 0x37 0x7A 0x58 0x5A)
+        // Detect compression by magic bytes: XZ (FD 37 7A 58 5A), zstd
+        // (28 B5 2F FD), else assume gzip. `incus image export` ships .tar.xz;
+        // `incus export` container backups and zstd-compressed exports
+        // (`--compression=zstd`) ship .tar.zst, so zstd must be handled
+        // explicitly — `tar -xzf` (gzip) on a zstd archive
+        // fails extraction. zstd support requires the `zstd` binary in the
+        // runtime image (installed in Dockerfile.backend).
         let is_xz = content.len() >= 5 && content[..5] == [0xFD, 0x37, 0x7A, 0x58, 0x5A];
-        // Leading `-` is required: GNU tar only treats a bare option bundle
-        // (`xzf`) as options when it is the FIRST argument. Here it follows
-        // `--no-same-owner`/`--mode=...`, so without the dash GNU tar parses
-        // `xzf` as a file operand and aborts with "You must specify one of
-        // the '-Acdtrux' options". (bsdtar on macOS is lenient, which is why
-        // local runs passed but Linux CI failed.)
-        let decompress_flag = if is_xz { "-xJf" } else { "-xzf" };
+        let is_zstd = content.len() >= 4 && content[..4] == [0x28, 0xB5, 0x2F, 0xFD];
 
-        run_command(
-            "tar",
-            &[
-                "--no-same-owner",
-                "--mode=u=rwX,go=rX",
-                decompress_flag,
-                &tarball_path.to_string_lossy(),
-                "-C",
-                &dest.to_string_lossy(),
-            ],
-            "tar extraction",
-        )
-        .await?;
+        let tarball_arg = tarball_path.to_string_lossy();
+        let dest_arg = dest.to_string_lossy();
+        // GNU tar only treats a bare option bundle (`xzf`) as options when it is
+        // the FIRST argument; here it follows `--no-same-owner`/`--mode=...`, so
+        // the leading `-` is required. zstd has no single-letter bundle, so it
+        // goes in as the long `--zstd` option plus a plain `-xf` extract bundle.
+        let mut args: Vec<&str> = vec!["--no-same-owner", "--mode=u=rwX,go=rX"];
+        if is_zstd {
+            args.push("--zstd");
+            args.push("-xf");
+        } else if is_xz {
+            args.push("-xJf");
+        } else {
+            args.push("-xzf");
+        }
+        args.push(tarball_arg.as_ref());
+        args.push("-C");
+        args.push(dest_arg.as_ref());
+
+        run_command("tar", &args, "tar extraction").await?;
 
         // Drop the source archive before walking the tree so it isn't counted
         // toward the extracted-size budget (and to free the disk early).

--- a/backend/src/services/incus_scanner.rs
+++ b/backend/src/services/incus_scanner.rs
@@ -1572,6 +1572,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extract_tarball_detects_zstd_magic() {
+        // Mirrors the xz/gzip cases: feed the zstd magic bytes (0x28 0xB5 0x2F
+        // 0xFD) followed by garbage and assert the function selects the zstd
+        // (`--zstd`) extraction path and fails gracefully on the invalid body.
+        // This exercises the `is_zstd` branch without needing a valid archive;
+        // tar still reports a non-zero exit (whether via the zstd filter or a
+        // missing-binary error), which `run_command` surfaces as the same
+        // "tar extraction failed" error.
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs_dir = dir.path().join("rootfs");
+        tokio::fs::create_dir_all(&rootfs_dir).await.unwrap();
+
+        let scanner = IncusScanner::new(
+            "http://trivy:8090".to_string(),
+            dir.path().to_string_lossy().to_string(),
+        );
+
+        // zstd magic: 0x28 0xB5 0x2F 0xFD followed by invalid data.
+        let mut zstd_content = vec![0x28, 0xB5, 0x2F, 0xFD];
+        zstd_content.extend_from_slice(b"not-valid-zstd-data");
+        let content = Bytes::from(zstd_content);
+
+        let result = scanner.extract_tarball(&content, &rootfs_dir).await;
+        assert!(result.is_err());
+        let err_msg = format!("{}", result.unwrap_err());
+        assert!(err_msg.contains("tar extraction failed"));
+    }
+
+    #[tokio::test]
     async fn test_extract_tarball_detects_gzip_fallback() {
         // Content without XZ magic bytes should be treated as gzip
         let dir = tempfile::tempdir().unwrap();

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -86,6 +86,7 @@ RUN mkdir -p /mnt/rootfs && \
         jq \
         tar \
         gzip \
+        zstd \
     && dnf --installroot /mnt/rootfs --releasever 9 \
         --setopt=reposdir=/etc/yum.repos.d/ upgrade -y \
     && dnf --installroot /mnt/rootfs clean all \


### PR DESCRIPTION
## Summary

Makes AK support zstd-compressed Incus images (`.tar.zst`) end-to-end — upload acceptance, metadata parsing, **and scanner extraction**. `incus export --compression=zstd` is a native incus/LXD option that produces `.tar.zst`, and `incus image import` accepts it round-trip, but AK currently rejects it at upload time:

```
HTTP 400
Invalid image path: Validation error:
Unsupported Incus image file: incus.tar.zst.
Expected .tar.xz, .squashfs, .qcow2, or .img
```

…and even once accepted, the security scanner's tarball extraction only handled xz/gzip, so a `.tar.zst` image would fail to extract and never get scanned.

## Changes

**Upload acceptance + metadata** — `backend/src/formats/incus.rs`, `backend/src/api/handlers/incus.rs`
- `IncusHandler::classify_file`: add `incus.tar.zst`, `lxd.tar.zst`, `metadata.tar.zst`, `meta.tar.zst` exact-match cases (plus the missing `.gz` variants for symmetry with the existing `.xz` matches), and add `.tar.zst` to the `ends_with` fall-through for `UnifiedTarball`. Update the error string.
- `IncusHandler::extract_metadata_from_reader`: add a zstd decoder branch (magic `28 B5 2F FD`) between the xz and gzip branches so `metadata.yaml` discovery still works on zstd tarballs. Uses `zstd::Decoder` from the already-present `zstd = "0.13"` dependency.
- `content_type_for_artifact` / `content_type_for_download`: `.tar.zst` → `application/zstd`. `simplestreams_ftype`: `.tar.zst` → `incus.tar.zst`.

**Scanner extraction** — `backend/src/services/incus_scanner.rs`
- `extract_tarball`: detect the zstd magic (`28 B5 2F FD`) and extract with `tar --zstd -xf`, alongside the existing xz (`-xJf`) and gzip (`-xzf`) paths. Without this, an accepted `.tar.zst` image fails extraction and the rootfs is never scanned. (The xz/gzip detection and the post-extraction hardening guard are unchanged.)

**Runtime image** — `docker/Dockerfile.backend`
- Add `zstd` to the `rootfs-builder` `dnf install` set: `tar --zstd` shells out to a `zstd` binary the minimal `ubi-micro` rootfs otherwise lacks, so without it the extraction is a no-op in the reference image.

## Tests

- `formats::incus::tests`: `test_parse_unified_tarball_zstd`, `test_parse_unified_tarball_gzip`, `test_parse_metadata_tarball_zstd`, `test_lxd_compat_tarball_zstd`.
- `api::handlers::incus::tests`: `test_content_type_for_artifact_tar_zst`, `test_content_type_for_download_tar_zst`, `test_simplestreams_ftype_tar_zst`.
- Scanner extraction reuses the existing `extract_tarball` magic-detection test pattern (mirrors `test_extract_tarball_detects_xz_magic`); a dedicated zstd-magic extraction test is a reasonable follow-up.

## Context

zstd is a natural output for any pipeline that runs `incus export --compression=zstd`: it compresses and decompresses faster than xz at comparable ratios, and is the format used for multi-GiB OS images published into AK. Re-encoding to `.tar.xz` purely to satisfy AK's validator is strictly worse than supporting the format AK's own dependency tree already bundles.

Rebased onto current `main`. PUT of a `.tar.zst` returns HTTP 201 and the artifact is browsable in the UI; the scanner now extracts the same artifacts that the validator accepts.

Closes #1454
