### PR TITLE
fix(repositories): restore build — set cache fields in cached-artifact listing (closes #1578)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1896,6 +1896,17 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
+        // #1542 added these required fields to ArtifactResponse after #1567
+        // introduced this initializer, so the two landed together and broke
+        // the build. This entry is, by construction, a live proxy-cache
+        // object, so its cache-freshness timestamp is exactly when it was
+        // cached. The listing's sidecar projection (`CachedArtifactEntry`)
+        // doesn't carry the expiry, so leave `cache_expires_at` to the
+        // per-artifact metadata endpoint (#1541). Both fields are
+        // `#[serde(skip_serializing_if = "Option::is_none")]`, so the listing
+        // wire shape is unchanged for callers that don't read them.
+        cache_cached_at: Some(entry.cached_at),
+        cache_expires_at: None,
     }
 }
 
@@ -4403,6 +4414,12 @@ mod tests {
         assert_eq!(resp.checksum_sha256, "deadbeef");
         assert_eq!(resp.download_count, 0);
         assert!(resp.version.is_none());
+        // A cached-listing entry is a live proxy-cache object, so its
+        // freshness timestamp is exactly when it was cached; the sidecar
+        // projection carries no expiry. (Asserting these guards the
+        // #1542/#1567 field-collision regression that broke the build.)
+        assert_eq!(resp.cache_cached_at, Some(entry.cached_at));
+        assert!(resp.cache_expires_at.is_none());
         // Same repo_key + path always yields the same id.
         let resp2 = build_cached_artifact_response(&entry, "npm-remote");
         assert_eq!(resp.id, resp2.id);


### PR DESCRIPTION
## Summary

`main` currently fails to compile (`error[E0063]: missing fields cache_cached_at and cache_expires_at`), and the scheduled CI on `main` is red.

Two PRs collided on merge:
- **#1567** added `build_cached_artifact_response()`.
- **#1542** added the now-required `cache_cached_at` / `cache_expires_at` fields to `ArtifactResponse` but, having branched before #1567, never updated that initializer.

This populates the two fields in `build_cached_artifact_response`:
- `cache_cached_at: Some(entry.cached_at)` — a cached-listing entry is a live proxy-cache object, so its freshness timestamp is exactly when it was cached.
- `cache_expires_at: None` — the sidecar projection (`CachedArtifactEntry`) doesn't carry expiry; the per-artifact metadata endpoint (#1541) surfaces it.

Both fields are `skip_serializing_if = "Option::is_none"`, so the listing wire shape is unchanged for existing callers.

## Test plan

- [x] `cargo build` / `cargo test --lib` now compile (were broken on `main`).
- [x] Extended `test_build_cached_artifact_response_maps_fields_and_is_deterministic` to assert `cache_cached_at == entry.cached_at` and `cache_expires_at.is_none()` — this assertion would have caught the collision.
- [x] `cargo fmt --check` clean.

Closes #1578.

Made with [Cursor](https://cursor.com)