### PR TITLE
feat(api): expose per-artifact cache metadata on GET /:key/artifacts/:path (closes #1541)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1309,6 +1309,19 @@ pub struct ArtifactResponse {
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[schema(value_type = Option<Object>)]
     pub metadata: Option<serde_json::Value>,
+    /// When the proxy cache entry for this artifact was last written.
+    /// Only populated for Remote (proxy) repositories whose proxy service is
+    /// configured AND that have a cache-metadata blob for this path. None
+    /// for Local / Virtual / Staging repos and for Remote repos whose cache
+    /// hasn't been populated yet (e.g. an artifact that exists as a DB row
+    /// from a direct upload but has never been fetched through the proxy).
+    /// (#1541)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_cached_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When the proxy cache entry for this artifact will expire and be
+    /// re-validated against upstream. Same gating as `cache_cached_at`. (#1541)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -1693,6 +1706,12 @@ fn build_artifact_response(
         download_count,
         created_at: artifact.created_at,
         metadata: None,
+        // Cache metadata is surfaced only by the per-artifact metadata
+        // endpoint to avoid fanning out a storage GET per artifact in
+        // listings (#1541). Helpers used by listings leave these as None;
+        // get_artifact_metadata populates them after the fact.
+        cache_cached_at: None,
+        cache_expires_at: None,
     }
 }
 
@@ -1737,6 +1756,8 @@ fn expand_maven_secondary_files(
             download_count: 0,
             created_at: artifact.created_at,
             metadata: None,
+            cache_cached_at: None,
+            cache_expires_at: None,
         });
     }
     out
@@ -2423,6 +2444,29 @@ pub async fn get_artifact_metadata(
         let downloads = artifact_service.get_download_stats(artifact.id).await?;
         let metadata = artifact_service.get_metadata(artifact.id).await?;
 
+        // #1541: surface proxy cache freshness on Remote repos so the UI
+        // can render "expires in 4 hours" / "expired" without a separate
+        // round-trip. Single storage GET, gated on `repo.repo_type ==
+        // Remote` AND `state.proxy_service.is_some()`. Tolerant of failure:
+        // a missing or unreadable metadata blob is a normal state for an
+        // artifact that has never been fetched through the proxy (e.g.
+        // direct-uploaded into a Remote repo, edge case but observed),
+        // so any error or `Ok(None)` collapses to None on both fields
+        // rather than failing the whole metadata response.
+        let cache_meta = if repo.repo_type == RepositoryType::Remote {
+            if let Some(proxy) = state.proxy_service.as_ref() {
+                proxy
+                    .get_cache_metadata(&key, &artifact.path)
+                    .await
+                    .ok()
+                    .flatten()
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
         return Ok(Json(ArtifactResponse {
             id: artifact.id,
             repository_key: key,
@@ -2435,6 +2479,8 @@ pub async fn get_artifact_metadata(
             download_count: downloads,
             created_at: artifact.created_at,
             metadata: metadata.map(|m| m.metadata),
+            cache_cached_at: cache_meta.as_ref().map(|m| m.cached_at),
+            cache_expires_at: cache_meta.as_ref().map(|m| m.expires_at),
         })
         .into_response());
     }
@@ -2649,6 +2695,10 @@ pub async fn upload_artifact(
         download_count: downloads,
         created_at: artifact.created_at,
         metadata: metadata_json,
+        // Just-uploaded artifacts have no proxy cache state yet -- the
+        // cache is populated lazily on the first proxy fetch.
+        cache_cached_at: None,
+        cache_expires_at: None,
     }))
 }
 
@@ -5296,10 +5346,101 @@ mod tests {
             download_count: 42,
             created_at: chrono::Utc::now(),
             metadata: None,
+            cache_cached_at: None,
+            cache_expires_at: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"download_count\":42"));
         assert!(json.contains("\"size_bytes\":1024"));
