### PR TITLE
fix(composer): populate packages table on upload so WebUI lists them

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -864,6 +864,30 @@ async fn upload(
     .execute(&state.db)
     .await;
 
+    // Populate packages / package_versions tables (best-effort).
+    //
+    // #1341: the WebUI Packages tab reads the `packages` table, not
+    // `artifacts`. Every other artifact-publishing handler (npm, pypi,
+    // nuget) calls PackageService after the artifact insert; the Composer
+    // handler did not, so a successfully uploaded Composer package was
+    // stored and served over the Composer wire protocol but never appeared
+    // in the WebUI. Mirror the npm/pypi pattern here. The call is
+    // fire-and-forget so a packages-table failure never blocks the upload.
+    {
+        let pkg_svc = crate::services::package_service::PackageService::new(state.db.clone());
+        pkg_svc
+            .try_create_or_update_from_artifact(
+                repo.id,
+                full_name,
+                &version,
+                size_bytes,
+                &sha256,
+                composer_json.description.as_deref(),
+                Some(serde_json::json!({ "format": "composer" })),
+            )
+            .await;
+    }
+
     info!(
         "Composer upload: {} {} to repo {}",
         full_name, version, repo_key

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1570,3 +1570,338 @@ mod tests {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// DB-backed router tests for the packages-index population added in
+// fix/1341-composer-webui-packages:
+//
+// After a successful Composer upload, the handler calls
+// `PackageService::try_create_or_update_from_artifact` so the package
+// surfaces in the WebUI Packages tab (which reads the `packages` table,
+// not `artifacts`). Before this fix, Composer was the only publishing
+// handler that did not populate `packages` / `package_versions`.
+//
+// These tests rely on `DATABASE_URL` being set. CI seeds + migrates a
+// Postgres before running `cargo llvm-cov --lib`, so they execute there
+// and cover the new lib lines in `upload`. In local environments without
+// a database they no-op cleanly via `tdh::Fixture::setup` returning None.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod upload_db_tests {
+    use crate::api::handlers::test_db_helpers as tdh;
+    use std::io::Write;
+
+    /// Build a minimal valid Composer package archive: a zip with a single
+    /// `composer.json` entry carrying the required fields. Stored (no
+    /// compression) so the tiny payload doesn't pay the deflate cost.
+    fn build_composer_zip(name: &str, version: &str, description: &str) -> Vec<u8> {
+        let composer_json = serde_json::json!({
+            "name": name,
+            "version": version,
+            "description": description,
+            "type": "library",
+            "license": "MIT",
+        });
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut cursor);
+            let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            zip.start_file("composer.json", options)
+                .expect("start composer.json");
+            zip.write_all(serde_json::to_string(&composer_json).unwrap().as_bytes())
+                .expect("write composer.json");
+            zip.finish().expect("finish zip");
+        }
+        cursor.into_inner()
+    }
+
+    /// Build a PUT request shaped like a real Composer publish.
+    fn put_composer(uri: String, zip_bytes: Vec<u8>) -> axum::http::Request<axum::body::Body> {
+        axum::http::Request::builder()
+            .method("PUT")
+            .uri(uri)
+            .header("content-type", "application/zip")
+            .body(axum::body::Body::from(zip_bytes))
+            .expect("build PUT request")
+    }
+
+    // -----------------------------------------------------------------------
+    // Happy path: a Composer upload populates the `packages` table with the
+    // description from composer.json and the `format: composer` metadata
+    // tag, AND inserts the matching `package_versions` row keyed by the
+    // package id. This is the new lib code path the coverage gate watches.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_populates_packages_index_with_description() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        let name = "acme/widget";
+        let version = "1.2.3";
+        let description = "An indexed Composer package (#1341)";
+        let zip = build_composer_zip(name, version, description);
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "expected 2xx for Composer upload, got {}: {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        // The artifact row was already correct pre-fix.
+        let artifact_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::bigint FROM artifacts \
+             WHERE repository_id = $1 AND name = $2 AND version = $3 AND is_deleted = false",
+        )
+        .bind(f.repo_id)
+        .bind(name)
+        .bind(version)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query artifacts");
+        assert_eq!(
+            artifact_count.0, 1,
+            "exactly one artifact row expected after upload"
+        );
+
+        // The regression assertion: the packages row must exist with the
+        // description folded from composer.json and the format-tag metadata
+        // the handler passes to PackageService.
+        let row: Option<(String, Option<String>, Option<serde_json::Value>)> = sqlx::query_as(
+            "SELECT name, description, metadata FROM packages \
+             WHERE repository_id = $1 AND name = $2 AND version = $3",
+        )
+        .bind(f.repo_id)
+        .bind(name)
+        .bind(version)
+        .fetch_optional(&f.pool)
+        .await
+        .expect("query packages");
+
+        let (pkg_name, desc, meta) = row.expect("packages row must exist after Composer upload");
+        assert_eq!(pkg_name, name);
+        assert_eq!(
+            desc.as_deref(),
+            Some(description),
+            "composer.json description must be persisted to packages.description"
+        );
+        let meta = meta.expect("metadata must be set");
+        assert_eq!(
+            meta["format"], "composer",
+            "handler passes {{format: composer}} to PackageService"
+        );
+
+        // package_versions UPSERTed by PackageService.
+        let version_count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::bigint FROM package_versions pv \
+             JOIN packages p ON p.id = pv.package_id \
+             WHERE p.repository_id = $1 AND p.name = $2 AND pv.version = $3",
+        )
+        .bind(f.repo_id)
+        .bind(name)
+        .bind(version)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query package_versions");
+        assert_eq!(
+            version_count.0, 1,
+            "exactly one package_versions row expected after a single upload"
+        );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // composer.json without a `description` key: the handler passes
+    // `composer_json.description.as_deref()` (== None) into
+    // `try_create_or_update_from_artifact`, which must land as NULL in the
+    // packages table (COALESCE keeps existing NULL on conflict).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_packages_index_missing_description_maps_to_null() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // No `description` field in the composer.json.
+        let composer_json = serde_json::json!({
+            "name": "acme/no-desc",
+            "version": "0.1.0",
+            "type": "library",
+            "license": "MIT",
+        });
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut cursor);
+            let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            zip.start_file("composer.json", options).unwrap();
+            zip.write_all(serde_json::to_string(&composer_json).unwrap().as_bytes())
+                .unwrap();
+            zip.finish().unwrap();
+        }
+        let zip_bytes = cursor.into_inner();
+
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages", f.repo_key), zip_bytes);
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "upload without description must still succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let row: Option<(Option<String>,)> = sqlx::query_as(
+            "SELECT description FROM packages \
+             WHERE repository_id = $1 AND name = $2 AND version = $3",
+        )
+        .bind(f.repo_id)
+        .bind("acme/no-desc")
+        .bind("0.1.0")
+        .fetch_optional(&f.pool)
+        .await
+        .expect("query packages");
+
+        let (desc,) = row.expect("packages row must exist even without description");
+        assert!(
+            desc.is_none(),
+            "missing composer.json description must fold to NULL, got {:?}",
+            desc
+        );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // composer.json without `version`: the handler defaults to `dev-main`
+    // (see `composer_json.version.as_deref().unwrap_or("dev-main")`). The
+    // packages-index row must use that resolved version so the WebUI lists
+    // the package as a dev branch rather than dropping it. Covers the
+    // `&version` argument the new code passes after the fallback resolves.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_default_version_indexed_as_dev_main() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // No `version` field: the handler should fall back to "dev-main".
+        let composer_json = serde_json::json!({
+            "name": "acme/dev-pkg",
+            "description": "dev-branch package",
+            "type": "library",
+            "license": "MIT",
+        });
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut zip = zip::ZipWriter::new(&mut cursor);
+            let options: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            zip.start_file("composer.json", options).unwrap();
+            zip.write_all(serde_json::to_string(&composer_json).unwrap().as_bytes())
+                .unwrap();
+            zip.finish().unwrap();
+        }
+        let zip_bytes = cursor.into_inner();
+
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages", f.repo_key), zip_bytes);
+        let (status, _) = tdh::send(app, req).await;
+        assert!(status.is_success(), "upload must succeed: {}", status);
+
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT version FROM packages \
+             WHERE repository_id = $1 AND name = $2",
+        )
+        .bind(f.repo_id)
+        .bind("acme/dev-pkg")
+        .fetch_optional(&f.pool)
+        .await
+        .expect("query packages");
+
+        let (ver,) = row.expect("packages row must exist for default-version upload");
+        assert_eq!(
+            ver, "dev-main",
+            "missing composer.json version must index as dev-main"
+        );
+
+        // And the matching package_versions row carries the resolved
+        // `&sha256` checksum (non-empty hex string) the handler passed.
+        let checksum: (String,) = sqlx::query_as(
+            "SELECT pv.checksum_sha256 FROM package_versions pv \
+             JOIN packages p ON p.id = pv.package_id \
+             WHERE p.repository_id = $1 AND p.name = $2 AND pv.version = $3",
+        )
+        .bind(f.repo_id)
+        .bind("acme/dev-pkg")
+        .bind("dev-main")
+        .fetch_one(&f.pool)
+        .await
+        .expect("query package_versions checksum");
+        assert_eq!(
+            checksum.0.len(),
+            64,
+            "package_versions.checksum_sha256 must be a 64-char hex digest"
+        );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // POST verb: composer's upload route is `put(upload).post(upload)`, so
+    // a POST publish must follow the same code path and end up in the
+    // packages index too. Guards against a future refactor that drops the
+    // POST handler and silently regresses CI clients that publish with
+    // POST.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_via_post_also_populates_packages_index() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        let name = "acme/postpkg";
+        let version = "2.0.0";
+        let zip = build_composer_zip(name, version, "posted via POST");
+        let app = f.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/{}/api/packages", f.repo_key))
+            .header("content-type", "application/zip")
+            .body(axum::body::Body::from(zip))
+            .expect("build POST request");
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "POST publish must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let row: Option<(String, i64)> = sqlx::query_as(
+            "SELECT name, size_bytes FROM packages \
+             WHERE repository_id = $1 AND name = $2 AND version = $3",
+        )
+        .bind(f.repo_id)
+        .bind(name)
+        .bind(version)
+        .fetch_optional(&f.pool)
+        .await
+        .expect("query packages");
+        let (got_name, size) = row.expect("packages row must exist after POST publish");
+        assert_eq!(got_name, name);
+        assert!(
+            size > 0,
+            "size_bytes must be the archive length the handler passed, got {}",
+            size
+        );
+
+        f.teardown().await;
+    }
+}

