### PR TITLE
fix(maven): include groupId in virtual local-member match (closes #1287)

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1148,24 +1148,30 @@ async fn serve_artifact(
                 let artifact_path = path.to_string();
 
                 // Supply-chain shadowing guard (#1217 follow-up, ak-hv3s).
-                // Maven `artifacts.name` stores `coords.artifact_id` (the
-                // artifactId component of GAV; see the publish-path
-                // around line 1634). To run the guard we have to parse
-                // the GAV out of the request path. The guard fires
-                // whenever a non-Remote member already owns the
-                // artifactId case-insensitively; this is strictly a
-                // safety net rather than an authority check, because
-                // different groupIds may legitimately share an
-                // artifactId. The trade-off is preferable to leaving
-                // the shadowing attack open. If the path fails to parse
-                // as a Maven coordinate (eg. dynamic metadata.xml
-                // requests reach this branch from earlier fall-through),
-                // skip the guard rather than block the request.
+                // Originally this used the generic `name`-only guard
+                // (`virtual_non_remote_owns_name`) keyed off
+                // `coords.artifact_id`. That over-matched across
+                // groupIds: a local `com.example.mylib:common:1.0` shadowed
+                // every remote `com/.../common/...` lookup, returning
+                // 404 instead of falling through to the remote member
+                // (#1287). The Maven-aware variant matches the full
+                // groupId+artifactId path prefix so only true GA
+                // collisions activate the suppression. The guard
+                // remains a safety net rather than an authority check:
+                // different versions under the same GA still
+                // legitimately share a directory, and we accept the
+                // false-positive within a single GA in exchange for
+                // closing the shadowing attack. If the path fails to
+                // parse as a Maven coordinate (eg. dynamic
+                // metadata.xml requests reach this branch from earlier
+                // fall-through), skip the guard rather than block the
+                // request.
                 let local_owns = match MavenHandler::parse_coordinates(path) {
                     Ok(coords) => {
-                        proxy_helpers::virtual_non_remote_owns_name(
+                        proxy_helpers::virtual_non_remote_owns_maven_ga(
                             &state.db,
                             repo.id,
+                            &coords.group_id,
                             &coords.artifact_id,
                         )
                         .await?

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1305,6 +1305,91 @@ pub async fn virtual_non_remote_owns_name(
     Ok(exists.is_some())
 }
 
+/// Build the SQL `LIKE` pattern that matches every artifact path under
+/// a given Maven `groupId/artifactId/` directory.
+///
+/// Pure helper extracted so the prefix construction has unit-test
+/// coverage without a database. Returns `<group-path>/<artifactId>/%`,
+/// where the dot-to-slash conversion runs before LIKE-escaping so
+/// directory separators in the groupId are preserved, and `%`/`_`/`\`
+/// inside either input become literal characters. Use with
+/// `LIKE ... ESCAPE '\'`.
+pub(crate) fn maven_ga_like_pattern(group_id: &str, artifact_id: &str) -> String {
+    let group_path = group_id.replace('.', "/");
+    let mut prefix = String::with_capacity(group_path.len() + artifact_id.len() + 3);
+    prefix.push_str(&super::escape_like_literal(&group_path));
+    prefix.push('/');
+    prefix.push_str(&super::escape_like_literal(artifact_id));
+    prefix.push('/');
+    prefix.push('%');
+    prefix
+}
+
+/// Maven-aware shadowing guard: returns true if any non-Remote member of
+/// `virtual_repo_id` owns an artifact under the same groupId + artifactId
+/// directory prefix.
+///
+/// The generic [`virtual_non_remote_owns_name`] matches by `artifacts.name`
+/// alone, which for Maven is the artifactId component of the GAV. Two
+/// distinct Maven coordinates that happen to share an artifactId (eg.
+/// `com.foo:bar:1.0` vs. `com.baz:bar:1.0`) collide under the generic
+/// guard, suppressing legitimate remote resolution for any sibling
+/// groupId (#1287). Matching on the full groupId/artifactId path prefix
+/// instead means a local `com/example/mylib/common/...` artifact no
+/// longer shadows a remote `com/android/tools/common/...` lookup.
+///
+/// `group_path` must be the dot-replaced groupId (`com.foo` ->
+/// `com/foo`); the function appends `/<artifact_id>/` and runs a
+/// `path LIKE` against `artifacts.path`. The prefix is escaped to
+/// neutralise `%` / `_` / `\` so a crafted artifactId cannot widen the
+/// match. Uses the `(repository_id, path)` btree (`idx_artifacts_repo_path`).
+///
+/// Fails closed on DB error (matches `virtual_non_remote_owns_name`).
+#[allow(clippy::result_large_err)]
+pub async fn virtual_non_remote_owns_maven_ga(
+    db: &PgPool,
+    virtual_repo_id: Uuid,
+    group_id: &str,
+    artifact_id: &str,
+) -> Result<bool, Response> {
+    let members = fetch_virtual_members(db, virtual_repo_id).await?;
+    let non_remote_ids: Vec<Uuid> = members
+        .iter()
+        .filter(|m| m.repo_type != RepositoryType::Remote)
+        .map(|m| m.id)
+        .collect();
+
+    if non_remote_ids.is_empty() {
+        return Ok(false);
+    }
+
+    let prefix = maven_ga_like_pattern(group_id, artifact_id);
+
+    let exists = sqlx::query(
+        "SELECT 1 FROM artifacts \
+                              WHERE repository_id = ANY($1) \
+                                AND is_deleted = false \
+                                AND path LIKE $2 ESCAPE '\\' \
+                              LIMIT 1",
+    )
+    .bind(&non_remote_ids)
+    .bind(&prefix)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| {
+        tracing::error!(
+            event = "shadowing_guard_db_error",
+            virtual_repo_id = %virtual_repo_id,
+            format = "maven",
+            error = %e,
+            "Maven shadowing-guard DB query failed; failing closed to 500",
+        );
+        (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response()
+    })?;
+
+    Ok(exists.is_some())
+}
+
 /// Try the proxy and virtual fallbacks for a download miss.
 ///
 /// Returns `Ok(Some(response))` if the artifact was served from upstream
@@ -1921,6 +2006,80 @@ mod tests {
     fn test_reverse_suffix_for_like_empty_input_just_slash() {
         // Empty suffix → reversed "/" → escaped "/"
         assert_eq!(reverse_suffix_for_like(""), "/");
+    }
+
+    // ── maven_ga_like_pattern tests (#1287) ─────────────────────────
+
+    #[test]
+    fn test_maven_ga_like_pattern_simple_groupid() {
+        // Regular groupId/artifactId pair: dots in groupId become
+        // path separators, then a `/<artifactId>/%` suffix is appended.
+        assert_eq!(
+            maven_ga_like_pattern("com.android.tools", "common"),
+            "com/android/tools/common/%"
+        );
+    }
+
+    #[test]
+    fn test_maven_ga_like_pattern_distinguishes_groupids() {
+        // Two artifactIds that collide on `name` alone but live under
+        // different groupIds must produce distinct LIKE prefixes.
+        // This is the core property #1287 needs.
+        let foo = maven_ga_like_pattern("com.foo", "bar");
+        let baz = maven_ga_like_pattern("com.baz", "bar");
+        assert_ne!(foo, baz);
+        assert_eq!(foo, "com/foo/bar/%");
+        assert_eq!(baz, "com/baz/bar/%");
+    }
+
+    #[test]
+    fn test_maven_ga_like_pattern_does_not_match_sibling_groupids() {
+        // `com.android.tools/common/...` must NOT be matched by a
+        // pattern derived from `com.example.mylib:common`. We assert
+        // the produced prefix is anchored at the full GA directory
+        // boundary.
+        let prefix = maven_ga_like_pattern("com.example.mylib", "common");
+        assert_eq!(prefix, "com/example/mylib/common/%");
+        // A path under a different groupId does not start with this
+        // prefix even though both share the `common` artifactId.
+        let unrelated_path = "com/android/tools/common/31.4.0/common-31.4.0.pom";
+        assert!(!unrelated_path.starts_with("com/example/mylib/common/"));
+        // Sanity: the matching local artifact path DOES start with it.
+        let local_path = "com/example/mylib/common/1.0.0/common-1.0.0.pom";
+        assert!(local_path.starts_with("com/example/mylib/common/"));
+        // And the LIKE suffix is open-ended.
+        assert!(prefix.ends_with('%'));
+    }
+
+    #[test]
+    fn test_maven_ga_like_pattern_escapes_metachars() {
+        // A crafted artifactId containing `%` or `_` must not widen
+        // the LIKE match. Both inputs get escaped before being woven
+        // into the pattern.
+        assert_eq!(
+            maven_ga_like_pattern("a.b", "ev%il"),
+            "a/b/ev\\%il/%",
+            "% inside artifactId must be escaped"
+        );
+        assert_eq!(
+            maven_ga_like_pattern("a.b", "ev_il"),
+            "a/b/ev\\_il/%",
+            "_ inside artifactId must be escaped"
+        );
+        // `%` inside the groupId is also escaped (after the
+        // dot-to-slash conversion has already happened).
+        assert_eq!(
+            maven_ga_like_pattern("a%.b", "c"),
+            "a\\%/b/c/%",
+            "% inside groupId must be escaped"
+        );
+    }
+
+    #[test]
+    fn test_maven_ga_like_pattern_escapes_backslash() {
+        // Backslashes get escaped so the ESCAPE '\' clause stays
+        // honest.
+        assert_eq!(maven_ga_like_pattern("a.b", "c\\d"), "a/b/c\\\\d/%");
     }
 
     // ── request_base_url tests ──────────────────────────────────────

--- a/backend/tests/maven_virtual_groupid_shadowing_test.rs
+++ b/backend/tests/maven_virtual_groupid_shadowing_test.rs
@@ -1,0 +1,248 @@
+//! Integration test: Maven virtual-repo shadowing guard must consider
+//! both `groupId` and `artifactId`, not just `artifactId` alone.
+//!
+//! Regression test for #1287. The original cross-format shadowing
+//! guard (`virtual_non_remote_owns_name`) matches on the
+//! `artifacts.name` column, which for Maven holds just the
+//! artifactId. That made a local `com.example.mylib:common:1.0` shadow
+//! every remote `com/android/tools/common/...` lookup, returning 404
+//! instead of falling through to the remote member. The Maven-aware
+//! variant `virtual_non_remote_owns_maven_ga` matches on the full
+//! `groupId/artifactId/` path prefix, so only true GA collisions
+//! activate the suppression.
+//!
+//! Requires a PostgreSQL database with migrations applied. Run with:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test maven_virtual_groupid_shadowing_test -- --ignored
+//! ```
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::proxy_helpers::virtual_non_remote_owns_maven_ga;
+
+async fn insert_repo(pool: &PgPool, key: &str, repo_type: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let storage_path = format!("/tmp/test-artifacts/{}", id);
+    // The `check_upstream_url` table constraint requires Remote repos
+    // to have an upstream_url set; Local/Virtual repos must leave it
+    // null. Mirror that here so the test fixture stays valid.
+    let upstream_url: Option<String> = if repo_type == "remote" {
+        Some("https://example.invalid/test".to_string())
+    } else {
+        None
+    };
+    sqlx::query(
+        r#"
+        INSERT INTO repositories (id, key, name, format, repo_type, storage_path, upstream_url)
+        VALUES ($1, $2, $2, 'maven'::repository_format, $3::repository_type, $4, $5)
+        "#,
+    )
+    .bind(id)
+    .bind(key)
+    .bind(repo_type)
+    .bind(&storage_path)
+    .bind(&upstream_url)
+    .execute(pool)
+    .await
+    .expect("failed to insert test repository");
+    id
+}
+
+async fn add_virtual_member(pool: &PgPool, virtual_id: Uuid, member_id: Uuid, priority: i32) {
+    sqlx::query(
+        "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+         VALUES ($1, $2, $3)",
+    )
+    .bind(virtual_id)
+    .bind(member_id)
+    .bind(priority)
+    .execute(pool)
+    .await
+    .expect("failed to insert virtual member");
+}
+
+/// Insert an artifact row that mirrors how Maven upload stores it:
+/// `path` is the full Maven 2 path, `name` is just the artifactId.
+async fn insert_maven_artifact(
+    pool: &PgPool,
+    repo_id: Uuid,
+    path: &str,
+    artifact_id: &str,
+    version: &str,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO artifacts (
+            id, repository_id, path, name, version,
+            size_bytes, checksum_sha256, content_type, storage_key
+        )
+        VALUES ($1, $2, $3, $4, $5, 0, $6, 'application/xml', $7)
+        "#,
+    )
+    .bind(id)
+    .bind(repo_id)
+    .bind(path)
+    .bind(artifact_id)
+    .bind(version)
+    // Use the artifact id as a synthetic checksum so we satisfy the
+    // NOT-NULL contract without colliding with real data.
+    .bind(format!("test-{}", id))
+    .bind(format!("artifacts/{}", id))
+    .execute(pool)
+    .await
+    .expect("failed to insert test artifact");
+    id
+}
+
+async fn cleanup(pool: &PgPool, virtual_id: Uuid, member_ids: &[Uuid]) {
+    sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+        .bind(virtual_id)
+        .execute(pool)
+        .await
+        .ok();
+    for &m in member_ids {
+        sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+            .bind(m)
+            .execute(pool)
+            .await
+            .ok();
+    }
+    let mut ids = member_ids.to_vec();
+    ids.push(virtual_id);
+    sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+        .bind(&ids)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+/// #1287 core regression: a local artifact with the same artifactId
+/// but a DIFFERENT groupId must NOT activate the shadowing guard for
+/// the unrelated groupId.
+#[tokio::test]
+#[ignore]
+async fn maven_shadowing_guard_does_not_fire_across_different_groupids() {
+    let pool = PgPool::connect(
+        &std::env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set to run this integration test"),
+    )
+    .await
+    .expect("connect");
+
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("mv-virt-1287-{}", suffix), "virtual").await;
+    let local_id = insert_repo(&pool, &format!("mv-local-1287-{}", suffix), "local").await;
+    let remote_id = insert_repo(&pool, &format!("mv-remote-1287-{}", suffix), "remote").await;
+
+    add_virtual_member(&pool, virtual_id, local_id, 1).await;
+    add_virtual_member(&pool, virtual_id, remote_id, 2).await;
+
+    // Local member owns `com.example.mylib:common:1.0.0` — artifactId
+    // "common" collides with a popular remote artifactId, but the
+    // groupId is different.
+    insert_maven_artifact(
+        &pool,
+        local_id,
+        "com/example/mylib/common/1.0.0/common-1.0.0.pom",
+        "common",
+        "1.0.0",
+    )
+    .await;
+
+    // Querying for the REMOTE groupId+artifactId must return false:
+    // the local member does not own this GA, so the guard must not
+    // suppress remote resolution.
+    let owns_remote_ga =
+        virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.android.tools", "common")
+            .await
+            .expect("guard query should succeed");
+    assert!(
+        !owns_remote_ga,
+        "local member's `com.example.mylib:common` must NOT shadow remote `com.android.tools:common` (#1287)"
+    );
+
+    // Sanity: querying for the LOCAL groupId+artifactId still returns
+    // true (the guard still does its job for genuine collisions).
+    let owns_local_ga =
+        virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.example.mylib", "common")
+            .await
+            .expect("guard query should succeed");
+    assert!(
+        owns_local_ga,
+        "guard must still fire when groupId+artifactId match the local artifact"
+    );
+
+    cleanup(&pool, virtual_id, &[local_id, remote_id]).await;
+}
+
+/// Sanity test: no non-remote members → guard returns false (matches
+/// the cross-format primitive's "allow proxy fan-out" semantic).
+#[tokio::test]
+#[ignore]
+async fn maven_shadowing_guard_no_non_remote_members_returns_false() {
+    let pool = PgPool::connect(
+        &std::env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set to run this integration test"),
+    )
+    .await
+    .expect("connect");
+
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("mv-virt-rmonly-{}", suffix), "virtual").await;
+    let remote_id = insert_repo(&pool, &format!("mv-remote-rmonly-{}", suffix), "remote").await;
+    add_virtual_member(&pool, virtual_id, remote_id, 1).await;
+
+    let owns = virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.foo", "bar")
+        .await
+        .expect("guard query should succeed");
+    assert!(
+        !owns,
+        "with only remote members the guard returns false to allow proxy fan-out"
+    );
+
+    cleanup(&pool, virtual_id, &[remote_id]).await;
+}
+
+/// A LIKE-metacharacter inside the artifactId must not widen the
+/// match: only true GA collisions activate the guard.
+#[tokio::test]
+#[ignore]
+async fn maven_shadowing_guard_escapes_like_metachars() {
+    let pool = PgPool::connect(
+        &std::env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set to run this integration test"),
+    )
+    .await
+    .expect("connect");
+
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("mv-virt-esc-{}", suffix), "virtual").await;
+    let local_id = insert_repo(&pool, &format!("mv-local-esc-{}", suffix), "local").await;
+    add_virtual_member(&pool, virtual_id, local_id, 1).await;
+
+    // Insert a local artifact with a literal-`a`-character artifactId.
+    insert_maven_artifact(
+        &pool,
+        local_id,
+        "com/example/aaa/1.0.0/aaa-1.0.0.pom",
+        "aaa",
+        "1.0.0",
+    )
+    .await;
+
+    // A LIKE-style query like `a%a` must not slip past escaping and
+    // match the `aaa` artifact: the guard treats `%` as a literal.
+    let widened = virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.example", "a%a")
+        .await
+        .expect("guard query should succeed");
+    assert!(
+        !widened,
+        "% inside artifactId must be escaped, not act as a wildcard"
+    );
+
+    cleanup(&pool, virtual_id, &[local_id]).await;
+}


### PR DESCRIPTION
## Summary

Closes #1287.

Maven virtual repos resolving a download were matching local members by artifactId only, ignoring groupId. The download handler called the cross-format shadowing guard `virtual_non_remote_owns_name`, which compares against `artifacts.name`. For Maven that column holds just the artifactId, so two coordinates that share an artifactId across different groupIds (e.g. `com.example.mylib:common:1.0.0` vs. `com.android.tools:common:31.4.0`) collided. Once the local artifact was uploaded, the guard fired for every request that ended in `.../common/...`, causing `proxy_for_virtual = None`, which made `resolve_virtual_download` skip all Remote members. The local path lookup then missed (the requested path lives under a different groupId) and the whole resolution returned 404.

The fix adds a Maven-aware variant `virtual_non_remote_owns_maven_ga` that matches on the full `groupId/artifactId/` path prefix using the existing `(repository_id, path)` btree (`idx_artifacts_repo_path`). Both inputs are LIKE-escaped so a crafted artifactId or groupId cannot widen the match beyond its GA directory. The Maven download handler swaps to this guard. The generic primitive is unchanged because non-Maven formats do not encode a hierarchical GA in the path.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Tests:
- 5 pure unit tests on `maven_ga_like_pattern` (groupId/artifactId composition, distinct groupIds produce distinct prefixes, sibling groupIds do not match, `%`/`_`/`\` are LIKE-escaped).
- 3 DB-driven integration tests in `backend/tests/maven_virtual_groupid_shadowing_test.rs` covering: the #1287 reproducer (a local `com.example.mylib:common` artifact must not shadow the remote `com.android.tools:common` GA), the no-non-Remote-members case (guard returns false), and crafted-artifactId LIKE-metachar escaping.

Verified locally:
- `cargo fmt --check` clean.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- `cargo test --workspace --lib maven` (180 maven-related tests) passes.
- `cargo test --test maven_virtual_groupid_shadowing_test -- --ignored` against `postgresql://registry:registry@localhost:30432/artifact_registry` passes 3/3.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes