### PR TITLE
feat(oci): reclaim orphan blob layers via manifest_blob_refs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,24 @@ jobs:
       # lib-test crate that OOM-killed check-rust, and incremental is useless
       # in CI's clean checkout while inflating peak RSS.
       CARGO_INCREMENTAL: "0"
+    services:
+      # The lib tests include DB-backed cases (OCI blob GC, blob refs, the
+      # readiness gate) that silently no-op via `Fixture::setup` when
+      # DATABASE_URL is unset. Provide the same Postgres the coverage job uses
+      # so they actually run (#1409 review).
+      postgres:
+        image: ghcr.io/artifact-keeper/ci-mirror/postgres:16-alpine
+        env:
+          POSTGRES_USER: registry
+          POSTGRES_PASSWORD: registry
+          POSTGRES_DB: artifact_registry
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -114,10 +132,40 @@ jobs:
             exit 1
           fi
 
+      - name: Wait for Postgres
+        run: |
+          set -euo pipefail
+          # The service --health-cmd already runs pg_isready, but the step can
+          # start before health flips to "healthy" on slower runners. A short
+          # TCP readiness loop avoids a flaky first connect.
+          for i in $(seq 1 30); do
+            if (echo > /dev/tcp/localhost/5432) >/dev/null 2>&1; then
+              echo "Postgres reachable on attempt $i"
+              exit 0
+            fi
+            echo "  waiting for postgres... ($i/30)"
+            sleep 1
+          done
+          echo "ERROR: Postgres did not become reachable within 30s"
+          exit 1
+
+      - name: Run database migrations
+        run: sqlx migrate run --source backend/migrations
+        env:
+          DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
+
       - name: Run unit tests
         env:
+          # SQLX_OFFLINE keeps the build using the committed .sqlx cache;
+          # DATABASE_URL lets the DB-backed lib tests run for real against the
+          # Postgres service above instead of no-op'ing.
           SQLX_OFFLINE: true
-        run: cargo test --workspace --lib --verbose
+          DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
+          JWT_SECRET: ci-coverage-secret-at-least-32-bytes-long-for-tests
+        # --test-threads=1: these DB-backed suites share global tables and the
+        # blob-GC readiness gate is a cluster-wide query, so a concurrent
+        # cross-module test's transient rows can make gate/GC assertions flaky.
+        run: cargo test --workspace --lib --verbose -- --test-threads=1
 
   shell-tests:
     name: 🐚 Shell Tests
@@ -139,11 +187,20 @@ jobs:
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners
-    # Disable incremental codegen (#1679): the coverage build compiles the
-    # same lib-test crate that OOM-killed check-rust. Incremental is useless
-    # in CI's clean checkout and inflates peak RSS.
+    # Memory guards for the instrumented lib-test compile (#1679/#1680,
+    # extended here to the coverage job). This job builds the same lib-test
+    # crate that OOM-killed check-rust, but under `-C instrument-coverage`
+    # *and* `-C debuginfo=2` — the heaviest compile in CI, which got SIGKILL'd
+    # (OOM) on larger PRs. CARGO_INCREMENTAL=0 drops incremental codegen
+    # (useless in a clean checkout), CARGO_BUILD_JOBS caps parallel rustc, and
+    # dropping debuginfo cuts peak RSS the most. Coverage mapping comes from
+    # the instrumentation (`__llvm_covmap`), not DWARF, so debuginfo=0 does
+    # not affect line-coverage accuracy.
     env:
       CARGO_INCREMENTAL: "0"
+      CARGO_BUILD_JOBS: "2"
+      CARGO_PROFILE_DEV_DEBUG: "0"
+      CARGO_PROFILE_TEST_DEBUG: "0"
     services:
       postgres:
         # Use the GHCR mirror maintained by .github/workflows/mirror-images.yml

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -1499,6 +1499,69 @@ pub(crate) fn is_index_content_type(content_type: &str) -> bool {
     )
 }
 
+const OCI_INDEX_MEDIA_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+const OCI_IMAGE_MEDIA_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+
+/// Content-based classification of a manifest body, independent of the
+/// declared media type.
+///
+/// The blob-GC readiness gate keys on the stored `manifest_content_type`,
+/// which is the (absent/spoofable) request/upstream header. So an index
+/// pushed with an image/missing Content-Type — or a degenerate body with
+/// neither a `manifests` array nor a `config` descriptor — must be
+/// recognised by CONTENT, else it lands as a ref-less "live image" and pins
+/// the gate forever (#1409 C1). Classifying by content lets the push path
+/// reject the degenerate case and lets callers store a media type that
+/// matches the body.
+#[derive(Debug)]
+pub(crate) enum ManifestClass {
+    /// Has a `manifests` array: an image index / manifest list. Protected
+    /// through `oci_manifest_refs`, not `manifest_blob_refs`.
+    Index,
+    /// Has a `config` descriptor: a normal image manifest.
+    Image,
+    /// Unparseable, or neither an index nor an image. The push path rejects
+    /// these; nothing may create a live tag for one.
+    Malformed,
+}
+
+pub(crate) fn classify_manifest(body: &[u8]) -> ManifestClass {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ManifestClass::Malformed;
+    };
+    if json.get("manifests").and_then(|m| m.as_array()).is_some() {
+        return ManifestClass::Index;
+    }
+    if json
+        .get("config")
+        .and_then(|c| c.get("digest"))
+        .and_then(|d| d.as_str())
+        .is_some()
+    {
+        return ManifestClass::Image;
+    }
+    ManifestClass::Malformed
+}
+
+/// The media type to STORE in `oci_tags.manifest_content_type`, derived from
+/// the manifest's CONTENT rather than trusting the (absent/spoofable)
+/// header, so it can never disagree with the body (the blob-GC gate keys on
+/// it, #1409 C1):
+/// - `Index`  → keep the header if it is already an index media type
+///   (preserving the OCI-vs-Docker variant), else the canonical OCI index
+///   type, so the gate always excludes it (even an empty index).
+/// - `Image`  → keep the header if it is a non-index type, else the canonical
+///   OCI image type (an image must never be stored with an index media type,
+///   which the gate would wrongly exclude).
+/// - `Malformed` → header verbatim; callers must not persist a tag for one.
+pub(crate) fn stored_media_type_for(class: &ManifestClass, header: &str) -> String {
+    match class {
+        ManifestClass::Index if !is_index_content_type(header) => OCI_INDEX_MEDIA_TYPE.to_string(),
+        ManifestClass::Image if is_index_content_type(header) => OCI_IMAGE_MEDIA_TYPE.to_string(),
+        _ => header.to_string(),
+    }
+}
+
 /// Parse an OCI image index manifest body and return the list of child
 /// manifest digests. Used by both the push handler (to populate
 /// `oci_manifest_refs` synchronously) and the startup backfill (to fill