--- a/backend/tests/composer_packages_index_tests.rs
+++ b/backend/tests/composer_packages_index_tests.rs
@@ -1,0 +1,395 @@
+//! Integration test for #1341: Composer (PHP) uploads must appear in the
+//! WebUI Packages tab.
+//!
+//! The WebUI Packages tab is backed by the `/api/v1/packages` list endpoint,
+//! which reads the `packages` table (NOT `artifacts`). Before the fix, the
+//! Composer upload handler inserted into `artifacts` + `artifact_metadata`
+//! but never called `PackageService`, so a successfully published Composer
+//! package was served over the Composer wire protocol yet never showed up in
+//! the WebUI. npm / pypi / nuget all call `PackageService` after their
+//! artifact insert; Composer did not.
+//!
+//! This test publishes a Composer package over the real Composer wire
+//! protocol, then queries the same `list_packages` handler the WebUI uses and
+//! asserts the package is listed.
+//!
+//! Requires a PostgreSQL database with migrations applied:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test composer_packages_index_tests -- --ignored
+//! ```
+
+use std::io::Write;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sqlx::{PgPool, Row};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::{composer, packages};
+use artifact_keeper_backend::api::middleware::auth::optional_auth_middleware;
+use artifact_keeper_backend::api::{AppState, SharedState};
+use artifact_keeper_backend::config::Config;
+use artifact_keeper_backend::services::auth_service::AuthService;
+
+// ===========================================================================
+// Test helpers
+// ===========================================================================
+
+fn test_config(storage_path: &str) -> Config {
+    Config {
+        database_url: std::env::var("DATABASE_URL").unwrap(),
+        bind_address: "127.0.0.1:0".into(),
+        log_level: "error".into(),
+        storage_backend: "filesystem".into(),
+        storage_path: storage_path.into(),
+        s3_bucket: None,
+        gcs_bucket: None,
+        s3_region: None,
+        s3_endpoint: None,
+        jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+        jwt_expiration_secs: 86400,
+        jwt_access_token_expiry_minutes: 30,
+        jwt_refresh_token_expiry_days: 7,
+        oidc_issuer: None,
+        oidc_client_id: None,
+        oidc_client_secret: None,
+        ldap_url: None,
+        ldap_base_dn: None,
+        trivy_url: None,
+        openscap_url: None,
+        openscap_profile: "standard".into(),
+        opensearch_url: None,
+        opensearch_username: None,
+        opensearch_password: None,
+        opensearch_allow_invalid_certs: false,
+        scan_workspace_path: "/tmp/scan".into(),
+        demo_mode: false,
+        guest_access_enabled: true,
+        peer_instance_name: "test".into(),
+        peer_public_endpoint: "http://localhost:8080".into(),
+        peer_api_key: "test-key".into(),
+        dependency_track_url: None,
+        otel_exporter_otlp_endpoint: None,
+        otel_service_name: "test".into(),
+        gc_schedule: "0 0 * * * *".into(),
+        lifecycle_check_interval_secs: 60,
+        stuck_scan_threshold_secs: 1800,
+        stuck_scan_check_interval_secs: 600,
+        stuck_scan_reap_limit: 1000,
+        allow_local_admin_login: false,
+        max_upload_size_bytes: 10_737_418_240,
+        metrics_port: None,
+        database_max_connections: 20,
+        database_min_connections: 5,
+        database_acquire_timeout_secs: 30,
+        database_idle_timeout_secs: 600,
+        database_max_lifetime_secs: 1800,
+        auth_max_concurrency: 8,
+        rate_limit_auth_per_window: 120,
+        rate_limit_api_per_window: 5000,
+        rate_limit_search_per_window: 300,
+        rate_limit_presign_per_window: 30,
+        rate_limit_password_change_per_window: 5,
+        rate_limit_password_change_window_secs: 900,
+        rate_limit_window_secs: 60,
+        rate_limit_exempt_usernames: Vec::new(),
+        rate_limit_exempt_service_accounts: false,
+        rate_limit_trusted_cidrs: Vec::new(),
+        account_lockout_threshold: 5,
+        account_lockout_duration_minutes: 30,
+        quarantine_enabled: false,
+        quarantine_duration_minutes: 60,
+        password_history_count: 0,
+        password_expiry_days: 0,
+        password_expiry_warning_days: vec![14, 7, 1],
+        password_expiry_check_interval_secs: 3600,
+        password_min_length: 8,
+        password_max_length: 128,
+        password_require_uppercase: false,
+        password_require_lowercase: false,
+        password_require_digit: false,
+        password_require_special: false,
+        password_min_strength: 0,
+        presigned_downloads_enabled: false,
+        presigned_download_expiry_secs: 300,
+        smtp_host: None,
+        smtp_port: 587,
+        smtp_username: None,
+        smtp_password: None,
+        smtp_from_address: "noreply@artifact-keeper.local".to_string(),
+        smtp_tls_mode: "starttls".to_string(),
+    }
+}
+
+fn basic_auth_header(username: &str, password: &str) -> String {
+    use base64::Engine;
+    let encoded =
+        base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", username, password));
+    format!("Basic {}", encoded)
+}
+
+/// Create a test user with bcrypt-hashed password.
+async fn create_test_user(pool: &PgPool, username: &str, password: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash = bcrypt::hash(password, 4).expect("bcrypt hash failed"); // cost=4 for speed in tests
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active)
+        VALUES ($1, $2, $3, $4, 'local', true, true)
+        "#,
+    )
+    .bind(id)
+    .bind(username)
+    .bind(format!("{}@test.local", username))
+    .bind(&hash)
+    .execute(pool)
+    .await
+    .expect("failed to create test user");
+    id
+}
+
+/// Create a public hosted Composer repository. Returns (repo_id, repo_key, storage_path).
+async fn create_composer_repo(pool: &PgPool) -> (Uuid, String, std::path::PathBuf) {
+    let id = Uuid::new_v4();
+    let key = format!("composer-test-{}", id);
+    let storage_path = std::env::temp_dir().join(format!("composer-test-{}", id));
+    std::fs::create_dir_all(&storage_path).expect("create storage dir");
+
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+         VALUES ($1, $2, $3, $4, 'local', 'composer', true)",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind("composer-index-test")
+    .bind(storage_path.to_string_lossy().as_ref())
+    .execute(pool)
+    .await
+    .expect("failed to create test repository");
+
+    (id, key, storage_path)
+}
+
+/// Build a minimal Composer package zip archive containing a composer.json.
+fn build_composer_zip(name: &str, version: &str, description: &str) -> Vec<u8> {
+    let composer_json = serde_json::json!({
+        "name": name,
+        "version": version,
+        "description": description,
+        "type": "library",
+        "license": "MIT",
+    });
+
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut cursor);
+        let options: zip::write::FileOptions<'_, ()> =
+            zip::write::FileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        zip.start_file("composer.json", options)
+            .expect("start composer.json");
+        zip.write_all(serde_json::to_string(&composer_json).unwrap().as_bytes())
+            .expect("write composer.json");
+        zip.finish().expect("finish zip");
+    }
+    cursor.into_inner()
+}
+
+/// Clean up all test data.
+async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    sqlx::query("DELETE FROM package_versions WHERE package_id IN (SELECT id FROM packages WHERE repository_id = $1)")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM packages WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM artifact_metadata WHERE artifact_id IN (SELECT id FROM artifacts WHERE repository_id = $1)")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+/// Build a SharedState for the composer / packages routers.
+fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+    let storage: std::sync::Arc<dyn artifact_keeper_backend::storage::StorageBackend> =
+        std::sync::Arc::new(
+            artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(storage_path),
+        );
+    let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+        std::collections::HashMap::new(),
+        "filesystem".to_string(),
+    ));
+    Arc::new(AppState::new(
+        test_config(storage_path),
+        pool,
+        storage,
+        registry,
+    ))
+}
+
+/// Build the `AuthService` used by the optional-auth middleware so the routers
+/// resolve the `Authorization: Basic ...` header into an `AuthExtension`
+/// exactly as they do in production. Without this layer the handlers' mandatory
+/// `Extension<Option<AuthExtension>>` extractor is missing and every request
+/// 500s ("Missing request extension").
+fn auth_service(state: &SharedState, storage_path: &str) -> Arc<AuthService> {
+    Arc::new(AuthService::new(
+        state.db.clone(),
+        Arc::new(test_config(storage_path)),
+    ))
+}
+
+// ===========================================================================
+// #1341: uploaded Composer package appears in the WebUI Packages list
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_composer_upload_appears_in_packages_list() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("composer-u1-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "composerpass").await;
+    let (repo_id, repo_key, storage_path) = create_composer_repo(&pool).await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+    let auth = auth_service(&state, storage_path.to_str().unwrap());
+
+    let pkg_name = "acme/widget";
+    let pkg_version = "1.2.3";
+    let pkg_description = "A widget library for testing #1341";
+    let archive = build_composer_zip(pkg_name, pkg_version, pkg_description);
+
+    // --- Publish over the Composer wire protocol ---------------------------
+    let app = composer::router()
+        .layer(axum::middleware::from_fn_with_state(
+            auth.clone(),
+            optional_auth_middleware,
+        ))
+        .with_state(state.clone());
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("/{}/api/packages", repo_key))
+        .header(
+            "Authorization",
+            basic_auth_header(&username, "composerpass"),
+        )
+        .body(Body::from(archive))
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body);
+    assert_eq!(
+        status,
+        StatusCode::CREATED,
+        "composer upload should return 201, got {}: {}",
+        status,
+        body_str
+    );
+
+    // The artifact row must exist (pre-fix behaviour was already correct here).
+    let artifact_count: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM artifacts WHERE repository_id = $1 AND name = $2 AND version = $3 AND is_deleted = false",
+    )
+    .bind(repo_id)
+    .bind(pkg_name)
+    .bind(pkg_version)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(artifact_count, 1, "exactly one artifact row expected");
+
+    // --- The actual regression assertion: the package must be listed by the
+    // same `list_packages` handler the WebUI Packages tab calls. The handler
+    // reads the `packages` table. Before the fix this returned an empty list.
+    // The packages router is mounted behind optional auth in production. We
+    // make an anonymous request (no Authorization header); the repo is public
+    // so the `public_only` filter still returns it. The same optional-auth
+    // middleware resolves the absent credential to an anonymous identity.
+    let app = packages::router()
+        .layer(axum::middleware::from_fn_with_state(
+            auth.clone(),
+            optional_auth_middleware,
+        ))
+        .with_state(state.clone());
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/?repository_key={}", repo_key))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "packages list endpoint should return 200"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    let items = json["items"]
+        .as_array()
+        .expect("packages list must have an items array");
+    assert_eq!(
+        items.len(),
+        1,
+        "WebUI Packages tab should list exactly the uploaded Composer package; \
+         got an empty/oversized list which is the #1341 regression. Body: {}",
+        json
+    );
+    let item = &items[0];
+    assert_eq!(item["name"].as_str().unwrap(), pkg_name);
+    assert_eq!(item["version"].as_str().unwrap(), pkg_version);
+    assert_eq!(item["format"].as_str().unwrap(), "composer");
+    assert_eq!(item["repository_key"].as_str().unwrap(), repo_key);
+    assert_eq!(item["description"].as_str().unwrap(), pkg_description);
+
+    // The `packages` table row backing the WebUI must exist directly too.
+    let pkg_row = sqlx::query(
+        "SELECT name, version, description FROM packages WHERE repository_id = $1 AND name = $2 AND version = $3",
+    )
+    .bind(repo_id)
+    .bind(pkg_name)
+    .bind(pkg_version)
+    .fetch_one(&pool)
+    .await
+    .expect("packages row should exist after composer upload (#1341)");
+    assert_eq!(pkg_row.get::<String, _>("name"), pkg_name);
+    assert_eq!(pkg_row.get::<String, _>("version"), pkg_version);
+    assert_eq!(
+        pkg_row.get::<Option<String>, _>("description").as_deref(),
+        Some(pkg_description)
+    );
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}


