### PR TITLE
fix(auth): write watermark = now + 1 in invalidate_user_tokens to close same-second JWT boundary (closes #1436)

### DIFF
--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -170,12 +170,20 @@ fn invalidation_map() -> &'static RwLock<HashMap<Uuid, (i64, Instant)>> {
 
 /// Record a local credential invalidation in the in-memory fast-path so
 /// subsequent token-validation checks on this replica reject tokens issued
-/// before `now` without first waiting for the DB cache to refresh. The DB
-/// columns (`password_changed_at`, `totp_verified_at`, `updated_at`) remain
-/// the source of truth across replicas.
+/// at or before `now` without first waiting for the DB cache to refresh.
+/// The DB columns (`password_changed_at`, `totp_verified_at`, `updated_at`)
+/// remain the source of truth across replicas.
+///
+/// Boundary (regression of #931, fixed by #1436): the replica-safe path in
+/// `is_token_invalidated_replica_safe` compares with strict `<` (#1265),
+/// not `<=`. A JWT minted in the same wall-clock second as the password
+/// change would otherwise survive: `iat == watermark` makes `iat < watermark`
+/// false. We write `now + 1` so any token with `iat <= now` is rejected.
+/// The sync map at `is_token_invalidated` uses `<=` so the `+1` does not
+/// double-count there.
 pub fn invalidate_user_tokens(user_id: Uuid) {
-    let now = Utc::now().timestamp();
-    invalidate_user_tokens_at(user_id, now);
+    let watermark = Utc::now().timestamp().saturating_add(1);
+    invalidate_user_tokens_at(user_id, watermark);
 }
 
 /// Variant of [`invalidate_user_tokens`] that exempts the caller's own JWT.
@@ -184,7 +192,9 @@ pub fn invalidate_user_tokens(user_id: Uuid) {
 /// watermark is set to `caller_iat - 1` so the sync `<=` check still passes
 /// for the calling token (`caller_iat <= caller_iat - 1` is false), while
 /// every token issued at any second strictly before `caller_iat` is
-/// invalidated.
+/// invalidated. The sync path is the one consulted by the gRPC interceptor
+/// (`grpc/auth_interceptor.rs`) and the TOTP causation tests, so the `-1`
+/// here is load-bearing on those code paths.
 ///
 /// Used by TOTP enable/disable so the session that initiated the credential
 /// change is not logged out by the same operation. Other sessions (and any
@@ -3166,7 +3176,11 @@ mod tests {
     fn test_token_issued_after_invalidation_is_accepted() {
         let user_id = Uuid::new_v4();
         invalidate_user_tokens(user_id);
-        let after = Utc::now().timestamp() + 1;
+        // Watermark is `now + 1` (#1436 fix) so the sync `<=` map rejects
+        // every iat <= now+1. We bump the test "after" to `now + 2` to
+        // represent a JWT minted at least one whole second after the
+        // invalidation completed.
+        let after = Utc::now().timestamp() + 2;
         assert!(!is_token_invalidated(user_id, after));
     }
 
@@ -3184,7 +3198,8 @@ mod tests {
         // Slight delay so second invalidation gets a newer timestamp
         std::thread::sleep(std::time::Duration::from_millis(10));
         invalidate_user_tokens(user_id);
-        let after = Utc::now().timestamp() + 1;
+        // Same `+2` rationale as test_token_issued_after_invalidation_is_accepted.
+        let after = Utc::now().timestamp() + 2;
         // Token issued before second invalidation is still rejected
         assert!(is_token_invalidated(user_id, mid - 1));
         // Token issued after second invalidation is accepted


### PR DESCRIPTION
## Summary

After PR #1265 dropped the sync `<=` fast-path from `is_token_invalidated_replica_safe` and left only the strict `<` DB-watermark check, `invalidate_user_tokens` continued to write `watermark = now`. A JWT minted in the same wall-clock second as a password change has `iat == watermark` and the strict `<` check accepts it. Effective consequence: changing a user's password no longer invalidates their existing JWTs. The credential boundary PR #931 was built to enforce is now leaky.

The release-gate auth-tests suite catches this as:

```
FAIL: OLD_JWT should be rejected after password change, got HTTP 200
      (regression of PR #931)
FAIL: NEW_JWT works (200) but OLD_JWT no longer rejected (200).
      CREDENTIAL_INVALIDATIONS map appears to no longer block
      pre-rotation tokens (regression of PR #931).
```

See artifact-keeper-test/tests/auth/test-jwt-after-password-change.sh and the regression diagnosis above the cited assertion lines.

## Fix

Bump the in-memory watermark by 1 second when invalidating. Strict `<` now correctly rejects any token with `iat <= now`.

```rust
pub fn invalidate_user_tokens(user_id: Uuid) {
    let watermark = Utc::now().timestamp().saturating_add(1);
    invalidate_user_tokens_at(user_id, watermark);
}
```

`invalidate_user_tokens_except_caller` is intentionally NOT changed: it stays at `caller_iat - 1`. The gRPC auth interceptor (`grpc/auth_interceptor.rs:91`) and the TOTP causation tests (`api/handlers/totp.rs:958, 962, 1137, 1141`) consult the sync `is_token_invalidated` map which uses `<=`. Writing `caller_iat` instead of `caller_iat - 1` would make `caller_iat <= caller_iat == true` and reject the caller's own token via gRPC. The `-1` is load-bearing on those code paths.

## Tests

- All 105 existing tests in `services::auth_service::tests` pass locally (`cargo test --lib services::auth_service::tests`).
- Two existing tests (`test_token_issued_after_invalidation_is_accepted`, `test_reinvalidation_updates_timestamp`) were using `let after = Utc::now().timestamp() + 1` to verify acceptance of post-invalidation tokens. Bumped both to `+2` because the sync `<=` map now rejects `iat <= now + 1`.
- The existing boundary test `test_token_issued_at_exact_invalidation_time_is_rejected` continues to validate that a same-second token is rejected by the sync path (it now also implicitly validates the replica-safe path because `watermark == now + 1 > iat == now`).
- Shell-level reproducer at artifact-keeper-test/tests/auth/test-jwt-after-password-change.sh will turn green on the next release-gate run after this lands and the dev image rebuilds.

## Remaining gap (follow-up)

The DB column `password_changed_at` is set to `NOW()` (microsecond precision, truncated to seconds via `.timestamp()`). On a different replica (or after the 5s in-memory cache TTL expires), the DB watermark is `now`, not `now + 1`. Strict `<` would let same-second tokens through on a replica that didn't handle the password change. The release-gate deploys a single backend replica so this fix is sufficient for gate purposes, but a follow-up should either:

1. Write `password_changed_at = NOW() + INTERVAL '1 second'` in the password-change handler (and TOTP, deactivation), OR
2. Flip the replica-safe comparator from `<` back to `<=` and special-case the fresh-user-creation path that #1248 originally guarded.

Option 1 is cleaner and isolated. Option 2 risks reintroducing the #1248/#1265 release-gate regression. Recommend filing a separate issue.

## Test plan

- [x] `cargo test --lib services::auth_service::tests` -- 105/105 pass
- [ ] `cargo clippy --workspace` clean (CI will verify)
- [ ] Release-gate auth-tests turns green after dev image rebuilds with this change
- [ ] Production multi-replica deployments: the same-replica path now works correctly; cross-replica gap tracked separately

Closes #1436