### PR TITLE
fix(repositories): restore build by populating ArtifactResponse cache fields

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1896,6 +1896,10 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
+        // This is a proxy-cache entry, so surface the cache timestamp.
+        // CachedArtifactEntry carries no expiry, so cache_expires_at is None.
+        cache_cached_at: Some(entry.cached_at),
+        cache_expires_at: None,
     }
 }
 


### PR DESCRIPTION
## Summary

`main` does not compile. `build_cached_artifact_response()` constructs `ArtifactResponse` without the `cache_cached_at`/`cache_expires_at` fields that #1542 made required, so the build fails with:

```
error[E0063]: missing fields `cache_cached_at` and `cache_expires_at` in initializer of `repositories::ArtifactResponse`
    --> backend/src/api/handlers/repositories.rs:1887
```

This is a semantic merge collision: #1542 added the fields, #1567 added this constructor without them. Each was green on its own branch; the break only exists in the merged result, so every open PR is currently red.

The input is a `CachedArtifactEntry` (proxy-cache projection) which carries a real `cached_at` but no expiry, so the fix surfaces the real timestamp and leaves expiry empty:

```rust
cache_cached_at: Some(entry.cached_at),
cache_expires_at: None,
```

Supersedes #1579 and #1588, both fixed this same line but were not verified against `clippy --all-targets`, which is the gate that stayed red.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — the bug is a compile error; a green build IS the regression signal, and CI's Check Rust + Unit Tests jobs (which were red on main) now pass. The existing `test_build_cached_artifact_response_*` unit test exercises this constructor.

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified locally against the full Tier-1 gate set:
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --lib` — 10670 passed, 4 ignored. The single failure (`services::http_client::tests::test_large_object_client_builder_does_not_apply_total_timeout`) is a localhost TCP-bind/connect timeout in the sandbox, unrelated to this change (it fails identically on unmodified main here) and passes in CI where localhost networking works.

## API Changes
- [x] N/A - no API changes (response shape already includes these fields from #1542; this only populates them)