### PR TITLE
fix(ci): smoke E2E virtual repo creates must supply member_repos (closes #1353)

### DIFF
--- a/scripts/devops-agent-stress-test.sh
+++ b/scripts/devops-agent-stress-test.sh
@@ -181,18 +181,23 @@ for fmt in "${STAGING_FORMATS[@]}"; do
 done
 
 # --- Test: Create virtual repos with members ---
+# Per #1281, POST /api/v1/repositories with repo_type=virtual must supply a
+# non-empty member_repos array at create time. The standalone members endpoint
+# still works for post-create updates and is exercised below as a 409 no-op
+# to keep that path covered.
 for fmt in "maven" "npm"; do
     VKEY="stress-${fmt}-virtual-${TIMESTAMP}"
     LKEY="stress-${fmt}-local-${TIMESTAMP}"
-    RESP=$(api_full POST "/api/v1/repositories" -d "{\"key\":\"$VKEY\",\"name\":\"Stress $fmt Virtual\",\"format\":\"$fmt\",\"repo_type\":\"virtual\"}")
+    RESP=$(api_full POST "/api/v1/repositories" \
+        -d "{\"key\":\"$VKEY\",\"name\":\"Stress $fmt Virtual\",\"format\":\"$fmt\",\"repo_type\":\"virtual\",\"member_repos\":[{\"repo_key\":\"$LKEY\",\"priority\":1}]}")
     CODE="${RESP%%|*}"
     if [ "$CODE" = "200" ] || [ "$CODE" = "201" ]; then
-        log_pass "Create $fmt virtual repo"
-        # Add member
+        log_pass "Create $fmt virtual repo with $LKEY member"
+        # Idempotent re-add to keep coverage on the standalone members endpoint
         MRESP=$(api_full POST "/api/v1/repositories/$VKEY/members" -d "{\"member_key\":\"$LKEY\",\"priority\":1}")
         MCODE="${MRESP%%|*}"
-        if [ "$MCODE" = "200" ] || [ "$MCODE" = "201" ]; then
-            log_pass "Add $LKEY as member of $VKEY"
+        if [ "$MCODE" = "200" ] || [ "$MCODE" = "201" ] || [ "$MCODE" = "409" ]; then
+            log_pass "Standalone add $LKEY -> $VKEY (idempotent, HTTP $MCODE)"
         else
             log_fail "Add virtual member: HTTP $MCODE - ${MRESP#*|}"
         fi

--- a/scripts/e2e-setup.sh
+++ b/scripts/e2e-setup.sh
@@ -94,23 +94,47 @@ do
 done
 
 echo "==> Creating virtual repositories..."
+# Per #1281, POST /api/v1/repositories with repo_type=virtual now requires a
+# non-empty member_repos array at create time. We embed the members inline.
+# Format: KEY:NAME:FMT|MEMBER1:PRI1,MEMBER2:PRI2
 for virtual in \
-  "npm-virtual:NPM Virtual:npm" \
-  "pypi-virtual:PyPI Virtual:pypi" \
-  "hex-virtual:Hex Virtual:hex"
+  "npm-virtual:NPM Virtual:npm|npm-local-e2e:1,npm-proxy:2" \
+  "pypi-virtual:PyPI Virtual:pypi|pypi-local-e2e:1,pypi-proxy:2" \
+  "hex-virtual:Hex Virtual:hex|hex-local-e2e:1,hex-proxy:2"
 do
-  KEY=$(echo "$virtual" | cut -d: -f1)
-  NAME=$(echo "$virtual" | cut -d: -f2)
-  FMT=$(echo "$virtual" | cut -d: -f3)
+  HEAD="${virtual%%|*}"
+  TAIL="${virtual#*|}"
+  KEY=$(echo "$HEAD" | cut -d: -f1)
+  NAME=$(echo "$HEAD" | cut -d: -f2)
+  FMT=$(echo "$HEAD" | cut -d: -f3)
+  # Build the member_repos JSON array from the comma-separated MEMBER:PRI list
+  MEMBERS_JSON="["
+  FIRST=1
+  IFS=',' read -ra PAIRS <<< "$TAIL"
+  for pair in "${PAIRS[@]}"; do
+    MKEY="${pair%%:*}"
+    PRI="${pair##*:}"
+    if [ $FIRST -eq 1 ]; then
+      FIRST=0
+    else
+      MEMBERS_JSON="$MEMBERS_JSON,"
+    fi
+    MEMBERS_JSON="$MEMBERS_JSON{\"repo_key\":\"$MKEY\",\"priority\":$PRI}"
+  done
+  MEMBERS_JSON="$MEMBERS_JSON]"
   curl -sf -X POST "$REGISTRY_URL/api/v1/repositories" \
     -H "Authorization: Bearer $TOKEN" \
     -H 'Content-Type: application/json' \
-    -d "{\"key\":\"$KEY\",\"name\":\"$NAME\",\"format\":\"$FMT\",\"repo_type\":\"virtual\",\"is_public\":true}" \
+    -d "{\"key\":\"$KEY\",\"name\":\"$NAME\",\"format\":\"$FMT\",\"repo_type\":\"virtual\",\"is_public\":true,\"member_repos\":$MEMBERS_JSON}" \
     >/dev/null 2>&1 || true
-  echo "  - $KEY ($FMT virtual)"
+  echo "  - $KEY ($FMT virtual, members: $TAIL)"
 done
 
-echo "==> Wiring virtual repository members..."
+# Idempotent reconciliation. Members are wired at create time above, so each
+# of these calls is expected to return 409 (already a member). We keep them so
+# re-runs against an existing database, where the virtuals may pre-exist
+# without members for any reason, still converge on the right shape.
+echo "==> Reconciling virtual repository members (idempotent)..."
 for member in \
   "npm-virtual:npm-local-e2e:1" \
   "npm-virtual:npm-proxy:2" \
@@ -127,7 +151,6 @@ do
     -H 'Content-Type: application/json' \
     -d "{\"member_key\":\"$MKEY\",\"priority\":$PRI}" \
     >/dev/null 2>&1 || true
-  echo "  - $VKEY <- $MKEY (priority=$PRI)"
 done
 
 echo "==> Setup complete"

--- a/scripts/native-tests/test-proxy-virtual.sh
+++ b/scripts/native-tests/test-proxy-virtual.sh
@@ -78,8 +78,18 @@ echo "  Authenticated successfully"
 echo ""
 
 # Helper: create a repository (deletes first if exists to ensure clean state)
+#
+# Args:
+#   $1  key
+#   $2  name
+#   $3  format
+#   $4  repo_type (local|remote|virtual|staging)
+#   $5  upstream_url (optional, only for remote)
+#   $6  member_repos JSON array (required for virtual; per #1281 the backend
+#       rejects virtual creates without members at 400). Example:
+#         '[{"repo_key":"npm-local","priority":1},{"repo_key":"npm-proxy","priority":2}]'
 create_repo() {
-    local key="$1" name="$2" format="$3" repo_type="$4" upstream_url="${5:-}"
+    local key="$1" name="$2" format="$3" repo_type="$4" upstream_url="${5:-}" member_repos="${6:-}"
 
     # Delete if exists (ignore errors)
     curl -s -o /dev/null -X DELETE "$API_URL/repositories/$key" -H "$AUTH" 2>/dev/null || true
@@ -88,6 +98,9 @@ create_repo() {
     if [ -n "$upstream_url" ]; then
         body="$body,\"upstream_url\":\"$upstream_url\""
     fi
+    if [ -n "$member_repos" ]; then
+        body="$body,\"member_repos\":$member_repos"
+    fi
     body="$body}"
     local http_code
     http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/repositories" \
@@ -95,8 +108,9 @@ create_repo() {
     if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
         return 0
     else
-        echo "  WARNING: create_repo $key returned HTTP $http_code"
-        return 1
+        echo "  ERROR: create_repo $key returned HTTP $http_code (body: $body)"
+        echo "  Aborting: subsequent tests depend on this repo existing."
+        exit 1
     fi
 }
 
@@ -144,28 +158,30 @@ echo "  - hex-local-e2e (local)"
 create_repo "hex-proxy" "Hex Proxy" "hex" "remote" "https://repo.hex.pm"
 echo "  - hex-proxy (remote -> repo.hex.pm)"
 
-# Virtual repos (aggregating local + remote)
-create_repo "npm-virtual" "NPM Virtual" "npm" "virtual"
-echo "  - npm-virtual (virtual)"
+# Virtual repos (aggregating local + remote).
+# Per #1281, virtual creates must supply member_repos at POST time; the standalone
+# POST /repositories/{key}/members endpoint still works for post-create edits and
+# is exercised below as an idempotent 409 to keep that path covered.
+create_repo "npm-virtual" "NPM Virtual" "npm" "virtual" "" \
+    '[{"repo_key":"npm-local-e2e","priority":1},{"repo_key":"npm-proxy","priority":2}]'
+echo "  - npm-virtual (virtual) members: npm-local-e2e (pri=1), npm-proxy (pri=2)"
 
-create_repo "pypi-virtual" "PyPI Virtual" "pypi" "virtual"
-echo "  - pypi-virtual (virtual)"
+create_repo "pypi-virtual" "PyPI Virtual" "pypi" "virtual" "" \
+    '[{"repo_key":"pypi-local-e2e","priority":1},{"repo_key":"pypi-proxy","priority":2}]'
+echo "  - pypi-virtual (virtual) members: pypi-local-e2e (pri=1), pypi-proxy (pri=2)"
 
-create_repo "hex-virtual" "Hex Virtual" "hex" "virtual"
-echo "  - hex-virtual (virtual)"
+create_repo "hex-virtual" "Hex Virtual" "hex" "virtual" "" \
+    '[{"repo_key":"hex-local-e2e","priority":1},{"repo_key":"hex-proxy","priority":2}]'
+echo "  - hex-virtual (virtual) members: hex-local-e2e (pri=1), hex-proxy (pri=2)"
 
-# Wire virtual members (local first = higher priority, then remote proxy)
+# Re-issue add_virtual_member as a 409 no-op so the dedicated endpoint stays
+# exercised in smoke. add_virtual_member() already accepts 409 as success.
 add_virtual_member "npm-virtual" "npm-local-e2e" 1
 add_virtual_member "npm-virtual" "npm-proxy" 2
-echo "  - npm-virtual members: npm-local-e2e (pri=1), npm-proxy (pri=2)"
-
 add_virtual_member "pypi-virtual" "pypi-local-e2e" 1
 add_virtual_member "pypi-virtual" "pypi-proxy" 2
-echo "  - pypi-virtual members: pypi-local-e2e (pri=1), pypi-proxy (pri=2)"
-
 add_virtual_member "hex-virtual" "hex-local-e2e" 1
 add_virtual_member "hex-virtual" "hex-proxy" 2
-echo "  - hex-virtual members: hex-local-e2e (pri=1), hex-proxy (pri=2)"
 
 echo ""
 


### PR DESCRIPTION
## Summary

Closes #1353. Main-branch `🔥 Smoke E2E Tests` is RED because the three virtual-repo creates in the smoke setup still POST the pre-#1281 shape. PR #1281 tightened `POST /api/v1/repositories` to require a non-empty `member_repos` array at create time for `repo_type=virtual`; the smoke scripts kept POSTing without it and ate the resulting 400 with `|| true`. The npm-virtual / pypi-virtual / hex-virtual repos therefore never got created, every subsequent fetch 404'd, and the first visible failure surfaced as `npm-virtual repo_type is '' (expected 'virtual')` from `jq` parsing an empty body.

Failing run for the record: https://github.com/artifact-keeper/artifact-keeper/actions/runs/26292180926/job/77400161180

Reproducible signal in the logs:

```
WARNING: create_repo npm-virtual returned HTTP 400
WARNING: create_repo pypi-virtual returned HTTP 400
WARNING: create_repo hex-virtual returned HTTP 400
WARNING: add_virtual_member npm-virtual/npm-local-e2e returned HTTP 404
...
FAIL: NPM publish to virtual repo returned HTTP 404 (expected 400)
FAIL: Virtual NPM tarball returned HTTP 404
FAIL: Virtual member listing returned HTTP 404
FAIL: npm install via virtual repo failed
FAIL: npm-virtual repo_type is '' (expected 'virtual')
```

This PR updates the three smoke E2E scripts to supply `member_repos` inline on the create POST:

- `scripts/native-tests/test-proxy-virtual.sh`: extend `create_repo()` with a 6th positional arg for the `member_repos` JSON array. Inline members on each of the three virtual-repo create calls. The follow-up `add_virtual_member` calls are kept as 409 no-ops so the standalone members endpoint stays exercised. `create_repo` now `exit 1`s on non-2xx instead of warn-and-continue so this class of drift fails the build at the source rather than 50 lines later in a confusing assertion.
- `scripts/e2e-setup.sh`: build the `member_repos` JSON from a `MEMBER:PRI,...` suffix on each virtual-repo entry and inline it on the create POST. The `Wiring virtual repository members` loop is preserved as idempotent reconciliation (409 expected on the common path).
- `scripts/devops-agent-stress-test.sh`: virtual-create now supplies the required `member_repos` at create time. The standalone members POST is retained as idempotent coverage and now also accepts 409 as success.

No backend code or API contract changes.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A

The smoke E2E `test-proxy-virtual.sh` itself IS the regression test: it exercises NPM publish/install through `npm-virtual`, virtual tarball download, and the `/repositories/{key}` API assertion `repo_type == "virtual"`. The bug was that the suite was scripted to swallow create-time failures. The `exit 1` hardening on `create_repo` ensures the same drift (a future tightening of any create-time contract that the scripts haven't caught up with) fails the smoke job at the create POST, not 200 lines later.

The backend validator behind this (introduced in #1281) already has full unit coverage:
```
cargo test --workspace --lib validate_virtual_repo_member
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured
```

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — three smoke E2E scripts updated; `test-proxy-virtual.sh` would have caught the original drift if `create_repo` had failed fast on the 400, which it now does
- [x] Manually tested locally — see Verification below
- [x] No regressions in existing tests — validator unit tests still pass

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Verification

Local validation in an isolated worktree against `3525b65` (current `main`):

```
bash -n scripts/native-tests/test-proxy-virtual.sh    OK
bash -n scripts/e2e-setup.sh                          OK
bash -n scripts/devops-agent-stress-test.sh           OK
shellcheck -S error <three scripts>                   clean
cargo test --workspace --lib validate_virtual_repo_member   4/4 pass
```

JSON shape dry-run on the new builders, piped through `jq -c .`:

```
{"key":"npm-virtual","name":"NPM Virtual","format":"npm","repo_type":"virtual","is_public":true,"member_repos":[{"repo_key":"npm-local-e2e","priority":1},{"repo_key":"npm-proxy","priority":2}]}
{"key":"pypi-virtual","name":"PyPI Virtual","format":"pypi","repo_type":"virtual","is_public":true,"member_repos":[{"repo_key":"pypi-local-e2e","priority":1},{"repo_key":"pypi-proxy","priority":2}]}
{"key":"hex-virtual","name":"Hex Virtual","format":"hex","repo_type":"virtual","is_public":true,"member_repos":[{"repo_key":"hex-local-e2e","priority":1},{"repo_key":"hex-proxy","priority":2}]}
```

End-to-end smoke verification will run automatically on this PR via `🔥 Smoke E2E Tests`. Merging blocked on all CI green.

## Out of scope

- `scripts/native-tests/test-conda.sh` has a similar virtual-create call that has been silently dead since long before #1281 (it uses a UUID where the route expects a key, and `member_repo_id` where the endpoint expects `member_key`). It's not in the smoke profile and not failing CI today. Track separately if we want to revive that path.
- `error: registry index was not found in any configuration: 'test-registry'` in `test-cargo.sh` is masked by `|| echo "Publish may have succeeded with warnings"` and does not affect the smoke exit code. Track separately.