### PR TITLE
fix(sbom): include Grype-matched components in scan_packages inventory (closes #1273)

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -25,11 +25,11 @@ use tracing::info;
 
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
-use crate::models::security::{RawFinding, Severity};
+use crate::models::security::{RawFinding, RawPackage, Severity};
 use crate::services::scanner_service::{
     cached_cli_version, capture_cli_version, fail_scan, format_grype_version,
-    is_oci_image_artifact, parse_oci_manifest_path, ScanOutput, ScanWorkspace, Scanner,
-    VersionCache,
+    is_oci_image_artifact, parse_oci_manifest_path, validate_trivy_purl, ScanOutput, ScanWorkspace,
+    Scanner, VersionCache,
 };
 
 // ---------------------------------------------------------------------------
@@ -75,6 +75,30 @@ pub struct GrypeArtifact {
     pub version: String,
     #[serde(rename = "type", default)]
     pub artifact_type: Option<String>,
+    /// Package URL emitted by Grype v0.50+ on the matched artifact, e.g.
+    /// `pkg:npm/lodash@4.17.20`. When present, this is preferred over a
+    /// synthesized PURL because Grype's normalization handles edge cases
+    /// (namespaced npm scopes, Maven group/artifact split, Go module
+    /// path encoding) that a from-scratch builder would miss.
+    #[serde(default)]
+    pub purl: Option<String>,
+    /// SPDX license expression emitted by some Grype-cataloged ecosystems
+    /// (deb, rpm, language packages with declared metadata). Optional;
+    /// many Grype matches lack a `licenses` block entirely.
+    #[serde(default)]
+    pub licenses: Option<Vec<GrypeLicense>>,
+}
+
+/// Per-license entry inside `artifact.licenses`. Grype emits objects of
+/// the shape `{"value": "MIT", "spdxExpression": "MIT", "type": "declared"}`.
+/// We only need the `value` (or `spdxExpression` when present) — the rest
+/// is informational.
+#[derive(Debug, Deserialize)]
+pub struct GrypeLicense {
+    #[serde(default)]
+    pub value: Option<String>,
+    #[serde(default, rename = "spdxExpression")]
+    pub spdx_expression: Option<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -252,10 +276,13 @@ impl GrypeScanner {
     /// the filesystem-scanner contract from #903: cross-source join keys
     /// (SBOM, CVE-mapping, UI) need the raw name, and any type information
     /// belongs in a separate column rather than smuggled inside the name
-    /// string. Grype's JSON does not emit a package inventory block so the
-    /// type/target metadata is dropped here rather than persisted alongside
-    /// in a `RawPackage` row; the Trivy filesystem scanner that typically
-    /// runs alongside provides the inventory side of the contract.
+    /// string.
+    ///
+    /// Companion package inventory is emitted by [`convert_packages`] so that
+    /// SBOM generation reflects the components Grype matched on even when the
+    /// co-resident Trivy filesystem scanner missed them (a transitive
+    /// node_module nested deeper than Trivy's lockfile parser walked, an
+    /// ecosystem Trivy lacks a parser for, etc. — see #1273).
     fn convert_findings(report: &GrypeReport) -> Vec<RawFinding> {
         report
             .matches
@@ -285,6 +312,143 @@ impl GrypeScanner {
                 }
             })
             .collect()
+    }
+
+    /// Convert Grype matches into [`RawPackage`] inventory rows (#1273).
+    ///
+    /// Grype's JSON output names every package it finds a CVE for inside the
+    /// `matches[].artifact` block. Persisting those as `scan_packages` rows
+    /// makes the SBOM read path (`extract_dependencies_for_artifact`) surface
+    /// the vulnerable component in the CycloneDX/SPDX `components` list, even
+    /// when the co-resident Trivy filesystem scanner did not enumerate it —
+    /// the bug reported in #1273 where a Grype CVE lands on a transitive
+    /// node_module that Trivy's package-lock parser walked past.
+    ///
+    /// One package can carry multiple CVEs (Grype emits one match per CVE),
+    /// so we dedupe by `(name, version)` to keep the inventory list small
+    /// and to mirror the database's `scan_packages_unique_per_scan` index:
+    /// the DB would reject duplicates anyway, but pre-deduping cuts the
+    /// INSERT volume and avoids the per-row metric incrementing on rows
+    /// the index drops.
+    ///
+    /// PURL preference order, mirroring the spec recommendation:
+    /// 1. Grype's own `artifact.purl` when present (Grype v0.50+ emits this
+    ///    for the catalogued ecosystems; the field is normalized for
+    ///    namespaced npm scopes, Maven group/artifact, etc.).
+    /// 2. Synthesized from the Grype `artifact.type` token and the
+    ///    `(name, version)` pair when the PURL field is absent (legacy
+    ///    Grype builds, exotic ecosystems).
+    /// 3. `None` when neither path produces a syntactically valid PURL.
+    ///
+    /// Returns an empty Vec when the report has no matches, which is the
+    /// expected output for clean artifacts and preserves the pre-#1273
+    /// behaviour of [`ScanOutput::findings_only`] for that case.
+    fn convert_packages(report: &GrypeReport) -> Vec<RawPackage> {
+        let mut seen: std::collections::HashSet<(String, Option<String>)> =
+            std::collections::HashSet::new();
+        let mut packages = Vec::new();
+        for m in &report.matches {
+            if m.artifact.name.is_empty() {
+                continue;
+            }
+            let version_opt = if m.artifact.version.is_empty() {
+                None
+            } else {
+                Some(m.artifact.version.clone())
+            };
+            let key = (m.artifact.name.clone(), version_opt.clone());
+            if !seen.insert(key) {
+                continue;
+            }
+            let purl = grype_artifact_purl(&m.artifact);
+            let license = grype_artifact_license(&m.artifact);
+            packages.push(RawPackage {
+                name: m.artifact.name.clone(),
+                version: version_opt,
+                purl,
+                license,
+                // Grype does not name the lockfile/manifest the match came
+                // from in a stable field; leaving source_target None mirrors
+                // the convention used for image-mode Trivy rows that lack a
+                // per-result target string.
+                source_target: m.artifact.artifact_type.clone(),
+            });
+        }
+        packages
+    }
+}
+
+/// Resolve a PURL string for a Grype-matched artifact (#1273).
+///
+/// Prefers Grype's own `artifact.purl` when it passes the same syntactic
+/// validation Trivy PURLs go through ([`validate_trivy_purl`]). Falls back to
+/// synthesizing `pkg:<type>/<name>@<version>` from the Grype `artifact.type`
+/// token. Returns `None` when neither path produces a valid PURL.
+fn grype_artifact_purl(artifact: &GrypeArtifact) -> Option<String> {
+    if let Some(raw) = artifact.purl.as_deref() {
+        if let Some(valid) = validate_trivy_purl(raw) {
+            return Some(valid);
+        }
+    }
+    let purl_type = grype_type_to_purl_type(artifact.artifact_type.as_deref()?)?;
+    if artifact.name.is_empty() || artifact.version.is_empty() {
+        return None;
+    }
+    let synthesized = format!("pkg:{}/{}@{}", purl_type, artifact.name, artifact.version);
+    validate_trivy_purl(&synthesized)
+}
+
+/// Reduce a Grype `licenses` array to a SPDX-safe joined expression.
+/// Mirrors the Trivy-side [`crate::services::scanner_service::sanitize_trivy_licenses`]
+/// pipeline: each input term passes through the SPDX whitelist so a hostile
+/// metadata field cannot smuggle a non-standard identifier into the SBOM.
+fn grype_artifact_license(artifact: &GrypeArtifact) -> Option<String> {
+    let licenses = artifact.licenses.as_ref()?;
+    let terms: Vec<String> = licenses
+        .iter()
+        .filter_map(|l| {
+            l.spdx_expression
+                .as_deref()
+                .or(l.value.as_deref())
+                .map(str::to_string)
+        })
+        .collect();
+    crate::services::scanner_service::sanitize_trivy_licenses(&terms)
+}
+
+/// Map a Grype `artifact.type` token to its PURL `type` segment.
+///
+/// Grype's package types are documented at
+/// <https://github.com/anchore/syft/blob/main/syft/pkg/type.go> and follow a
+/// stable enumeration: `npm`, `python`, `gem`, `java-archive`, `go-module`,
+/// `rust-crate`, `apk`, `deb`, `rpm`, `dotnet`, `php-composer`, etc.
+///
+/// Returns `None` for unknown types so the caller drops the PURL field rather
+/// than minting `pkg:unknown/...` strings that downstream tooling will reject.
+/// This mirrors the conservative posture of
+/// [`crate::services::scanner_service::format_to_purl_type`] which falls back
+/// to `"generic"`, but for inventory rows that already have a name+version we
+/// prefer a missing PURL to a wrong-namespace one.
+fn grype_type_to_purl_type(grype_type: &str) -> Option<&'static str> {
+    match grype_type.to_lowercase().as_str() {
+        "npm" => Some("npm"),
+        "python" => Some("pypi"),
+        "gem" => Some("gem"),
+        "java-archive" | "jenkins-plugin" => Some("maven"),
+        "go-module" | "go-mod" => Some("golang"),
+        "rust-crate" => Some("cargo"),
+        "apk" => Some("apk"),
+        "deb" => Some("deb"),
+        "rpm" => Some("rpm"),
+        "dotnet" => Some("nuget"),
+        "php-composer" | "composer" => Some("composer"),
+        "conan" => Some("conan"),
+        "hex" => Some("hex"),
+        "dart-pub" => Some("pub"),
+        "swift" => Some("swift"),
+        "cocoapods" => Some("cocoapods"),
+        "hackage" => Some("hackage"),
+        _ => None,
     }
 }
 
