### PR TITLE
fix(migration): to_artifact_keeper() returns Nexus types instead of AK enum values

### DIFF
--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -84,9 +84,9 @@ impl RepositoryType {
     /// Convert to Artifact Keeper repository type string
     pub fn to_artifact_keeper(&self) -> &'static str {
         match self {
-            Self::Local => "hosted",
-            Self::Remote => "proxy",
-            Self::Virtual => "group",
+            Self::Local => "local",
+            Self::Remote => "remote",
+            Self::Virtual => "virtual",
         }
     }
 }
@@ -1460,9 +1460,9 @@ mod tests {
 
     #[test]
     fn test_repository_type_to_artifact_keeper() {
-        assert_eq!(RepositoryType::Local.to_artifact_keeper(), "hosted");
-        assert_eq!(RepositoryType::Remote.to_artifact_keeper(), "proxy");
-        assert_eq!(RepositoryType::Virtual.to_artifact_keeper(), "group");
+        assert_eq!(RepositoryType::Local.to_artifact_keeper(), "local");
+        assert_eq!(RepositoryType::Remote.to_artifact_keeper(), "remote");
+        assert_eq!(RepositoryType::Virtual.to_artifact_keeper(), "virtual");
     }
 
     #[test]
@@ -1472,7 +1472,7 @@ mod tests {
             let ak_type = repo_type.to_artifact_keeper();
             // Verify the AK type is valid
             assert!(
-                ["hosted", "proxy", "group"].contains(&ak_type),
+                ["local", "remote", "virtual"].contains(&ak_type),
                 "Unexpected AK type '{}' for '{}'",
                 ak_type,
                 rclass


### PR DESCRIPTION
Fixes #1576.

## Bug

`RepositoryType::to_artifact_keeper()` returns Nexus terminology (`hosted`, `proxy`, `group`) instead of Artifact Keeper's own `repository_type` enum values (`local`, `remote`, `virtual`).

This breaks **every JFrog → AK migration job** in two places:

### 1. `check_repository_conflict` (line 337)

```rust
let target_type = repo_type.to_artifact_keeper(); // returns "hosted"
if existing_type != target_type {                 // "local" != "hosted" → always true
```

The DB stores `"local"` but the comparison uses `"hosted"`, so any existing repo (even one with a matching type) is flagged as `TypeMismatch` and skipped.

### 2. `create_repository` (line 394)

```rust
let repo_type = config.repo_type.to_artifact_keeper(); // returns "hosted"
INSERT INTO repositories (..., repo_type, ...) VALUES (...)
.bind(repo_type) // "hosted" is not in the repository_type enum → DB error
```

The INSERT always fails with:
```
invalid input value for enum repository_type: "hosted"
```

## Fix

Return AK's own enum values from `to_artifact_keeper()` and update the three test assertions that encoded the wrong expected output.

## Verified against

- DB schema: `CREATE TYPE repository_type AS ENUM ('local', 'remote', 'virtual')` (migration 003)
- AK version: 1.2.0-rc.3 / 1.2.0