### PR TITLE
fix: harden peer replication sync worker

### DIFF
--- a/backend/migrations/119_upload_session_artifact_metadata.sql
+++ b/backend/migrations/119_upload_session_artifact_metadata.sql
@@ -1,0 +1,10 @@
+-- Preserve source artifact metadata across resumable upload sessions.
+--
+-- Regular client uploads can omit these nullable columns and retain the
+-- existing fallback behavior. Peer replication sets them from the source
+-- artifact row so chunked replication does not derive name/version from the
+-- path at completion time.
+
+ALTER TABLE upload_sessions
+    ADD COLUMN artifact_name TEXT,
+    ADD COLUMN artifact_version TEXT;

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1904,6 +1904,8 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
+        cache_cached_at: Some(entry.cached_at),
+        cache_expires_at: None,
     }
 }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -43,6 +43,14 @@ fn require_auth(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))
 }
 
+fn is_replication_request(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-artifact-keeper-replication")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
+        .unwrap_or(false)
+}
+
 /// Coerce the requested `is_public` value against the server-wide guest-access
 /// policy (issue #850).
 ///
@@ -2975,7 +2983,7 @@ pub async fn upload_artifact(
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &path).await;
 
     let artifact = artifact_service
-        .upload(
+        .upload_with_sync_options(
             repo.id,
             &path,
             &name,
@@ -2983,6 +2991,7 @@ pub async fn upload_artifact(
             &content_type,
             body,
             Some(auth.user_id),
+            !is_replication_request(&headers),
         )
         .await?;
 
@@ -3431,6 +3440,7 @@ pub async fn delete_artifact(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, path)): Path<(String, String)>,
+    headers: HeaderMap,
 ) -> Result<()> {
     let auth = require_auth(auth)?;
     auth.require_scope("delete")?;
@@ -3452,7 +3462,9 @@ pub async fn delete_artifact(
     .map_err(|e| AppError::Database(e.to_string()))?
     .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
 
-    artifact_service.delete(artifact).await?;
+    artifact_service
+        .delete_with_sync_options(artifact, !is_replication_request(&headers))
+        .await?;
 
     Ok(())
 }

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
+use crate::services::package_service::PackageService;
 use crate::services::upload_service::{self, UploadError, UploadService};
 
 // ---------------------------------------------------------------------------
@@ -52,6 +53,16 @@ pub struct CreateSessionRequest {
     pub repository_key: String,
     /// Path within the repository (e.g. "images/vm.ova")
     pub artifact_path: String,
+    /// Artifact name to persist when the upload completes.
+    ///
+    /// Optional for regular client uploads. Peer replication sets this from
+    /// the source artifact row so chunked replication preserves metadata.
+    pub artifact_name: Option<String>,
+    /// Artifact version to persist when the upload completes.
+    ///
+    /// Optional for regular client uploads. Peer replication sets this from
+    /// the source artifact row so chunked replication preserves metadata.
+    pub artifact_version: Option<String>,
     /// Total file size in bytes
     pub total_size: i64,
     /// Expected SHA256 checksum of the complete file
@@ -150,6 +161,8 @@ async fn create_session(
         repo_id: repo.0,
         repo_key: &req.repository_key,
         artifact_path: &req.artifact_path,
+        artifact_name: req.artifact_name.as_deref(),
+        artifact_version: req.artifact_version.as_deref(),
         total_size: req.total_size,
         chunk_size: req.chunk_size,
         checksum_sha256: &req.checksum_sha256,
@@ -387,21 +400,24 @@ async fn complete(
     let _ = tokio::fs::remove_file(&temp_path).await;
 
     // Create artifact record
+    let artifact_name = completed_artifact_name(&session);
+    let artifact_version = completed_artifact_version(&session);
     let artifact_id: Uuid = sqlx::query_scalar(
         r#"
         INSERT INTO artifacts (repository_id, path, name, version, size_bytes,
                                checksum_sha256, content_type, storage_key, uploaded_by)
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
         ON CONFLICT (repository_id, path) DO UPDATE SET
-            size_bytes = $5, checksum_sha256 = $6, content_type = $7, storage_key = $8,
-            uploaded_by = $9, updated_at = NOW(), is_deleted = false
+            name = $3, version = $4, size_bytes = $5, checksum_sha256 = $6,
+            content_type = $7, storage_key = $8, uploaded_by = $9,
+            updated_at = NOW(), is_deleted = false
         RETURNING id
         "#,
     )
     .bind(session.repository_id)
     .bind(&session.artifact_path)
-    .bind(artifact_name_from_path(&session.artifact_path))
-    .bind::<Option<String>>(None) // version
+    .bind(artifact_name)
+    .bind(artifact_version)
     .bind(session.total_size)
     .bind(&session.checksum_sha256)
     .bind(&session.content_type)
@@ -410,6 +426,20 @@ async fn complete(
     .fetch_one(&state.db)
     .await
     .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    if let Some((package_name, package_version)) = completed_package_catalog_entry(&session) {
+        PackageService::new(state.db.clone())
+            .try_create_or_update_from_artifact(
+                session.repository_id,
+                package_name,
+                package_version,
+                session.total_size,
+                &session.checksum_sha256,
+                None,
+                None,
+            )
+            .await;
+    }
 
     tracing::info!(
         "Finalized chunked upload {} -> artifact {} ({}B, sha256:{})",
@@ -523,6 +553,28 @@ fn artifact_name_from_path(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
 }
 
+fn completed_artifact_name(session: &upload_service::UploadSession) -> &str {
+    session
+        .artifact_name
+        .as_deref()
+        .filter(|name| !name.is_empty())
+        .unwrap_or_else(|| artifact_name_from_path(&session.artifact_path))
+}
+
+fn completed_artifact_version(session: &upload_service::UploadSession) -> Option<&str> {
+    session
+        .artifact_version
+        .as_deref()
+        .filter(|version| !version.is_empty())
+}
+
+fn completed_package_catalog_entry(
+    session: &upload_service::UploadSession,
+) -> Option<(&str, &str)> {
+    let version = completed_artifact_version(session)?;
+    Some((completed_artifact_name(session), version))
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -583,6 +635,80 @@ mod tests {
         );
     }
 
+    fn test_upload_session(
+        path: &str,
+        name: Option<&str>,
+        version: Option<&str>,
+    ) -> upload_service::UploadSession {
+        upload_service::UploadSession {
+            id: Uuid::nil(),
+            user_id: Uuid::nil(),
+            repository_id: Uuid::nil(),
+            repository_key: "repo".to_string(),
+            artifact_path: path.to_string(),
+            artifact_name: name.map(str::to_string),
+            artifact_version: version.map(str::to_string),
+            content_type: "application/octet-stream".to_string(),
+            total_size: 1,
+            chunk_size: 1_048_576,
+            total_chunks: 1,
+            completed_chunks: 1,
+            bytes_received: 1,
+            checksum_sha256: "deadbeef".to_string(),
+            temp_file_path: "/tmp/upload-session".to_string(),
+            status: "completed".to_string(),
+            error_message: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            expires_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_completed_artifact_metadata_prefers_session_metadata() {
+        let session = test_upload_session(
+            "name-check/20260603T072902Z/large-160m.bin",
+            Some("name-check"),
+            Some("20260603T072902Z"),
+        );
+
+        assert_eq!(completed_artifact_name(&session), "name-check");
+        assert_eq!(
+            completed_artifact_version(&session),
+            Some("20260603T072902Z")
+        );
+    }
+
+    #[test]
+    fn test_completed_artifact_metadata_falls_back_to_path_basename() {
+        let session = test_upload_session("name-check/20260603T072902Z/large-160m.bin", None, None);
+
+        assert_eq!(completed_artifact_name(&session), "large-160m.bin");
+        assert_eq!(completed_artifact_version(&session), None);
+    }
+
+    #[test]
+    fn test_completed_package_catalog_entry_uses_session_metadata() {
+        let session = test_upload_session(
+            "large-check/20260603T082854Z/large-160m.bin",
+            Some("large-check"),
+            Some("20260603T082854Z"),
+        );
+
+        assert_eq!(
+            completed_package_catalog_entry(&session),
+            Some(("large-check", "20260603T082854Z"))
+        );
+    }
+
+    #[test]
+    fn test_completed_package_catalog_entry_skips_unversioned_upload() {
+        let session =
+            test_upload_session("large-check/20260603T082854Z/large-160m.bin", None, None);
+
+        assert_eq!(completed_package_catalog_entry(&session), None);
+    }
+
     // -----------------------------------------------------------------------
     // CreateSessionRequest deserialization
     // -----------------------------------------------------------------------
@@ -592,6 +718,8 @@ mod tests {
         let json = r#"{
             "repository_key": "my-repo",
             "artifact_path": "images/vm.ova",
+            "artifact_name": "vm-image",
+            "artifact_version": "2026.06.03",
             "total_size": 21474836480,
             "checksum_sha256": "abc123def456",
             "chunk_size": 16777216,
@@ -600,6 +728,8 @@ mod tests {
         let req: CreateSessionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.repository_key, "my-repo");
         assert_eq!(req.artifact_path, "images/vm.ova");
+        assert_eq!(req.artifact_name.as_deref(), Some("vm-image"));
+        assert_eq!(req.artifact_version.as_deref(), Some("2026.06.03"));
         assert_eq!(req.total_size, 21_474_836_480);
         assert_eq!(req.checksum_sha256, "abc123def456");
         assert_eq!(req.chunk_size, Some(16_777_216));
@@ -617,6 +747,8 @@ mod tests {
         let req: CreateSessionRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.repository_key, "repo");
         assert_eq!(req.artifact_path, "file.bin");
+        assert_eq!(req.artifact_name, None);
+        assert_eq!(req.artifact_version, None);
         assert_eq!(req.total_size, 1024);
         assert_eq!(req.checksum_sha256, "deadbeef");
         assert!(req.chunk_size.is_none());
@@ -1061,6 +1193,8 @@ mod tests {
         let req = CreateSessionRequest {
             repository_key: "repo".into(),
             artifact_path: "file.bin".into(),
+            artifact_name: None,
+            artifact_version: None,
             total_size: 100,
             checksum_sha256: "abc".into(),
             chunk_size: None,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -669,7 +669,11 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     let grpc_db_pool = db_pool.clone();
 
     // Spawn background sync worker for peer replication
-    artifact_keeper_backend::services::sync_worker::spawn_sync_worker(db_pool).await;
+    artifact_keeper_backend::services::sync_worker::spawn_sync_worker(
+        db_pool,
+        storage_registry.clone(),
+    )
+    .await;
     tracing::info!("Sync worker started");
 
     // Conditionally clone state for the metrics listener before the router takes

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -213,6 +213,32 @@ impl ArtifactService {
         data: Bytes,
         uploaded_by: Option<Uuid>,
     ) -> Result<Artifact> {
+        self.upload_with_sync_options(
+            repository_id,
+            path,
+            name,
+            version,
+            content_type,
+            data,
+            uploaded_by,
+            true,
+        )
+        .await
+    }
+
+    /// Upload an artifact, optionally suppressing peer sync task fan-out.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upload_with_sync_options(
+        &self,
+        repository_id: Uuid,
+        path: &str,
+        name: &str,
+        version: Option<&str>,
+        content_type: &str,
+        data: Bytes,
+        uploaded_by: Option<Uuid>,
+        enqueue_sync_tasks: bool,
+    ) -> Result<Artifact> {
         let size_bytes = data.len() as i64;
 
         // Check quota
@@ -417,7 +443,7 @@ impl ArtifactService {
             .await;
 
         // Queue sync tasks for peer replication (non-blocking)
-        {
+        if enqueue_sync_tasks {
             let db = self.db.clone();
             let artifact_id = artifact.id;
             let repository_id = artifact.repository_id;
@@ -846,6 +872,11 @@ impl ArtifactService {
 
     /// Soft-delete an artifact
     pub async fn delete(&self, id: Uuid) -> Result<()> {
+        self.delete_with_sync_options(id, true).await
+    }
+
+    /// Soft-delete an artifact, optionally suppressing peer sync task fan-out.
+    pub async fn delete_with_sync_options(&self, id: Uuid, enqueue_sync_tasks: bool) -> Result<()> {
         // Get artifact info for plugin hooks
         let artifact = self.get_by_id(id).await?;
         let artifact_info = ArtifactInfo::from(&artifact);
@@ -866,19 +897,16 @@ impl ArtifactService {
             return Err(AppError::NotFound("Artifact not found".to_string()));
         }
 
-        // Enqueue delete sync tasks for all eligible peers (non-blocking)
+        // A delete supersedes any upload retries for the same artifact.
         let _ = sqlx::query(
             r#"
-            INSERT INTO sync_tasks (id, peer_instance_id, artifact_id, task_type, status, priority)
-            SELECT gen_random_uuid(), pi.id, $1, 'delete', 'pending', 0
-            FROM peer_instances pi
-            JOIN peer_repo_subscriptions prs ON prs.peer_instance_id = pi.id
-            JOIN artifacts a ON a.repository_id = prs.repository_id AND a.id = $1
-            WHERE pi.is_local = false
-              AND pi.status IN ('online', 'syncing')
-              AND prs.replication_mode::text IN ('push', 'mirror')
-              AND prs.sync_enabled = true
-            ON CONFLICT (peer_instance_id, artifact_id, task_type) DO NOTHING
+            UPDATE sync_tasks
+            SET status = 'cancelled',
+                completed_at = NOW(),
+                error_message = 'superseded by artifact delete'
+            WHERE artifact_id = $1
+              AND task_type = 'push'
+              AND status IN ('pending', 'failed')
             "#,
         )
         .bind(id)
@@ -886,12 +914,41 @@ impl ArtifactService {
         .await
         .map_err(|e| {
             tracing::warn!(
-                "Failed to enqueue delete sync tasks for artifact {}: {}",
+                "Failed to cancel superseded push sync tasks for artifact {}: {}",
                 id,
                 e
             );
             e
         });
+
+        // Enqueue delete sync tasks for all eligible peers (non-blocking)
+        if enqueue_sync_tasks {
+            let _ = sqlx::query(
+                r#"
+                INSERT INTO sync_tasks (id, peer_instance_id, artifact_id, task_type, status, priority)
+                SELECT gen_random_uuid(), pi.id, $1, 'delete', 'pending', 0
+                FROM peer_instances pi
+                JOIN peer_repo_subscriptions prs ON prs.peer_instance_id = pi.id
+                JOIN artifacts a ON a.repository_id = prs.repository_id AND a.id = $1
+                WHERE pi.is_local = false
+                  AND pi.status IN ('online', 'syncing')
+                  AND prs.replication_mode::text IN ('push', 'mirror')
+                  AND prs.sync_enabled = true
+                ON CONFLICT (peer_instance_id, artifact_id, task_type) DO NOTHING
+                "#,
+            )
+            .bind(id)
+            .execute(&self.db)
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    "Failed to enqueue delete sync tasks for artifact {}: {}",
+                    id,
+                    e
+                );
+                e
+            });
+        }
 
         // Trigger AfterDelete hooks (non-blocking)
         self.trigger_hook_non_blocking(PluginEventType::AfterDelete, &artifact_info)

--- a/backend/src/services/sync_worker.rs
+++ b/backend/src/services/sync_worker.rs
@@ -4,14 +4,13 @@
 //! instances.  Runs on a 10-second tick, respects per-peer concurrency limits,
 //! sync windows, and configurable backoff on failures.
 //!
-//! For artifacts larger than `SYNC_CHUNKED_THRESHOLD_BYTES`, the worker uses
-//! the swarm-based chunked transfer system instead of sending the full file
-//! in a single HTTP request.  This prevents timeouts and memory exhaustion
+//! For artifacts larger than `SYNC_CHUNKED_THRESHOLD_BYTES`, the worker creates
+//! a resumable upload session on the remote peer instead of sending the full
+//! file in a single HTTP request. This prevents timeouts and memory exhaustion
 //! when syncing large Docker images, ML models, etc.
 
 use crate::storage::{StorageLocation, StorageRegistry};
 use chrono::{NaiveTime, Timelike, Utc};
-use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::time::{interval, Duration};
@@ -115,6 +114,7 @@ const DEFAULT_SYNC_CHUNK_SIZE_BYTES: i32 = 50 * 1024 * 1024;
 
 const REPLICATION_REQUEST_HEADER: &str = "X-Artifact-Keeper-Replication";
 const REPLICATION_REQUEST_VALUE: &str = "true";
+const CHECKSUM_SHA256_HEADER: &str = "x-checksum-sha256";
 
 /// Default retry backoff cap for sync tasks.
 ///
@@ -879,7 +879,7 @@ async fn execute_transfer(
             task.artifact_version.as_deref().unwrap_or(""),
         )
         .header("X-Artifact-Path", &task.artifact_path)
-        .header("X-Artifact-Checksum-SHA256", &task.checksum_sha256)
+        .header(CHECKSUM_SHA256_HEADER, &task.checksum_sha256)
         .body(file_bytes)
         .send()
         .await;
@@ -914,12 +914,15 @@ async fn execute_transfer(
     }
 }
 
-/// Execute a chunked transfer for a large artifact.
+/// Execute a chunked upload for a large replicated artifact.
 ///
 /// Instead of reading the entire artifact into memory and sending it in one
-/// request, this splits the file into chunks and uploads each one individually.
-/// The remote peer's transfer session API tracks progress so transfers can
-/// resume after partial failures.
+/// request, this creates a regular upload session on the remote peer, sends
+/// each byte range as one PATCH request, then asks the peer to finalize the
+/// upload into its repository storage. This is intentionally the same API used
+/// by direct large uploads: it works when the target peer has never seen the
+/// artifact before, verifies the final checksum, and materializes the target
+/// artifact row + storage object on completion.
 async fn execute_chunked_transfer(
     db: &PgPool,
     client: &reqwest::Client,
@@ -939,12 +942,9 @@ async fn execute_chunked_transfer(
         task.id
     );
 
-    // 1. Initialize a transfer session on the remote peer.
-    let init_url = build_chunked_init_url(peer_endpoint, &task.peer_instance_id);
-    let init_body = serde_json::json!({
-        "artifact_id": task.artifact_id,
-        "chunk_size": chunk_size,
-    });
+    // 1. Initialize a resumable upload session on the remote peer.
+    let init_url = build_chunked_upload_session_url(peer_endpoint);
+    let init_body = build_chunked_upload_session_body(task, chunk_size);
 
     let init_response = client
         .post(&init_url)
@@ -954,7 +954,7 @@ async fn execute_chunked_transfer(
         .json(&init_body)
         .send()
         .await
-        .map_err(|e| format!("Failed to init chunked transfer: {e}"))?;
+        .map_err(|e| format!("Failed to init chunked upload: {e}"))?;
 
     if !init_response.status().is_success() {
         let status = init_response.status();
@@ -962,22 +962,35 @@ async fn execute_chunked_transfer(
             .text()
             .await
             .unwrap_or_else(|_| "<unreadable>".to_string());
-        let msg = format!("Chunked transfer init returned {status}: {body}");
+        let msg = format!("Chunked upload init returned {status}: {body}");
         handle_transfer_failure(db, task, &msg, retry_policy).await;
         return Err(msg);
     }
 
-    let session: serde_json::Value = init_response
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse transfer session response: {e}"))?;
+    let session: serde_json::Value = match init_response.json().await {
+        Ok(session) => session,
+        Err(e) => {
+            let msg = format!("Failed to parse upload session response: {e}");
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
+            return Err(msg);
+        }
+    };
 
-    let session_id = session["id"]
+    let session_id = match session["session_id"]
         .as_str()
         .and_then(|s| Uuid::parse_str(s).ok())
-        .ok_or_else(|| "Missing session id in transfer init response".to_string())?;
+    {
+        Some(session_id) => session_id,
+        None => {
+            let msg = "Missing session_id in chunked upload init response".to_string();
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
+            return Err(msg);
+        }
+    };
 
-    // 2. Upload chunks one at a time, streaming each from disk.
+    // 2. Upload chunks one at a time. Each chunk is read through the
+    // repository's storage backend using `get_range`; for S3 this is a
+    // true HTTP Range GET rather than a full-object re-download.
     let chunk_ranges = compute_chunk_ranges(task.artifact_size, chunk_size);
     let mut bytes_transferred: i64 = 0;
 
@@ -997,61 +1010,31 @@ async fn execute_chunked_transfer(
                     "Failed to read chunk {} (offset={}, len={}): {e}",
                     chunk_index, byte_offset, byte_length
                 );
+                cancel_chunked_upload_session(client, peer_endpoint, peer_api_key, &session_id)
+                    .await;
                 handle_transfer_failure(db, task, &msg, retry_policy).await;
                 return Err(msg);
             }
         };
 
-        // Compute SHA-256 of this chunk for verification.
-        let mut hasher = Sha256::new();
-        hasher.update(&chunk_data);
-        let chunk_checksum = format!("{:x}", hasher.finalize());
-
-        // Upload the chunk data to the peer's artifact storage. The chunk is
-        // sent as a PUT with the byte range headers so the peer can reassemble.
-        let chunk_upload_url = format!(
-            "{}/api/v1/repositories/{}/artifacts/chunks/{}/{}",
-            peer_endpoint.trim_end_matches('/'),
-            task.repository_key,
-            session_id,
-            chunk_index
-        );
+        // Upload the chunk to the peer's resumable upload session. The
+        // Content-Range header lets the receiver write it at the correct
+        // offset in its temp file before final checksum verification.
+        let chunk_upload_url = build_chunked_upload_chunk_url(peer_endpoint, &session_id);
+        let content_range = build_content_range(*byte_offset, *byte_length, task.artifact_size);
 
         let upload_result = client
-            .put(&chunk_upload_url)
+            .patch(&chunk_upload_url)
             .header("Authorization", format!("Bearer {}", peer_api_key))
             .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
             .header("Content-Type", "application/octet-stream")
-            .header("X-Chunk-Offset", byte_offset.to_string())
-            .header("X-Chunk-Length", byte_length.to_string())
-            .header("X-Chunk-Checksum-SHA256", &chunk_checksum)
+            .header("Content-Range", content_range)
             .body(chunk_data)
             .send()
             .await;
 
         match upload_result {
             Ok(resp) if resp.status().is_success() => {
-                // Mark chunk as completed on the remote session.
-                let complete_url = build_chunk_complete_url(
-                    peer_endpoint,
-                    &task.peer_instance_id,
-                    &session_id,
-                    *chunk_index,
-                );
-                let complete_body = serde_json::json!({
-                    "checksum": chunk_checksum,
-                    "source_peer_id": null,
-                });
-
-                let _ = client
-                    .post(&complete_url)
-                    .header("Authorization", format!("Bearer {}", peer_api_key))
-                    .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
-                    .header("Content-Type", "application/json")
-                    .json(&complete_body)
-                    .send()
-                    .await;
-
                 bytes_transferred += *byte_length as i64;
                 tracing::debug!(
                     "Chunk {}/{} uploaded for task {} ({} bytes)",
@@ -1068,23 +1051,28 @@ async fn execute_chunked_transfer(
                     .await
                     .unwrap_or_else(|_| "<unreadable>".to_string());
                 let msg = format!("Chunk {} upload returned {status}: {body}", chunk_index);
+                cancel_chunked_upload_session(client, peer_endpoint, peer_api_key, &session_id)
+                    .await;
                 handle_transfer_failure(db, task, &msg, retry_policy).await;
                 return Err(msg);
             }
             Err(e) => {
                 let msg = format!("Chunk {} upload failed: {e}", chunk_index);
+                cancel_chunked_upload_session(client, peer_endpoint, peer_api_key, &session_id)
+                    .await;
                 handle_transfer_failure(db, task, &msg, retry_policy).await;
                 return Err(msg);
             }
         }
     }
 
-    // 3. Finalize the transfer session.
-    let session_complete_url =
-        build_session_complete_url(peer_endpoint, &task.peer_instance_id, &session_id);
+    // 3. Finalize the upload session. The remote peer verifies the complete
+    // file SHA-256, writes to the repository's configured storage backend, and
+    // creates/updates the target artifact row.
+    let session_complete_url = build_chunked_upload_complete_url(peer_endpoint, &session_id);
 
     let complete_result = client
-        .post(&session_complete_url)
+        .put(&session_complete_url)
         .header("Authorization", format!("Bearer {}", peer_api_key))
         .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
         .send()
@@ -1108,12 +1096,14 @@ async fn execute_chunked_transfer(
                 .text()
                 .await
                 .unwrap_or_else(|_| "<unreadable>".to_string());
-            let msg = format!("Chunked transfer session complete returned {status}: {body}");
+            let msg = format!("Chunked upload session complete returned {status}: {body}");
+            cancel_chunked_upload_session(client, peer_endpoint, peer_api_key, &session_id).await;
             handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
         Err(e) => {
-            let msg = format!("Chunked transfer session complete failed: {e}");
+            let msg = format!("Chunked upload session complete failed: {e}");
+            cancel_chunked_upload_session(client, peer_endpoint, peer_api_key, &session_id).await;
             handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
@@ -1214,63 +1204,33 @@ async fn read_artifact_chunk_from_storage(
     offset: u64,
     length: usize,
 ) -> Result<Vec<u8>, String> {
-    use futures::StreamExt;
-
     if length == 0 {
         return Ok(Vec::new());
     }
 
     let storage = storage_for_task(storage_registry, task)?;
-    let mut stream = storage.get_stream(&task.storage_key).await.map_err(|e| {
-        let location = storage_location_for_task(task);
-        format!(
-            "Failed to open stream for '{}' from storage backend '{}': {e}",
-            task.storage_key, location.backend
-        )
-    })?;
-
-    let mut consumed = 0u64;
-    let mut remaining = length;
-    let mut out = Vec::with_capacity(length);
-
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| {
+    let bytes = storage
+        .get_range(&task.storage_key, offset, length)
+        .await
+        .map_err(|e| {
             let location = storage_location_for_task(task);
             format!(
-                "Failed to read stream for '{}' from storage backend '{}': {e}",
-                task.storage_key, location.backend
+                "Failed to read range for '{}' from storage backend '{}' (offset={}, length={}): {e}",
+                task.storage_key, location.backend, offset, length
             )
         })?;
-        let chunk_len = chunk.len() as u64;
-        let chunk_end = consumed.saturating_add(chunk_len);
 
-        if chunk_end <= offset {
-            consumed = chunk_end;
-            continue;
-        }
-
-        let start = offset.saturating_sub(consumed) as usize;
-        let available = &chunk[start..];
-        let take = available.len().min(remaining);
-        out.extend_from_slice(&available[..take]);
-        remaining -= take;
-
-        if remaining == 0 {
-            break;
-        }
-
-        consumed = chunk_end;
-    }
-
-    if out.len() == length {
-        Ok(out)
+    if bytes.len() == length {
+        Ok(bytes.to_vec())
     } else {
+        let location = storage_location_for_task(task);
         Err(format!(
-            "Failed to read complete chunk for '{}' (offset={}, length={}, got={})",
+            "Failed to read complete chunk for '{}' from storage backend '{}' (offset={}, length={}, got={})",
             task.storage_key,
+            location.backend,
             offset,
             length,
-            out.len()
+            bytes.len()
         ))
     }
 }
@@ -1506,43 +1466,68 @@ fn percent_encode_path_segment(segment: &str) -> String {
     encoded
 }
 
-/// Build the URL to initialize a chunked transfer session on a peer.
-pub(crate) fn build_chunked_init_url(peer_endpoint: &str, peer_id: &Uuid) -> String {
-    format!(
-        "{}/api/v1/peers/{}/transfer/init",
-        peer_endpoint.trim_end_matches('/'),
-        peer_id
-    )
+/// Build the URL to initialize a resumable upload session on a peer.
+pub(crate) fn build_chunked_upload_session_url(peer_endpoint: &str) -> String {
+    format!("{}/api/v1/uploads", peer_endpoint.trim_end_matches('/'))
 }
 
-/// Build the URL to complete a single chunk within a transfer session.
-pub(crate) fn build_chunk_complete_url(
-    peer_endpoint: &str,
-    peer_id: &Uuid,
-    session_id: &Uuid,
-    chunk_index: i32,
-) -> String {
-    format!(
-        "{}/api/v1/peers/{}/transfer/{}/chunk/{}/complete",
-        peer_endpoint.trim_end_matches('/'),
-        peer_id,
-        session_id,
-        chunk_index
-    )
+fn build_chunked_upload_session_body(task: &TaskRow, chunk_size: i32) -> serde_json::Value {
+    serde_json::json!({
+        "repository_key": task.repository_key,
+        "artifact_path": task.artifact_path,
+        "artifact_name": task.artifact_name,
+        "artifact_version": task.artifact_version,
+        "total_size": task.artifact_size,
+        "checksum_sha256": task.checksum_sha256,
+        "chunk_size": chunk_size,
+        "content_type": task.content_type,
+    })
 }
 
-/// Build the URL to finalize an entire transfer session.
-pub(crate) fn build_session_complete_url(
-    peer_endpoint: &str,
-    peer_id: &Uuid,
-    session_id: &Uuid,
-) -> String {
+/// Build the URL to upload one chunk to a resumable upload session.
+pub(crate) fn build_chunked_upload_chunk_url(peer_endpoint: &str, session_id: &Uuid) -> String {
     format!(
-        "{}/api/v1/peers/{}/transfer/{}/complete",
+        "{}/api/v1/uploads/{}",
         peer_endpoint.trim_end_matches('/'),
-        peer_id,
         session_id
     )
+}
+
+/// Build the URL to finalize a resumable upload session.
+pub(crate) fn build_chunked_upload_complete_url(peer_endpoint: &str, session_id: &Uuid) -> String {
+    format!(
+        "{}/api/v1/uploads/{}/complete",
+        peer_endpoint.trim_end_matches('/'),
+        session_id
+    )
+}
+
+/// Build the RFC 9110 byte range header for one chunk.
+pub(crate) fn build_content_range(byte_offset: i64, byte_length: i32, total_size: i64) -> String {
+    let end = byte_offset + byte_length as i64 - 1;
+    format!("bytes {}-{}/{}", byte_offset, end, total_size)
+}
+
+async fn cancel_chunked_upload_session(
+    client: &reqwest::Client,
+    peer_endpoint: &str,
+    peer_api_key: &str,
+    session_id: &Uuid,
+) {
+    let url = build_chunked_upload_chunk_url(peer_endpoint, session_id);
+    if let Err(e) = client
+        .delete(&url)
+        .header("Authorization", format!("Bearer {}", peer_api_key))
+        .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
+        .send()
+        .await
+    {
+        tracing::warn!(
+            session_id = %session_id,
+            error = %e,
+            "Failed to cancel remote chunked upload session after transfer error"
+        );
+    }
 }
 
 /// Read the configured chunked transfer threshold from `SYNC_CHUNKED_THRESHOLD_BYTES`,
@@ -1773,8 +1758,143 @@ fn parse_utc_offset_secs(tz: &str) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
     use chrono::NaiveTime;
+    use futures::stream::BoxStream;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
     use tokio::time::Duration;
+
+    struct RangeRecordingBackend {
+        data: Bytes,
+        range_calls: Mutex<Vec<(String, u64, usize)>>,
+        stream_calls: AtomicUsize,
+    }
+
+    impl RangeRecordingBackend {
+        fn new(data: &'static [u8]) -> Self {
+            Self {
+                data: Bytes::from_static(data),
+                range_calls: Mutex::new(Vec::new()),
+                stream_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::storage::StorageBackend for RangeRecordingBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            Ok(self.data.clone())
+        }
+
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        async fn get_stream(
+            &self,
+            _key: &str,
+        ) -> crate::error::Result<BoxStream<'static, crate::error::Result<Bytes>>> {
+            self.stream_calls.fetch_add(1, Ordering::SeqCst);
+            Err(crate::error::AppError::Storage(
+                "get_stream should not be used for chunk reads".to_string(),
+            ))
+        }
+
+        async fn get_range(
+            &self,
+            key: &str,
+            offset: u64,
+            length: usize,
+        ) -> crate::error::Result<Bytes> {
+            self.range_calls
+                .lock()
+                .unwrap()
+                .push((key.to_string(), offset, length));
+
+            let start = offset as usize;
+            if start >= self.data.len() {
+                return Ok(Bytes::new());
+            }
+
+            let end = start.saturating_add(length).min(self.data.len());
+            Ok(self.data.slice(start..end))
+        }
+    }
+
+    fn test_task(storage_backend: &str) -> TaskRow {
+        TaskRow {
+            id: Uuid::new_v4(),
+            peer_instance_id: Uuid::new_v4(),
+            artifact_id: Uuid::new_v4(),
+            priority: 0,
+            storage_key: "object-key".to_string(),
+            artifact_size: 26,
+            artifact_name: "artifact.bin".to_string(),
+            artifact_version: None,
+            artifact_path: "path/artifact.bin".to_string(),
+            repository_key: "repo".to_string(),
+            repository_id: Uuid::new_v4(),
+            repository_storage_backend: storage_backend.to_string(),
+            repository_storage_path: String::new(),
+            content_type: "application/octet-stream".to_string(),
+            checksum_sha256: "source-sha256".to_string(),
+            task_type: "push".to_string(),
+            replication_filter: None,
+            retry_count: 0,
+            max_retries: DEFAULT_MAX_RETRIES,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_read_artifact_chunk_uses_storage_range_read() {
+        let backend = Arc::new(RangeRecordingBackend::new(b"abcdefghijklmnopqrstuvwxyz"));
+        let mut backends: HashMap<String, Arc<dyn crate::storage::StorageBackend>> = HashMap::new();
+        backends.insert("s3-peer".to_string(), backend.clone());
+        let registry = StorageRegistry::new(backends, "s3-peer".to_string());
+        let task = test_task("s3-peer");
+
+        let chunk = read_artifact_chunk_from_storage(&registry, &task, 5, 8)
+            .await
+            .unwrap();
+
+        assert_eq!(chunk, b"fghijklm");
+        assert_eq!(
+            *backend.range_calls.lock().unwrap(),
+            vec![("object-key".to_string(), 5, 8)]
+        );
+        assert_eq!(backend.stream_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn test_read_artifact_chunk_rejects_short_range_read() {
+        let backend = Arc::new(RangeRecordingBackend::new(b"abcdefghijklmnopqrstuvwxyz"));
+        let mut backends: HashMap<String, Arc<dyn crate::storage::StorageBackend>> = HashMap::new();
+        backends.insert("s3-peer".to_string(), backend);
+        let registry = StorageRegistry::new(backends, "s3-peer".to_string());
+        let task = test_task("s3-peer");
+
+        let err = read_artifact_chunk_from_storage(&registry, &task, 24, 4)
+            .await
+            .unwrap_err();
+
+        assert!(err.contains("Failed to read complete chunk"));
+        assert!(err.contains("got=2"));
+    }
+
+    #[test]
+    fn test_replication_upload_checksum_header_matches_put_handler() {
+        assert_eq!(CHECKSUM_SHA256_HEADER, "x-checksum-sha256");
+    }
 
     // ── calculate_backoff ───────────────────────────────────────────────
 
@@ -2955,67 +3075,97 @@ mod tests {
         }
     }
 
-    // ── build_chunked_init_url ─────────────────────────────────────────
+    // ── chunked upload URL helpers ─────────────────────────────────────
 
     #[test]
-    fn test_build_chunked_init_url() {
-        let peer_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    fn test_build_chunked_upload_session_url() {
         assert_eq!(
-            build_chunked_init_url("https://peer.example.com", &peer_id),
-            "https://peer.example.com/api/v1/peers/11111111-1111-1111-1111-111111111111/transfer/init"
+            build_chunked_upload_session_url("https://peer.example.com"),
+            "https://peer.example.com/api/v1/uploads"
         );
     }
 
     #[test]
-    fn test_build_chunked_init_url_trailing_slash() {
-        let peer_id = Uuid::parse_str("22222222-2222-2222-2222-222222222222").unwrap();
+    fn test_build_chunked_upload_session_url_trailing_slash() {
         assert_eq!(
-            build_chunked_init_url("https://peer.example.com/", &peer_id),
-            "https://peer.example.com/api/v1/peers/22222222-2222-2222-2222-222222222222/transfer/init"
+            build_chunked_upload_session_url("https://peer.example.com/"),
+            "https://peer.example.com/api/v1/uploads"
         );
     }
 
-    // ── build_chunk_complete_url ───────────────────────────────────────
+    #[test]
+    fn test_build_chunked_upload_session_body_preserves_artifact_metadata() {
+        let mut task = test_task("filesystem");
+        task.artifact_name = "name-check".to_string();
+        task.artifact_version = Some("20260603T072902Z".to_string());
+        task.artifact_path = "name-check/20260603T072902Z/large-160m.bin".to_string();
+
+        let body = build_chunked_upload_session_body(&task, 52_428_800);
+
+        assert_eq!(body["repository_key"], "repo");
+        assert_eq!(
+            body["artifact_path"],
+            "name-check/20260603T072902Z/large-160m.bin"
+        );
+        assert_eq!(body["artifact_name"], "name-check");
+        assert_eq!(body["artifact_version"], "20260603T072902Z");
+        assert_eq!(body["chunk_size"], 52_428_800);
+    }
 
     #[test]
-    fn test_build_chunk_complete_url() {
-        let peer_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    fn test_build_chunked_upload_chunk_url() {
         let session_id = Uuid::parse_str("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa").unwrap();
         assert_eq!(
-            build_chunk_complete_url("https://peer.example.com", &peer_id, &session_id, 3),
-            "https://peer.example.com/api/v1/peers/11111111-1111-1111-1111-111111111111/transfer/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa/chunk/3/complete"
+            build_chunked_upload_chunk_url("https://peer.example.com", &session_id),
+            "https://peer.example.com/api/v1/uploads/aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
         );
     }
 
     #[test]
-    fn test_build_chunk_complete_url_trailing_slash() {
-        let peer_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    fn test_build_chunked_upload_chunk_url_trailing_slash() {
         let session_id = Uuid::parse_str("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb").unwrap();
         assert_eq!(
-            build_chunk_complete_url("https://peer.example.com/", &peer_id, &session_id, 0),
-            "https://peer.example.com/api/v1/peers/11111111-1111-1111-1111-111111111111/transfer/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb/chunk/0/complete"
+            build_chunked_upload_chunk_url("https://peer.example.com/", &session_id),
+            "https://peer.example.com/api/v1/uploads/bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
         );
     }
 
-    // ── build_session_complete_url ─────────────────────────────────────
-
     #[test]
-    fn test_build_session_complete_url() {
-        let peer_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    fn test_build_chunked_upload_complete_url() {
         let session_id = Uuid::parse_str("cccccccc-cccc-cccc-cccc-cccccccccccc").unwrap();
         assert_eq!(
-            build_session_complete_url("https://peer.example.com", &peer_id, &session_id),
-            "https://peer.example.com/api/v1/peers/11111111-1111-1111-1111-111111111111/transfer/cccccccc-cccc-cccc-cccc-cccccccccccc/complete"
+            build_chunked_upload_complete_url("https://peer.example.com", &session_id),
+            "https://peer.example.com/api/v1/uploads/cccccccc-cccc-cccc-cccc-cccccccccccc/complete"
         );
     }
 
     #[test]
-    fn test_build_session_complete_url_trailing_slash() {
-        let peer_id = Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap();
+    fn test_build_chunked_upload_complete_url_trailing_slash() {
         let session_id = Uuid::parse_str("dddddddd-dddd-dddd-dddd-dddddddddddd").unwrap();
         assert_eq!(
-            build_session_complete_url("https://peer.example.com/", &peer_id, &session_id),
-            "https://peer.example.com/api/v1/peers/11111111-1111-1111-1111-111111111111/transfer/dddddddd-dddd-dddd-dddd-dddddddddddd/complete"
+            build_chunked_upload_complete_url("https://peer.example.com/", &session_id),
+            "https://peer.example.com/api/v1/uploads/dddddddd-dddd-dddd-dddd-dddddddddddd/complete"
+        );
+    }
+
+    #[test]
+    fn test_build_content_range_first_chunk() {
+        assert_eq!(build_content_range(0, 1024, 4096), "bytes 0-1023/4096");
+    }
+
+    #[test]
+    fn test_build_content_range_middle_chunk() {
+        assert_eq!(
+            build_content_range(1_048_576, 1_048_576, 3_145_728),
+            "bytes 1048576-2097151/3145728"
+        );
+    }
+
+    #[test]
+    fn test_build_content_range_last_short_chunk() {
+        assert_eq!(
+            build_content_range(104_857_600, 10, 104_857_610),
+            "bytes 104857600-104857609/104857610"
         );
     }
 

--- a/backend/src/services/sync_worker.rs
+++ b/backend/src/services/sync_worker.rs
@@ -2,16 +2,18 @@
 //!
 //! Processes the `sync_tasks` queue by transferring artifacts to remote peer
 //! instances.  Runs on a 10-second tick, respects per-peer concurrency limits,
-//! sync windows, and exponential backoff on failures.
+//! sync windows, and configurable backoff on failures.
 //!
 //! For artifacts larger than `SYNC_CHUNKED_THRESHOLD_BYTES`, the worker uses
 //! the swarm-based chunked transfer system instead of sending the full file
 //! in a single HTTP request.  This prevents timeouts and memory exhaustion
 //! when syncing large Docker images, ML models, etc.
 
+use crate::storage::{StorageLocation, StorageRegistry};
 use chrono::{NaiveTime, Timelike, Utc};
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
+use std::sync::Arc;
 use tokio::time::{interval, Duration};
 use uuid::Uuid;
 
@@ -23,6 +25,12 @@ use uuid::Uuid;
 /// a 90s test budget; production should keep the conservative default to
 /// avoid flapping under transient heartbeat loss.
 const STALE_PEER_THRESHOLD_MINUTES: i32 = 5;
+
+/// Default interval between active peer liveness probes.
+const PEER_HEARTBEAT_INTERVAL_SECS: u64 = 60;
+
+/// Default timeout for one peer liveness probe request.
+const PEER_HEARTBEAT_TIMEOUT_SECS: u64 = 10;
 
 /// How many ticks (10s each) between stale peer detection runs.
 /// 6 ticks = 60 seconds.
@@ -105,12 +113,30 @@ const DEFAULT_CHUNKED_THRESHOLD_BYTES: i64 = 100 * 1024 * 1024;
 /// Override with the `SYNC_CHUNK_SIZE_BYTES` env var.
 const DEFAULT_SYNC_CHUNK_SIZE_BYTES: i32 = 50 * 1024 * 1024;
 
+const REPLICATION_REQUEST_HEADER: &str = "X-Artifact-Keeper-Replication";
+const REPLICATION_REQUEST_VALUE: &str = "true";
+
+/// Default retry backoff cap for sync tasks.
+///
+/// The default base backoff is the same value, so retries happen every five
+/// minutes unless operators explicitly opt back into exponential backoff.
+pub(crate) const DEFAULT_SYNC_TASK_RETRY_BACKOFF_MAX_SECS: u64 = 300;
+
+/// Default maximum retries for sync tasks (matches migration default).
+#[allow(dead_code)]
+pub(crate) const DEFAULT_MAX_RETRIES: i32 = 3;
+
 /// Check whether the current tick should trigger a stale peer detection run.
 ///
 /// Returns `true` every `interval_ticks` ticks (e.g. every 6th tick = 60s
 /// when each tick is 10s).
 pub(crate) fn should_run_stale_check(tick_count: u64, interval_ticks: u64) -> bool {
     interval_ticks > 0 && tick_count % interval_ticks == 0
+}
+
+/// Check whether the current tick should trigger an active peer heartbeat probe.
+pub(crate) fn should_run_peer_heartbeat_probe(tick_count: u64, interval_ticks: u64) -> bool {
+    tick_count > 0 && interval_ticks > 0 && (tick_count == 1 || tick_count % interval_ticks == 0)
 }
 
 /// Compute the effective stale check period in seconds.
@@ -144,7 +170,7 @@ pub(crate) fn format_stale_detection_log(
 /// The worker runs in an infinite loop on a 10-second interval, picking up
 /// pending sync tasks and dispatching transfers to remote peers.  Every 60
 /// seconds it also checks for stale peers and marks them offline.
-pub async fn spawn_sync_worker(db: PgPool) {
+pub async fn spawn_sync_worker(db: PgPool, storage_registry: Arc<StorageRegistry>) {
     tokio::spawn(async move {
         // Small startup delay so the server can finish initializing.
         tokio::time::sleep(Duration::from_secs(5)).await;
@@ -162,6 +188,20 @@ pub async fn spawn_sync_worker(db: PgPool) {
         let mut tick_count: u64 = 0;
         let stale_interval_ticks = stale_check_interval_ticks();
         let stale_threshold_min = stale_peer_threshold_minutes();
+        let peer_heartbeat_enabled = env_bool("PEER_HEARTBEAT_ENABLED", true);
+        let peer_heartbeat_interval_secs = env_u64_min(
+            "PEER_HEARTBEAT_INTERVAL_SECS",
+            PEER_HEARTBEAT_INTERVAL_SECS,
+            TICK_INTERVAL_SECS,
+        );
+        let peer_heartbeat_interval_ticks =
+            interval_ticks_for_secs(peer_heartbeat_interval_secs, TICK_INTERVAL_SECS);
+        let peer_heartbeat_timeout_secs = env_u64_min(
+            "PEER_HEARTBEAT_TIMEOUT_SECS",
+            PEER_HEARTBEAT_TIMEOUT_SECS,
+            1,
+        );
+        let retry_policy = SyncRetryPolicy::from_env();
         tracing::info!(
             "Sync worker started: stale-check every {}s, threshold {}m, failover deadline ~{}s",
             stale_interval_ticks * TICK_INTERVAL_SECS,
@@ -172,17 +212,46 @@ pub async fn spawn_sync_worker(db: PgPool) {
                 TICK_INTERVAL_SECS,
             )
         );
+        tracing::info!(
+            "Peer heartbeat probes are {} (interval={}s, timeout={}s)",
+            if peer_heartbeat_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            peer_heartbeat_interval_secs,
+            peer_heartbeat_timeout_secs,
+        );
+        tracing::info!(
+            "Sync task retry policy: max_retries={}, backoff_base={}s, backoff_max={}s",
+            retry_policy.max_retries,
+            retry_policy.backoff_base_secs,
+            retry_policy.backoff_max_secs,
+        );
 
         loop {
             tick.tick().await;
             tick_count += 1;
+
+            if peer_heartbeat_enabled
+                && should_run_peer_heartbeat_probe(tick_count, peer_heartbeat_interval_ticks)
+            {
+                run_peer_heartbeat_probes(
+                    &db,
+                    &client,
+                    Duration::from_secs(peer_heartbeat_timeout_secs),
+                )
+                .await;
+            }
 
             // Periodically check for stale peers and mark them offline.
             if should_run_stale_check(tick_count, stale_interval_ticks) {
                 run_stale_peer_detection(&db, stale_threshold_min).await;
             }
 
-            if let Err(e) = process_pending_tasks(&db, &client).await {
+            if let Err(e) =
+                process_pending_tasks(&db, &client, storage_registry.clone(), retry_policy).await
+            {
                 tracing::error!("Sync worker error: {e}");
             }
         }
@@ -205,6 +274,177 @@ async fn run_stale_peer_detection(db: &PgPool, threshold_minutes: i32) {
     }
 }
 
+async fn run_peer_heartbeat_probes(
+    db: &PgPool,
+    client: &reqwest::Client,
+    request_timeout: Duration,
+) {
+    let peers: Vec<PeerHeartbeatRow> = match sqlx::query_as(
+        r#"
+        SELECT id, name, endpoint_url, api_key
+        FROM peer_instances
+        WHERE is_local = false
+        "#,
+    )
+    .fetch_all(db)
+    .await
+    {
+        Ok(peers) => peers,
+        Err(e) => {
+            tracing::warn!("Failed to load peers for heartbeat probe: {e}");
+            return;
+        }
+    };
+
+    for peer in peers {
+        match probe_peer(client, &peer, request_timeout).await {
+            Ok(()) => {
+                if let Err(e) = mark_peer_online(db, peer.id).await {
+                    tracing::warn!(
+                        "Peer heartbeat probe succeeded for '{}', but status update failed: {e}",
+                        peer.name
+                    );
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Peer heartbeat probe failed for '{}': {e}", peer.name);
+                if let Err(update_err) = mark_peer_probe_failed(db, peer.id).await {
+                    tracing::warn!(
+                        "Failed to record heartbeat probe failure for '{}': {update_err}",
+                        peer.name
+                    );
+                }
+            }
+        }
+    }
+}
+
+async fn probe_peer(
+    client: &reqwest::Client,
+    peer: &PeerHeartbeatRow,
+    request_timeout: Duration,
+) -> Result<(), String> {
+    let url = format!("{}/api/v1/peers", peer.endpoint_url.trim_end_matches('/'));
+    let response = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {}", peer.api_key))
+        .timeout(request_timeout)
+        .send()
+        .await
+        .map_err(|e| format!("request to {url} failed: {e}"))?;
+
+    if response.status().is_success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "request to {url} returned HTTP {}",
+            response.status()
+        ))
+    }
+}
+
+async fn mark_peer_online(db: &PgPool, peer_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        UPDATE peer_instances
+        SET status = 'online',
+            last_heartbeat_at = NOW(),
+            consecutive_failures = 0,
+            updated_at = NOW()
+        WHERE id = $1
+        "#,
+    )
+    .bind(peer_id)
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+async fn mark_peer_probe_failed(db: &PgPool, peer_id: Uuid) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        UPDATE peer_instances
+        SET consecutive_failures = CASE
+                WHEN consecutive_failures < 2147483647 THEN consecutive_failures + 1
+                ELSE consecutive_failures
+            END,
+            updated_at = NOW()
+        WHERE id = $1
+        "#,
+    )
+    .bind(peer_id)
+    .execute(db)
+    .await?;
+
+    Ok(())
+}
+
+fn env_bool(key: &str, default: bool) -> bool {
+    match std::env::var(key) {
+        Ok(value) => match value.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "on" => true,
+            "0" | "false" | "no" | "off" => false,
+            _ => default,
+        },
+        Err(_) => default,
+    }
+}
+
+fn env_u64_min(key: &str, default: u64, min: u64) -> u64 {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(default)
+        .max(min)
+}
+
+fn env_i32_min(key: &str, default: i32, min: i32) -> i32 {
+    std::env::var(key)
+        .ok()
+        .and_then(|value| value.parse::<i32>().ok())
+        .unwrap_or(default)
+        .max(min)
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SyncRetryPolicy {
+    max_retries: i32,
+    backoff_base_secs: u64,
+    backoff_max_secs: u64,
+}
+
+impl SyncRetryPolicy {
+    fn from_env() -> Self {
+        let backoff_max_secs = env_u64_min(
+            "SYNC_TASK_RETRY_BACKOFF_MAX_SECS",
+            DEFAULT_SYNC_TASK_RETRY_BACKOFF_MAX_SECS,
+            1,
+        );
+        let backoff_base_secs =
+            env_u64_min("SYNC_TASK_RETRY_BACKOFF_BASE_SECS", backoff_max_secs, 1);
+        let max_retries = env_i32_min("SYNC_TASK_MAX_RETRIES", DEFAULT_MAX_RETRIES, 1);
+
+        Self {
+            max_retries,
+            backoff_base_secs,
+            backoff_max_secs,
+        }
+    }
+
+    fn calculate_backoff(self, consecutive_failures: i32) -> Duration {
+        calculate_configured_backoff(
+            consecutive_failures,
+            self.backoff_base_secs,
+            self.backoff_max_secs,
+        )
+    }
+}
+
+fn interval_ticks_for_secs(interval_secs: u64, tick_secs: u64) -> u64 {
+    interval_secs.div_ceil(tick_secs).max(1)
+}
+
 // ── Internal row types ──────────────────────────────────────────────────────
 
 /// Lightweight projection of `peer_instances` used by the worker.
@@ -219,6 +459,15 @@ struct PeerRow {
     sync_window_timezone: Option<String>,
     concurrent_transfers_limit: Option<i32>,
     active_transfers: i32,
+}
+
+/// Lightweight projection used by active peer heartbeat probes.
+#[derive(Debug, sqlx::FromRow)]
+struct PeerHeartbeatRow {
+    id: Uuid,
+    name: String,
+    endpoint_url: String,
+    api_key: String,
 }
 
 /// Lightweight projection of a pending sync task joined with the artifact.
@@ -236,6 +485,8 @@ struct TaskRow {
     artifact_path: String,
     repository_key: String,
     repository_id: Uuid,
+    repository_storage_backend: String,
+    repository_storage_path: String,
     content_type: String,
     checksum_sha256: String,
     task_type: String,
@@ -330,7 +581,12 @@ async fn get_local_peer_id(db: &PgPool) -> Option<Uuid> {
 // ── Core logic ──────────────────────────────────────────────────────────────
 
 /// Process all eligible peers and their pending sync tasks.
-async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<(), String> {
+async fn process_pending_tasks(
+    db: &PgPool,
+    client: &reqwest::Client,
+    storage_registry: Arc<StorageRegistry>,
+    retry_policy: SyncRetryPolicy,
+) -> Result<(), String> {
     // Fetch non-local peers that are online or syncing and not in backoff.
     let peers: Vec<PeerRow> = sqlx::query_as(
         r#"
@@ -363,7 +619,13 @@ async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<
         UPDATE sync_tasks
         SET status = 'pending', error_message = NULL, started_at = NULL, completed_at = NULL
         WHERE status = 'failed'
-          AND retry_count < max_retries
+          AND retry_count < GREATEST(max_retries, $1)
+          AND EXISTS (
+              SELECT 1
+              FROM artifacts a
+              WHERE a.id = sync_tasks.artifact_id
+                AND (sync_tasks.task_type = 'delete' OR a.is_deleted = false)
+          )
           AND peer_instance_id = ANY(
               SELECT id FROM peer_instances
               WHERE is_local = false
@@ -372,6 +634,7 @@ async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<
           )
         "#,
     )
+    .bind(retry_policy.max_retries)
     .execute(db)
     .await
     .map_err(|e| format!("Failed to reset retriable tasks: {e}"))?;
@@ -434,12 +697,14 @@ async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<
                 a.path AS artifact_path,
                 r.key AS repository_key,
                 r.id AS repository_id,
+                r.storage_backend AS repository_storage_backend,
+                r.storage_path AS repository_storage_path,
                 a.content_type,
                 a.checksum_sha256,
                 st.task_type,
                 prs.replication_filter,
                 st.retry_count,
-                st.max_retries
+                GREATEST(st.max_retries, $3)::INT AS max_retries
             FROM sync_tasks st
             JOIN artifacts a ON a.id = st.artifact_id
             JOIN repositories r ON r.id = a.repository_id
@@ -448,12 +713,14 @@ async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<
                AND prs.repository_id = r.id
             WHERE st.peer_instance_id = $1
               AND st.status = 'pending'
+              AND (st.task_type = 'delete' OR a.is_deleted = false)
             ORDER BY st.priority DESC, st.created_at ASC
             LIMIT $2
             "#,
         )
         .bind(peer.id)
         .bind(available_slots as i64)
+        .bind(retry_policy.max_retries)
         .fetch_all(db)
         .await
         .map_err(|e| format!("Failed to fetch tasks for peer '{}': {e}", peer.name))?;
@@ -500,10 +767,19 @@ async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<
             let db = db.clone();
             let client = client.clone();
             let peer_name = peer.name.clone();
+            let storage_registry = storage_registry.clone();
 
             tokio::spawn(async move {
-                if let Err(e) =
-                    execute_transfer(&db, &client, &task, &peer_endpoint, &peer_api_key).await
+                if let Err(e) = execute_transfer(
+                    &db,
+                    &client,
+                    storage_registry,
+                    &task,
+                    &peer_endpoint,
+                    &peer_api_key,
+                    retry_policy,
+                )
+                .await
                 {
                     tracing::error!(
                         "Transfer failed for task {} to peer '{}': {e}",
@@ -522,9 +798,11 @@ async fn process_pending_tasks(db: &PgPool, client: &reqwest::Client) -> Result<
 async fn execute_transfer(
     db: &PgPool,
     client: &reqwest::Client,
+    storage_registry: Arc<StorageRegistry>,
     task: &TaskRow,
     peer_endpoint: &str,
     peer_api_key: &str,
+    retry_policy: SyncRetryPolicy,
 ) -> Result<(), String> {
     // 1. Mark task as in_progress, increment active_transfers.
     sqlx::query(
@@ -552,35 +830,48 @@ async fn execute_transfer(
     .map_err(|e| format!("Failed to increment active_transfers: {e}"))?;
 
     if task.task_type == "delete" {
-        return execute_delete(db, client, task, peer_endpoint, peer_api_key).await;
+        return execute_delete(db, client, task, peer_endpoint, peer_api_key, retry_policy).await;
     }
 
     // Push flow: decide between single-request upload and chunked transfer
     // based on the artifact size.
     let threshold = chunked_threshold_bytes();
     if should_use_chunked_transfer(task.artifact_size, threshold) {
-        return execute_chunked_transfer(db, client, task, peer_endpoint, peer_api_key).await;
+        return execute_chunked_transfer(
+            db,
+            client,
+            &storage_registry,
+            task,
+            peer_endpoint,
+            peer_api_key,
+            retry_policy,
+        )
+        .await;
     }
 
-    // Fast path for small artifacts: read entire file and POST in one request.
+    // Fast path for small artifacts: read entire file and PUT it to the same
+    // artifact path on the remote peer. POST /artifacts is the multipart upload
+    // endpoint.
 
     // 2. Read the artifact bytes from local storage.
-    let file_bytes = match read_artifact_from_storage(db, &task.storage_key).await {
+    let file_bytes = match read_artifact_from_storage(&storage_registry, task).await {
         Ok(bytes) => bytes,
         Err(e) => {
-            handle_transfer_failure(db, task, &format!("Storage read error: {e}")).await;
+            handle_transfer_failure(db, task, &format!("Storage read error: {e}"), retry_policy)
+                .await;
             return Err(format!("Storage read error: {e}"));
         }
     };
 
     let bytes_len = file_bytes.len() as i64;
 
-    // 3. POST the artifact to the remote peer.
-    let url = build_transfer_url(peer_endpoint, &task.repository_key);
+    // 3. PUT the artifact to the remote peer.
+    let url = build_transfer_url(peer_endpoint, &task.repository_key, &task.artifact_path);
 
     let result = client
-        .post(&url)
+        .put(&url)
         .header("Authorization", format!("Bearer {}", peer_api_key))
+        .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
         .header("Content-Type", &task.content_type)
         .header("X-Artifact-Name", &task.artifact_name)
         .header(
@@ -612,12 +903,12 @@ async fn execute_transfer(
                 .await
                 .unwrap_or_else(|_| "<unreadable>".to_string());
             let msg = format!("Remote peer returned {status}: {body}");
-            handle_transfer_failure(db, task, &msg).await;
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
         Err(e) => {
             let msg = format!("HTTP request failed: {e}");
-            handle_transfer_failure(db, task, &msg).await;
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
     }
@@ -632,9 +923,11 @@ async fn execute_transfer(
 async fn execute_chunked_transfer(
     db: &PgPool,
     client: &reqwest::Client,
+    storage_registry: &StorageRegistry,
     task: &TaskRow,
     peer_endpoint: &str,
     peer_api_key: &str,
+    retry_policy: SyncRetryPolicy,
 ) -> Result<(), String> {
     let chunk_size = sync_chunk_size_bytes();
 
@@ -656,6 +949,7 @@ async fn execute_chunked_transfer(
     let init_response = client
         .post(&init_url)
         .header("Authorization", format!("Bearer {}", peer_api_key))
+        .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
         .header("Content-Type", "application/json")
         .json(&init_body)
         .send()
@@ -669,7 +963,7 @@ async fn execute_chunked_transfer(
             .await
             .unwrap_or_else(|_| "<unreadable>".to_string());
         let msg = format!("Chunked transfer init returned {status}: {body}");
-        handle_transfer_failure(db, task, &msg).await;
+        handle_transfer_failure(db, task, &msg, retry_policy).await;
         return Err(msg);
     }
 
@@ -690,7 +984,8 @@ async fn execute_chunked_transfer(
     for (chunk_index, byte_offset, byte_length) in &chunk_ranges {
         // Read just this chunk from storage.
         let chunk_data = match read_artifact_chunk_from_storage(
-            &task.storage_key,
+            storage_registry,
+            task,
             *byte_offset as u64,
             *byte_length as usize,
         )
@@ -702,7 +997,7 @@ async fn execute_chunked_transfer(
                     "Failed to read chunk {} (offset={}, len={}): {e}",
                     chunk_index, byte_offset, byte_length
                 );
-                handle_transfer_failure(db, task, &msg).await;
+                handle_transfer_failure(db, task, &msg, retry_policy).await;
                 return Err(msg);
             }
         };
@@ -725,6 +1020,7 @@ async fn execute_chunked_transfer(
         let upload_result = client
             .put(&chunk_upload_url)
             .header("Authorization", format!("Bearer {}", peer_api_key))
+            .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
             .header("Content-Type", "application/octet-stream")
             .header("X-Chunk-Offset", byte_offset.to_string())
             .header("X-Chunk-Length", byte_length.to_string())
@@ -750,6 +1046,7 @@ async fn execute_chunked_transfer(
                 let _ = client
                     .post(&complete_url)
                     .header("Authorization", format!("Bearer {}", peer_api_key))
+                    .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
                     .header("Content-Type", "application/json")
                     .json(&complete_body)
                     .send()
@@ -771,12 +1068,12 @@ async fn execute_chunked_transfer(
                     .await
                     .unwrap_or_else(|_| "<unreadable>".to_string());
                 let msg = format!("Chunk {} upload returned {status}: {body}", chunk_index);
-                handle_transfer_failure(db, task, &msg).await;
+                handle_transfer_failure(db, task, &msg, retry_policy).await;
                 return Err(msg);
             }
             Err(e) => {
                 let msg = format!("Chunk {} upload failed: {e}", chunk_index);
-                handle_transfer_failure(db, task, &msg).await;
+                handle_transfer_failure(db, task, &msg, retry_policy).await;
                 return Err(msg);
             }
         }
@@ -789,6 +1086,7 @@ async fn execute_chunked_transfer(
     let complete_result = client
         .post(&session_complete_url)
         .header("Authorization", format!("Bearer {}", peer_api_key))
+        .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
         .send()
         .await;
 
@@ -811,12 +1109,12 @@ async fn execute_chunked_transfer(
                 .await
                 .unwrap_or_else(|_| "<unreadable>".to_string());
             let msg = format!("Chunked transfer session complete returned {status}: {body}");
-            handle_transfer_failure(db, task, &msg).await;
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
         Err(e) => {
             let msg = format!("Chunked transfer session complete failed: {e}");
-            handle_transfer_failure(db, task, &msg).await;
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
     }
@@ -829,12 +1127,14 @@ async fn execute_delete(
     task: &TaskRow,
     peer_endpoint: &str,
     peer_api_key: &str,
+    retry_policy: SyncRetryPolicy,
 ) -> Result<(), String> {
     let url = build_delete_url(peer_endpoint, &task.repository_key, &task.artifact_path);
 
     let result = client
         .delete(&url)
         .header("Authorization", format!("Bearer {}", peer_api_key))
+        .header(REPLICATION_REQUEST_HEADER, REPLICATION_REQUEST_VALUE)
         .send()
         .await;
 
@@ -856,62 +1156,123 @@ async fn execute_delete(
                 .await
                 .unwrap_or_else(|_| "<unreadable>".to_string());
             let msg = format!("Remote peer returned {status} for delete: {body}");
-            handle_transfer_failure(db, task, &msg).await;
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
         Err(e) => {
             let msg = format!("HTTP delete request failed: {e}");
-            handle_transfer_failure(db, task, &msg).await;
+            handle_transfer_failure(db, task, &msg, retry_policy).await;
             Err(msg)
         }
     }
 }
 
-/// Read artifact bytes from the storage backend using the storage_key.
-///
-/// Uses the `STORAGE_PATH` environment variable (same as the main server) to
-/// locate the filesystem storage root.  For S3 backends the storage_key is
-/// fetched directly.
-async fn read_artifact_from_storage(_db: &PgPool, storage_key: &str) -> Result<Vec<u8>, String> {
-    // Determine storage path from env (fallback to default).
-    let storage_path = std::env::var("STORAGE_PATH")
-        .unwrap_or_else(|_| "/var/lib/artifact-keeper/artifacts".into());
-    let full_path = std::path::PathBuf::from(&storage_path).join(storage_key);
-
-    tokio::fs::read(&full_path)
-        .await
-        .map_err(|e| format!("Failed to read '{}': {e}", full_path.display()))
+fn storage_location_for_task(task: &TaskRow) -> StorageLocation {
+    StorageLocation {
+        backend: task.repository_storage_backend.clone(),
+        path: task.repository_storage_path.clone(),
+    }
 }
 
-/// Read a specific byte range from a stored artifact.
-///
-/// Seeks to `offset` and reads exactly `length` bytes.  Used by the chunked
-/// transfer path to avoid loading the entire artifact into memory.
+fn storage_for_task(
+    storage_registry: &StorageRegistry,
+    task: &TaskRow,
+) -> Result<Arc<dyn crate::storage::StorageBackend>, String> {
+    let location = storage_location_for_task(task);
+    storage_registry.backend_for(&location).map_err(|e| {
+        format!(
+            "Failed to resolve storage backend '{}': {e}",
+            location.backend
+        )
+    })
+}
+
+/// Read artifact bytes through the repository's configured storage backend.
+async fn read_artifact_from_storage(
+    storage_registry: &StorageRegistry,
+    task: &TaskRow,
+) -> Result<Vec<u8>, String> {
+    let storage = storage_for_task(storage_registry, task)?;
+
+    storage
+        .get(&task.storage_key)
+        .await
+        .map(|bytes| bytes.to_vec())
+        .map_err(|e| {
+            let location = storage_location_for_task(task);
+            format!(
+                "Failed to read '{}' from storage backend '{}': {e}",
+                task.storage_key, location.backend
+            )
+        })
+}
+
+/// Read a specific byte range through the repository's configured storage backend.
 async fn read_artifact_chunk_from_storage(
-    storage_key: &str,
+    storage_registry: &StorageRegistry,
+    task: &TaskRow,
     offset: u64,
     length: usize,
 ) -> Result<Vec<u8>, String> {
-    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+    use futures::StreamExt;
 
-    let storage_path = std::env::var("STORAGE_PATH")
-        .unwrap_or_else(|_| "/var/lib/artifact-keeper/artifacts".into());
-    let full_path = std::path::PathBuf::from(&storage_path).join(storage_key);
+    if length == 0 {
+        return Ok(Vec::new());
+    }
 
-    let mut file = tokio::fs::File::open(&full_path)
-        .await
-        .map_err(|e| format!("Failed to open '{}': {e}", full_path.display()))?;
+    let storage = storage_for_task(storage_registry, task)?;
+    let mut stream = storage.get_stream(&task.storage_key).await.map_err(|e| {
+        let location = storage_location_for_task(task);
+        format!(
+            "Failed to open stream for '{}' from storage backend '{}': {e}",
+            task.storage_key, location.backend
+        )
+    })?;
 
-    file.seek(std::io::SeekFrom::Start(offset))
-        .await
-        .map_err(|e| format!("Failed to seek in '{}': {e}", full_path.display()))?;
+    let mut consumed = 0u64;
+    let mut remaining = length;
+    let mut out = Vec::with_capacity(length);
 
-    let mut buf = vec![0u8; length];
-    file.read_exact(&mut buf)
-        .await
-        .map_err(|e| format!("Failed to read chunk from '{}': {e}", full_path.display()))?;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| {
+            let location = storage_location_for_task(task);
+            format!(
+                "Failed to read stream for '{}' from storage backend '{}': {e}",
+                task.storage_key, location.backend
+            )
+        })?;
+        let chunk_len = chunk.len() as u64;
+        let chunk_end = consumed.saturating_add(chunk_len);
 
-    Ok(buf)
+        if chunk_end <= offset {
+            consumed = chunk_end;
+            continue;
+        }
+
+        let start = offset.saturating_sub(consumed) as usize;
+        let available = &chunk[start..];
+        let take = available.len().min(remaining);
+        out.extend_from_slice(&available[..take]);
+        remaining -= take;
+
+        if remaining == 0 {
+            break;
+        }
+
+        consumed = chunk_end;
+    }
+
+    if out.len() == length {
+        Ok(out)
+    } else {
+        Err(format!(
+            "Failed to read complete chunk for '{}' (offset={}, length={}, got={})",
+            task.storage_key,
+            offset,
+            length,
+            out.len()
+        ))
+    }
 }
 
 /// Handle a successful transfer: mark task completed, update peer counters.
@@ -1028,17 +1389,18 @@ pub(crate) fn format_retry_log(
     }
 }
 
-/// Default maximum retries for sync tasks (matches migration default).
-#[allow(dead_code)]
-pub(crate) const DEFAULT_MAX_RETRIES: i32 = 3;
-
 /// Handle a failed transfer: mark task, apply backoff, update peer counters.
 ///
 /// If the task has remaining retries (`retry_count < max_retries`), it is
 /// marked `failed` with an incremented `retry_count`. The peer-recovery
 /// reset at the top of `process_pending_tasks` will flip it back to
 /// `pending` once the peer's backoff expires.
-async fn handle_transfer_failure(db: &PgPool, task: &TaskRow, error_message: &str) {
+async fn handle_transfer_failure(
+    db: &PgPool,
+    task: &TaskRow,
+    error_message: &str,
+    retry_policy: SyncRetryPolicy,
+) {
     let decision = evaluate_task_failure(task.retry_count, task.max_retries);
 
     // Mark task as failed with updated retry count.
@@ -1073,7 +1435,7 @@ async fn handle_transfer_failure(db: &PgPool, task: &TaskRow, error_message: &st
             .await
             .unwrap_or(0);
 
-    let backoff = calculate_backoff(consecutive);
+    let backoff = retry_policy.calculate_backoff(consecutive);
 
     // Update peer instance: decrement active_transfers, bump failure counters, set backoff.
     let _ = sqlx::query(
@@ -1094,12 +1456,17 @@ async fn handle_transfer_failure(db: &PgPool, task: &TaskRow, error_message: &st
     .await;
 }
 
-/// Build the full URL for posting an artifact to a remote peer.
-pub(crate) fn build_transfer_url(peer_endpoint: &str, repository_key: &str) -> String {
+/// Build the full URL for uploading an artifact to a remote peer.
+pub(crate) fn build_transfer_url(
+    peer_endpoint: &str,
+    repository_key: &str,
+    artifact_path: &str,
+) -> String {
     format!(
-        "{}/api/v1/repositories/{}/artifacts",
+        "{}/api/v1/repositories/{}/artifacts/{}",
         peer_endpoint.trim_end_matches('/'),
-        repository_key
+        repository_key,
+        encode_artifact_path(artifact_path)
     )
 }
 
@@ -1113,8 +1480,30 @@ pub(crate) fn build_delete_url(
         "{}/api/v1/repositories/{}/artifacts/{}",
         peer_endpoint.trim_end_matches('/'),
         repository_key,
-        artifact_path
+        encode_artifact_path(artifact_path)
     )
+}
+
+fn encode_artifact_path(path: &str) -> String {
+    path.split('/')
+        .map(percent_encode_path_segment)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn percent_encode_path_segment(segment: &str) -> String {
+    let mut encoded = String::with_capacity(segment.len());
+
+    for byte in segment.as_bytes() {
+        match *byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(*byte as char)
+            }
+            other => encoded.push_str(&format!("%{other:02X}")),
+        }
+    }
+
+    encoded
 }
 
 /// Build the URL to initialize a chunked transfer session on a peer.
@@ -1274,13 +1663,23 @@ fn matches_replication_filter(
     true
 }
 
-/// Calculate exponential backoff duration from consecutive failure count.
-///
-/// Formula: `min(300, 10 * 2^failures)` seconds.
+/// Calculate backoff duration from consecutive failure count using the default
+/// retry policy.
 pub fn calculate_backoff(consecutive_failures: i32) -> Duration {
+    SyncRetryPolicy::from_env().calculate_backoff(consecutive_failures)
+}
+
+pub(crate) fn calculate_configured_backoff(
+    consecutive_failures: i32,
+    base_secs: u64,
+    max_secs: u64,
+) -> Duration {
+    let failures = consecutive_failures.max(0) as u32;
+    let capped_base = base_secs.max(1);
+    let capped_max = max_secs.max(1);
     let secs = std::cmp::min(
-        300u64,
-        10u64.saturating_mul(2u64.saturating_pow(consecutive_failures as u32)),
+        capped_max,
+        capped_base.saturating_mul(2u64.saturating_pow(failures)),
     );
     Duration::from_secs(secs)
 }
@@ -1381,42 +1780,38 @@ mod tests {
 
     #[test]
     fn test_backoff_zero_failures() {
-        // 10 * 2^0 = 10s
+        // Default policy retries every five minutes.
         let d = calculate_backoff(0);
-        assert_eq!(d, Duration::from_secs(10));
+        assert_eq!(d, Duration::from_secs(300));
     }
 
     #[test]
     fn test_backoff_one_failure() {
-        // 10 * 2^1 = 20s
+        // Default base and max are both 300s, so there is no ramp-up.
         let d = calculate_backoff(1);
-        assert_eq!(d, Duration::from_secs(20));
+        assert_eq!(d, Duration::from_secs(300));
     }
 
     #[test]
     fn test_backoff_two_failures() {
-        // 10 * 2^2 = 40s
         let d = calculate_backoff(2);
-        assert_eq!(d, Duration::from_secs(40));
+        assert_eq!(d, Duration::from_secs(300));
     }
 
     #[test]
     fn test_backoff_three_failures() {
-        // 10 * 2^3 = 80s
         let d = calculate_backoff(3);
-        assert_eq!(d, Duration::from_secs(80));
+        assert_eq!(d, Duration::from_secs(300));
     }
 
     #[test]
     fn test_backoff_four_failures() {
-        // 10 * 2^4 = 160s
         let d = calculate_backoff(4);
-        assert_eq!(d, Duration::from_secs(160));
+        assert_eq!(d, Duration::from_secs(300));
     }
 
     #[test]
     fn test_backoff_five_failures_capped() {
-        // 10 * 2^5 = 320 → capped at 300
         let d = calculate_backoff(5);
         assert_eq!(d, Duration::from_secs(300));
     }
@@ -1431,10 +1826,28 @@ mod tests {
     #[test]
     fn test_backoff_negative_failures_treated_as_zero() {
         // Negative shouldn't happen but handle gracefully.
-        // 2^(u32::MAX wrap) would overflow; saturating_pow returns u64::MAX,
-        // then saturating_mul caps and min caps to 300.
         let d = calculate_backoff(-1);
         assert_eq!(d, Duration::from_secs(300));
+    }
+
+    #[test]
+    fn test_configured_backoff_can_use_old_exponential_shape() {
+        assert_eq!(
+            calculate_configured_backoff(0, 10, 300),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            calculate_configured_backoff(1, 10, 300),
+            Duration::from_secs(20)
+        );
+        assert_eq!(
+            calculate_configured_backoff(4, 10, 300),
+            Duration::from_secs(160)
+        );
+        assert_eq!(
+            calculate_configured_backoff(5, 10, 300),
+            Duration::from_secs(300)
+        );
     }
 
     // ── is_within_sync_window ───────────────────────────────────────────
@@ -1549,40 +1962,52 @@ mod tests {
     #[test]
     fn test_build_transfer_url_basic() {
         assert_eq!(
-            build_transfer_url("https://peer.example.com", "maven-releases"),
-            "https://peer.example.com/api/v1/repositories/maven-releases/artifacts"
+            build_transfer_url("https://peer.example.com", "maven-releases", "org/acme/app.jar"),
+            "https://peer.example.com/api/v1/repositories/maven-releases/artifacts/org/acme/app.jar"
         );
     }
 
     #[test]
     fn test_build_transfer_url_trailing_slash() {
         assert_eq!(
-            build_transfer_url("https://peer.example.com/", "npm-proxy"),
-            "https://peer.example.com/api/v1/repositories/npm-proxy/artifacts"
+            build_transfer_url("https://peer.example.com/", "npm-proxy", "@scope/pkg.tgz"),
+            "https://peer.example.com/api/v1/repositories/npm-proxy/artifacts/%40scope/pkg.tgz"
         );
     }
 
     #[test]
     fn test_build_transfer_url_multiple_trailing_slashes() {
         assert_eq!(
-            build_transfer_url("https://peer.example.com///", "cargo-local"),
-            "https://peer.example.com/api/v1/repositories/cargo-local/artifacts"
+            build_transfer_url(
+                "https://peer.example.com///",
+                "cargo-local",
+                "crates/foo crate"
+            ),
+            "https://peer.example.com/api/v1/repositories/cargo-local/artifacts/crates/foo%20crate"
         );
     }
 
     #[test]
     fn test_build_transfer_url_with_port() {
         assert_eq!(
-            build_transfer_url("http://localhost:8080", "docker-hub"),
-            "http://localhost:8080/api/v1/repositories/docker-hub/artifacts"
+            build_transfer_url("http://localhost:8080", "docker-hub", "v2/name/manifests/latest"),
+            "http://localhost:8080/api/v1/repositories/docker-hub/artifacts/v2/name/manifests/latest"
         );
     }
 
     #[test]
     fn test_build_transfer_url_with_path_prefix() {
         assert_eq!(
-            build_transfer_url("https://peer.example.com/v2", "pypi-local"),
-            "https://peer.example.com/v2/api/v1/repositories/pypi-local/artifacts"
+            build_transfer_url("https://peer.example.com/v2", "pypi-local", "pkg/file?x=1"),
+            "https://peer.example.com/v2/api/v1/repositories/pypi-local/artifacts/pkg/file%3Fx%3D1"
+        );
+    }
+
+    #[test]
+    fn test_build_delete_url_encodes_artifact_path() {
+        assert_eq!(
+            build_delete_url("https://peer.example.com", "raw", "dir/file name.txt"),
+            "https://peer.example.com/api/v1/repositories/raw/artifacts/dir/file%20name.txt"
         );
     }
 
@@ -1942,10 +2367,10 @@ mod tests {
     #[test]
     fn test_default_max_retries() {
         assert_eq!(DEFAULT_MAX_RETRIES, 3);
-        // First two failures are retriable with default max
+        // First two failures are retriable with default max.
         assert!(evaluate_task_failure(0, DEFAULT_MAX_RETRIES).is_retriable());
         assert!(evaluate_task_failure(1, DEFAULT_MAX_RETRIES).is_retriable());
-        // Third failure exhausts retries
+        // Third failure exhausts retries.
         assert!(!evaluate_task_failure(2, DEFAULT_MAX_RETRIES).is_retriable());
     }
 
@@ -2004,6 +2429,21 @@ mod tests {
         assert_eq!(STALE_CHECK_INTERVAL_TICKS, 6);
         assert!(should_run_stale_check(6, STALE_CHECK_INTERVAL_TICKS));
         assert!(!should_run_stale_check(5, STALE_CHECK_INTERVAL_TICKS));
+    }
+
+    #[test]
+    fn test_peer_heartbeat_probe_fires_on_first_tick_and_interval() {
+        assert!(should_run_peer_heartbeat_probe(1, 6));
+        assert!(should_run_peer_heartbeat_probe(6, 6));
+        assert!(should_run_peer_heartbeat_probe(12, 6));
+        assert!(!should_run_peer_heartbeat_probe(2, 6));
+        assert!(!should_run_peer_heartbeat_probe(0, 6));
+    }
+
+    #[test]
+    fn test_peer_heartbeat_probe_interval_zero_never_fires() {
+        assert!(!should_run_peer_heartbeat_probe(1, 0));
+        assert!(!should_run_peer_heartbeat_probe(6, 0));
     }
 
     #[test]

--- a/backend/src/services/upload_service.rs
+++ b/backend/src/services/upload_service.rs
@@ -22,6 +22,8 @@ pub struct UploadSession {
     pub repository_id: Uuid,
     pub repository_key: String,
     pub artifact_path: String,
+    pub artifact_name: Option<String>,
+    pub artifact_version: Option<String>,
     pub content_type: String,
     pub total_size: i64,
     pub chunk_size: i32,
@@ -167,6 +169,8 @@ pub struct CreateSessionParams<'a> {
     pub repo_id: Uuid,
     pub repo_key: &'a str,
     pub artifact_path: &'a str,
+    pub artifact_name: Option<&'a str>,
+    pub artifact_version: Option<&'a str>,
     pub total_size: i64,
     pub chunk_size: Option<i32>,
     pub checksum_sha256: &'a str,
@@ -195,6 +199,8 @@ impl UploadService {
 
         let total_chunks = ((p.total_size + chunk_size as i64 - 1) / chunk_size as i64) as i32;
         let content_type = p.content_type.unwrap_or("application/octet-stream");
+        let artifact_name = p.artifact_name.filter(|name| !name.is_empty());
+        let artifact_version = p.artifact_version.filter(|version| !version.is_empty());
 
         let session_id = Uuid::new_v4();
         let temp_dir = PathBuf::from(p.storage_path).join(".uploads");
@@ -218,9 +224,9 @@ impl UploadService {
             r#"
             INSERT INTO upload_sessions
                 (id, user_id, repository_id, repository_key, artifact_path,
-                 content_type, total_size, chunk_size, total_chunks,
-                 checksum_sha256, temp_file_path)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                 artifact_name, artifact_version, content_type, total_size,
+                 chunk_size, total_chunks, checksum_sha256, temp_file_path)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             RETURNING *
             "#,
         )
@@ -229,6 +235,8 @@ impl UploadService {
         .bind(p.repo_id)
         .bind(p.repo_key)
         .bind(p.artifact_path)
+        .bind(artifact_name)
+        .bind(artifact_version)
         .bind(content_type)
         .bind(p.total_size)
         .bind(chunk_size)
@@ -1307,6 +1315,8 @@ mod tests {
             repository_id: Uuid::nil(),
             repository_key: "test-repo".into(),
             artifact_path: "path/to/file.bin".into(),
+            artifact_name: Some("source-name".into()),
+            artifact_version: Some("1.0.0".into()),
             content_type: "application/octet-stream".into(),
             total_size: 1024,
             chunk_size: DEFAULT_CHUNK_SIZE,
@@ -1334,6 +1344,8 @@ mod tests {
             repository_id: Uuid::nil(),
             repository_key: "repo".into(),
             artifact_path: "file.bin".into(),
+            artifact_name: None,
+            artifact_version: None,
             content_type: "application/octet-stream".into(),
             total_size: 100,
             chunk_size: DEFAULT_CHUNK_SIZE,

--- a/backend/src/storage/azure.rs
+++ b/backend/src/storage/azure.rs
@@ -1205,11 +1205,9 @@ impl StorageBackend for AzureBackend {
 
         if block_ids.is_empty() {
             self.put(key, Bytes::new()).await?;
-        } else {
-            if let Err(e) = self.commit_stream_blocks(key, &block_ids).await {
-                self.report_uncommitted_stream_blocks(key, &block_ids).await;
-                return Err(e);
-            }
+        } else if let Err(e) = self.commit_stream_blocks(key, &block_ids).await {
+            self.report_uncommitted_stream_blocks(key, &block_ids).await;
+            return Err(e);
         }
 
         Ok(PutStreamResult {

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -5,9 +5,10 @@ use bytes::Bytes;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use sha2::{Digest, Sha256};
+use std::io::SeekFrom;
 use std::path::{Path, PathBuf};
 use tokio::fs;
-use tokio::io::{AsyncWriteExt, BufReader};
+use tokio::io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt, BufReader};
 use tokio_util::io::ReaderStream;
 use uuid::Uuid;
 
@@ -277,6 +278,44 @@ impl StorageBackend for FilesystemStorage {
         Ok(Box::pin(mapped))
     }
 
+    async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
+        if length == 0 {
+            return Ok(Bytes::new());
+        }
+
+        let path = self.key_to_path(key);
+        let mut file = fs::File::open(&path).await.map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                AppError::NotFound(format!("Storage key not found: {}", key))
+            } else {
+                AppError::Storage(format!("Failed to open {}: {}", key, e))
+            }
+        })?;
+
+        file.seek(SeekFrom::Start(offset))
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to seek {}: {}", key, e)))?;
+
+        let mut remaining = length;
+        let mut out = Vec::with_capacity(length);
+
+        while remaining > 0 {
+            let mut buf = vec![0u8; remaining.min(STREAM_CHUNK_SIZE)];
+            let read = file
+                .read(&mut buf)
+                .await
+                .map_err(|e| AppError::Storage(format!("Failed to read {}: {}", key, e)))?;
+            if read == 0 {
+                break;
+            }
+            buf.truncate(read);
+            out.extend_from_slice(&buf);
+            remaining -= read;
+        }
+
+        Ok(Bytes::from(out))
+    }
+
     async fn put_stream(
         &self,
         key: &str,
@@ -518,6 +557,35 @@ mod tests {
 
         let retrieved = storage.get(key).await.unwrap();
         assert_eq!(retrieved, content);
+    }
+
+    #[tokio::test]
+    async fn test_get_range_reads_requested_window() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "range-key";
+        storage
+            .put(key, Bytes::from_static(b"abcdefghijklmnopqrstuvwxyz"))
+            .await
+            .unwrap();
+
+        let range = storage.get_range(key, 5, 8).await.unwrap();
+
+        assert_eq!(range, Bytes::from_static(b"fghijklm"));
+    }
+
+    #[tokio::test]
+    async fn test_get_range_past_eof_returns_empty() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let storage = FilesystemStorage::new(temp_dir.path());
+
+        let key = "short-range-key";
+        storage.put(key, Bytes::from_static(b"abc")).await.unwrap();
+
+        let range = storage.get_range(key, 10, 4).await.unwrap();
+
+        assert!(range.is_empty());
     }
 
     /// B6 (stampede 502 leak, storage half): `put` writes via a temp file +

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -148,6 +148,51 @@ pub trait StorageBackend: Send + Sync {
         Ok(Box::pin(futures::stream::once(async { Ok(content) })))
     }
 
+    /// Retrieve a byte range from an object.
+    ///
+    /// Backends with native random/ranged reads should override this method
+    /// so large-object consumers do not have to re-download and discard bytes
+    /// for every chunk. The default implementation remains correct for
+    /// backends without native ranges by streaming once and collecting only
+    /// the requested window.
+    async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
+        use futures::StreamExt;
+
+        if length == 0 {
+            return Ok(Bytes::new());
+        }
+
+        let mut stream = self.get_stream(key).await?;
+        let mut consumed = 0u64;
+        let mut remaining = length;
+        let mut out = Vec::with_capacity(length);
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            let chunk_len = chunk.len() as u64;
+            let chunk_end = consumed.saturating_add(chunk_len);
+
+            if chunk_end <= offset {
+                consumed = chunk_end;
+                continue;
+            }
+
+            let start = offset.saturating_sub(consumed) as usize;
+            let available = &chunk[start..];
+            let take = available.len().min(remaining);
+            out.extend_from_slice(&available[..take]);
+            remaining -= take;
+
+            if remaining == 0 {
+                break;
+            }
+
+            consumed = chunk_end;
+        }
+
+        Ok(Bytes::from(out))
+    }
+
     /// Store content from a byte stream, computing a SHA-256 checksum
     /// incrementally as data arrives. The default implementation collects
     /// the stream into memory and delegates to `put()`.
@@ -399,6 +444,24 @@ mod tests {
         assert_eq!(writes.len(), 1);
         assert_eq!(writes[0].0, "dest-key");
         assert_eq!(writes[0].1, Bytes::from_static(b"copied bytes"));
+    }
+
+    #[tokio::test]
+    async fn test_default_get_range_slices_streamed_bytes() {
+        let backend = TestBackend;
+
+        let range = backend.get_range("any-key", 1, 2).await.unwrap();
+
+        assert_eq!(range, Bytes::from_static(b"es"));
+    }
+
+    #[tokio::test]
+    async fn test_default_get_range_zero_length() {
+        let backend = TestBackend;
+
+        let range = backend.get_range("any-key", 2, 0).await.unwrap();
+
+        assert!(range.is_empty());
     }
 
     #[tokio::test]

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -819,6 +819,22 @@ impl S3Backend {
         artifactory_fallback_path(key)
     }
 
+    fn byte_range(offset: u64, length: usize) -> Result<std::ops::Range<u64>> {
+        let length = u64::try_from(length).map_err(|_| {
+            AppError::Storage(format!(
+                "Requested range length {} does not fit in u64",
+                length
+            ))
+        })?;
+        let end = offset.checked_add(length).ok_or_else(|| {
+            AppError::Storage(format!(
+                "Requested range offset {} length {} overflows u64",
+                offset, length
+            ))
+        })?;
+        Ok(offset..end)
+    }
+
     async fn try_fallback_get(&self, key: &str, reason: &'static str) -> Result<Option<Bytes>> {
         if !self.path_format.has_fallback() {
             return Ok(None);
@@ -853,6 +869,49 @@ impl S3Backend {
             Err(object_store::Error::NotFound { .. }) => Ok(None),
             Err(e) => Err(AppError::Storage(format!(
                 "Failed to get fallback object '{}' for '{}': {}",
+                fallback_key, key, e
+            ))),
+        }
+    }
+
+    async fn try_fallback_get_range(
+        &self,
+        key: &str,
+        range: std::ops::Range<u64>,
+        reason: &'static str,
+    ) -> Result<Option<Bytes>> {
+        if !self.path_format.has_fallback() {
+            return Ok(None);
+        }
+
+        let Some(fallback_key) = self.try_artifactory_fallback(key) else {
+            return Ok(None);
+        };
+
+        let fallback_full_key = self.full_key(&fallback_key);
+        tracing::debug!(
+            original = %key,
+            fallback = %fallback_key,
+            range_start = range.start,
+            range_end = range.end,
+            reason,
+            "Trying Artifactory fallback path range"
+        );
+
+        let path: ObjectPath = fallback_full_key.into();
+        match self.store.get_range(&path, range).await {
+            Ok(bytes) => {
+                tracing::info!(
+                    key = %key,
+                    fallback = %fallback_key,
+                    size = bytes.len(),
+                    "Found artifact range at Artifactory fallback path"
+                );
+                Ok(Some(bytes))
+            }
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(e) => Err(AppError::Storage(format!(
+                "Failed to get fallback object range '{}' for '{}': {}",
                 fallback_key, key, e
             ))),
         }
@@ -1132,6 +1191,45 @@ impl super::StorageBackend for S3Backend {
             .map(|r| r.map_err(|e| AppError::Storage(format!("Stream read error: {}", e))));
 
         Ok(Box::pin(stream))
+    }
+
+    async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
+        if length == 0 {
+            return Ok(Bytes::new());
+        }
+
+        let range = Self::byte_range(offset, length)?;
+        let full_key = self.full_key(key);
+        let path: ObjectPath = full_key.into();
+
+        match self.store.get_range(&path, range.clone()).await {
+            Ok(bytes) => {
+                tracing::debug!(
+                    key = %key,
+                    offset,
+                    length,
+                    size = bytes.len(),
+                    "S3 get object range successful"
+                );
+                Ok(bytes)
+            }
+            Err(object_store::Error::NotFound { .. }) => {
+                if let Some(bytes) = self
+                    .try_fallback_get_range(key, range, "primary range not found")
+                    .await?
+                {
+                    return Ok(bytes);
+                }
+                Err(AppError::NotFound(format!(
+                    "Storage key not found: {}",
+                    key
+                )))
+            }
+            Err(e) => Err(AppError::Storage(format!(
+                "Failed to get object range '{}' (offset={}, length={}): {}",
+                key, offset, length, e
+            ))),
+        }
     }
 
     /// Streams `stream` to S3 as a multipart upload.
@@ -1592,6 +1690,20 @@ mod tests {
         let key = format!("a/b/c/d/{}", checksum);
         let result = artifactory_fallback_path(&key);
         assert_eq!(result.unwrap(), format!("91/{}", checksum));
+    }
+
+    #[test]
+    fn test_byte_range_is_end_exclusive() {
+        assert_eq!(S3Backend::byte_range(1_024, 4_096).unwrap(), 1_024..5_120);
+    }
+
+    #[test]
+    fn test_byte_range_rejects_overflow() {
+        let err = S3Backend::byte_range(u64::MAX - 1, 4).unwrap_err();
+        assert!(
+            err.to_string().contains("overflows u64"),
+            "error should explain overflow: {err}"
+        );
     }
 
     // --- S3Config constructor / builder tests ---


### PR DESCRIPTION
## Summary

Fix peer-to-peer replication for repositories backed by non-local storage, especially S3-backed peers, and harden mirror-mode sync behavior.

Previously, peer replication assumed artifacts could be read from the backend local filesystem. That broke S3 peer <-> S3 peer replication because the sync worker did not read artifacts through the repository's configured storage backend. This also exposed a few related mirror-mode problems: heartbeat status was not actively probed, replicated deletes could re-enter the sync pipeline, and failed sync retries were not configurable enough for real peer outages.

Changes included here:

- Make the sync worker read artifacts from the repository's configured storage backend instead of assuming local storage.
- Push replicated artifacts through the path-aware `PUT /artifacts/{path}` endpoint.
- Add a replication marker header so mirrored uploads/deletes are applied on the target peer without enqueueing a new sync task.
- Prevent delete replication loops in mirror mode.
- Cancel superseded pending push tasks when an artifact is deleted.
- Add active peer heartbeat probes so peer online/offline state is refreshed even when no sync task is currently running.
- Make sync retry behavior configurable through environment variables:
  - `SYNC_TASK_MAX_RETRIES`
  - `SYNC_TASK_RETRY_BACKOFF_BASE_SECS`
  - `SYNC_TASK_RETRY_BACKOFF_MAX_SECS`
- Keep the default max retry count conservative at `3`; longer retry windows can be enabled by deployment-specific env vars.

This fixes the main failure mode where S3-backed peers could not replicate artifacts to each other because the backend tried to read files as if they were stored locally. It also makes mirror-mode delete propagation safe by distinguishing replication traffic from user/API traffic and avoiding recursive sync task creation.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [ ] No regressions in existing tests

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Linked issue

Fixes #1565