### PR TITLE
feat(storage-gc): read-only OCI blob footprint report (#1408)

### DIFF
--- a/backend/src/api/handlers/storage_gc.rs
+++ b/backend/src/api/handlers/storage_gc.rs
@@ -60,15 +60,38 @@ pub async fn run_storage_gc(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<StorageGcRequest>,
 ) -> Result<Json<StorageGcResult>> {
-    if !auth.is_admin {
-        return Err(AppError::Unauthorized(
-            "Admin privileges required".to_string(),
-        ));
-    }
+    require_admin(auth.is_admin)?;
 
     let service = StorageGcService::new(state.db.clone(), state.storage_registry.clone());
     let result = service.run_gc(payload.dry_run).await?;
     Ok(Json(result))
+}
+
+/// Gate an admin-only endpoint.
+///
+/// Returns `Ok(())` when the caller is an admin and an
+/// [`AppError::Unauthorized`] otherwise. Extracted from the handlers so the
+/// authorization branch is unit-testable without constructing a full axum
+/// request (the handlers themselves require a live DB-backed `SharedState`).
+fn require_admin(is_admin: bool) -> Result<()> {
+    if is_admin {
+        Ok(())
+    } else {
+        Err(AppError::Unauthorized(
+            "Admin privileges required".to_string(),
+        ))
+    }
+}
+
+/// Resolve the effective grace-window argument for the blob report from the
+/// optional `grace_hours` query parameter.
+///
+/// An absent parameter resolves to `0`, which the service layer then clamps
+/// to [`crate::services::storage_gc_service::BLOB_REPORT_GRACE_HOURS_DEFAULT`].
+/// Keeping this mapping in a pure helper makes the query-param handling
+/// coverable without standing up the HTTP stack.
+fn resolve_report_grace_hours(grace_hours: Option<i64>) -> i64 {
+    grace_hours.unwrap_or_default()
 }
 
 /// Query parameters for the read-only OCI blob footprint report.
@@ -103,15 +126,11 @@ pub async fn oci_blob_report(
     Extension(auth): Extension<AuthExtension>,
     Query(query): Query<OciBlobReportQuery>,
 ) -> Result<Json<OciBlobFootprintReport>> {
-    if !auth.is_admin {
-        return Err(AppError::Unauthorized(
-            "Admin privileges required".to_string(),
-        ));
-    }
+    require_admin(auth.is_admin)?;
 
     let service = StorageGcService::new(state.db.clone(), state.storage_registry.clone());
     let report = service
-        .oci_blob_footprint_report(query.grace_hours.unwrap_or_default())
+        .oci_blob_footprint_report(resolve_report_grace_hours(query.grace_hours))
         .await?;
     Ok(Json(report))
 }
@@ -356,6 +375,49 @@ mod tests {
             json.contains("oci_blob_report"),
             "OpenAPI doc should contain operation ID 'oci_blob_report'"
         );
+    }
+
+    // -- require_admin authorization gate --
+
+    #[test]
+    fn test_require_admin_allows_admin() {
+        assert!(require_admin(true).is_ok());
+    }
+
+    #[test]
+    fn test_require_admin_rejects_non_admin() {
+        let err = require_admin(false).unwrap_err();
+        match err {
+            AppError::Unauthorized(msg) => {
+                assert!(
+                    msg.contains("Admin privileges required"),
+                    "unexpected message: {msg}"
+                );
+            }
+            other => panic!("expected Unauthorized, got {other:?}"),
+        }
+    }
+
+    // -- resolve_report_grace_hours query-param mapping --
+
+    #[test]
+    fn test_resolve_report_grace_hours_absent_is_zero() {
+        // Absent resolves to 0, which the service clamps to the default
+        // window; the handler must not itself substitute a default.
+        assert_eq!(resolve_report_grace_hours(None), 0);
+    }
+
+    #[test]
+    fn test_resolve_report_grace_hours_passes_through_value() {
+        assert_eq!(resolve_report_grace_hours(Some(48)), 48);
+        assert_eq!(resolve_report_grace_hours(Some(0)), 0);
+    }
+
+    #[test]
+    fn test_resolve_report_grace_hours_passes_through_negative() {
+        // Negative values are forwarded unchanged; clamping is the service's
+        // responsibility, not the handler's.
+        assert_eq!(resolve_report_grace_hours(Some(-7)), -7);
     }
 
     #[test]

--- a/backend/src/api/handlers/storage_gc.rs
+++ b/backend/src/api/handlers/storage_gc.rs
@@ -1,24 +1,37 @@
 //! Storage garbage collection API handler.
 
-use axum::extract::Extension;
-use axum::{extract::State, routing::post, Json, Router};
+use axum::extract::{Extension, Query};
+use axum::{
+    extract::State,
+    routing::{get, post},
+    Json, Router,
+};
 use serde::Deserialize;
-use utoipa::{OpenApi, ToSchema};
+use utoipa::{IntoParams, OpenApi, ToSchema};
 
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
-use crate::services::storage_gc_service::{StorageGcResult, StorageGcService};
+use crate::services::storage_gc_service::{
+    OciBlobFootprintReport, OciBlobRepoFootprint, StorageGcResult, StorageGcService,
+};
 
 #[derive(OpenApi)]
 #[openapi(
-    paths(run_storage_gc),
-    components(schemas(StorageGcRequest, StorageGcResult))
+    paths(run_storage_gc, oci_blob_report),
+    components(schemas(
+        StorageGcRequest,
+        StorageGcResult,
+        OciBlobFootprintReport,
+        OciBlobRepoFootprint,
+    ))
 )]
 pub struct StorageGcApiDoc;
 
 pub fn router() -> Router<SharedState> {
-    Router::new().route("/", post(run_storage_gc))
+    Router::new()
+        .route("/", post(run_storage_gc))
+        .route("/oci-blob-report", get(oci_blob_report))
 }
 
 /// Request body for storage GC.
