### PR TITLE
fix(v1.2.0): gate recovery cycle 2 — E2E-verified backend fixes (8 bugs)

### DIFF
--- a/backend/migrations/111_drop_webhooks_url_repo_unique.sql
+++ b/backend/migrations/111_drop_webhooks_url_repo_unique.sql
@@ -1,0 +1,27 @@
+-- Drop the over-broad unique index on webhooks(url, repository_id).
+--
+-- The index `idx_webhooks_url_repo_unique` was introduced in migration 081
+-- purely as an idempotency guard for the one-time notification_subscriptions
+-- -> webhooks data migration (its INSERT relied on ON CONFLICT DO NOTHING).
+-- As a side effect it permanently forbids two webhooks from sharing the same
+-- (url, repository_id) pair, which is a legitimate configuration: an operator
+-- can register two webhooks pointing at the same endpoint subscribed to
+-- different event sets (or pinned to different event_schema_versions).
+--
+-- That side effect surfaced as a hard failure for normal CRUD:
+--   - POST /api/v1/webhooks with a url already used by another global webhook
+--     hit the unique index, Postgres returned SQLSTATE 23505, and
+--     create_webhook surfaced it as a bare HTTP 500 DATABASE_ERROR instead of
+--     a meaningful response. Tests that legitimately register two webhooks at
+--     one receiver (webhook-multi-event-filter, webhook-event-versioning)
+--     failed on the second create.
+--
+-- Migration 081 has already run on every cluster that needs it; once the
+-- migrator records 081 as applied it never re-executes, so dropping the index
+-- now does not weaken the historical migration's idempotency. New clusters
+-- run 081 against an empty notification_subscriptions table (the index exists
+-- for that single INSERT) and then immediately run this migration to remove
+-- it. Webhook identity is the primary key `id`, not the URL, so no uniqueness
+-- on url is required for correctness.
+
+DROP INDEX IF EXISTS idx_webhooks_url_repo_unique;

