### PR TITLE
chore(hooks): add native git hooks for fmt and pre-push checks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Artifact Keeper pre-commit hook (fast: formatting only).
+#
+# Enable once (also done by `./scripts/dev.sh setup`):
+#   git config core.hooksPath .githooks
+#
+# This stage is intentionally cheap so commits stay instant. The heavier
+# checks (cargo check + unit tests) run on `git push` via .githooks/pre-push.
+#
+# Bypass in an emergency with `git commit --no-verify`. CI is the real
+# enforcement; this is just fast local feedback.
+
+# 1) Rust formatting, only when Rust files are staged (matches CI: cargo fmt --all -- --check)
+if git diff --cached --name-only --diff-filter=ACM | grep -q '\.rs$'; then
+    if command -v cargo >/dev/null 2>&1; then
+        echo "pre-commit: cargo fmt --check"
+        if ! cargo fmt --all -- --check; then
+            echo >&2
+            echo "Formatting check failed. Run 'cargo fmt --all', then re-stage and commit." >&2
+            exit 1
+        fi
+    else
+        echo "pre-commit: cargo not found, skipping fmt check" >&2
+    fi
+fi
+
+# 2) beads (bd) JSONL flush. Maintainer workflow; silently skipped when bd or
+#    a .beads workspace is absent, so external contributors are unaffected.
+if command -v bd >/dev/null 2>&1; then
+    BEADS_DIR=""
+    if [ "$(git rev-parse --git-dir)" != "$(git rev-parse --git-common-dir)" ]; then
+        MAIN_ROOT="$(dirname "$(git rev-parse --git-common-dir)")"
+        [ -d "$MAIN_ROOT/.beads" ] && BEADS_DIR="$MAIN_ROOT/.beads"
+    elif [ -d .beads ]; then
+        BEADS_DIR=".beads"
+    fi
+    if [ -n "$BEADS_DIR" ]; then
+        # Skip Dolt backend (uses its own sync, not JSONL)
+        if ! grep -q '"backend"[[:space:]]*:[[:space:]]*"dolt"' "$BEADS_DIR/metadata.json" 2>/dev/null; then
+            bd sync --flush-only >/dev/null 2>&1 || true
+            if [ -f "$BEADS_DIR/issues.jsonl" ] && \
+               [ "$(git rev-parse --git-dir)" = "$(git rev-parse --git-common-dir)" ]; then
+                git add "$BEADS_DIR/issues.jsonl" 2>/dev/null || true
+            fi
+        fi
+    fi
+fi
+
+exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,41 @@
+#!/bin/sh
+#
+# Artifact Keeper pre-push hook.
+#
+# Runs the same fast checks CI gates on, before code leaves your machine,
+# so compile errors and unit-test failures are caught locally instead of in
+# a red PR. Mirrors CI's "Check Rust" (compile) and "Backend Unit Tests".
+#
+# SQLX_OFFLINE=true matches CI and uses the committed .sqlx/ query cache, so
+# no database is required.
+#
+# Bypass in an emergency with `git push --no-verify`.
+
+if ! command -v cargo >/dev/null 2>&1; then
+    echo "pre-push: cargo not found, skipping checks" >&2
+    exit 0
+fi
+
+export SQLX_OFFLINE=true
+
+echo "pre-push: cargo check --workspace --all-targets"
+if ! cargo check --workspace --all-targets; then
+    echo >&2
+    echo "Build failed. Fix the compile errors above before pushing." >&2
+    echo "(Bypass with 'git push --no-verify' only if you know what you are doing.)" >&2
+    exit 1
+fi
+
+echo "pre-push: cargo test --workspace --lib"
+if ! cargo test --workspace --lib; then
+    echo >&2
+    echo "Unit tests failed. Fix them before pushing." >&2
+    exit 1
+fi
+
+# Note: clippy (-D warnings), the 70% new-line coverage gate, and the 3%
+# duplication gate are also enforced in CI. They are not run here to keep
+# push times reasonable. Run clippy manually before large changes:
+#   cargo clippy --workspace --all-targets -- -D warnings
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,11 +6,51 @@ Thanks for your interest in contributing! Here's how to get started.
 
 1. Fork the repository
 2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/artifact-keeper.git`
-3. Create a feature branch: `git checkout -b feature/your-feature`
-4. Make your changes
-5. Run checks: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --lib`
-6. Commit and push to your fork
-7. Open a Pull Request against `main`
+3. Enable the git hooks: `./scripts/setup-hooks.sh` (one time, see [Git hooks](#git-hooks))
+4. Create a feature branch: `git checkout -b feat/your-feature` (use `fix/`, `chore/`, or `docs/` as appropriate)
+5. Make your changes
+6. Run the same checks CI runs (see [What CI checks](#what-ci-checks))
+7. Commit and push to your fork
+8. Open a Pull Request against `main`, referencing an issue (`Closes #N`)
+
+## Git hooks
+
+Run `./scripts/setup-hooks.sh` once after cloning (or `./scripts/dev.sh setup`). It points
+git at the version-controlled hooks in `.githooks/`, which require only git and cargo, no
+extra tooling to install:
+
+- **pre-commit** runs `cargo fmt --all -- --check` when Rust files are staged (instant).
+- **pre-push** runs `cargo check --workspace --all-targets` and `cargo test --workspace --lib`
+  with `SQLX_OFFLINE=true`, so compile errors and unit-test failures are caught before they
+  reach a red PR. No database needed.
+
+The hooks are fast local feedback, not a substitute for CI. Bypass once with
+`git commit --no-verify` / `git push --no-verify` only when you genuinely need to.
+
+## What CI checks
+
+Every PR must be fully green before merge. The pipeline (`.github/workflows/ci.yml` and
+related workflows) enforces, in order of how fast you can reproduce each locally:
+
+| Gate | What it runs | Reproduce locally |
+| --- | --- | --- |
+| Formatting | `cargo fmt --all -- --check` | `cargo fmt --all -- --check` (pre-commit hook) |
+| Lint | `cargo clippy --workspace --all-targets -- -D warnings` | same command |
+| Migration slots | migration files must have unique numeric prefixes | `ls backend/migrations/ \| tail` |
+| Unit tests | `cargo test --workspace --lib` | same command (pre-push hook) |
+| Shell tests | dtrack-init regression test | `./docker/test-init-dtrack.sh` |
+| Coverage floor | `cargo llvm-cov --workspace --lib --fail-under-lines 50` | `cargo llvm-cov --workspace --lib --summary-only` |
+| New-code coverage | new/changed lines must be >= 70% covered (skipped under 10 new lines) | add tests for the lines you changed |
+| Duplication | jscpd over changed `.rs` files, <= 3% | `jscpd --min-lines 10 --threshold 3 --format rust <files>` |
+| Integration tests | `cargo test --workspace` (needs Postgres) | `./scripts/dev.sh start` then `cargo test --workspace` |
+| Smoke E2E | docker compose up + smoke profile | `./scripts/run-e2e-tests.sh` |
+| Security audit | `cargo audit` on the dependency tree | `cargo audit` |
+| Linked issue | PR body must reference an issue (`Closes #N`) | n/a (PR body) |
+| CodeQL | static analysis | n/a (runs in CI) |
+
+The fmt/clippy/unit-test gates are the ones the hooks cover. The coverage, duplication, and
+linked-issue gates run only in CI, so check those before pushing a large change. Do not use
+"push and see if CI passes" as a workflow, and do not bypass a failing gate with `--admin`.
 
 ## Development Setup
 

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -45,8 +45,13 @@ case "${1:-start}" in
     exec "$0" start
     ;;
 
+  setup)
+    echo "==> Enabling git hooks..."
+    exec ./scripts/setup-hooks.sh
+    ;;
+
   *)
-    echo "Usage: $0 {start|stop|reset}"
+    echo "Usage: $0 {start|stop|reset|setup}"
     exit 1
     ;;
 esac

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Enable the repository's git hooks (one-time, per clone).
+#
+#   ./scripts/setup-hooks.sh
+#
+# Points git at the version-controlled hooks in .githooks/ so formatting,
+# build, and unit-test checks run automatically on commit and push. No extra
+# tooling required beyond git and cargo.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "Git hooks enabled (core.hooksPath -> .githooks)."
+echo "  pre-commit: cargo fmt --check"
+echo "  pre-push:   cargo check + cargo test --workspace --lib"
+echo
+echo "Bypass once with --no-verify if ever needed. Disable with:"
+echo "  git config --unset core.hooksPath"


### PR DESCRIPTION
## Summary

Adds version-controlled git hooks in `.githooks/` so the documented local checks actually run, without taking on a `pre-commit` framework dependency (just git and cargo):

- **pre-commit**: `cargo fmt --all -- --check` when Rust files are staged (instant). Folds in the existing beads JSONL flush so enabling `core.hooksPath` does not drop it; gracefully skipped when `bd` or a `.beads` workspace is absent, so external contributors are unaffected.
- **pre-push**: `cargo check --workspace --all-targets` and `cargo test --workspace --lib` with `SQLX_OFFLINE=true`, catching compile errors and unit-test failures before they reach a red PR. No database required.

Enable once per clone with `./scripts/setup-hooks.sh` (sets `core.hooksPath .githooks`), also available as `./scripts/dev.sh setup`. Git intentionally does not let a repo auto-enable its own hooks, so the one-line activation stays per-clone.

This moves the previously local-only beads hooks (which lived in un-versioned `.git/hooks/`) under version control for everyone.

CONTRIBUTING.md is updated with a table mapping every CI gate to the local command that reproduces it (fmt, clippy -D warnings, migration-slot uniqueness, unit tests, coverage floor, 70% new-line coverage, 3% jscpd duplication, integration, smoke E2E, cargo audit, linked-issue, CodeQL).

Note: local hooks catch single-branch mistakes only. They cannot catch a semantic merge collision between two separately-green PRs (the recent red `main`); that needs branch protection "require branches up to date before merging" / a merge queue, which is out of scope here.

Closes #1589

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual testing: enabled the hooks via `core.hooksPath`, staged a deliberately mis-formatted Rust file, and confirmed the pre-commit hook blocked the commit (exit 1) with a clear message, then reverted clean. shellcheck passes on all three scripts. The shipped tree is already `cargo fmt` clean.

## API Changes
- [x] N/A - no API changes