### PR TITLE
fix: apply rustfmt to unblock v1.2.0-rc.2 (closes #1337)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4823,10 +4823,7 @@ mod tests {
         // Pathological case: both sizes near i64::MAX should saturate
         // instead of wrapping to a negative number that the UI would
         // render as a nonsense size.
-        let row = docker_tag_row(
-            "application/vnd.oci.image.index.v1+json",
-            i64::MAX - 100,
-        );
+        let row = docker_tag_row("application/vnd.oci.image.index.v1+json", i64::MAX - 100);
         let mut children = std::collections::HashMap::new();
         children.insert("sha256:parentdigest".to_string(), 1_000);
 


### PR DESCRIPTION
Closes #1337.

## Linked issue (required)
Closes #1337

## Summary

`cargo fmt --all`. Unblocks the failing 🦀 Check Rust job on main so we can tag v1.2.0-rc.2.

Root cause: PR #1336 merged with a known fmt nit (Architect reviewer flagged it; author didn't address before merge).

## Regression test
- [x] N/A — formatting-only

## Test Checklist
- [x] cargo fmt --all -- --check passes
- [x] cargo clippy --workspace --all-targets -- -D warnings passes
- [x] No code changes