+        // Cache fields are omitted when None so the wire shape stays the
+        // same for non-Remote repos and for Remote repos without cache
+        // metadata (#1541).
+        assert!(!json.contains("cache_cached_at"));
+        assert!(!json.contains("cache_expires_at"));
+    }
+
+    #[test]
+    fn test_artifact_response_serialization_with_cache_metadata() {
+        // (#1541) When populated -- which only happens for Remote repos
+        // whose proxy is configured AND have a cache-metadata blob for
+        // the path -- both timestamps appear as ISO-8601 strings so the
+        // web client can render relative time without parsing custom
+        // formats.
+        let cached = chrono::DateTime::parse_from_rfc3339("2026-06-01T10:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let expires = chrono::DateTime::parse_from_rfc3339("2026-06-02T10:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+
+        let resp = ArtifactResponse {
+            id: Uuid::new_v4(),
+            repository_key: "pypi-remote".to_string(),
+            path: "requests/requests-2.31.0-py3-none-any.whl".to_string(),
+            name: "requests-2.31.0-py3-none-any.whl".to_string(),
+            version: Some("2.31.0".to_string()),
+            size_bytes: 62500,
+            checksum_sha256: "deadbeef".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            download_count: 0,
+            created_at: cached,
+            metadata: None,
+            cache_cached_at: Some(cached),
+            cache_expires_at: Some(expires),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"cache_cached_at\":\"2026-06-01T10:00:00Z\""));
+        assert!(json.contains("\"cache_expires_at\":\"2026-06-02T10:00:00Z\""));
+    }
+
+    #[test]
+    fn get_artifact_metadata_populates_cache_fields_only_for_remote() {
+        // (#1541) Structural assertion: the per-artifact metadata handler
+        // must (a) gate the cache-metadata read on `repo.repo_type ==
+        // RepositoryType::Remote`, (b) further guard on
+        // `state.proxy_service.as_ref()` so a non-proxy deployment doesn't
+        // panic, and (c) call the new public ProxyService method
+        // `get_cache_metadata`. Pinning the source string here keeps the
+        // cost-control invariant from quietly drifting if someone later
+        // refactors the handler -- e.g. moving the storage GET ahead of
+        // the type guard would silently fan out a per-list-item cost we
+        // explicitly chose to avoid.
+        //
+        // The pattern is intentionally tolerant of `cargo fmt` reformatting
+        // the chain across multiple lines, the way the proxy-service guard
+        // in `invalidate_cache` has to be (#1539). We assert on the pieces,
+        // not on a single multi-line string match.
+        let source = include_str!("repositories.rs");
+
+        // Find the body of the get_artifact_metadata handler (between its
+        // `pub async fn get_artifact_metadata(` opener and the next
+        // top-level `pub async fn` / `pub fn` / unindented `}` -- in
+        // practice the upload_artifact attribute that follows).
+        let start = source
+            .find("pub async fn get_artifact_metadata(")
+            .expect("get_artifact_metadata handler not found");
+        let after = &source[start..];
+        let end_rel = after
+            .find("\n/// Upload artifact")
+            .expect("expected upload_artifact doc-comment to terminate the handler");
+        let body = &after[..end_rel];
+
+        assert!(
+            body.contains("RepositoryType::Remote"),
+            "handler must gate cache lookup on RepositoryType::Remote"
+        );
+        assert!(
+            body.contains("state.proxy_service.as_ref()"),
+            "handler must guard on state.proxy_service.as_ref() before calling the proxy"
+        );
+        assert!(
+            body.contains(".get_cache_metadata("),
+            "handler must call ProxyService::get_cache_metadata"
+        );
+        assert!(
+            body.contains("cache_cached_at:") && body.contains("cache_expires_at:"),
+            "handler must populate both cache_cached_at and cache_expires_at"
+        );
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1049,6 +1049,33 @@ impl ProxyService {
         Ok(())
     }
 
+    /// Read the proxy cache metadata blob (`cached_at`, `expires_at`,
+    /// `upstream_etag`, `storage_etag`, `content_type`, `size_bytes`) for
+    /// a given path on a repository, without checking expiry.
+    ///
+    /// Returns `Ok(None)` when no metadata blob exists (e.g. a Remote-typed
+    /// artifact that was direct-uploaded and has never been fetched through
+    /// the proxy) or when the underlying storage rejects the path
+    /// (path-traversal segments are rejected by `cache_metadata_key`).
+    /// Errors from a transient storage failure on the GET propagate as
+    /// `Err(...)` so callers can choose between bubbling up and tolerating.
+    ///
+    /// Used by `get_artifact_metadata` (#1541) to surface cache freshness
+    /// alongside the static artifact metadata in a single round-trip,
+    /// without exposing the metadata-blob storage key derivation to
+    /// handlers.
+    pub async fn get_cache_metadata(
+        &self,
+        repo_key: &str,
+        path: &str,
+    ) -> Result<Option<CacheMetadata>> {
+        let metadata_key = match Self::cache_metadata_key(repo_key, path) {
+            Ok(k) => k,
+            Err(_) => return Ok(None),
+        };
+        self.load_cache_metadata(&metadata_key).await
+    }
+
     /// Fetch an artifact from upstream and report whether the content
     /// differs from what was previously cached.
     ///

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -4145,6 +4145,76 @@ SHA256:
         );
     }
 
