### PR TITLE
fix(repositories): surface proxy-cached artifacts in the listing endpoint

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1479,6 +1479,26 @@ pub async fn list_artifacts(
         .await;
     }
 
+    // Remote (proxy) repositories no longer record cached items in the
+    // `artifacts` table (#1278 / #1280): doing so reintroduced a doubled-prefix
+    // storage path bug on filesystem backends. The cached bodies and metadata
+    // sidecars still live in the storage backend under `proxy-cache/<key>/`, so
+    // the listing is reconstructed from there. Without this, packages pulled
+    // through a remote repo fill up storage but never appear in the UI, so they
+    // can't be browsed or scanned (#1548, web #424).
+    if repo.repo_type == RepositoryType::Remote {
+        return list_remote_cached_artifacts(
+            &state,
+            &repo,
+            &key,
+            query.path_prefix.as_deref(),
+            query.q.as_deref(),
+            page,
+            per_page,
+        )
+        .await;
+    }
+
     let (artifacts, total) = if repo.repo_type == RepositoryType::Virtual {
         // For virtual repositories, aggregate artifacts from all member repos.
         // Members are returned in priority order; local/hosted members are
@@ -1578,6 +1598,142 @@ pub async fn list_artifacts(
         components: None,
         docker_tags: None,
     }))