@@ -56,6 +69,51 @@ pub async fn run_storage_gc(
     let service = StorageGcService::new(state.db.clone(), state.storage_registry.clone());
     let result = service.run_gc(payload.dry_run).await?;
     Ok(Json(result))
+}
+
+/// Query parameters for the read-only OCI blob footprint report.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct OciBlobReportQuery {
+    /// Grace window in hours used to compute the `aged_*` figures. Defaults
+    /// to 24h; non-positive or out-of-range values are clamped server-side.
+    pub grace_hours: Option<i64>,
+}
+
+/// GET /api/v1/admin/storage-gc/oci-blob-report
+///
+/// Read-only report of the OCI blob (`oci_blobs`) storage footprint
+/// (issue #1408). Performs no deletion and takes no locks — it only runs
+/// aggregate `SELECT`s. Surfaces logical vs dedup-aware physical bytes so
+/// operators can see how much un-reclaimed blob storage exists before any
+/// garbage-collection sweep is enabled.
+#[utoipa::path(
+    get,
+    path = "/oci-blob-report",
+    context_path = "/api/v1/admin/storage-gc",
+    tag = "admin",
+    operation_id = "oci_blob_report",
+    params(OciBlobReportQuery),
+    responses(
+        (status = 200, description = "OCI blob footprint report", body = OciBlobFootprintReport),
+    ),
+    security(("bearer_auth" = [])),
+)]
+pub async fn oci_blob_report(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Query(query): Query<OciBlobReportQuery>,
+) -> Result<Json<OciBlobFootprintReport>> {
+    if !auth.is_admin {
+        return Err(AppError::Unauthorized(
+            "Admin privileges required".to_string(),
+        ));
+    }
+
+    let service = StorageGcService::new(state.db.clone(), state.storage_registry.clone());
+    let report = service
+        .oci_blob_footprint_report(query.grace_hours.unwrap_or_default())
+        .await?;
+    Ok(Json(report))
 }
 
 #[cfg(test)]
@@ -215,11 +273,42 @@ mod tests {
     }
 
     #[test]
