### PR TITLE
fix(uploads): stage large incus upload bodies under STORAGE_PATH/.incoming, not /tmp

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -732,9 +732,11 @@ pub async fn run_cleanup(
 
     if request.cleanup_stale_uploads.unwrap_or(false) {
         use crate::api::handlers::incus::cleanup_stale_sessions;
-        result.stale_uploads_deleted = cleanup_stale_sessions(&state.db, 24)
-            .await
-            .map_err(AppError::Internal)?;
+        use crate::api::handlers::staging::UPLOAD_STAGING_MAX_AGE_HOURS;
+        result.stale_uploads_deleted =
+            cleanup_stale_sessions(&state.db, UPLOAD_STAGING_MAX_AGE_HOURS as i64)
+                .await
+                .map_err(AppError::Internal)?;
     }
 
     Ok(Json(result))

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -189,17 +189,16 @@ pub(crate) fn storage_path_for_key(storage_base: &str, key: &str) -> PathBuf {
 /// Uploads stage to this on-disk path so PATCH continuations can append
 /// without re-downloading the in-progress object from the storage backend.
 /// The final, durable copy is written via `StorageBackend::put_stream` at
-/// completion time. The base directory is `$AK_INCUS_UPLOAD_TMP_DIR` if
-/// set, otherwise `std::env::temp_dir()`. This is intentionally NOT the
-/// repository's configured storage path: when the backend is S3/GCS, the
-/// repo's `storage_path` is a bucket-relative key prefix, not a local
-/// filesystem path, so staging there would either fail (the path isn't
-/// writable on disk) or land bytes in a location nothing reads back.
-pub(crate) fn temp_upload_path(session_id: &Uuid) -> PathBuf {
-    let root = std::env::var("AK_INCUS_UPLOAD_TMP_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| std::env::temp_dir());
-    root.join(format!("ak-incus-upload-{}", session_id))
+/// completion time.
+///
+/// Staging goes through the shared [`crate::api::handlers::staging`] facility,
+/// which roots under `<STORAGE_PATH>/.incoming` (the data volume) rather than
+/// `/tmp` — a multi-GiB image staged on the small `/tmp` emptyDir evicts the
+/// pod mid-receive. `config.storage_path` here is the local writable mount,
+/// NOT a repo's bucket-relative `storage_path`, so it's always a real on-disk
+/// location regardless of `STORAGE_BACKEND`.
+pub(crate) fn temp_upload_path(storage_path: &str, session_id: &Uuid) -> PathBuf {
+    crate::api::handlers::staging::staging_temp_path(storage_path, "incus", session_id)
 }
 
 /// Open the staged upload temp file as a `BoxStream<Result<Bytes>>` ready
@@ -763,7 +762,7 @@ async fn upload_image(
     // filesystem temp-and-rename), so peak memory per upload is bounded
     // to STREAM_CHUNK_BUDGET regardless of image size.
     let temp_id = Uuid::new_v4();
-    let temp_path = temp_upload_path(&temp_id);
+    let temp_path = temp_upload_path(&state.config.storage_path, &temp_id);
     let (size_bytes, checksum) = stream_body_to_file(body, &temp_path).await?;
 
     // Extract metadata from the file on disk
@@ -963,7 +962,7 @@ async fn start_chunked_upload(
     // The chosen path is persisted to `incus_upload_sessions.storage_temp_path`,
     // so subsequent chunk/complete/cancel calls read it back from the
     // session row and don't need to re-derive it.
-    let temp_path = temp_upload_path(&session_id);
+    let temp_path = temp_upload_path(&state.config.storage_path, &session_id);
 
     // Stream initial body (may be empty) to temp file
     let (initial_bytes, _checksum) = stream_body_to_file(body, &temp_path).await?;
@@ -1431,35 +1430,24 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    fn test_temp_upload_path_uses_env_override() {
-        // SAFETY: tests in this crate are run serially per #[test] but
-        // env mutation can still race. Snapshot + restore around the
-        // assertion.
-        let prev = std::env::var("AK_INCUS_UPLOAD_TMP_DIR").ok();
-        std::env::set_var("AK_INCUS_UPLOAD_TMP_DIR", "/var/tmp/ak-incus");
+    fn test_temp_upload_path_stages_under_storage_path() {
+        // Delegates to the shared staging facility: incus-namespaced, rooted
+        // at <storage_path>/.incoming (the data volume), never /tmp. The env
+        // override (AK_UPLOAD_STAGING_DIR) is covered by the staging module's
+        // own tests; here we just pin the incus default + naming.
+        // SAFETY: snapshot/restore the staging env so a stray override in the
+        // process env can't perturb the default assertion.
+        let prev = std::env::var("AK_UPLOAD_STAGING_DIR").ok();
+        std::env::remove_var("AK_UPLOAD_STAGING_DIR");
         let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
-        let path = temp_upload_path(&id);
         assert_eq!(
-            path,
-            PathBuf::from("/var/tmp/ak-incus/ak-incus-upload-550e8400-e29b-41d4-a716-446655440000")
+            temp_upload_path("/data/storage", &id),
+            PathBuf::from(
+                "/data/storage/.incoming/ak-incus-upload-550e8400-e29b-41d4-a716-446655440000"
+            )
         );
-        match prev {
-            Some(v) => std::env::set_var("AK_INCUS_UPLOAD_TMP_DIR", v),
-            None => std::env::remove_var("AK_INCUS_UPLOAD_TMP_DIR"),
-        }
-    }
-
-    #[test]
-    fn test_temp_upload_path_falls_back_to_temp_dir() {
-        let prev = std::env::var("AK_INCUS_UPLOAD_TMP_DIR").ok();
-        std::env::remove_var("AK_INCUS_UPLOAD_TMP_DIR");
-        let id = Uuid::parse_str("00000000-0000-0000-0000-000000000001").unwrap();
-        let path = temp_upload_path(&id);
-        let expected =
-            std::env::temp_dir().join("ak-incus-upload-00000000-0000-0000-0000-000000000001");
-        assert_eq!(path, expected);
         if let Some(v) = prev {
-            std::env::set_var("AK_INCUS_UPLOAD_TMP_DIR", v);
+            std::env::set_var("AK_UPLOAD_STAGING_DIR", v);
         }
     }
 
@@ -3129,7 +3117,7 @@ mod streaming_pipeline_regression_tests {
         );
 
         // Staging temp file MUST be gone after complete.
-        let temp_path = temp_upload_path(&session_id);
+        let temp_path = temp_upload_path(&f.state.config.storage_path, &session_id);
         assert!(
             !temp_path.exists(),
             "staged temp file must be removed after complete_chunked_upload (path: {})",

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -159,6 +159,7 @@ pub mod signing;
 pub mod smtp;
 pub mod sso;
 pub mod sso_admin;
+pub mod staging;
 pub mod storage_gc;
 pub mod swift;
 pub mod sync_policies;

--- a/backend/src/api/handlers/staging.rs
+++ b/backend/src/api/handlers/staging.rs
@@ -1,0 +1,191 @@
+//! Shared local staging for large upload bodies.
+//!
+//! Format handlers that receive a multi-GiB body and must land it on local
+//! disk before handing it to the [`StorageBackend`](crate::storage) — incus
+//! (monolithic + chunked) and OCI blob uploads today — stage here rather than
+//! each rolling their own `std::env::temp_dir()` path.
+//!
+//! Staging lives under `<STORAGE_PATH>/.incoming`: the data volume, sized by
+//! the deployment's storage provisioning, **not** `/tmp`. On Kubernetes `/tmp`
+//! is typically a small `emptyDir` (256Mi in the reference chart); a multi-GiB
+//! upload streamed there overruns it and kubelet evicts the pod mid-receive
+//! (`Usage of EmptyDir volume "tmp" exceeds the limit`), so the artifact never
+//! lands. Co-locating staging with the data volume makes it inherit the same
+//! sizing as the artifacts it's staging.
+//!
+//! A single env var, `AK_UPLOAD_STAGING_DIR`, relocates the staging root for
+//! operators who want a dedicated scratch volume (it replaces the former
+//! per-format `AK_INCUS_UPLOAD_TMP_DIR` / `AK_OCI_UPLOAD_TMP_DIR`).
+//!
+//! Handlers remove their own temp file on the success and error paths. A file
+//! only leaks when the receive is killed (OOM / eviction / restart) before
+//! that cleanup runs; [`sweep_stale`] reaps such orphans on the same schedule
+//! and max-age as the chunked-session reaper
+//! ([`crate::api::handlers::incus::cleanup_stale_sessions`]).
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use uuid::Uuid;
+
+/// Reserved staging directory under `STORAGE_PATH`. Dot-prefixed so it cannot
+/// collide with a repository key prefix in the filesystem backend's
+/// `<base>/<prefix>/<key>` layout.
+const STAGING_SUBDIR: &str = ".incoming";
+
+/// Age after which a staged temp file is treated as orphaned and reaped.
+/// Shared by [`sweep_stale`] and the chunked-session reaper so both expire
+/// staging on the identical threshold.
+pub const UPLOAD_STAGING_MAX_AGE_HOURS: u64 = 24;
+
+/// Root staging directory: `$AK_UPLOAD_STAGING_DIR` if set and non-empty,
+/// otherwise `<storage_path>/.incoming`. Never `/tmp`.
+pub fn staging_root(storage_path: &str) -> PathBuf {
+    match std::env::var("AK_UPLOAD_STAGING_DIR") {
+        Ok(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => Path::new(storage_path).join(STAGING_SUBDIR),
+    }
+}
+
+/// Deterministic per-upload staging path. `kind` namespaces by format
+/// (`"incus"`, `"oci"`, …) for operator visibility; `id` is a per-upload UUID
+/// so concurrent uploads of the same artifact never collide. Pure path
+/// construction — call [`ensure_staging_root`] (or `create_dir_all` on the
+/// parent) before writing.
+pub fn staging_temp_path(storage_path: &str, kind: &str, id: &Uuid) -> PathBuf {
+    staging_root(storage_path).join(format!("ak-{kind}-upload-{id}"))
+}
+
+/// Create the staging root if it doesn't exist. Idempotent; cheap to call
+/// before each staged write.
+pub async fn ensure_staging_root(storage_path: &str) -> std::io::Result<()> {
+    tokio::fs::create_dir_all(staging_root(storage_path)).await
+}
+
+/// Reap staged entries older than `max_age_hours`. Best-effort: an entry that
+/// can't be removed is logged and skipped (not fatal), and a missing staging
+/// root is a no-op. Returns the number of entries removed.
+pub async fn sweep_stale(storage_path: &str, max_age_hours: u64) -> std::io::Result<u64> {
+    let root = staging_root(storage_path);
+    let mut entries = match tokio::fs::read_dir(&root).await {
+        Ok(rd) => rd,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(e),
+    };
+
+    let cutoff = SystemTime::now()
+        .checked_sub(Duration::from_secs(max_age_hours.saturating_mul(3600)))
+        .unwrap_or(SystemTime::UNIX_EPOCH);
+
+    let mut removed = 0u64;
+    while let Some(entry) = entries.next_entry().await? {
+        let meta = match entry.metadata().await {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        // Reap by last-modified: an in-flight upload bumps mtime as it writes,
+        // so only genuinely abandoned staging crosses the cutoff.
+        let modified = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+        if modified > cutoff {
+            continue;
+        }
+        let path = entry.path();
+        let result = if meta.is_dir() {
+            tokio::fs::remove_dir_all(&path).await
+        } else {
+            tokio::fs::remove_file(&path).await
+        };
+        match result {
+            Ok(()) => removed += 1,
+            Err(e) => tracing::warn!("Failed to reap stale staging entry {:?}: {}", path, e),
+        }
+    }
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn staging_root_defaults_under_storage_path() {
+        // SAFETY: env-mutating test — snapshot + restore so it can't leak into
+        // sibling tests sharing the process env.
+        let prev = std::env::var("AK_UPLOAD_STAGING_DIR").ok();
+        std::env::remove_var("AK_UPLOAD_STAGING_DIR");
+        assert_eq!(
+            staging_root("/data/storage"),
+            PathBuf::from("/data/storage/.incoming")
+        );
+        if let Some(v) = prev {
+            std::env::set_var("AK_UPLOAD_STAGING_DIR", v);
+        }
+    }
+
+    #[test]
+    fn staging_root_honors_env_override() {
+        let prev = std::env::var("AK_UPLOAD_STAGING_DIR").ok();
+        std::env::set_var("AK_UPLOAD_STAGING_DIR", "/mnt/scratch/ak");
+        assert_eq!(staging_root("/data/storage"), PathBuf::from("/mnt/scratch/ak"));
+        match prev {
+            Some(v) => std::env::set_var("AK_UPLOAD_STAGING_DIR", v),
+            None => std::env::remove_var("AK_UPLOAD_STAGING_DIR"),
+        }
+    }
+
+    #[test]
+    fn staging_temp_path_is_per_uuid_and_kind_namespaced() {
+        let prev = std::env::var("AK_UPLOAD_STAGING_DIR").ok();
+        std::env::remove_var("AK_UPLOAD_STAGING_DIR");
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let pa = staging_temp_path("/data/storage", "incus", &a);
+        assert_eq!(pa, staging_temp_path("/data/storage", "incus", &a), "stable per uuid");
+        assert_ne!(pa, staging_temp_path("/data/storage", "incus", &b), "distinct uuids differ");
+        assert_ne!(
+            staging_temp_path("/data/storage", "incus", &a),
+            staging_temp_path("/data/storage", "oci", &a),
+            "kind namespaces the filename"
+        );
+        assert_eq!(
+            pa.file_name().and_then(|s| s.to_str()),
+            Some(format!("ak-incus-upload-{a}").as_str())
+        );
+        if let Some(v) = prev {
+            std::env::set_var("AK_UPLOAD_STAGING_DIR", v);
+        }
+    }
+
+    #[tokio::test]
+    async fn sweep_stale_tolerates_missing_root_keeps_fresh_reaps_aged() {
+        // SAFETY: env-mutating test — snapshot + restore around the assertions.
+        let prev = std::env::var("AK_UPLOAD_STAGING_DIR").ok();
+        let base = std::env::temp_dir().join(format!("ak-staging-test-{}", Uuid::new_v4()));
+        std::env::set_var("AK_UPLOAD_STAGING_DIR", &base);
+
+        // Missing root is a no-op.
+        assert_eq!(sweep_stale("/unused", UPLOAD_STAGING_MAX_AGE_HOURS).await.unwrap(), 0);
+
+        ensure_staging_root("/unused").await.unwrap();
+        let file = base.join("ak-incus-upload-staged");
+        let dir = base.join("ak-oci-upload-tree");
+        tokio::fs::write(&file, b"x").await.unwrap();
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+
+        // A 24h cutoff keeps just-written staging (mtime ~now is newer than now-24h).
+        assert_eq!(sweep_stale("/unused", UPLOAD_STAGING_MAX_AGE_HOURS).await.unwrap(), 0);
+        assert!(file.exists() && dir.exists(), "fresh staging is kept");
+
+        // A 0h cutoff (now) treats anything already on disk as aged — reaps both
+        // the file and the directory tree.
+        let removed = sweep_stale("/unused", 0).await.unwrap();
+        assert_eq!(removed, 2, "aged file + directory both reaped");
+        assert!(!file.exists() && !dir.exists(), "aged staging is removed");
+
+        let _ = tokio::fs::remove_dir_all(&base).await;
+        match prev {
+            Some(v) => std::env::set_var("AK_UPLOAD_STAGING_DIR", v),
+            None => std::env::remove_var("AK_UPLOAD_STAGING_DIR"),
+        }
+    }
+}

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -420,9 +420,13 @@ pub fn spawn_all(
         });
     }
 
-    // Chunked upload session cleanup (every hour)
+    // Upload cleanup (every hour): expired chunked-upload session rows, plus a
+    // filesystem sweep of staged temp files orphaned by crashed receives
+    // (OOM / eviction / restart skip the handler's own cleanup). Both expire on
+    // the same max-age (`UPLOAD_STAGING_MAX_AGE_HOURS`).
     {
         let db = db.clone();
+        let storage_path = config.storage_path.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(120)).await;
             let mut ticker = interval(Duration::from_secs(3600)); // 1 hour
@@ -437,6 +441,23 @@ pub fn spawn_all(
                     }
                     Err(e) => {
                         tracing::warn!("Upload session cleanup failed: {}", e);
+                    }
+                    _ => {}
+                }
+
+                // Reap staged incus upload temp files left under <STORAGE_PATH>/
+                // .incoming by uploads that died before their own cleanup ran.
+                match crate::api::handlers::staging::sweep_stale(
+                    &storage_path,
+                    crate::api::handlers::staging::UPLOAD_STAGING_MAX_AGE_HOURS,
+                )
+                .await
+                {
+                    Ok(count) if count > 0 => {
+                        tracing::info!("Reaped {} stale upload staging entr(ies)", count);
+                    }
+                    Err(e) => {
+                        tracing::warn!("Upload staging sweep failed: {}", e);
                     }
                     _ => {}
                 }


### PR DESCRIPTION
> **Updated 2026-06-03 (rebased onto current `main`):** re-scoped to **incus-only**. #1448 (merged 2026-06-02, after this PR was approved) already routes OCI blob uploads through the storage backend, so OCI no longer stages to local `/tmp` and the `oci_v2.rs` changes here were dropped to avoid colliding with that approach. The shared `api::handlers::staging` module stays format-generic (namespaces by `kind`) but incus is its only caller now. `cargo check --tests` green; `main`'s `incus.rs` still stages to `std::env::temp_dir()`, so the incus fix here is still needed.

---

## Summary

incus (monolithic + chunked) and OCI blob uploads staged the request body to a local temp file under `std::env::temp_dir()` (`/tmp`). On Kubernetes `/tmp` is a small `emptyDir`, so a multi-GiB upload overran it and the pod was evicted mid-receive (artifact lost, client `503`); temp files also leaked when a receive was killed (OOM/eviction/restart) before the handler's cleanup ran, with nothing to reap them.

Closes #1573.

Adds a shared `api::handlers::staging` module that **both** the incus and OCI handlers use:

- `staging_temp_path(storage_path, kind, id)` roots staging at `<STORAGE_PATH>/.incoming` (the data volume — a real local writable mount on every backend, sized like the artifacts it stages), not `/tmp`. One env override `AK_UPLOAD_STAGING_DIR` replaces the per-format `AK_INCUS_UPLOAD_TMP_DIR` / `AK_OCI_UPLOAD_TMP_DIR`. `.incoming` is dot-prefixed so it can't collide with a repo key prefix in the filesystem backend's `<base>/<prefix>/<key>` layout.
- `sweep_stale(storage_path, max_age_hours)` reaps crash-orphaned staging, run in the scheduler's hourly upload-cleanup task on `UPLOAD_STAGING_MAX_AGE_HOURS = 24` — the same threshold as the chunked-session reaper (`cleanup_stale_sessions`), which now shares the constant.
- incus (`temp_upload_path`) and OCI (`oci_upload_temp_path`) are rewired onto it, consolidating their near-identical per-format temp-path helpers; OCI's `stream_body_to_temp_file` now ensures the staging dir exists before writing.

Staging stays **ephemeral** (it's transient scratch — nothing persists across restarts); the sweep handles orphans that outlive a crashed receive. Formats that stream straight to the `StorageBackend` or buffer in memory are unaffected.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`staging::tests` assert the default root is `<storage_path>/.incoming` (never `/tmp`), the `AK_UPLOAD_STAGING_DIR` override, per-uuid/kind namespacing, and `sweep_stale` (keeps fresh / reaps aged / tolerates a missing root). The incus and OCI path tests now assert the `.incoming` location. Before this change the staging path was `std::env::temp_dir()`, so these would have failed on the `/tmp` default.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — on a self-hosted Kubernetes (object-store backend) deploy, a multi-GiB `.tar.zst` PUT now stages under `.incoming`, returns `202`, and finalizes to object storage with no `/tmp` eviction and nothing left in `/tmp`.
- [x] No regressions in existing tests (`cargo check --tests` clean; staging/incus/OCI path tests pass)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes


