### PR TITLE
chore(release): finalize workspace version to 1.2.1-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.0-rc.2"
+version = "1.2.1-dev"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.0-rc.2"
+version = "1.2.1-dev"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"


### PR DESCRIPTION
Bumps `[workspace.package].version` from `1.2.0-rc.2` to `1.2.1-dev` (and the matching Cargo.lock entry) so dev builds report a correct post-1.2.0 in-development version instead of the stale rc.2.

Context: the v1.2.0 tag was cut on rc.2 source, so the released `backend:1.2.0` image reports `1.2.0-rc.2` in the UI. Per discussion we are fixing this forward: the published 1.2.0 image is left untouched (code-identical, only the version string differs), and 1.2.1 will ship the correction (setting the version to `1.2.1`).

Closes #1596