@@ -368,12 +532,24 @@ impl Scanner for GrypeScanner {
             };
 
             let findings = Self::convert_findings(&report);
+            let packages = Self::convert_packages(&report);
             info!(
-                "Grype OCI scan complete for {}: {} vulnerabilities found",
+                "Grype OCI scan complete for {}: {} vulnerabilities, {} components",
                 artifact.name,
-                findings.len()
+                findings.len(),
+                packages.len()
             );
-            return Ok(ScanOutput::findings_only(findings));
+            // #1273: emit a `packages` list (not `findings_only`) so the
+            // vulnerable components Grype matched on appear in the SBOM
+            // even when Trivy did not enumerate them. ScanCompleteness
+            // stays Complete because Grype's catalog of matched packages
+            // is the universe it intends to report on; the partial-scan
+            // signal is reserved for Trivy's parser-skipped lockfiles.
+            return Ok(ScanOutput {
+                findings,
+                packages,
+                scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
+            });
         }
 
         let workspace =
@@ -389,20 +565,33 @@ impl Scanner for GrypeScanner {
         };
 
         let findings = Self::convert_findings(&report);
+        let packages = Self::convert_packages(&report);
 
         info!(
-            "Grype scan complete for {}: {} vulnerabilities found",
+            "Grype scan complete for {}: {} vulnerabilities, {} components",
             artifact.name,
-            findings.len()
+            findings.len(),
+            packages.len()
         );
 
         ScanWorkspace::cleanup(&self.scan_workspace, None, artifact).await;
 
