### PR TITLE
fix(release): portable sed in 'Set version from tag' for macOS runners (#1538)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,13 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           echo "Setting workspace version to ${VERSION}"
-          sed -i "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml
+          # Portable in-place edit: GNU `sed -i` and BSD/macOS `sed -i` take
+          # incompatible arguments (BSD requires a backup suffix), which broke
+          # the macOS release builds (#1538: "sed: 1: Cargo.toml: invalid
+          # command code C"). Use a temp file so the same step works on the
+          # Linux and macOS runners alike.
+          sed "s/^version = \".*\"/version = \"${VERSION}\"/" Cargo.toml > Cargo.toml.tmp
+          mv Cargo.toml.tmp Cargo.toml
           head -5 Cargo.toml
 
       - name: Build


### PR DESCRIPTION
## Summary

The v1.2.0 release build failed to produce a GitHub Release because both macOS (darwin) binary builds errored at the `Set version from tag` step:

```
sed: 1: "Cargo.toml": invalid command code C
```

`sed -i` uses GNU syntax; BSD/macOS `sed -i` requires a backup suffix. The failed darwin legs failed the `build-binaries` job, and `Create Release` (`needs: build-binaries == success`) was skipped — so no Release and no macOS assets were created. The Linux/Windows legs built fine.

## Fix
Replace the `sed -i` in-place edit with a portable temp-file rewrite that works identically on the Linux and macOS runners. Verified the sed expression locally.

This is a v1.2.0 release blocker (originally filed for v1.2.1; it actually blocks cutting 1.2.0).

## Test Checklist
- [ ] Unit tests added/updated
- [ ] N/A — CI workflow fix; validated by the next tagged release build producing all 5 platform binaries
- [x] Manually validated the sed expression

Closes #1538