@@ -2501,9 +2564,29 @@ async fn cache_manifest_reference_locally(
         .await
         .map_err(|e| e.to_string())?;
 
-    let manifest_content_type = content_type
-        .unwrap_or("application/vnd.oci.image.manifest.v1+json")
-        .to_string();
+    // Classify by CONTENT — the upstream Content-Type is advisory. A body we
+    // cannot classify as an image or an index is not a real manifest: keep
+    // the cached body for the client, but do NOT create an `oci_tags` row, or
+    // a ref-less live tag would pin the blob-GC gate deployment-wide
+    // (#1409 C1).
+    let class = classify_manifest(content);
+    if matches!(class, ManifestClass::Malformed) {
+        tracing::warn!(
+            repo = %repo.key,
+            image = %repo.image,
+            reference = %reference,
+            manifest_digest = %digest,
+            "Proxied manifest is neither an index nor an image; cached the body \
+             but recorded no oci_tags row or refs (would otherwise pin blob GC)"
+        );
+        return Ok(digest);
+    }
+    // Store a media type derived from content, not the upstream header, so the
+    // gate can't be misled by a mislabeled index.
+    let manifest_content_type = stored_media_type_for(
+        &class,
+        content_type.unwrap_or("application/vnd.oci.image.manifest.v1+json"),
+    );
     let cached_reference = cached_manifest_reference_key(&repo.repo_type, reference, &digest);
 
     sqlx::query(
@@ -2683,20 +2766,42 @@ async fn cache_manifest_reference_locally(
     // `handle_put_manifest`. The manifest body and oci_tags rows are already
     // persisted; failure here only affects GC/UI accounting until the
     // startup backfill in main.rs runs again.
-    if is_index_content_type(&manifest_content_type) {
-        if let Err(e) = record_oci_manifest_refs(&state.db, repo.id, &digest, content).await {
-            tracing::warn!(
-                repo = %repo.key,
-                image = %repo.image,
-                reference = %reference,
-                parent_digest = %digest,
-                error = %e,
-                "Failed to record oci_manifest_refs for proxied index manifest; \
-                 storage GC may treat child manifests as orphaned and the UI \
-                 size accounting will under-report multi-arch totals until the \
-                 next backfill pass runs"
-            );
+    // Route on the CONTENT classification (not a re-derived string): an
+    // image needs its blob refs recorded too, or a proxy-cached image is a
+    // live tag with zero refs that pins the blob-GC gate (#1409). Best-effort
+    // + warn (the startup backfill reconciles any gap); `Malformed` returned
+    // early above without a tag.
+    match &class {
+        ManifestClass::Index => {
+            if let Err(e) = record_oci_manifest_refs(&state.db, repo.id, &digest, content).await {
+                tracing::warn!(
+                    repo = %repo.key,
+                    image = %repo.image,
+                    reference = %reference,
+                    parent_digest = %digest,
+                    error = %e,
+                    "Failed to record oci_manifest_refs for proxied index manifest; \
+                     storage GC may treat child manifests as orphaned and the UI \
+                     size accounting will under-report multi-arch totals until the \
+                     next backfill pass runs"
+                );
+            }
         }
+        ManifestClass::Image => {
+            if let Err(e) = record_manifest_blob_refs(&state.db, repo.id, &digest, content).await {
+                tracing::warn!(
+                    repo = %repo.key,
+                    image = %repo.image,
+                    reference = %reference,
+                    manifest_digest = %digest,
+                    error = %e,
+                    "Failed to record manifest_blob_refs for proxied image manifest; \
+                     blob GC stays gated deployment-wide until the refs are recorded \
+                     (next proxy refresh or startup backfill), but no blob is at risk"
+                );
+            }
+        }
+        ManifestClass::Malformed => {}
     }
 
     Ok(digest)
@@ -5330,6 +5435,27 @@ async fn handle_put_manifest(
     let digest = compute_sha256(&body);
     let manifest_key = manifest_storage_key(&digest);
 
+    // Classify by content BEFORE storing or tagging. The Content-Type header
+    // is unreliable (defaults to the image type when absent), so a degenerate
+    // body — neither an index (`manifests[]`) nor an image (`config.digest`),
+    // or unparseable — must be rejected here; accepting it would create a
+    // live tag with zero `manifest_blob_refs` and pin the blob-GC gate
+    // deployment-wide (#1409 C1).
+    let class = classify_manifest(&body);
+    if matches!(class, ManifestClass::Malformed) {
+        return oci_error(
+            StatusCode::BAD_REQUEST,
+            "MANIFEST_INVALID",
+            "manifest is neither an image index (no `manifests`) nor an image \
+             (no `config` descriptor), or is not valid JSON",
+        );
+    }
+    // Store a media type derived from content, not the header, so the gate
+    // (which keys on it) treats an index as an index even when pushed with an
+    // image/missing Content-Type. The index/image ref-routing below then
+    // stays correct because it reads this canonicalized value.
+    let content_type = stored_media_type_for(&class, &content_type);
+
     // Store manifest
     let storage = match state.storage_for_repo(&repo.location) {
         Ok(s) => s,
@@ -5341,10 +5467,12 @@ async fn handle_put_manifest(
             )
         }
     };
+    // A storage write failure is a server/storage fault, not an invalid
+    // manifest (the body already passed classification) — surface 500.
     if let Err(e) = storage.put(&manifest_key, body.clone()).await {
         return oci_error(
             StatusCode::INTERNAL_SERVER_ERROR,
-            "MANIFEST_INVALID",
+            "INTERNAL_ERROR",
             &e.to_string(),
         );
     }
@@ -5383,39 +5511,41 @@ async fn handle_put_manifest(
     // the push, since the manifest itself has been persisted and the tag
     // upsert succeeded. The startup backfill in main.rs will fill in any
     // gaps on the next restart.
-    if is_index_content_type(&content_type) {
-        if let Err(e) = record_oci_manifest_refs(&state.db, repo_id, &digest, &body).await {
-            warn!(
-                image = image_name,
-                reference = reference,
-                parent_digest = digest.as_str(),
-                error = %e,
-                "Failed to record oci_manifest_refs for index manifest; storage GC may treat \
-                 child manifests as orphaned until the next backfill pass runs"
-            );
+    // Route ref-recording on the CONTENT classification, not a re-derived
+    // media-type string: an image body pushed with an index Content-Type
+    // would otherwise record `oci_manifest_refs` (0 children) and skip its
+    // blob refs, leaving a live image's layers unreferenced — blob GC would
+    // delete them after the grace period (#1409 C1). `Malformed` was
+    // rejected with 400 above.
+    match class {
+        ManifestClass::Index => {
+            if let Err(e) = record_oci_manifest_refs(&state.db, repo_id, &digest, &body).await {
+                warn!(
+                    image = image_name,
+                    reference = reference,
+                    parent_digest = digest.as_str(),
+                    error = %e,
+                    "Failed to record oci_manifest_refs for index manifest; storage GC may treat \
+                     child manifests as orphaned until the next backfill pass runs"
+                );
+            }
         }
-    } else {
-        // For regular (non-index) image manifests, record the
-        // (manifest_digest -> blob_digest) edges (config + layers) so a
-        // future blob GC can safely judge `oci_blobs` orphanhood (#1635).
-        // Image indexes carry no blobs of their own, so they are skipped
-        // here; their child manifests are tracked via oci_manifest_refs
-        // above and each child records its own blob refs on its own PUT.
-        //
-        // Best-effort: a failure to write the refs is logged but does not
-        // fail the push, since the manifest and tag/artifact rows are
-        // already persisted. The startup backfill in main.rs reconstructs
-        // any gaps on the next restart.
-        if let Err(e) = record_manifest_blob_refs(&state.db, repo_id, &digest, &body).await {
-            warn!(
-                image = image_name,
-                reference = reference,
-                manifest_digest = digest.as_str(),
-                error = %e,
-                "Failed to record manifest_blob_refs for image manifest; blob references will \
-                 be reconstructed by the startup backfill on the next restart"
-            );
+        ManifestClass::Image => {
+            // (manifest_digest -> blob_digest) edges (config + layers) so a
+            // future blob GC can safely judge `oci_blobs` orphanhood (#1635).
+            // Best-effort: the startup backfill reconstructs any gap.
+            if let Err(e) = record_manifest_blob_refs(&state.db, repo_id, &digest, &body).await {
+                warn!(
+                    image = image_name,
+                    reference = reference,
+                    manifest_digest = digest.as_str(),
+                    error = %e,
+                    "Failed to record manifest_blob_refs for image manifest; blob references will \
+                     be reconstructed by the startup backfill on the next restart"
+                );
+            }
         }
+        ManifestClass::Malformed => {}
     }
 
     // Calculate total image size from manifest (config + layers)
@@ -6232,6 +6362,45 @@ async fn catalog_local_entries(
     Ok((entries, has_more))
 }
 
+/// Remove the `manifest_blob_refs` rows for a manifest being deleted, so its
+/// config + layer blobs become reclaimable by blob GC once nothing else
+/// references them (#1409). Without this, refs live forever and a blob stays
+/// pinned even after every referencing manifest is gone.
+///
+/// Scoped to NOT delete refs for a digest that is still a live
+/// per-architecture child of a tagged image index: such a child's blobs are
+/// protected ONLY by these rows (the blob-orphan predicate has no
+/// `oci_manifest_refs` join), so deleting them while the index still serves
+/// the child would strip a live image's protection. The caller deletes the
+/// manifest's `oci_tags` rows first; this then runs in the same delete path.
+async fn delete_manifest_blob_refs(
+    db: &PgPool,
+    repo_id: Uuid,
+    manifest_digest: &str,
+) -> Result<u64, sqlx::Error> {
+    let res = sqlx::query(
+        r#"
+        DELETE FROM manifest_blob_refs
+        WHERE repository_id = $1
+          AND manifest_digest = $2
+          AND NOT EXISTS (
+            SELECT 1
+            FROM oci_manifest_refs omr
+            JOIN oci_tags ot
+              ON ot.repository_id = omr.repository_id
+             AND ot.manifest_digest = omr.parent_digest
+            WHERE omr.repository_id = $1
+              AND omr.child_digest = $2
+          )
+        "#,
+    )
+    .bind(repo_id)
+    .bind(manifest_digest)
+    .execute(db)
+    .await?;
+    Ok(res.rows_affected())
+}
+
 async fn handle_delete_manifest(
     state: &SharedState,
     headers: &HeaderMap,
@@ -6257,9 +6426,12 @@ async fn handle_delete_manifest(
         Err(e) => return e,
     };
 
-    // Resolve the manifest digest. The reference may be a tag name or a digest.
-    let manifest_digest: Option<String> = if reference.starts_with("sha256:") {
-        // Verify the digest actually exists in our tag table
+    // Resolve the manifest digest. The reference may be a tag name or a
+    // digest. A query error must surface as 500, never be flattened into a
+    // 404: an OCI client treats 404 as "already deleted" and stops retrying,
+    // so masking a transient DB outage as MANIFEST_UNKNOWN would silently
+    // abandon the delete and hide the outage in the logs as not-founds.
+    let manifest_digest: Result<Option<String>, sqlx::Error> = if reference.starts_with("sha256:") {
         sqlx::query_scalar!(
             "SELECT manifest_digest FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 LIMIT 1",
             repo.id,
@@ -6267,8 +6439,6 @@ async fn handle_delete_manifest(
         )
         .fetch_optional(&state.db)
         .await
-        .ok()
-        .flatten()
     } else {
         sqlx::query_scalar!(
             "SELECT manifest_digest FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3",
@@ -6278,17 +6448,22 @@ async fn handle_delete_manifest(
         )
         .fetch_optional(&state.db)
         .await
-        .ok()
-        .flatten()
     };
 
     let digest = match manifest_digest {
-        Some(d) => d,
-        None => {
+        Ok(Some(d)) => d,
+        Ok(None) => {
             return oci_error(
                 StatusCode::NOT_FOUND,
                 "MANIFEST_UNKNOWN",
                 "manifest not found",
+            )
+        }
+        Err(e) => {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                &e.to_string(),
             )
         }
     };
@@ -6306,6 +6481,21 @@ async fn handle_delete_manifest(
             StatusCode::INTERNAL_SERVER_ERROR,
             "INTERNAL_ERROR",
             &e.to_string(),
+        );
+    }
+
+    // #1409: drop the manifest's blob refs so its config + layer blobs become
+    // reclaimable once nothing else references them. Scoped to skip a digest
+    // still referenced as a live per-architecture child of a tagged index
+    // (its blobs are protected ONLY by these rows). Best-effort: leaving refs
+    // only over-protects (a leak), never deletes a live blob.
+    if let Err(e) = delete_manifest_blob_refs(&state.db, repo.id, &digest).await {
+        warn!(
+            image = image_name,
+            digest = %digest,
+            error = %e,
+            "Failed to delete manifest_blob_refs on manifest deletion; the \
+             manifest's blobs stay GC-protected until this is retried"
         );
     }
 
@@ -10415,6 +10605,111 @@ mod oci_manifest_refs_tests {
     use super::*;
 
     #[test]
+    fn classify_manifest_detects_index_image_and_malformed() {
+        assert!(matches!(
+            classify_manifest(br#"{"manifests":[{"digest":"sha256:c"}]}"#),
+            ManifestClass::Index
+        ));
+        assert!(matches!(
+            classify_manifest(br#"{"config":{"digest":"sha256:cfg"},"layers":[]}"#),
+            ManifestClass::Image
+        ));
+        // Neither manifests[] nor config.digest, and unparseable.
+        assert!(matches!(
+            classify_manifest(br#"{"schemaVersion":2}"#),
+            ManifestClass::Malformed
+        ));
+        assert!(matches!(
+            classify_manifest(b"not json"),
+            ManifestClass::Malformed
+        ));
+        // An index wins even when a config is also present.
+        assert!(matches!(
+            classify_manifest(br#"{"manifests":[],"config":{"digest":"sha256:x"}}"#),
+            ManifestClass::Index
+        ));
+    }
+
+    /// #1409 C1: the STORED media type is derived from content, so the gate
+    /// can't be misled. An index body (even empty) stores an index media type
+    /// even when pushed with an image/missing Content-Type; images keep their
+    /// non-index header.
+    #[test]
+    fn stored_media_type_is_derived_from_content() {
+        let img = "application/vnd.oci.image.manifest.v1+json";
+        let docker_list = "application/vnd.docker.distribution.manifest.list.v2+json";
+        let idx = classify_manifest(br#"{"manifests":[{"digest":"sha256:c"}]}"#);
+        assert!(is_index_content_type(&stored_media_type_for(&idx, img)));
+        let empty_idx = classify_manifest(br#"{"manifests":[]}"#);
+        assert!(is_index_content_type(&stored_media_type_for(
+            &empty_idx, img
+        )));
+        // Docker manifest-list variant preserved.
+        assert_eq!(stored_media_type_for(&idx, docker_list), docker_list);
+        // Image keeps its (non-index) header.
+        let image = classify_manifest(br#"{"config":{"digest":"sha256:cfg"}}"#);
+        assert_eq!(stored_media_type_for(&image, img), img);
+        assert!(!is_index_content_type(&stored_media_type_for(&image, img)));
+        // #1409 C1: an image body pushed with an INDEX Content-Type must NOT
+        // be stored as an index type (the gate would wrongly exclude it).
+        assert!(!is_index_content_type(&stored_media_type_for(
+            &image,
+            docker_list
+        )));
+    }
+
+    /// #1409: delete_manifest_blob_refs removes a deleted manifest's refs but
+    /// preserves a digest still live as a tagged index's child.
+    #[tokio::test]
+    async fn delete_manifest_blob_refs_preserves_live_index_child() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+        let repo = fixture.repo_id;
+        let standalone = format!("sha256:{}", "1".repeat(64));
+        let index = format!("sha256:{}", "2".repeat(64));
+        let child = format!("sha256:{}", "3".repeat(64));
+        for m in [&standalone, &child] {
+            sqlx::query(
+                "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
+                 VALUES ($1, $1 || ':cfg', $2, 'config'), ($1, $1 || ':l0', $2, 'layer')",
+            )
+            .bind(m)
+            .bind(repo)
+            .execute(&fixture.pool)
+            .await
+            .expect("seed refs");
+        }
+        sqlx::query("INSERT INTO oci_manifest_refs (parent_digest, child_digest, repository_id) VALUES ($1,$2,$3)")
+            .bind(&index).bind(&child).bind(repo).execute(&fixture.pool).await.expect("seed edge");
+        sqlx::query("INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type) VALUES ($1,'i/x','latest',$2,'application/vnd.oci.image.index.v1+json')")
+            .bind(repo).bind(&index).execute(&fixture.pool).await.expect("seed index tag");
+
+        let removed = delete_manifest_blob_refs(&fixture.pool, repo, &standalone)
+            .await
+            .expect("delete standalone");
+        let child_removed = delete_manifest_blob_refs(&fixture.pool, repo, &child)
+            .await
+            .expect("delete child (guarded)");
+        let child_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM manifest_blob_refs WHERE repository_id=$1 AND manifest_digest=$2",
+        )
+        .bind(repo)
+        .bind(&child)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("count");
+        fixture.teardown().await;
+        assert_eq!(removed, 2, "standalone manifest's refs removed");
+        assert_eq!(
+            child_removed, 0,
+            "live index child's refs must be preserved"
+        );
+        assert_eq!(child_rows, 2, "child refs still present");
+    }
+
+    #[test]
     fn is_index_content_type_matches_oci_and_docker_index() {
         assert!(is_index_content_type(
             "application/vnd.oci.image.index.v1+json"
@@ -10864,6 +11159,148 @@ mod oci_blob_upload_streaming_tests {
             .await
             .expect("response body");
         (status, headers, body)
+    }
+
+    async fn count_manifest_blob_refs(f: &OciUploadFixture, digest: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM manifest_blob_refs WHERE repository_id = $1 AND manifest_digest = $2",
+        )
+        .bind(f.inner.repo_id)
+        .bind(digest)
+        .fetch_one(&f.inner.pool)
+        .await
+        .expect("count manifest_blob_refs")
+    }
+
+    /// #1409 C1: a non-index PUT that is neither an image nor an index (here
+    /// valid JSON with neither, no Content-Type so the header defaults to the
+    /// image type) must be rejected (400) and create NO live tag.
+    #[tokio::test]
+    async fn put_degenerate_manifest_is_rejected_and_creates_no_tag() {
+        let Some(f) = OciUploadFixture::setup().await else {
+            return;
+        };
+        let body = Bytes::from_static(br#"{"schemaVersion":2,"layers":[]}"#);
+        let (status, _h, _b) = send(
+            f.app(),
+            request(
+                Method::PUT,
+                format!("/{}/app/manifests/v1", f.inner.repo_key),
+                &f.authorization,
+                body,
+            ),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "degenerate manifest must be rejected"
+        );
+        let tags: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM oci_tags WHERE repository_id = $1")
+                .bind(f.inner.repo_id)
+                .fetch_one(&f.inner.pool)
+                .await
+                .expect("count tags");
+        f.teardown().await;
+        assert_eq!(
+            tags, 0,
+            "a rejected degenerate manifest must not create a live tag"
+        );
+    }
+
+    /// #1409: a manifest DELETE removes its blob refs (so the blobs become
+    /// reclaimable) end-to-end through the router.
+    #[tokio::test]
+    async fn delete_manifest_removes_blob_refs() {
+        let Some(f) = OciUploadFixture::setup().await else {
+            return;
+        };
+        let digest = format!("sha256:{}", "a".repeat(64));
+        sqlx::query(
+            "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+             VALUES ($1, 'app', 'v1', $2, 'application/vnd.oci.image.manifest.v1+json')",
+        )
+        .bind(f.inner.repo_id)
+        .bind(&digest)
+        .execute(&f.inner.pool)
+        .await
+        .expect("seed tag");
+        sqlx::query(
+            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
+             VALUES ($1, $1 || ':cfg', $2, 'config'), ($1, $1 || ':l0', $2, 'layer')",
+        )
+        .bind(&digest)
+        .bind(f.inner.repo_id)
+        .execute(&f.inner.pool)
+        .await
+        .expect("seed refs");
+
+        let (status, _h, _b) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/v1", f.inner.repo_key),
+                &f.authorization,
+                Bytes::new(),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED, "delete must return 202");
+        let remaining = count_manifest_blob_refs(&f, &digest).await;
+        f.teardown().await;
+        assert_eq!(remaining, 0, "manifest delete must remove its blob refs");
+    }
+
+    /// #1409: deleting a child by digest while its index is still tagged must
+    /// NOT strip the child's blob refs.
+    #[tokio::test]
+    async fn delete_manifest_preserves_live_index_child_blob_refs() {
+        let Some(f) = OciUploadFixture::setup().await else {
+            return;
+        };
+        let index = format!("sha256:{}", "1".repeat(64));
+        let child = format!("sha256:{}", "2".repeat(64));
+        sqlx::query(
+            "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+             VALUES ($1, 'app', 'latest', $2, 'application/vnd.oci.image.index.v1+json'),
+                    ($1, 'app', $3, $3, 'application/vnd.oci.image.manifest.v1+json')",
+        )
+        .bind(f.inner.repo_id)
+        .bind(&index)
+        .bind(&child)
+        .execute(&f.inner.pool)
+        .await
+        .expect("seed tags");
+        sqlx::query("INSERT INTO oci_manifest_refs (parent_digest, child_digest, repository_id) VALUES ($1,$2,$3)")
+            .bind(&index).bind(&child).bind(f.inner.repo_id).execute(&f.inner.pool).await.expect("seed edge");
+        sqlx::query(
+            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
+             VALUES ($1, $1 || ':cfg', $2, 'config'), ($1, $1 || ':l0', $2, 'layer')",
+        )
+        .bind(&child)
+        .bind(f.inner.repo_id)
+        .execute(&f.inner.pool)
+        .await
+        .expect("seed child refs");
+
+        let (status, _h, _b) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/{}", f.inner.repo_key, child),
+                &f.authorization,
+                Bytes::new(),
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED, "child delete must return 202");
+        let child_refs = count_manifest_blob_refs(&f, &child).await;
+        f.teardown().await;
+        assert_eq!(
+            child_refs, 2,
+            "a live index child's refs must survive its by-digest delete"
+        );
     }
 
     async fn oci_blob_count(f: &OciUploadFixture, digest: &str) -> i64 {
@@ -15389,7 +15826,7 @@ mod proxy_manifest_artifact_indexing_tests {
         };
 
         let body = Bytes::from_static(
-            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{},"layers":[]}"#,
+            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"size":7,"digest":"sha256:00"},"layers":[]}"#,
         );
 
         // First and second proxy fetches both call cache_manifest_reference_locally.
@@ -15577,6 +16014,60 @@ mod proxy_manifest_artifact_indexing_tests {
         );
     }
 
+    /// #1409 C1: a proxied body that is neither an index nor an image
+    /// (malformed) is cached for the client but must NOT create an `oci_tags`
+    /// row — a ref-less live tag would pin the blob-GC gate deployment-wide.
+    #[tokio::test]
+    async fn cache_manifest_malformed_body_writes_no_tag() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "remote", "docker").await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let info = OciRepoInfo {
+            id: repo_id,
+            key: repo_key,
+            location: crate::storage::StorageLocation {
+                backend: "filesystem".to_string(),
+                path: storage_dir.to_string_lossy().to_string(),
+            },
+            repo_type: RepositoryType::Remote.as_str().to_string(),
+            upstream_url: Some("https://registry-1.docker.io".to_string()),
+            is_public: false,
+            image: "library/redis".to_string(),
+        };
+        let body = Bytes::from_static(br#"{"schemaVersion":2}"#);
+        let _ = cache_manifest_reference_locally(
+            &state,
+            &info,
+            "latest",
+            &body,
+            Some("application/vnd.oci.image.manifest.v1+json"),
+        )
+        .await
+        .expect("cache must succeed — body is still stored");
+
+        let tag_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM oci_tags WHERE repository_id = $1")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count tags");
+        let _ = sqlx::query("DELETE FROM oci_tags WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+        assert_eq!(
+            tag_count, 0,
+            "a malformed proxied body must NOT create an oci_tags row"
+        );
+    }
+
     /// For multi-arch image-index manifests the proxy path must also
     /// populate `oci_manifest_refs`, mirroring the push-path behaviour in
     /// `handle_put_manifest`. Without these rows the storage GC over-
@@ -15705,7 +16196,7 @@ mod proxy_manifest_artifact_indexing_tests {
         };
 
         let body = Bytes::from_static(
-            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{},"layers":[]}"#,
+            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"size":7,"digest":"sha256:00"},"layers":[]}"#,
         );
         let _ = cache_manifest_reference_locally(
             &state,
@@ -15798,7 +16289,7 @@ mod proxy_manifest_artifact_indexing_tests {
         };
 
         let body = Bytes::from_static(
-            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{},"layers":[]}"#,
+            br#"{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{"size":7,"digest":"sha256:00"},"layers":[]}"#,
         );
         // Caller supplies a digest reference, NOT a human-readable tag.
         let digest_ref = "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -1752,6 +1752,124 @@ pub async fn record_manifest_blob_refs(
     Ok(res.rows_affected() as usize)
 }
 
+/// Atomically upsert the `oci_tags` row for a pushed/cached manifest AND
+/// record its blob/child references in a SINGLE database transaction
+/// (#1409, review finding 3).
+///
+/// Why a transaction: previously the tag upsert and the ref recording ran
+/// as two separate, non-transactional statements, with ref recording
+/// best-effort (warn-on-error, the push/cache still succeeded). That could
+/// leave a live tag whose `manifest_blob_refs` / `oci_manifest_refs` rows
+/// were missing, which pins the blob-GC readiness gate
+/// (`any_live_manifest_missing_refs`) on indefinitely. Wrapping both writes
+/// in one transaction makes the invariant atomic: either the tag AND its
+/// refs are committed together, or neither is. If the ref insert fails the
+/// whole transaction rolls back and the caller fails the push/cache, so a
+/// live tag can NEVER be acked without its references.
+///
+/// Scope of the transaction is deliberately narrow — it wraps ONLY the two
+/// DB writes (the `oci_tags` upsert and the single batched ref insert).
+/// Manifest classification, blob/manifest storage I/O, and any network I/O
+/// happen entirely outside `tx`, so this never holds a transaction open
+/// across slow I/O and keeps lock-ordering identical to the rest of the
+/// push path (the only rows touched are `oci_tags` for `(repo, name, tag)`
+/// and the `*_refs` rows for the new `manifest_digest`).
+///
+/// On the success path the resulting database state is byte-identical to
+/// the previous two-statement form (same upsert SQL, same `UNNEST` ref
+/// insert with the same `ON CONFLICT DO NOTHING`). The only behavioural
+/// change is in the failure direction: a ref-write error now rolls the tag
+/// back and propagates instead of being swallowed by a `warn!`.
+///
+/// `class` must already be the CONTENT-based classification
+/// ([`classify_manifest`]); `Malformed` records no refs (callers reject it
+/// before reaching here, but the arm is harmless if hit). `Index` bodies
+/// record `oci_manifest_refs` (parent→child edges); `Image` bodies record
+/// `manifest_blob_refs` (config + layer edges).
+///
+/// TODO(#1610): the residual sub-grace-period TOCTOU between a concurrent
+/// re-push of an already-existing >24h-old blob and `run_blob_gc` is NOT
+/// closed here — it is bounded by the grace window + readiness gate +
+/// opt-in `BLOB_GC_ENABLED` and tracked as a follow-up. The push-side
+/// `SELECT ... FOR UPDATE` on `oci_blobs` that would close it would go
+/// inside this transaction, before the ref insert.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn persist_tag_and_refs(
+    pool: &PgPool,
+    repo_id: Uuid,
+    name: &str,
+    tag: &str,
+    manifest_digest: &str,
+    manifest_content_type: &str,
+    class: &ManifestClass,
+    manifest_body: &[u8],
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    // 1. Tag upsert (identical SQL/semantics to the previous standalone form).
+    sqlx::query(
+        r#"INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (repository_id, name, tag) DO UPDATE SET
+             manifest_digest = EXCLUDED.manifest_digest,
+             manifest_content_type = EXCLUDED.manifest_content_type,
+             updated_at = NOW()"#,
+    )
+    .bind(repo_id)
+    .bind(name)
+    .bind(tag)
+    .bind(manifest_digest)
+    .bind(manifest_content_type)
+    .execute(&mut *tx)
+    .await?;
+
+    // 2. Reference recording, in the SAME transaction. A failure here rolls
+    //    the tag back when `tx` is dropped without a commit.
+    match class {
+        ManifestClass::Index => {
+            let children = extract_child_digests(manifest_body);
+            if !children.is_empty() {
+                sqlx::query(
+                    r#"
+                    INSERT INTO oci_manifest_refs (parent_digest, child_digest, repository_id)
+                    SELECT $1, child, $3
+                    FROM UNNEST($2::text[]) AS t(child)
+                    ON CONFLICT (parent_digest, child_digest, repository_id) DO NOTHING
+                    "#,
+                )
+                .bind(manifest_digest)
+                .bind(&children)
+                .bind(repo_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        ManifestClass::Image => {
+            let refs = extract_blob_refs(manifest_body);
+            if let Some((blob_digests, kinds)) = blob_refs_to_columns(&refs) {
+                sqlx::query(
+                    r#"
+                    INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
+                    SELECT $1, blob, $4, knd
+                    FROM UNNEST($2::text[], $3::text[]) AS t(blob, knd)
+                    ON CONFLICT (manifest_digest, blob_digest, repository_id) DO NOTHING
+                    "#,
+                )
+                .bind(manifest_digest)
+                .bind(&blob_digests)
+                .bind(&kinds)
+                .bind(repo_id)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        ManifestClass::Malformed => {}
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Tags/list and catalog response types
 // ---------------------------------------------------------------------------
@@ -2589,20 +2707,32 @@ async fn cache_manifest_reference_locally(
     );
     let cached_reference = cached_manifest_reference_key(&repo.repo_type, reference, &digest);
 
-    sqlx::query(
-        r#"INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
-           VALUES ($1, $2, $3, $4, $5)
-           ON CONFLICT (repository_id, name, tag) DO UPDATE SET
-             manifest_digest = EXCLUDED.manifest_digest,
-             manifest_content_type = EXCLUDED.manifest_content_type,
-             updated_at = NOW()"#,
+    // Atomically upsert the digest-keyed tag AND record this manifest's
+    // references in one transaction (#1409 finding 2 + 3). Previously the tag
+    // upsert and the ref recording (the `match` block that used to live near
+    // the end of this fn) were separate statements with ref recording
+    // best-effort. A proxy-cached IMAGE manifest could therefore land as a
+    // live tag with zero `manifest_blob_refs`, which keeps
+    // `any_live_manifest_missing_refs` permanently true and disables blob GC
+    // for the whole deployment. `persist_tag_and_refs` makes the two writes
+    // atomic and propagates a ref-write failure (the caller falls back to a
+    // digest-only pull), so a cached live tag can never exist without its refs.
+    //
+    // Routing is CONTENT-classified inside the helper: an index records
+    // `oci_manifest_refs`, an image records `manifest_blob_refs`. `Malformed`
+    // returned early above without a tag. The secondary tag-keyed `oci_tags`
+    // row and the `artifacts` rows below stay best-effort — they are UI/listing
+    // conveniences, not GC-correctness inputs.
+    persist_tag_and_refs(
+        &state.db,
+        repo.id,
+        &repo.image,
+        &cached_reference,
+        &digest,
+        &manifest_content_type,
+        &class,
+        content,
     )
-    .bind(repo.id)
-    .bind(&repo.image)
-    .bind(&cached_reference)
-    .bind(&digest)
-    .bind(&manifest_content_type)
-    .execute(&state.db)
     .await
     .map_err(|e| e.to_string())?;
 
@@ -2752,56 +2882,6 @@ async fn cache_manifest_reference_locally(
                  proxy refresh succeeds"
             );
         }
-    }
-
-    // #1357 (review feedback): for multi-arch image-index manifests, record
-    // the (parent_digest -> child_digest) edges so:
-    //   1. The storage GC can protect per-architecture children for as long
-    //      as the index is still tagged (mirrors the push path #1179 guard).
-    //   2. The UI size accounting can walk the index children and report the
-    //      true multi-platform total, rather than just the index body size
-    //      (which is only a few KB for an image whose children sum to GBs).
-    //
-    // Best-effort, warn-on-error: matches the push-path semantics in
-    // `handle_put_manifest`. The manifest body and oci_tags rows are already
-    // persisted; failure here only affects GC/UI accounting until the
-    // startup backfill in main.rs runs again.
-    // Route on the CONTENT classification (not a re-derived string): an
-    // image needs its blob refs recorded too, or a proxy-cached image is a
-    // live tag with zero refs that pins the blob-GC gate (#1409). Best-effort
-    // + warn (the startup backfill reconciles any gap); `Malformed` returned
-    // early above without a tag.
-    match &class {
-        ManifestClass::Index => {
-            if let Err(e) = record_oci_manifest_refs(&state.db, repo.id, &digest, content).await {
-                tracing::warn!(
-                    repo = %repo.key,
-                    image = %repo.image,
-                    reference = %reference,
-                    parent_digest = %digest,
-                    error = %e,
-                    "Failed to record oci_manifest_refs for proxied index manifest; \
-                     storage GC may treat child manifests as orphaned and the UI \
-                     size accounting will under-report multi-arch totals until the \
-                     next backfill pass runs"
-                );
-            }
-        }
-        ManifestClass::Image => {
-            if let Err(e) = record_manifest_blob_refs(&state.db, repo.id, &digest, content).await {
-                tracing::warn!(
-                    repo = %repo.key,
-                    image = %repo.image,
-                    reference = %reference,
-                    manifest_digest = %digest,
-                    error = %e,
-                    "Failed to record manifest_blob_refs for proxied image manifest; \
-                     blob GC stays gated deployment-wide until the refs are recorded \
-                     (next proxy refresh or startup backfill), but no blob is at risk"
-                );
-            }
-        }
-        ManifestClass::Malformed => {}
     }
 
     Ok(digest)
@@ -5477,21 +5557,30 @@ async fn handle_put_manifest(
         );
     }
 
-    // Upsert tag mapping
-    if let Err(e) = sqlx::query!(
-        r#"INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
-           VALUES ($1, $2, $3, $4, $5)
-           ON CONFLICT (repository_id, name, tag) DO UPDATE SET
-             manifest_digest = EXCLUDED.manifest_digest,
-             manifest_content_type = EXCLUDED.manifest_content_type,
-             updated_at = NOW()"#,
+    // Atomically upsert the tag AND record this manifest's references in one
+    // transaction (#1409 finding 3). Previously the tag upsert and the ref
+    // recording were two separate statements with ref recording best-effort
+    // (warn-on-error, push still 201). That could ack a live tag whose refs
+    // were missing, pinning the blob-GC readiness gate. `persist_tag_and_refs`
+    // makes the two writes atomic: a ref-write failure rolls the tag back and
+    // fails the push, so a live tag can never exist without its references.
+    //
+    // Routing stays CONTENT-classified inside the helper: an image body pushed
+    // with an index Content-Type still records `manifest_blob_refs`, never
+    // `oci_manifest_refs` with 0 children (#1409 C1). `Malformed` was rejected
+    // with 400 above. The startup backfill in main.rs remains a safety net for
+    // rows that pre-date this code, but is no longer needed to repair a push
+    // that returned 201.
+    if let Err(e) = persist_tag_and_refs(
+        &state.db,
         repo_id,
-        image,
+        &image,
         reference,
-        digest,
-        content_type
+        &digest,
+        &content_type,
+        &class,
+        &body,
     )
-    .execute(&state.db)
     .await
     {
         return oci_error(
@@ -5499,53 +5588,6 @@ async fn handle_put_manifest(
             "INTERNAL_ERROR",
             &e.to_string(),
         );
-    }
-
-    // For multi-arch image indexes, record the (parent_digest -> child_digest)
-    // edges so the storage GC can protect per-architecture children for as
-    // long as the index is still tagged (#1179). The storage GC's NOT EXISTS
-    // guards in `storage_gc_service.rs` only protect digests that appear in
-    // `oci_tags` directly; children of an index never appear there.
-    //
-    // Best-effort: a failure to write the refs is logged but does not fail
-    // the push, since the manifest itself has been persisted and the tag
-    // upsert succeeded. The startup backfill in main.rs will fill in any
-    // gaps on the next restart.
-    // Route ref-recording on the CONTENT classification, not a re-derived
-    // media-type string: an image body pushed with an index Content-Type
-    // would otherwise record `oci_manifest_refs` (0 children) and skip its
-    // blob refs, leaving a live image's layers unreferenced — blob GC would
-    // delete them after the grace period (#1409 C1). `Malformed` was
-    // rejected with 400 above.
-    match class {
-        ManifestClass::Index => {
-            if let Err(e) = record_oci_manifest_refs(&state.db, repo_id, &digest, &body).await {
-                warn!(
-                    image = image_name,
-                    reference = reference,
-                    parent_digest = digest.as_str(),
-                    error = %e,
-                    "Failed to record oci_manifest_refs for index manifest; storage GC may treat \
-                     child manifests as orphaned until the next backfill pass runs"
-                );
-            }
-        }
-        ManifestClass::Image => {
-            // (manifest_digest -> blob_digest) edges (config + layers) so a
-            // future blob GC can safely judge `oci_blobs` orphanhood (#1635).
-            // Best-effort: the startup backfill reconstructs any gap.
-            if let Err(e) = record_manifest_blob_refs(&state.db, repo_id, &digest, &body).await {
-                warn!(
-                    image = image_name,
-                    reference = reference,
-                    manifest_digest = digest.as_str(),
-                    error = %e,
-                    "Failed to record manifest_blob_refs for image manifest; blob references will \
-                     be reconstructed by the startup backfill on the next restart"
-                );
-            }
-        }
-        ManifestClass::Malformed => {}
     }
 
     // Calculate total image size from manifest (config + layers)
@@ -16162,6 +16204,255 @@ mod proxy_manifest_artifact_indexing_tests {
             refs.iter().any(|(_, c)| c
                 == "sha256:2222222222222222222222222222222222222222222222222222222222222222"),
             "arm64 child digest must be recorded"
+        );
+    }
+
+    /// #1409 finding 2 (headline test): a proxy-cached IMAGE manifest must
+    /// record the COMPLETE set of its blob references (config + every layer)
+    /// in `manifest_blob_refs`, so the blob-GC readiness gate
+    /// (`any_live_manifest_missing_refs`) clears for it. Before this PR the
+    /// proxy path wrote only the `oci_tags` row and `oci_manifest_refs` for
+    /// indexes, leaving cached image manifests as ref-less live tags that
+    /// pinned the gate true forever — disabling blob GC across the whole
+    /// deployment wherever proxy repos cache new images.
+    #[tokio::test]
+    async fn cache_manifest_records_blob_refs_for_image_manifest() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "remote", "docker").await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let image = "library/nginx";
+        let info = OciRepoInfo {
+            id: repo_id,
+            key: repo_key,
+            location: crate::storage::StorageLocation {
+                backend: "filesystem".to_string(),
+                path: storage_dir.to_string_lossy().to_string(),
+            },
+            repo_type: RepositoryType::Remote.as_str().to_string(),
+            upstream_url: Some("https://registry-1.docker.io".to_string()),
+            is_public: false,
+            image: image.to_string(),
+        };
+
+        // A regular OCI image manifest: one config blob + two layer blobs.
+        let cfg = format!("sha256:{}", "c".repeat(64));
+        let l0 = format!("sha256:{}", "0".repeat(64));
+        let l1 = format!("sha256:{}", "1".repeat(64));
+        let body_str = format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.manifest.v1+json","config":{{"mediaType":"application/vnd.oci.image.config.v1+json","digest":"{cfg}","size":7023}},"layers":[{{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"{l0}","size":100}},{{"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip","digest":"{l1}","size":200}}]}}"#
+        );
+        let body = Bytes::from(body_str);
+
+        let manifest_digest = cache_manifest_reference_locally(
+            &state,
+            &info,
+            "latest",
+            &body,
+            Some("application/vnd.oci.image.manifest.v1+json"),
+        )
+        .await
+        .expect("cache_manifest_reference_locally must succeed");
+
+        // Collect the recorded refs for this manifest.
+        let refs: Vec<(String, String)> = sqlx::query_as(
+            "SELECT blob_digest, kind
+             FROM manifest_blob_refs
+             WHERE repository_id = $1 AND manifest_digest = $2
+             ORDER BY blob_digest",
+        )
+        .bind(repo_id)
+        .bind(&manifest_digest)
+        .fetch_all(&pool)
+        .await
+        .expect("query manifest_blob_refs");
+
+        // The gate must no longer flag THIS manifest as unbackfilled. Mirror
+        // the `select_unbackfilled_manifests` predicate (tagged non-index
+        // manifest with zero manifest_blob_refs rows) scoped to this repo +
+        // digest, so the assertion is deterministic on a shared test DB.
+        let this_manifest_still_unbackfilled: bool = sqlx::query_scalar(
+            r#"
+            SELECT EXISTS (
+                SELECT 1 FROM oci_tags ot
+                WHERE ot.repository_id = $1
+                  AND ot.manifest_digest = $2
+                  AND NOT EXISTS (
+                        SELECT 1 FROM oci_manifest_refs omr
+                        WHERE omr.repository_id = ot.repository_id
+                          AND omr.parent_digest = ot.manifest_digest
+                    )
+                  AND NOT EXISTS (
+                        SELECT 1 FROM manifest_blob_refs mbr
+                        WHERE mbr.repository_id = ot.repository_id
+                          AND mbr.manifest_digest = ot.manifest_digest
+                    )
+            )
+            "#,
+        )
+        .bind(repo_id)
+        .bind(&manifest_digest)
+        .fetch_one(&pool)
+        .await
+        .expect("scoped unbackfilled check");
+
+        // Clean up before assertions so cleanup runs even on failure.
+        let _ = sqlx::query("DELETE FROM manifest_blob_refs WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM oci_tags WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        assert_eq!(
+            refs.len(),
+            3,
+            "a proxy-cached image manifest must record one manifest_blob_refs \
+             row per config+layer blob (1 config + 2 layers). Got: {:?}",
+            refs
+        );
+        assert!(
+            refs.iter().any(|(b, k)| b == &cfg && k == "config"),
+            "config blob ref must be recorded with kind=config"
+        );
+        assert!(
+            refs.iter().any(|(b, k)| b == &l0 && k == "layer"),
+            "first layer blob ref must be recorded with kind=layer"
+        );
+        assert!(
+            refs.iter().any(|(b, k)| b == &l1 && k == "layer"),
+            "second layer blob ref must be recorded with kind=layer"
+        );
+        assert!(
+            !this_manifest_still_unbackfilled,
+            "after caching an image manifest with its complete blob refs, the \
+             readiness gate must no longer flag it as missing refs"
+        );
+    }
+
+    /// #1409 finding 3 (atomicity): `persist_tag_and_refs` writes the
+    /// `oci_tags` upsert and the `manifest_blob_refs` insert in ONE
+    /// transaction. If the ref insert fails, the whole transaction rolls
+    /// back — the tag must NOT be left committed, otherwise a live tag could
+    /// exist without its blob refs (the readiness gate would be pinned and
+    /// blob GC disabled, or worse, GC could later delete the live blobs).
+    ///
+    /// Forces the ref insert to fail with a scoped `AFTER INSERT` trigger on
+    /// `manifest_blob_refs` that raises only for this repo's rows, mirroring
+    /// the existing forced-failure trigger pattern used by the upload tests.
+    #[tokio::test]
+    async fn persist_tag_and_refs_rolls_back_tag_on_ref_failure() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (repo_id, _repo_key, storage_dir) = tdh::create_repo(&pool, "local", "docker").await;
+
+        // Scoped failure trigger: any INSERT into manifest_blob_refs for THIS
+        // repository raises, so the ref insert inside the transaction fails
+        // while the tag upsert before it would otherwise have succeeded.
+        let suffix = Uuid::new_v4().simple().to_string();
+        let function_name = format!("ak_test_force_ref_insert_failure_{}", suffix);
+        let trigger_name = format!("ak_test_force_ref_insert_failure_{}", suffix);
+        sqlx::query(&format!(
+            "CREATE FUNCTION {function_name}() RETURNS trigger
+             LANGUAGE plpgsql AS $$
+             BEGIN
+                 RAISE EXCEPTION 'forced manifest_blob_refs insert failure for atomicity test';
+             END;
+             $$"
+        ))
+        .execute(&pool)
+        .await
+        .expect("create failure function");
+        sqlx::query(&format!(
+            "CREATE TRIGGER {trigger_name}
+             BEFORE INSERT ON manifest_blob_refs
+             FOR EACH ROW
+             WHEN (NEW.repository_id = '{repo_id}'::uuid)
+             EXECUTE FUNCTION {function_name}()"
+        ))
+        .execute(&pool)
+        .await
+        .expect("create failure trigger");
+
+        let cfg = format!("sha256:{}", "c".repeat(64));
+        let l0 = format!("sha256:{}", "0".repeat(64));
+        let body_str = format!(
+            r#"{{"schemaVersion":2,"config":{{"digest":"{cfg}","size":1}},"layers":[{{"digest":"{l0}","size":2}}]}}"#
+        );
+        let body = body_str.as_bytes();
+
+        let result = persist_tag_and_refs(
+            &pool,
+            repo_id,
+            "app",
+            "v1",
+            "sha256:deadbeef",
+            "application/vnd.oci.image.manifest.v1+json",
+            &ManifestClass::Image,
+            body,
+        )
+        .await;
+
+        let tag_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM oci_tags WHERE repository_id = $1")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count tags");
+        let ref_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM manifest_blob_refs WHERE repository_id = $1")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count refs");
+
+        // Cleanup (trigger first, so the cascade delete on repositories works).
+        let _ = sqlx::query(&format!(
+            "DROP TRIGGER IF EXISTS {trigger_name} ON manifest_blob_refs"
+        ))
+        .execute(&pool)
+        .await;
+        let _ = sqlx::query(&format!("DROP FUNCTION IF EXISTS {function_name}()"))
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM oci_tags WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        assert!(
+            result.is_err(),
+            "persist_tag_and_refs must propagate the ref-insert failure"
+        );
+        assert_eq!(
+            tag_count, 0,
+            "the oci_tags upsert must be rolled back when the ref insert fails: \
+             a live tag may never be committed without its blob refs"
+        );
+        assert_eq!(
+            ref_count, 0,
+            "no manifest_blob_refs row may survive the rollback"
         );
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -496,12 +496,33 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     // backends. Failures are logged but do not block startup; on a fresh
     // database or after the first successful run the candidate query
     // returns zero rows and this is a near-instant no-op.
-    let _blob_refs_backfill_stats =
+    let blob_refs_backfill_stats =
         artifact_keeper_backend::services::manifest_blob_refs_backfill::run_backfill(
             &db_pool,
             storage_registry.clone(),
         )
         .await;
+    // A failed candidate (body missing from storage, over-cap, DB write
+    // error) leaves that manifest ref-less, which keeps the blob-GC readiness
+    // gate closed — the feature stays OFF. This startup log is the earliest
+    // signal; the scheduler escalates per-tick thereafter (#1409).
+    if blob_refs_backfill_stats.candidates_failed > 0 {
+        tracing::error!(
+            candidates_scanned = blob_refs_backfill_stats.candidates_scanned,
+            edges_inserted = blob_refs_backfill_stats.edges_inserted,
+            candidates_failed = blob_refs_backfill_stats.candidates_failed,
+            "manifest_blob_refs backfill left {} live manifest(s) un-backfilled; \
+             blob GC will stay gated off until they are resolved (re-pushed, or \
+             the offending tag deleted)",
+            blob_refs_backfill_stats.candidates_failed
+        );
+    } else {
+        tracing::info!(
+            candidates_scanned = blob_refs_backfill_stats.candidates_scanned,
+            edges_inserted = blob_refs_backfill_stats.edges_inserted,
+            "manifest_blob_refs backfill complete"
+        );
+    }
 
     // Initialize security scanner service
     let advisory_client = Arc::new(AdvisoryClient::new(std::env::var("GITHUB_TOKEN").ok()));

--- a/backend/src/services/manifest_blob_refs_backfill.rs
+++ b/backend/src/services/manifest_blob_refs_backfill.rs
@@ -205,8 +205,12 @@ fn insert_rows_error(e: impl std::fmt::Display) -> String {
 /// manifests that have zero rows in `manifest_blob_refs`. Two reachability
 /// sources are unioned:
 ///
-///   1. `oci_tags` rows whose content-type is NOT an image index -- these
-///      are directly tagged image manifests.
+///   1. `oci_tags` rows whose content-type is NOT an image index AND which
+///      are not structurally an index (no children in `oci_manifest_refs`)
+///      -- these are directly tagged image manifests. The structural guard
+///      (#1409 C1) keeps an index pushed with a wrong/absent Content-Type
+///      out of the image-candidate set, since it has no blobs of its own and
+///      would otherwise pin the readiness gate forever.
 ///   2. `oci_manifest_refs.child_digest` -- the per-architecture child
 ///      manifests of multi-arch image indexes. These never appear in
 ///      `oci_tags` directly but are image manifests with their own blobs.
@@ -232,6 +236,19 @@ async fn select_unbackfilled_manifests(db: &PgPool) -> sqlx::Result<Vec<Backfill
             WHERE ot.manifest_content_type NOT IN (
                     'application/vnd.oci.image.index.v1+json',
                     'application/vnd.docker.distribution.manifest.list.v2+json'
+                )
+              -- Structural index guard (#1409 C1): exclude any tagged digest
+              -- that is itself an index (has children in oci_manifest_refs),
+              -- even when its stored content-type does not match the two
+              -- index media types above (pushed with a wrong/absent
+              -- Content-Type). An index carries no blobs of its own, so it
+              -- can never gain manifest_blob_refs rows; left in the candidate
+              -- set it would pin the readiness gate true forever and disable
+              -- blob GC permanently.
+              AND NOT EXISTS (
+                    SELECT 1 FROM oci_manifest_refs omr_parent
+                    WHERE omr_parent.repository_id = ot.repository_id
+                      AND omr_parent.parent_digest = ot.manifest_digest
                 )
             UNION
             SELECT omr.child_digest AS manifest_digest,
@@ -554,6 +571,75 @@ mod tests {
         assert_eq!(
             still_candidate, 0,
             "once refs are recorded the manifest must no longer be an unbackfilled candidate"
+        );
+    }
+
+    /// C1 (#1409): a tagged manifest that is structurally an index (has
+    /// children in `oci_manifest_refs`) but was pushed with a wrong/absent
+    /// Content-Type must NOT appear as an unbackfilled image candidate. An
+    /// index carries no blobs of its own, so it can never gain
+    /// `manifest_blob_refs` rows; if it stayed in the candidate set it would
+    /// pin `any_live_manifest_missing_refs` true forever and disable blob GC
+    /// for the whole deployment. The structural guard in
+    /// [`select_unbackfilled_manifests`] excludes it regardless of its stored
+    /// content-type.
+    #[tokio::test]
+    async fn select_unbackfilled_manifests_excludes_mislabeled_index() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let index_digest = format!("sha256:{}", "a".repeat(64));
+        let child_digest = format!("sha256:{}", "b".repeat(64));
+
+        // Tag the index with a NON-index content-type, so only the structural
+        // guard (its oci_manifest_refs children), not the content-type filter,
+        // can keep it out of the candidate set.
+        sqlx::query(
+            r#"
+            INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+            VALUES ($1, 'c1/index', 'latest', $2, 'application/octet-stream')
+            "#,
+        )
+        .bind(fixture.repo_id)
+        .bind(&index_digest)
+        .execute(&fixture.pool)
+        .await
+        .expect("insert mislabeled index tag");
+        sqlx::query(
+            r#"
+            INSERT INTO oci_manifest_refs (parent_digest, child_digest, repository_id)
+            VALUES ($1, $2, $3)
+            "#,
+        )
+        .bind(&index_digest)
+        .bind(&child_digest)
+        .bind(fixture.repo_id)
+        .execute(&fixture.pool)
+        .await
+        .expect("insert index child");
+
+        let candidates = select_unbackfilled_manifests(&fixture.pool)
+            .await
+            .expect("candidate query runs");
+
+        fixture.teardown().await;
+
+        assert!(
+            !candidates
+                .iter()
+                .any(|c| c.manifest_digest == index_digest && c.repository_id == fixture.repo_id),
+            "a tagged index with a non-index content-type must be excluded from image candidates; \
+             otherwise it would pin the readiness gate forever and disable blob GC"
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|c| c.manifest_digest == child_digest && c.repository_id == fixture.repo_id),
+            "the index's per-architecture child (a real image manifest with no refs) must still be \
+             enumerated as an unbackfilled candidate"
         );
     }
 }

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -505,6 +505,23 @@ impl StorageGcService {
     /// grace window and the per-row locked re-check. Every deletion is
     /// audit-logged at INFO with the digest and freed byte count.
     pub async fn run_blob_gc(&self, dry_run: bool) -> Result<StorageGcResult> {
+        // Apply mode: first prune `manifest_blob_refs` of manifests that are no
+        // longer live (tag overwrite / lifecycle expiry / index or manifest
+        // deletion), so their config + layer blobs become eligible in this same
+        // pass (#1409 H1). Without this the protect predicate keeps a digest
+        // pinned forever once any manifest referenced it, even after every
+        // referencing manifest is gone. Dry-run stays strictly read-only and so
+        // reports the pre-prune orphan set only.
+        if !dry_run {
+            match self.prune_orphan_blob_refs().await {
+                Ok(pruned) if pruned > 0 => {
+                    tracing::info!("Blob GC: pruned {} stale manifest_blob_refs rows", pruned);
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!("Blob GC: manifest_blob_refs prune failed: {}", e),
+            }
+        }
+
         let orphans = self.select_orphan_blobs().await?;
 
         let mut result = empty_gc_result(dry_run);
@@ -632,6 +649,42 @@ impl StorageGcService {
         }
 
         Ok(result)
+    }
+
+    /// Delete `manifest_blob_refs` rows whose manifest is no longer live, so
+    /// the blobs they pinned become reclaimable (#1409 H1).
+    ///
+    /// A ref is stale when its `manifest_digest` is neither tagged in its repo
+    /// (`oci_tags`) nor a live per-architecture child of a tagged index
+    /// (`oci_manifest_refs` -> tagged `parent_digest`). Tag overwrite, lifecycle
+    /// expiry and manifest/index deletion all leave such orphan refs behind;
+    /// without pruning them [`BLOB_PROTECTED_BY_REFS_SQL`] would protect the
+    /// digest forever. Conservative: any still-reachable manifest keeps its
+    /// refs, so this can only ever over-protect (a leak), never expose a live
+    /// blob.
+    async fn prune_orphan_blob_refs(&self) -> Result<u64> {
+        let res = sqlx::query(
+            r#"
+            DELETE FROM manifest_blob_refs mbr
+            WHERE NOT EXISTS (
+                SELECT 1 FROM oci_tags ot
+                WHERE ot.repository_id = mbr.repository_id
+                  AND ot.manifest_digest = mbr.manifest_digest
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM oci_manifest_refs omr
+                JOIN oci_tags ot2
+                  ON ot2.repository_id = omr.repository_id
+                 AND ot2.manifest_digest = omr.parent_digest
+                WHERE omr.repository_id = mbr.repository_id
+                  AND omr.child_digest = mbr.manifest_digest
+            )
+            "#,
+        )
+        .execute(&self.db)
+        .await
+        .map_err(|e| crate::error::AppError::Database(e.to_string()))?;
+        Ok(res.rows_affected())
     }
 
     /// List `oci_blobs` rows older than the grace period whose digest is
@@ -4258,6 +4311,25 @@ mod tests {
         .execute(&fixture.pool)
         .await
         .expect("insert manifest_blob_refs row");
+        // The referencing manifest must be LIVE (tagged) for the ref to be
+        // legitimate: apply-mode prunes refs of manifests that are no longer
+        // reachable (#1409 H1), so an untagged manifest's ref would be
+        // correctly removed and its blob reclaimed. Tagging keeps this the
+        // "referenced by a live manifest" case the test asserts.
+        sqlx::query(
+            r#"
+            INSERT INTO oci_tags (
+                repository_id, name, tag, manifest_digest, manifest_content_type
+            )
+            VALUES ($1, 'keep-img', 'latest', $2,
+                    'application/vnd.oci.image.manifest.v1+json')
+            "#,
+        )
+        .bind(fixture.repo_id)
+        .bind(&manifest_digest)
+        .execute(&fixture.pool)
+        .await
+        .expect("tag referencing manifest so its ref is live");
 
         let service =
             StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
@@ -4282,6 +4354,100 @@ mod tests {
         assert!(
             file_still_exists,
             "storage object must survive when a manifest_blob_refs entry references the digest"
+        );
+    }
+
+    /// H1 (#1409): apply-mode first prunes `manifest_blob_refs` whose
+    /// manifest is no longer live, so a blob pinned only by a dead manifest is
+    /// reclaimed in the same pass. Here the referencing manifest is never
+    /// tagged and is not an index child, so its ref is stale; after prune the
+    /// blob has no protection and must be deleted. This is the headline
+    /// scenario ("reclaim orphan blobs once their manifests are gone") that
+    /// could not happen before H1 because the ref pinned the digest forever.
+    #[tokio::test]
+    async fn test_run_blob_gc_prunes_orphan_ref_and_reclaims_blob() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let manifest_digest = format!("sha256:{}", "4".repeat(64));
+        let blob_digest = format!("sha256:{}", "5".repeat(64));
+        let storage_key = format!("oci-blobs/{}", blob_digest);
+        let blob_body = Bytes::from_static(b"dead-manifest-payload");
+        let location = StorageLocation {
+            backend: "filesystem".to_string(),
+            path: fixture.storage_dir.to_string_lossy().to_string(),
+        };
+        let storage = fixture
+            .state
+            .storage_registry
+            .backend_for(&location)
+            .expect("filesystem backend");
+        storage
+            .put(&storage_key, blob_body.clone())
+            .await
+            .expect("write blob to storage");
+
+        insert_old_blob(
+            &fixture.pool,
+            fixture.repo_id,
+            &blob_digest,
+            &storage_key,
+            blob_body.len() as i64,
+        )
+        .await;
+        // A ref from a manifest that is NOT tagged and NOT an index child:
+        // stale, so prune must remove it.
+        sqlx::query(
+            r#"
+            INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
+            VALUES ($1, $2, $3, 'layer')
+            "#,
+        )
+        .bind(&manifest_digest)
+        .bind(&blob_digest)
+        .bind(fixture.repo_id)
+        .execute(&fixture.pool)
+        .await
+        .expect("insert stale manifest_blob_refs row");
+
+        let service =
+            StorageGcService::new(fixture.pool.clone(), fixture.state.storage_registry.clone());
+        let _ = service.run_blob_gc(false).await.expect("apply succeeds");
+
+        let refs_remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM manifest_blob_refs WHERE repository_id = $1 AND manifest_digest = $2",
+        )
+        .bind(fixture.repo_id)
+        .bind(&manifest_digest)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("count manifest_blob_refs");
+        let blob_remaining: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+        )
+        .bind(fixture.repo_id)
+        .bind(&blob_digest)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("count oci_blobs");
+        let file_still_exists = storage.exists(&storage_key).await.expect("exists check");
+
+        fixture.teardown().await;
+
+        assert_eq!(
+            refs_remaining, 0,
+            "apply-mode must prune the manifest_blob_refs row of a manifest that is no longer live"
+        );
+        assert_eq!(
+            blob_remaining, 0,
+            "once its only (stale) ref is pruned, the orphan blob row must be reclaimed in the same pass"
+        );
+        assert!(
+            !file_still_exists,
+            "the orphan blob's storage object must be deleted after its stale ref is pruned"
         );
     }
 

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -1066,9 +1066,19 @@ impl super::StorageBackend for S3Backend {
         if self.disable_multi_delete {
             self.single_object_delete(&path, key).await?;
         } else {
-            self.store.delete(&path).await.map_err(|e| {
-                AppError::Storage(format!("Failed to delete object '{}': {}", key, e))
-            })?;
+            // Deleting a missing object is idempotent (matches
+            // `single_object_delete` and the filesystem backend): map
+            // NotFound to Ok so callers like blob GC can treat "already
+            // gone" as success instead of re-erroring every pass (#1409 H3).
+            match self.store.delete(&path).await {
+                Ok(()) | Err(object_store::Error::NotFound { .. }) => {}
+                Err(e) => {
+                    return Err(AppError::Storage(format!(
+                        "Failed to delete object '{}': {}",
+                        key, e
+                    )))
+                }
+            }
         }
 
         tracing::debug!(key = %key, "S3 delete object successful");


### PR DESCRIPTION
## Summary

Adds the **completeness layer for OCI blob-layer GC** on top of #1655. #1655 merged the deletion *core* (`run_blob_gc`, `select_orphan_blobs`, the backend-aware orphan predicate, the readiness gate, scheduler wiring) -- design originated here -- but deliberately left out the parts below. This PR is re-scoped to add exactly those, addressing the open completeness findings from the maintainer reviews. Closes #1696. Follow-up to #1408 and #1655.

Rebased onto current `main`; **no migration** (uses the already-merged `120_manifest_blob_refs` table).

### What it adds (what #1655 left out)
- **Reclaim actually happens (review finding 1).** `handle_delete_manifest` now prunes the manifest's `manifest_blob_refs` (guarding a live per-architecture child of a tagged index), and `run_blob_gc` prunes refs of *any* manifest no longer live (tag overwrite / lifecycle expiry / deletion) before each apply pass. Without this, `BLOB_PROTECTED_BY_REFS_SQL` pins a digest forever once any manifest referenced it, so the headline goal ("reclaim orphan blobs once their manifests are gone") never fired.
- **Proxy deployments aren't permanently gated off (review finding 2).** `cache_manifest_reference_locally` now records `manifest_blob_refs` for cached **image** manifests (it previously recorded only index refs). Without it a proxied image lands with a tag but zero blob refs, keeping `any_live_manifest_missing_refs` true forever and making the scheduler skip blob GC every tick. Covered by a new DB-backed test (`cache_manifest_records_blob_refs_for_image_manifest`) that asserts the complete config+layer ref set is recorded and the readiness gate clears for that manifest.
- **Atomic tag + refs on push/cache (review finding 3 -- now implemented).** A new `persist_tag_and_refs` helper wraps the `oci_tags` upsert AND the `manifest_blob_refs` / `oci_manifest_refs` insert for a pushed/cached manifest in a **single database transaction**. Both `handle_put_manifest` and `cache_manifest_reference_locally` use it. On success the resulting state is byte-identical to the previous two-statement form (same upsert SQL, same `UNNEST` ref insert, same `ON CONFLICT DO NOTHING`); the only behavioural change is in the failure direction -- a ref-write failure now rolls the tag back and fails the push/cache instead of being swallowed by a `warn!`, so a live tag can **never** be acked without its blob references. The transaction wraps only the two DB writes (no blob/network I/O held open), keeping lock ordering consistent with the rest of the push path. Covered by a new DB-backed atomicity test (`persist_tag_and_refs_rolls_back_tag_on_ref_failure`) that forces the ref insert to fail and asserts the tag is rolled back.
- **Content-based classification + gate hardening (C1).** `classify_manifest` rejects a structurally-degenerate manifest (`400`) and routes ref recording on the classification rather than the spoofable media-type header. The backfill gate now also excludes any tagged digest that is *structurally* an index (an `oci_manifest_refs` parent), so an index pushed with a wrong/absent `Content-Type` can't sit in the image-candidate set, never gain refs, and pin the gate -- disabling blob GC deployment-wide.
- **Idempotent storage delete + observability.** S3 default multi-object delete treats `NotFound` as success (matching single-object delete and the filesystem backend); startup logs the count of un-backfilled live manifests; and the `test-backend-unit` CI job now runs Postgres so the DB-backed gate/GC tests execute instead of no-op'ing.

### Explicit follow-up / non-goal
- **Residual sub-grace-period TOCTOU is not closed here.** A concurrent re-push that re-references an already-existing >24h-old blob can still race `run_blob_gc` between its locked re-check and the per-row delete (the push path does not `SELECT ... FOR UPDATE` on `oci_blobs` before the ref insert). This is bounded by the 24h grace window, the readiness gate, and opt-in `BLOB_GC_ENABLED` (default off), and is tracked as a follow-up under the #1610 epic before arming blob GC for dedup-heavy production workloads. A `TODO(#1610)` marks where the push-side lock would go (inside `persist_tag_and_refs`, before the ref insert).

Verified locally on the rebased + finalized commit: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib` against a live Postgres all pass (the only failures are the two known environment-specific flakies -- the macOS APFS case-insensitivity test and the sandbox `http_client` timeout test). New/changed-line coverage is comfortably above the 70% gate; jscpd reports no new duplication from the production code (`oci_v2.rs` exceeds jscpd's default file-size/line limits, so CI's duplication step skips it as it does for every prior change to this file).

## Regression test (required for `fix/*` PRs)
- [x] N/A -- this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no new endpoints, types, or migrations (behavioral: a structurally-invalid manifest PUT is now rejected with 400; a manifest push/cache whose ref write fails now fails instead of silently warning)
