### PR TITLE
fix(npm): align scoped-tarball regression mock with literal-slash upstream path

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2678,12 +2678,15 @@ mod tests {
 
     /// Regression: a Remote npm repo must be able to fetch a scoped-package
     /// tarball through the proxy. The upstream URL the proxy hits must be
-    /// `@scope%2Fpkg/-/{filename}` — the npm registry protocol requires the
-    /// scope separator to be percent-encoded, because some private
-    /// registries (Nexus, Verdaccio, GitHub Packages) reject the unencoded
-    /// form. The handler must also unwrap axum's path extractor correctly
-    /// so the test request `/repo/@scope/pkg/-/file.tgz` reaches
-    /// `download_scoped_tarball` (not the unscoped fallback).
+    /// `@scope/pkg/-/{filename}` with the scope separator kept as a literal
+    /// `/`. Unlike npm metadata (which encodes the separator as `%2F`),
+    /// tarball routes expect `@scope` and `pkg` as separate path segments;
+    /// percent-encoding the slash collapses them into one `@scope%2Fpkg`
+    /// segment that no upstream tarball route matches, so the proxy fetch
+    /// 404s. See `build_tarball_upstream_path` (B7 / #1377). The handler must
+    /// also unwrap axum's path extractor correctly so the test request
+    /// `/repo/@scope/pkg/-/file.tgz` reaches `download_scoped_tarball` (not
+    /// the unscoped fallback).
     #[tokio::test]
     async fn test_remote_proxy_download_scoped_tarball_hits_encoded_upstream_path() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -2697,11 +2700,13 @@ mod tests {
         let mock_server = MockServer::start().await;
         let tarball_bytes = b"\x1f\x8b\x08mock-scoped-tarball-bytes";
 
-        // Upstream must see the scope encoded as %2F. wiremock's `path`
-        // matcher receives the raw request path (after axum's transport
-        // decoded it), so we match the canonical npm-registry shape.
+        // Upstream must see the scope separator as a literal `/`
+        // (`@scope/pkg/-/file.tgz`), matching the canonical npm tarball
+        // route. wiremock's `path` matcher receives the request path with
+        // scope and package as separate segments; this is the shape
+        // `build_tarball_upstream_path` produces (B7 / #1377).
         Mock::given(method("GET"))
-            .and(path("/@e2escope%2Ftestpkg/-/testpkg-1.0.0.tgz"))
+            .and(path("/@e2escope/testpkg/-/testpkg-1.0.0.tgz"))
             .respond_with(
                 ResponseTemplate::new(200)
                     .insert_header("content-type", "application/octet-stream")


### PR DESCRIPTION
## Summary

Fixes the Code Coverage CI job's only red test, `api::handlers::npm::tests::test_remote_proxy_download_scoped_tarball_hits_encoded_upstream_path`, which has been blocking every open PR for 3+ commits on `main`.

**Root cause** (not a flake): PR #1478 (B7 / refs #1377) deliberately changed `build_tarball_upstream_path` so scoped-tarball upstream URLs keep the scope separator as a literal `/` (`@scope/pkg/-/file.tgz`) rather than percent-encoding it. Scoped npm tarball routes expect `@scope` and `pkg` as separate path segments; collapsing them into one `@scope%2Fpkg` segment 404s upstream. The regression test added in #1391 was not updated to match. Its wiremock mock still matched `/@e2escope%2Ftestpkg/-/testpkg-1.0.0.tgz`, so the proxy's actual request to `/@e2escope/testpkg/-/testpkg-1.0.0.tgz` (empirically confirmed via `mock_server.received_requests()`) fell through to wiremock's default 404 and the test panicked with `download_scoped_tarball returned 404 Not Found`.

**Why coverage was the only red job**: the "Backend Unit Tests" job runs `cargo test --workspace --lib` with no Postgres service and no `DATABASE_URL`. `tdh::Fixture::setup` returns `None` and the test no-ops. The "Code Coverage" job provisions Postgres, applies migrations, and sets `DATABASE_URL`, so the fixture actually creates a Remote repo and the test runs for real. There is no instrumentation-induced timeout or wiremock race involved; the failure is fully deterministic once the DB is present.

**Fix**: update the mock path and the test/mock comments to match the literal-slash upstream shape that `build_tarball_upstream_path` produces. The test still verifies the same intent (scoped tarball reaches upstream with scope/package as separate segments and the bytes round-trip), now against the current production behavior.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

This PR fixes the regression test itself. The corrected mock now exercises the post-#1478 literal-slash production path; if `build_tarball_upstream_path` ever regresses back to emitting `%2F`, the upstream request will no longer match the mock and the test will fail.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification (against `postgresql://registry:registry@localhost:30432/ak_flaky` with all 99 migrations applied):

- `cargo test --lib -- api::handlers::npm::tests::test_remote_proxy_download_scoped_tarball_hits_encoded_upstream_path --exact` passes
- `cargo llvm-cov --lib --no-report -- api::handlers::npm::tests::test_remote_proxy_download_scoped_tarball_hits_encoded_upstream_path --exact` passes 5/5 consecutive runs (deterministic, no flake)
- Full npm test module: 69 passed, 0 failed
- All proxy-named tests: 436 passed, 0 failed
- All tarball-named tests: 92 passed, 0 failed
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #1490