### PR TITLE
fix(gate): cycle-2b SBOM convert projection + mesh sync-task/filter/failover (closes #1484)

### DIFF
--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -14,7 +14,7 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::peer_instance_service::{
     InstanceStatus, PeerInstanceService, RegisterPeerInstanceRequest as ServiceRegisterReq,
-    ReplicationMode,
+    ReplicationMode, SyncStatus,
 };
 use crate::services::peer_service::{PeerAnnouncement, PeerService};
 use crate::services::sync_policy_service::SyncPolicyService;
@@ -134,6 +134,13 @@ pub struct SyncTaskResponse {
     pub storage_key: String,
     pub artifact_size: i64,
     pub priority: i32,
+    /// Task status (e.g. "pending"). Listing currently returns pending tasks.
+    pub status: String,
+    /// When the task was enqueued. Lets clients tell a freshly-scheduled task
+    /// apart from a stale queue entry (used by the replication-schedule check).
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    /// When the worker began transferring, if it has started.
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -155,6 +162,17 @@ pub struct IdentityResponse {
 
 fn require_admin(auth: &AuthExtension) -> Result<()> {
     auth.require_admin()
+}
+
+/// Map a `SyncStatus` to its wire label (snake_case, matching the DB enum).
+fn sync_status_label(status: SyncStatus) -> &'static str {
+    match status {
+        SyncStatus::Pending => "pending",
+        SyncStatus::InProgress => "in_progress",
+        SyncStatus::Completed => "completed",
+        SyncStatus::Failed => "failed",
+        SyncStatus::Cancelled => "cancelled",
+    }
 }
 
 fn parse_status(s: &str) -> Option<InstanceStatus> {
@@ -458,6 +476,10 @@ pub async fn get_sync_tasks(
             storage_key: t.storage_key,
             artifact_size: t.artifact_size,
             priority: t.priority,
+            // get_pending_sync_tasks only returns rows with status='pending'.
+            status: sync_status_label(t.status).to_string(),
+            created_at: t.created_at,
+            started_at: t.started_at,
         })
         .collect();
 
@@ -750,6 +772,39 @@ pub struct PeersApiDoc;
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // -----------------------------------------------------------------------
+    // sync_status_label tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sync_status_label_all_variants() {
+        assert_eq!(sync_status_label(SyncStatus::Pending), "pending");
+        assert_eq!(sync_status_label(SyncStatus::InProgress), "in_progress");
+        assert_eq!(sync_status_label(SyncStatus::Completed), "completed");
+        assert_eq!(sync_status_label(SyncStatus::Failed), "failed");
+        assert_eq!(sync_status_label(SyncStatus::Cancelled), "cancelled");
+    }
+
+    #[test]
+    fn test_sync_task_response_exposes_timestamps() {
+        // The replication-schedule e2e check reasons about task freshness via
+        // created_at; the response must serialize it.
+        let resp = SyncTaskResponse {
+            id: Uuid::nil(),
+            artifact_id: Uuid::nil(),
+            storage_key: "k".to_string(),
+            artifact_size: 1,
+            priority: 0,
+            status: "pending".to_string(),
+            created_at: chrono::Utc::now(),
+            started_at: None,
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert!(v.get("created_at").is_some());
+        assert!(v.get("status").is_some());
+        assert!(v.as_object().unwrap().contains_key("started_at"));
+    }
 
     // -----------------------------------------------------------------------
     // parse_status tests
@@ -1114,6 +1169,9 @@ mod tests {
             storage_key: "artifacts/maven/com/example/1.0/foo.jar".to_string(),
             artifact_size: 1024 * 1024,
             priority: 5,
+            status: "pending".to_string(),
+            created_at: chrono::Utc::now(),
+            started_at: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], id.to_string());
@@ -1124,6 +1182,7 @@ mod tests {
         );
         assert_eq!(json["artifact_size"], 1048576);
         assert_eq!(json["priority"], 5);
+        assert_eq!(json["status"], "pending");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -138,9 +138,41 @@ pub struct SyncTaskResponse {
     pub status: String,
     /// When the task was enqueued. Lets clients tell a freshly-scheduled task
     /// apart from a stale queue entry (used by the replication-schedule check).
+    /// Serialized as whole-second RFC3339 with a `Z` suffix
+    /// (e.g. `2026-05-29T12:34:56Z`) so simple ISO8601 parsers can consume it.
+    #[serde(serialize_with = "serialize_ts_secs")]
     pub created_at: chrono::DateTime<chrono::Utc>,
-    /// When the worker began transferring, if it has started.
+    /// When the worker began transferring, if it has started. Same format as
+    /// `created_at`.
+    #[serde(serialize_with = "serialize_opt_ts_secs")]
     pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Serialize a timestamp as whole-second RFC3339 with a `Z` suffix
+/// (e.g. `2026-05-29T12:34:56Z`). chrono's default RFC3339 includes
+/// fractional seconds and a `+00:00` offset, which strict ISO8601 parsers
+/// (jq's `fromdateiso8601`, some SDKs) reject.
+fn serialize_ts_secs<S>(
+    ts: &chrono::DateTime<chrono::Utc>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(&ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true))
+}
+
+fn serialize_opt_ts_secs<S>(
+    ts: &Option<chrono::DateTime<chrono::Utc>>,
+    serializer: S,
+) -> std::result::Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match ts {
+        Some(t) => serialize_ts_secs(t, serializer),
+        None => serializer.serialize_none(),
+    }
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -804,6 +836,33 @@ mod tests {
         assert!(v.get("created_at").is_some());
         assert!(v.get("status").is_some());
         assert!(v.as_object().unwrap().contains_key("started_at"));
+    }
+
+    #[test]
+    fn test_sync_task_created_at_serializes_whole_second_z() {
+        // jq's fromdateiso8601 (and strict ISO8601 parsers) only accept the
+        // whole-second `...Z` form. chrono's default RFC3339 (fractional secs,
+        // +00:00 offset) is rejected, so the field must use the second-precision
+        // Z serializer.
+        let ts = chrono::DateTime::parse_from_rfc3339("2026-05-29T12:34:56.123456789Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let resp = SyncTaskResponse {
+            id: Uuid::nil(),
+            artifact_id: Uuid::nil(),
+            storage_key: "k".to_string(),
+            artifact_size: 1,
+            priority: 0,
+            status: "pending".to_string(),
+            created_at: ts,
+            started_at: Some(ts),
+        };
+        let v = serde_json::to_value(&resp).unwrap();
+        assert_eq!(v["created_at"], "2026-05-29T12:34:56Z");
+        assert_eq!(v["started_at"], "2026-05-29T12:34:56Z");
+        // No fractional seconds, no numeric offset.
+        assert!(!v["created_at"].as_str().unwrap().contains('.'));
+        assert!(!v["created_at"].as_str().unwrap().contains('+'));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -629,6 +629,17 @@ async fn get_sbom_components(
 }
 
 /// Convert an SBOM to a different format
+///
+/// Returns the converted SBOM as a [`SbomContentResponse`]: the metadata
+/// row plus the full converted document under `content`. The `content` is
+/// load-bearing here. A consumer that asked for `target_format=spdx` needs
+/// the SPDX document (`content.spdxVersion`, `content.SPDXID`, ...) to feed
+/// downstream attestation tooling, and a `target_format=cyclonedx` request
+/// needs `content.bomFormat == "CycloneDX"`. Returning metadata-only
+/// (`SbomResponse`) dropped the converted document entirely, so callers
+/// could not tell an SPDX result from a CycloneDX one and round-trip
+/// conversion appeared to lose the document shape. (release-gate
+/// `test-sbom-convert.sh` 2.5.a / 2.5.b.)
 #[utoipa::path(
     post,
     path = "/{id}/convert",
@@ -639,7 +650,7 @@ async fn get_sbom_components(
     ),
     request_body = ConvertSbomRequest,
     responses(
-        (status = 200, description = "Converted SBOM", body = SbomResponse),
+        (status = 200, description = "Converted SBOM with content", body = SbomContentResponse),
         (status = 404, description = "SBOM not found", body = crate::api::openapi::ErrorResponse),
         (status = 422, description = "Validation error", body = crate::api::openapi::ErrorResponse),
     ),
@@ -650,13 +661,13 @@ async fn convert_sbom(
     Extension(_auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(body): Json<ConvertSbomRequest>,
-) -> Result<Json<SbomResponse>> {
+) -> Result<Json<SbomContentResponse>> {
     let service = SbomService::new(state.db.clone());
     let target_format = SbomFormat::parse(&body.target_format)
         .ok_or_else(|| AppError::Validation(format!("Unknown format: {}", body.target_format)))?;
 
     let doc = service.convert_sbom(id, target_format).await?;
-    Ok(Json(SbomResponse::from(doc)))
+    Ok(Json(SbomContentResponse::from(doc)))
 }
 
 // === CVE History ===
@@ -1558,6 +1569,91 @@ mod tests {
         let resp = SbomContentResponse::from(doc);
         assert_eq!(resp.content, content);
         assert_eq!(resp.content["components"][0]["name"], "serde");
+    }
+
+    /// Contract pinned by release-gate `test-sbom-convert.sh` 2.5.a: the
+    /// `/sbom/{id}/convert` response is a [`SbomContentResponse`], and when
+    /// the target format is SPDX the serialized body must expose the SPDX
+    /// document under `content` so the test's `.content.spdxVersion` /
+    /// `.content.SPDXID` reads resolve. The handler previously returned a
+    /// metadata-only `SbomResponse`, which carried neither field and made
+    /// every convert-to-SPDX call look like it dropped `spdxVersion`.
+    #[test]
+    fn test_convert_response_surfaces_spdx_content_keys() {
+        let now = Utc::now();
+        let spdx_content = serde_json::json!({
+            "spdxVersion": "SPDX-2.3",
+            "SPDXID": "SPDXRef-DOCUMENT",
+            "dataLicense": "CC0-1.0",
+            "name": "artifact-sbom",
+            "packages": []
+        });
+        let doc = SbomDocument {
+            id: Uuid::new_v4(),
+            artifact_id: Uuid::new_v4(),
+            repository_id: Uuid::new_v4(),
+            format: "spdx".to_string(),
+            format_version: "2.3".to_string(),
+            spec_version: Some("SPDX-2.3".to_string()),
+            content: spdx_content,
+            component_count: 0,
+            dependency_count: 0,
+            license_count: 0,
+            licenses: vec![],
+            content_hash: "hash".to_string(),
+            generator: None,
+            generator_version: None,
+            generated_at: now,
+            created_at: now,
+            updated_at: now,
+        };
+        // The handler builds exactly this from `convert_sbom`'s SbomDocument.
+        let resp = SbomContentResponse::from(doc);
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["content"]["spdxVersion"], "SPDX-2.3");
+        assert_eq!(json["content"]["SPDXID"], "SPDXRef-DOCUMENT");
+        // Metadata is flattened alongside content (id is load-bearing for the
+        // round-trip step, which converts the returned id back).
+        assert_eq!(json["format"], "spdx");
+        assert!(json["id"].is_string());
+    }
+
+    /// Contract pinned by release-gate `test-sbom-convert.sh` 2.5.b
+    /// (round-trip): converting back to CycloneDX must expose
+    /// `content.bomFormat == "CycloneDX"`. The metadata-only response had no
+    /// `content`, so the reverse conversion read an empty `bomFormat`.
+    #[test]
+    fn test_convert_response_surfaces_cyclonedx_bom_format() {
+        let now = Utc::now();
+        let cdx_content = serde_json::json!({
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "components": []
+        });
+        let doc = SbomDocument {
+            id: Uuid::new_v4(),
+            artifact_id: Uuid::new_v4(),
+            repository_id: Uuid::new_v4(),
+            format: "cyclonedx".to_string(),
+            format_version: "1.5".to_string(),
+            spec_version: Some("CycloneDX 1.5".to_string()),
+            content: cdx_content,
+            component_count: 0,
+            dependency_count: 0,
+            license_count: 0,
+            licenses: vec![],
+            content_hash: "hash".to_string(),
+            generator: None,
+            generator_version: None,
+            generated_at: now,
+            created_at: now,
+            updated_at: now,
+        };
+        let resp = SbomContentResponse::from(doc);
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["content"]["bomFormat"], "CycloneDX");
+        assert_eq!(json["format"], "cyclonedx");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/sync_policies.rs
+++ b/backend/src/api/handlers/sync_policies.rs
@@ -78,6 +78,10 @@ pub struct SyncPolicyResponse {
     pub priority: i32,
     #[schema(value_type = Object)]
     pub artifact_filter: serde_json::Value,
+    /// Convenience glob filter, mirrored from `artifact_filter.include_paths`.
+    /// Round-trips the single-pattern shorthand accepted on create
+    /// (e.g. `"*.tar.gz"`). Empty when no include pattern is set.
+    pub filter: String,
     pub precedence: i32,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
@@ -109,6 +113,12 @@ pub struct CreateSyncPolicyPayload {
     #[schema(value_type = Object)]
     #[serde(default)]
     pub artifact_filter: Option<serde_json::Value>,
+    /// Convenience glob filter (e.g. `"*.tar.gz"`). When set, it is folded
+    /// into `artifact_filter.include_paths` so only matching artifact paths
+    /// are eligible for sync. Ignored if `artifact_filter.include_paths` is
+    /// already provided.
+    #[serde(default)]
+    pub filter: Option<String>,
     #[serde(default = "default_precedence")]
     pub precedence: i32,
 }
@@ -257,7 +267,40 @@ fn default_precedence() -> i32 {
 // Converters
 // ---------------------------------------------------------------------------
 
+/// Fold a convenience glob `filter` into an artifact_filter JSON value's
+/// `include_paths`. If the caller already supplied `include_paths`, the
+/// explicit value wins and the shorthand is ignored.
+///
+/// Returns the (possibly modified) artifact_filter as parsed `ArtifactFilter`.
+fn apply_filter_shorthand(
+    artifact_filter: ArtifactFilter,
+    filter: Option<String>,
+) -> ArtifactFilter {
+    match filter {
+        Some(glob) if !glob.trim().is_empty() && artifact_filter.include_paths.is_empty() => {
+            ArtifactFilter {
+                include_paths: vec![glob],
+                ..artifact_filter
+            }
+        }
+        _ => artifact_filter,
+    }
+}
+
+/// Extract the convenience `filter` string from a stored artifact_filter
+/// JSON value. Mirrors the first `include_paths` entry, or "" when absent.
+fn filter_shorthand_from_value(artifact_filter: &serde_json::Value) -> String {
+    artifact_filter
+        .get("include_paths")
+        .and_then(|v| v.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
 fn policy_to_response(p: SyncPolicy) -> SyncPolicyResponse {
+    let filter = filter_shorthand_from_value(&p.artifact_filter);
     SyncPolicyResponse {
         id: p.id,
         name: p.name,
@@ -268,6 +311,7 @@ fn policy_to_response(p: SyncPolicy) -> SyncPolicyResponse {
         replication_mode: p.replication_mode,
         priority: p.priority,
         artifact_filter: p.artifact_filter,
+        filter,
         precedence: p.precedence,
         created_at: p.created_at,
         updated_at: p.updated_at,
@@ -388,6 +432,7 @@ async fn create_policy(
     let repo_selector: RepoSelector = parse_selector(payload.repo_selector)?;
     let peer_selector: PeerSelector = parse_selector(payload.peer_selector)?;
     let artifact_filter: ArtifactFilter = parse_selector(payload.artifact_filter)?;
+    let artifact_filter = apply_filter_shorthand(artifact_filter, payload.filter);
 
     let req = CreateSyncPolicyRequest {
         name: payload.name,
@@ -625,6 +670,49 @@ async fn preview_policy(
 mod tests {
     use super::*;
 
+    /// DB-backed round-trip: create a policy with the convenience `filter`
+    /// glob, then read it back and confirm the glob survives via the
+    /// `filter` field (folded into and extracted from artifact_filter).
+    ///
+    /// Requires a migrated PostgreSQL at `DATABASE_URL`. Run with:
+    ///   DATABASE_URL=postgres://... cargo test --lib \
+    ///     api::handlers::sync_policies::tests::filter_round_trip -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn filter_round_trip_through_service() {
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let db = sqlx::PgPool::connect(&url).await.unwrap();
+        let svc = SyncPolicyService::new(db);
+
+        // Mirror the handler's create path: fold the shorthand into artifact_filter.
+        let artifact_filter =
+            apply_filter_shorthand(ArtifactFilter::default(), Some("*.tar.gz".to_string()));
+        let req = crate::services::sync_policy_service::CreateSyncPolicyRequest {
+            name: format!("filter-rt-{}", uuid::Uuid::new_v4()),
+            description: String::new(),
+            enabled: true,
+            repo_selector: RepoSelector::default(),
+            peer_selector: PeerSelector::default(),
+            replication_mode: "push".to_string(),
+            priority: 0,
+            artifact_filter,
+            precedence: 100,
+        };
+        let created = svc.create_policy(req).await.unwrap();
+
+        // Read back and surface the response (mirrors GET handler).
+        let fetched = svc.get_policy(created.id).await.unwrap();
+        let resp = policy_to_response(fetched);
+        assert_eq!(resp.filter, "*.tar.gz", "filter glob must round-trip");
+        assert_eq!(
+            resp.artifact_filter["include_paths"][0], "*.tar.gz",
+            "glob must persist in artifact_filter.include_paths"
+        );
+
+        // Cleanup.
+        svc.delete_policy(created.id).await.unwrap();
+    }
+
     #[test]
     fn test_create_payload_deserialization_minimal() {
         let json = r#"{"name": "test-policy"}"#;
@@ -691,6 +779,76 @@ mod tests {
     }
 
     #[test]
+    fn test_filter_shorthand_folded_into_include_paths() {
+        let af = apply_filter_shorthand(ArtifactFilter::default(), Some("*.tar.gz".to_string()));
+        assert_eq!(af.include_paths, vec!["*.tar.gz".to_string()]);
+    }
+
+    #[test]
+    fn test_filter_shorthand_ignored_when_blank() {
+        let af = apply_filter_shorthand(ArtifactFilter::default(), Some("   ".to_string()));
+        assert!(af.include_paths.is_empty());
+        let af = apply_filter_shorthand(ArtifactFilter::default(), None);
+        assert!(af.include_paths.is_empty());
+    }
+
+    #[test]
+    fn test_filter_shorthand_explicit_include_paths_win() {
+        let explicit = ArtifactFilter {
+            include_paths: vec!["release/*".to_string()],
+            ..Default::default()
+        };
+        // Shorthand must not clobber an explicit include_paths.
+        let af = apply_filter_shorthand(explicit, Some("*.tar.gz".to_string()));
+        assert_eq!(af.include_paths, vec!["release/*".to_string()]);
+    }
+
+    #[test]
+    fn test_filter_shorthand_roundtrip_from_value() {
+        // Create-side fold, then read-side extract -> the glob survives.
+        let af = apply_filter_shorthand(ArtifactFilter::default(), Some("*.tar.gz".to_string()));
+        let stored = serde_json::to_value(&af).unwrap();
+        assert_eq!(filter_shorthand_from_value(&stored), "*.tar.gz");
+    }
+
+    #[test]
+    fn test_filter_shorthand_from_empty_value() {
+        assert_eq!(filter_shorthand_from_value(&serde_json::json!({})), "");
+        assert_eq!(
+            filter_shorthand_from_value(&serde_json::json!({"include_paths": []})),
+            ""
+        );
+    }
+
+    #[test]
+    fn test_create_payload_accepts_filter_field() {
+        let json = r#"{"name":"f","filter":"*.tar.gz","schedule":"manual","direction":"push"}"#;
+        let payload: CreateSyncPolicyPayload = serde_json::from_str(json).unwrap();
+        // Unknown fields (schedule, direction) are ignored; filter is captured.
+        assert_eq!(payload.filter.as_deref(), Some("*.tar.gz"));
+    }
+
+    #[test]
+    fn test_policy_to_response_surfaces_filter() {
+        let policy = SyncPolicy {
+            id: uuid::Uuid::nil(),
+            name: "t".to_string(),
+            description: String::new(),
+            enabled: true,
+            repo_selector: serde_json::json!({}),
+            peer_selector: serde_json::json!({}),
+            replication_mode: "push".to_string(),
+            priority: 0,
+            artifact_filter: serde_json::json!({"include_paths": ["*.tar.gz"]}),
+            precedence: 100,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let resp = policy_to_response(policy);
+        assert_eq!(resp.filter, "*.tar.gz");
+    }
+
+    #[test]
     fn test_policy_to_response_mapping() {
         let policy = SyncPolicy {
             id: uuid::Uuid::nil(),
@@ -724,6 +882,7 @@ mod tests {
             replication_mode: "push".to_string(),
             priority: 0,
             artifact_filter: serde_json::json!({}),
+            filter: String::new(),
             precedence: 100,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -880,6 +1039,7 @@ mod tests {
             replication_mode: "push".to_string(),
             priority: 0,
             artifact_filter: serde_json::json!({}),
+            filter: String::new(),
             precedence: 100,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
@@ -895,6 +1055,7 @@ mod tests {
             "replication_mode",
             "priority",
             "artifact_filter",
+            "filter",
             "precedence",
             "created_at",
             "updated_at",
@@ -905,6 +1066,6 @@ mod tests {
             );
         }
         let obj = json.as_object().unwrap();
-        assert_eq!(obj.len(), 12, "SyncPolicyResponse should have 12 fields");
+        assert_eq!(obj.len(), 13, "SyncPolicyResponse should have 13 fields");
     }
 }

--- a/backend/src/services/peer_instance_service.rs
+++ b/backend/src/services/peer_instance_service.rs
@@ -799,6 +799,92 @@ mod tests {
     use super::*;
     use chrono::Duration;
 
+    /// DB-backed: a queued sync task must surface a populated `created_at`
+    /// through `get_pending_sync_tasks`, so callers can tell a freshly
+    /// scheduled task from a stale queue entry. (Backs the replication-schedule
+    /// e2e check, which keys on task timestamp recency.)
+    ///
+    /// Requires a migrated PostgreSQL at `DATABASE_URL`. Run with:
+    ///   DATABASE_URL=postgres://... cargo test --lib \
+    ///     services::peer_instance_service::tests::pending_task_exposes_created_at -- --ignored
+    #[tokio::test]
+    #[ignore]
+    async fn pending_task_exposes_created_at() {
+        let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+        let db = sqlx::PgPool::connect(&url).await.unwrap();
+
+        let suffix = Uuid::new_v4();
+        // Minimal repo.
+        let repo_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO repositories (key, name, format, repo_type, storage_path) \
+             VALUES ($1, $1, 'generic', 'local', $1) RETURNING id",
+        )
+        .bind(format!("ptask-repo-{suffix}"))
+        .fetch_one(&db)
+        .await
+        .unwrap();
+
+        // Minimal artifact in that repo.
+        let artifact_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO artifacts (repository_id, name, path, storage_key, size_bytes, \
+             content_type, checksum_sha256) \
+             VALUES ($1, 'marker.txt', 'sched/marker.txt', $2, 12, 'text/plain', $3) RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(format!("storage/{suffix}"))
+        .bind(format!("{:064x}", 1))
+        .fetch_one(&db)
+        .await
+        .unwrap();
+
+        // Non-local online peer.
+        let svc = PeerInstanceService::new(db.clone());
+        let peer = svc
+            .register(RegisterPeerInstanceRequest {
+                name: format!("ptask-peer-{suffix}"),
+                endpoint_url: "http://127.0.0.1:65535".to_string(),
+                region: None,
+                cache_size_bytes: 0,
+                sync_filter: None,
+                api_key: "k".to_string(),
+            })
+            .await
+            .unwrap();
+
+        let before = chrono::Utc::now() - chrono::Duration::seconds(5);
+        svc.queue_sync_task(peer.id, artifact_id, 0).await.unwrap();
+
+        let tasks = svc.get_pending_sync_tasks(peer.id, 50).await.unwrap();
+        assert_eq!(tasks.len(), 1, "queued task must be listed");
+        assert!(
+            tasks[0].created_at >= before,
+            "created_at must be populated and recent (got {})",
+            tasks[0].created_at
+        );
+
+        // Cleanup (FK cascade order).
+        sqlx::query("DELETE FROM sync_tasks WHERE peer_instance_id = $1")
+            .bind(peer.id)
+            .execute(&db)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+            .bind(peer.id)
+            .execute(&db)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM artifacts WHERE id = $1")
+            .bind(artifact_id)
+            .execute(&db)
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&db)
+            .await
+            .unwrap();
+    }
+
     // -----------------------------------------------------------------------
     // Pure helper functions (moved from module scope — test-only)
     // -----------------------------------------------------------------------

--- a/backend/src/services/sync_worker.rs
+++ b/backend/src/services/sync_worker.rs
@@ -72,6 +72,30 @@ pub(crate) fn failover_detection_deadline_secs(
 /// Duration of each worker tick in seconds.
 const TICK_INTERVAL_SECS: u64 = 10;
 
+/// Default per-peer TCP connect timeout (seconds) for sync transfers.
+///
+/// Bounds how long a single transfer waits to establish a connection to a
+/// peer. Without this, a peer whose endpoint black-holes connections (firewall
+/// DROP, dead host) would hold a transfer slot for the full request timeout
+/// (300s). In a fan-out to multiple peers, that unreachable peer would then
+/// occupy one of its own concurrency slots for minutes. Capping the connect
+/// phase lets the worker fail the broken leg quickly and retry under backoff,
+/// while healthy peers (separate tasks) are unaffected.
+///
+/// Override with `SYNC_PEER_CONNECT_TIMEOUT_SECS` (positive integer).
+const DEFAULT_PEER_CONNECT_TIMEOUT_SECS: u64 = 10;
+
+/// Read the configured per-peer connect timeout from
+/// `SYNC_PEER_CONNECT_TIMEOUT_SECS`, falling back to
+/// `DEFAULT_PEER_CONNECT_TIMEOUT_SECS`. Non-positive values are rejected.
+pub(crate) fn peer_connect_timeout_secs() -> u64 {
+    std::env::var("SYNC_PEER_CONNECT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_PEER_CONNECT_TIMEOUT_SECS)
+}
+
 /// Default threshold (in bytes) above which chunked transfer is used instead
 /// of a single-request upload.  100 MB.
 /// Override with the `SYNC_CHUNKED_THRESHOLD_BYTES` env var.
@@ -125,8 +149,13 @@ pub async fn spawn_sync_worker(db: PgPool) {
         // Small startup delay so the server can finish initializing.
         tokio::time::sleep(Duration::from_secs(5)).await;
         let mut tick = interval(Duration::from_secs(TICK_INTERVAL_SECS));
+        let connect_timeout = peer_connect_timeout_secs();
         let client = crate::services::http_client::base_client_builder()
             .timeout(Duration::from_secs(300))
+            // Bound the connect phase so an unreachable peer in a fan-out
+            // fails fast instead of holding a transfer slot for the full
+            // request timeout.
+            .connect_timeout(Duration::from_secs(connect_timeout))
             .build()
             .expect("Failed to build HTTP client for sync worker");
 
@@ -2564,5 +2593,35 @@ mod tests {
     fn test_sync_chunk_size_bytes_default() {
         let val = DEFAULT_SYNC_CHUNK_SIZE_BYTES;
         assert_eq!(val, 52_428_800);
+    }
+
+    // ── peer_connect_timeout_secs ───────────────────────────────────────
+
+    #[test]
+    fn test_peer_connect_timeout_default_is_bounded() {
+        // The default must be small relative to the 300s request timeout so a
+        // black-holed peer in a fan-out cannot hold a transfer slot for long.
+        assert_eq!(DEFAULT_PEER_CONNECT_TIMEOUT_SECS, 10);
+        assert!(DEFAULT_PEER_CONNECT_TIMEOUT_SECS < 300);
+    }
+
+    #[test]
+    fn test_peer_connect_timeout_env_override() {
+        // Guarded against parallel env mutation by using a unique read path:
+        // set, read, clear. Other tests don't touch this var.
+        std::env::set_var("SYNC_PEER_CONNECT_TIMEOUT_SECS", "3");
+        assert_eq!(peer_connect_timeout_secs(), 3);
+        std::env::set_var("SYNC_PEER_CONNECT_TIMEOUT_SECS", "0");
+        // Non-positive is rejected, falls back to default.
+        assert_eq!(
+            peer_connect_timeout_secs(),
+            DEFAULT_PEER_CONNECT_TIMEOUT_SECS
+        );
+        std::env::set_var("SYNC_PEER_CONNECT_TIMEOUT_SECS", "notanumber");
+        assert_eq!(
+            peer_connect_timeout_secs(),
+            DEFAULT_PEER_CONNECT_TIMEOUT_SECS
+        );
+        std::env::remove_var("SYNC_PEER_CONNECT_TIMEOUT_SECS");
     }
 }

--- a/backend/src/services/sync_worker.rs
+++ b/backend/src/services/sync_worker.rs
@@ -2601,8 +2601,8 @@ mod tests {
     fn test_peer_connect_timeout_default_is_bounded() {
         // The default must be small relative to the 300s request timeout so a
         // black-holed peer in a fan-out cannot hold a transfer slot for long.
+        // Pins the exact default; 10 is well under the 300s request timeout.
         assert_eq!(DEFAULT_PEER_CONNECT_TIMEOUT_SECS, 10);
-        assert!(DEFAULT_PEER_CONNECT_TIMEOUT_SECS < 300);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Wave-2 E2E triage of gate run 26616763325. Four backend defects across the SBOM and mesh suites, each verified against a live local backend (SBOM) or DB-backed integration test (mesh).

## Fixes
- **SBOM convert** (`handlers/sbom.rs`): `POST /sbom/{id}/convert` returned a metadata-only projection, discarding the converted document the service already builds. Now returns `SbomContentResponse` with `.content` populated. Live-verified: CDX->SPDX yields `content.spdxVersion=SPDX-2.3`, round-trip yields `content.bomFormat=CycloneDX`. +2 unit tests.
- **Mesh replication scheduler** (`handlers/peers.rs`): `SyncTaskResponse` dropped `created_at`/`started_at`, so the test's window poll could never pass; and chrono's fractional-second RFC3339 broke jq's `fromdateiso8601`. Added the timestamps + a whole-second `Z` serializer. DB-verified.
- **Mesh sync-filter** (`handlers/sync_policies.rs`): contract mismatch (test POSTs a flat `filter` glob; backend only accepted nested `artifact_filter`). Now folds a flat `filter` into `include_paths` and echoes it back. Persists in the existing JSONB column, no migration. DB-verified.
- **Mesh peer-failover** (`services/sync_worker.rs`): worker HTTP client had no connect timeout, so a black-holing peer held a transfer slot for the full 300s. Added a bounded `connect_timeout` (default 10s, `SYNC_PEER_CONNECT_TIMEOUT_SECS`). Fan-out dispatch was already non-blocking (per-peer `tokio::spawn`); full multi-peer delivery is not locally verifiable.

## Test plan
- [x] cargo fmt --check
- [x] cargo clippy --lib (clean)
- [x] sbom convert/components scripts pass against live backend
- [x] mesh DB-backed tests (sync-task timestamps, filter round-trip) pass
- [ ] Release Gate re-run after dev rebuild

Test-side companion: artifact-keeper-test #219 (SBOM components graceful-skip).

Closes #1484