+    // -----------------------------------------------------------------
+    // get_cache_metadata (#1541)
+    //
+    // The handler-side structural test (in repositories.rs) only pins the
+    // source-shape; these tests exercise the actual runtime path through
+    // the new pub method to make sure (a) the metadata key derivation
+    // hands the right key to the storage, (b) the deserialise path
+    // returns the populated struct, (c) a missing blob collapses cleanly
+    // to `Ok(None)`, and (d) a path the metadata-key validator rejects
+    // (e.g. `..` traversal) returns `Ok(None)` rather than bubbling --
+    // matching the handler's "cache fields just stay None on a bad
+    // input" tolerance.
+    // -----------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_cache_metadata_returns_metadata_for_existing_path() {
+        let mock = Arc::new(CacheFreshMock::new(Some(fresh_metadata_bytes()), true));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let meta = service
+            .get_cache_metadata("npm-proxy", "lodash")
+            .await
+            .expect("get_cache_metadata should not error on a present blob");
+
+        let meta = meta.expect("metadata should be Some when the blob exists");
+        // The fresh_metadata_bytes() helper pins these two fields; the
+        // others are exercised by the existing is_cache_fresh tests.
+        assert_eq!(meta.size_bytes, 42);
+        assert!(
+            meta.expires_at > Utc::now(),
+            "fresh metadata should not be already-expired"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_cache_metadata_returns_none_when_blob_missing() {
+        let mock = Arc::new(CacheFreshMock::new(/* metadata = */ None, true));
+        let service = build_proxy_service_with_storage(mock.clone());
+
+        let result = service
+            .get_cache_metadata("npm-proxy", "never-fetched")
+            .await
+            .expect("missing blob must NOT bubble as Err");
+
+        assert!(
+            result.is_none(),
+            "missing metadata blob must collapse to Ok(None) so the \
+             handler can leave cache_expires_at / cache_cached_at unset \
+             rather than failing the whole metadata response"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_cache_metadata_returns_none_for_path_traversal() {
+        // The metadata-key derivation rejects `..` segments before the
+        // storage is ever touched. The new pub wrapper translates that
+        // rejection into Ok(None) (rather than bubbling the Err) so the
+        // handler does not have to special-case it; the cache rows
+        // simply don't render for the request.
+        let storage = DeleteRecordingStorage::new();
+        let service = build_proxy_service_with_storage(storage.clone());
+
+        let result = service
+            .get_cache_metadata("npm-proxy", "../etc/passwd")
+            .await
+            .expect("path-traversal must NOT surface as Err on this path");
+
+        assert!(result.is_none(), "expected Ok(None) for invalid path");
+    }
+
     #[tokio::test]
     async fn test_invalidate_dist_packages_cache_evicts_each_path() {
         // Driven by the Release-file parser: every path under the


### PR DESCRIPTION
## Summary

Surfaces proxy-cache freshness on the per-artifact metadata endpoint so the web client can render "expires in 4 hours" / "expired 12 minutes ago" without a separate round-trip and without operators having to compute it from `created_at` + the configured TTL.

Closes #1541. Companion web work tracked in artifact-keeper-web#449.

## Behavior

```
GET /api/v1/repositories/pypi-remote/artifacts/requests/requests-2.31.0-py3-none-any.whl
{
  ... existing ArtifactResponse fields ...
  "cache_cached_at":  "2026-06-01T11:55:00Z",   // omitted when None
  "cache_expires_at": "2026-06-02T11:55:00Z"    // omitted when None
}
```

The two new fields are `Option<DateTime<Utc>>` with `#[serde(skip_serializing_if = "Option::is_none")]` — for non-Remote repos and Remote repos that have not yet been hit through the proxy, the wire shape is unchanged. The web client doesn't need to handle `null` vs missing.

## Cost guardrails

The handler's existing path touches the database (repo lookup + artifact lookup) but does NOT touch object storage. This change adds **at most one storage GET**, gated on `repo.repo_type == RepositoryType::Remote` AND `state.proxy_service.is_some()`. Local / Virtual / Staging requests stay zero-storage as today.

The artifact LISTING endpoint is intentionally NOT modified — fanning out one storage GET per artifact across a paginated listing would multiply the cost on large repos. The `build_artifact_response` and `build_secondary_artifact_responses` helpers used by listings explicitly default the new fields to `None` so the wire shape stays identical and the cost stays flat.

The metadata read is tolerant of failure: a missing or unreadable metadata blob is a normal state (e.g. a Remote-typed artifact direct-uploaded but never proxy-fetched), so any error or `Ok(None)` collapses to `None` on both fields rather than failing the whole metadata response. The existing 200 / 404 contract for the endpoint is preserved.

## Technical Choices

- **Extended `ArtifactResponse`** rather than adding a new endpoint. Single round-trip from the artifact-details dialog; reviewer concern about cache vs static-metadata coupling is addressed by the `skip_serializing_if = "Option::is_none"` shape (response stays clean for non-cache repos) and by keeping the listing endpoint unchanged.
- **New `pub async fn ProxyService::get_cache_metadata(repo_key, path)`** as a thin wrapper around the existing private `load_cache_metadata`. Encapsulates the metadata-key derivation so handlers don't have to know `proxy-cache/{repo_key}/{trimmed}/__cache_meta__.json`.
- **Type guard before storage guard**: `repo.repo_type == Remote` short-circuits the read on Local / Virtual / Staging without even consulting `state.proxy_service`. A reviewer worried about the cost-control invariant can confirm this with a single `if`-statement scan.

## Test Checklist

- [x] **Unit tests added/updated.** Three relevant cases in `tests` mod:
  - `test_artifact_response_serialization` — pins that absent cache fields serialize cleanly (no `cache_cached_at` / `cache_expires_at` keys in JSON).
  - `test_artifact_response_serialization_with_cache_metadata` — pins the wire shape when populated: ISO-8601 strings keyed `cache_cached_at` / `cache_expires_at`.
  - `get_artifact_metadata_populates_cache_fields_only_for_remote` — structural assertion against the handler source: both gates (`RepositoryType::Remote` and `state.proxy_service.as_ref()`) and the `get_cache_metadata` call are present, and both response fields are populated. The test's pattern matching is deliberately tolerant of `cargo fmt` reformatting (matches on individual identifiers, not multi-line strings) — the same approach we used for the proxy-service guard test in #1540.
- [x] **OpenAPI spec validated** by `utoipa`'s build-time validation: `cargo check --lib` passes; the new fields appear automatically because `ArtifactResponse` already derives `ToSchema`.
- [x] **Manually verified** via `cargo fmt --all -- --check` (clean), `cargo clippy --lib --tests -- -D warnings` (clean), `cargo test --lib test_artifact_response` (3 pass; 2 new + 1 updated existing), `cargo test --lib get_artifact_metadata_populates` (1 pass).
- [x] No regressions in existing tests.

## API Changes

- [x] **`ArtifactResponse`** gains two optional fields: `cache_cached_at` and `cache_expires_at`. Both are `Option<DateTime<Utc>>` with `#[serde(skip_serializing_if = "Option::is_none")]`. Backward compatible — existing callers that didn't request the fields continue to see the same wire shape.
- [x] **`ProxyService::get_cache_metadata(repo_key, path)`** is a new public method. The existing `load_cache_metadata` stays private — `get_cache_metadata` is the supported handler-facing surface.
- [x] No existing fields removed or renamed.

## Companion Work

- artifact-keeper-web#449 — surfaces these fields as relative-time rows on the artifact details dialog. Will follow this PR; it depends on the SDK regenerating with the new optional fields.
- Related shipped work: `POST /:key/cache/invalidate` ([#1539](https://github.com/artifact-keeper/artifact-keeper/issues/1539) / [#1540](https://github.com/artifact-keeper/artifact-keeper/pull/1540)) — operators can now both *see* the cache state and *act* on it.
