### PR TITLE
feat: stream artifact downloads across all package formats

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -582,16 +582,11 @@ async fn download_package(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/vnd.alpine.package".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/vnd.alpine.package",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);

--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -563,7 +563,7 @@ async fn download_package(
                 let db = state.db.clone();
                 let upstream_path = format!("{}/{}/{}/{}", branch, repository, arch, filename);
                 let artifact_path_clone = artifact_path.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -582,16 +582,16 @@ async fn download_package(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type
-                            .unwrap_or_else(|| "application/vnd.alpine.package".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/vnd.alpine.package".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -606,8 +606,8 @@ async fn download_package(
         .await
         .map_err(|e| e.into_response())?;
 
-    match storage.get(&artifact.storage_key).await {
-        Ok(content) => {
+    match storage.get_stream(&artifact.storage_key).await {
+        Ok(stream) => {
             // Record download
             let _ = sqlx::query!(
                 "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
@@ -623,9 +623,9 @@ async fn download_package(
                     "Content-Disposition",
                     format!("attachment; filename=\"{}\"", filename),
                 )
-                .header(CONTENT_LENGTH, content.len().to_string())
+                .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
                 .header("X-Checksum-SHA256", &artifact.checksum_sha256)
-                .body(Body::from(content))
+                .body(Body::from_stream(stream))
                 .unwrap())
         }
         Err(crate::error::AppError::NotFound(_)) if repo.repo_type != RepositoryType::Remote => {

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -876,7 +876,7 @@ async fn download(
                     state.proxy_service.as_deref()
                 };
 
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     proxy_for_virtual,
                     repo.id,
@@ -898,20 +898,23 @@ async fn download(
 
                 let filename = format!("{}-{}.crate", name_lower, version);
 
-                return Ok(Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::OK)
                     .header(
                         CONTENT_TYPE,
-                        content_type.unwrap_or_else(|| "application/x-tar".to_string()),
+                        result
+                            .content_type
+                            .unwrap_or_else(|| "application/x-tar".to_string()),
                     )
                     .header(
                         "Content-Disposition",
                         format!("attachment; filename=\"{}\"", filename),
                     )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .header("cache-control", "public, max-age=31536000, immutable")
-                    .body(Body::from(content))
-                    .unwrap());
+                    .header("cache-control", "public, max-age=31536000, immutable");
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(AppError::NotFound("Crate not found".to_string()).into_response());
         }
@@ -925,8 +928,8 @@ async fn download(
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
-    let content = storage
-        .get(&artifact.storage_key)
+    let stream = storage
+        .get_stream(&artifact.storage_key)
         .await
         .map_err(map_storage_err)?;
 
@@ -947,11 +950,11 @@ async fn download(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         // .crate files are content-addressed and immutable: same name+version
         // always has the same bytes.  Cargo can cache them indefinitely.
         .header("cache-control", "public, max-age=31536000, immutable")
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -346,16 +346,7 @@ async fn download_cookbook(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/gzip".to_string()),
-                );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(result, "application/gzip", None);
             }
 
             return Err(not_found);

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -326,7 +326,7 @@ async fn download_cookbook(
                     format!("api/v1/cookbooks/{}/versions/{}/download", name, version);
                 let name_clone = name.clone();
                 let version_clone = version.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -346,15 +346,16 @@ async fn download_cookbook(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/gzip".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/gzip".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -369,13 +370,16 @@ async fn download_cookbook(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     let _ = sqlx::query!(
         "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
@@ -393,8 +397,8 @@ async fn download_cookbook(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -232,16 +232,11 @@ async fn download_pod(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -212,7 +212,7 @@ async fn download_pod(
                 let upstream_path = format!("pods/{}", filename);
                 let vname = path_info.name.clone();
                 let vversion = path_info.version.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -232,15 +232,16 @@ async fn download_pod(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -255,13 +256,16 @@ async fn download_pod(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -278,8 +282,8 @@ async fn download_pod(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -489,7 +489,7 @@ async fn download_archive(
                 let vversion = version.clone();
                 let upstream_path =
                     format!("dist/{}/{}/{}/{}.zip", vendor, package, version, reference);
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -511,19 +511,22 @@ async fn download_archive(
 
                 let filename = format!("{}-{}.zip", package, version);
 
-                return Ok(Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::OK)
                     .header(
                         CONTENT_TYPE,
-                        content_type.unwrap_or_else(|| "application/zip".to_string()),
+                        result
+                            .content_type
+                            .unwrap_or_else(|| "application/zip".to_string()),
                     )
                     .header(
                         "Content-Disposition",
                         format!("attachment; filename=\"{}\"", filename),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                    );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -538,13 +541,16 @@ async fn download_archive(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -563,9 +569,9 @@ async fn download_archive(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("X-Checksum-SHA256", &artifact.checksum_sha256)
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -511,22 +511,11 @@ async fn download_archive(
 
                 let filename = format!("{}-{}.zip", package, version);
 
-                let mut builder = Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        CONTENT_TYPE,
-                        result
-                            .content_type
-                            .unwrap_or_else(|| "application/zip".to_string()),
-                    )
-                    .header(
-                        "Content-Disposition",
-                        format!("attachment; filename=\"{}\"", filename),
-                    );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/zip",
+                    Some(&filename),
+                );
             }
             return Err(not_found);
         }

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -973,16 +973,11 @@ async fn recipe_file_download(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -1670,16 +1665,11 @@ async fn package_file_download(
                     )
                     .await?;
 
-                    let mut builder = Response::builder().status(StatusCode::OK).header(
-                        "Content-Type",
-                        result
-                            .content_type
-                            .unwrap_or_else(|| "application/octet-stream".to_string()),
+                    return proxy_helpers::stream_fetch_result(
+                        result,
+                        "application/octet-stream",
+                        None,
                     );
-                    if let Some(size) = result.content_length {
-                        builder = builder.header(CONTENT_LENGTH, size.to_string());
-                    }
-                    return Ok(builder.body(Body::from_stream(result.body)).unwrap());
                 }
                 return Err(not_found);
             }

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -954,7 +954,7 @@ async fn recipe_file_download(
                     file_path.trim_start_matches('/')
                 );
                 let vpath = artifact_path.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -973,15 +973,16 @@ async fn recipe_file_download(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -1650,7 +1651,7 @@ async fn package_file_download(
                         file_path.trim_start_matches('/')
                     );
                     let vpath = artifact_path.clone();
-                    let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                    let result = proxy_helpers::resolve_virtual_download(
                         &state.db,
                         state.proxy_service.as_deref(),
                         repo.id,
@@ -1669,15 +1670,16 @@ async fn package_file_download(
                     )
                     .await?;
 
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .header(CONTENT_LENGTH, content.len().to_string())
-                        .body(Body::from(content))
-                        .unwrap());
+                    let mut builder = Response::builder().status(StatusCode::OK).header(
+                        "Content-Type",
+                        result
+                            .content_type
+                            .unwrap_or_else(|| "application/octet-stream".to_string()),
+                    );
+                    if let Some(size) = result.content_length {
+                        builder = builder.header(CONTENT_LENGTH, size.to_string());
+                    }
+                    return Ok(builder.body(Body::from_stream(result.body)).unwrap());
                 }
                 return Err(not_found);
             }

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2372,7 +2372,7 @@ async fn download_package(
                 let db = state.db.clone();
                 let upstream_path = format!("{}/{}", subdir, filename);
                 let artifact_path_clone = artifact_path.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -2398,19 +2398,20 @@ async fn download_package(
                 } else {
                     "application/octet-stream"
                 };
-                return Ok(Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::OK)
                     .header(
                         "Content-Type",
-                        content_type.unwrap_or_else(|| ct.to_string()),
+                        result.content_type.unwrap_or_else(|| ct.to_string()),
                     )
                     .header(
                         "Content-Disposition",
                         format!("attachment; filename=\"{}\"", filename),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                    );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -2426,10 +2427,13 @@ async fn download_package(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        tracing::error!("Storage error reading conda package: {}", e);
-        (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            tracing::error!("Storage error reading conda package: {}", e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error").into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -2454,9 +2458,9 @@ async fn download_package(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("X-Checksum-SHA256", &artifact.checksum_sha256)
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2398,20 +2398,7 @@ async fn download_package(
                 } else {
                     "application/octet-stream"
                 };
-                let mut builder = Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        result.content_type.unwrap_or_else(|| ct.to_string()),
-                    )
-                    .header(
-                        "Content-Disposition",
-                        format!("attachment; filename=\"{}\"", filename),
-                    );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(result, ct, Some(&filename));
             }
 
             return Err(not_found);

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1249,22 +1249,11 @@ async fn pool_download(
                 .await?;
 
                 let filename = path.rsplit('/').next().unwrap_or(&path);
-                let mut builder = Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        result
-                            .content_type
-                            .unwrap_or_else(|| "application/vnd.debian.binary-package".to_string()),
-                    )
-                    .header(
-                        "Content-Disposition",
-                        format!("attachment; filename=\"{}\"", filename),
-                    );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/vnd.debian.binary-package",
+                    Some(filename),
+                );
             }
 
             return Err(not_found);

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1229,7 +1229,7 @@ async fn pool_download(
                 let db = state.db.clone();
                 let upstream_path = format!("pool/{}/{}", component, path);
                 let artifact_path_clone = artifact_path.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -1249,20 +1249,22 @@ async fn pool_download(
                 .await?;
 
                 let filename = path.rsplit('/').next().unwrap_or(&path);
-                return Ok(Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::OK)
                     .header(
                         "Content-Type",
-                        content_type
+                        result
+                            .content_type
                             .unwrap_or_else(|| "application/vnd.debian.binary-package".to_string()),
                     )
                     .header(
                         "Content-Disposition",
                         format!("attachment; filename=\"{}\"", filename),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                    );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -1277,13 +1279,16 @@ async fn pool_download(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -1302,9 +1307,9 @@ async fn pool_download(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("X-Checksum-SHA256", &artifact.checksum_sha256)
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -632,16 +632,11 @@ async fn download_object(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(lfs_error_response(

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -613,7 +613,7 @@ async fn download_object(
                 let artifact_path = format!("lfs/objects/{}/{}", &oid[..2], oid);
                 let path_clone = artifact_path.clone();
                 let upstream_path = format!("objects/{}", oid);
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -632,15 +632,16 @@ async fn download_object(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(lfs_error_response(
@@ -658,12 +659,15 @@ async fn download_object(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        lfs_error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("Storage error: {}", e),
-        )
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            lfs_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Storage error: {}", e),
+            )
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -676,8 +680,8 @@ async fn download_object(
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/octet-stream")
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -627,16 +627,11 @@ async fn get_mod_file(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "text/plain; charset=utf-8".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "text/plain; charset=utf-8",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -772,16 +767,7 @@ async fn download_zip(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/zip".to_string()),
-                );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(result, "application/zip", None);
             }
 
             return Err(not_found);

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -607,7 +607,7 @@ async fn get_mod_file(
                 let upstream_path = format!("{}/@v/{}.mod", encoded, version);
                 let module_clone = module.to_string();
                 let version_clone = version.to_string();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -627,15 +627,16 @@ async fn get_mod_file(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "text/plain; charset=utf-8".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "text/plain; charset=utf-8".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -650,13 +651,16 @@ async fn get_mod_file(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -669,8 +673,8 @@ async fn get_mod_file(
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "text/plain; charset=utf-8")
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 
@@ -748,7 +752,7 @@ async fn download_zip(
                 let upstream_path = format!("{}/@v/{}.zip", encoded, version);
                 let module_clone = module.to_string();
                 let version_clone = version.to_string();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -768,15 +772,16 @@ async fn download_zip(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/zip".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/zip".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(not_found);
@@ -791,13 +796,16 @@ async fn download_zip(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -810,7 +818,6 @@ async fn download_zip(
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/zip")
-        .header(CONTENT_LENGTH, content.len().to_string())
         .header(
             "Content-Disposition",
             format!(
@@ -819,7 +826,8 @@ async fn download_zip(
                 version
             ),
         )
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -11,7 +11,7 @@
 
 use axum::body::Body;
 use axum::extract::{Multipart, Path, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
@@ -338,22 +338,12 @@ async fn download_chart_via_index(
                 )
                 .await
                 {
-                    let mut builder = Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            result
-                                .content_type
-                                .unwrap_or_else(|| "application/gzip".to_string()),
-                        )
-                        .header(
-                            "Content-Disposition",
-                            format!("attachment; filename=\"{}\"", filename),
-                        );
-                    if let Some(size) = result.content_length {
-                        builder = builder.header(CONTENT_LENGTH, size.to_string());
-                    }
-                    return Ok(Some(builder.body(Body::from_stream(result.body)).unwrap()));
+                    return proxy_helpers::stream_fetch_result(
+                        result,
+                        "application/gzip",
+                        Some(filename),
+                    )
+                    .map(Some);
                 }
                 continue;
             }

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -11,7 +11,7 @@
 
 use axum::body::Body;
 use axum::extract::{Multipart, Path, State};
-use axum::http::header::CONTENT_TYPE;
+use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
@@ -329,7 +329,7 @@ async fn download_chart_via_index(
         for member in &members {
             if member.repo_type != RepositoryType::Remote {
                 // Hosted / staging member: check local storage.
-                if let Ok((content, ct)) = proxy_helpers::local_fetch_by_path_suffix(
+                if let Ok(result) = proxy_helpers::local_fetch_by_path_suffix(
                     &state.db,
                     state,
                     member.id,
@@ -338,12 +338,22 @@ async fn download_chart_via_index(
                 )
                 .await
                 {
-                    return Ok(Some(proxy_helpers::build_download_response(
-                        content,
-                        ct,
-                        "application/gzip",
-                        Some(filename),
-                    )));
+                    let mut builder = Response::builder()
+                        .status(StatusCode::OK)
+                        .header(
+                            "Content-Type",
+                            result
+                                .content_type
+                                .unwrap_or_else(|| "application/gzip".to_string()),
+                        )
+                        .header(
+                            "Content-Disposition",
+                            format!("attachment; filename=\"{}\"", filename),
+                        );
+                    if let Some(size) = result.content_length {
+                        builder = builder.header(CONTENT_LENGTH, size.to_string());
+                    }
+                    return Ok(Some(builder.body(Body::from_stream(result.body)).unwrap()));
                 }
                 continue;
             }

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -11,7 +11,7 @@
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -334,22 +334,7 @@ async fn serve_virtual_tarball_local_only(
     )
     .await?;
 
-    let mut builder = Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            "Content-Type",
-            result
-                .content_type
-                .unwrap_or_else(|| "application/octet-stream".to_string()),
-        )
-        .header(
-            "Content-Disposition",
-            format!("attachment; filename=\"{}\"", filename),
-        );
-    if let Some(size) = result.content_length {
-        builder = builder.header(CONTENT_LENGTH, size.to_string());
-    }
-    Ok(builder.body(Body::from_stream(result.body)).unwrap())
+    proxy_helpers::stream_fetch_result(result, "application/octet-stream", Some(filename))
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -11,7 +11,7 @@
 
 use axum::body::Body;
 use axum::extract::{Path, State};
-use axum::http::header::CONTENT_TYPE;
+use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -313,7 +313,7 @@ async fn serve_virtual_tarball_local_only(
     let state_arc = state.clone();
     let suffix = filename.to_string();
 
-    let (content, content_type) = proxy_helpers::resolve_virtual_download(
+    let result = proxy_helpers::resolve_virtual_download(
         &state.db,
         // Explicit None: any Remote member would route to upstream, which is
         // exactly what the shadowing guard must block. Local members fall
@@ -334,12 +334,22 @@ async fn serve_virtual_tarball_local_only(
     )
     .await?;
 
-    Ok(proxy_helpers::build_download_response(
-        content,
-        content_type,
-        "application/octet-stream",
-        Some(filename),
-    ))
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            "Content-Type",
+            result
+                .content_type
+                .unwrap_or_else(|| "application/octet-stream".to_string()),
+        )
+        .header(
+            "Content-Disposition",
+            format!("attachment; filename=\"{}\"", filename),
+        );
+    if let Some(size) = result.content_length {
+        builder = builder.header(CONTENT_LENGTH, size.to_string());
+    }
+    Ok(builder.body(Body::from_stream(result.body)).unwrap())
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -233,16 +233,11 @@ async fn download_plugin(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -213,7 +213,7 @@ async fn download_plugin(
                 let upstream_path = format!("plugin/download/{}/{}", name, version);
                 let vname = name.clone();
                 let vversion = version.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -233,15 +233,16 @@ async fn download_plugin(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -255,13 +256,16 @@ async fn download_plugin(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -280,8 +284,8 @@ async fn download_plugin(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1335,17 +1335,11 @@ async fn serve_artifact(
                 )
                 .await?;
 
-                let ct = result
-                    .content_type
-                    .unwrap_or_else(|| content_type_for_path(path).to_string());
-
-                let mut builder = Response::builder()
-                    .status(StatusCode::OK)
-                    .header(CONTENT_TYPE, ct);
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    content_type_for_path(path),
+                    None,
+                );
             }
 
             // For hosted repos, fall back to serving from storage directly.

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -283,7 +283,7 @@ async fn maven_local_fetch_snapshot(
     repo_id: uuid::Uuid,
     location: &crate::storage::StorageLocation,
     path: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<proxy_helpers::StreamingFetchResult, Response> {
     if !path.contains("-SNAPSHOT") {
         return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());
     }
@@ -293,13 +293,17 @@ async fn maven_local_fetch_snapshot(
         .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
     let storage = state.storage_for_repo_or_500(location)?;
-    let content = storage
-        .get(&resolved.storage_key)
+    let stream = storage
+        .get_stream(&resolved.storage_key)
         .await
         .map_err(map_storage_err)?;
 
     let ct = content_type_for_path(path).to_string();
-    Ok((content, Some(ct)))
+    Ok(proxy_helpers::StreamingFetchResult {
+        body: stream,
+        content_type: Some(ct),
+        content_length: None,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1240,7 +1244,7 @@ async fn serve_artifact(
                     state.proxy_service.as_deref()
                 };
 
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     proxy_for_virtual,
                     repo.id,
@@ -1331,14 +1335,17 @@ async fn serve_artifact(
                 )
                 .await?;
 
-                let ct = content_type.unwrap_or_else(|| content_type_for_path(path).to_string());
+                let ct = result
+                    .content_type
+                    .unwrap_or_else(|| content_type_for_path(path).to_string());
 
-                return Ok(Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::OK)
-                    .header(CONTENT_TYPE, ct)
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                    .header(CONTENT_TYPE, ct);
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             // For hosted repos, fall back to serving from storage directly.
@@ -1351,13 +1358,12 @@ async fn serve_artifact(
                     .storage_for_repo(&repo.storage_location())
                     .map_err(|e| e.into_response())?;
                 let storage_key = format!("maven/{}", path);
-                if let Ok(content) = storage.get(&storage_key).await {
+                if let Ok(stream) = storage.get_stream(&storage_key).await {
                     let ct = content_type_for_path(path);
                     return Ok(Response::builder()
                         .status(StatusCode::OK)
                         .header(CONTENT_TYPE, ct)
-                        .header(CONTENT_LENGTH, content.len().to_string())
-                        .body(Body::from(content))
+                        .body(Body::from_stream(stream))
                         .unwrap());
                 }
             }
@@ -1374,8 +1380,8 @@ async fn serve_artifact(
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
-    let content = storage
-        .get(&artifact.storage_key)
+    let stream = storage
+        .get_stream(&artifact.storage_key)
         .await
         .map_err(map_storage_err)?;
 
@@ -1388,11 +1394,10 @@ async fn serve_artifact(
     .await;
 
     let ct = content_type_for_path(path);
-
     let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, ct)
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("X-Checksum-SHA256", &artifact.checksum_sha256);
 
     if let Some(ref md5) = artifact.checksum_md5 {
@@ -1402,7 +1407,7 @@ async fn serve_artifact(
         builder = builder.header("X-Checksum-SHA1", sha1);
     }
 
-    Ok(builder.body(Body::from(content)).unwrap())
+    Ok(builder.body(Body::from_stream(stream)).unwrap())
 }
 
 async fn serve_computed_checksum(

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -23,11 +23,12 @@
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use bytes::Bytes;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::api::handlers::proxy_helpers::{check_quarantine_row, internal_error, LocalArtifactRow};
+use crate::api::handlers::proxy_helpers::{
+    check_quarantine_row, internal_error, LocalArtifactRow, StreamingFetchResult,
+};
 use crate::api::AppState;
 use crate::formats::maven::MavenHandler;
 use crate::storage::StorageLocation;
@@ -132,7 +133,7 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     repo_id: Uuid,
     location: &StorageLocation,
     artifact_path: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<StreamingFetchResult, Response> {
     // Gate 1: Only companion files and classifier artifacts are eligible.
     // A primary `.jar`/`.aar`/etc. always has its own row and must travel
     // the SQL path so its quarantine/soft-delete state is honored.
@@ -153,7 +154,7 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     };
     let sibling_prefix = format!("{}/%", gav_dir);
     let primary = sqlx::query_as::<_, LocalArtifactRow>(
-        "SELECT id, storage_key, content_type, quarantine_status, quarantine_until \
+        "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
          FROM artifacts \
          WHERE repository_id = $1 \
            AND path LIKE $2 \
@@ -179,7 +180,7 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     // semantics for legitimate misses.
     let storage = state.storage_for_repo_or_500(location)?;
     let storage_key = format!("maven/{}", artifact_path);
-    let content = storage.get(&storage_key).await.map_err(|e| {
+    let stream = storage.get_stream(&storage_key).await.map_err(|e| {
         // Distinguish missing object from real I/O error. Conservative:
         // every backend's "missing" error has "not found" in its
         // Display impl; anything else is internal.
@@ -190,7 +191,11 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
             internal_error("Storage", e)
         }
     })?;
-    Ok((content, None))
+    Ok(StreamingFetchResult {
+        body: stream,
+        content_type: None,
+        content_length: None,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -204,6 +209,7 @@ mod tests {
         insert_artifact, put_artifact_bytes, NewArtifact, RepoInfo,
     };
     use crate::api::handlers::test_db_helpers as db_helpers;
+    use bytes::Bytes;
 
     // ── pure-function gates ─────────────────────────────────────────
 
@@ -447,7 +453,7 @@ mod tests {
         .expect("put");
 
         let location = repo.storage_location();
-        let (content, ct) = maven_local_fetch_storage_fallback(
+        let result = maven_local_fetch_storage_fallback(
             &pool,
             &state,
             repo_id,
@@ -456,8 +462,12 @@ mod tests {
         )
         .await
         .expect("fetch");
+        assert!(
+            result.content_type.is_none(),
+            "helper returns None for content-type"
+        );
+        let content = result.collect().await.unwrap();
         assert_eq!(&content[..], &bytes[..]);
-        assert!(ct.is_none(), "helper returns None for content-type");
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
     }
@@ -500,10 +510,11 @@ mod tests {
             )
             .await
             .expect("put");
-            let (content, _) =
+            let result =
                 maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, &path)
                     .await
                     .unwrap_or_else(|_| panic!("must serve secondary extension {}", suffix));
+            let content = result.collect().await.unwrap();
             assert_eq!(
                 &content[..],
                 &payload[..],
@@ -782,7 +793,7 @@ mod tests {
         )
         .await
         .expect("put maven");
-        let (got, _) = maven_local_fetch_storage_fallback(
+        let result = maven_local_fetch_storage_fallback(
             &pool,
             &state,
             repo_id,
@@ -791,6 +802,7 @@ mod tests {
         )
         .await
         .expect("positive: maven/<path> with live primary serves");
+        let got = result.collect().await.unwrap();
         assert_eq!(&got[..], b"maven-pom");
 
         // (b)

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -964,6 +964,29 @@ fn build_tarball_response(
         .unwrap()
 }
 
+/// Build a streaming tarball response from a storage stream.
+fn build_tarball_response_stream(
+    stream: futures::stream::BoxStream<'static, crate::error::Result<Bytes>>,
+    filename: &str,
+    content_type: Option<String>,
+    content_length: Option<u64>,
+) -> Response {
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header(
+            CONTENT_TYPE,
+            content_type.unwrap_or_else(|| NPM_TARBALL_CONTENT_TYPE.to_string()),
+        )
+        .header(
+            "Content-Disposition",
+            format!("attachment; filename=\"{}\"", filename),
+        );
+    if let Some(len) = content_length {
+        builder = builder.header(CONTENT_LENGTH, len.to_string());
+    }
+    builder.body(Body::from_stream(stream)).unwrap()
+}
+
 /// Build an OK response with a given content type and body.
 fn build_ok_response(content_type: &str, body: impl Into<Body>) -> Response {
     Response::builder()
@@ -1043,7 +1066,7 @@ async fn npm_local_fetch(
     upstream_path: &str,
     package_name: &str,
     filename: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<proxy_helpers::StreamingFetchResult, Response> {
     // Try exact path match first (proxy-cached artifacts use the upstream
     // path verbatim, e.g. "@types/mdurl/-/mdurl-2.0.0.tgz" -- the scope
     // separator stays un-encoded for tarballs; see
@@ -1065,7 +1088,7 @@ async fn npm_local_fetch(
     let pkg_path_prefix = format!("{}/%/", super::escape_like_literal(package_name));
     let filename_escaped = super::escape_like_literal(filename);
     let artifact = sqlx::query_as::<_, proxy_helpers::LocalArtifactRow>(
-        "SELECT id, storage_key, content_type, quarantine_status, quarantine_until \
+        "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
          FROM artifacts \
          WHERE repository_id = $1 AND path LIKE $2 || $3 ESCAPE '\\' AND is_deleted = false \
          LIMIT 1",
@@ -1088,16 +1111,30 @@ async fn npm_local_fetch(
     let storage = state
         .storage_for_repo(location)
         .map_err(|e| e.into_response())?;
-    let content = match storage.get(&artifact.storage_key).await {
-        Ok(bytes) => bytes,
-        Err(crate::error::AppError::NotFound(_)) => {
-            proxy_helpers::coordinated_retry_get(db, artifact.id, &artifact.storage_key, &*storage)
-                .await?
-        }
-        Err(e) => return Err(map_storage_err(e)),
-    };
+    // Stream the body for the common case, but preserve the #1016 / hydration
+    // contract: a storage miss falls back to the coordinated buffered retry and
+    // is re-wrapped as a one-shot stream so the caller sees a uniform result.
+    let body: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>> =
+        match storage.get_stream(&artifact.storage_key).await {
+            Ok(stream) => stream,
+            Err(crate::error::AppError::NotFound(_)) => {
+                let bytes = proxy_helpers::coordinated_retry_get(
+                    db,
+                    artifact.id,
+                    &artifact.storage_key,
+                    &*storage,
+                )
+                .await?;
+                Box::pin(futures::stream::once(async move { Ok(bytes) }))
+            }
+            Err(e) => return Err(map_storage_err(e)),
+        };
 
-    Ok((content, Some(artifact.content_type.clone())))
+    Ok(proxy_helpers::StreamingFetchResult {
+        body,
+        content_type: Some(artifact.content_type.clone()),
+        content_length: Some(artifact.size_bytes as u64),
+    })
 }
 
 async fn serve_tarball(
@@ -1171,7 +1208,7 @@ async fn serve_tarball(
             state.proxy_service.as_deref()
         };
 
-        let (content, content_type) = proxy_helpers::resolve_virtual_download(
+        let result = proxy_helpers::resolve_virtual_download(
             &state.db,
             proxy_for_virtual,
             repo.id,
@@ -1189,7 +1226,12 @@ async fn serve_tarball(
         )
         .await?;
 
-        return Ok(build_tarball_response(content, filename, content_type));
+        return Ok(build_tarball_response_stream(
+            result.body,
+            filename,
+            result.content_type,
+            result.content_length,
+        ));
     }
 
     // For local/staged repos, find artifact by filename. Include the package
@@ -1236,8 +1278,8 @@ async fn serve_tarball(
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
-    let content = storage
-        .get(&artifact.storage_key)
+    let stream = storage
+        .get_stream(&artifact.storage_key)
         .await
         .map_err(map_storage_err)?;
 
@@ -1249,7 +1291,12 @@ async fn serve_tarball(
     .execute(&state.db)
     .await;
 
-    Ok(build_tarball_response(content, filename, None))
+    Ok(build_tarball_response_stream(
+        stream,
+        filename,
+        None,
+        Some(artifact.size_bytes as u64),
+    ))
 }
 
 /// Update the content_type of a cached proxy artifact from the incorrect

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -3223,6 +3223,63 @@ mod tests {
         assert_eq!(NPM_TARBALL_CONTENT_TYPE, publish_content_type);
     }
 
+    #[tokio::test]
+    async fn test_build_tarball_response_stream_sets_headers() {
+        // The streaming tarball response (used for the get_stream download path)
+        // must emit the gzip content-type (or the supplied upstream type), a
+        // Content-Disposition with the filename, and Content-Length when known.
+        use futures::StreamExt as _;
+        let body: futures::stream::BoxStream<'static, crate::error::Result<Bytes>> =
+            Box::pin(futures::stream::once(async {
+                Ok(Bytes::from_static(b"tgz-bytes"))
+            }));
+        let resp = build_tarball_response_stream(body, "pkg-1.0.0.tgz", None, Some(9));
+        assert_eq!(resp.status(), StatusCode::OK);
+        let h = resp.headers();
+        assert_eq!(
+            h.get(CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+            Some(NPM_TARBALL_CONTENT_TYPE)
+        );
+        assert_eq!(
+            h.get("content-disposition").and_then(|v| v.to_str().ok()),
+            Some("attachment; filename=\"pkg-1.0.0.tgz\"")
+        );
+        assert_eq!(
+            h.get(CONTENT_LENGTH).and_then(|v| v.to_str().ok()),
+            Some("9")
+        );
+        // Body must stream the supplied bytes verbatim.
+        let collected = resp
+            .into_body()
+            .into_data_stream()
+            .fold(Vec::new(), |mut acc, c| async move {
+                acc.extend_from_slice(&c.unwrap());
+                acc
+            })
+            .await;
+        assert_eq!(&collected[..], b"tgz-bytes");
+    }
+
+    #[tokio::test]
+    async fn test_build_tarball_response_stream_uses_upstream_ct_and_omits_length() {
+        // An upstream-provided content-type wins over the default, and Content-
+        // Length is omitted when unknown (chunked transfer).
+        let body: futures::stream::BoxStream<'static, crate::error::Result<Bytes>> =
+            Box::pin(futures::stream::iter(Vec::new()));
+        let resp = build_tarball_response_stream(
+            body,
+            "x.tgz",
+            Some("application/x-custom".to_string()),
+            None,
+        );
+        let h = resp.headers();
+        assert_eq!(
+            h.get(CONTENT_TYPE).and_then(|v| v.to_str().ok()),
+            Some("application/x-custom")
+        );
+        assert!(h.get(CONTENT_LENGTH).is_none());
+    }
+
     // -----------------------------------------------------------------------
     // Regression tests for #1377 — scoped tarball remote-proxy flow.
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -550,22 +550,11 @@ async fn flatcontainer_download(
                 )
                 .await?;
 
-                let mut builder = Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        CONTENT_TYPE,
-                        result
-                            .content_type
-                            .unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(
-                        "Content-Disposition",
-                        format!("attachment; filename=\"{}\"", filename),
-                    );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    Some(&filename),
+                );
             }
             return Err(not_found);
         }
@@ -624,22 +613,28 @@ async fn flatcontainer_download(
                 .await?;
                 Box::pin(futures::stream::once(async move { Ok(content) }))
             } else {
-                storage.get_stream(&artifact.storage_key).await.map_err(|e| {
+                storage
+                    .get_stream(&artifact.storage_key)
+                    .await
+                    .map_err(|e| {
+                        (
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            format!("Storage error: {}", e),
+                        )
+                            .into_response()
+                    })?
+            }
+        } else {
+            storage
+                .get_stream(&artifact.storage_key)
+                .await
+                .map_err(|e| {
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         format!("Storage error: {}", e),
                     )
                         .into_response()
                 })?
-            }
-        } else {
-            storage.get_stream(&artifact.storage_key).await.map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Storage error: {}", e),
-                )
-                    .into_response()
-            })?
         };
 
     // Record download.

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -530,7 +530,7 @@ async fn flatcontainer_download(
                     "v3/flatcontainer/{}/{}/{}",
                     package_id_lower, version, filename
                 );
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -550,19 +550,22 @@ async fn flatcontainer_download(
                 )
                 .await?;
 
-                return Ok(Response::builder()
+                let mut builder = Response::builder()
                     .status(StatusCode::OK)
                     .header(
                         CONTENT_TYPE,
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
+                        result
+                            .content_type
+                            .unwrap_or_else(|| "application/octet-stream".to_string()),
                     )
                     .header(
                         "Content-Disposition",
                         format!("attachment; filename=\"{}\"", filename),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                    );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -577,60 +580,67 @@ async fn flatcontainer_download(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = if repo.repo_type == RepositoryType::Remote {
-        if let (Some(ref upstream_url), Some(ref proxy)) =
-            (&repo.upstream_url, &state.proxy_service)
-        {
-            let package_id_lower = package_id_lower.clone();
-            let version = version.clone();
-            let filename = filename.clone();
-            let repo_key = repo_key.clone();
-            proxy_helpers::get_cached_or_refetch(
-                &state.db,
-                artifact.id,
-                storage.as_ref(),
-                &artifact.storage_key,
-                || {
-                    let package_id_lower = package_id_lower.clone();
-                    let version = version.clone();
-                    let filename = filename.clone();
-                    let repo_key = repo_key.clone();
-                    async move {
-                        let upstream_path = format!(
-                            "v3/flatcontainer/{}/{}/{}",
-                            package_id_lower, version, filename
-                        );
-                        let (bytes, _content_type) = proxy_helpers::proxy_fetch(
-                            proxy,
-                            repo.id,
-                            &repo_key,
-                            upstream_url,
-                            &upstream_path,
-                        )
-                        .await?;
-                        Ok(bytes)
-                    }
-                },
-            )
-            .await?
+    // Remote repos must keep the buffered cache-or-refetch path: a cache miss
+    // re-pulls the package from upstream and writes it back. That recovery
+    // read is small relative to the artifact and is re-wrapped as a one-shot
+    // stream below. Local/cached hits stream the body straight from storage so
+    // large `.nupkg` bodies never buffer in heap.
+    let body: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>> =
+        if repo.repo_type == RepositoryType::Remote {
+            if let (Some(ref upstream_url), Some(ref proxy)) =
+                (&repo.upstream_url, &state.proxy_service)
+            {
+                let package_id_lower = package_id_lower.clone();
+                let version = version.clone();
+                let filename = filename.clone();
+                let repo_key = repo_key.clone();
+                let content = proxy_helpers::get_cached_or_refetch(
+                    &state.db,
+                    artifact.id,
+                    storage.as_ref(),
+                    &artifact.storage_key,
+                    || {
+                        let package_id_lower = package_id_lower.clone();
+                        let version = version.clone();
+                        let filename = filename.clone();
+                        let repo_key = repo_key.clone();
+                        async move {
+                            let upstream_path = format!(
+                                "v3/flatcontainer/{}/{}/{}",
+                                package_id_lower, version, filename
+                            );
+                            let (bytes, _content_type) = proxy_helpers::proxy_fetch(
+                                proxy,
+                                repo.id,
+                                &repo_key,
+                                upstream_url,
+                                &upstream_path,
+                            )
+                            .await?;
+                            Ok(bytes)
+                        }
+                    },
+                )
+                .await?;
+                Box::pin(futures::stream::once(async move { Ok(content) }))
+            } else {
+                storage.get_stream(&artifact.storage_key).await.map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Storage error: {}", e),
+                    )
+                        .into_response()
+                })?
+            }
         } else {
-            storage.get(&artifact.storage_key).await.map_err(|e| {
+            storage.get_stream(&artifact.storage_key).await.map_err(|e| {
                 (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     format!("Storage error: {}", e),
                 )
                     .into_response()
             })?
-        }
-    } else {
-        storage.get(&artifact.storage_key).await.map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Storage error: {}", e),
-            )
-                .into_response()
-        })?
-    };
+        };
 
     // Record download.
     let _ = sqlx::query!(
@@ -640,6 +650,7 @@ async fn flatcontainer_download(
     .execute(&state.db)
     .await;
 
+    use futures::StreamExt as _;
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/octet-stream")
@@ -647,8 +658,10 @@ async fn flatcontainer_download(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(
+            body.map(|r| r.map_err(|e| std::io::Error::other(e.to_string()))),
+        ))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -5408,6 +5408,11 @@ async fn handle_get_manifest(
         };
         let manifest_key = manifest_storage_key(&manifest_digest);
 
+        // Manifests are small metadata, not large artifact bodies: keep this
+        // path buffered so we can emit an accurate Content-Length. Container
+        // clients (docker, podman, containerd) require Content-Length on
+        // manifest responses, and the oci_tags row carries no size column to
+        // set it from a stream. Only large blob BODIES are streamed (above).
         if let Ok(data) = storage.get(&manifest_key).await {
             tracing::debug!(repo = %repo.key, image = %repo.image, reference = %reference, digest = %manifest_digest, "GET manifest: serving from migrated oci_tags (local hit)");
             return Response::builder()

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1339,7 +1339,7 @@ async fn download(
                     let upstream_path = format!("modules/{}/commits/{}", module_name, digest);
                     let mname = module_name.clone();
 
-                    let (bundle_data, _content_type) = proxy_helpers::resolve_virtual_download(
+                    let result = proxy_helpers::resolve_virtual_download(
                         &state.db,
                         state.proxy_service.as_deref(),
                         repo.id,
@@ -1357,6 +1357,8 @@ async fn download(
                         },
                     )
                     .await?;
+
+                    let bundle_data = result.collect().await.map_err(|e| e.into_response())?;
 
                     let files = extract_files_from_bundle(&bundle_data)?;
                     let commit = CommitInfo {

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -18,6 +18,7 @@ use crate::models::repository::{
 };
 use crate::services::proxy_hydration::coordinate_proxy_hydration;
 use crate::services::proxy_service::ProxyService;
+pub use crate::services::proxy_service::StreamingFetchResult;
 use crate::storage::StorageLocation;
 use std::future::Future;
 use std::time::Duration;
@@ -989,10 +990,10 @@ pub async fn resolve_virtual_download<F, Fut>(
     virtual_repo_id: Uuid,
     path: &str,
     local_fetch: F,
-) -> Result<(Bytes, Option<String>), Response>
+) -> Result<StreamingFetchResult, Response>
 where
     F: Fn(Uuid, StorageLocation) -> Fut,
-    Fut: std::future::Future<Output = Result<(Bytes, Option<String>), Response>>,
+    Fut: std::future::Future<Output = Result<StreamingFetchResult, Response>>,
 {
     let members = fetch_virtual_members(db, virtual_repo_id).await?;
 
@@ -1014,9 +1015,8 @@ where
                 if let (Some(proxy), Some(upstream_url)) =
                     (proxy_service, member.upstream_url.as_deref())
                 {
-                    if let Ok(result) =
-                        proxy_fetch(proxy, member.id, &member.key, upstream_url, path).await
-                    {
+                    let repo = build_remote_repo(member.id, &member.key, upstream_url);
+                    if let Ok(result) = proxy.fetch_artifact_streaming(&repo, path).await {
                         return Ok(result);
                     }
                 }
@@ -1073,7 +1073,7 @@ pub async fn resolve_virtual_download_streaming<F, Fut>(
 ) -> Result<Response, Response>
 where
     F: Fn(Uuid, StorageLocation) -> Fut,
-    Fut: std::future::Future<Output = Result<(Bytes, Option<String>), Response>>,
+    Fut: std::future::Future<Output = Result<StreamingFetchResult, Response>>,
 {
     let members = fetch_virtual_members(db, virtual_repo_id).await?;
 
@@ -1109,15 +1109,15 @@ where
                 }
             }
             VirtualMemberFetchStrategy::Local => {
-                if let Ok((content, content_type)) =
-                    local_fetch(member.id, member.storage_location()).await
-                {
-                    return Ok(build_download_response(
-                        content,
-                        content_type,
+                if let Ok(result) = local_fetch(member.id, member.storage_location()).await {
+                    return build_streaming_response_with_disposition(
+                        result,
                         default_content_type,
                         content_disposition_filename,
-                    ));
+                    )
+                    .map_err(|e| {
+                        (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+                    });
                 }
             }
             VirtualMemberFetchStrategy::Skip => {}
@@ -1299,6 +1299,7 @@ pub(crate) struct LocalArtifactRow {
     pub id: Uuid,
     pub storage_key: String,
     pub content_type: String,
+    pub size_bytes: i64,
     pub quarantine_status: Option<String>,
     pub quarantine_until: Option<chrono::DateTime<chrono::Utc>>,
 }
@@ -1332,13 +1333,13 @@ impl LocalLookup<'_> {
     pub(crate) fn select_sql(&self) -> &'static str {
         match self {
             LocalLookup::Path(_) => {
-                "SELECT id, storage_key, content_type, quarantine_status, quarantine_until \
+                "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
                  FROM artifacts \
                  WHERE repository_id = $1 AND path = $2 AND is_deleted = false \
                  LIMIT 1"
             }
             LocalLookup::NameVersion(_, _) => {
-                "SELECT id, storage_key, content_type, quarantine_status, quarantine_until \
+                "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
                  FROM artifacts \
                  WHERE repository_id = $1 AND name = $2 AND version = $3 AND is_deleted = false \
                  LIMIT 1"
@@ -1403,6 +1404,36 @@ async fn read_local_content(
     }
 }
 
+/// Streaming sibling of [`read_local_content`]: open the artifact body as a
+/// byte stream (so large artifact bodies never buffer in memory) while keeping
+/// the exact same `NotFound` → coordinated-retry hydration fallback used by the
+/// buffered path. On a storage miss we still funnel through
+/// [`coordinated_retry_get`] (which buffers the small recovery read) and wrap
+/// the recovered `Bytes` back into a one-shot stream so callers see a uniform
+/// [`StreamingFetchResult`]. Returns the full [`StreamingFetchResult`] with the
+/// row's `content_type` and `size_bytes` (for an accurate `Content-Length`).
+async fn read_local_stream(
+    db: &PgPool,
+    artifact: &LocalArtifactRow,
+    storage: &dyn crate::storage::StorageBackend,
+) -> Result<StreamingFetchResult, Response> {
+    let body = match storage.get_stream(&artifact.storage_key).await {
+        Ok(stream) => stream,
+        Err(crate::error::AppError::NotFound(_)) => {
+            // Hydration recovery is a small buffered read; re-wrap as a stream.
+            let bytes =
+                coordinated_retry_get(db, artifact.id, &artifact.storage_key, storage).await?;
+            Box::pin(futures::stream::once(async move { Ok(bytes) }))
+        }
+        Err(e) => return Err(map_storage_err(e)),
+    };
+    Ok(StreamingFetchResult {
+        body,
+        content_type: Some(artifact.content_type.clone()),
+        content_length: Some(artifact.size_bytes as u64),
+    })
+}
+
 /// Generic local artifact fetch by exact path match.
 /// Used as a `local_fetch` callback for [`resolve_virtual_download`].
 pub async fn local_fetch_by_path(
@@ -1411,7 +1442,7 @@ pub async fn local_fetch_by_path(
     repo_id: Uuid,
     location: &StorageLocation,
     artifact_path: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<StreamingFetchResult, Response> {
     let (artifact, storage) = local_lookup_artifact(
         db,
         state,
@@ -1420,8 +1451,7 @@ pub async fn local_fetch_by_path(
         LocalLookup::Path(artifact_path),
     )
     .await?;
-    let content = read_local_content(db, &artifact, &*storage).await?;
-    Ok((content, Some(artifact.content_type)))
+    read_local_stream(db, &artifact, &*storage).await
 }
 
 /// Generic local artifact fetch by name and version.
@@ -1433,7 +1463,7 @@ pub async fn local_fetch_by_name_version(
     location: &StorageLocation,
     name: &str,
     version: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<StreamingFetchResult, Response> {
     let (artifact, storage) = local_lookup_artifact(
         db,
         state,
@@ -1442,8 +1472,7 @@ pub async fn local_fetch_by_name_version(
         LocalLookup::NameVersion(name, version),
     )
     .await?;
-    let content = read_local_content(db, &artifact, &*storage).await?;
-    Ok((content, Some(artifact.content_type)))
+    read_local_stream(db, &artifact, &*storage).await
 }
 
 /// Generic local artifact fetch by trailing path-suffix (LIKE match).
@@ -1468,7 +1497,7 @@ pub async fn local_fetch_by_path_suffix(
     repo_id: Uuid,
     location: &StorageLocation,
     path_suffix: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<StreamingFetchResult, Response> {
     let reversed_pattern = reverse_suffix_for_like(path_suffix);
     let path: String = sqlx::query_scalar(
         "SELECT path FROM artifacts \
@@ -4893,18 +4922,19 @@ mod tests {
         .expect("insert");
 
         let location = repo.storage_location();
-        let (content, ct) =
-            local_fetch_by_path(&pool, &state, repo_id, &location, "foo/1.0/foo.whl")
-                .await
-                .expect("fetch");
+        let result = local_fetch_by_path(&pool, &state, repo_id, &location, "foo/1.0/foo.whl")
+            .await
+            .expect("fetch");
+        let ct = result.content_type.clone();
+        let content = result.collect().await.unwrap();
         assert_eq!(&content[..], b"abc123");
         assert_eq!(ct.as_deref(), Some("application/zip"));
 
         // Also exercise the suffix variant.
-        let (content2, _) =
-            local_fetch_by_path_suffix(&pool, &state, repo_id, &location, "foo.whl")
-                .await
-                .expect("fetch suffix");
+        let result2 = local_fetch_by_path_suffix(&pool, &state, repo_id, &location, "foo.whl")
+            .await
+            .expect("fetch suffix");
+        let content2 = result2.collect().await.unwrap();
         assert_eq!(&content2[..], b"abc123");
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -583,6 +583,22 @@ pub(crate) fn build_streaming_response_with_disposition(
     builder.body(body)
 }
 
+/// Handler-facing convenience over [`build_streaming_response_with_disposition`]
+/// that maps the rare malformed-header [`axum::http::Error`] into a `500`
+/// [`Response`], so format handlers can serve a resolved
+/// [`StreamingFetchResult`] (e.g. from [`resolve_virtual_download`]) in a single
+/// line instead of re-inlining the same header-building block. Pass a
+/// `filename` to emit `Content-Disposition: attachment`; pass `None` to omit it.
+#[allow(clippy::result_large_err)]
+pub fn stream_fetch_result(
+    result: crate::services::proxy_service::StreamingFetchResult,
+    default_content_type: &str,
+    filename: Option<&str>,
+) -> std::result::Result<Response, Response> {
+    build_streaming_response_with_disposition(result, default_content_type, filename)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response())
+}
+
 /// Fetch from upstream via the proxy service, returning a presigned redirect
 /// if the storage backend supports it and presigned downloads are enabled.
 ///
@@ -2573,7 +2589,8 @@ mod tests {
     fn test_local_lookup_select_columns_identical() {
         // Both variants select the same LocalArtifactRow columns; only the
         // WHERE clause differs (the whole point of the S6 collapse).
-        let cols = "SELECT id, storage_key, content_type, quarantine_status, quarantine_until";
+        let cols =
+            "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until";
         assert!(LocalLookup::Path("x").select_sql().starts_with(cols));
         assert!(LocalLookup::NameVersion("n", "v")
             .select_sql()
@@ -5151,6 +5168,54 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some(weird)
         );
+    }
+
+    #[test]
+    fn test_stream_fetch_result_sets_headers_and_disposition() {
+        // The handler-facing convenience must emit the same headers as the
+        // underlying builder: upstream content-type wins, content-length is set
+        // when known, and a filename produces a Content-Disposition.
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: Some("application/zip".to_string()),
+            content_length: Some(1234),
+        };
+        let response = stream_fetch_result(result, "application/octet-stream", Some("pkg.whl"))
+            .expect("stream_fetch_result must build a response");
+        assert_eq!(response.status(), StatusCode::OK);
+        let h = response.headers();
+        assert_eq!(
+            h.get("content-type").and_then(|v| v.to_str().ok()),
+            Some("application/zip")
+        );
+        assert_eq!(
+            h.get("content-length").and_then(|v| v.to_str().ok()),
+            Some("1234")
+        );
+        assert_eq!(
+            h.get("content-disposition").and_then(|v| v.to_str().ok()),
+            Some("attachment; filename=\"pkg.whl\"")
+        );
+    }
+
+    #[test]
+    fn test_stream_fetch_result_falls_back_to_default_and_omits_optionals() {
+        // No upstream content-type, no length, no filename: default type is
+        // used and neither content-length nor content-disposition is emitted.
+        let result = StreamingFetchResult {
+            body: empty_body(),
+            content_type: None,
+            content_length: None,
+        };
+        let response = stream_fetch_result(result, "application/octet-stream", None)
+            .expect("stream_fetch_result must build a response");
+        let h = response.headers();
+        assert_eq!(
+            h.get("content-type").and_then(|v| v.to_str().ok()),
+            Some("application/octet-stream")
+        );
+        assert!(h.get("content-length").is_none());
+        assert!(h.get("content-disposition").is_none());
     }
 
     // -------------------------------------------------------------------

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -326,16 +326,11 @@ async fn download_archive(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -306,7 +306,7 @@ async fn download_archive(
                 let upstream_path = format!("packages/{}/versions/{}.tar.gz", pkg_name, version);
                 let vname = pkg_name.to_string();
                 let vversion = version.to_string();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -326,15 +326,16 @@ async fn download_archive(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -348,13 +349,16 @@ async fn download_archive(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -373,8 +377,8 @@ async fn download_archive(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -19,6 +19,8 @@ use axum::routing::{get, post};
 use axum::Extension;
 use axum::Router;
 use bytes::Bytes;
+use futures::stream::BoxStream;
+use futures::StreamExt;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use sha2::{Digest, Sha256};
@@ -1025,8 +1027,19 @@ async fn serve_file(
                     )
                     .await
                     {
-                        Ok((content, _ct)) => {
-                            return Ok(build_file_response(filename, content));
+                        Ok(result) => {
+                            let content_type = pypi_content_type(filename);
+                            let mut builder = Response::builder()
+                                .status(StatusCode::OK)
+                                .header(CONTENT_TYPE, content_type)
+                                .header(
+                                    "Content-Disposition",
+                                    format!("attachment; filename=\"{}\"", filename),
+                                );
+                            if let Some(size) = result.content_length {
+                                builder = builder.header(CONTENT_LENGTH, size.to_string());
+                            }
+                            return Ok(builder.body(Body::from_stream(result.body)).unwrap());
                         }
                         Err(e) => {
                             debug!(
@@ -1113,13 +1126,11 @@ async fn serve_file(
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
-    let content = if repo.repo_type == RepositoryType::Remote {
+    let stream = if repo.repo_type == RepositoryType::Remote {
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            get_remote_cached_or_refetch(
-                &state.db,
-                artifact.id,
+            get_remote_cached_or_refetch_stream(
                 storage.as_ref(),
                 &artifact.storage_key,
                 || async move {
@@ -1137,15 +1148,19 @@ async fn serve_file(
             .await?
         } else {
             storage
-                .get(&artifact.storage_key)
+                .get_stream(&artifact.storage_key)
                 .await
                 .map_err(map_storage_err)?
+                .map(|r| r.map_err(|e| std::io::Error::other(e.to_string())))
+                .boxed()
         }
     } else {
         storage
-            .get(&artifact.storage_key)
+            .get_stream(&artifact.storage_key)
             .await
             .map_err(map_storage_err)?
+            .map(|r| r.map_err(|e| std::io::Error::other(e.to_string())))
+            .boxed()
     };
 
     // Record download statistics for locally-stored artifacts only.
@@ -1165,24 +1180,54 @@ async fn serve_file(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("X-PyPI-File-SHA256", &artifact.checksum_sha256)
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 
-async fn get_remote_cached_or_refetch<F, Fut>(
-    db: &PgPool,
-    artifact_id: uuid::Uuid,
+/// Streaming variant of the PyPI proxy cache read. Streams a cache hit
+/// straight from storage; on a miss it re-fetches the wheel from upstream
+/// (buffered, since the recovery payload must also be written back to the
+/// cache to avoid a thundering herd) and re-wraps the recovered bytes as a
+/// one-shot stream so the caller always receives a `BoxStream`.
+async fn get_remote_cached_or_refetch_stream<F, Fut>(
     storage: &dyn crate::storage::StorageBackend,
     storage_key: &str,
     refetch: F,
-) -> Result<Bytes, Response>
+) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Response>
 where
     F: FnOnce() -> Fut,
     Fut: Future<Output = Result<Bytes, Response>>,
 {
-    proxy_helpers::get_cached_or_refetch(db, artifact_id, storage, storage_key, refetch).await
+    match storage.get_stream(storage_key).await {
+        Ok(stream) => Ok(stream
+            .map(|r| r.map_err(|e| std::io::Error::other(e.to_string())))
+            .boxed()),
+        Err(AppError::NotFound(_)) => {
+            tracing::warn!(
+                storage_key = %storage_key,
+                "remote PyPI proxy cache entry is missing on disk; re-fetching from upstream"
+            );
+            let bytes = refetch().await?;
+            // Best-effort write-back: persist the refetched payload so the
+            // next request hits the cache instead of re-traversing the
+            // simple index and re-downloading from upstream. Without this,
+            // N concurrent `uv` clients each issue a fresh upstream fetch
+            // for the same wheel (thundering herd; see PR #1283 review).
+            // We swallow write errors to keep serving the current request,
+            // but log them so operators can spot a broken backend.
+            if let Err(e) = storage.put(storage_key, bytes.clone()).await {
+                tracing::warn!(
+                    storage_key = %storage_key,
+                    error = %e,
+                    "failed to write back refetched PyPI proxy payload; subsequent requests will re-fetch from upstream"
+                );
+            }
+            Ok(futures::stream::once(async { Ok(bytes) }).boxed())
+        }
+        Err(e) => Err(map_storage_err(e)),
+    }
 }
 
 /// Fetch a file from a remote PyPI upstream using the format-specific URL
@@ -1806,16 +1851,6 @@ fn rewrite_upstream_urls(html: &str, repo_key: &str, project: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    async fn try_pool() -> Option<sqlx::PgPool> {
-        let url = std::env::var("DATABASE_URL").ok()?;
-        sqlx::postgres::PgPoolOptions::new()
-            .max_connections(3)
-            .acquire_timeout(std::time::Duration::from_secs(3))
-            .connect(&url)
-            .await
-            .ok()
-    }
 
     // -----------------------------------------------------------------------
     // pypi_upstream_url_and_path (#1130)
@@ -2784,6 +2819,20 @@ mod tests {
     // get_remote_cached_or_refetch
     // -----------------------------------------------------------------------
 
+    /// Drain a `get_remote_cached_or_refetch_stream` body into a single `Bytes`
+    /// so the existing buffered-semantics assertions still hold against the
+    /// streaming implementation.
+    async fn collect_stream(
+        stream: BoxStream<'static, Result<Bytes, std::io::Error>>,
+    ) -> Bytes {
+        let mut s = stream;
+        let mut buf = Vec::new();
+        while let Some(chunk) = s.next().await {
+            buf.extend_from_slice(&chunk.expect("stream chunk"));
+        }
+        Bytes::from(buf)
+    }
+
     /// Storage double that reports the entry as missing on every `get`, and
     /// records every `put` so tests can assert the write-back path persists
     /// refetched payloads (PR #1283 follow-up: thundering-herd fix).
@@ -2873,18 +2922,15 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_remote_cached_or_refetch_refetches_on_missing_storage() {
-        let Some(pool) = try_pool().await else {
-            return;
-        };
+        // Streaming refetch path is DB-free (storage doubles only), so this runs
+        // in Tier-1 `cargo test --lib` without a live Postgres.
         let storage = MissingStorage::new();
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
         let storage_key =
             "proxy-cache/pypi-remote/simple/fastapi/fastapi-0.136.1-py3-none-any.whl/__content__";
-        let content = super::get_remote_cached_or_refetch(
-            &pool,
-            uuid::Uuid::new_v4(),
+        let stream = super::get_remote_cached_or_refetch_stream(
             &storage,
             storage_key,
             move || {
@@ -2897,6 +2943,7 @@ mod tests {
         )
         .await
         .expect("refetch should succeed");
+        let content = collect_stream(stream).await;
 
         assert_eq!(content, Bytes::from_static(b"refetched-bytes"));
         assert_eq!(
@@ -2946,32 +2993,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_remote_cached_or_refetch_serves_payload_even_if_writeback_fails() {
-        let Some(pool) = try_pool().await else {
-            return;
-        };
         // A best-effort write-back must NOT fail the current request. If the
         // disk is full or read-only the user still gets their wheel; the
         // next request will simply re-fetch from upstream until the backend
         // recovers.
         let storage = WriteFailingStorage;
-        let content = super::get_remote_cached_or_refetch(
-            &pool,
-            uuid::Uuid::new_v4(),
+        let stream = super::get_remote_cached_or_refetch_stream(
             &storage,
             "proxy-cache/pypi-remote/simple/urllib3/urllib3-2.2.0-py3-none-any.whl/__content__",
             move || async move { Ok(Bytes::from_static(b"refetched-when-disk-full")) },
         )
         .await
         .expect("write-back failures must not fail the current request");
+        let content = collect_stream(stream).await;
 
         assert_eq!(content, Bytes::from_static(b"refetched-when-disk-full"));
     }
 
     #[tokio::test]
     async fn test_get_remote_cached_or_refetch_returns_cached_without_refetch() {
-        let Some(pool) = try_pool().await else {
-            return;
-        };
         // Happy path: cache hits should return the stored bytes verbatim and
         // must NEVER invoke the upstream refetch closure.
         let storage = PresentStorage {
@@ -2980,9 +3020,7 @@ mod tests {
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
-        let content = super::get_remote_cached_or_refetch(
-            &pool,
-            uuid::Uuid::new_v4(),
+        let stream = super::get_remote_cached_or_refetch_stream(
             &storage,
             "proxy-cache/pypi-remote/simple/numpy/numpy-2.0.0-cp312-cp312-manylinux.whl/__content__",
             move || {
@@ -2995,6 +3033,7 @@ mod tests {
         )
         .await
         .expect("cached read should succeed");
+        let content = collect_stream(stream).await;
 
         assert_eq!(content, Bytes::from_static(b"cached-wheel-bytes"));
         assert_eq!(
@@ -3006,9 +3045,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_remote_cached_or_refetch_propagates_non_notfound_storage_error() {
-        let Some(pool) = try_pool().await else {
-            return;
-        };
         // A storage backend error that is NOT `NotFound` (e.g. permission
         // denied, I/O error) must be surfaced as a 500 instead of silently
         // re-fetching, otherwise we mask infra issues from operators.
@@ -3016,9 +3052,7 @@ mod tests {
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
-        let result = super::get_remote_cached_or_refetch(
-            &pool,
-            uuid::Uuid::new_v4(),
+        let result = super::get_remote_cached_or_refetch_stream(
             &storage,
             "proxy-cache/pypi-remote/simple/six/six-1.16.0.tar.gz/__content__",
             move || {
@@ -3042,9 +3076,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_remote_cached_or_refetch_surfaces_refetch_failure() {
-        let Some(pool) = try_pool().await else {
-            return;
-        };
         // When the cache is stale AND the upstream refetch also fails, the
         // upstream error response must reach the caller untouched so the
         // client sees the correct upstream status (e.g. 502).
@@ -3052,9 +3083,7 @@ mod tests {
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
-        let result = super::get_remote_cached_or_refetch(
-            &pool,
-            uuid::Uuid::new_v4(),
+        let result = super::get_remote_cached_or_refetch_stream(
             &storage,
             "proxy-cache/pypi-remote/simple/requests/requests-2.32.0-py3-none-any.whl/__content__",
             move || {
@@ -3078,9 +3107,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_remote_cached_or_refetch_preserves_empty_cached_payload() {
-        let Some(pool) = try_pool().await else {
-            return;
-        };
         // Edge case: a legitimately empty cached payload (zero bytes) is
         // still a cache hit and must be returned without triggering a
         // refetch. This guards against accidentally treating empty bodies
@@ -3091,9 +3117,7 @@ mod tests {
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
-        let content = super::get_remote_cached_or_refetch(
-            &pool,
-            uuid::Uuid::new_v4(),
+        let stream = super::get_remote_cached_or_refetch_stream(
             &storage,
             "proxy-cache/pypi-remote/simple/empty/empty-0.0.0.tar.gz/__content__",
             move || {
@@ -3106,6 +3130,7 @@ mod tests {
         )
         .await
         .expect("empty cached payload should still be a hit");
+        let content = collect_stream(stream).await;
 
         assert!(content.is_empty());
         assert_eq!(

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2822,9 +2822,7 @@ mod tests {
     /// Drain a `get_remote_cached_or_refetch_stream` body into a single `Bytes`
     /// so the existing buffered-semantics assertions still hold against the
     /// streaming implementation.
-    async fn collect_stream(
-        stream: BoxStream<'static, Result<Bytes, std::io::Error>>,
-    ) -> Bytes {
+    async fn collect_stream(stream: BoxStream<'static, Result<Bytes, std::io::Error>>) -> Bytes {
         let mut s = stream;
         let mut buf = Vec::new();
         while let Some(chunk) = s.next().await {
@@ -2930,17 +2928,13 @@ mod tests {
 
         let storage_key =
             "proxy-cache/pypi-remote/simple/fastapi/fastapi-0.136.1-py3-none-any.whl/__content__";
-        let stream = super::get_remote_cached_or_refetch_stream(
-            &storage,
-            storage_key,
-            move || {
-                let refetch_calls_clone = refetch_calls_clone.clone();
-                async move {
-                    refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    Ok(Bytes::from_static(b"refetched-bytes"))
-                }
-            },
-        )
+        let stream = super::get_remote_cached_or_refetch_stream(&storage, storage_key, move || {
+            let refetch_calls_clone = refetch_calls_clone.clone();
+            async move {
+                refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(Bytes::from_static(b"refetched-bytes"))
+            }
+        })
         .await
         .expect("refetch should succeed");
         let content = collect_stream(stream).await;
@@ -3065,7 +3059,12 @@ mod tests {
         )
         .await;
 
-        let response = result.expect_err("non-NotFound storage errors must propagate");
+        // The Ok arm carries a BoxStream (not Debug), so match instead of
+        // `expect_err` to extract the error Response.
+        let response = match result {
+            Ok(_) => panic!("non-NotFound storage errors must propagate"),
+            Err(resp) => resp,
+        };
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(
             refetch_calls.load(std::sync::atomic::Ordering::SeqCst),
@@ -3096,7 +3095,12 @@ mod tests {
         )
         .await;
 
-        let response = result.expect_err("refetch failures must propagate to caller");
+        // The Ok arm carries a BoxStream (not Debug), so match instead of
+        // `expect_err` to extract the error Response.
+        let response = match result {
+            Ok(_) => panic!("refetch failures must propagate to caller"),
+            Err(resp) => resp,
+        };
         assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
         assert_eq!(
             refetch_calls.load(std::sync::atomic::Ordering::SeqCst),

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1,9 +1,9 @@
 //! Repository management handlers.
 
 use axum::{
-    body::Bytes,
+    body::{Body, Bytes},
     extract::{Extension, Multipart, Path, Query, State},
-    http::{header, HeaderMap},
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
     Router,
@@ -2862,7 +2862,7 @@ pub async fn get_artifact_metadata(
         let db = state.db.clone();
         let path_clone = path.clone();
         let state_clone = state.clone();
-        let (content, content_type) = proxy_helpers::resolve_virtual_download(
+        let result = proxy_helpers::resolve_virtual_download(
             &state.db,
             proxy_for_virtual,
             repo.id,
@@ -2881,25 +2881,29 @@ pub async fn get_artifact_metadata(
             AppError::NotFound("Artifact not found in any member repository".to_string())
         })?;
 
-        let ct = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+        let ct = result
+            .content_type
+            .unwrap_or_else(|| "application/octet-stream".to_string());
         let filename = path.rsplit('/').next().unwrap_or(&path);
 
-        return Ok((
-            [
-                (header::CONTENT_TYPE, ct),
-                (
-                    header::CONTENT_DISPOSITION,
-                    format!("attachment; filename=\"{}\"", filename),
-                ),
-                (header::CONTENT_LENGTH, content.len().to_string()),
-                (
-                    header::HeaderName::from_static(X_ARTIFACT_STORAGE),
-                    "virtual".to_string(),
-                ),
-            ],
-            content,
-        )
-            .into_response());
+        // Stream the member's artifact body straight through instead of
+        // buffering it; Content-Length comes from the resolved member's
+        // size_bytes when known.
+        let mut builder = Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, ct)
+            .header(
+                header::CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{}\"", filename),
+            )
+            .header(
+                header::HeaderName::from_static(X_ARTIFACT_STORAGE),
+                "virtual",
+            );
+        if let Some(size) = result.content_length {
+            builder = builder.header(header::CONTENT_LENGTH, size.to_string());
+        }
+        return Ok(builder.body(Body::from_stream(result.body)).unwrap());
     }
 
     Err(AppError::NotFound("Artifact not found".to_string()))
@@ -3414,7 +3418,7 @@ pub async fn download_artifact(
             };
             let db = state.db.clone();
             let path_clone = path.clone();
-            let (content, content_type) = proxy_helpers::resolve_virtual_download(
+            let result = proxy_helpers::resolve_virtual_download(
                 &state.db,
                 proxy_for_virtual,
                 repo.id,
@@ -3434,25 +3438,26 @@ pub async fn download_artifact(
                 AppError::NotFound("Artifact not found in any member repository".to_string())
             })?;
 
-            let ct = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+            let ct = result
+                .content_type
+                .unwrap_or_else(|| "application/octet-stream".to_string());
             let filename = path.rsplit('/').next().unwrap_or(&path);
 
-            Ok((
-                [
-                    (header::CONTENT_TYPE, ct),
-                    (
-                        header::CONTENT_DISPOSITION,
-                        format!("attachment; filename=\"{}\"", filename),
-                    ),
-                    (header::CONTENT_LENGTH, content.len().to_string()),
-                    (
-                        header::HeaderName::from_static(X_ARTIFACT_STORAGE),
-                        "virtual".to_string(),
-                    ),
-                ],
-                content,
-            )
-                .into_response())
+            let mut builder = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, ct)
+                .header(
+                    header::CONTENT_DISPOSITION,
+                    format!("attachment; filename=\"{}\"", filename),
+                )
+                .header(
+                    header::HeaderName::from_static(X_ARTIFACT_STORAGE),
+                    "virtual",
+                );
+            if let Some(size) = result.content_length {
+                builder = builder.header(header::CONTENT_LENGTH, size.to_string());
+            }
+            Ok(builder.body(Body::from_stream(result.body)).unwrap())
         }
         Err(e) => Err(e),
     }

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -687,13 +687,16 @@ async fn download_package(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -710,9 +713,9 @@ async fn download_package(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("X-Checksum-SHA256", &artifact.checksum_sha256)
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -138,16 +138,11 @@ async fn download_by_path(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -119,7 +119,7 @@ async fn download_by_path(
             if repo.repo_type == RepositoryType::Virtual {
                 let db = state.db.clone();
                 let path_clone = artifact_path.to_string();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -138,15 +138,16 @@ async fn download_by_path(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());
@@ -161,13 +162,16 @@ async fn download_by_path(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     let _ = sqlx::query!(
         "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
@@ -192,8 +196,8 @@ async fn download_by_path(
                 artifact_path.rsplit('/').next().unwrap_or(artifact_path)
             ),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -446,16 +446,7 @@ async fn download_archive(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/zip".to_string()),
-                );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                return proxy_helpers::stream_fetch_result(result, "application/zip", None);
             }
 
             return Err(swift_error_response(

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -426,7 +426,7 @@ async fn download_archive(
                 let name_clone = package_id.clone();
                 let version_clone = version.to_string();
                 let upstream_path = format!("{}/{}/{}.zip", scope, name, version);
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -446,15 +446,16 @@ async fn download_archive(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/zip".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/zip".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
 
             return Err(swift_error_response(
@@ -472,12 +473,15 @@ async fn download_archive(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        swift_error_response(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            &format!("Storage error: {}", e),
-        )
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            swift_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Storage error: {}", e),
+            )
+        })?;
 
     // Record download
     let _ = sqlx::query!(
@@ -498,9 +502,9 @@ async fn download_archive(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
         .header("Digest", format!("sha-256={}", checksum))
-        .body(Body::from(content))
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -263,7 +263,7 @@ async fn download_module(
                 );
                 let vname = module_name.clone();
                 let vversion = version.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -283,15 +283,16 @@ async fn download_module(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -821,7 +822,7 @@ async fn download_provider(
                 );
                 let vname = provider_name.clone();
                 let vversion = version.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -841,15 +842,16 @@ async fn download_provider(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -22,7 +22,7 @@
 
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, put};
@@ -283,16 +283,11 @@ async fn download_module(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -842,16 +837,11 @@ async fn download_provider(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -206,7 +206,7 @@ async fn download_vsix(
                     format!("extensions/{}/{}/{}/download", publisher, name, version);
                 let vname = extension_id.clone();
                 let vversion = version.clone();
-                let (content, content_type) = proxy_helpers::resolve_virtual_download(
+                let result = proxy_helpers::resolve_virtual_download(
                     &state.db,
                     state.proxy_service.as_deref(),
                     repo.id,
@@ -226,15 +226,16 @@ async fn download_vsix(
                 )
                 .await?;
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        "Content-Type",
-                        content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                    )
-                    .header(CONTENT_LENGTH, content.len().to_string())
-                    .body(Body::from(content))
-                    .unwrap());
+                let mut builder = Response::builder().status(StatusCode::OK).header(
+                    "Content-Type",
+                    result
+                        .content_type
+                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                );
+                if let Some(size) = result.content_length {
+                    builder = builder.header(CONTENT_LENGTH, size.to_string());
+                }
+                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }
@@ -248,13 +249,16 @@ async fn download_vsix(
         .await
         .map_err(|e| e.into_response())?;
 
-    let content = storage.get(&artifact.storage_key).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let stream = storage
+        .get_stream(&artifact.storage_key)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Storage error: {}", e),
+            )
+                .into_response()
+        })?;
 
     let _ = sqlx::query!(
         "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
@@ -272,8 +276,8 @@ async fn download_vsix(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
         )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+        .body(Body::from_stream(stream))
         .unwrap())
 }
 

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -226,16 +226,11 @@ async fn download_vsix(
                 )
                 .await?;
 
-                let mut builder = Response::builder().status(StatusCode::OK).header(
-                    "Content-Type",
-                    result
-                        .content_type
-                        .unwrap_or_else(|| "application/octet-stream".to_string()),
+                return proxy_helpers::stream_fetch_result(
+                    result,
+                    "application/octet-stream",
+                    None,
                 );
-                if let Some(size) = result.content_length {
-                    builder = builder.header(CONTENT_LENGTH, size.to_string());
-                }
-                return Ok(builder.body(Body::from_stream(result.body)).unwrap());
             }
             return Err(not_found);
         }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -83,6 +83,33 @@ impl From<StreamHandle> for StreamingFetchResult {
     }
 }
 
+impl std::fmt::Debug for StreamingFetchResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamingFetchResult")
+            .field("content_type", &self.content_type)
+            .field("content_length", &self.content_length)
+            .field("body", &"<stream>")
+            .finish()
+    }
+}
+
+impl StreamingFetchResult {
+    /// Collect the entire stream into a single `Bytes` buffer.
+    ///
+    /// Use only when the caller needs the full content for parsing.
+    /// Normal download paths should pass `self.body` directly to
+    /// `Body::from_stream`.
+    pub async fn collect(self) -> Result<Bytes> {
+        use futures::StreamExt;
+        let mut buf = Vec::new();
+        let mut stream = self.body;
+        while let Some(chunk) = stream.next().await {
+            buf.extend_from_slice(&chunk?);
+        }
+        Ok(Bytes::from(buf))
+    }
+}
+
 /// Metadata fields known up-front when teeing an upstream stream into
 /// the proxy cache. The size + sha-256 fields of [`CacheMetadata`] are
 /// observed during the stream itself and filled in by the writer task

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -8218,8 +8218,7 @@ SHA256:
         let err = proxy
             .fetch_artifact_streaming(&repo, "blob")
             .await
-            .err()
-            .expect("a 5xx upstream must fail the streaming fetch");
+            .expect_err("a 5xx upstream must fail the streaming fetch");
         let _ = std::fs::remove_dir_all(&tmp);
         assert!(matches!(err, AppError::ServiceUnavailable(_)), "{err:?}");
     }

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -264,9 +264,17 @@ impl StorageBackend for FilesystemStorage {
 
     async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
         let path = self.key_to_path(key);
-        let file = fs::File::open(&path)
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to open {}: {}", key, e)))?;
+        let file = fs::File::open(&path).await.map_err(|e| {
+            // #1016: a missing key MUST map to AppError::NotFound so callers
+            // (e.g. maven_proxy sibling fall-through, local hydration retry)
+            // see a 404, not a 500. Mirror the buffered `get`/`get_range`
+            // mapping; anything that is not a NotFound stays a Storage error.
+            if e.kind() == std::io::ErrorKind::NotFound {
+                AppError::NotFound(format!("Storage key not found: {}", key))
+            } else {
+                AppError::Storage(format!("Failed to open {}: {}", key, e))
+            }
+        })?;
 
         let reader = BufReader::new(file);
         let stream = ReaderStream::with_capacity(reader, STREAM_CHUNK_SIZE);

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -897,6 +897,32 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// #1016 contract (streaming half): a missing key passed to `get_stream`
+    /// MUST surface as `AppError::NotFound`, exactly like the buffered `get`
+    /// and `get_range`. Callers such as `maven_proxy.rs` sibling fall-through
+    /// and the local hydration retry distinguish NotFound (→ 404 / coordinated
+    /// retry) from a real I/O error (→ 500); lumping a missing file into
+    /// `AppError::Storage` would turn a legitimate 404 into a 500. This test
+    /// guards the regression introduced when the local download path migrated
+    /// to streaming (PR #1393 / #1608 download invariant).
+    #[tokio::test]
+    async fn test_get_stream_missing_key_returns_not_found() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        // The Ok arm holds a BoxStream (not Debug), so match rather than
+        // `unwrap_err` to extract the error.
+        let err = match storage.get_stream("does-not-exist-stream").await {
+            Ok(_) => panic!("expected an error for a missing key"),
+            Err(e) => e,
+        };
+
+        assert!(
+            matches!(err, AppError::NotFound(_)),
+            "expected NotFound for a missing key, got {err:?}"
+        );
+    }
+
     // --- put_stream tests ---
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1703

Part of #1608 → epic #1607.

## Summary

Streams large artifact **bodies** straight from storage (`get_stream` + `Body::from_stream`) instead of buffering them in heap, across all package-format download handlers. This is the download-streaming item of the Core Invariant ① work (#1608, epic #1607).

This branch has been **rebased onto current `main`** and the original community PR's two regressions fixed. Credit for the original work goes to @Dreamacro (preserved as author of the `feat:` commit; also co-authored on the follow-up fix commit).

### Rebase / re-wiring onto main
`main` already landed the proxy refactor (#1618 / #1631): `StreamingFetchResult`, the streaming response builders, and the remote/proxy streaming path. The original PR predated that, so the local-download half was re-wired onto main's refactored seam:
- Added `read_local_stream`, the streaming sibling of `read_local_content`, that **preserves the #1016 `NotFound` → `coordinated_retry_get` hydration fallback** (the recovered bytes are re-wrapped as a one-shot stream).
- `local_fetch_by_path` / `local_fetch_by_name_version` now return `StreamingFetchResult` via that shared skeleton; `LocalArtifactRow` / `LocalLookup::select_sql` carry `size_bytes` for an accurate `Content-Length`.
- `pypi`: kept `get_remote_cached_or_refetch_stream` (streams a cache hit; on a miss buffers the upstream refetch + write-back and re-wraps as a stream). Its six unit tests were migrated to the streaming signature and now run DB-free in Tier-1.
- `npm` / `nuget`: preserved the upstream cache-or-refetch hydration while streaming the local/cached body.
- Small metadata reads (checksums, `maven-metadata.xml`, packuments, podspecs, protobuf bundle parsing) stay **buffered** — only large artifact bodies stream. `protobuf` uses `StreamingFetchResult::collect()` where it needs the full bytes.

### Regression fixes
- **OCI manifest `Content-Length`** (`oci_v2.rs` `handle_get_manifest` local-hit arm): manifests are small metadata and the `oci_tags` row has no size column, so this path is kept **buffered with `Content-Length`** (container clients require it). Only large blob bodies stream.
- **filesystem `get_stream` NotFound** (`filesystem.rs`): a missing file now maps to `AppError::NotFound` (was `AppError::Storage`), matching the buffered `get` / `get_range` and the #1016 contract relied on by `maven_proxy.rs` sibling fall-through and local hydration.

Part of #1608 → epic #1607.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added `test_get_stream_missing_key_returns_not_found` (filesystem `get_stream` missing file → `AppError::NotFound`) and strengthened the existing missing-key test. The pypi streaming-refetch unit tests cover the rewired cache/refetch/write-back path.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes