### PR TITLE
fix(repositories): look up npm cache metadata under the upstream URL path (closes #1580)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1941,6 +1941,29 @@ fn lookup_path_candidates(path: &str, format: &RepositoryFormat) -> Vec<String> 
     out
 }
 
+/// Map a stored artifact path to the path the proxy cache is keyed under,
+/// for the purpose of looking up cache-freshness metadata (#1541 follow-up).
+///
+/// npm-family tarballs are stored under the version-segmented layout
+/// (`<name>/<version>/<file>.tgz`) by `npm::store_npm_version`, but the proxy
+/// cached them under the upstream download-URL shape (`<name>/-/<file>.tgz`)
+/// because `npm::serve_tarball` fetches via `build_tarball_upstream_path`.
+/// Looking up cache metadata by the stored path therefore always missed.
+/// Translating the stored tarball path back to the URL shape makes the cache
+/// key match what the proxy wrote.
+///
+/// Returns the literal `path` unchanged for non-npm formats and for npm rows
+/// that are not stored tarballs (metadata paths, raw uploads, paths already
+/// in URL form) — `tarball_url_path_from_stored` returns `None` for those.
+fn cache_metadata_lookup_path(path: &str, format: &RepositoryFormat) -> String {
+    if is_npm_family_format(format) {
+        if let Some(url_path) = crate::formats::npm::tarball_url_path_from_stored(path) {
+            return url_path;
+        }
+    }
+    path.to_string()
+}
+
 /// npm-family formats share the publish/download path conventions of
 /// the npm registry (`yarn`, `pnpm`, and `bower` all wrap the same
 /// upstream wire format). Keep this in sync with the `format` mapping
