### PR TITLE
fix(repositories): populate cache fields in build_cached_artifact_response

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1896,6 +1896,10 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
+        // This response represents a recovered proxy cache entry, so surface
+        // when it was cached. The cache entry tracks no explicit expiry.
+        cache_cached_at: Some(entry.cached_at),
+        cache_expires_at: None,
     }
 }
 


### PR DESCRIPTION
Fixes #1587.

## Summary

`build_cached_artifact_response()` built an `ArtifactResponse` without the `cache_cached_at`/`cache_expires_at` fields the struct declares, so `cargo test --lib` fails to compile on a clean checkout:

```
error[E0063]: missing fields `cache_cached_at` and `cache_expires_at` in initializer of `repositories::ArtifactResponse`
  --> backend/src/api/handlers/repositories.rs:1887
```

## Change

This function maps a recovered proxy cache entry, so it now surfaces `cache_cached_at: Some(entry.cached_at)`. The cache entry tracks no explicit expiry, so `cache_expires_at: None`.

## Why this matters

Blocks the Backend Unit Tests CI job for any branch cut from main until the fields are set.