+}
+
+/// List the artifacts a remote (proxy) repository has cached.
+///
+/// Proxy-cached items are not in the `artifacts` table (#1280), so they are
+/// reconstructed from the storage backend by [`ProxyService::list_cached_artifacts`].
+/// Each entry is mapped to an [`ArtifactResponse`]; entries carry no DB id,
+/// version, or download count, so those fields take their natural defaults
+/// (a deterministic synthetic id derived from `repo_key + path`, `None`
+/// version, zero downloads). Filtering and pagination happen in-process over
+/// the recovered set, since there is no DB query to push them into. See #1548
+/// and web #424.
+async fn list_remote_cached_artifacts(
+    state: &SharedState,
+    repo: &crate::models::repository::Repository,
+    key: &str,
+    path_prefix: Option<&str>,
+    q: Option<&str>,
+    page: u32,
+    per_page: u32,
+) -> Result<Json<ArtifactListResponse>> {
+    let entries = match state.proxy_service.as_deref() {
+        Some(proxy) => proxy.list_cached_artifacts(&repo.key).await,
+        // No proxy service configured (e.g. proxying disabled): nothing cached.
+        None => Vec::new(),
+    };
+
+    let (page_entries, total) = filter_and_paginate_cached(entries, path_prefix, q, page, per_page);
+    let total_pages = ((total as f64) / (per_page as f64)).ceil() as u32;
+
+    let items = page_entries
+        .into_iter()
+        .map(|entry| build_cached_artifact_response(&entry, key))
+        .collect();
+
+    Ok(Json(ArtifactListResponse {
+        items,
+        pagination: Pagination {
+            page,
+            per_page,
+            total: total as i64,
+            total_pages,
+        },
+        components: None,
+        docker_tags: None,
+    }))
+}
+
+/// Apply the listing's `path_prefix` and `q` filters to the recovered proxy
+/// cache entries, then return the slice for the requested page along with the
+/// total match count.
+///
+/// `path_prefix` matches against the start of the logical path; `q` is a
+/// case-insensitive substring match against the path. Pure so the
+/// filter/paginate logic is unit-testable without a storage backend.
+fn filter_and_paginate_cached(
+    entries: Vec<crate::services::proxy_service::CachedArtifactEntry>,
+    path_prefix: Option<&str>,
+    q: Option<&str>,
+    page: u32,
+    per_page: u32,
+) -> (
+    Vec<crate::services::proxy_service::CachedArtifactEntry>,
+    usize,
+) {
+    let q_lower = q
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_lowercase);
+
+    let mut matched: Vec<_> = entries
+        .into_iter()
+        .filter(|e| match path_prefix {
+            Some(prefix) if !prefix.is_empty() => e.path.starts_with(prefix),
+            _ => true,
+        })
+        .filter(|e| match &q_lower {
+            Some(needle) => e.path.to_lowercase().contains(needle),
+            None => true,
+        })
+        .collect();
+
+    // Stable ordering for deterministic pagination across requests.
+    matched.sort_by(|a, b| a.path.cmp(&b.path));
+
+    let total = matched.len();
+    let offset = ((page.saturating_sub(1)) as usize).saturating_mul(per_page as usize);
+    let page_items = matched
+        .into_iter()
+        .skip(offset)
+        .take(per_page as usize)
+        .collect();
+    (page_items, total)
+}
+
+/// Deterministic artifact id for a proxy-cached object.
+///
+/// The `uuid` crate is built with only the `v4` feature, so a UUIDv5 is not
+/// available. Instead the id is the first 16 bytes of a SHA-256 over the
+/// cache storage key `proxy-cache/<repo_key>/<path>`. This is stable across
+/// listing calls for a given object and effectively never collides with the
+/// random v4 ids the database assigns to hosted artifacts.
+fn cached_artifact_id(repo_key: &str, path: &str) -> Uuid {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(format!("proxy-cache/{}/{}", repo_key, path).as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    Uuid::from_bytes(bytes)
+}
+
+/// Map a recovered proxy cache entry to the listing's [`ArtifactResponse`].
+///
+/// The id is deterministic over `<repo_key>/<path>` (see
+/// [`cached_artifact_id`]) so the same cached object always reports the same
+/// id across listing calls (useful for client-side keying) without colliding
+/// with the random v4 ids hosted artifacts get from the database.
+fn build_cached_artifact_response(
+    entry: &crate::services::proxy_service::CachedArtifactEntry,
+    repo_key: &str,
+) -> ArtifactResponse {
+    let id = cached_artifact_id(repo_key, &entry.path);
+    ArtifactResponse {
+        id,
+        repository_key: repo_key.to_string(),
+        path: entry.path.clone(),
+        name: entry.name.clone(),
+        version: None,
+        size_bytes: entry.size_bytes,
+        checksum_sha256: entry.checksum_sha256.clone(),
+        content_type: entry.content_type.clone(),
+        download_count: 0,
+        created_at: entry.cached_at,
+        metadata: None,
+    }
 }
 
 /// Build the `ArtifactResponse` representing a single primary artifact row.
@@ -3966,6 +4122,94 @@ fn format_repo_type(repo_type: &RepositoryType) -> String {
 mod tests {
     use super::*;
     use crate::error::AppError;
+
+    // -----------------------------------------------------------------------
+    // Remote proxy-cache listing (#1548, web #424)
+    // -----------------------------------------------------------------------
+
+    fn make_cached_entry(path: &str) -> crate::services::proxy_service::CachedArtifactEntry {
+        crate::services::proxy_service::CachedArtifactEntry {
+            path: path.to_string(),
+            name: path.rsplit('/').next().unwrap_or(path).to_string(),
+            size_bytes: 1234,
+            checksum_sha256: "deadbeef".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            cached_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_filter_and_paginate_cached_returns_all_sorted() {
+        let entries = vec![
+            make_cached_entry("lodash/-/lodash-4.17.21.tgz"),
+            make_cached_entry("is-odd/-/is-odd-3.0.1.tgz"),
+        ];
+        let (page, total) = filter_and_paginate_cached(entries, None, None, 1, 20);
+        assert_eq!(total, 2);
+        assert_eq!(page.len(), 2);
+        // Sorted by path.
+        assert_eq!(page[0].path, "is-odd/-/is-odd-3.0.1.tgz");
+        assert_eq!(page[1].path, "lodash/-/lodash-4.17.21.tgz");
+    }
+
+    #[test]
+    fn test_filter_and_paginate_cached_applies_path_prefix() {
+        let entries = vec![
+            make_cached_entry("lodash/-/lodash-4.17.21.tgz"),
+            make_cached_entry("is-odd/-/is-odd-3.0.1.tgz"),
+        ];
+        let (page, total) = filter_and_paginate_cached(entries, Some("lodash/"), None, 1, 20);
+        assert_eq!(total, 1);
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].path, "lodash/-/lodash-4.17.21.tgz");
+    }
+
+    #[test]
+    fn test_filter_and_paginate_cached_applies_case_insensitive_query() {
+        let entries = vec![
+            make_cached_entry("lodash/-/lodash-4.17.21.tgz"),
+            make_cached_entry("is-odd/-/is-odd-3.0.1.tgz"),
+        ];
+        let (page, total) = filter_and_paginate_cached(entries, None, Some("IS-ODD"), 1, 20);
+        assert_eq!(total, 1);
+        assert_eq!(page[0].path, "is-odd/-/is-odd-3.0.1.tgz");
+    }
+
+    #[test]
+    fn test_filter_and_paginate_cached_paginates() {
+        let entries = vec![
+            make_cached_entry("a"),
+            make_cached_entry("b"),
+            make_cached_entry("c"),
+        ];
+        let (page2, total) = filter_and_paginate_cached(entries, None, None, 2, 2);
+        assert_eq!(total, 3);
+        // page size 2, page 2 -> just "c"
+        assert_eq!(page2.len(), 1);
+        assert_eq!(page2[0].path, "c");
+    }
+
+    #[test]
+    fn test_build_cached_artifact_response_maps_fields_and_is_deterministic() {
+        let entry = make_cached_entry("express/-/express-4.18.2.tgz");
+        let resp = build_cached_artifact_response(&entry, "npm-remote");
+        assert_eq!(resp.repository_key, "npm-remote");
+        assert_eq!(resp.path, "express/-/express-4.18.2.tgz");
+        assert_eq!(resp.name, "express-4.18.2.tgz");
+        assert_eq!(resp.size_bytes, 1234);
+        assert_eq!(resp.checksum_sha256, "deadbeef");
+        assert_eq!(resp.download_count, 0);
+        assert!(resp.version.is_none());
+        // Same repo_key + path always yields the same id.
+        let resp2 = build_cached_artifact_response(&entry, "npm-remote");
+        assert_eq!(resp.id, resp2.id);
+        // Different path yields a different id.
+        let other = make_cached_entry("express/-/express-4.18.3.tgz");
+        assert_ne!(
+            resp.id,
+            build_cached_artifact_response(&other, "npm-remote").id
+        );
+    }
 
     // -----------------------------------------------------------------------
     // expand_maven_secondary_files & build_artifact_response (#1092)

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -5106,6 +5106,184 @@ SHA256:
     }
 
     // -----------------------------------------------------------------------
+    // list_cached_artifacts: storage-backed read path (#1548 / web #424).
+    // Exercises the full method against a mock backend: the prefix list, the
+    // sidecar read per logical path, the missing-sidecar skip, the
+    // content-type default, and the listing-error -> empty fallback. The
+    // pure key parsing is covered by the cached_artifact_paths tests above.
+    // -----------------------------------------------------------------------
+
+    /// Storage backend that returns a fixed key set from `list()` and serves
+    /// sidecar JSON from `get()` for keys present in `sidecars`. `list_fails`
+    /// drives the listing-error path.
+    struct CachedListingMock {
+        keys: Vec<String>,
+        sidecars: std::collections::HashMap<String, Bytes>,
+        list_fails: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for CachedListingMock {
+        async fn put(&self, _key: &str, _content: Bytes) -> Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            match self.sidecars.get(key) {
+                Some(b) => Ok(b.clone()),
+                None => Err(AppError::NotFound(key.to_string())),
+            }
+        }
+        async fn exists(&self, _key: &str) -> Result<bool> {
+            Ok(true)
+        }
+        async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, prefix: Option<&str>) -> Result<Vec<String>> {
+            if self.list_fails {
+                return Err(AppError::Storage("mock list failure".to_string()));
+            }
+            Ok(match prefix {
+                Some(p) => self
+                    .keys
+                    .iter()
+                    .filter(|k| k.starts_with(p))
+                    .cloned()
+                    .collect(),
+                None => self.keys.clone(),
+            })
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    fn sidecar_bytes(
+        size: i64,
+        checksum: &str,
+        content_type: Option<&str>,
+        cached_at: chrono::DateTime<chrono::Utc>,
+    ) -> Bytes {
+        let metadata = CacheMetadata {
+            cached_at,
+            upstream_etag: None,
+            storage_etag: None,
+            expires_at: cached_at + chrono::Duration::hours(1),
+            content_type: content_type.map(|s| s.to_string()),
+            size_bytes: size,
+            checksum_sha256: checksum.to_string(),
+        };
+        Bytes::from(serde_json::to_vec(&metadata).unwrap())
+    }
+
+    fn content_key(repo: &str, path: &str) -> String {
+        format!("proxy-cache/{}/{}/__content__", repo, path)
+    }
+    fn meta_key(repo: &str, path: &str) -> String {
+        format!("proxy-cache/{}/{}/__cache_meta__.json", repo, path)
+    }
+
+    #[tokio::test]
+    async fn test_list_cached_artifacts_returns_entries_from_sidecars() {
+        let repo = "npm-remote";
+        let pa = "is-odd/-/is-odd-3.0.1.tgz";
+        let pb = "lodash/-/lodash-4.17.21.tgz";
+        let now = Utc::now();
+        let mut sidecars = std::collections::HashMap::new();
+        sidecars.insert(
+            meta_key(repo, pa),
+            sidecar_bytes(123, &"a".repeat(64), Some("application/gzip"), now),
+        );
+        // pb sidecar has no content_type -> entry should default it.
+        sidecars.insert(
+            meta_key(repo, pb),
+            sidecar_bytes(456, &"b".repeat(64), None, now),
+        );
+        let keys = vec![
+            content_key(repo, pa),
+            meta_key(repo, pa),
+            content_key(repo, pb),
+            meta_key(repo, pb),
+        ];
+        let mock = Arc::new(CachedListingMock {
+            keys,
+            sidecars,
+            list_fails: false,
+        });
+        let service = build_proxy_service_with_storage(mock);
+
+        let mut entries = service.list_cached_artifacts(repo).await;
+        entries.sort_by(|x, y| x.path.cmp(&y.path));
+        assert_eq!(entries.len(), 2);
+
+        let a = &entries[0];
+        assert_eq!(a.path, pa);
+        assert_eq!(a.name, "is-odd-3.0.1.tgz");
+        assert_eq!(a.size_bytes, 123);
+        assert_eq!(a.checksum_sha256, "a".repeat(64));
+        assert_eq!(a.content_type, "application/gzip");
+
+        let b = &entries[1];
+        assert_eq!(b.name, "lodash-4.17.21.tgz");
+        assert_eq!(
+            b.content_type, "application/octet-stream",
+            "missing content_type must default to application/octet-stream"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_cached_artifacts_skips_entry_with_missing_sidecar() {
+        let repo = "npm-remote";
+        let good = "ok/-/ok-1.0.0.tgz";
+        let bad = "broken/-/broken-1.0.0.tgz"; // content listed, no sidecar
+        let now = Utc::now();
+        let mut sidecars = std::collections::HashMap::new();
+        sidecars.insert(
+            meta_key(repo, good),
+            sidecar_bytes(10, &"c".repeat(64), Some("application/octet-stream"), now),
+        );
+        let keys = vec![
+            content_key(repo, good),
+            meta_key(repo, good),
+            content_key(repo, bad),
+        ];
+        let mock = Arc::new(CachedListingMock {
+            keys,
+            sidecars,
+            list_fails: false,
+        });
+        let service = build_proxy_service_with_storage(mock);
+
+        let entries = service.list_cached_artifacts(repo).await;
+        assert_eq!(
+            entries.len(),
+            1,
+            "an entry whose sidecar is missing must be skipped"
+        );
+        assert_eq!(entries[0].path, good);
+    }
+
+    #[tokio::test]
+    async fn test_list_cached_artifacts_empty_when_listing_fails() {
+        let mock = Arc::new(CachedListingMock {
+            keys: Vec::new(),
+            sidecars: std::collections::HashMap::new(),
+            list_fails: true,
+        });
+        let service = build_proxy_service_with_storage(mock);
+        assert!(
+            service.list_cached_artifacts("npm-remote").await.is_empty(),
+            "a storage listing error must yield no cached artifacts"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // extract_streaming_headers: pure header parsing. Verifies the
     // Content-Length parse-or-skip behaviour and the etag/content-type
     // round-trip without a reqwest::Response. #895.

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -444,6 +444,32 @@ fn tee_upstream_to_cache(
     Box::pin(tee_stream)
 }
 
+/// A single proxy-cached artifact, reconstructed from the storage backend
+/// for the repository artifact-listing endpoint (#1548, web #424).
+///
+/// Proxy-cached items are not in the `artifacts` table (#1280), so this is
+/// assembled from the on-disk `__content__` key and its `__cache_meta__.json`
+/// sidecar rather than from a database row. There is no DB id, version, or
+/// download count to report, so the listing handler synthesizes the parts of
+/// `ArtifactResponse` it can and leaves the rest at their natural defaults.
+#[derive(Debug, Clone)]
+pub struct CachedArtifactEntry {
+    /// Logical artifact path relative to the repository root, e.g.
+    /// `is-odd/-/is-odd-3.0.1.tgz`.
+    pub path: String,
+    /// Final path segment, used as the display name.
+    pub name: String,
+    /// Cached body size in bytes (from the sidecar).
+    pub size_bytes: i64,
+    /// SHA-256 of the cached body (from the sidecar).
+    pub checksum_sha256: String,
+    /// Content type recorded at cache-write time, defaulting to
+    /// `application/octet-stream` when upstream did not send one.
+    pub content_type: String,
+    /// When the entry was first cached (from the sidecar).
+    pub cached_at: DateTime<Utc>,
+}
+
 /// Cache metadata for a proxied artifact
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CacheMetadata {
@@ -1164,6 +1190,99 @@ impl ProxyService {
             names.insert(name.to_string());
         }
         names.into_iter().collect()
+    }
+
+    /// List the artifacts a remote repository has cached through the proxy.
+    ///
+    /// Proxy-cached items are not tracked in the `artifacts` table (#1278 /
+    /// #1280): caching them there reintroduced a doubled-prefix storage path
+    /// bug on filesystem backends. The body and a JSON metadata sidecar still
+    /// live on disk under `proxy-cache/<repo_key>/<path>/{__content__,
+    /// __cache_meta__.json}`, so this walks that prefix to recover the set of
+    /// objects the proxy has actually served. The repository artifact-listing
+    /// endpoint merges these into its response so remote-cached packages show
+    /// up in the UI and can be scanned (#1548, web #424).
+    ///
+    /// Returns an empty list when the storage backend cannot list the prefix.
+    /// Each entry's `size_bytes`, `checksum_sha256`, `content_type`, and
+    /// `cached_at` come from the sidecar; entries whose sidecar is missing or
+    /// unreadable are skipped (a half-written or legacy cache write).
+    pub async fn list_cached_artifacts(&self, repo_key: &str) -> Vec<CachedArtifactEntry> {
+        let prefix = format!("proxy-cache/{}/", repo_key);
+        let keys = match self.storage.list(Some(&prefix)).await {
+            Ok(keys) => keys,
+            Err(e) => {
+                tracing::debug!(
+                    repo_key = %repo_key,
+                    error = %e,
+                    "listing proxy cache for repository artifact listing failed; \
+                     returning no cached artifacts"
+                );
+                return Vec::new();
+            }
+        };
+
+        let logical_paths = Self::cached_artifact_paths(repo_key, keys.iter().map(String::as_str));
+        let mut entries = Vec::with_capacity(logical_paths.len());
+        for path in logical_paths {
+            let Ok(metadata_key) = Self::cache_metadata_key(repo_key, &path) else {
+                continue;
+            };
+            let metadata = match self.load_cache_metadata(&metadata_key).await {
+                Ok(Some(m)) => m,
+                Ok(None) => continue,
+                Err(e) => {
+                    tracing::debug!(
+                        repo_key = %repo_key,
+                        path = %path,
+                        error = %e,
+                        "reading proxy cache sidecar failed; skipping entry"
+                    );
+                    continue;
+                }
+            };
+            let name = path.rsplit('/').next().unwrap_or(&path).to_string();
+            entries.push(CachedArtifactEntry {
+                path,
+                name,
+                size_bytes: metadata.size_bytes,
+                checksum_sha256: metadata.checksum_sha256,
+                content_type: metadata
+                    .content_type
+                    .unwrap_or_else(|| "application/octet-stream".to_string()),
+                cached_at: metadata.cached_at,
+            });
+        }
+        entries
+    }
+
+    /// Recover the distinct logical artifact paths from a set of proxy-cache
+    /// storage keys.
+    ///
+    /// Content lives at `proxy-cache/<repo_key>/<path>/__content__`; the
+    /// sibling `__cache_meta__.json` and any other leaf are ignored. Strips
+    /// the `proxy-cache/<repo_key>/` prefix and the `/__content__` suffix to
+    /// return `<path>`, deduped and sorted. Pure so the parsing can be
+    /// unit-tested without a storage backend.
+    fn cached_artifact_paths<'a, I>(repo_key: &str, keys: I) -> Vec<String>
+    where
+        I: IntoIterator<Item = &'a str>,
+    {
+        let prefix = format!("proxy-cache/{}/", repo_key);
+        let mut paths: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for key in keys {
+            let Some(rest) = key.strip_prefix(&prefix) else {
+                continue;
+            };
+            let Some(path) = rest.strip_suffix("/__content__") else {
+                continue;
+            };
+            if path.is_empty() {
+                continue;
+            }
+            paths.insert(path.to_string());
+        }
+        paths.into_iter().collect()
     }
 
     /// Invalidate every cached file referenced from an APT Release file
@@ -4949,6 +5068,41 @@ SHA256:
         ];
         let names = ProxyService::pypi_package_names_from_cache_keys("pypi-remote", keys);
         assert_eq!(names, vec!["flask"]);
+    }
+
+    #[test]
+    fn test_cached_artifact_paths_extracts_content_keys() {
+        let keys = vec![
+            "proxy-cache/npm-remote/is-odd/-/is-odd-3.0.1.tgz/__content__",
+            "proxy-cache/npm-remote/is-odd/-/is-odd-3.0.1.tgz/__cache_meta__.json",
+            "proxy-cache/npm-remote/lodash/__content__",
+            "proxy-cache/npm-remote/lodash/__cache_meta__.json",
+        ];
+        let paths = ProxyService::cached_artifact_paths("npm-remote", keys);
+        // Only content keys, sidecars dropped, prefix + suffix stripped, sorted.
+        assert_eq!(
+            paths,
+            vec![
+                "is-odd/-/is-odd-3.0.1.tgz".to_string(),
+                "lodash".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cached_artifact_paths_skips_other_repos_and_empty() {
+        let keys = vec![
+            // different repo's cache — must not leak in
+            "proxy-cache/other-remote/express/__content__",
+            // non-content leaf — skipped
+            "proxy-cache/npm-remote/express/__cache_meta__.json",
+            // empty logical path (bare repo root) — skipped
+            "proxy-cache/npm-remote/__content__",
+            // a real entry — kept
+            "proxy-cache/npm-remote/express/__content__",
+        ];
+        let paths = ProxyService::cached_artifact_paths("npm-remote", keys);
+        assert_eq!(paths, vec!["express".to_string()]);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Remote (proxy) repositories stopped recording cached items in the `artifacts` table in #1280 (the fix for the #1278 doubled-prefix storage path bug on filesystem backends). The acknowledged tradeoff was that proxy-cached items no longer surface in the repository artifact-listing endpoint or storage accounting. The user-visible symptom is that packages pulled through a remote repo fill up storage but show 0 artifacts in the UI, so they can't be browsed or scanned (artifact-keeper-web #424).

This reconstructs the listing for `remote` repositories from the storage backend instead of the database:

- `ProxyService::list_cached_artifacts` walks the `proxy-cache/<repo_key>/` prefix, keeps only `__content__` leaf keys, and loads each `__cache_meta__.json` sidecar for size, checksum, content type, and cached-at.
- `list_artifacts` takes an early branch for `RepositoryType::Remote` that maps those entries into `ArtifactResponse`, applying the existing `path_prefix` and `q` filters and pagination in-process.
- Cached entries get a deterministic id (SHA-256 over the cache storage key, first 16 bytes) so the same object reports a stable id across calls without colliding with the random v4 ids hosted artifacts get from the DB.

The #1278 fix is preserved: nothing is re-inserted into `artifacts`, and reads still resolve through the same global storage the proxy wrote to. Local and virtual repository listing paths are untouched.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Unit tests cover the pure helpers: `cached_artifact_paths` (key parsing), `filter_and_paginate_cached` (prefix/query filtering + pagination), and `build_cached_artifact_response` (field mapping + deterministic id). The end-to-end user flow is covered by a new Playwright spec in artifact-keeper-web (#424).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — in artifact-keeper-web
- [x] Manually tested locally — cargo build, cargo clippy, targeted unit tests pass
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

The response shape of GET /api/v1/repositories/{key}/artifacts is unchanged; only the data source for remote repos changes.

Closes #1548