@@ -2770,10 +2793,22 @@ pub async fn get_artifact_metadata(
         // direct-uploaded into a Remote repo, edge case but observed),
         // so any error or `Ok(None)` collapses to None on both fields
         // rather than failing the whole metadata response.
+        //
+        // #1541 follow-up (npm path mismatch): npm-family tarballs are stored
+        // under the version-segmented layout (`<name>/<version>/<file>.tgz`)
+        // but the proxy cached them under the upstream download-URL shape
+        // (`<name>/-/<file>.tgz`, see `npm::serve_tarball` ->
+        // `build_tarball_upstream_path`). Keying the cache lookup on the
+        // stored `artifact.path` therefore always missed, leaving the
+        // freshness fields `None` even when a valid cache entry existed.
+        // `cache_metadata_lookup_path` maps the stored path back to the URL
+        // shape for npm-family tarballs so the cache key matches what the
+        // proxy wrote.
+        let cache_lookup_path = cache_metadata_lookup_path(&artifact.path, &repo.format);
         let cache_meta = if repo.repo_type == RepositoryType::Remote {
             if let Some(proxy) = state.proxy_service.as_ref() {
                 proxy
-                    .get_cache_metadata(&key, &artifact.path)
+                    .get_cache_metadata(&key, &cache_lookup_path)
                     .await
                     .ok()
                     .flatten()
@@ -5854,6 +5889,65 @@ mod tests {
         assert!(
             body.contains("cache_cached_at:") && body.contains("cache_expires_at:"),
             "handler must populate both cache_cached_at and cache_expires_at"
+        );
+    }
+
+    #[test]
+    fn cache_metadata_lookup_path_maps_npm_stored_to_url_shape() {
+        // (#1541 follow-up) The proxy caches npm tarballs under the upstream
+        // download-URL shape, but the artifact row stores the version-
+        // segmented shape. The cache lookup must translate so it hits.
+
+        // Unscoped: stored `<name>/<version>/<file>.tgz` -> URL `<name>/-/<file>.tgz`.
+        assert_eq!(
+            cache_metadata_lookup_path("lodash/4.17.21/lodash-4.17.21.tgz", &RepositoryFormat::Npm),
+            "lodash/-/lodash-4.17.21.tgz",
+        );
+
+        // Scoped: stored `@scope/name/<version>/<file>.tgz` -> URL `@scope/name/-/<file>.tgz`.
+        assert_eq!(
+            cache_metadata_lookup_path(
+                "@types/node/20.1.0/node-20.1.0.tgz",
+                &RepositoryFormat::Npm
+            ),
+            "@types/node/-/node-20.1.0.tgz",
+        );
+
+        // The whole npm family shares the convention.
+        assert_eq!(
+            cache_metadata_lookup_path(
+                "left-pad/1.3.0/left-pad-1.3.0.tgz",
+                &RepositoryFormat::Yarn
+            ),
+            "left-pad/-/left-pad-1.3.0.tgz",
+        );
+        assert_eq!(
+            cache_metadata_lookup_path(
+                "left-pad/1.3.0/left-pad-1.3.0.tgz",
+                &RepositoryFormat::Pnpm
+            ),
+            "left-pad/-/left-pad-1.3.0.tgz",
+        );
+    }
+
+    #[test]
+    fn cache_metadata_lookup_path_is_identity_for_non_npm_and_non_tarball() {
+        // Non-npm formats are never rewritten, even if the path happens to
+        // look tarball-shaped.
+        assert_eq!(
+            cache_metadata_lookup_path("foo/1.0.0/foo-1.0.0.tgz", &RepositoryFormat::Maven),
+            "foo/1.0.0/foo-1.0.0.tgz",
+        );
+
+        // npm rows that aren't stored tarballs (metadata, already-URL-shape,
+        // raw uploads) fall through unchanged so we don't fabricate a key.
+        assert_eq!(
+            cache_metadata_lookup_path("lodash/package.json", &RepositoryFormat::Npm),
+            "lodash/package.json",
+        );
+        assert_eq!(
+            cache_metadata_lookup_path("lodash/-/lodash-4.17.21.tgz", &RepositoryFormat::Npm),
+            "lodash/-/lodash-4.17.21.tgz",
         );
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1896,6 +1896,17 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
+        // #1542 added these required fields to ArtifactResponse after #1567
+        // introduced this initializer, so the two landed together and broke
+        // the build. This entry is, by construction, a live proxy-cache
+        // object, so its cache-freshness timestamp is exactly when it was
+        // cached. The listing's sidecar projection (`CachedArtifactEntry`)
+        // doesn't carry the expiry, so leave `cache_expires_at` to the
+        // per-artifact metadata endpoint (#1541). Both fields are
+        // `#[serde(skip_serializing_if = "Option::is_none")]`, so the listing
+        // wire shape is unchanged for callers that don't read them.
+        cache_cached_at: Some(entry.cached_at),
+        cache_expires_at: None,
     }
 }
 
@@ -4403,6 +4414,12 @@ mod tests {
         assert_eq!(resp.checksum_sha256, "deadbeef");
         assert_eq!(resp.download_count, 0);
         assert!(resp.version.is_none());
+        // A cached-listing entry is a live proxy-cache object, so its
+        // freshness timestamp is exactly when it was cached; the sidecar
+        // projection carries no expiry. (Asserting these guards the
+        // #1542/#1567 field-collision regression that broke the build.)
+        assert_eq!(resp.cache_cached_at, Some(entry.cached_at));
+        assert!(resp.cache_expires_at.is_none());
         // Same repo_key + path always yields the same id.
         let resp2 = build_cached_artifact_response(&entry, "npm-remote");
         assert_eq!(resp.id, resp2.id);


### PR DESCRIPTION
## Summary

Follow-up to @brandonrc's non-blocking note on #1542.

For npm-family Remote repos, `GET /:key/artifacts/:path` resolved the row to the **stored** path (`<name>/<version>/<file>.tgz`) and keyed `ProxyService::get_cache_metadata` on it. The proxy, however, caches npm tarballs under the **upstream download-URL** shape (`<name>/-/<file>.tgz`, written by `npm::serve_tarball` → `build_tarball_upstream_path` → `cache_metadata_key`). The shapes differ, so the lookup always missed and `cache_cached_at` / `cache_expires_at` stayed `None` even with a valid cache entry — silently suppressing the artifact-details cache rows (web#449). It never errored, so this was a follow-up rather than a blocker.

This adds `cache_metadata_lookup_path()`, which maps the stored tarball path back to the URL shape for npm-family formats (the exact inverse the listing endpoint already uses via `formats::npm::tarball_url_path_from_stored`), and keys the cache lookup on it. Non-npm formats and npm non-tarball rows (metadata, raw uploads, already-URL paths) fall through to the literal path unchanged.

## ⚠️ Stacked on #1579

`main` currently does not compile (see #1578). This branch is based on the build fix in **#1579**, so its first commit is that fix. **Please merge #1579 first**; I will then rebase this onto `main` so only the npm commit remains.

## Test plan

- [x] `cargo test --lib cache_metadata_lookup_path` — unscoped/scoped npm + yarn/pnpm mapping, plus identity cases (non-npm format, npm metadata path, already-URL path).
- [x] Existing structural test `get_artifact_metadata_populates_cache_fields_only_for_remote` still passes (gates + `.get_cache_metadata(` call unchanged).
- [x] `cargo fmt --check` and `cargo clippy --lib` clean.

Closes #1580.

Made with [Cursor](https://cursor.com)