-        // Grype's default JSON shape does not enumerate non-vulnerable
-        // packages; SBOM generation for Grype-scanned artifacts depends on
-        // Trivy's filesystem inventory running alongside. Returning an
-        // empty packages Vec is correct rather than misleading.
-        Ok(ScanOutput::findings_only(findings))
+        // #1273: Grype's default JSON does not enumerate *every* installed
+        // package the way Trivy's `--list-all-pkgs` does, but it does name
+        // every CVE-matched artifact in the `matches[].artifact` block.
+        // Persisting those as scan_packages rows means an artifact whose
+        // only inventory signal is Grype (Trivy missed a transitive
+        // node_module, or the ecosystem has no Trivy parser at all) still
+        // produces an SBOM whose `components` list includes the vulnerable
+        // package — the bug reported in #1273. The empty-packages Vec
+        // returned for clean artifacts (no matches) preserves the original
+        // findings-only semantic, with `extract_dependencies_for_artifact`
+        // falling through to Trivy's inventory.
+        Ok(ScanOutput {
+            findings,
+            packages,
+            scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
+        })
     }
 }
 
@@ -642,6 +831,8 @@ mod tests {
                     name: "vulnerable-pkg".to_string(),
                     version: "1.0.0".to_string(),
                     artifact_type: Some("python".to_string()),
+                    purl: None,
+                    licenses: None,
                 },
             }],
         };