### PR DESCRIPTION
## Summary

The WebUI Packages tab is backed by `GET /api/v1/packages`, which reads the `packages` table. The Composer upload handler (`PUT/POST /composer/{repo}/api/packages`) inserted into `artifacts` and `artifact_metadata` but never called `PackageService`, so a successfully published Composer package was stored and served over the Composer wire protocol yet never showed up in the WebUI. npm, pypi, and nuget all call `PackageService` after their artifact insert; Composer was the only artifact-publishing handler that did not.

The fix mirrors the npm/pypi pattern: after the artifact insert, the handler upserts the package and version into `packages` / `package_versions` via `PackageService::try_create_or_update_from_artifact`. The call is fire-and-forget, so a packages-table failure never blocks the upload.

Live verification against a local backend (isolated DB, hosted Composer repo):

- Before: `PUT .../api/packages` returns 201, `packages.json` lists the package, the `artifacts` row exists, but `GET /api/v1/packages?repository_key=...` returns `{"total":0,"items":[]}` and the `packages` table has 0 rows.
- After: the same upload makes `GET /api/v1/packages` return `total: 1` with the package, and `packages` / `package_versions` rows are populated.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`backend/tests/composer_packages_index_tests.rs` publishes a Composer package over the real wire protocol and asserts it is returned by the same `list_packages` handler the WebUI calls. Verified the test FAILS on the unfixed handler (empty list) and PASSES with the fix.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #1341