--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -380,6 +380,7 @@ pub async fn restore_backup(
     responses(
         (status = 200, description = "Backup cancelled"),
         (status = 404, description = "Backup not found"),
+        (status = 409, description = "Backup is not in a cancellable state"),
         (status = 500, description = "Internal server error")
     ),
     security(("bearer_auth" = []))

--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -573,14 +573,35 @@ async fn delete_connection(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
 ) -> Result<StatusCode> {
+    // A connection is the parent resource for its migration jobs. The
+    // migration_jobs.source_connection_id FK has no ON DELETE clause (it
+    // defaults to NO ACTION), so a raw DELETE on a connection that still has
+    // jobs surfaced a bare Postgres FK-violation as HTTP 500. Cascade the
+    // delete explicitly inside a transaction: remove the dependent jobs first
+    // (migration_items and migration_reports already CASCADE off migration_jobs),
+    // then the connection. This makes connection deletion idempotent and a
+    // second DELETE correctly returns 404 instead of repeating the 500.
+    let mut tx = state.db.begin().await?;
+
+    sqlx::query("DELETE FROM migration_jobs WHERE source_connection_id = $1")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
     let result = sqlx::query("DELETE FROM source_connections WHERE id = $1")
         .bind(id)
-        .execute(&state.db)
+        .execute(&mut *tx)
         .await?;
 
     if result.rows_affected() == 0 {
+        // Nothing was deleted: the connection did not exist. Roll the
+        // transaction back (the job-delete above was a no-op anyway) and
+        // report 404 so a repeat delete is distinguishable from a server error.
+        tx.rollback().await?;
         return Err(AppError::NotFound("Source connection not found".into()));
     }
+
+    tx.commit().await?;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -1281,6 +1302,18 @@ async fn cancel_migration(
     .ok_or_else(|| {
         AppError::Conflict("Migration cannot be cancelled (wrong state or not found)".into())
     })?;
+
+    // Cancellation is a terminal transition, so materialise the migration
+    // report for the audit trail. Operators (and compliance tooling) fetch
+    // GET /{id}/report after a job stops; without this the report endpoint
+    // would 404 forever for cancelled jobs. generate_report upserts on the
+    // UNIQUE job_id, so this is safe even if a report already exists. A
+    // failure here is logged but does not roll back the cancel: the job is
+    // already cancelled and reporting is best-effort metadata.
+    let service = MigrationService::new(state.db.clone());
+    if let Err(e) = service.generate_report(job.id).await {
+        tracing::error!(job_id = %job.id, error = %e, "Failed to generate migration report on cancel");
+    }
 
     Ok(Json(job.into()))
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4,7 +4,7 @@ use axum::{
     body::Bytes,
     extract::{Extension, Multipart, Path, Query, State},
     http::{header, HeaderMap},
-    response::IntoResponse,
+    response::{IntoResponse, Response},
     routing::get,
     Router,
 };
@@ -2308,7 +2308,7 @@ pub async fn get_artifact_metadata(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, path)): Path<(String, String)>,
-) -> Result<Json<ArtifactResponse>> {
+) -> Result<Response> {
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_visible(&repo, &auth)?;
@@ -2328,26 +2328,93 @@ pub async fn get_artifact_metadata(
     // normalised stored shape for npm-family repos when the caller
     // handed us the URL shape.
     let candidates = lookup_path_candidates(&path, &repo.format);
-    let artifact = lookup_artifact_by_paths(&state.db, repo.id, &candidates)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+    let direct = lookup_artifact_by_paths(&state.db, repo.id, &candidates).await?;
 
-    let downloads = artifact_service.get_download_stats(artifact.id).await?;
-    let metadata = artifact_service.get_metadata(artifact.id).await?;
+    if let Some(artifact) = direct {
+        let downloads = artifact_service.get_download_stats(artifact.id).await?;
+        let metadata = artifact_service.get_metadata(artifact.id).await?;
 
-    Ok(Json(ArtifactResponse {
-        id: artifact.id,
-        repository_key: key,
-        path: artifact.path,
-        name: artifact.name,
-        version: artifact.version,
-        size_bytes: artifact.size_bytes,
-        checksum_sha256: artifact.checksum_sha256,
-        content_type: artifact.content_type,
-        download_count: downloads,
-        created_at: artifact.created_at,
-        metadata: metadata.map(|m| m.metadata),
-    }))
+        return Ok(Json(ArtifactResponse {
+            id: artifact.id,
+            repository_key: key,
+            path: artifact.path,
+            name: artifact.name,
+            version: artifact.version,
+            size_bytes: artifact.size_bytes,
+            checksum_sha256: artifact.checksum_sha256,
+            content_type: artifact.content_type,
+            download_count: downloads,
+            created_at: artifact.created_at,
+            metadata: metadata.map(|m| m.metadata),
+        })
+        .into_response());
+    }
+
+    // B9 / #1221 / #1217: a virtual repository owns no `artifacts` rows of
+    // its own -- its content lives in its member repositories. The generic
+    // GET /:key/artifacts/*path route is the format-agnostic artifact-fetch
+    // surface clients use to pull bytes through a virtual repo (the
+    // virtual-shadowing-guard E2E fetches L's trusted artifact this way).
+    // A virtual repo therefore has no direct row to describe, and returning
+    // 404 here would make the local member's artifact unreachable through
+    // the virtual. Resolve members in priority order and serve the winning
+    // member's BYTES, applying the same local-over-remote shadowing guard
+    // as `download_artifact`: if a non-Remote member owns the exact path,
+    // suppress the proxy so a Remote member cannot shadow the trusted
+    // local artifact.
+    if repo.repo_type == RepositoryType::Virtual {
+        let owns_locally = proxy_helpers::virtual_non_remote_owns_path(&state.db, repo.id, &path)
+            .await
+            .map_err(|_| AppError::Internal("virtual shadowing-guard query failed".to_string()))?;
+        let proxy_for_virtual = if owns_locally {
+            None
+        } else {
+            state.proxy_service.as_deref()
+        };
+        let db = state.db.clone();
+        let path_clone = path.clone();
+        let state_clone = state.clone();
+        let (content, content_type) = proxy_helpers::resolve_virtual_download(
+            &state.db,
+            proxy_for_virtual,
+            repo.id,
+            &path,
+            move |member_id, location| {
+                let db = db.clone();
+                let state = state_clone.clone();
+                let p = path_clone.clone();
+                async move {
+                    proxy_helpers::local_fetch_by_path(&db, &state, member_id, &location, &p).await
+                }
+            },
+        )
+        .await
+        .map_err(|_| {
+            AppError::NotFound("Artifact not found in any member repository".to_string())
+        })?;
+
+        let ct = content_type.unwrap_or_else(|| "application/octet-stream".to_string());
+        let filename = path.rsplit('/').next().unwrap_or(&path);
+
+        return Ok((
+            [
+                (header::CONTENT_TYPE, ct),
+                (
+                    header::CONTENT_DISPOSITION,
+                    format!("attachment; filename=\"{}\"", filename),
+                ),
+                (header::CONTENT_LENGTH, content.len().to_string()),
+                (
+                    header::HeaderName::from_static(X_ARTIFACT_STORAGE),
+                    "virtual".to_string(),
+                ),
+            ],
+            content,
+        )
+            .into_response());
+    }
+
+    Err(AppError::NotFound("Artifact not found".to_string()))
 }
 
 /// Upload artifact

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -416,6 +416,27 @@ pub async fn auth_middleware(
             Some((username, password)) => {
                 match auth_service.authenticate(&username, &password).await {
                     Ok((user, _token_pair)) => Ok((AuthExtension::from(user), None)),
+                    // A transient bcrypt-capacity shed must NOT be collapsed
+                    // into a 401. `authenticate()` runs bcrypt(cost=12) under a
+                    // process-wide concurrency cap (see
+                    // `auth_service::acquire_auth_permit_for_bcrypt`); when that
+                    // cap saturates under a burst of concurrent Basic-auth
+                    // requests it returns `AppError::ServiceUnavailable`, which
+                    // is a retryable 503, not "wrong password". Collapsing it to
+                    // 401 "Invalid credentials" is what made `twine upload` fail
+                    // in the release gate (a curl -u upload with byte-identical
+                    // credentials passed because it didn't coincide with a
+                    // saturated cap): twine does not retry on 401 but does on
+                    // 503. Surface the shed as 503 + Retry-After so well-behaved
+                    // clients back off and retry instead of aborting.
+                    Err(AppError::ServiceUnavailable(msg)) => {
+                        return (
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            [(axum::http::header::RETRY_AFTER, "1")],
+                            msg,
+                        )
+                            .into_response();
+                    }
                     Err(_) => Err("Invalid credentials"),
                 }
             }
@@ -505,7 +526,9 @@ pub(crate) async fn try_resolve_auth(
 ) -> Option<AuthExtension> {
     match try_resolve_auth_outcome(auth_service, extracted).await {
         AuthOutcome::Resolved(ext) => Some(ext),
-        AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => None,
+        AuthOutcome::NoCredential | AuthOutcome::InvalidCredential | AuthOutcome::Overloaded => {
+            None
+        }
     }
 }
 
@@ -534,6 +557,16 @@ pub(crate) enum AuthOutcome {
     Resolved(AuthExtension),
     NoCredential,
     InvalidCredential,
+    /// A credential was presented and is well-formed, but validation could
+    /// not be completed because the bcrypt-bound auth-concurrency cap is
+    /// saturated (see `auth_service::acquire_auth_permit_for_bcrypt`). This
+    /// is a transient overload, NOT "wrong password": the correct response
+    /// is a retryable 503, never a 401. Collapsing it into `InvalidCredential`
+    /// is what made `twine upload` fail in the release gate under parallel
+    /// load (a curl -u upload with byte-identical credentials passed because
+    /// it did not coincide with a saturated cap); twine does not retry on
+    /// 401 but does on 503.
+    Overloaded,
 }
 
 /// Resolve a possibly-missing credential into an [`AuthOutcome`].
@@ -570,8 +603,12 @@ pub(crate) async fn try_resolve_auth_outcome(
             // that are base64-encoded `username:password` rather than JWTs or
             // API keys. Try decoding as credentials before giving up.
             if let Some((username, password)) = decode_basic_credentials(token) {
-                if let Ok((user, _)) = auth_service.authenticate(&username, &password).await {
-                    return AuthOutcome::Resolved(AuthExtension::from(user));
+                match auth_service.authenticate(&username, &password).await {
+                    Ok((user, _)) => return AuthOutcome::Resolved(AuthExtension::from(user)),
+                    // A transient bcrypt-capacity shed must surface as 503, not
+                    // 401. See `AuthOutcome::Overloaded`.
+                    Err(AppError::ServiceUnavailable(_)) => return AuthOutcome::Overloaded,
+                    Err(_) => {}
                 }
             }
             AuthOutcome::InvalidCredential
@@ -587,8 +624,15 @@ pub(crate) async fn try_resolve_auth_outcome(
                 return AuthOutcome::InvalidCredential;
             };
             // Try bcrypt username/password auth first
-            if let Ok((user, _)) = auth_service.authenticate(&username, &password).await {
-                return AuthOutcome::Resolved(AuthExtension::from(user));
+            match auth_service.authenticate(&username, &password).await {
+                Ok((user, _)) => return AuthOutcome::Resolved(AuthExtension::from(user)),
+                // A transient bcrypt-capacity shed must surface as 503, not a
+                // 401. Without this, twine (which sends standard Basic auth)
+                // gets a spurious 401 under parallel-suite load and aborts,
+                // while a single curl -u upload with the same credentials
+                // succeeds. See `AuthOutcome::Overloaded`.
+                Err(AppError::ServiceUnavailable(_)) => return AuthOutcome::Overloaded,
+                Err(_) => {}
             }
             // Fall back to treating the password as an API token — compatible with
             // pip netrc / Artifactory-style `token:<api_token>` credential format
@@ -837,10 +881,20 @@ pub async fn optional_auth_middleware(
 ) -> Response {
     let extracted = extract_token(&request);
     let outcome = try_resolve_auth_outcome(&auth_service, extracted).await;
+    // A transient bcrypt-capacity shed surfaces here as `Overloaded`. Return a
+    // retryable 503 immediately rather than silently dropping to anonymous and
+    // letting a downstream `require_auth_basic*` turn it into a misleading 401
+    // "Authentication required" (the twine-upload gate failure). See
+    // `AuthOutcome::Overloaded`.
+    if matches!(outcome, AuthOutcome::Overloaded) {
+        return service_unavailable_response();
+    }
     let credential_invalid = matches!(outcome, AuthOutcome::InvalidCredential);
     let mut auth_ext: Option<AuthExtension> = match outcome {
         AuthOutcome::Resolved(ext) => Some(ext),
         AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => None,
+        // Handled above with an early 503 return.
+        AuthOutcome::Overloaded => None,
     };
 
     // If header-based auth produced no identity, fall back to a `?ticket=`
@@ -999,6 +1053,24 @@ fn unauthorized_response() -> Response {
         .unwrap()
 }
 
+/// Build a 503 response for the transient bcrypt-capacity shed
+/// (`AuthOutcome::Overloaded`). Carries a `Retry-After: 1` hint so
+/// well-behaved clients (twine, cargo, pip) back off and retry instead of
+/// aborting the way they would on a 401. Keeping this distinct from
+/// `unauthorized_response` is the load-bearing fix for the twine-upload
+/// gate failure: a saturated auth cap is "retry shortly", not "wrong
+/// password".
+fn service_unavailable_response() -> Response {
+    Response::builder()
+        .status(StatusCode::SERVICE_UNAVAILABLE)
+        .header(axum::http::header::RETRY_AFTER, "1")
+        .header(axum::http::header::CONTENT_TYPE, "text/plain")
+        .body(axum::body::Body::from(
+            "Authentication service is at capacity, retry shortly",
+        ))
+        .unwrap()
+}
+
 /// Build a 403 response for API tokens that lack access to the requested
 /// repository.
 fn forbidden_repo_response() -> Response {
@@ -1140,10 +1212,16 @@ pub async fn repo_visibility_middleware(
     let Some(repo) = repo else {
         let extracted = extract_token(&request);
         let outcome = try_resolve_auth_outcome(&vis_state.auth_service, extracted).await;
+        // Transient bcrypt-capacity shed -> retryable 503 (see
+        // `AuthOutcome::Overloaded`), never a 401.
+        if matches!(outcome, AuthOutcome::Overloaded) {
+            return service_unavailable_response();
+        }
         let credential_invalid = matches!(outcome, AuthOutcome::InvalidCredential);
         let auth_ext: Option<AuthExtension> = match outcome {
             AuthOutcome::Resolved(ext) => Some(ext),
             AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => None,
+            AuthOutcome::Overloaded => None,
         };
         if credential_invalid && auth_ext.is_none() {
             return unauthorized_response();
@@ -1161,10 +1239,16 @@ pub async fn repo_visibility_middleware(
     // Perform optional auth (shared with optional_auth_middleware).
     let extracted = extract_token(&request);
     let outcome = try_resolve_auth_outcome(&vis_state.auth_service, extracted).await;
+    // Transient bcrypt-capacity shed -> retryable 503 (see
+    // `AuthOutcome::Overloaded`), never a 401.
+    if matches!(outcome, AuthOutcome::Overloaded) {
+        return service_unavailable_response();
+    }
     let credential_invalid = matches!(outcome, AuthOutcome::InvalidCredential);
     let mut auth_ext: Option<AuthExtension> = match outcome {
         AuthOutcome::Resolved(ext) => Some(ext),
         AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => None,
+        AuthOutcome::Overloaded => None,
     };
     // `credential_invalid` was captured before the match consumed `outcome`.
 
@@ -3113,6 +3197,21 @@ mod tests {
         assert!(matches!(outcome, AuthOutcome::NoCredential));
     }
 
+    #[test]
+    fn test_service_unavailable_response_is_503_with_retry_after() {
+        // The bcrypt-capacity shed (`AuthOutcome::Overloaded`) must surface as
+        // a retryable 503 with Retry-After, never the 401 that made twine
+        // abort its upload in the release gate.
+        let resp = service_unavailable_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok()),
+            Some("1")
+        );
+    }
+
     #[tokio::test]
     async fn test_try_resolve_auth_outcome_invalid_for_garbage_scheme() {
         let auth_service = make_test_auth_service();
@@ -3171,11 +3270,17 @@ mod tests {
         let flatten = |outcome: AuthOutcome| -> Option<AuthExtension> {
             match outcome {
                 AuthOutcome::Resolved(ext) => Some(ext),
-                AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => None,
+                AuthOutcome::NoCredential
+                | AuthOutcome::InvalidCredential
+                | AuthOutcome::Overloaded => None,
             }
         };
         assert!(flatten(AuthOutcome::NoCredential).is_none());
         assert!(flatten(AuthOutcome::InvalidCredential).is_none());
+        // A transient bcrypt-capacity shed also flattens to None for the
+        // legacy Option-shaped helper (callers that need the 503 distinction
+        // use the tri-state outcome directly).
+        assert!(flatten(AuthOutcome::Overloaded).is_none());
     }
 
     #[tokio::test]

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -426,6 +426,18 @@ pub async fn auth_middleware(
 
     let header_error = match header_result {
         Ok((ext, token_iat)) => {
+            // Insert BOTH shapes so handlers behind this middleware can
+            // extract either `Extension<AuthExtension>` or
+            // `Extension<Option<AuthExtension>>`. Without the Option-wrapped
+            // copy, a handler declaring `Extension<Option<AuthExtension>>`
+            // (e.g. the permission handlers, which gate on require_auth +
+            // require_scope) fails Axum extraction with HTTP 500
+            // ("Missing request extension: Extension of type
+            // Option<AuthExtension>") before the in-handler scope check runs.
+            // That surfaced as a 500 instead of the canonical 403 for a
+            // read-scope service-account token on POST /api/v1/permissions.
+            // See #1438 (B10).
+            request.extensions_mut().insert(Some(ext.clone()));
             request.extensions_mut().insert(ext);
             if let Some(iat) = token_iat {
                 request.extensions_mut().insert(iat);
@@ -441,6 +453,10 @@ pub async fn auth_middleware(
     let ticket_parts = extract_ticket_request_parts(&request);
     if let Some(parts) = ticket_parts.as_ref() {
         if let Some(ext) = try_resolve_ticket_for_parts(auth_service.db(), parts).await {
+            // Same dual-shape insertion as the header-auth path above so
+            // `Extension<Option<AuthExtension>>` handlers resolve under a
+            // ticket-authenticated request too (#1438 / B10).
+            request.extensions_mut().insert(Some(ext.clone()));
             request.extensions_mut().insert(ext);
             request.extensions_mut().insert(DownloadTicketAuth);
             return next.run(request).await;
@@ -3096,6 +3112,84 @@ mod tests {
     async fn test_optional_auth_middleware_passes_through_without_credentials() {
         let resp = run_through_optional_auth(empty_get("/probe")).await;
         assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    // -----------------------------------------------------------------------
+    // #1438 (B10): auth_middleware must insert BOTH `AuthExtension` and
+    // `Option<AuthExtension>` on its success path so handlers can declare
+    // either extractor shape. The permission handlers declare
+    // `Extension<Option<AuthExtension>>`; before this fix the middleware only
+    // inserted a bare `AuthExtension`, so the `Option<AuthExtension>`
+    // extractor failed request extraction with HTTP 500 ("Missing request
+    // extension") before the in-handler scope check ran -- a read-scope SA
+    // token got 500 instead of the canonical 403 on POST /api/v1/permissions.
+    //
+    // The middleware's success path requires a valid token + live AuthService,
+    // which the unit harness cannot provide. We instead pin the load-bearing
+    // contract directly: a request whose extensions carry the dual insertion
+    // (exactly what the fixed success path does) resolves BOTH
+    // `Extension<AuthExtension>` and `Extension<Option<AuthExtension>>` to 200.
+    // A regression that drops the Option-wrapped copy turns the second route
+    // into a 500, which this test catches.
+    // -----------------------------------------------------------------------
+    #[tokio::test]
+    async fn test_dual_auth_extension_insertion_resolves_both_extractor_shapes() {
+        use axum::{extract::Extension, middleware::Next, routing::get, Router};
+        use tower::ServiceExt;
+
+        fn sample_ext() -> AuthExtension {
+            AuthExtension {
+                user_id: Uuid::new_v4(),
+                username: "sa-dual".to_string(),
+                email: "sa@example.com".to_string(),
+                is_admin: false,
+                is_api_token: true,
+                is_service_account: true,
+                scopes: Some(vec!["read".to_string()]),
+                allowed_repo_ids: None,
+            }
+        }
+
+        // Mirror the exact dual insertion auth_middleware now performs on its
+        // success path.
+        async fn insert_both(mut request: Request, next: Next) -> Response {
+            let ext = sample_ext();
+            request.extensions_mut().insert(Some(ext.clone()));
+            request.extensions_mut().insert(ext);
+            next.run(request).await
+        }
+
+        let app: Router = Router::new()
+            .route(
+                "/bare",
+                get(|Extension(_a): Extension<AuthExtension>| async { (StatusCode::OK, "bare") }),
+            )
+            .route(
+                "/opt",
+                get(
+                    |Extension(a): Extension<Option<AuthExtension>>| async move {
+                        // Must be Some, not None: the fix inserts Some(ext),
+                        // not a None placeholder.
+                        assert!(a.is_some(), "Option<AuthExtension> must be Some");
+                        (StatusCode::OK, "opt")
+                    },
+                ),
+            )
+            .layer(axum::middleware::from_fn(insert_both));
+
+        let bare = app.clone().oneshot(empty_get("/bare")).await.unwrap();
+        assert_eq!(
+            bare.status(),
+            StatusCode::OK,
+            "Extension<AuthExtension> must resolve"
+        );
+
+        let opt = app.oneshot(empty_get("/opt")).await.unwrap();
+        assert_eq!(
+            opt.status(),
+            StatusCode::OK,
+            "Extension<Option<AuthExtension>> must resolve (B10 regression guard)"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -412,7 +412,20 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                     optional_auth_middleware,
                 )),
         )
-        // Permission routes with auth middleware
+        // Permission routes with auth middleware.
+        //
+        // The permission handlers declare `Extension<Option<AuthExtension>>`
+        // and do their own authorization (require_auth + require_scope /
+        // require_admin). `auth_middleware` now injects BOTH the bare
+        // `AuthExtension` and an `Option<AuthExtension>` (see its body), so
+        // either extractor shape resolves. Before that fix the
+        // `Option<AuthExtension>` extractor failed during request extraction
+        // with HTTP 500 ("Missing request extension: Extension of type
+        // Option<AuthExtension>") before the in-handler scope check ran, so a
+        // read-scope service-account token got 500 instead of the canonical
+        // 403 on POST /api/v1/permissions. Hard auth (401 for anonymous) is
+        // preserved because auth_middleware still rejects unauthenticated
+        // requests up front. See #1438 (B10).
         .nest(
             "/permissions",
             handlers::permissions::router()

--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -728,9 +728,16 @@ impl BackupService {
         let backup = self.get_by_id(backup_id).await?;
 
         if backup.status != BackupStatus::InProgress && backup.status != BackupStatus::Pending {
-            return Err(AppError::Validation(
-                "Can only cancel pending or in-progress backups".to_string(),
-            ));
+            // A backup in a terminal state (completed/failed/cancelled) cannot be
+            // cancelled. This is a state conflict, not a malformed request, so it
+            // maps to HTTP 409 rather than 400. The executor for an empty backup
+            // can finish before the cancel call lands, so callers (and the E2E
+            // lifecycle test) must be able to distinguish "too late to cancel"
+            // (409) from "bad input" (400).
+            return Err(AppError::Conflict(format!(
+                "Cannot cancel backup in '{}' state; only pending or in-progress backups can be cancelled",
+                backup.status
+            )));
         }
 
         self.update_status(backup_id, BackupStatus::Cancelled, None)

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -46,6 +46,22 @@ pub struct GrypeReport {
 pub struct GrypeMatch {
     pub vulnerability: GrypeVulnerability,
     pub artifact: GrypeArtifact,
+    /// Aliases Grype maps the primary match to. For ecosystem advisories
+    /// (npm, RubyGems, etc.) Grype's primary `vulnerability.id` is frequently
+    /// the GHSA identifier (e.g. `GHSA-jf85-cpcp-j695`) and the NVD `CVE-` id
+    /// lives here as a related vulnerability. Consumers and the release-gate
+    /// keyed on the canonical CVE id never see it unless we surface the alias.
+    ///
+    /// CRITICAL (#1375 / B15): in Grype's JSON this array is a TOP-LEVEL field
+    /// of the *match* object (a sibling of `vulnerability` and `artifact`),
+    /// NOT a field nested inside `vulnerability`. An earlier fix placed it
+    /// inside `GrypeVulnerability`, so it deserialized to an empty Vec against
+    /// real Grype output and the GHSA->CVE mapping silently never fired. It
+    /// must live here on `GrypeMatch`. Verified against grype v0.112.0 output
+    /// for lodash 4.17.4: `.matches[].relatedVulnerabilities[].id` ==
+    /// "CVE-2019-10744".
+    #[serde(default, rename = "relatedVulnerabilities")]
+    pub related_vulnerabilities: Vec<GrypeRelatedVulnerability>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -59,14 +75,6 @@ pub struct GrypeVulnerability {
     pub fix: Option<GrypeFix>,
     #[serde(default)]
     pub urls: Option<Vec<String>>,
-    /// Aliases Grype maps the primary match to. For ecosystem advisories
-    /// (npm, RubyGems, etc.) Grype's primary `id` is frequently the GHSA
-    /// identifier (e.g. `GHSA-jf85-cpcp-j695`) and the NVD `CVE-` id lives
-    /// here as a related vulnerability. Consumers and the release-gate keyed
-    /// on the canonical CVE id never see it unless we surface the alias.
-    /// (#1375 / B15)
-    #[serde(default, rename = "relatedVulnerabilities")]
-    pub related_vulnerabilities: Vec<GrypeRelatedVulnerability>,
 }
 
 /// A cross-referenced vulnerability id Grype attaches to a primary match.
@@ -314,8 +322,7 @@ impl GrypeScanner {
                 // GHSA id is retained in the title so neither identifier is
                 // lost.
                 let primary_id = &m.vulnerability.id;
-                let canonical_cve =
-                    canonical_cve_id(primary_id, &m.vulnerability.related_vulnerabilities);
+                let canonical_cve = canonical_cve_id(primary_id, &m.related_vulnerabilities);
                 RawFinding {
                     severity: Severity::from_str_loose(&m.vulnerability.severity)
                         .unwrap_or(Severity::Info),
@@ -901,7 +908,6 @@ mod tests {
                     urls: Some(vec![
                         "https://nvd.nist.gov/vuln/detail/CVE-2023-99999".to_string()
                     ]),
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "vulnerable-pkg".to_string(),
@@ -910,6 +916,7 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
 
@@ -954,7 +961,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "log4j-core".to_string(),
@@ -963,6 +969,7 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
 
@@ -995,7 +1002,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "some-lib".to_string(),
@@ -1004,6 +1010,7 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
 
@@ -1042,10 +1049,6 @@ mod tests {
                     urls: Some(vec![
                         "https://github.com/advisories/GHSA-jf85-cpcp-j695".to_string()
                     ]),
-                    related_vulnerabilities: vec![GrypeRelatedVulnerability {
-                        id: "CVE-2019-10744".to_string(),
-                        namespace: Some("nvd:cpe".to_string()),
-                    }],
                 },
                 artifact: GrypeArtifact {
                     name: "lodash".to_string(),
@@ -1054,6 +1057,10 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![GrypeRelatedVulnerability {
+                    id: "CVE-2019-10744".to_string(),
+                    namespace: Some("nvd:cpe".to_string()),
+                }],
             }],
         };
 
@@ -1088,10 +1095,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![GrypeRelatedVulnerability {
-                        id: "CVE-2021-45046".to_string(),
-                        namespace: Some("nvd:cpe".to_string()),
-                    }],
                 },
                 artifact: GrypeArtifact {
                     name: "log4j-core".to_string(),
@@ -1100,6 +1103,10 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![GrypeRelatedVulnerability {
+                    id: "CVE-2021-45046".to_string(),
+                    namespace: Some("nvd:cpe".to_string()),
+                }],
             }],
         };
         let findings = GrypeScanner::convert_findings(&report);
@@ -1139,29 +1146,93 @@ mod tests {
         assert!(!is_cve_id("CVE-2019-10744-extra")); // stray suffix
     }
 
-    /// B15: grype JSON with a relatedVulnerabilities block deserializes the
-    /// alias ids. Pins the serde rename so a field rename does not silently
-    /// drop the aliases.
+    /// B15: grype JSON with a `relatedVulnerabilities` block deserializes the
+    /// alias ids and the GHSA->CVE mapping fires.
+    ///
+    /// CRITICAL: this fixture mirrors grype's REAL output shape, where
+    /// `relatedVulnerabilities` is a TOP-LEVEL field of the match object (a
+    /// sibling of `vulnerability` and `artifact`). Verified against grype
+    /// v0.112.0 for lodash 4.17.4. An earlier version of this test nested the
+    /// array inside `vulnerability`, which matched the (buggy) struct shape
+    /// and made the test pass while real scans produced GHSA ids -- the exact
+    /// B15 gate failure. Keep this fixture faithful to grype's wire format.
     #[test]
     fn test_grype_report_deserializes_related_vulnerabilities() {
         let json = r#"{
             "matches": [{
                 "vulnerability": {
                     "id": "GHSA-jf85-cpcp-j695",
-                    "severity": "High",
-                    "relatedVulnerabilities": [
-                        {"id": "CVE-2019-10744", "namespace": "nvd:cpe"}
-                    ]
+                    "severity": "High"
                 },
+                "relatedVulnerabilities": [
+                    {"id": "CVE-2019-10744", "namespace": "nvd:cpe"}
+                ],
                 "artifact": {"name": "lodash", "version": "4.17.4", "type": "npm"}
             }]
         }"#;
         let report: GrypeReport = serde_json::from_str(json).unwrap();
-        let related = &report.matches[0].vulnerability.related_vulnerabilities;
-        assert_eq!(related.len(), 1);
+        let related = &report.matches[0].related_vulnerabilities;
+        assert_eq!(
+            related.len(),
+            1,
+            "match-level relatedVulnerabilities must deserialize"
+        );
         assert_eq!(related[0].id, "CVE-2019-10744");
         let findings = GrypeScanner::convert_findings(&report);
+        assert_eq!(
+            findings[0].cve_id,
+            Some("CVE-2019-10744".to_string()),
+            "GHSA->CVE mapping must fire from match-level relatedVulnerabilities"
+        );
+    }
+
+    /// B15 regression guard: prove the JSON nesting matters. If a future
+    /// change moves `related_vulnerabilities` back inside `GrypeVulnerability`,
+    /// real grype output (which carries the array at the MATCH level) would
+    /// deserialize to an empty Vec and the mapping would silently regress to
+    /// the primary GHSA id. This test pins that the array is read from the
+    /// match level by feeding grype's real shape and asserting the CVE wins,
+    /// and that an array MISplaced inside `vulnerability` is ignored.
+    #[test]
+    fn test_related_vulnerabilities_is_read_from_match_level_not_vulnerability() {
+        // Correct (real grype) shape: array at match level -> CVE surfaces.
+        let correct = r#"{
+            "matches": [{
+                "vulnerability": {"id": "GHSA-jf85-cpcp-j695", "severity": "High"},
+                "relatedVulnerabilities": [{"id": "CVE-2019-10744"}],
+                "artifact": {"name": "lodash", "version": "4.17.4", "type": "npm"}
+            }]
+        }"#;
+        let report: GrypeReport = serde_json::from_str(correct).unwrap();
+        let findings = GrypeScanner::convert_findings(&report);
         assert_eq!(findings[0].cve_id, Some("CVE-2019-10744".to_string()));
+
+        // Misplaced shape: array nested under vulnerability (the old bug's
+        // assumption). The match-level field is absent, so the alias is NOT
+        // picked up and the primary GHSA id is kept. This documents why the
+        // nesting is load-bearing.
+        let misplaced = r#"{
+            "matches": [{
+                "vulnerability": {
+                    "id": "GHSA-jf85-cpcp-j695",
+                    "severity": "High",
+                    "relatedVulnerabilities": [{"id": "CVE-2019-10744"}]
+                },
+                "artifact": {"name": "lodash", "version": "4.17.4", "type": "npm"}
+            }]
+        }"#;
+        let report2: GrypeReport = serde_json::from_str(misplaced).unwrap();
+        assert!(
+            report2.matches[0].related_vulnerabilities.is_empty(),
+            "a relatedVulnerabilities array nested under vulnerability must NOT \
+             populate the match-level field"
+        );
+        let findings2 = GrypeScanner::convert_findings(&report2);
+        assert_eq!(
+            findings2[0].cve_id,
+            Some("GHSA-jf85-cpcp-j695".to_string()),
+            "with no match-level alias, the primary GHSA id is kept"
+        );
     }
 
     #[test]
@@ -1451,7 +1522,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "log4j-core".to_string(),
@@ -1460,6 +1530,7 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
 
@@ -1499,7 +1570,6 @@ mod tests {
                 description: None,
                 fix: None,
                 urls: None,
-                related_vulnerabilities: vec![],
             },
             artifact: GrypeArtifact {
                 name: "lodash".to_string(),
@@ -1508,6 +1578,7 @@ mod tests {
                 purl: None,
                 licenses: None,
             },
+            related_vulnerabilities: vec![],
         };
         let report = GrypeReport {
             matches: vec![
@@ -1540,7 +1611,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "@types/node".to_string(),
@@ -1549,6 +1619,7 @@ mod tests {
                     purl: Some("pkg:npm/%40types/node@20.0.0".to_string()),
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
 
@@ -1574,7 +1645,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "".to_string(),
@@ -1583,6 +1653,7 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
         assert!(GrypeScanner::convert_packages(&report).is_empty());
@@ -1602,7 +1673,6 @@ mod tests {
                     description: None,
                     fix: None,
                     urls: None,
-                    related_vulnerabilities: vec![],
                 },
                 artifact: GrypeArtifact {
                     name: "esoteric-pkg".to_string(),
@@ -1611,6 +1681,7 @@ mod tests {
                     purl: None,
                     licenses: None,
                 },
+                related_vulnerabilities: vec![],
             }],
         };
         let packages = GrypeScanner::convert_packages(&report);

--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -725,11 +725,21 @@ impl MigrationService {
             })
             .collect();
 
-        // Insert report
+        // Insert (or refresh) the report. migration_reports.job_id is UNIQUE,
+        // so an ON CONFLICT upsert keeps report generation idempotent: a job
+        // that reaches a terminal state more than once (e.g. a cancel after a
+        // prior failed-assessment that already wrote a report) regenerates the
+        // audit envelope instead of erroring on the unique constraint.
         let report_id: (Uuid,) = sqlx::query_as(
             r#"
             INSERT INTO migration_reports (job_id, summary, warnings, errors, recommendations)
             VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (job_id) DO UPDATE
+            SET generated_at = NOW(),
+                summary = EXCLUDED.summary,
+                warnings = EXCLUDED.warnings,
+                errors = EXCLUDED.errors,
+                recommendations = EXCLUDED.recommendations
             RETURNING id
             "#,
         )

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -739,17 +739,40 @@ impl ProxyService {
         match upstream_result {
             Ok(resp) => {
                 let cache_ttl = self.get_cache_ttl_for_repo(repo.id).await;
-                self.cache_artifact(
-                    &cache_key,
-                    &metadata_key,
-                    &resp.content,
-                    resp.content_type.clone(),
-                    resp.etag,
-                    cache_ttl,
-                    repo.id,
-                    cache_path,
-                )
-                .await?;
+                // B6 (coalescing 502 leak, remaining path): the upstream fetch
+                // already SUCCEEDED -- `resp.content` is in hand. A failure to
+                // persist the cache entry must NOT fail the client request.
+                // Under a cold-cache stampede, N concurrent waiters all miss
+                // the cache and all race to write the SAME cache file; one of
+                // those writes can transiently fail (e.g. ENOENT from a
+                // create_dir_all/File::create race against a sibling writer, a
+                // half-renamed temp file, or a poisoned entry). Propagating
+                // that write error via `?` surfaced as `AppError::Io` ->
+                // `map_proxy_error` -> raw 502, which is exactly the leak the
+                // stampede gate rejects (`200 502 200 ...`). Treat the cache
+                // write as best-effort: log at warn and still serve the bytes
+                // we fetched. The cache self-heals on the next request (the
+                // streaming path already documents this self-healing).
+                if let Err(cache_err) = self
+                    .cache_artifact(
+                        &cache_key,
+                        &metadata_key,
+                        &resp.content,
+                        resp.content_type.clone(),
+                        resp.etag,
+                        cache_ttl,
+                        repo.id,
+                        cache_path,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        cache_key = %cache_key,
+                        error = %cache_err,
+                        "proxy cache write failed after successful upstream fetch; \
+                         serving fetched bytes and leaving cache to self-heal on next request"
+                    );
+                }
 
                 Ok((resp.content, resp.content_type))
             }

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -80,10 +80,38 @@ impl StorageBackend for FilesystemStorage {
             fs::create_dir_all(parent).await?;
         }
 
-        // Write content
-        let mut file = fs::File::create(&path).await?;
-        file.write_all(&content).await?;
-        file.sync_all().await?;
+        // Write to a unique temp file in the same directory, then atomically
+        // rename into place (same filesystem => atomic rename on POSIX). The
+        // previous implementation wrote directly to `path` via
+        // `File::create` + `write_all`, which is NOT atomic: under a
+        // cold-cache proxy stampede, N concurrent writers target the SAME
+        // cache file and race on truncate/write, and a reader interleaving
+        // with a sibling writer's truncate can observe a torn or
+        // transiently-missing file. Writing to a per-writer temp path and
+        // renaming gives each writer an isolated file and makes the visible
+        // `path` flip atomically from old bytes to new bytes, never to a
+        // partial/empty state. This closes the B6 stampede 502 leak at the
+        // storage layer (the proxy-service call site additionally treats a
+        // cache-write failure as best-effort).
+        let mut temp_name = path.as_os_str().to_os_string();
+        temp_name.push(format!(".tmp.{}", Uuid::new_v4()));
+        let temp_path = PathBuf::from(temp_name);
+
+        let mut file = fs::File::create(&temp_path).await?;
+        if let Err(e) = file.write_all(&content).await {
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(e.into());
+        }
+        if let Err(e) = file.sync_all().await {
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(e.into());
+        }
+        drop(file);
+
+        if let Err(e) = fs::rename(&temp_path, &path).await {
+            let _ = fs::remove_file(&temp_path).await;
+            return Err(e.into());
+        }
 
         Ok(())
     }
@@ -383,6 +411,52 @@ mod tests {
 
         let retrieved = storage.get(key).await.unwrap();
         assert_eq!(retrieved, content);
+    }
+
+    /// B6 (stampede 502 leak, storage half): `put` writes via a temp file +
+    /// atomic rename so concurrent writers to the SAME key never observe a
+    /// torn / transiently-missing file. Before the fix, `put` did
+    /// `File::create(&dest) + write_all`, which truncated `dest` in place and
+    /// let a reader interleave with a sibling writer's truncate. This test
+    /// fires many concurrent writers + readers at one key and asserts every
+    /// `put` succeeds, no `.tmp.` files leak, and the final read returns a
+    /// complete (non-empty) body.
+    #[tokio::test]
+    async fn test_concurrent_put_same_key_is_atomic() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = std::sync::Arc::new(FilesystemStorage::new(temp_dir.path()));
+        let key = "proxy-cache/stampede-repo/simple/pkg/__content__";
+        let content = Bytes::from(vec![b'x'; 4096]);
+
+        let mut handles = Vec::new();
+        for _ in 0..24 {
+            let s = storage.clone();
+            let c = content.clone();
+            handles.push(tokio::spawn(async move {
+                // Each writer writes the same body; the read may race a
+                // concurrent rename but must never see a partial file.
+                s.put(key, c).await
+            }));
+        }
+        for h in handles {
+            // Every put must succeed (no ENOENT from the create_dir_all /
+            // File::create race the old non-atomic path exhibited).
+            h.await.unwrap().expect("concurrent put must not fail");
+        }
+
+        let got = storage.get(key).await.expect("final read must succeed");
+        assert_eq!(got.len(), content.len(), "body must be complete, not torn");
+
+        // No leftover temp files.
+        let mut leftovers = Vec::new();
+        let mut entries = fs::read_dir(temp_dir.path()).await.unwrap();
+        while let Some(entry) = entries.next_entry().await.unwrap() {
+            collect_tmp_files(entry.path(), &mut leftovers).await;
+        }
+        assert!(
+            leftovers.is_empty(),
+            "atomic put must not leave .tmp. files: {leftovers:?}"
+        );
     }
 
     // #1073 regression: a proxy-cache key written by the un-sharded writer


### PR DESCRIPTION
## Summary
Second recovery cycle for the v1.2.0 release gate. Unlike cycle 1 (which fixed from logs and had a ~50% miss rate), every fix here was reproduced against a LIVE local backend, fixed on the correct side, and re-run against the actual gate script to confirm the assertion flips. Triage found ~40% of the gate red was test-side (handled in a companion test-repo PR); these are the genuine backend defects.

## Backend fixes (all E2E-verified)
- **permissions 500->403** (B10): `auth_middleware` now inserts both `AuthExtension` and `Option<AuthExtension>` so the Option extractor doesn't fail before the scope check.
- **grype GHSA->CVE alias** (B15): `related_vulnerabilities` is a top-level field of the grype match, not nested under `vulnerability`; moved it so CVE-2019-10744 surfaces (verified vs real grype 0.112).
- **stampede 502 leak** (B6): cache-write failures under concurrent fetch no longer fail the request (best-effort write; bytes still served); `FilesystemStorage::put` made atomic (temp+rename).
- **generic + maven virtual fetch** (B9, #1221/#1217): `GET /:key/artifacts/*path` on a virtual repo now resolves members and serves the winning member's bytes with the local-over-remote shadowing guard (was 404 — only queried the virtual's own id).
- **twine 401 under load**: bcrypt auth-concurrency shedding now returns 503+Retry-After (was 401, which twine doesn't retry).
- **webhooks same-URL create 500**: dropped the over-broad `(url, repo)` unique index (migration 111) so two webhooks can share a URL.
- **lifecycle/admin terminal semantics**: migration connection DELETE cascades (was FK-violation 500); migration report is now generated on terminal transition (was never written → 404); backup cancel returns 409 for terminal state (was 400).

## Verification
`cargo build` clean; `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -D warnings` clean; `cargo test --workspace --lib` 10,232 passed, 0 failed. Each fix additionally verified by running the actual artifact-keeper-test script against a live backend (per-item evidence in the triage).

## Companion work
- Test-repo PR (separate): the ~7 test/config-side gate failures (jq `//false` bugs, FIFO-barrier hang, subshell var scope, dedup row-counting, promotion-shape assertion, webhook producer env, etc.).
- SBOM convert/components + mesh ×3: follow-up wave.

Closes #1481