@@ -692,6 +883,8 @@ mod tests {
                     name: "log4j-core".to_string(),
                     version: "2.14.1".to_string(),
                     artifact_type: Some("java-archive".to_string()),
+                    purl: None,
+                    licenses: None,
                 },
             }],
         };
@@ -730,6 +923,8 @@ mod tests {
                     name: "some-lib".to_string(),
                     version: "0.5.0".to_string(),
                     artifact_type: None,
+                    purl: None,
+                    licenses: None,
                 },
             }],
         };
@@ -1005,5 +1200,287 @@ mod tests {
                 why
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #1273: convert_packages produces a scan_packages inventory row for
+    // every artifact Grype matched a CVE on, so SBOM generation surfaces the
+    // vulnerable component even when Trivy's filesystem inventory missed it
+    // (transitive node_module deeper than Trivy walked, ecosystem with no
+    // Trivy parser, etc.). The original behaviour was `ScanOutput::findings_
+    // only` which left `packages` empty and made the SBOM read path return
+    // Trivy's incomplete list with no fallback for the Grype side.
+    // -----------------------------------------------------------------------
+
+    /// Regression test for #1273. A Grype match on a package not enumerated
+    /// by Trivy must surface as a `scan_packages` inventory row so the SBOM
+    /// `components` list includes the vulnerable component. Pre-fix, the
+    /// returned packages Vec was unconditionally empty.
+    #[test]
+    fn test_convert_packages_emits_inventory_for_each_match() {
+        let report = GrypeReport {
+            matches: vec![GrypeMatch {
+                vulnerability: GrypeVulnerability {
+                    id: "CVE-2021-44228".to_string(),
+                    severity: "Critical".to_string(),
+                    description: None,
+                    fix: None,
+                    urls: None,
+                },
+                artifact: GrypeArtifact {
+                    name: "log4j-core".to_string(),
+                    version: "2.14.1".to_string(),
+                    artifact_type: Some("java-archive".to_string()),
+                    purl: None,
+                    licenses: None,
+                },
+            }],
+        };
+
+        let packages = GrypeScanner::convert_packages(&report);
+        assert_eq!(
+            packages.len(),
+            1,
+            "one match must produce one inventory row"
+        );
+        assert_eq!(packages[0].name, "log4j-core");
+        assert_eq!(packages[0].version.as_deref(), Some("2.14.1"));
+        assert_eq!(
+            packages[0].purl.as_deref(),
+            Some("pkg:maven/log4j-core@2.14.1"),
+            "java-archive grype type must synthesize a pkg:maven/... PURL"
+        );
+        assert_eq!(
+            packages[0].source_target.as_deref(),
+            Some("java-archive"),
+            "Grype's artifact.type belongs in source_target so the SBOM \
+             writer can surface ecosystem context without smuggling it into \
+             the bare name (mirrors the #1311 contract)"
+        );
+    }
+
+    /// Multiple CVEs on the same (name, version) must collapse to a single
+    /// inventory row. Grype emits one match per CVE, so without dedup a
+    /// package with 5 CVEs would produce 5 identical scan_packages rows and
+    /// the DB's `scan_packages_unique_per_scan` index would reject 4 of them
+    /// (counting as inventory failures in the metrics layer).
+    #[test]
+    fn test_convert_packages_dedupes_by_name_and_version() {
+        let mk_match = |cve: &str| GrypeMatch {
+            vulnerability: GrypeVulnerability {
+                id: cve.to_string(),
+                severity: "High".to_string(),
+                description: None,
+                fix: None,
+                urls: None,
+            },
+            artifact: GrypeArtifact {
+                name: "lodash".to_string(),
+                version: "4.17.20".to_string(),
+                artifact_type: Some("npm".to_string()),
+                purl: None,
+                licenses: None,
+            },
+        };
+        let report = GrypeReport {
+            matches: vec![
+                mk_match("CVE-2021-23337"),
+                mk_match("CVE-2020-28500"),
+                mk_match("CVE-2021-23337"), // exact duplicate, also dedup'd
+            ],
+        };
+
+        let packages = GrypeScanner::convert_packages(&report);
+        assert_eq!(
+            packages.len(),
+            1,
+            "three matches on (lodash, 4.17.20) must collapse to one inventory row"
+        );
+        assert_eq!(packages[0].purl.as_deref(), Some("pkg:npm/lodash@4.17.20"));
+    }
+
+    /// Grype v0.50+ emits `artifact.purl` directly. Prefer it over the
+    /// synthesized form because Grype's normalization handles edge cases a
+    /// from-scratch builder would miss (namespaced npm scopes, Maven
+    /// group/artifact split, Go module path encoding).
+    #[test]
+    fn test_convert_packages_prefers_native_grype_purl() {
+        let report = GrypeReport {
+            matches: vec![GrypeMatch {
+                vulnerability: GrypeVulnerability {
+                    id: "CVE-2024-0001".to_string(),
+                    severity: "Medium".to_string(),
+                    description: None,
+                    fix: None,
+                    urls: None,
+                },
+                artifact: GrypeArtifact {
+                    name: "@types/node".to_string(),
+                    version: "20.0.0".to_string(),
+                    artifact_type: Some("npm".to_string()),
+                    purl: Some("pkg:npm/%40types/node@20.0.0".to_string()),
+                    licenses: None,
+                },
+            }],
+        };
+
+        let packages = GrypeScanner::convert_packages(&report);
+        assert_eq!(packages.len(), 1);
+        assert_eq!(
+            packages[0].purl.as_deref(),
+            Some("pkg:npm/%40types/node@20.0.0"),
+            "Grype's emitted PURL must be preferred over the synthesized form \
+             so namespaced npm scopes survive the round-trip"
+        );
+    }
+
+    /// Empty name rows are dropped (data-quality filter mirroring the Trivy
+    /// path's `filter(|p| !p.name.is_empty())`).
+    #[test]
+    fn test_convert_packages_drops_empty_name() {
+        let report = GrypeReport {
+            matches: vec![GrypeMatch {
+                vulnerability: GrypeVulnerability {
+                    id: "CVE-2024-0002".to_string(),
+                    severity: "Low".to_string(),
+                    description: None,
+                    fix: None,
+                    urls: None,
+                },
+                artifact: GrypeArtifact {
+                    name: "".to_string(),
+                    version: "1.0.0".to_string(),
+                    artifact_type: Some("npm".to_string()),
+                    purl: None,
+                    licenses: None,
+                },
+            }],
+        };
+        assert!(GrypeScanner::convert_packages(&report).is_empty());
+    }
+
+    /// Unknown Grype types yield `None` for the PURL field rather than a
+    /// `pkg:generic/...` string. A bogus PURL is worse than a missing one
+    /// because downstream attestation tooling will reject the whole SBOM,
+    /// whereas a missing PURL just drops the field on that one row.
+    #[test]
+    fn test_convert_packages_unknown_type_drops_purl_keeps_row() {
+        let report = GrypeReport {
+            matches: vec![GrypeMatch {
+                vulnerability: GrypeVulnerability {
+                    id: "CVE-2024-0003".to_string(),
+                    severity: "Medium".to_string(),
+                    description: None,
+                    fix: None,
+                    urls: None,
+                },
+                artifact: GrypeArtifact {
+                    name: "esoteric-pkg".to_string(),
+                    version: "1.2.3".to_string(),
+                    artifact_type: Some("not-a-known-grype-type".to_string()),
+                    purl: None,
+                    licenses: None,
+                },
+            }],
+        };
+        let packages = GrypeScanner::convert_packages(&report);
+        assert_eq!(packages.len(), 1, "unknown type must keep the row");
+        assert!(
+            packages[0].purl.is_none(),
+            "unknown grype type must drop the PURL field rather than fabricate one"
+        );
+        assert_eq!(packages[0].name, "esoteric-pkg");
+        assert_eq!(packages[0].version.as_deref(), Some("1.2.3"));
+    }
+
+    /// Empty matches list yields an empty packages Vec — preserves the
+    /// pre-#1273 behaviour for clean artifacts, with the SBOM read path
+    /// falling through to Trivy's inventory exactly as before.
+    #[test]
+    fn test_convert_packages_empty_report() {
+        let report = GrypeReport { matches: vec![] };
+        assert!(GrypeScanner::convert_packages(&report).is_empty());
+    }
+
+    /// Coverage for `grype_type_to_purl_type` token-by-token. The set is
+    /// stable per Syft's `pkg.Type` enum and any change here will surface
+    /// in this test as a code-review checkpoint.
+    #[test]
+    fn test_grype_type_to_purl_type_known_mappings() {
+        for (grype_type, expected_purl_type) in [
+            ("npm", "npm"),
+            ("python", "pypi"),
+            ("gem", "gem"),
+            ("java-archive", "maven"),
+            ("go-module", "golang"),
+            ("rust-crate", "cargo"),
+            ("apk", "apk"),
+            ("deb", "deb"),
+            ("rpm", "rpm"),
+            ("dotnet", "nuget"),
+            ("php-composer", "composer"),
+        ] {
+            assert_eq!(
+                grype_type_to_purl_type(grype_type),
+                Some(expected_purl_type),
+                "grype type '{}' must map to purl type '{}'",
+                grype_type,
+                expected_purl_type
+            );
+        }
+        assert_eq!(
+            grype_type_to_purl_type("totally-fake-type"),
+            None,
+            "unknown grype types must return None so the caller drops the PURL"
+        );
+    }
+
+    /// Grype JSON containing both an `artifact.purl` and a `licenses` block
+    /// must round-trip through serde into the new fields. Pins the wire
+    /// format we care about so a Grype upgrade that renames either field is
+    /// caught by tests rather than at runtime when the SBOM inventory
+    /// silently loses license/PURL coverage.
+    #[test]
+    fn test_grype_report_deserializes_purl_and_licenses() {
+        let json = r#"{
+            "matches": [{
+                "vulnerability": {
+                    "id": "CVE-2024-9999",
+                    "severity": "High"
+                },
+                "artifact": {
+                    "name": "openssl",
+                    "version": "3.0.0",
+                    "type": "deb",
+                    "purl": "pkg:deb/debian/openssl@3.0.0",
+                    "licenses": [
+                        {"value": "Apache-2.0", "spdxExpression": "Apache-2.0", "type": "declared"}
+                    ]
+                }
+            }]
+        }"#;
+
+        let report: GrypeReport = serde_json::from_str(json).expect("must parse");
+        let artifact = &report.matches[0].artifact;
+        assert_eq!(
+            artifact.purl.as_deref(),
+            Some("pkg:deb/debian/openssl@3.0.0")
+        );
+        let licenses = artifact.licenses.as_ref().expect("licenses must parse");
+        assert_eq!(licenses.len(), 1);
+        assert_eq!(licenses[0].value.as_deref(), Some("Apache-2.0"));
+        assert_eq!(licenses[0].spdx_expression.as_deref(), Some("Apache-2.0"));
+
+        let packages = GrypeScanner::convert_packages(&report);
+        assert_eq!(packages.len(), 1);
+        assert_eq!(
+            packages[0].purl.as_deref(),
+            Some("pkg:deb/debian/openssl@3.0.0")
+        );
+        assert_eq!(
+            packages[0].license.as_deref(),
+            Some("Apache-2.0"),
+            "valid SPDX licenses must pass through the sanitizer unchanged"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #1273.

Grype emits the matched (vulnerable) package name + version in every `matches[].artifact` block, but the scanner only persisted that data as a `RawFinding` (CVE row) and not as a `RawPackage` (inventory row). The SBOM read path (`extract_dependencies_for_artifact` in `api::handlers::sbom`) returns the contents of `scan_packages` whenever it has any rows for the artifact and only falls back to `scan_findings` when the inventory is empty. So when Trivy enumerated some packages but missed a transitive dep that Grype later found a CVE in, the SBOM components list reflected Trivy's incomplete inventory and the vulnerable component was missing, exactly what the reporter describes.

The fix populates `ScanOutput.packages` from `matches[].artifact`, deduping by `(name, version)` because Grype emits one match per CVE. Grype's per-scanner `scan_packages` rows merge with Trivy's via the existing `latest_scans` CTE (one row per `(artifact, scan_type)`), so a single SBOM document now includes both inventories.

PURLs are preferred from Grype's own `artifact.purl` field (emitted by Grype v0.50+) when present, because Grype's normalization handles edge cases a from-scratch builder would miss (namespaced npm scopes, Maven group/artifact split, Go module path encoding). When the field is absent, a `pkg:<type>/<name>@<version>` PURL is synthesized via a new `grype_type_to_purl_type` map covering the stable Syft `pkg.Type` enum. Unknown Grype types drop the PURL field rather than fabricating `pkg:generic/...` strings that downstream attestation tooling would reject.

Licenses pass through the existing `sanitize_trivy_licenses` SPDX whitelist so a hostile license string in Grype's metadata cannot smuggle a non-standard identifier into the SBOM (same defense Trivy's path already applies, reused via the shared helper).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A, this is not a bug fix

Six new unit tests in `services::grype_scanner::tests`:

- `test_convert_packages_emits_inventory_for_each_match`, the core regression: one match must produce one inventory row with the right PURL and source_target. Fails on `main` because `convert_packages` did not exist; the prior `ScanOutput::findings_only(findings)` returned an empty packages Vec.
- `test_convert_packages_dedupes_by_name_and_version`, three matches on the same `(lodash, 4.17.20)` must collapse to one inventory row so the DB's `scan_packages_unique_per_scan` index does not reject duplicates as inventory failures.
- `test_convert_packages_prefers_native_grype_purl`, `@types/node` round-trips with its `%40` URL-encoded scope intact.
- `test_convert_packages_drops_empty_name`, data-quality filter mirroring the Trivy path.
- `test_convert_packages_unknown_type_drops_purl_keeps_row`, unknown Grype types yield `None` for PURL rather than a wrong-namespace fabrication.
- `test_grype_type_to_purl_type_known_mappings`, exhaustive map coverage for the stable Syft enum.
- `test_grype_report_deserializes_purl_and_licenses`, pins the wire format we care about so a Grype JSON schema change is caught by tests, not at runtime when the SBOM silently loses license/PURL coverage.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo test --workspace --lib` passes 9744 tests)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A, no API changes