-    fn test_openapi_doc_path_has_post_method() {
+    fn test_openapi_doc_every_path_has_an_operation() {
+        // The router mixes a POST (run GC) and a GET (blob report); each
+        // documented path must carry at least one of the two so the spec is
+        // never missing a method.
         let doc = StorageGcApiDoc::openapi();
-        for item in doc.paths.paths.values() {
-            assert!(item.post.is_some(), "Path should have POST method");
+        for (path, item) in &doc.paths.paths {
+            assert!(
+                item.post.is_some() || item.get.is_some(),
+                "Path {path} should have a GET or POST method"
+            );
         }
+    }
+
+    #[test]
+    fn test_openapi_doc_has_post_run_and_get_report() {
+        // The merged doc keys paths by their full context path, so match by
+        // suffix: there must be exactly one POST-bearing path (run GC) and
+        // exactly one GET-bearing path ending in /oci-blob-report.
+        let doc = StorageGcApiDoc::openapi();
+        let post_paths = doc
+            .paths
+            .paths
+            .values()
+            .filter(|item| item.post.is_some())
+            .count();
+        let report_get = doc
+            .paths
+            .paths
+            .iter()
+            .filter(|(path, item)| path.ends_with("/oci-blob-report") && item.get.is_some())
+            .count();
+        assert_eq!(post_paths, 1, "exactly one POST path (run GC) expected");
+        assert_eq!(
+            report_get, 1,
+            "exactly one GET /oci-blob-report path expected"
+        );
     }
 
     // -- Router test --
@@ -227,5 +316,63 @@ mod tests {
     #[test]
     fn test_router_returns_valid_router() {
         let _router = router();
+    }
+
+    // -- OciBlobReportQuery deserialization (issue #1408) --
+
+    #[test]
+    fn test_oci_blob_report_query_absent_grace_hours() {
+        let q: OciBlobReportQuery = serde_json::from_str("{}").unwrap();
+        assert_eq!(q.grace_hours, None);
+    }
+
+    #[test]
+    fn test_oci_blob_report_query_explicit_grace_hours() {
+        let q: OciBlobReportQuery = serde_json::from_str(r#"{"grace_hours": 48}"#).unwrap();
+        assert_eq!(q.grace_hours, Some(48));
+    }
+
+    #[test]
+    fn test_oci_blob_report_query_negative_grace_hours_parses() {
+        // Negative values parse here; the service clamps them. The endpoint
+        // must not reject a bad query param with a 4xx.
+        let q: OciBlobReportQuery = serde_json::from_str(r#"{"grace_hours": -3}"#).unwrap();
+        assert_eq!(q.grace_hours, Some(-3));
+    }
+
+    #[test]
+    fn test_oci_blob_report_query_invalid_type_errors() {
+        let result = serde_json::from_str::<OciBlobReportQuery>(r#"{"grace_hours": "soon"}"#);
+        assert!(result.is_err());
+    }
+
+    // -- OpenAPI registration for the new report endpoint --
+
+    #[test]
+    fn test_openapi_doc_includes_blob_report_operation() {
+        let doc = StorageGcApiDoc::openapi();
+        let json = serde_json::to_string(&doc).unwrap();
+        assert!(
+            json.contains("oci_blob_report"),
+            "OpenAPI doc should contain operation ID 'oci_blob_report'"
+        );
+    }
+
+    #[test]
+    fn test_openapi_doc_includes_blob_report_schemas() {
+        let doc = StorageGcApiDoc::openapi();
+        let schemas = &doc
+            .components
+            .as_ref()
+            .expect("components should exist")
+            .schemas;
+        assert!(
+            schemas.contains_key("OciBlobFootprintReport"),
+            "Schema should contain OciBlobFootprintReport"
+        );
+        assert!(
+            schemas.contains_key("OciBlobRepoFootprint"),
+            "Schema should contain OciBlobRepoFootprint"
+        );
     }
 }

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -101,6 +101,68 @@ pub struct StorageGcResult {
     pub errors: Vec<String>,
 }
 
+/// Default grace window (hours) used to classify "recent" OCI blobs in the
+/// reclaimable report. A blob younger than this is excluded from the
+/// `aged_*` figures because its parent manifest push may still be in
+/// flight (the upload writes the `oci_blobs` row before the manifest that
+/// references it commits). This mirrors the grace-window guard that the
+/// future blob GC sweep will use, but here it only affects *reporting* —
+/// nothing is ever deleted by this path.
+pub const BLOB_REPORT_GRACE_HOURS_DEFAULT: i64 = 24;
+
+/// Per-repository row in the OCI blob footprint report.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct OciBlobRepoFootprint {
+    /// Repository id owning these `oci_blobs` rows.
+    pub repository_id: Uuid,
+    /// Number of `oci_blobs` rows attributed to this repository.
+    pub blob_rows: i64,
+    /// Sum of `oci_blobs.size_bytes` for this repository's rows. Because OCI
+    /// blob storage is content-addressed and deduplicated across repos, the
+    /// same physical bytes can be counted under more than one repository
+    /// here; see [`OciBlobFootprintReport::physical_bytes`] for the
+    /// dedup-aware total.
+    pub logical_bytes: i64,
+}
+
+/// Read-only OCI blob storage footprint report (issue #1408).
+///
+/// This is a **reporting-only** view. It performs no deletion and takes no
+/// locks. It surfaces how much storage the tracked `oci_blobs` rows
+/// account for so operators can see the magnitude of un-reclaimed blob
+/// layers before any garbage-collection mechanism is enabled.
+///
+/// It deliberately does NOT attempt to classify which blobs are
+/// "reclaimable orphans": that requires a manifest -> blob reference table
+/// that does not yet exist in the schema, and any per-`(repository_id,
+/// digest)` orphan heuristic would mis-handle the cross-repo dedup case
+/// (multiple `oci_blobs` rows, one physical object) and report in-use
+/// blobs as reclaimable. The numbers here are exact aggregates only.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
+pub struct OciBlobFootprintReport {
+    /// Total number of `oci_blobs` rows across all repositories.
+    pub total_blob_rows: i64,
+    /// Number of distinct blob digests (content-addressed identities). When
+    /// this is smaller than `total_blob_rows`, the difference is cross-repo
+    /// deduplication: rows that share one physical storage object.
+    pub distinct_digests: i64,
+    /// Sum of `size_bytes` over every `oci_blobs` row. Double-counts
+    /// deduplicated blobs once per referencing repository.
+    pub logical_bytes: i64,
+    /// Sum of `size_bytes` counting each distinct digest exactly once. This
+    /// approximates the physical bytes occupied in the storage backend.
+    pub physical_bytes: i64,
+    /// Grace window (hours) applied to the `aged_*` figures below.
+    pub grace_hours: i64,
+    /// Distinct digests older than `grace_hours` (eligible to be *considered*
+    /// by a future GC sweep once a reference table exists). Reporting only.
+    pub aged_distinct_digests: i64,
+    /// Physical bytes (distinct-digest) older than `grace_hours`.
+    pub aged_physical_bytes: i64,
+    /// Per-repository logical footprint, largest `logical_bytes` first.
+    pub per_repository: Vec<OciBlobRepoFootprint>,
+}
+
 /// Storage garbage collection service.
 ///
 /// For cloud backends (S3/Azure/GCS), the shared storage instance handles all
@@ -381,6 +443,94 @@ impl StorageGcService {
             .fetch_all(&self.db)
             .await
             .map_err(|e| crate::error::AppError::Database(e.to_string()))
+    }
+
+    /// Build the read-only OCI blob footprint report (issue #1408).
+    ///
+    /// Performs only `SELECT` aggregates against `oci_blobs`; it never
+    /// deletes anything, takes no row locks, and touches no storage
+    /// backend. Safe to call on a hot production database — the two
+    /// aggregate queries are index-friendly scans of `oci_blobs`.
+    ///
+    /// `grace_hours` is clamped to a sane range via
+    /// [`clamp_grace_hours`]; the clamped value is echoed back in the
+    /// report so callers see exactly what window was applied.
+    pub async fn oci_blob_footprint_report(
+        &self,
+        grace_hours: i64,
+    ) -> Result<OciBlobFootprintReport> {
+        let grace_hours = clamp_grace_hours(grace_hours);
+
+        // Aggregate 1: global totals + dedup-aware physical bytes + aged
+        // figures, all in one pass. `size_bytes` is taken as MAX per digest
+        // so a single physical object is counted once even though it has one
+        // row per referencing repository (rows for the same digest share a
+        // size, so MAX == the per-object size).
+        let totals_sql = r#"
+            WITH per_digest AS (
+                SELECT digest,
+                       MAX(size_bytes) AS size_bytes,
+                       MIN(created_at) AS first_seen
+                FROM oci_blobs
+                GROUP BY digest
+            )
+            SELECT
+                (SELECT COUNT(*) FROM oci_blobs)                       AS total_blob_rows,
+                (SELECT COALESCE(SUM(size_bytes), 0) FROM oci_blobs)   AS logical_bytes,
+                COUNT(*)                                               AS distinct_digests,
+                COALESCE(SUM(size_bytes), 0)                           AS physical_bytes,
+                COUNT(*) FILTER (
+                    WHERE first_seen < NOW() - make_interval(hours => $1)
+                )                                                      AS aged_distinct_digests,
+                COALESCE(SUM(size_bytes) FILTER (
+                    WHERE first_seen < NOW() - make_interval(hours => $1)
+                ), 0)                                                  AS aged_physical_bytes
+            FROM per_digest
+        "#;
+
+        let totals = sqlx::query(totals_sql)
+            .bind(grace_hours)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Aggregate 2: per-repository logical footprint, biggest first.
+        let per_repo_sql = r#"
+            SELECT repository_id,
+                   COUNT(*) AS blob_rows,
+                   COALESCE(SUM(size_bytes), 0) AS logical_bytes
+            FROM oci_blobs
+            GROUP BY repository_id
+            ORDER BY logical_bytes DESC, repository_id ASC
+        "#;
+        let per_repo_rows = sqlx::query(per_repo_sql)
+            .fetch_all(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let per_repository = per_repo_rows
+            .into_iter()
+            .map(|row| {
+                Ok(OciBlobRepoFootprint {
+                    repository_id: row
+                        .try_get("repository_id")
+                        .map_err(|e| AppError::Database(e.to_string()))?,
+                    blob_rows: row.try_get("blob_rows").unwrap_or(0),
+                    logical_bytes: row.try_get("logical_bytes").unwrap_or(0),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(OciBlobFootprintReport {
+            total_blob_rows: totals.try_get("total_blob_rows").unwrap_or(0),
+            distinct_digests: totals.try_get("distinct_digests").unwrap_or(0),
+            logical_bytes: totals.try_get("logical_bytes").unwrap_or(0),
+            physical_bytes: totals.try_get("physical_bytes").unwrap_or(0),
+            grace_hours,
+            aged_distinct_digests: totals.try_get("aged_distinct_digests").unwrap_or(0),
+            aged_physical_bytes: totals.try_get("aged_physical_bytes").unwrap_or(0),
+            per_repository,
+        })
     }
 
     async fn cleanup_abandoned_oci_uploads(
@@ -1020,6 +1170,25 @@ pub(crate) fn record_gc_success(result: &mut StorageGcResult, bytes: i64, count:
 /// Format a GC error message for a specific operation and storage key.
 pub(crate) fn format_gc_error(operation: &str, storage_key: &str, error: &str) -> String {
     format!("Failed to {} for key {}: {}", operation, storage_key, error)
+}
+
+/// Clamp a caller-supplied grace window (hours) for the blob footprint
+/// report into a defensible range.
+///
+/// A non-positive or absurd value is coerced rather than rejected so the
+/// reporting endpoint never errors on a bad query parameter:
+/// - values `<= 0` fall back to [`BLOB_REPORT_GRACE_HOURS_DEFAULT`]
+///   (a zero/negative grace window would mark freshly-uploaded blobs as
+///   "aged", defeating the upload-race guard the window represents);
+/// - values are capped at one year (8760 h) so `make_interval` cannot be
+///   handed a pathological argument.
+pub(crate) fn clamp_grace_hours(grace_hours: i64) -> i64 {
+    const MAX_GRACE_HOURS: i64 = 24 * 365;
+    if grace_hours <= 0 {
+        BLOB_REPORT_GRACE_HOURS_DEFAULT
+    } else {
+        grace_hours.min(MAX_GRACE_HOURS)
+    }
 }
 
 /// Check whether a storage backend type uses a shared (cloud) backend.
@@ -3096,5 +3265,148 @@ mod tests {
             "the soft-deleted artifact row must still exist (not hard-deleted) after the racing \
              tag insert"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // clamp_grace_hours (issue #1408 blob footprint report)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_clamp_grace_hours_zero_falls_back_to_default() {
+        assert_eq!(clamp_grace_hours(0), BLOB_REPORT_GRACE_HOURS_DEFAULT);
+    }
+
+    #[test]
+    fn test_clamp_grace_hours_negative_falls_back_to_default() {
+        assert_eq!(clamp_grace_hours(-5), BLOB_REPORT_GRACE_HOURS_DEFAULT);
+        assert_eq!(clamp_grace_hours(i64::MIN), BLOB_REPORT_GRACE_HOURS_DEFAULT);
+    }
+
+    #[test]
+    fn test_clamp_grace_hours_passes_through_normal_values() {
+        assert_eq!(clamp_grace_hours(1), 1);
+        assert_eq!(clamp_grace_hours(24), 24);
+        assert_eq!(clamp_grace_hours(168), 168);
+    }
+
+    #[test]
+    fn test_clamp_grace_hours_caps_at_one_year() {
+        let one_year = 24 * 365;
+        assert_eq!(clamp_grace_hours(one_year), one_year);
+        assert_eq!(clamp_grace_hours(one_year + 1), one_year);
+        assert_eq!(clamp_grace_hours(i64::MAX), one_year);
+    }
+
+    #[test]
+    fn test_clamp_grace_hours_default_is_positive() {
+        // A zero input must clamp to a strictly positive window, otherwise
+        // the upload-race guard the grace window represents is defeated.
+        assert!(clamp_grace_hours(0) > 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // OciBlobFootprintReport / OciBlobRepoFootprint serde contract
+    // -----------------------------------------------------------------------
+
+    fn sample_report() -> OciBlobFootprintReport {
+        OciBlobFootprintReport {
+            total_blob_rows: 120,
+            distinct_digests: 95,
+            logical_bytes: 432_000_000_000,
+            physical_bytes: 403_000_000_000,
+            grace_hours: 24,
+            aged_distinct_digests: 80,
+            aged_physical_bytes: 344_000_000_000,
+            per_repository: vec![
+                OciBlobRepoFootprint {
+                    repository_id: Uuid::nil(),
+                    blob_rows: 70,
+                    logical_bytes: 300_000_000_000,
+                },
+                OciBlobRepoFootprint {
+                    repository_id: Uuid::from_u128(1),
+                    blob_rows: 50,
+                    logical_bytes: 132_000_000_000,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn test_blob_footprint_report_serde_roundtrip() {
+        let original = sample_report();
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: OciBlobFootprintReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn test_blob_footprint_report_field_names() {
+        let json = serde_json::to_string(&sample_report()).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        for field in [
+            "total_blob_rows",
+            "distinct_digests",
+            "logical_bytes",
+            "physical_bytes",
+            "grace_hours",
+            "aged_distinct_digests",
+            "aged_physical_bytes",
+            "per_repository",
+        ] {
+            assert!(value.get(field).is_some(), "missing field '{field}'");
+        }
+    }
+
+    #[test]
+    fn test_blob_footprint_report_preserves_large_byte_totals() {
+        // The whole point of the report is making ~403 GB visible; ensure the
+        // i64 byte fields survive a serde round trip without truncation.
+        let json = serde_json::to_string(&sample_report()).unwrap();
+        let restored: OciBlobFootprintReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.logical_bytes, 432_000_000_000);
+        assert_eq!(restored.physical_bytes, 403_000_000_000);
+        assert_eq!(restored.aged_physical_bytes, 344_000_000_000);
+    }
+
+    #[test]
+    fn test_blob_footprint_report_physical_le_logical_in_sample() {
+        // Dedup-aware physical bytes can never exceed the double-counting
+        // logical sum; the sample data must respect that invariant.
+        let r = sample_report();
+        assert!(r.physical_bytes <= r.logical_bytes);
+        assert!(r.distinct_digests <= r.total_blob_rows);
+        assert!(r.aged_physical_bytes <= r.physical_bytes);
+        assert!(r.aged_distinct_digests <= r.distinct_digests);
+    }
+
+    #[test]
+    fn test_blob_repo_footprint_serde_roundtrip() {
+        let original = OciBlobRepoFootprint {
+            repository_id: Uuid::from_u128(42),
+            blob_rows: 7,
+            logical_bytes: 9_999,
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: OciBlobRepoFootprint = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, original);
+    }
+
+    #[test]
+    fn test_blob_footprint_report_empty_per_repository() {
+        let report = OciBlobFootprintReport {
+            total_blob_rows: 0,
+            distinct_digests: 0,
+            logical_bytes: 0,
+            physical_bytes: 0,
+            grace_hours: BLOB_REPORT_GRACE_HOURS_DEFAULT,
+            aged_distinct_digests: 0,
+            aged_physical_bytes: 0,
+            per_repository: vec![],
+        };
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("\"per_repository\":[]"));
+        let restored: OciBlobFootprintReport = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored, report);
     }
 }

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -511,26 +511,31 @@ impl StorageGcService {
         let per_repository = per_repo_rows
             .into_iter()
             .map(|row| {
-                Ok(OciBlobRepoFootprint {
-                    repository_id: row
-                        .try_get("repository_id")
-                        .map_err(|e| AppError::Database(e.to_string()))?,
-                    blob_rows: row.try_get("blob_rows").unwrap_or(0),
-                    logical_bytes: row.try_get("logical_bytes").unwrap_or(0),
-                })
+                let repository_id = row
+                    .try_get("repository_id")
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+                Ok(map_repo_footprint(
+                    repository_id,
+                    row.try_get("blob_rows").unwrap_or(0),
+                    row.try_get("logical_bytes").unwrap_or(0),
+                ))
             })
             .collect::<Result<Vec<_>>>()?;
 
-        Ok(OciBlobFootprintReport {
+        let totals = BlobFootprintTotals {
             total_blob_rows: totals.try_get("total_blob_rows").unwrap_or(0),
             distinct_digests: totals.try_get("distinct_digests").unwrap_or(0),
             logical_bytes: totals.try_get("logical_bytes").unwrap_or(0),
             physical_bytes: totals.try_get("physical_bytes").unwrap_or(0),
-            grace_hours,
             aged_distinct_digests: totals.try_get("aged_distinct_digests").unwrap_or(0),
             aged_physical_bytes: totals.try_get("aged_physical_bytes").unwrap_or(0),
+        };
+
+        Ok(assemble_blob_footprint_report(
+            totals,
+            grace_hours,
             per_repository,
-        })
+        ))
     }
 
     async fn cleanup_abandoned_oci_uploads(
@@ -1170,6 +1175,65 @@ pub(crate) fn record_gc_success(result: &mut StorageGcResult, bytes: i64, count:
 /// Format a GC error message for a specific operation and storage key.
 pub(crate) fn format_gc_error(operation: &str, storage_key: &str, error: &str) -> String {
     format!("Failed to {} for key {}: {}", operation, storage_key, error)
+}
+
+/// Decoded global aggregate values for the OCI blob footprint report.
+///
+/// This is the row-free intermediate between the `totals_sql` query in
+/// [`StorageGcService::oci_blob_footprint_report`] and the final
+/// [`OciBlobFootprintReport`]. Splitting it out lets the report-assembly
+/// logic (which is pure arithmetic/struct shuffling, not I/O) be unit
+/// tested without a live database.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BlobFootprintTotals {
+    pub total_blob_rows: i64,
+    pub distinct_digests: i64,
+    pub logical_bytes: i64,
+    pub physical_bytes: i64,
+    pub aged_distinct_digests: i64,
+    pub aged_physical_bytes: i64,
+}
+
+/// Build a single per-repository footprint row from decoded column values.
+///
+/// Pure mapping helper shared by the per-repo aggregate decode loop and
+/// the unit tests. Holds no row/DB dependency so the construction can be
+/// exercised without Postgres.
+pub(crate) fn map_repo_footprint(
+    repository_id: Uuid,
+    blob_rows: i64,
+    logical_bytes: i64,
+) -> OciBlobRepoFootprint {
+    OciBlobRepoFootprint {
+        repository_id,
+        blob_rows,
+        logical_bytes,
+    }
+}
+
+/// Assemble the final [`OciBlobFootprintReport`] from already-decoded
+/// totals, the (already clamped) grace window, and the per-repository
+/// rows.
+///
+/// Pure: it does no I/O and takes no locks. Extracted from
+/// [`StorageGcService::oci_blob_footprint_report`] so the report-assembly
+/// step is covered by `--lib` unit tests even though the surrounding query
+/// execution requires a database.
+pub(crate) fn assemble_blob_footprint_report(
+    totals: BlobFootprintTotals,
+    grace_hours: i64,
+    per_repository: Vec<OciBlobRepoFootprint>,
+) -> OciBlobFootprintReport {
+    OciBlobFootprintReport {
+        total_blob_rows: totals.total_blob_rows,
+        distinct_digests: totals.distinct_digests,
+        logical_bytes: totals.logical_bytes,
+        physical_bytes: totals.physical_bytes,
+        grace_hours,
+        aged_distinct_digests: totals.aged_distinct_digests,
+        aged_physical_bytes: totals.aged_physical_bytes,
+        per_repository,
+    }
 }
 
 /// Clamp a caller-supplied grace window (hours) for the blob footprint
@@ -3390,6 +3454,99 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: OciBlobRepoFootprint = serde_json::from_str(&json).unwrap();
         assert_eq!(restored, original);
+    }
+
+    // -----------------------------------------------------------------------
+    // map_repo_footprint / assemble_blob_footprint_report (pure assembly)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_map_repo_footprint_copies_all_fields() {
+        let id = Uuid::from_u128(7);
+        let row = map_repo_footprint(id, 13, 4096);
+        assert_eq!(row.repository_id, id);
+        assert_eq!(row.blob_rows, 13);
+        assert_eq!(row.logical_bytes, 4096);
+    }
+
+    #[test]
+    fn test_map_repo_footprint_zero_values() {
+        let row = map_repo_footprint(Uuid::nil(), 0, 0);
+        assert_eq!(row.repository_id, Uuid::nil());
+        assert_eq!(row.blob_rows, 0);
+        assert_eq!(row.logical_bytes, 0);
+    }
+
+    fn sample_totals() -> BlobFootprintTotals {
+        BlobFootprintTotals {
+            total_blob_rows: 120,
+            distinct_digests: 95,
+            logical_bytes: 432_000_000_000,
+            physical_bytes: 403_000_000_000,
+            aged_distinct_digests: 80,
+            aged_physical_bytes: 344_000_000_000,
+        }
+    }
+
+    #[test]
+    fn test_assemble_blob_footprint_report_maps_every_total() {
+        let totals = sample_totals();
+        let per_repo = vec![
+            map_repo_footprint(Uuid::nil(), 70, 300_000_000_000),
+            map_repo_footprint(Uuid::from_u128(1), 50, 132_000_000_000),
+        ];
+        let report = assemble_blob_footprint_report(totals, 24, per_repo.clone());
+
+        assert_eq!(report.total_blob_rows, totals.total_blob_rows);
+        assert_eq!(report.distinct_digests, totals.distinct_digests);
+        assert_eq!(report.logical_bytes, totals.logical_bytes);
+        assert_eq!(report.physical_bytes, totals.physical_bytes);
+        assert_eq!(report.aged_distinct_digests, totals.aged_distinct_digests);
+        assert_eq!(report.aged_physical_bytes, totals.aged_physical_bytes);
+        assert_eq!(report.per_repository, per_repo);
+    }
+
+    #[test]
+    fn test_assemble_blob_footprint_report_echoes_grace_hours() {
+        // The clamped grace window is threaded straight through; assembly
+        // must not re-clamp or otherwise mutate it.
+        let report = assemble_blob_footprint_report(sample_totals(), 168, vec![]);
+        assert_eq!(report.grace_hours, 168);
+        assert!(report.per_repository.is_empty());
+    }
+
+    #[test]
+    fn test_assemble_blob_footprint_report_matches_sample_report_shape() {
+        // Building via the assembly helper must yield the same value as the
+        // hand-written sample used by the serde contract tests.
+        let report = assemble_blob_footprint_report(
+            sample_totals(),
+            24,
+            vec![
+                map_repo_footprint(Uuid::nil(), 70, 300_000_000_000),
+                map_repo_footprint(Uuid::from_u128(1), 50, 132_000_000_000),
+            ],
+        );
+        assert_eq!(report, sample_report());
+    }
+
+    #[test]
+    fn test_assemble_blob_footprint_report_empty_repositories() {
+        let report = assemble_blob_footprint_report(
+            BlobFootprintTotals {
+                total_blob_rows: 0,
+                distinct_digests: 0,
+                logical_bytes: 0,
+                physical_bytes: 0,
+                aged_distinct_digests: 0,
+                aged_physical_bytes: 0,
+            },
+            BLOB_REPORT_GRACE_HOURS_DEFAULT,
+            vec![],
+        );
+        assert_eq!(report.total_blob_rows, 0);
+        assert_eq!(report.grace_hours, BLOB_REPORT_GRACE_HOURS_DEFAULT);
+        assert!(report.per_repository.is_empty());
     }
 
     #[test]

--- a/docs/audits/1408-oci-blob-garbage-collection.md
+++ b/docs/audits/1408-oci-blob-garbage-collection.md
@@ -1,0 +1,222 @@
+# OCI Blob Layer Garbage Collection — Design (#1408)
+
+Status: design + safe first slice shipped (read-only report).
+Author: Backend Architecture review for issue #1408.
+Scope: backend (`backend/src/services/storage_gc_service.rs`,
+`backend/src/api/handlers/oci_v2.rs`, `backend/migrations/`).
+
+## 1. Problem
+
+`StorageGcService` (`backend/src/services/storage_gc_service.rs`) only
+reclaims **manifest JSON** storage keys. It iterates `artifacts` rows and
+applies `ORPHAN_PREDICATE_SQL`, which contains an `oci_blobs` clause — but
+that clause is *defensive*: it stops a soft-deleted artifact that happens
+to share a blob storage key from being collected. There is no source that
+iterates `oci_blobs` itself, and `DELETE FROM oci_blobs` exists nowhere in
+the tree.
+
+Consequently the actual large objects of an image — the config blob plus
+every entry in `layers[].digest` — leak in the storage backend forever
+once their parent manifests are deleted or soft-deleted. Observed in
+production on a Ceph RGW bucket: 426 GB bucket, `SUM(oci_blobs.size_bytes)`
+≈ 403 GB, of which an out-of-band reconciler reclaimed ~344 GB (≈81%) in a
+single pass. On long-lived registries blob accumulation is unbounded.
+
+## 2. Reference model in THIS codebase
+
+Tables that participate (migrations `026`, `092`):
+
+- **`oci_blobs`** — `(id, repository_id, digest, size_bytes, storage_key,
+  created_at)`, `UNIQUE(repository_id, digest)`. One row **per repository**
+  per blob. The physical object lives at storage key `oci-blobs/<digest>`
+  with **no per-repo prefix**, so the same bytes back every row sharing a
+  digest. This is the cross-repo dedup hazard.
+- **`oci_tags`** — `(repository_id, name, tag, manifest_digest, ...)`. The
+  tag → manifest-digest mapping. Only the *tagged* (and, for multi-arch,
+  the *index*) digest appears here.
+- **`oci_manifest_refs`** — `(parent_digest, child_digest, repository_id)`.
+  Records image-index → per-arch-child-manifest edges, written at PUT time
+  by the v2 handler and backfilled at startup. Index `idx_oci_manifest_refs_child`
+  supports the reverse lookup.
+- **`artifacts`** — the manifest JSON bodies are tracked here as
+  `oci-manifests/<digest>` storage keys; layers/config are **not** tracked
+  in `artifacts`.
+
+**Missing link.** There is no manifest → blob reference table. Nothing in
+the schema says "manifest digest X references config/layer blob digest Y".
+So today the only data the GC could use to judge a blob is
+`(repository_id, digest)` from `oci_blobs` — which is exactly the data that
+makes a per-repo orphan rule *wrong*.
+
+### Why per-repo orphan classification is unsafe
+
+Because `oci-blobs/<digest>` is global and deduplicated, classifying
+orphan-ness per `(repository_id, digest)` and deleting the storage object
+on the first orphan row breaks every surviving repo that still references
+that digest. The out-of-band reconciler that ran a per-`(repo, digest)`
+rule produced 57 broken blobs (1.73 GB) across 85 tags in three repos
+(`konflux-step-images:task-runner-1.6.0-kub2`, `kub-coreos:2`,
+`stream-coreos:4.20` all returned `BLOB_UNKNOWN`). **Any in-tree GC must
+evaluate orphan-ness per digest, globally**, mirroring how
+`ORPHAN_PREDICATE_SQL` already treats cloud backends as a shared keyspace.
+
+## 3. Proposed GC subsystem
+
+### 3.1 `manifest_blob_refs` table
+
+```
+manifest_blob_refs(
+  manifest_digest TEXT NOT NULL,
+  blob_digest     TEXT NOT NULL,
+  repository_id   UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+  kind            TEXT NOT NULL,   -- 'config' | 'layer'
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (manifest_digest, blob_digest, repository_id)
+);
+CREATE INDEX idx_manifest_blob_refs_blob ON manifest_blob_refs(blob_digest);
+```
+
+The reverse index on `blob_digest` is the hot path for the GC predicate
+("is this blob referenced by any live manifest anywhere?"). Mirror the
+existing `record_oci_manifest_refs` UNNEST batch-insert so a manifest with
+N layers costs one round-trip.
+
+Populate at push time inside `handle_put_manifest`, for **non-index**
+manifests (image manifests carry `config.digest` + `layers[].digest`;
+indexes carry no layers and are already covered by `oci_manifest_refs`).
+Use `ON CONFLICT DO NOTHING` for idempotency.
+
+### 3.2 Startup backfill
+
+Mirror `oci_manifest_refs` backfill: on boot, walk every image manifest
+reachable through `oci_tags` or `oci_manifest_refs.child_digest` that has
+zero rows in `manifest_blob_refs`, load each body from per-repo storage,
+parse `config` + `layers`, and insert edges. Idempotent on re-runs. This is
+what makes GC safe for the existing ~403 GB that predates the table.
+
+### 3.3 `run_blob_gc` — mark and sweep with global predicate
+
+New source on `oci_blobs`:
+
+```
+-- candidate: blob with no live manifest reference, anywhere, and old enough
+SELECT ob.digest, MAX(ob.size_bytes) AS size_bytes
+FROM oci_blobs ob
+WHERE ob.created_at < NOW() - make_interval(hours => $grace)
+  AND NOT EXISTS (
+    SELECT 1 FROM manifest_blob_refs mbr WHERE mbr.blob_digest = ob.digest
+  )
+GROUP BY ob.digest;
+```
+
+The predicate keys on `blob_digest` **globally** — never per repo. A digest
+is reclaimable only when *no* manifest in *any* repo references it.
+
+**Per-digest delete transaction** (mirrors the manifest GC TOCTOU
+protection from #1180):
+
+1. `BEGIN`.
+2. `SELECT ... FROM oci_blobs WHERE digest = $1 FOR UPDATE` — lock every
+   row for the digest.
+3. Re-check the predicate under the lock (`NOT EXISTS manifest_blob_refs`
+   and still older than grace). If a push landed a reference, `ROLLBACK`
+   and skip.
+4. **Delete from object storage first** is wrong here — see §3.5. Instead:
+   delete the `oci_blobs` rows for the digest inside the tx, `COMMIT`, then
+   delete `oci-blobs/<digest>` from storage. Bias to leaking over losing
+   data.
+
+### 3.4 Grace window
+
+`oci_blobs.created_at` younger than the grace window (default 24h) is never
+collected. A blob upload and its parent manifest push are **not**
+transactionally bundled: during a `docker push` the blob rows exist before
+the manifest that references them commits, so a fresh blob is legitimately
+"unreferenced" for the duration of the client's push. The grace window
+absorbs that without a global lock. Residual sub-second TOCTOU (a manifest
+push landing mid-sweep for a blob older than grace) is closed fully by
+having the push path `SELECT ... FOR UPDATE` the `oci_blobs` rows before
+writing `manifest_blob_refs`; that can ship as a follow-up.
+
+### 3.5 Ordering rule — bias to leaking, never to data loss
+
+Storage backends are not inside Postgres' atomic boundary. The rule:
+**commit the metadata transaction first, delete the object afterward.**
+
+- If we crash after COMMIT but before the storage delete, we leak one
+  object (recoverable: a later sweep with an "objects with no `oci_blobs`
+  row" reconciler picks it up). Harmless.
+- If we deleted storage first and then failed to commit, a surviving
+  reference would point at a missing object → `BLOB_UNKNOWN` on pull. Data
+  loss. Forbidden.
+
+This is the inverse of the manifest GC (which deletes storage while holding
+the row lock) because there the lock + `is_deleted` flag guarantee no live
+reference; here the cross-repo dedup means we prefer the leak.
+
+### 3.6 Single-leader execution across replicas
+
+Two replicas must never sweep concurrently. Wrap each `run_blob_gc` pass in
+a Postgres **advisory lock**:
+
+```
+SELECT pg_try_advisory_lock($BLOB_GC_LOCK_KEY);   -- e.g. hashtext('ak.blob_gc')
+-- if false: another replica is sweeping; return early.
+-- ... run sweep ...
+SELECT pg_advisory_unlock($BLOB_GC_LOCK_KEY);
+```
+
+`pg_try_advisory_lock` is non-blocking and session-scoped; a crashed leader
+releases it when its connection drops. The per-digest `FOR UPDATE` is the
+inner correctness guarantee; the advisory lock is the outer
+single-leader/throughput guarantee.
+
+### 3.7 Dry-run, audit log, admin surface
+
+- **Dry-run** computes the reclaimable set and reports digest count + bytes
+  without deleting (same shape as the existing `StorageGcResult.dry_run`).
+- **Audit log**: every real deletion writes a row `(blob_digest,
+  size_bytes, repository_ids[], deleted_at, actor)` to a
+  `blob_gc_audit` table so every reclamation is attributable and
+  reversible-by-re-push.
+- **Admin surface**: extend `POST /api/v1/admin/storage-gc` (admin-gated)
+  and the scheduler; add the **read-only** `GET .../oci-blob-report`
+  shipped in this PR for visibility ahead of deletion.
+
+## 4. What ships in THIS PR (safe first slice)
+
+A **read-only** OCI blob footprint report — no deletion, no locks, pure
+aggregate `SELECT`s over `oci_blobs`:
+
+- `GET /api/v1/admin/storage-gc/oci-blob-report?grace_hours=24` (admin only).
+- `StorageGcService::oci_blob_footprint_report(grace_hours)` returning
+  `OciBlobFootprintReport`: `total_blob_rows`, `distinct_digests`,
+  `logical_bytes` (sum over all rows, double-counts dedup),
+  `physical_bytes` (distinct-digest sum ≈ bytes on disk),
+  `aged_distinct_digests` / `aged_physical_bytes` (older than the grace
+  window), and a per-repository breakdown.
+
+It deliberately does **not** emit a "reclaimable orphans" number. That
+number is impossible to compute correctly until `manifest_blob_refs`
+exists; a per-`(repo, digest)` heuristic would reproduce the exact bug that
+broke 57 blobs in production. The report gives operators immediate
+visibility into the ~403 GB (the `physical_bytes` figure maps directly to
+the bucket observation) with zero deletion risk.
+
+## 5. Why deletion is not in this PR
+
+Actual blob reclamation depends on three pieces that need human design
+review and their own migrations/PRs:
+
+1. `manifest_blob_refs` table + push-path write + startup backfill — without
+   it, GC has no safe global reference signal.
+2. The global (not per-repo) sweep predicate, advisory-lock leadership, and
+   commit-then-delete ordering.
+3. The `blob_gc_audit` table and dry-run/report parity.
+
+Shipping any deletion path before (1) lands would either delete in-use
+blobs or delete nothing. **Recommended next step:** land
+`manifest_blob_refs` (table + synchronous push-path writer + idempotent
+startup backfill) as its own reviewed PR, verify the backfill reconstructs
+references for the existing corpus, *then* add `run_blob_gc` behind dry-run
+with the advisory lock and audit table.


### PR DESCRIPTION
Closes #1623 — read-only diagnostic slice. The full GC deletion path remains open under the umbrella issue #1408 (see PR body).

## Summary

OCI **blob layer** objects (the config blob + every `layers[].digest`)
leak in the storage backend forever: `StorageGcService` only reclaims
manifest JSON keys and has no source iterating `oci_blobs`. On long-lived
registries this is unbounded (~403 GB observed in production, #1408).

Actual blob reclamation is **not** safe to ship yet. `oci-blobs/<digest>`
is content-addressed and **deduplicated across repos** (one physical
object backs many `oci_blobs` rows), so any per-`(repository_id, digest)`
orphan rule deletes in-use blobs — the exact bug that broke 57 blobs /
1.73 GB across three repos in the out-of-band reconciler described in the
issue. Safe deletion needs a `manifest_blob_refs` table + backfill that
does not exist yet.

This PR therefore ships only the **safe, read-only first slice** plus the
full design doc:

- `StorageGcService::oci_blob_footprint_report(grace_hours)` — pure
  aggregate `SELECT`s over `oci_blobs`. No deletion, no locks, no storage
  access. Reports `logical_bytes` (double-counts dedup), dedup-aware
  `physical_bytes`, `distinct_digests`, and `aged_*` figures gated by a
  clamped grace window, plus a per-repository breakdown.
- `GET /api/v1/admin/storage-gc/oci-blob-report?grace_hours=24`
  (admin-gated) exposing the report.
- `clamp_grace_hours` helper (clamps non-positive → 24h default, caps at
  1 year) with unit tests.
- `docs/audits/1408-oci-blob-garbage-collection.md` — full GC design:
  `manifest_blob_refs` reference model, **global** (not per-repo) orphan
  predicate, grace window, `pg_try_advisory_lock` single-leader execution,
  commit-then-delete ordering (bias to leaking over data loss), audit log,
  dry-run.

The report deliberately does **not** emit a "reclaimable orphans" number —
that is impossible to compute correctly until `manifest_blob_refs` lands.
`physical_bytes` maps directly to the bucket observation in #1408, giving
operators immediate visibility into the leaked storage with zero risk.

**No deletion path is included.** Recommended next step (per the design
doc): land `manifest_blob_refs` (table + synchronous push-path writer +
idempotent startup backfill) as its own reviewed PR, then add `run_blob_gc`
behind dry-run with the advisory lock + audit table.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (read-only feature slice; deletion fix is staged separately)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo fmt --check`, `clippy -D warnings`, `cargo test --lib storage_gc` all green)
- [x] No regressions in existing tests (two unrelated failures in full run — `http_client` network test and an `oci_v2` negative-cache test — reproduce on clean `main`/in parallel and are untouched by this change; both pass in isolation)

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable) — no migration in this PR
- [ ] N/A - no API changes
