### PR TITLE
feat: add support for custom OIDC_NAME environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -228,6 +228,7 @@ JWT_EXPIRATION_SECS=86400
 # the backend when the corresponding OIDC_* entries are also forwarded under the
 # backend service's environment section in docker-compose.yml, for example:
 # environment:
+#   OIDC_NAME: ${OIDC_NAME:-}
 #   OIDC_ISSUER: ${OIDC_ISSUER:-}
 #   OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
 #   OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
@@ -244,6 +245,7 @@ JWT_EXPIRATION_SECS=86400
 # OIDC_CLIENT_SECRET=xxx
 
 # The remaining OIDC_* values are optional and default to the backend defaults when unset.
+# OIDC_NAME=default
 # OIDC_REDIRECT_URI=https://registry.example.com/api/v1/auth/sso/oidc/callback
 # OIDC_GROUPS_CLAIM=groups
 # OIDC_SCOPES=openid profile email

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1099,6 +1099,7 @@ async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
 /// Raw OIDC environment variable values for bootstrap.
 #[derive(Default)]
 struct OidcEnvVars {
+    name: Option<String>,
     issuer: Option<String>,
     client_id: Option<String>,
     client_secret: Option<String>,
@@ -1114,6 +1115,7 @@ struct OidcEnvVars {
 fn build_oidc_bootstrap_request(
 ) -> Option<artifact_keeper_backend::services::auth_config_service::CreateOidcConfigRequest> {
     build_oidc_request_from_values(OidcEnvVars {
+        name: std::env::var("OIDC_NAME").ok(),
         issuer: std::env::var("OIDC_ISSUER").ok(),
         client_id: std::env::var("OIDC_CLIENT_ID").ok(),
         client_secret: std::env::var("OIDC_CLIENT_SECRET").ok(),
@@ -1135,6 +1137,10 @@ fn build_oidc_request_from_values(
     let issuer = env.issuer.filter(|v| !v.is_empty())?;
     let client_id = env.client_id.filter(|v| !v.is_empty())?;
     let client_secret = env.client_secret.filter(|v| !v.is_empty())?;
+    let name = env
+        .name
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "default".to_string());
 
     let scopes = env
         .scopes
@@ -1158,7 +1164,7 @@ fn build_oidc_request_from_values(
     }
 
     Some(CreateOidcConfigRequest {
-        name: "default".to_string(),
+        name,
         issuer_url: issuer,
         client_id,
         client_secret,
@@ -1685,6 +1691,32 @@ mod tests {
     }
 
     #[test]
+    fn test_bootstrap_request_custom_name() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.name = Some("Corporate SSO".into());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.name, "Corporate SSO");
+    }
+
+    #[test]
+    fn test_bootstrap_request_empty_name_defaults_to_default() {
+        let mut e = env(
+            Some("https://idp.example.com"),
+            Some("client"),
+            Some("secret"),
+        );
+        e.name = Some(String::new());
+        let req = build_oidc_request_from_values(e).unwrap();
+
+        assert_eq!(req.name, "default");
+    }
+
+    #[test]
     fn test_bootstrap_request_missing_issuer() {
         let req = build_oidc_request_from_values(env(None, Some("client"), Some("secret")));
         assert!(req.is_none());
@@ -1849,6 +1881,7 @@ mod tests {
     #[test]
     fn test_bootstrap_request_all_optional_fields() {
         let req = build_oidc_request_from_values(OidcEnvVars {
+            name: Some("Corporate OIDC".into()),
             issuer: Some("https://auth.corp.com/realms/main".into()),
             client_id: Some("artifact-keeper".into()),
             client_secret: Some("super-secret-123".into()),
@@ -1860,6 +1893,7 @@ mod tests {
         })
         .unwrap();
 
+        assert_eq!(req.name, "Corporate OIDC");
         assert_eq!(req.issuer_url, "https://auth.corp.com/realms/main");
         assert_eq!(req.client_id, "artifact-keeper");
         assert_eq!(req.client_secret, "super-secret-123");

--- a/scripts/sso-e2e/docker-compose.oidc-bootstrap-test.yml
+++ b/scripts/sso-e2e/docker-compose.oidc-bootstrap-test.yml
@@ -55,6 +55,7 @@ services:
       SKIP_ADMIN_PROVISIONING: "true"
 
       # OIDC env vars that should be bootstrapped into oidc_configs table
+      OIDC_NAME: Test Keycloak OIDC
       OIDC_ISSUER: http://keycloak:8080/realms/artifact-keeper
       OIDC_CLIENT_ID: artifact-keeper
       OIDC_CLIENT_SECRET: artifact-keeper-secret

--- a/scripts/sso-e2e/test-oidc-bootstrap.sh
+++ b/scripts/sso-e2e/test-oidc-bootstrap.sh
@@ -120,6 +120,12 @@ run_test "Bootstrapped config has correct issuer_url" '
     [[ "$issuer" == "http://keycloak:8080/realms/artifact-keeper" ]]
 '
 
+run_test "Bootstrapped config has custom name from OIDC_NAME" '
+    name=$(docker compose -f "$COMPOSE_FILE" exec -T postgres \
+        psql -U registry -d artifact_registry -t -c "SELECT name FROM oidc_configs LIMIT 1;" | sed "s/^ *//;s/ *$//")
+    [[ "$name" == "Test Keycloak OIDC" ]]
+'
+
 run_test "Bootstrapped config has groups_claim=roles in attribute_mapping" '
     mapping=$(docker compose -f "$COMPOSE_FILE" exec -T postgres \
         psql -U registry -d artifact_registry -t -c "SELECT attribute_mapping FROM oidc_configs LIMIT 1;")


### PR DESCRIPTION
## Summary

Closes #1396.

Adds optional `OIDC_NAME` support to environment-based OIDC bootstrap.

- Reads `OIDC_NAME` when creating an OIDC provider from env vars
- Preserves existing behavior by defaulting to `default` when `OIDC_NAME` is unset or empty
- Documents `OIDC_NAME` in `.env.example`
- Updates the OIDC bootstrap E2E fixture and assertion to cover the custom provider name

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verification run locally:

- `protoc --version`
- `cargo fmt --check`
- `bash -n scripts/sso-e2e/test-oidc-bootstrap.sh`
- `docker compose -f scripts/sso-e2e/docker-compose.oidc-bootstrap-test.yml config`
- `git diff --check`
- `cargo test -p artifact-keeper-backend --bin artifact-keeper bootstrap_request`
- `cargo test --workspace --lib`
- `cargo clippy --workspace --all-targets -- -D warnings`

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
