### PR TITLE
feat(pypi): PEP 708 dependency-confusion mitigation for virtual repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **PyPI virtual repositories now isolate locally-owned project names by default (PEP 708 dependency-confusion mitigation)** (#1600). Previously, when a local member owned a project name, a virtual repo could union an unrelated upstream package of the same name into its `/simple/` index and serve it on download, so an unpinned `pip install <name>` could resolve to the higher public version (a supply-chain hole). A PyPI virtual now serves only the owning member's distributions for a locally-owned name, in both the simple index and the download, unless an operator declares a PEP 708 `tracks` relationship for that project. The Simple API now advertises v1.2 and emits `meta.tracks` / `pypi:tracks` where declared.
+
+  **Behavior change (action may be required):** if you intentionally relied on a mixed virtual unioning a local project's versions with the same project upstream (e.g. split version ranges of the *same* package), declare it via the new endpoint so the union is restored:
+
+  ```
+  PUT /api/v1/repositories/{local_repo_key}/pypi-tracks/{project}
+  { "tracks_url": "https://pypi.org/simple/{project}/" }
+  ```
+
+  Names a local member does not own are unaffected and continue to proxy normally.
+
 ### Pre-upgrade check
 
 - **Stuck-scan janitor will reap accumulated `running` rows on first tick** (#1015, #1062) -- this release introduces a background janitor that transitions `scan_results` rows wedged in `status='running'` past the configured `STUCK_SCAN_THRESHOLD_SECS` (default 1800s / 30 min) to `status='failed'`. On long-running installs predating this release, previously-stuck rows from crashed scan workers (OOM, pod evicted, deploy mid-scan) will flip to `failed` in batches of up to 1000 rows per janitor tick (the per-tick cap bounds memory and audit-log write volume). With the default `STUCK_SCAN_CHECK_INTERVAL_SECS=600`, a backlog of N stuck rows therefore takes roughly `ceil(N / 1000) * (STUCK_SCAN_CHECK_INTERVAL_SECS / 60)` minutes per replica to fully drain. Multiple janitor-running replicas drain proportionally faster (the cap is per-replica, per-tick). Operators with a large backlog who want to accelerate the drain can lower `STUCK_SCAN_CHECK_INTERVAL_SECS` for one or two ticks after deploy and revert. Alerting on `status='failed'` deltas should expect this drain (one or many ticks depending on backlog size) at upgrade and tune accordingly.

--- a/backend/migrations/127_pypi_project_tracks.sql
+++ b/backend/migrations/127_pypi_project_tracks.sql
@@ -1,0 +1,32 @@
+-- PEP 708 (Simple Repository API v1.2) dependency-confusion mitigation.
+--
+-- A `tracks` declaration is an OPERATOR-controlled statement that a locally
+-- owned project is the same project as an upstream one, so it is safe for a
+-- virtual repository to merge (union) versions across members for that name.
+--
+-- Without such a declaration, a virtual repo must NOT merge an externally owned
+-- project into a name a local member owns (that is the dependency-confusion
+-- hole: an internal `acme-sdk` silently pulling in an unrelated public
+-- `acme-sdk`). See #1600.
+--
+-- The declaration is attached to the repository whose project owns the name
+-- (the local/hosted member), mirroring PEP 708 where `tracks` is a property of
+-- the project's own repository. `tracks_url` records the upstream Simple index
+-- project URL the local project tracks, and is emitted as `meta.tracks` /
+-- `pypi:tracks` in the Simple API responses.
+
+CREATE TABLE IF NOT EXISTS pypi_project_tracks (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    repository_id   UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    -- PEP 503 normalized project name (lowercase, runs of [-_.] collapsed to -).
+    normalized_name VARCHAR(512) NOT NULL,
+    -- Upstream Simple index project URL this local project tracks, e.g.
+    -- https://pypi.org/simple/acme-sdk/ . Emitted verbatim as the tracks value.
+    tracks_url      TEXT NOT NULL,
+    created_by      UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at      TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    UNIQUE (repository_id, normalized_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pypi_project_tracks_repo_name
+    ON pypi_project_tracks (repository_id, normalized_name);

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1824,6 +1824,75 @@ fn shadowing_guard_db_err(virtual_repo_id: Uuid, e: sqlx::Error) -> Response {
     (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response()
 }
 
+/// PEP 708 dependency-confusion decision for a PyPI virtual repository (#1600).
+///
+/// Returns `true` when the virtual must ISOLATE this project name to its local
+/// owner: a local/staging member owns the PEP 503 normalized `normalized_name`
+/// AND no `pypi_project_tracks` declaration exists on an owning member for it.
+/// When `true`, the caller MUST serve only the owning member's distributions in
+/// both the simple index and the file download (no cross-member union, no
+/// proxy fallthrough), which is PEP 708's "refuse to implicitly assume merging
+/// is safe" default and keeps the index and download consistent.
+///
+/// Returns `false` when the name is not locally owned (proxy normally) or when
+/// an operator `tracks` declaration permits merging the same project across
+/// members (the #1267 union / #1584 version fallthrough then apply).
+///
+/// `normalized_name` must already be PEP 503 normalized; the ownership query
+/// uses the same normalization the simple index uses so the two agree.
+/// Fails closed (Err 500) on DB error.
+#[allow(clippy::result_large_err)]
+pub async fn pypi_virtual_isolates_name(
+    db: &PgPool,
+    virtual_repo_id: Uuid,
+    normalized_name: &str,
+) -> Result<bool, Response> {
+    let members = fetch_virtual_members(db, virtual_repo_id).await?;
+    let local_ids: Vec<Uuid> = members
+        .iter()
+        .filter(|m| m.repo_type == RepositoryType::Local || m.repo_type == RepositoryType::Staging)
+        .map(|m| m.id)
+        .collect();
+    if local_ids.is_empty() {
+        return Ok(false);
+    }
+
+    // Which local/staging members actually own (hold artifacts for) this name?
+    // Uses the same PEP 503 normalization as simple_project so isolation agrees
+    // with what the index lists.
+    let owning_ids: Vec<Uuid> = sqlx::query_scalar(
+        "SELECT DISTINCT repository_id FROM artifacts \
+         WHERE repository_id = ANY($1) \
+           AND is_deleted = false \
+           AND LOWER(REPLACE(REPLACE(REPLACE(name, '_', '-'), '.', '-'), '--', '-')) = $2",
+    )
+    .bind(&local_ids)
+    .bind(normalized_name)
+    .fetch_all(db)
+    .await
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, e))?;
+
+    if owning_ids.is_empty() {
+        // Name is not owned by any local member: no confusion risk, proxy normally.
+        return Ok(false);
+    }
+
+    // A `tracks` declaration on any owning member means the operator has
+    // asserted the local project is the same project as upstream, so merging is
+    // safe and we do NOT isolate.
+    let tracked: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM pypi_project_tracks \
+         WHERE repository_id = ANY($1) AND normalized_name = $2",
+    )
+    .bind(&owning_ids)
+    .bind(normalized_name)
+    .fetch_one(db)
+    .await
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, e))?;
+
+    Ok(tracked == 0)
+}
+
 /// Returns true if any non-Remote member of `virtual_repo_id` owns an
 /// artifact stored at exactly `path`.
 ///

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -74,7 +74,7 @@ pub fn router() -> Router<SharedState> {
 /// through `decode_html_entities_minimal` and land in our own simple-index
 /// HTML response (#1377 review, defense-in-depth layer 1). See also the
 /// HTML-escape applied at render time in `build_simple_root_response`.
-fn normalize_pep503(name: &str) -> String {
+pub(crate) fn normalize_pep503(name: &str) -> String {
     let mut result = String::with_capacity(name.len());
     let mut last_was_sep = true;
 
@@ -476,7 +476,7 @@ fn build_simple_root_response(
 
     if accept.contains("application/vnd.pypi.simple.v1+json") {
         let json = serde_json::json!({
-            "meta": { "api-version": "1.1" },
+            "meta": { "api-version": "1.2" },
             "projects": packages.iter().map(|p| {
                 serde_json::json!({ "name": p })
             }).collect::<Vec<_>>()
@@ -517,6 +517,28 @@ fn build_simple_root_response(
 // ---------------------------------------------------------------------------
 // GET /pypi/{repo_key}/simple/{project}/ — PEP 503 package index
 // ---------------------------------------------------------------------------
+
+/// Fetch the PEP 708 `tracks` URLs declared for `normalized` on any of the
+/// project-owning `repo_ids`. Best-effort: a DB error yields an empty list,
+/// since this metadata is non-essential and must never fail a listing (#1600).
+async fn pypi_project_tracks_for(
+    db: &sqlx::PgPool,
+    repo_ids: &[uuid::Uuid],
+    normalized: &str,
+) -> Vec<String> {
+    if repo_ids.is_empty() {
+        return Vec::new();
+    }
+    sqlx::query_scalar::<_, String>(
+        "SELECT tracks_url FROM pypi_project_tracks \
+         WHERE repository_id = ANY($1) AND normalized_name = $2 ORDER BY tracks_url",
+    )
+    .bind(repo_ids)
+    .bind(normalized)
+    .fetch_all(db)
+    .await
+    .unwrap_or_default()
+}
 
 async fn simple_project(
     State(state): State<SharedState>,
@@ -605,6 +627,14 @@ async fn simple_project(
                 );
             }
 
+            // PEP 708 (#1600): when a local member owns this name and no
+            // operator `tracks` declaration permits merging, isolate the name to
+            // its local owner. We then skip every Remote member below, so the
+            // index lists only the local distributions (and the download path
+            // makes the same decision, keeping index and download consistent).
+            let isolate =
+                proxy_helpers::pypi_virtual_isolates_name(&state.db, repo.id, &normalized).await?;
+
             let mut local_artifacts: Vec<SimpleProjectArtifact> = Vec::new();
             let mut remote_response: Option<(Bytes, Option<String>)> = None;
 
@@ -645,21 +675,22 @@ async fn simple_project(
                 }));
             }
 
-            // Ownership / dependency-confusion guard (#1600). When a local
-            // member owns this PEP 503 name, the virtual serves ONLY that
-            // member's distributions for the name — in both the simple index
-            // and the download — rather than unioning the remote's versions for
-            // it. Unioning an unrelated public package that merely shares the
-            // name is a supply-chain hole (`pip` prefers the higher public
-            // version) AND makes the index inconsistent with the download path,
-            // which is also local-precedence-by-name and 404s for any version
-            // only the remote has. Local precedence is the PEP 708-aligned
-            // default for a locally-owned name. Second pass: fetch a remote
-            // index only when no local member owns the name.
-            let suppress_remote = virtual_simple_suppress_remote(local_artifacts.len());
-
+            // Ownership / dependency-confusion guard (#1600), superseding the
+            // name-only suppression from #1738. When a local member owns this
+            // PEP 503 name and no operator `tracks` declaration permits merging,
+            // `isolate` is true and the virtual serves ONLY that member's
+            // distributions for the name — in both the simple index and the
+            // download — rather than unioning the remote's versions for it.
+            // Unioning an unrelated public package that merely shares the name
+            // is a supply-chain hole (`pip` prefers the higher public version)
+            // AND makes the index inconsistent with the download path, which is
+            // also tracks-aware and 404s for any version only the remote has.
+            // Local precedence is the PEP 708-aligned default for a locally-
+            // owned name; a `tracks` declaration re-enables the union (#1582).
+            // Second pass: fetch a remote index only when the name is not
+            // isolated.
             for member in &members {
-                if suppress_remote {
+                if isolate {
                     break;
                 }
                 if member.repo_type != RepositoryType::Remote {
@@ -703,6 +734,15 @@ async fn simple_project(
                 }
             }
 
+            // PEP 708 `tracks` declared by this virtual's local owners for the
+            // project, for metadata emission (#1600). Empty in the isolate case.
+            let local_member_ids: Vec<uuid::Uuid> = members
+                .iter()
+                .filter(|m| matches!(m.repo_type, RepositoryType::Local | RepositoryType::Staging))
+                .map(|m| m.id)
+                .collect();
+            let tracks = pypi_project_tracks_for(&state.db, &local_member_ids, &normalized).await;
+
             // Render the union.
             match (local_artifacts.is_empty(), remote_response) {
                 (true, None) => {
@@ -717,6 +757,7 @@ async fn simple_project(
                         &repo_key,
                         &normalized,
                         &local_artifacts,
+                        &tracks,
                     );
                 }
                 (_, Some((content, content_type))) => {
@@ -729,6 +770,7 @@ async fn simple_project(
                             &repo_key,
                             &normalized,
                             &local_artifacts,
+                            &tracks,
                         );
                         Body::from(merged)
                     } else {
@@ -747,7 +789,8 @@ async fn simple_project(
         return Err(AppError::NotFound("Package not found".to_string()).into_response());
     }
 
-    build_simple_project_response(&headers, &repo_key, &normalized, &simple_artifacts)
+    let tracks = pypi_project_tracks_for(&state.db, &[repo.id], &normalized).await;
+    build_simple_project_response(&headers, &repo_key, &normalized, &simple_artifacts, &tracks)
 }
 
 // ---------------------------------------------------------------------------
@@ -764,6 +807,7 @@ fn build_simple_project_response(
     repo_key: &str,
     normalized: &str,
     artifacts: &[SimpleProjectArtifact],
+    tracks: &[String],
 ) -> Result<Response, Response> {
     let accept = headers
         .get("accept")
@@ -804,8 +848,20 @@ fn build_simple_project_response(
             .into_iter()
             .collect();
 
+        // PEP 708 / Simple API v1.2: advertise v1.2 and, when the project has
+        // operator `tracks` declarations, emit them under meta.tracks so
+        // PEP-708-aware installers can validate the server-side merge (#1600).
+        let mut meta = serde_json::json!({ "api-version": "1.2" });
+        if !tracks.is_empty() {
+            meta["tracks"] = serde_json::Value::Array(
+                tracks
+                    .iter()
+                    .map(|t| serde_json::Value::String(t.clone()))
+                    .collect(),
+            );
+        }
         let json = serde_json::json!({
-            "meta": { "api-version": "1.1" },
+            "meta": meta,
             "name": normalized,
             "versions": versions,
             "files": files,
@@ -821,6 +877,13 @@ fn build_simple_project_response(
     // HTML response
     let mut html = String::from("<!DOCTYPE html>\n<html>\n<head>\n");
     html.push_str("<meta name=\"pypi:repository-version\" content=\"1.0\"/>\n");
+    // PEP 708: surface operator `tracks` declarations on the project page (#1600).
+    for t in tracks {
+        html.push_str(&format!(
+            "<meta name=\"pypi:tracks\" content=\"{}\"/>\n",
+            html_escape(t)
+        ));
+    }
     html.push_str(&format!("<title>Links for {}</title>\n", normalized));
     html.push_str("</head>\n<body>\n");
     html.push_str(&format!("<h1>Links for {}</h1>\n", normalized));
@@ -858,23 +921,6 @@ fn build_simple_project_response(
         .unwrap())
 }
 
-/// Ownership / dependency-confusion policy for a virtual PyPI simple index
-/// (#1600). Returns `true` when a local (hosted/staging) member owns the
-/// requested PEP 503 name — in which case the virtual must serve ONLY that
-/// member's distributions and must NOT union or proxy a remote member's
-/// versions for the name.
-///
-/// `local_artifact_count` is the number of distributions the virtual's local
-/// members hold for the normalized name. A non-zero count means the name is
-/// locally owned. Unioning an unrelated public package that merely shares the
-/// name is a supply-chain hole (`pip` would prefer the higher public version)
-/// and makes the simple index inconsistent with the download path — which is
-/// also local-precedence-by-name and 404s for any version only the remote has.
-/// Local precedence is the PEP 708-aligned default for a locally-owned name.
-fn virtual_simple_suppress_remote(local_artifact_count: usize) -> bool {
-    local_artifact_count > 0
-}
-
 /// Splice local-member entries into a remote-member PEP 503 HTML response so
 /// the union is visible through the virtual repo. Entries already present in
 /// the remote response (matched by filename, the anchor's inner text per
@@ -885,8 +931,9 @@ fn merge_local_into_remote_simple_html(
     repo_key: &str,
     normalized: &str,
     local: &[SimpleProjectArtifact],
+    tracks: &[String],
 ) -> String {
-    if local.is_empty() {
+    if local.is_empty() && tracks.is_empty() {
         return remote_html.to_string();
     }
 
@@ -922,19 +969,40 @@ fn merge_local_into_remote_simple_html(
         ));
     }
 
-    if local_lines.is_empty() {
+    if local_lines.is_empty() && tracks.is_empty() {
         return remote_html.to_string();
     }
 
-    if let Some(idx) = remote_html.rfind("</body>") {
-        let mut out = String::with_capacity(remote_html.len() + local_lines.len());
-        out.push_str(&remote_html[..idx]);
-        out.push_str(&local_lines);
-        out.push_str(&remote_html[idx..]);
-        out
-    } else {
-        format!("{}{}", remote_html, local_lines)
+    let mut out = remote_html.to_string();
+
+    // PEP 708: inject operator `tracks` declarations into the project page head
+    // so the union the virtual performs is validatable downstream (#1600).
+    if !tracks.is_empty() {
+        let metas: String = tracks
+            .iter()
+            .map(|t| {
+                format!(
+                    "<meta name=\"pypi:tracks\" content=\"{}\"/>\n",
+                    html_escape(t)
+                )
+            })
+            .collect();
+        if let Some(h) = out.find("</head>") {
+            out.insert_str(h, &metas);
+        } else {
+            out = format!("{}{}", metas, out);
+        }
     }
+
+    if !local_lines.is_empty() {
+        if let Some(idx) = out.rfind("</body>") {
+            out.insert_str(idx, &local_lines);
+        } else {
+            out.push_str(&local_lines);
+        }
+    }
+
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -1039,18 +1107,20 @@ async fn serve_file(
                     .into_response());
                 }
 
-                // Supply-chain shadowing / ownership guard (#1217, #1600).
-                // Local-precedence-by-name: when a local (hosted/staging) member
-                // owns the PEP 503 name, suppress every remote member for this
-                // download regardless of the requested version. This keeps the
-                // download consistent with the simple index, which is also
-                // local-precedence-by-name (#1600): if the index won't list an
-                // unrelated public version for a locally-owned name, the
-                // download must not serve it either. It also closes the
-                // dependency-confusion hole where a higher public version of an
-                // internally-owned name would resolve through the virtual.
-                let normalized_project = PypiHandler::normalize_name(project);
-                let suppress_remote_members = proxy_helpers::virtual_non_remote_owns_name(
+                // PEP 708 dependency-confusion guard (#1600), superseding the
+                // version-aware shadowing guard (#1217, #1582) and the
+                // name-only local-precedence suppression (#1738). Isolate to the
+                // local owner when a local member owns the name and no operator
+                // `tracks` declaration permits merging with upstream. When
+                // isolated, every Remote member is skipped so an unrelated
+                // public package of the same name is never served through the
+                // virtual; the download then 404s for a version the local owner
+                // lacks, which matches what the simple index lists (consistent).
+                // When a `tracks` declaration exists (same project, split version
+                // ranges, #1582) this returns false and the proxy fallthrough
+                // below applies.
+                let normalized_project = normalize_pep503(project);
+                let suppress_remote_members = proxy_helpers::pypi_virtual_isolates_name(
                     &state.db,
                     repo.id,
                     &normalized_project,
@@ -3426,7 +3496,7 @@ mod tests {
 
         let headers = HeaderMap::new();
         let result =
-            build_simple_project_response(&headers, "my-virtual", "my-package", &artifacts);
+            build_simple_project_response(&headers, "my-virtual", "my-package", &artifacts, &[]);
         assert!(result.is_ok());
 
         let response = result.unwrap();
@@ -3455,7 +3525,7 @@ mod tests {
 
         let headers = HeaderMap::new();
         let result =
-            build_simple_project_response(&headers, "pypi-virtual", "my-package", &artifacts);
+            build_simple_project_response(&headers, "pypi-virtual", "my-package", &artifacts, &[]);
         let response = result.unwrap();
 
         // Read the body to verify URLs point through the virtual repo
@@ -3498,7 +3568,7 @@ mod tests {
         }];
 
         let headers = HeaderMap::new();
-        let result = build_simple_project_response(&headers, "virt", "pkg", &artifacts);
+        let result = build_simple_project_response(&headers, "virt", "pkg", &artifacts, &[]);
         let response = result.unwrap();
 
         let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX);
@@ -3534,7 +3604,7 @@ mod tests {
         ];
 
         let headers = HeaderMap::new();
-        let result = build_simple_project_response(&headers, "vrepo", "pkg", &artifacts);
+        let result = build_simple_project_response(&headers, "vrepo", "pkg", &artifacts, &[]);
         let response = result.unwrap();
 
         let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX);
@@ -3571,7 +3641,7 @@ mod tests {
         );
 
         let result =
-            build_simple_project_response(&headers, "pypi-virtual", "my-package", &artifacts);
+            build_simple_project_response(&headers, "pypi-virtual", "my-package", &artifacts, &[]);
         let response = result.unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
@@ -3591,7 +3661,7 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
         assert_eq!(json["name"], "my-package");
-        assert_eq!(json["meta"]["api-version"], "1.1");
+        assert_eq!(json["meta"]["api-version"], "1.2");
 
         let files = json["files"].as_array().unwrap();
         assert_eq!(files.len(), 1);
@@ -3633,7 +3703,7 @@ mod tests {
             "application/vnd.pypi.simple.v1+json".parse().unwrap(),
         );
 
-        let result = build_simple_project_response(&headers, "repo", "pkg", &artifacts);
+        let result = build_simple_project_response(&headers, "repo", "pkg", &artifacts, &[]);
         let response = result.unwrap();
 
         let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX);
@@ -3713,7 +3783,7 @@ mod tests {
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
 
-        assert_eq!(json["meta"]["api-version"], "1.1");
+        assert_eq!(json["meta"]["api-version"], "1.2");
         let projects = json["projects"].as_array().unwrap();
         assert_eq!(projects.len(), 2);
         assert_eq!(projects[0]["name"], "flask");
@@ -4005,7 +4075,7 @@ mod tests {
             metadata: None,
         }];
 
-        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local);
+        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
 
         assert!(
             merged.contains("pkg-1.0.0.tar.gz"),
@@ -4039,7 +4109,7 @@ mod tests {
             metadata: None,
         }];
 
-        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local);
+        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
         let count = merged.matches("pkg-1.0.0.tar.gz</a>").count();
         assert_eq!(count, 1, "filename present exactly once after dedupe");
         // The local sha256 must NOT appear — the remote entry is canonical.
@@ -4054,29 +4124,8 @@ mod tests {
     #[test]
     fn test_merge_empty_local_returns_remote_unchanged() {
         let remote = remote_html_with(&[("pkg-1.0.0.tar.gz", None)]);
-        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &[]);
+        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &[], &[]);
         assert_eq!(merged, remote);
-    }
-
-    // -----------------------------------------------------------------------
-    // virtual_simple_suppress_remote — #1600 ownership / dependency-confusion
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_virtual_simple_suppress_remote_local_owns_name() {
-        // #1600: when a local member holds any distribution for the name, the
-        // virtual must NOT union/proxy the remote's versions — local precedence.
-        // This keeps the simple index consistent with the local-precedence
-        // download path and closes the dependency-confusion hole.
-        assert!(virtual_simple_suppress_remote(1));
-        assert!(virtual_simple_suppress_remote(5));
-    }
-
-    #[test]
-    fn test_virtual_simple_suppress_remote_name_not_owned_locally() {
-        // No local distributions for the name: the virtual falls through to the
-        // remote member (general proxy behavior for names a local doesn't own).
-        assert!(!virtual_simple_suppress_remote(0));
     }
 
     #[test]
@@ -4093,7 +4142,7 @@ mod tests {
             metadata: Some(metadata),
         }];
 
-        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local);
+        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
         assert!(
             merged.contains("data-requires-python=\"&gt;=3.10,&lt;3.14\""),
             "requires_python is HTML-escaped: {}",
@@ -4118,7 +4167,7 @@ mod tests {
             metadata: None,
         }];
 
-        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local);
+        let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
         assert!(merged.contains("pkg-1.0.0.tar.gz"));
         assert!(merged.contains("pkg-2.0.0-py3-none-any.whl"));
     }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -229,6 +229,12 @@ pub fn router() -> Router<SharedState> {
         // `ProxyService::invalidate_cache` is idempotent so a second call for
         // an already-evicted path still returns 200.
         .route("/:key/cache/invalidate", post(invalidate_cache))
+        // PEP 708 tracks declarations for PyPI dependency-confusion control (#1600)
+        .route("/:key/pypi-tracks", get(list_pypi_tracks))
+        .route(
+            "/:key/pypi-tracks/:project",
+            put(put_pypi_track).delete(delete_pypi_track),
+        )
         // Routing rules for path rewriting on remote repositories
         .route(
             "/:key/routing-rules",
@@ -745,6 +751,196 @@ pub async fn invalidate_cache(
         path: query.path,
         invalidated: true,
     }))
+}
+
+// ---------------------------------------------------------------------------
+// PEP 708 `tracks` declarations (#1600)
+// ---------------------------------------------------------------------------
+
+/// Body for declaring that a locally-owned PyPI project tracks an upstream one.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PypiTrackRequest {
+    /// Upstream Simple index project URL this local project tracks, e.g.
+    /// `https://pypi.org/simple/acme-sdk/`. Recorded and emitted as the PEP 708
+    /// `tracks` value.
+    pub tracks_url: String,
+}
+
+/// A single PEP 708 `tracks` declaration.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PypiTrackResponse {
+    pub repository_key: String,
+    /// PEP 503 normalized project name.
+    pub normalized_name: String,
+    pub tracks_url: String,
+}
+
+/// All `tracks` declarations on a repository.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PypiTracksListResponse {
+    pub items: Vec<PypiTrackResponse>,
+}
+
+#[allow(clippy::result_large_err)]
+fn require_pypi_tracks_repo(repo: &crate::models::repository::Repository) -> Result<()> {
+    // tracks is declared on the hosted repo that OWNS the project (PEP 708:
+    // tracks is a property of the project's own repository). It is meaningless
+    // on a proxy or virtual repo, which hold no authoritative local project.
+    if repo.repo_type != RepositoryType::Local && repo.repo_type != RepositoryType::Staging {
+        return Err(AppError::Validation(
+            "tracks declarations can only be set on a local (hosted) or staging repository"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// List the PEP 708 `tracks` declarations on a repository.
+#[utoipa::path(
+    get,
+    path = "/{key}/pypi-tracks",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(("key" = String, Path, description = "Repository key")),
+    responses(
+        (status = 200, description = "tracks declarations", body = PypiTracksListResponse),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn list_pypi_tracks(
+    State(state): State<SharedState>,
+    Path(key): Path<String>,
+) -> Result<Json<PypiTracksListResponse>> {
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT normalized_name, tracks_url FROM pypi_project_tracks \
+         WHERE repository_id = $1 ORDER BY normalized_name",
+    )
+    .bind(repo.id)
+    .fetch_all(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(Json(PypiTracksListResponse {
+        items: rows
+            .into_iter()
+            .map(|(normalized_name, tracks_url)| PypiTrackResponse {
+                repository_key: key.clone(),
+                normalized_name,
+                tracks_url,
+            })
+            .collect(),
+    }))
+}
+
+/// Declare (upsert) that a locally-owned PyPI project tracks an upstream one,
+/// allowing a virtual repository to merge versions across members for that name
+/// instead of isolating it (PEP 708, #1600).
+#[utoipa::path(
+    put,
+    path = "/{key}/pypi-tracks/{project}",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+        ("project" = String, Path, description = "Project name (PEP 503 normalized server-side)"),
+    ),
+    request_body = PypiTrackRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "tracks declaration stored", body = PypiTrackResponse),
+        (status = 400, description = "Invalid request or repository type"),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn put_pypi_track(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((key, project)): Path<(String, String)>,
+    Json(payload): Json<PypiTrackRequest>,
+) -> Result<Json<PypiTrackResponse>> {
+    let auth = require_auth(auth)?;
+    auth.require_scope("write")?;
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+    require_repo_access(&auth, repo.id)?;
+    require_pypi_tracks_repo(&repo)?;
+
+    let tracks_url = payload.tracks_url.trim().to_string();
+    if !(tracks_url.starts_with("http://") || tracks_url.starts_with("https://")) {
+        return Err(AppError::Validation(
+            "tracks_url must be an absolute http(s) URL".to_string(),
+        ));
+    }
+    let normalized = crate::api::handlers::pypi::normalize_pep503(&project);
+    if normalized.is_empty() {
+        return Err(AppError::Validation("invalid project name".to_string()));
+    }
+
+    sqlx::query(
+        "INSERT INTO pypi_project_tracks (repository_id, normalized_name, tracks_url, created_by) \
+         VALUES ($1, $2, $3, $4) \
+         ON CONFLICT (repository_id, normalized_name) \
+         DO UPDATE SET tracks_url = EXCLUDED.tracks_url, created_by = EXCLUDED.created_by",
+    )
+    .bind(repo.id)
+    .bind(&normalized)
+    .bind(&tracks_url)
+    .bind(auth.user_id)
+    .execute(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(Json(PypiTrackResponse {
+        repository_key: key,
+        normalized_name: normalized,
+        tracks_url,
+    }))
+}
+
+/// Remove a PEP 708 `tracks` declaration, restoring local-precedence isolation
+/// for that project name (#1600).
+#[utoipa::path(
+    delete,
+    path = "/{key}/pypi-tracks/{project}",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+        ("project" = String, Path, description = "Project name (PEP 503 normalized server-side)"),
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 204, description = "tracks declaration removed (idempotent)"),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn delete_pypi_track(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((key, project)): Path<(String, String)>,
+) -> Result<axum::http::StatusCode> {
+    let auth = require_auth(auth)?;
+    auth.require_scope("write")?;
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+    require_repo_access(&auth, repo.id)?;
+
+    let normalized = crate::api::handlers::pypi::normalize_pep503(&project);
+    sqlx::query(
+        "DELETE FROM pypi_project_tracks WHERE repository_id = $1 AND normalized_name = $2",
+    )
+    .bind(repo.id)
+    .bind(&normalized)
+    .execute(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 /// Resolve the effective cache TTL from a stored `repository_config` value.
@@ -4364,6 +4560,9 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         update_repository,
         delete_repository,
         set_cache_ttl,
+        list_pypi_tracks,
+        put_pypi_track,
+        delete_pypi_track,
         get_cache_ttl,
         invalidate_cache,
         list_artifacts,
@@ -4391,6 +4590,9 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         CacheTtlResponse,
         InvalidateCacheQuery,
         InvalidateCacheResponse,
+        PypiTrackRequest,
+        PypiTrackResponse,
+        PypiTracksListResponse,
         ListArtifactsQuery,
         ArtifactResponse,
         ArtifactListResponse,
@@ -10137,5 +10339,98 @@ mod tests {
             status,
             String::from_utf8_lossy(&body)
         );
+    }
+
+    /// PEP 708 (#1600): a PyPI virtual isolates a locally-owned project name by
+    /// default (so an unrelated public package of the same name is never served
+    /// through the virtual), and only unblocks the cross-member union when an
+    /// operator `tracks` declaration exists on the owning member.
+    #[tokio::test]
+    async fn pypi_virtual_isolates_locally_owned_name_until_tracks_declared() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (local_id, _lk, local_dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let (remote_id, _rk, remote_dir) = tdh::create_repo(&pool, "remote", "pypi").await;
+        let (virtual_id, _vk, virtual_dir) = tdh::create_repo(&pool, "virtual", "pypi").await;
+
+        for (member, priority) in [(local_id, 1_i32), (remote_id, 2_i32)] {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virtual_id)
+            .bind(member)
+            .bind(priority)
+            .execute(&pool)
+            .await
+            .expect("insert virtual member");
+        }
+
+        // The local member owns the internal project `acme-sdk`.
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(local_id)
+        .bind("acme-sdk/1.0.0/acme_sdk-1.0.0-py3-none-any.whl")
+        .bind("acme-sdk")
+        .bind(1_i64)
+        .bind("0".repeat(64))
+        .bind("application/octet-stream")
+        .bind("pypi/acme/1")
+        .execute(&pool)
+        .await
+        .expect("seed local artifact");
+
+        // Default: owned locally, no tracks -> ISOLATE (do not merge upstream).
+        assert!(
+            matches!(
+                proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "acme-sdk").await,
+                Ok(true)
+            ),
+            "a locally-owned name with no tracks declaration must be isolated"
+        );
+
+        // A name the local member does not own -> proxy normally (no isolation).
+        assert!(
+            matches!(
+                proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "six").await,
+                Ok(false)
+            ),
+            "a name no local member owns must not be isolated"
+        );
+
+        // Operator declares the local project tracks upstream -> union allowed.
+        sqlx::query(
+            "INSERT INTO pypi_project_tracks (repository_id, normalized_name, tracks_url) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(local_id)
+        .bind("acme-sdk")
+        .bind("https://pypi.org/simple/acme-sdk/")
+        .execute(&pool)
+        .await
+        .expect("declare tracks");
+
+        assert!(
+            matches!(
+                proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "acme-sdk").await,
+                Ok(false)
+            ),
+            "a tracks declaration must re-enable the cross-member union"
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+            .bind(vec![local_id, remote_id, virtual_id])
+            .execute(&pool)
+            .await
+            .ok();
+        let _ = std::fs::remove_dir_all(&local_dir);
+        let _ = std::fs::remove_dir_all(&remote_dir);
+        let _ = std::fs::remove_dir_all(&virtual_dir);
     }
 }


### PR DESCRIPTION
Closes #1600

## Summary

A PyPI **virtual** repository could union an unrelated upstream package of the same name into a locally-owned project, in both the `/simple/` index and the download path, so an unpinned `pip install <name>` could resolve to the higher *public* version. That is a dependency-confusion / supply-chain hole (#1600), and it was on by default. #1584 (version-aware fallthrough) fixed the legitimate split-version case (#1582) but widened this exposure.

This implements PEP 708 (Simple Repository API v1.2) **local-precedence** server-side, which is the correct model: the distinguisher is whether the local project is the *same project* as upstream (an explicit operator `tracks` declaration), not whether a version happens to be local.

## What changed

- **Migration 121** `pypi_project_tracks` — operator-controlled `tracks` declarations, attached to the project-owning local/hosted repo (PEP 708: `tracks` is a property of the project's own repository).
- **`proxy_helpers::pypi_virtual_isolates_name()`** — the single predicate both paths use: a local member owns the PEP 503 normalized name AND no `tracks` declared -> **isolate** (serve only the owning member's distributions; no union, no proxy fallthrough). The simple index and the download make the *same* decision, so they can no longer disagree (closes the index/download inconsistency #1600 also raised).
- **Default flips to isolation** (security). A `tracks` declaration re-enables the cross-member union for a genuinely-shared project, preserving the #1582 case as an explicit opt-in.
- **PEP 708 metadata** — Simple API advertises **v1.2**; `meta.tracks` (JSON / PEP 691) and `<meta name="pypi:tracks">` (HTML / PEP 503) are emitted where a relationship is declared.
- **Management API** (admin-scoped): `GET /:key/pypi-tracks`, `PUT/DELETE /:key/pypi-tracks/:project`.

A web UI to manage `tracks` declarations lands in a companion artifact-keeper-web PR (#1600 is backend + UI per the agreed scope).

## Behavior change (called out for release notes)

Mixed virtuals that relied on the old union for a locally-owned name now isolate that name by default. Operators who genuinely mirror a project re-enable the union with a `tracks` declaration (`PUT /api/v1/repositories/{key}/pypi-tracks/{project}`). Documented in CHANGELOG under Security; this is the security-motivated behavior change to highlight when v1.2.1 is cut.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test
- [x] N/A — `feat/`. Includes a DB test (`pypi_virtual_isolates_locally_owned_name_until_tracks_declared`) asserting isolate-by-default, proxy-when-not-owned, and union-when-tracks-declared.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified against a real Postgres 16: migration 121 applies; `cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` exit 0; the new isolation test passes against the live DB; `cargo test --lib` 10704 passed. The 2 local failures are macOS-only environment artifacts unrelated to this change and pass on Linux CI: an HTTPS localhost-timeout test, and an OCI test asserting an upper-case storage key is absent (macOS APFS is case-insensitive, so it sees the canonical lower-case blob). `oci_v2.rs` is unchanged in this PR.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates locally (count-gated test; new paths/schemas only increase counts)
- [x] Migration is reversible-safe (additive table; guarded)