### PR TITLE
fix(smtp): accept `recipient` alias on test email endpoint (closes #1332)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4823,10 +4823,7 @@ mod tests {
         // Pathological case: both sizes near i64::MAX should saturate
         // instead of wrapping to a negative number that the UI would
         // render as a nonsense size.
-        let row = docker_tag_row(
-            "application/vnd.oci.image.index.v1+json",
-            i64::MAX - 100,
-        );
+        let row = docker_tag_row("application/vnd.oci.image.index.v1+json", i64::MAX - 100);
         let mut children = std::collections::HashMap::new();
         children.insert("sha256:parentdigest".to_string(), 1_000);
 

--- a/backend/src/api/handlers/smtp.rs
+++ b/backend/src/api/handlers/smtp.rs
@@ -23,6 +23,10 @@ pub struct SmtpApiDoc;
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct SmtpTestRequest {
     /// Recipient email address for the test message.
+    ///
+    /// Accepts `recipient` as an alias for backward compatibility with Web UI
+    /// versions <= 1.1.3, which send `{"recipient": "..."}`.
+    #[serde(alias = "recipient")]
     pub to: String,
 }
 
@@ -83,4 +87,33 @@ pub async fn send_test_email(
         success: true,
         message: format!("Test email sent to {}", req.to),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smtp_test_request_accepts_to_field() {
+        let body = r#"{"to":"user@example.com"}"#;
+        let req: SmtpTestRequest = serde_json::from_str(body).expect("should parse `to`");
+        assert_eq!(req.to, "user@example.com");
+    }
+
+    #[test]
+    fn smtp_test_request_accepts_recipient_alias() {
+        // Web UI 1.1.3 and earlier send `{"recipient": "..."}`. The backend
+        // must accept this for backward compatibility (issue #1332).
+        let body = r#"{"recipient":"user@example.com"}"#;
+        let req: SmtpTestRequest =
+            serde_json::from_str(body).expect("should parse `recipient` alias");
+        assert_eq!(req.to, "user@example.com");
+    }
+
+    #[test]
+    fn smtp_test_request_rejects_missing_field() {
+        let body = r#"{}"#;
+        let result: std::result::Result<SmtpTestRequest, _> = serde_json::from_str(body);
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

Web UI 1.1.3 sends `{"recipient": "..."}` to `POST /api/v1/admin/smtp/test`, but the backend `SmtpTestRequest` only deserialized `to`, so the request was rejected with HTTP 422 before any SMTP delivery was attempted.

This adds `#[serde(alias = "recipient")]` on the `to` field so both shapes deserialize correctly. The fix is backward compatible:

- New Web UIs (which send `to`) continue to work unchanged.
- Web UI 1.1.3 (and any older clients sending `recipient`) now succeed.

Backend logs in the issue confirm the request reaches the handler and fails at JSON deserialization (422), so a serde-level fix is sufficient.

Closes #1332.

## Linked issue (required)
Closes #1332

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

Added three unit tests in `backend/src/api/handlers/smtp.rs`:
- `smtp_test_request_accepts_to_field` - the canonical shape still works
- `smtp_test_request_accepts_recipient_alias` - the Web UI 1.1.3 shape now works (would fail on `main`)
- `smtp_test_request_rejects_missing_field` - missing both fields is still rejected

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo test --workspace --lib api::handlers::smtp` 3/3 pass; full lib suite 9766/9766 pass)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

The OpenAPI schema for `SmtpTestRequest` is unchanged. `to` remains the documented field; `recipient` is accepted at the serde layer only for backward compatibility.