### PR TITLE
fix(incus): use server-wide STORAGE_PATH for staging, not per-repo storage_path

### DIFF
--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -632,9 +632,20 @@ async fn upload_image(
             .into_response()
     })?;
 
-    // Stream body to temp file (never buffers entire image in RAM)
+    // Stream body to temp file (never buffers entire image in RAM).
+    //
+    // Stage + final paths both live under `state.config.storage_path` (the
+    // server-wide STORAGE_PATH env), not `repo.storage_path`. When the
+    // repo's `storage_backend` isn't `filesystem`, `repo.storage_path` is
+    // just the repo key (a bare relative string — see repositories.rs's
+    // create handler), which would land `tokio::fs::create_dir_all` on
+    // the process CWD (`/` in a container) and abort with
+    // `Failed to create directory: Read-only file system`. The incus
+    // handler is currently always local-disk regardless of backend, so
+    // routing through the server-wide writable mount is correct here.
+    // Long-term, this should move onto `StorageBackend::put_streaming`.
     let temp_id = Uuid::new_v4();
-    let temp_path = temp_upload_path(&repo.storage_path, &temp_id);
+    let temp_path = temp_upload_path(&state.config.storage_path, &temp_id);
     let (size_bytes, checksum) = stream_body_to_file(body, &temp_path).await?;
 
     // Extract metadata from the file on disk
@@ -643,7 +654,7 @@ async fn upload_image(
 
     // Move temp file to final storage location (atomic rename, same filesystem)
     let storage_key = build_storage_key(&repo.id, &artifact_path);
-    let final_path = storage_path_for_key(&repo.storage_path, &storage_key);
+    let final_path = storage_path_for_key(&state.config.storage_path, &storage_key);
     finalize_temp_file(&temp_path, &final_path).await?;
 
     let artifact_id = upsert_artifact(UpsertArtifactParams {
@@ -785,7 +796,12 @@ async fn start_chunked_upload(
     })?;
 
     let session_id = Uuid::new_v4();
-    let temp_path = temp_upload_path(&repo.storage_path, &session_id);
+    // See upload_image for why staging goes under state.config.storage_path
+    // rather than repo.storage_path. The chosen path is also persisted to
+    // `incus_upload_sessions.storage_temp_path`, so subsequent
+    // chunk/complete/cancel calls naturally read it back from the session
+    // row and don't need to re-derive it.
+    let temp_path = temp_upload_path(&state.config.storage_path, &session_id);
 
     // Stream initial body (may be empty) to temp file
     let (initial_bytes, _checksum) = stream_body_to_file(body, &temp_path).await?;
@@ -931,9 +947,10 @@ async fn complete_chunked_upload(
     let metadata = IncusHandler::parse_metadata_from_file(&session.artifact_path, &temp_path)
         .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"}));
 
-    // Move temp file to final storage location
+    // Move temp file to final storage location. See upload_image for why
+    // the base is state.config.storage_path, not repo.storage_path.
     let storage_key = build_storage_key(&session.repository_id, &session.artifact_path);
-    let final_path = storage_path_for_key(&repo.storage_path, &storage_key);
+    let final_path = storage_path_for_key(&state.config.storage_path, &storage_key);
     finalize_temp_file(&temp_path, &final_path).await?;
 
     // Create artifact record

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -912,7 +912,7 @@ async fn complete_chunked_upload(
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let _user_id = require_auth_basic_scope(auth, "incus", "write")?.user_id;
     let session = get_session(&state.db, session_id).await?;
-    let repo = resolve_incus_repo(&state.db, &repo_key).await?;
+    let _repo = resolve_incus_repo(&state.db, &repo_key).await?;
     let temp_path = PathBuf::from(&session.storage_temp_path);
 
     // Append any final body data


### PR DESCRIPTION
Closes #1298

## Summary

The incus handler's monolithic + chunked upload paths fail with `HTTP 500: Failed to create directory: Read-only file system (os error 30)` on any cluster where `STORAGE_BACKEND` isn't \`filesystem\`. Root cause: `backend/src/api/handlers/repositories.rs:820-825` sets `storage_path` to the bare repo key (a relative string, e.g. \`\"mechos\"\`) when the global backend is GCS/S3, and the incus handler passes that value straight into \`temp_upload_path\` / \`storage_path_for_key\`. \`tokio::fs::create_dir_all\` then resolves the path against the process CWD (\`/\` in the published container image) and aborts on the read-only root filesystem.

Filesystem-backed repos are unaffected because the corresponding branch in \`repositories.rs\` already produces \`format!(\"{}/{}\", state.config.storage_path, payload.key)\`.

## Changes

\`backend/src/api/handlers/incus.rs\` — replace every \`&repo.storage_path\` call site in the incus upload + chunked-upload + finalize paths with \`&state.config.storage_path\`. Five call sites total:

- Monolithic upload: \`temp_upload_path\` + \`storage_path_for_key\` (line 643, 652 prior).
- Chunked upload start: \`temp_upload_path\` (line 794 prior).
- Chunked upload complete: \`storage_path_for_key\` (line 942 prior).

The chunked-upload session row's \`storage_temp_path\` is written at session-start from the corrected \`temp_upload_path\` result, so subsequent chunk + complete + cancel calls read back the correct absolute path naturally.

\`build_storage_key\` already prefixes every storage key with \`incus/<repo_id>/\`, so moving the base path off \`repo.storage_path\` doesn't lose per-repo isolation — final files still land at \`<state.config.storage_path>/in/incus/<repo_uuid>/<artifact_path>\`.

## Tests

No test changes: the existing \`storage_path_for_key\` / \`temp_upload_path\` tests use arbitrary base strings and continue to pass. All 80 \`api::handlers::incus::tests\` pass locally.

## Reproduction

Stock chart install with \`backend.env.STORAGE_BACKEND: \"gcs\"\`. Create an \`incus\` repo via the UI. PUT any valid filename to \`/incus/<repo>/images/<product>/<version>/incus.tar.xz\`:

\`\`\`
HTTP 500
Failed to create directory: Read-only file system (os error 30)
\`\`\`

Validated on a self-hosted AK \`1.2.0-rc.1\` deploy on GKE: pre-fix, both monolithic and chunked uploads abort with the read-only-fs error; post-fix, a 3.4 GiB \`.tar.zst\` streams to disk and lands as HTTP 201.

## Follow-up still needed (not in this PR)

The incus handler is the only format handler that does its own \`tokio::fs::*\` calls instead of routing through the \`StorageBackend\` trait — \`api::handlers::incus::download_image\` already reads via \`state.storage_for_repo(&repo.storage_location())\`, so for GCS/S3-backed repos, downloads go to the cloud backend and reads from a location uploads never wrote to. Pairs with moving incus onto \`StorageBackend::put_streaming\` / \`get_stream\` so uploads + downloads share one abstraction (and so GCS/S3 actually receive incus content rather than the artifact living only on the backend pod's local emptyDir).

That refactor is larger than this PR's scope; this change is the minimum to stop the immediate crash on GCS/S3 clusters while the abstraction work lands separately. Filesystem-backed installs see no behaviour change — \`state.config.storage_path\` is the same value those installs were already getting via the existing \`format!\` branch in \`repositories.rs\`.

Pairs with #1296 — for an Incus repo to actually accept our \`.tar.zst\` artifacts, both fixes need to land.