### PR TITLE
test: cache-correctness + virtual-resolution E2E suite (#1625)

### DIFF
--- a/.github/workflows/cache-correctness-e2e.yml
+++ b/.github/workflows/cache-correctness-e2e.yml
@@ -1,0 +1,82 @@
+name: Cache-Correctness E2E
+
+# Cache-correctness + virtual-resolution E2E suite (issue #1625, acceptance gate
+# for #1611). These tests are RED on `main` BY DESIGN — they reproduce the open
+# wrong-result bugs #1600 / #1595 / #1562 and the immutable-vs-mutable
+# mis-caching. They must therefore NEVER run on `pull_request` (they would block
+# every PR). Run manually via workflow_dispatch, plus a weekly schedule so the
+# reproduction does not silently rot. When #1611 lands, flip this green and turn
+# it into the regression gate (and only then consider gating PRs on it).
+
+on:
+  workflow_dispatch:
+    inputs:
+      suite:
+        description: 'Which suite to run'
+        type: choice
+        options:
+          - both
+          - virtual-resolution
+          - cache-correctness
+        default: both
+  schedule:
+    # Weekly, Mondays 04:00 UTC. Non-blocking; surfaces drift in the repros.
+    - cron: '0 4 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-correctness-e2e-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cache-correctness-e2e:
+    name: 🧊 Cache-correctness + virtual-resolution
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    # Do NOT fail the workflow run if the suite is red on `main`: a red result is
+    # the EXPECTED outcome until #1611 lands (it proves the bugs reproduce). The
+    # per-step logs carry the PASS/FAIL detail. Once #1611 lands, remove this
+    # `continue-on-error` so regressions hard-fail.
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Run virtual-resolution regression suite (#1600/#1595/#1562)
+        if: ${{ github.event.inputs.suite == 'both' || github.event.inputs.suite == 'virtual-resolution' || github.event_name == 'schedule' }}
+        run: |
+          docker compose -f docker-compose.test.yml --profile cache-correctness up \
+            --build --exit-code-from virtual-resolution-test \
+            backend postgres trivy setup cache-mock-upstream virtual-resolution-test \
+            || echo "::warning::virtual-resolution suite reported failures (EXPECTED on main — reproduces #1600/#1595/#1562)"
+
+      - name: Tear down between suites
+        if: always()
+        run: docker compose -f docker-compose.test.yml --profile cache-correctness down -v --remove-orphans
+
+      - name: Run cache-correctness suite (immutable vs mutable, negative cache)
+        if: ${{ github.event.inputs.suite == 'both' || github.event.inputs.suite == 'cache-correctness' || github.event_name == 'schedule' }}
+        run: |
+          docker compose -f docker-compose.test.yml --profile cache-correctness up \
+            --build --exit-code-from cache-correctness-test \
+            backend postgres trivy setup cache-mock-upstream cache-correctness-test \
+            || echo "::warning::cache-correctness suite reported failures (EXPECTED on main — reproduces immutable-vs-mutable mis-caching)"
+
+      - name: Dump failure diagnostics
+        if: always()
+        run: |
+          echo "::group::backend container logs"
+          docker compose -f docker-compose.test.yml logs backend || true
+          echo "::endgroup::"
+          echo "::group::mock-upstream container logs"
+          docker compose -f docker-compose.test.yml logs cache-mock-upstream || true
+          echo "::endgroup::"
+
+      - name: Cleanup
+        if: always()
+        run: docker compose -f docker-compose.test.yml --profile cache-correctness down -v --remove-orphans

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -105,7 +105,7 @@ services:
       retries: 30
     networks:
       - e2e-test-network
-    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation"]
+    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation", "cache-correctness"]
 
   # PKI service: uses pre-generated files from .pki/ if available (CI), otherwise generates them (local)
   pki:
@@ -139,7 +139,7 @@ services:
       retries: 20
     networks:
       - e2e-test-network
-    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation"]
+    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation", "cache-correctness"]
 
   # ==========================================================================
   # SMOKE TEST SERVICES (pypi, npm, cargo)
@@ -551,6 +551,79 @@ services:
     volumes:
       - ./scripts/native-tests:/scripts:ro
     entrypoint: ["sh", "-c", "apk add --no-cache curl jq postgresql-client bash > /dev/null 2>&1 && bash /scripts/test-curation.sh"]
+    networks:
+      - e2e-test-network
+
+  # ==========================================================================
+  # CACHE-CORRECTNESS + VIRTUAL-RESOLUTION TESTS (#1625, gate for #1611)
+  #
+  # RED on `main` by design: these reproduce open bugs #1600/#1595/#1562 and the
+  # immutable-vs-mutable mis-caching. Do NOT add the `cache-correctness` profile
+  # to any per-PR gate. Run via the cache-correctness-e2e.yml workflow_dispatch.
+  #
+  # NOTE (consolidation, re #1624): `cache-mock-upstream` is an ETag/counter/
+  # mutation-aware Python server. The #1624 concurrency harness needs a similar
+  # counter+latency mock. Once both land, consolidate into one mock-upstream
+  # image with both knob-sets (this one already exposes a /__mock__/latency
+  # control endpoint toward that goal).
+  # ==========================================================================
+
+  cache-mock-upstream:
+    build:
+      context: ./scripts/native-tests/mock-upstream
+      dockerfile: Dockerfile
+    image: artifact-keeper-mock-upstream:test
+    container_name: e2e-test-cache-mock-upstream
+    profiles: ["cache-correctness"]
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9101/__mock__/health').read()==b'ok' else 1)"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
+    networks:
+      - e2e-test-network
+
+  virtual-resolution-test:
+    image: ghcr.io/artifact-keeper/ci-mirror/python:3.12-slim
+    container_name: e2e-test-virtual-resolution
+    profiles: ["cache-correctness"]
+    depends_on:
+      setup:
+        condition: service_healthy
+      cache-mock-upstream:
+        condition: service_healthy
+    environment:
+      REGISTRY_URL: http://backend:8080
+      ADMIN_USER: admin
+      ADMIN_PASS: TestRunner!2026secure
+      MOCK_UPSTREAM_URL: http://cache-mock-upstream:9101
+    volumes:
+      - ./scripts/native-tests:/scripts:ro
+    command: ["bash", "-c", "apt-get update -qq && apt-get install -y -qq curl jq >/dev/null 2>&1 && bash /scripts/test-virtual-resolution.sh"]
+    networks:
+      - e2e-test-network
+
+  cache-correctness-test:
+    image: ghcr.io/artifact-keeper/ci-mirror/alpine:3.19
+    container_name: e2e-test-cache-correctness
+    profiles: ["cache-correctness"]
+    depends_on:
+      setup:
+        condition: service_healthy
+      cache-mock-upstream:
+        condition: service_healthy
+    environment:
+      REGISTRY_URL: http://backend:8080
+      ADMIN_USER: admin
+      ADMIN_PASS: TestRunner!2026secure
+      MOCK_UPSTREAM_URL: http://cache-mock-upstream:9101
+      # TTL waits are env-overridable so the workflow can match the backend's
+      # configured metadata/negative TTLs once #1611 makes them explicit.
+      CACHE_TTL_SECONDS: "30"
+      NEG_TTL_SECONDS: "15"
+    volumes:
+      - ./scripts/native-tests:/scripts:ro
+    command: ["sh", "-c", "apk add --no-cache bash curl jq >/dev/null 2>&1 && bash /scripts/test-proxy-cache-correctness.sh"]
     networks:
       - e2e-test-network
 

--- a/scripts/native-tests/mock-upstream/Dockerfile
+++ b/scripts/native-tests/mock-upstream/Dockerfile
@@ -1,0 +1,13 @@
+# Minimal ETag/counter/mutation-aware mock upstream for cache-correctness E2E.
+# Stdlib-only Python server — no pip install, tiny image, fast startup.
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY mock_upstream.py /app/mock_upstream.py
+
+EXPOSE 9101
+# Healthcheck hits the out-of-band control endpoint (never proxied).
+HEALTHCHECK --interval=3s --timeout=3s --retries=10 \
+  CMD python3 -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:9101/__mock__/health').read()==b'ok' else 1)"
+
+ENTRYPOINT ["python3", "/app/mock_upstream.py", "--port", "9101", "--host", "0.0.0.0"]

--- a/scripts/native-tests/mock-upstream/README.md
+++ b/scripts/native-tests/mock-upstream/README.md
@@ -1,0 +1,184 @@
+# Cache-correctness + virtual-resolution E2E suite (#1625)
+
+Black-box E2E tests that pin **cache correctness** (immutable-vs-mutable
+classification, TTL, conditional revalidation, negative cache) and
+**virtual-repository resolution** correctness.
+
+This suite is the **acceptance gate for #1611** and **reproduces three open
+wrong-result bugs**: #1600, #1595, #1562.
+
+> **These tests are RED on `main` BY DESIGN.**
+> A failure proves the bug still exists. When #1611 lands they flip green and
+> become its regression gate. They are wired to a `workflow_dispatch` +
+> weekly-schedule workflow (`cache-correctness-e2e.yml`), **never** to the
+> per-PR gate.
+
+## Components
+
+| File | Purpose |
+| --- | --- |
+| `mock_upstream.py` | ETag/counter/mutation-aware HTTP mock upstream (stdlib only). |
+| `Dockerfile` | Minimal container image for the mock upstream. |
+| `../test-virtual-resolution.sh` | Virtual-resolution regressions (#1600/#1595/#1562). |
+| `../test-proxy-cache-correctness.sh` | Cache-correctness (immutable/mutable/negative). |
+
+## The mock upstream
+
+`mock_upstream.py` is a small stdlib HTTP server giving the artifact-keeper proxy
+a *controllable* upstream. It is more capable than a static nginx fixture: it
+counts requests, answers conditional requests, mutates resources, and supports
+404-then-publish.
+
+### Data plane (proxied through artifact-keeper)
+
+| Path | Kind | Used by |
+| --- | --- | --- |
+| `/maven2/com/example/widget/1.0.0/widget-1.0.0.jar` | immutable | cache: counter==1 |
+| `/maven2/com/example/widget/maven-metadata.xml` | mutable | cache: revalidate |
+| `/maven2/org/example/plugins/maven-metadata.xml` | mutable (group-level) | #1595 |
+| `/maven2/com/example/parent/1.0.0/parent-1.0.0.pom` | immutable (remote-only) | #1562 control |
+| `/maven2/com/example/vonly-parent/1.0.0/vonly-parent-1.0.0.pom` | immutable (remote-only, never primed) | #1562 virtual-first-request |
+| `/simple/lonelydep/` + `/packages/ld/lonelydep/lonelydep-2.3.0-py3-none-any.whl` | mutable index + immutable wheel | #1600, cache |
+| `/maven2/com/example/late/1.0.0/late-1.0.0.jar` | starts 404, publishable | negative cache |
+
+### Control plane (out-of-band, never proxied)
+
+```
+GET  /__mock__/health                      -> "ok"
+GET  /__mock__/count?path=/p                -> {"path","count","revalidations"}
+GET  /__mock__/count_all                    -> {"/p": {...}, ...}
+POST /__mock__/reset                        -> zero all counters
+POST /__mock__/mutate?path=/p               -> change body+ETag (mutable paths)
+POST /__mock__/publish?path=/p   (body)     -> make a 404 path exist
+POST /__mock__/unpublish?path=/p            -> make a path 404 again
+POST /__mock__/latency?ms=N                 -> artificial per-response latency
+```
+
+Conditional requests (`If-None-Match` matching the current ETag, or
+`If-Modified-Since` >= last-modified) get a `304` and bump `revalidations`
+instead of `count`.
+
+## What each script asserts
+
+### `test-virtual-resolution.sh` (assert CORRECT behavior → red on `main`)
+
+- **#1600 (PyPI virtual, remote-only download):** a package present only on the
+  remote member (`lonelydep`) is listed in the virtual's `/simple/<name>/` index
+  **and** its wheel downloads `200` through the virtual (not `404` bound to the
+  local member). Optional `pip download` end-to-end through the virtual.
+- **#1595 (Maven virtual, group-level plugin-prefix metadata):** the
+  group-level `<groupPath>/maven-metadata.xml` (the `<plugins>` list, no
+  artifactId) is proxied `200` from the remote member and exposes `<prefix>` —
+  enabling `mvn <prefix>:<goal>`.
+- **#1562 (Maven virtual, remote-only artifact):** a remote-only parent POM
+  (`com.example:parent:1.0.0`) — which the remote member serves `200` directly —
+  resolves `200` through the virtual on first request, instead of `404`.
+
+### `test-proxy-cache-correctness.sh` (assert cache invariant ④ → red on `main`)
+
+- **Immutable:** a versioned jar pulled N times within the TTL window hits the
+  upstream **exactly once** (`/__mock__/count` stays `1`).
+- **Mutable:** `maven-metadata.xml` and the PyPI simple index are served from
+  cache within the TTL; after TTL they **revalidate conditionally** (mock
+  answers `304`, `revalidations >= 1`); a **mutated** upstream (new ETag/body)
+  is reflected promptly.
+- **Negative cache:** a missing path returns `404`, then after upstream
+  `publish` it becomes visible within the short negative-TTL window.
+
+## Running
+
+### Standalone mock upstream (no full stack — validates the harness itself)
+
+```bash
+python3 scripts/native-tests/mock-upstream/mock_upstream.py --port 9101 &
+curl -s http://localhost:9101/__mock__/health           # -> ok
+curl -s -X POST http://localhost:9101/__mock__/reset
+curl -s "http://localhost:9101/__mock__/count?path=/maven2/com/example/widget/1.0.0/widget-1.0.0.jar"
+```
+
+### Full stack via docker compose
+
+```bash
+# Builds the backend + mock upstream, runs both suites under the dedicated profile.
+docker compose -f docker-compose.test.yml --profile cache-correctness up --build --abort-on-container-exit
+docker compose -f docker-compose.test.yml --profile cache-correctness down -v --remove-orphans
+```
+
+### Against an already-running backend + standalone mock
+
+```bash
+python3 scripts/native-tests/mock-upstream/mock_upstream.py --port 9101 &
+REGISTRY_URL=http://localhost:8080 MOCK_UPSTREAM_URL=http://localhost:9101 \
+  scripts/native-tests/test-virtual-resolution.sh
+
+REGISTRY_URL=http://localhost:8080 MOCK_UPSTREAM_URL=http://localhost:9101 \
+  CACHE_TTL_SECONDS=30 NEG_TTL_SECONDS=15 \
+  scripts/native-tests/test-proxy-cache-correctness.sh
+```
+
+### CI
+
+`.github/workflows/cache-correctness-e2e.yml` — `workflow_dispatch` (choose
+`both` / `virtual-resolution` / `cache-correctness`) plus a weekly schedule.
+The job uses `continue-on-error: true` so a red result (the expected outcome on
+`main`) does not fail the run; remove that once #1611 lands.
+
+## Interpreting results
+
+| Branch | Expected | Meaning |
+| --- | --- | --- |
+| `main` (pre-#1611) | **FAIL** | Bugs reproduced — correct outcome. |
+| post-#1611 | **PASS** | Cache classification + virtual resolution fixed. |
+
+A *green* run on `main` would mean the repros stopped reproducing — investigate
+the harness before trusting it.
+
+### Observed on the `:dev` (main) backend image — 2026-06-04
+
+A manual run against `ghcr.io/artifact-keeper/artifact-keeper-backend:dev`
+(postgres + dev backend + this mock, on a shared docker network):
+
+- **#1600 — reproduced RED.** The virtual `/simple/lonelydep/` index lists
+  `lonelydep-2.3.0` but the wheel download through the virtual returns `404`
+  (and `pip download` fails). Index/download inconsistency confirmed.
+- **#1595 — reproduced RED.** The virtual returns `404` for the group-level
+  plugin-prefix `maven-metadata.xml` while the remote member serves it `200`.
+- **#1562 — PASSED (green) on this build.** A remote-only parent POM (even an
+  uncached `vonly-parent`) resolved `200` through the virtual. The original
+  #1562 is a subtle buffered-vs-streaming / cache-key discrepancy that a trivial
+  flat-namespace static POM on this mock does not trigger; it may need a more
+  faithful upstream (redirects / content-length quirks like Confluent's repo) or
+  may already be partially addressed on this image. The assertion still guards
+  against regression; it simply does not reproduce here. **Follow-up:** make the
+  mock more faithful (redirect + chunked transfer) to try to reproduce #1562
+  deterministically, or confirm via the live Confluent repro from the issue.
+- **Cache — immutable-vs-mutable mis-caching reproduced RED.** After the upstream
+  `maven-metadata.xml` changed (`1.0.0` → `1.1.0`), the proxy kept serving stale
+  `1.0.0`; the mock counter stayed `count=1, revalidations=0` — i.e. the proxy
+  never re-fetched **or** conditionally revalidated the mutable path. The PyPI
+  simple index showed the same staleness. This is exactly invariant ④ (#1611).
+- **Immutable counter==1 PASSED**, but a second cached read of the immutable jar
+  returned `500 STORAGE_ERROR` (`Failed to read .../__content__: No such file`).
+  This appeared in a standalone container without a persistent `/data` volume,
+  so it may be an environment artifact rather than a confirmed product bug —
+  re-run under the compose `cache-correctness` profile (persistent backend
+  storage) to confirm before treating it as a real defect.
+
+## Tuning the TTL waits
+
+`CACHE_TTL_SECONDS` (default 30) and `NEG_TTL_SECONDS` (default 15) are the
+sleeps before asserting revalidation / negative-cache expiry. Once #1611 makes
+the backend's metadata and negative TTLs explicit/configurable, set these to
+match so the suite stays fast and deterministic.
+
+## Consolidation note (re #1624)
+
+Issue #1624 builds a sibling **mock upstream** under `scripts/concurrency/` with
+a request **counter + injectable latency** for the single-flight concurrency
+harness. This mock already shares that shape (counter + a `/__mock__/latency`
+control endpoint) and adds the knobs #1625 needs (ETag/Last-Modified conditional
+handling, a mutating resource, 404-then-publish). The two were kept separate to
+avoid a merge collision while both land. **Follow-up: consolidate into a single
+mock-upstream image exposing both knob-sets** (counter+latency for #1624,
+ETag+mutation+publish for #1625). This dir is intentionally self-contained to
+make that merge mechanical.

--- a/scripts/native-tests/mock-upstream/mock_upstream.py
+++ b/scripts/native-tests/mock-upstream/mock_upstream.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""ETag / counter / mutation-aware mock upstream for cache-correctness E2E tests.
+
+This is a deliberately small HTTP server used by `test-proxy-cache-correctness.sh`
+and `test-virtual-resolution.sh` to give the artifact-keeper proxy a *controllable*
+upstream. Unlike a static nginx fixture it can:
+
+  * count requests per path (to assert immutable artifacts are fetched exactly once),
+  * answer conditional requests (If-None-Match / If-Modified-Since -> 304),
+  * MUTATE a resource between requests (to assert mutable paths revalidate),
+  * 404 a path then "publish" it (to assert negative-cache TTL expiry),
+  * (optionally) inject latency.
+
+It also serves a handful of Maven/PyPI shaped paths so the virtual-resolution
+regression tests (#1562, #1595) have a deterministic remote member.
+
+CONTROL PLANE (out-of-band, never proxied through artifact-keeper):
+  GET  /__mock__/health                       -> 200 "ok"
+  GET  /__mock__/count?path=/p                 -> {"path": "/p", "count": N}
+  GET  /__mock__/count_all                     -> {"/p": N, ...}
+  POST /__mock__/reset                         -> zero all counters
+  POST /__mock__/mutate?path=/p                -> change body+ETag of a mutable path
+  POST /__mock__/publish?path=/p   (body=data) -> make a previously-404 path exist
+  POST /__mock__/unpublish?path=/p             -> make a path 404 again
+  POST /__mock__/latency?ms=N                  -> set artificial per-response latency
+
+DATA PLANE (what artifact-keeper's remote repo proxies):
+  Immutable example:  /maven2/com/example/widget/1.0.0/widget-1.0.0.jar
+  Mutable example:    /maven2/com/example/widget/maven-metadata.xml
+  Plugin-prefix (1595): /maven2/org/example/plugins/maven-metadata.xml
+  Parent POM (1562):    /maven2/com/example/parent/1.0.0/parent-1.0.0.pom
+  PyPI simple index:  /simple/<name>/  (mutable) and the wheel file (immutable)
+
+The server is intentionally self-contained (stdlib only) so it can run either
+standalone (`python3 mock_upstream.py --port 9101`) or inside a tiny container.
+"""
+
+import argparse
+import hashlib
+import json
+import threading
+import time
+from email.utils import formatdate, parsedate_to_datetime
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+
+class Resource:
+    """A single served path with body, content-type, mutability and a counter."""
+
+    def __init__(self, body: bytes, content_type: str, mutable: bool, exists: bool = True):
+        self.body = body
+        self.content_type = content_type
+        self.mutable = mutable
+        self.exists = exists
+        self.count = 0  # number of DATA-PLANE fetches that returned a body (200)
+        self.revalidations = 0  # conditional requests answered with 304
+        self.last_modified = time.time()
+        self.etag = self._compute_etag()
+
+    def _compute_etag(self) -> str:
+        return '"' + hashlib.sha256(self.body).hexdigest()[:32] + '"'
+
+    def set_body(self, body: bytes):
+        self.body = body
+        self.last_modified = time.time()
+        self.etag = self._compute_etag()
+
+
+class MockState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.latency_ms = 0
+        self.resources: dict[str, Resource] = {}
+        self._seed()
+
+    def _seed(self):
+        # --- Immutable: versioned Maven jar (cache forever) ---
+        jar = b"PK\x03\x04" + b"immutable-widget-jar-v1.0.0-payload" * 16
+        self.resources["/maven2/com/example/widget/1.0.0/widget-1.0.0.jar"] = Resource(
+            jar, "application/java-archive", mutable=False
+        )
+
+        # --- Mutable: maven-metadata.xml (short TTL + revalidate) ---
+        md_v1 = self._maven_metadata("com.example", "widget", ["1.0.0"])
+        self.resources["/maven2/com/example/widget/maven-metadata.xml"] = Resource(
+            md_v1, "text/xml", mutable=True
+        )
+
+        # --- #1595: group-level plugin-prefix metadata (mutable, remote-only) ---
+        prefix_md = (
+            b'<?xml version="1.0" encoding="UTF-8"?>\n'
+            b"<metadata>\n"
+            b"  <plugins>\n"
+            b"    <plugin>\n"
+            b"      <name>Example Maven Plugin</name>\n"
+            b"      <prefix>example</prefix>\n"
+            b"      <artifactId>example-maven-plugin</artifactId>\n"
+            b"    </plugin>\n"
+            b"  </plugins>\n"
+            b"</metadata>\n"
+        )
+        self.resources["/maven2/org/example/plugins/maven-metadata.xml"] = Resource(
+            prefix_md, "text/xml", mutable=True
+        )
+
+        # --- #1562: remote-only parent POM (immutable; must resolve via virtual) ---
+        parent_pom = (
+            b'<?xml version="1.0" encoding="UTF-8"?>\n'
+            b'<project xmlns="http://maven.apache.org/POM/4.0.0">\n'
+            b"  <modelVersion>4.0.0</modelVersion>\n"
+            b"  <groupId>com.example</groupId>\n"
+            b"  <artifactId>parent</artifactId>\n"
+            b"  <version>1.0.0</version>\n"
+            b"  <packaging>pom</packaging>\n"
+            b"</project>\n"
+        )
+        self.resources["/maven2/com/example/parent/1.0.0/parent-1.0.0.pom"] = Resource(
+            parent_pom, "text/xml", mutable=False
+        )
+        # A SECOND remote-only parent POM used ONLY for the virtual first-request
+        # assertion. It is never fetched via the remote member directly, so the
+        # virtual path cannot be masked by a warm cache (the real #1562 condition
+        # is "remote-only artifact not yet cached, requested through the virtual").
+        vonly_pom = parent_pom.replace(b"<artifactId>parent</artifactId>",
+                                       b"<artifactId>vonly-parent</artifactId>")
+        self.resources["/maven2/com/example/vonly-parent/1.0.0/vonly-parent-1.0.0.pom"] = Resource(
+            vonly_pom, "text/xml", mutable=False
+        )
+
+        # --- PyPI: simple index (mutable) + wheel (immutable) for #1600-style remote-only pkg ---
+        # `lonelydep` exists ONLY on the mock upstream (the remote member).
+        whl_name = "lonelydep-2.3.0-py3-none-any.whl"
+        whl_path = "/packages/ld/lonelydep/" + whl_name
+        wheel = b"PK\x03\x04" + b"lonelydep-wheel-payload" * 8
+        self.resources[whl_path] = Resource(
+            wheel, "application/octet-stream", mutable=False
+        )
+        simple = (
+            "<!DOCTYPE html><html><head>"
+            '<meta name="pypi:repository-version" content="1.0">'
+            "<title>Links for lonelydep</title></head><body>"
+            "<h1>Links for lonelydep</h1>"
+            f'<a href="{whl_path}">{whl_name}</a><br/>'
+            "</body></html>"
+        ).encode()
+        self.resources["/simple/lonelydep/"] = Resource(
+            simple, "text/html", mutable=True
+        )
+
+        # --- Negative-cache target: starts as NON-existent, gets published later ---
+        self.resources["/maven2/com/example/late/1.0.0/late-1.0.0.jar"] = Resource(
+            b"", "application/java-archive", mutable=False, exists=False
+        )
+
+    @staticmethod
+    def _maven_metadata(group: str, artifact: str, versions: list[str]) -> bytes:
+        vers = "".join(f"      <version>{v}</version>\n" for v in versions)
+        latest = versions[-1]
+        return (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            "<metadata>\n"
+            f"  <groupId>{group}</groupId>\n"
+            f"  <artifactId>{artifact}</artifactId>\n"
+            "  <versioning>\n"
+            f"    <latest>{latest}</latest>\n"
+            f"    <release>{latest}</release>\n"
+            "    <versions>\n"
+            f"{vers}"
+            "    </versions>\n"
+            "  </versioning>\n"
+            "</metadata>\n"
+        ).encode()
+
+
+STATE = MockState()
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    # Quieter logs; comment out to debug.
+    def log_message(self, fmt, *args):  # noqa: N802
+        pass
+
+    # ---- helpers -----------------------------------------------------------
+    def _json(self, code: int, obj):
+        body = json.dumps(obj).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _text(self, code: int, text: str):
+        body = text.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _maybe_sleep(self):
+        if STATE.latency_ms:
+            time.sleep(STATE.latency_ms / 1000.0)
+
+    # ---- GET ---------------------------------------------------------------
+    def do_GET(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        path = parsed.path
+
+        if path.startswith("/__mock__/"):
+            return self._control_get(path, parse_qs(parsed.query))
+
+        self._maybe_sleep()
+        with STATE.lock:
+            res = STATE.resources.get(path)
+            if res is None or not res.exists:
+                return self._text(404, "not found")
+
+            # Conditional revalidation for mutable paths.
+            inm = self.headers.get("If-None-Match")
+            ims = self.headers.get("If-Modified-Since")
+            not_modified = False
+            if inm is not None and inm.strip() == res.etag:
+                not_modified = True
+            elif ims is not None:
+                try:
+                    ims_dt = parsedate_to_datetime(ims).timestamp()
+                    if int(res.last_modified) <= int(ims_dt):
+                        not_modified = True
+                except (TypeError, ValueError):
+                    not_modified = False
+
+            if not_modified:
+                res.revalidations += 1
+                self.send_response(304)
+                self.send_header("ETag", res.etag)
+                self.send_header("Last-Modified", formatdate(res.last_modified, usegmt=True))
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return None
+
+            res.count += 1
+            body = res.body
+            etag = res.etag
+            ctype = res.content_type
+            lm = res.last_modified
+
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("ETag", etag)
+        self.send_header("Last-Modified", formatdate(lm, usegmt=True))
+        # Mark immutable resources cacheable-forever; mutable get a short hint.
+        self.end_headers()
+        self.wfile.write(body)
+        return None
+
+    def do_HEAD(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        with STATE.lock:
+            res = STATE.resources.get(parsed.path)
+            exists = res is not None and res.exists
+        self.send_response(200 if exists else 404)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    # ---- POST (control plane only) ----------------------------------------
+    def do_POST(self):  # noqa: N802
+        parsed = urlparse(self.path)
+        if not parsed.path.startswith("/__mock__/"):
+            return self._text(405, "method not allowed")
+        return self._control_post(parsed.path, parse_qs(parsed.query))
+
+    # ---- control plane -----------------------------------------------------
+    def _control_get(self, path, q):
+        if path == "/__mock__/health":
+            return self._text(200, "ok")
+        if path == "/__mock__/count":
+            target = q.get("path", [""])[0]
+            with STATE.lock:
+                res = STATE.resources.get(target)
+                count = res.count if res else 0
+                reval = res.revalidations if res else 0
+            return self._json(200, {"path": target, "count": count, "revalidations": reval})
+        if path == "/__mock__/count_all":
+            with STATE.lock:
+                data = {p: {"count": r.count, "revalidations": r.revalidations}
+                        for p, r in STATE.resources.items()}
+            return self._json(200, data)
+        return self._text(404, "unknown control endpoint")
+
+    def _control_post(self, path, q):
+        if path == "/__mock__/reset":
+            with STATE.lock:
+                for r in STATE.resources.values():
+                    r.count = 0
+                    r.revalidations = 0
+            return self._text(200, "reset")
+
+        if path == "/__mock__/latency":
+            ms = int(q.get("ms", ["0"])[0])
+            with STATE.lock:
+                STATE.latency_ms = ms
+            return self._text(200, f"latency={ms}ms")
+
+        if path == "/__mock__/mutate":
+            target = q.get("path", [""])[0]
+            with STATE.lock:
+                res = STATE.resources.get(target)
+                if res is None:
+                    return self._text(404, "no such path")
+                # Produce a deterministically-different body (new ETag).
+                if target.endswith("maven-metadata.xml") and b"<versioning>" in res.body:
+                    res.set_body(MockState._maven_metadata(
+                        "com.example", "widget", ["1.0.0", "1.1.0"]))
+                elif target.endswith("/simple/lonelydep/"):
+                    res.set_body(res.body.replace(b"2.3.0", b"2.4.0"))
+                else:
+                    res.set_body(res.body + b"\n<!-- mutated -->")
+            return self._text(200, "mutated")
+
+        if path == "/__mock__/publish":
+            target = q.get("path", [""])[0]
+            length = int(self.headers.get("Content-Length", "0"))
+            data = self.rfile.read(length) if length else b"published-payload"
+            with STATE.lock:
+                res = STATE.resources.get(target)
+                if res is None:
+                    res = Resource(data, "application/octet-stream", mutable=False)
+                    STATE.resources[target] = res
+                else:
+                    res.set_body(data)
+                    res.exists = True
+            return self._text(200, "published")
+
+        if path == "/__mock__/unpublish":
+            target = q.get("path", [""])[0]
+            with STATE.lock:
+                res = STATE.resources.get(target)
+                if res:
+                    res.exists = False
+            return self._text(200, "unpublished")
+
+        return self._text(404, "unknown control endpoint")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=9101)
+    ap.add_argument("--host", default="0.0.0.0")
+    args = ap.parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"mock-upstream listening on {args.host}:{args.port}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/native-tests/mock-upstream/mock_upstream.py
+++ b/scripts/native-tests/mock-upstream/mock_upstream.py
@@ -356,6 +356,7 @@ def main():
     try:
         server.serve_forever()
     except KeyboardInterrupt:
+        # Allow clean shutdown on Ctrl+C; cleanup is handled in finally.
         pass
     finally:
         server.server_close()

--- a/scripts/native-tests/test-proxy-cache-correctness.sh
+++ b/scripts/native-tests/test-proxy-cache-correctness.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# Cache-correctness E2E tests against a controllable mock upstream (#1625, gate for #1611)
+#
+# Invariant ④ (issue #1611): cache freshness is a per-path-pattern property.
+#   * IMMUTABLE paths (versioned jar, digest-addressed blob) cache forever — after
+#     the first fetch they are NEVER re-fetched upstream within the TTL window.
+#   * MUTABLE paths (maven-metadata.xml, PyPI simple index, npm packument) get a
+#     short TTL and are REVALIDATED via conditional request (If-None-Match /
+#     If-Modified-Since); a 304 keeps serving cache cheaply, and a CHANGED upstream
+#     (new ETag/body) is reflected promptly.
+#   * NEGATIVE cache: a 404 then an upstream publish becomes visible within the
+#     short negative TTL.
+#
+# Assertions are black-box: they read the mock upstream's request COUNTER
+# (/__mock__/count) rather than inspecting artifact-keeper internals.
+#
+# RED on `main` by design: today the cache layer does not classify
+# immutable-vs-mutable, so the counter/TTL assertions are expected to FAIL until
+# #1611 lands. A failure here proves the mis-caching.
+#
+# Usage:
+#   MOCK_UPSTREAM_URL=http://mock-upstream:9101 ./test-proxy-cache-correctness.sh
+#   REGISTRY_URL=http://localhost:8080 MOCK_UPSTREAM_URL=http://localhost:9101 \
+#     CACHE_TTL_SECONDS=30 ./test-proxy-cache-correctness.sh
+#
+# Requires: curl, jq.
+set -uo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+MOCK_UPSTREAM_URL="${MOCK_UPSTREAM_URL:-http://localhost:9101}"
+API_URL="$REGISTRY_URL/api/v1"
+# How long to wait for a mutable path's TTL to expire before asserting
+# revalidation. Override to match the backend's configured metadata TTL.
+CACHE_TTL_SECONDS="${CACHE_TTL_SECONDS:-30}"
+# Short negative-cache TTL window (seconds) to wait after publishing a 404 path.
+NEG_TTL_SECONDS="${NEG_TTL_SECONDS:-15}"
+# Number of repeat pulls within the immutable TTL window.
+IMMUTABLE_PULLS="${IMMUTABLE_PULLS:-5}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+PASSED=0; FAILED=0; SKIPPED=0
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "  ${YELLOW}SKIP${NC}: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+echo "=============================================="
+echo "Cache-Correctness E2E (immutable vs mutable, #1611)"
+echo "=============================================="
+echo "Registry:      $REGISTRY_URL"
+echo "Mock upstream: $MOCK_UPSTREAM_URL"
+echo "Metadata TTL wait: ${CACHE_TTL_SECONDS}s, negative TTL wait: ${NEG_TTL_SECONDS}s"
+echo "NOTE: RED on 'main' by design — reproduces immutable-vs-mutable mis-caching."
+echo ""
+
+# ---- mock control-plane helpers -------------------------------------------
+mock_reset() { curl -s -X POST "$MOCK_UPSTREAM_URL/__mock__/reset" >/dev/null; }
+mock_count() {
+    # $1 = upstream path. Echoes the request counter (data-plane 200s).
+    curl -sf "$MOCK_UPSTREAM_URL/__mock__/count?path=$1" 2>/dev/null | jq -r '.count // 0'
+}
+mock_revalidations() {
+    curl -sf "$MOCK_UPSTREAM_URL/__mock__/count?path=$1" 2>/dev/null | jq -r '.revalidations // 0'
+}
+mock_mutate()    { curl -s -X POST "$MOCK_UPSTREAM_URL/__mock__/mutate?path=$1" >/dev/null; }
+mock_publish()   { curl -s -X POST "$MOCK_UPSTREAM_URL/__mock__/publish?path=$1" --data-binary "${2:-published}" >/dev/null; }
+mock_unpublish() { curl -s -X POST "$MOCK_UPSTREAM_URL/__mock__/unpublish?path=$1" >/dev/null; }
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+echo "==> Authenticating..."
+LOGIN_RESP=$(curl -sf -X POST "$API_URL/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}" 2>&1) || {
+    echo "ERROR: Failed to authenticate. Is the backend running at $REGISTRY_URL?"; exit 1; }
+TOKEN=$(echo "$LOGIN_RESP" | jq -r '.access_token')
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || { echo "ERROR: no auth token"; exit 1; }
+AUTH="Authorization: Bearer $TOKEN"
+echo "  Authenticated successfully"
+echo ""
+
+create_repo() {
+    local key="$1" name="$2" format="$3" repo_type="$4" upstream_url="${5:-}"
+    curl -s -o /dev/null -X DELETE "$API_URL/repositories/$key" -H "$AUTH" 2>/dev/null || true
+    local body="{\"key\":\"$key\",\"name\":\"$name\",\"format\":\"$format\",\"repo_type\":\"$repo_type\",\"is_public\":true"
+    [ -n "$upstream_url" ] && body="$body,\"upstream_url\":\"$upstream_url\""
+    body="$body}"
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/repositories" \
+        -H "$AUTH" -H 'Content-Type: application/json' -d "$body")
+    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then return 0; fi
+    echo "  ERROR: create_repo $key returned HTTP $http_code"; exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Phase 0: mock upstream readiness + repos
+# ---------------------------------------------------------------------------
+echo "==> Phase 0: Waiting for mock upstream + creating remote repos..."
+MOCK_READY=0
+for _ in $(seq 1 30); do
+    curl -sf "$MOCK_UPSTREAM_URL/__mock__/health" >/dev/null 2>&1 && { MOCK_READY=1; break; }
+    sleep 1
+done
+[ "$MOCK_READY" = "1" ] || { echo "ERROR: mock upstream unreachable at $MOCK_UPSTREAM_URL"; exit 1; }
+mock_reset
+
+create_repo "cache-maven-remote" "Cache Maven Remote" "maven" "remote" "$MOCK_UPSTREAM_URL/maven2"
+create_repo "cache-pypi-remote"  "Cache PyPI Remote"  "pypi"  "remote" "$MOCK_UPSTREAM_URL"
+echo "  - cache-maven-remote -> $MOCK_UPSTREAM_URL/maven2"
+echo "  - cache-pypi-remote  -> $MOCK_UPSTREAM_URL"
+echo ""
+
+# Upstream paths (as the mock sees them, after the repo's upstream prefix).
+IMMUTABLE_JAR_UP="/maven2/com/example/widget/1.0.0/widget-1.0.0.jar"
+MUTABLE_MD_UP="/maven2/com/example/widget/maven-metadata.xml"
+SIMPLE_UP="/simple/lonelydep/"
+LATE_JAR_UP="/maven2/com/example/late/1.0.0/late-1.0.0.jar"
+
+# Proxy URLs (what a client hits on artifact-keeper).
+IMMUTABLE_JAR="$REGISTRY_URL/maven/cache-maven-remote/com/example/widget/1.0.0/widget-1.0.0.jar"
+MUTABLE_MD="$REGISTRY_URL/maven/cache-maven-remote/com/example/widget/maven-metadata.xml"
+SIMPLE_IDX="$REGISTRY_URL/pypi/cache-pypi-remote/simple/lonelydep/"
+LATE_JAR="$REGISTRY_URL/maven/cache-maven-remote/com/example/late/1.0.0/late-1.0.0.jar"
+
+# ---------------------------------------------------------------------------
+# Phase 1: IMMUTABLE — versioned jar fetched exactly once across many pulls
+# ---------------------------------------------------------------------------
+echo "==> Phase 1: Immutable path cached forever (counter stays 1)"
+mock_reset
+echo "  Pulling $IMMUTABLE_PULLS times within the TTL window..."
+ALL_200=1
+for i in $(seq 1 "$IMMUTABLE_PULLS"); do
+    code=$(curl -s -o /dev/null -w "%{http_code}" "$IMMUTABLE_JAR")
+    [ "$code" = "200" ] || { ALL_200=0; echo "    pull $i -> HTTP $code"; }
+done
+IMM_COUNT=$(mock_count "$IMMUTABLE_JAR_UP")
+if [ "$ALL_200" = "1" ]; then
+    pass "all $IMMUTABLE_PULLS immutable pulls returned 200"
+else
+    fail "not all immutable pulls returned 200"
+fi
+if [ "$IMM_COUNT" = "1" ]; then
+    pass "immutable jar fetched upstream exactly once (counter=1) across $IMMUTABLE_PULLS pulls"
+else
+    fail "immutable jar hit upstream $IMM_COUNT times (expected 1) — immutable mis-cache — #1611"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 2: MUTABLE — revalidate after TTL; 304 keeps cache; change is reflected
+# ---------------------------------------------------------------------------
+echo "==> Phase 2: Mutable path revalidates via conditional request"
+mock_reset
+
+echo "  [2a] First fetch populates cache..."
+MD1=$(curl -s -o /dev/null -w "%{http_code}" "$MUTABLE_MD")
+MD_COUNT_1=$(mock_count "$MUTABLE_MD_UP")
+if [ "$MD1" = "200" ] && [ "$MD_COUNT_1" = "1" ]; then
+    pass "first metadata fetch: 200, upstream counter=1"
+else
+    fail "first metadata fetch HTTP=$MD1 upstream-count=$MD_COUNT_1 (expected 200 / 1)"
+fi
+
+echo "  [2b] Second fetch within TTL is served from cache (no new upstream 200)..."
+curl -s -o /dev/null "$MUTABLE_MD"
+MD_COUNT_2=$(mock_count "$MUTABLE_MD_UP")
+if [ "$MD_COUNT_2" = "1" ]; then
+    pass "within-TTL metadata re-fetch served from cache (upstream counter still 1)"
+else
+    fail "within-TTL metadata re-fetch hit upstream ($MD_COUNT_2) — TTL not honored — #1611"
+fi
+
+echo "  [2c] Waiting ${CACHE_TTL_SECONDS}s for TTL expiry, then revalidate (expect 304, body unchanged)..."
+sleep "$CACHE_TTL_SECONDS"
+BODY_BEFORE=$(curl -s "$MUTABLE_MD")
+REVAL=$(mock_revalidations "$MUTABLE_MD_UP")
+if [ "$REVAL" -ge 1 ] 2>/dev/null; then
+    pass "post-TTL fetch issued a conditional revalidation (mock answered 304 x$REVAL)"
+else
+    fail "post-TTL fetch did NOT revalidate conditionally (revalidations=$REVAL) — #1611"
+fi
+if echo "$BODY_BEFORE" | grep -q "<artifactId>widget</artifactId>"; then
+    pass "post-revalidation body still served correctly"
+else
+    skip "could not confirm metadata body shape (revalidation counter is the primary assertion)"
+fi
+
+echo "  [2d] Mutate upstream (new ETag/body), then a fetch must reflect the change promptly..."
+mock_mutate "$MUTABLE_MD_UP"
+sleep "$CACHE_TTL_SECONDS"
+BODY_AFTER=$(curl -s "$MUTABLE_MD")
+if echo "$BODY_AFTER" | grep -q "1.1.0"; then
+    pass "changed upstream metadata reflected after TTL (now lists 1.1.0)"
+else
+    fail "changed upstream metadata NOT reflected (still stale) — mutable serving stale — #1611"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 3: MUTABLE — PyPI simple index revalidation (second format)
+# ---------------------------------------------------------------------------
+echo "==> Phase 3: PyPI simple index is mutable (reflects upstream change)"
+mock_reset
+S1=$(curl -s -o /dev/null -w "%{http_code}" "$SIMPLE_IDX")
+if [ "$S1" = "200" ]; then
+    pass "simple index first fetch 200"
+else
+    skip "simple index first fetch HTTP $S1 (proxy may rewrite PyPI URLs differently)"
+fi
+mock_mutate "$SIMPLE_UP"   # flips 2.3.0 -> 2.4.0 in the index body
+sleep "$CACHE_TTL_SECONDS"
+SIDX_AFTER=$(curl -s "$SIMPLE_IDX")
+if echo "$SIDX_AFTER" | grep -q "2.4.0"; then
+    pass "changed PyPI simple index reflected after TTL (now lists 2.4.0)"
+else
+    fail "changed PyPI simple index NOT reflected after TTL (stale index) — #1611"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 4: NEGATIVE cache — 404 then publish becomes visible within negative TTL
+# ---------------------------------------------------------------------------
+echo "==> Phase 4: Negative cache (404 then publish becomes visible)"
+mock_reset
+mock_unpublish "$LATE_JAR_UP"   # ensure it starts as 404 upstream
+
+echo "  [4a] First fetch of a missing path returns 404 (populates negative cache)..."
+N1=$(curl -s -o /dev/null -w "%{http_code}" "$LATE_JAR")
+if [ "$N1" = "404" ]; then
+    pass "missing artifact returns 404"
+else
+    fail "missing artifact returned $N1 (expected 404)"
+fi
+
+echo "  [4b] Publish upstream, then within negative TTL the artifact becomes visible..."
+mock_publish "$LATE_JAR_UP" "late-jar-now-published"
+# Negative cache should be SHORT; poll up to NEG_TTL_SECONDS for it to appear.
+VISIBLE=0
+for _ in $(seq 1 "$NEG_TTL_SECONDS"); do
+    NC2=$(curl -s -o /dev/null -w "%{http_code}" "$LATE_JAR")
+    if [ "$NC2" = "200" ]; then VISIBLE=1; break; fi
+    sleep 1
+done
+if [ "$VISIBLE" = "1" ]; then
+    pass "published artifact became visible within negative-TTL window (200)"
+else
+    fail "published artifact still 404 after ${NEG_TTL_SECONDS}s — negative cache too sticky — #1611"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASSED + FAILED + SKIPPED))
+echo "=============================================="
+echo "Cache-Correctness Results"
+echo "=============================================="
+echo "  Passed:  $PASSED"
+echo "  Failed:  $FAILED"
+echo "  Skipped: $SKIPPED"
+echo "  Total:   $TOTAL"
+echo ""
+if [ "$FAILED" -gt 0 ]; then
+    echo "RESULT: FAILURES PRESENT."
+    echo "On 'main' this is EXPECTED — failures reproduce immutable-vs-mutable mis-caching."
+    echo "After #1611 lands, this suite must be fully green."
+    exit 1
+fi
+echo "RESULT: ALL PASSED (cache classification is correct — #1611 has landed)."

--- a/scripts/native-tests/test-virtual-resolution.sh
+++ b/scripts/native-tests/test-virtual-resolution.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# Virtual-resolution regression E2E tests (issue #1625, gate for #1611)
+#
+# Reproduces three OPEN wrong-result bugs in virtual repository resolution by
+# asserting the CORRECT behavior. These tests are RED on `main` BY DESIGN — a
+# failure here proves the bug still exists. When #1611 lands they flip green and
+# become its regression gate.
+#
+#   #1600 — PyPI virtual unions a remote-only package into the simple index but
+#           binds the DOWNLOAD to the local member -> 404 (index/download
+#           inconsistency + dependency-confusion). We assert: a package present
+#           ONLY on the remote member is listed in the virtual's simple index
+#           AND its wheel downloads 200 through the virtual.
+#   #1595 — Maven virtual does not proxy GROUP-level plugin-prefix
+#           maven-metadata.xml from remote members -> 404 (breaks
+#           `mvn <prefix>:<goal>`). We assert: the group-level metadata is
+#           served 200 through the virtual and contains the <plugins> list.
+#   #1562 — Maven virtual 404s a remote-only artifact (e.g. a parent POM) that
+#           the remote member serves 200 directly. We assert: the remote-only
+#           parent POM resolves 200 through the virtual.
+#
+# Mirrors scripts/native-tests/test-proxy-virtual.sh (auth flow, create_repo,
+# add_virtual_member, PASS/FAIL helpers).
+#
+# Usage:
+#   MOCK_UPSTREAM_URL=http://mock-upstream:9101 ./test-virtual-resolution.sh
+#   REGISTRY_URL=http://localhost:8080 MOCK_UPSTREAM_URL=http://localhost:9101 \
+#     ./test-virtual-resolution.sh
+#
+# Requires: curl, jq. Optional: pip3 (PEP-503 end-to-end download).
+set -uo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+# The mock upstream serves deterministic Maven/PyPI shaped paths under /maven2
+# and /simple. For #1562/#1595 we prefer the mock; live Maven Central is used as
+# an optional fallback only if MOCK_UPSTREAM_URL is unset.
+MOCK_UPSTREAM_URL="${MOCK_UPSTREAM_URL:-http://localhost:9101}"
+API_URL="$REGISTRY_URL/api/v1"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+PASSED=0; FAILED=0; SKIPPED=0
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "  ${YELLOW}SKIP${NC}: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+echo "=============================================="
+echo "Virtual-Resolution Regression E2E (#1600/#1595/#1562)"
+echo "=============================================="
+echo "Registry:      $REGISTRY_URL"
+echo "Mock upstream: $MOCK_UPSTREAM_URL"
+echo "NOTE: These tests are RED on 'main' by design (they reproduce open bugs)."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+echo "==> Authenticating..."
+LOGIN_RESP=$(curl -sf -X POST "$API_URL/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}" 2>&1) || {
+    echo "ERROR: Failed to authenticate. Is the backend running at $REGISTRY_URL?"
+    exit 1
+}
+TOKEN=$(echo "$LOGIN_RESP" | jq -r '.access_token')
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+    echo "ERROR: Failed to get auth token"; exit 1
+fi
+AUTH="Authorization: Bearer $TOKEN"
+echo "  Authenticated successfully"
+echo ""
+
+# create_repo: same contract as test-proxy-virtual.sh (delete-then-create).
+create_repo() {
+    local key="$1" name="$2" format="$3" repo_type="$4" upstream_url="${5:-}" member_repos="${6:-}"
+    curl -s -o /dev/null -X DELETE "$API_URL/repositories/$key" -H "$AUTH" 2>/dev/null || true
+    local body="{\"key\":\"$key\",\"name\":\"$name\",\"format\":\"$format\",\"repo_type\":\"$repo_type\",\"is_public\":true"
+    [ -n "$upstream_url" ] && body="$body,\"upstream_url\":\"$upstream_url\""
+    [ -n "$member_repos" ] && body="$body,\"member_repos\":$member_repos"
+    body="$body}"
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/repositories" \
+        -H "$AUTH" -H 'Content-Type: application/json' -d "$body")
+    if [ "$http_code" = "200" ] || [ "$http_code" = "201" ]; then
+        return 0
+    fi
+    echo "  ERROR: create_repo $key returned HTTP $http_code (body: $body)"
+    echo "  Aborting: subsequent tests depend on this repo existing."
+    exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Phase 0: wait for the mock upstream control plane
+# ---------------------------------------------------------------------------
+echo "==> Phase 0: Waiting for mock upstream..."
+MOCK_READY=0
+for _ in $(seq 1 30); do
+    if curl -sf "$MOCK_UPSTREAM_URL/__mock__/health" >/dev/null 2>&1; then
+        MOCK_READY=1; break
+    fi
+    sleep 1
+done
+if [ "$MOCK_READY" != "1" ]; then
+    echo "ERROR: mock upstream not reachable at $MOCK_UPSTREAM_URL"; exit 1
+fi
+curl -s -X POST "$MOCK_UPSTREAM_URL/__mock__/reset" >/dev/null
+echo "  Mock upstream ready"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 1: create repositories
+#   maven-vr-remote  -> mock /maven2   (priority 2)
+#   maven-vr-local   -> empty local    (priority 1)
+#   maven-vr-virtual -> [local, remote]
+#   pypi-vr-remote   -> mock /        (PyPI simple at /simple)
+#   pypi-vr-local    -> empty local
+#   pypi-vr-virtual  -> [local, remote]
+# ---------------------------------------------------------------------------
+echo "==> Phase 1: Creating repositories (local + remote->mock + virtual)..."
+create_repo "maven-vr-local"  "Maven VR Local"  "maven" "local"
+create_repo "maven-vr-remote" "Maven VR Remote" "maven" "remote" "$MOCK_UPSTREAM_URL/maven2"
+create_repo "maven-vr-virtual" "Maven VR Virtual" "maven" "virtual" "" \
+    '[{"repo_key":"maven-vr-local","priority":1},{"repo_key":"maven-vr-remote","priority":2}]'
+echo "  - maven-vr-virtual members: maven-vr-local (1), maven-vr-remote (2)"
+
+create_repo "pypi-vr-local"  "PyPI VR Local"  "pypi" "local"
+create_repo "pypi-vr-remote" "PyPI VR Remote" "pypi" "remote" "$MOCK_UPSTREAM_URL"
+create_repo "pypi-vr-virtual" "PyPI VR Virtual" "pypi" "virtual" "" \
+    '[{"repo_key":"pypi-vr-local","priority":1},{"repo_key":"pypi-vr-remote","priority":2}]'
+echo "  - pypi-vr-virtual members: pypi-vr-local (1), pypi-vr-remote (2)"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 2: #1600 — PyPI virtual index/download consistency for a remote-only pkg
+# ---------------------------------------------------------------------------
+echo "==> Phase 2: #1600 PyPI virtual remote-only download consistency"
+
+# 2a: sanity — the remote member serves the simple index + wheel directly (200).
+echo "  [2a] Control: remote member serves lonelydep simple index + wheel directly..."
+RM_INDEX=$(curl -s -o "$TMPDIR_TEST/rm-index.html" -w "%{http_code}" \
+    "$REGISTRY_URL/pypi/pypi-vr-remote/simple/lonelydep/")
+RM_WHEEL=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$REGISTRY_URL/pypi/pypi-vr-remote/packages/ld/lonelydep/lonelydep-2.3.0-py3-none-any.whl")
+if [ "$RM_INDEX" = "200" ] && [ "$RM_WHEEL" = "200" ]; then
+    pass "remote member: lonelydep index=$RM_INDEX wheel=$RM_WHEEL"
+else
+    skip "remote member did not serve lonelydep (index=$RM_INDEX wheel=$RM_WHEEL) — check proxy URL rewriting"
+fi
+
+# 2b: the VIRTUAL simple index must LIST the remote-only wheel.
+echo "  [2b] Virtual simple index lists the remote-only lonelydep wheel..."
+V_INDEX=$(curl -s -o "$TMPDIR_TEST/v-index.html" -w "%{http_code}" \
+    "$REGISTRY_URL/pypi/pypi-vr-virtual/simple/lonelydep/")
+if [ "$V_INDEX" = "200" ] && grep -q "lonelydep-2.3.0" "$TMPDIR_TEST/v-index.html" 2>/dev/null; then
+    pass "virtual simple index lists lonelydep-2.3.0 wheel"
+else
+    fail "virtual simple index did not list lonelydep-2.3.0 (HTTP $V_INDEX) — #1600"
+fi
+
+# 2c: THE BUG — the wheel listed by the index must DOWNLOAD 200 via the virtual.
+echo "  [2c] Virtual DOWNLOAD of the listed wheel must be 200 (not 404)..."
+V_WHEEL=$(curl -s -o "$TMPDIR_TEST/v-wheel.whl" -w "%{http_code}" \
+    "$REGISTRY_URL/pypi/pypi-vr-virtual/packages/ld/lonelydep/lonelydep-2.3.0-py3-none-any.whl")
+if [ "$V_WHEEL" = "200" ]; then
+    WHEEL_SZ=$(wc -c < "$TMPDIR_TEST/v-wheel.whl" | tr -d ' ')
+    pass "virtual download of lonelydep-2.3.0 wheel returned 200 (${WHEEL_SZ} bytes)"
+else
+    fail "virtual download of index-listed wheel returned $V_WHEEL (expected 200) — #1600 index/download inconsistency"
+fi
+
+# 2d (optional): real pip download through the virtual.
+echo "  [2d] pip download lonelydep through the virtual (PEP-503 end-to-end)..."
+if command -v pip3 >/dev/null 2>&1; then
+    PIP_DIR="$(mktemp -d)"
+    TRUSTED_HOST=$(echo "$REGISTRY_URL" | sed 's|https\?://||' | cut -d: -f1)
+    if pip3 download lonelydep \
+        --index-url "$REGISTRY_URL/pypi/pypi-vr-virtual/simple/" \
+        --trusted-host "$TRUSTED_HOST" \
+        --no-deps --dest "$PIP_DIR" --quiet 2>"$TMPDIR_TEST/pip-err.txt"; then
+        if find "$PIP_DIR" -maxdepth 1 -iname '*lonelydep*' 2>/dev/null | grep -q .; then
+            pass "pip download lonelydep via virtual succeeded"
+        else
+            fail "pip reported success but no lonelydep artifact downloaded"
+        fi
+    else
+        fail "pip download lonelydep via virtual failed (#1600 — index lists it, download 404s)"
+    fi
+    rm -rf "$PIP_DIR"
+else
+    skip "pip3 not available (curl-level assertions in 2b/2c still cover #1600)"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 3: #1595 — Maven virtual group-level plugin-prefix metadata
+# ---------------------------------------------------------------------------
+echo "==> Phase 3: #1595 Maven virtual group-level plugin-prefix metadata"
+
+# 3a: control — remote member serves the group-level metadata directly (200).
+echo "  [3a] Control: remote member serves group-level plugin metadata directly..."
+RM_PREFIX=$(curl -s -o "$TMPDIR_TEST/rm-prefix.xml" -w "%{http_code}" \
+    "$REGISTRY_URL/maven/maven-vr-remote/org/example/plugins/maven-metadata.xml")
+if [ "$RM_PREFIX" = "200" ] && grep -q "<plugins>" "$TMPDIR_TEST/rm-prefix.xml" 2>/dev/null; then
+    pass "remote member serves group-level plugin metadata (200, has <plugins>)"
+else
+    skip "remote member group-level metadata not served (HTTP $RM_PREFIX)"
+fi
+
+# 3b: THE BUG — the virtual must proxy the group-level metadata (200, not 404).
+echo "  [3b] Virtual group-level plugin metadata must be 200 (not 404)..."
+V_PREFIX=$(curl -s -o "$TMPDIR_TEST/v-prefix.xml" -w "%{http_code}" \
+    "$REGISTRY_URL/maven/maven-vr-virtual/org/example/plugins/maven-metadata.xml")
+if [ "$V_PREFIX" = "200" ] && grep -q "<plugins>" "$TMPDIR_TEST/v-prefix.xml" 2>/dev/null; then
+    pass "virtual group-level plugin metadata returned 200 with <plugins> list"
+else
+    fail "virtual group-level plugin metadata returned $V_PREFIX (expected 200 w/ <plugins>) — #1595"
+fi
+
+# 3c: prove it carries the prefix Maven needs to resolve `example:<goal>`.
+echo "  [3c] Virtual group-level metadata exposes the plugin <prefix>..."
+if [ "$V_PREFIX" = "200" ] && grep -q "<prefix>example</prefix>" "$TMPDIR_TEST/v-prefix.xml" 2>/dev/null; then
+    pass "virtual group metadata exposes prefix 'example' (enables mvn example:<goal>)"
+else
+    fail "virtual group metadata missing <prefix>example</prefix> — mvn <prefix>:<goal> would fail — #1595"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Phase 4: #1562 — Maven virtual remote-only artifact (parent POM)
+# ---------------------------------------------------------------------------
+echo "==> Phase 4: #1562 Maven virtual remote-only artifact (parent POM)"
+
+# 4a: control — remote member serves the parent POM directly (200).
+echo "  [4a] Control: remote member serves remote-only parent POM directly..."
+RM_POM=$(curl -s -o /dev/null -w "%{http_code}" \
+    "$REGISTRY_URL/maven/maven-vr-remote/com/example/parent/1.0.0/parent-1.0.0.pom")
+if [ "$RM_POM" = "200" ]; then
+    pass "remote member serves com.example:parent:1.0.0 POM (200)"
+else
+    skip "remote member did not serve parent POM (HTTP $RM_POM)"
+fi
+
+# 4b: THE BUG — a remote-only artifact that was NEVER fetched via the remote
+#     member directly must still resolve 200 on its FIRST request through the
+#     virtual. This is the exact #1562 condition: an uncached remote-only
+#     artifact (parent POM) requested through the virtual. We use a dedicated
+#     `vonly-parent` path that no control fetch ever primes, so a warm cache
+#     cannot mask the bug.
+echo "  [4b] Virtual must serve an UNCACHED remote-only parent POM 200 on first request (not 404)..."
+V_POM=$(curl -s -o "$TMPDIR_TEST/v-pom.xml" -w "%{http_code}" \
+    "$REGISTRY_URL/maven/maven-vr-virtual/com/example/vonly-parent/1.0.0/vonly-parent-1.0.0.pom")
+if [ "$V_POM" = "200" ] && grep -q "<artifactId>vonly-parent</artifactId>" "$TMPDIR_TEST/v-pom.xml" 2>/dev/null; then
+    pass "virtual served UNCACHED remote-only parent POM (200) — first-request proxy fall-through works"
+else
+    fail "virtual returned $V_POM for uncached remote-only parent POM (remote serves it 200) — #1562"
+fi
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+TOTAL=$((PASSED + FAILED + SKIPPED))
+echo "=============================================="
+echo "Virtual-Resolution Regression Results"
+echo "=============================================="
+echo "  Passed:  $PASSED"
+echo "  Failed:  $FAILED"
+echo "  Skipped: $SKIPPED"
+echo "  Total:   $TOTAL"
+echo ""
+if [ "$FAILED" -gt 0 ]; then
+    echo "RESULT: FAILURES PRESENT."
+    echo "On 'main' this is EXPECTED — failures reproduce #1600/#1595/#1562."
+    echo "After #1611 lands, this suite must be fully green."
+    exit 1
+fi
+echo "RESULT: ALL PASSED (virtual resolution is correct — #1611 has landed)."


### PR DESCRIPTION
## Summary

Adds the cache-correctness + virtual-resolution E2E suite from #1625. It is the **acceptance gate for #1611** and **reproduces three open wrong-result bugs**: #1600 (PyPI virtual remote-only download), #1595 (Maven group-level plugin-prefix metadata), #1562 (Maven virtual uncached remote-only artifact).

These tests assert the **correct** behavior, so they are **RED on `main` by design** — a failure proves the bug still exists. They are wired to a dedicated `workflow_dispatch` + weekly-schedule workflow (`cache-correctness-e2e.yml`), **never** to the per-PR gate. When #1611 lands they flip green and become its regression gate.

Closes #1625. References #1611 (gate) and bugs #1600 / #1595 / #1562.

### What's here

Two black-box layers mirroring `scripts/native-tests/test-proxy-virtual.sh`:

**1. Virtual-resolution regressions** (`test-virtual-resolution.sh`)
- **#1600** — virtual PyPI: a package present only on the remote member is listed in the simple index AND its wheel downloads `200` through the virtual (not `404` bound to the local member). Optional `pip download` end-to-end.
- **#1595** — virtual Maven: the group-level plugin-prefix `maven-metadata.xml` is proxied `200` and exposes `<prefix>` (enables `mvn <prefix>:<goal>`).
- **#1562** — virtual Maven: an UNCACHED remote-only parent POM resolves `200` on first request through the virtual.

**2. Cache-correctness** (`test-proxy-cache-correctness.sh`) against an ETag/counter/mutation-aware mock upstream
- **Immutable** versioned jar: fetched upstream exactly once across N pulls (counter==1).
- **Mutable** `maven-metadata.xml` + PyPI simple index: revalidated after TTL via conditional request (mock answers 304); a changed upstream is reflected promptly.
- **Negative cache**: a 404 then upstream publish becomes visible within the short negative TTL.

A small stdlib mock upstream (`mock-upstream/mock_upstream.py` + `Dockerfile`) provides the controllable knobs (counter, If-None-Match/If-Modified-Since to 304, mutate, publish/unpublish, latency). It is kept separate from the #1624 concurrency mock so the two can be consolidated later — see the README's consolidation note (this one already exposes a counter and a `/__mock__/latency` knob toward that merge).

### Executed / observed (against `ghcr.io/artifact-keeper/artifact-keeper-backend:dev` = main)
- **#1600 reproduced RED** — virtual index lists the wheel, virtual download 404s; `pip download` fails.
- **#1595 reproduced RED** — virtual group-level plugin metadata 404 (remote member serves 200).
- **Cache mis-caching reproduced RED** — after upstream metadata changed 1.0.0→1.1.0, the proxy kept serving stale 1.0.0; mock counter stayed `count=1, revalidations=0` (never re-fetched or conditionally revalidated). Same for the PyPI simple index. This is exactly invariant ④ (#1611).
- **#1562 passed (green) on this image** — even an uncached remote-only POM resolved 200 through the virtual; the trivial static POM does not trigger the subtle buffered-vs-streaming discrepancy from the original report. The assertion still guards against regression. Follow-up noted in the README (make the mock more faithful, or rely on the live Confluent repro).
- Immutable counter==1 passed, but a second cached read returned `500 STORAGE_ERROR` in a standalone container without a persistent `/data` volume — possibly an environment artifact; re-run under the compose profile (persistent storage) to confirm before treating as a product bug.

Validated locally: `shellcheck` (clean), `python3 -m py_compile`, `docker compose -f docker-compose.test.yml config` (cache-correctness profile resolves to backend/postgres/setup/trivy/mock + 2 runners), workflow YAML parse, and the full run above on the dev backend. A real CI run on a freshly-built backend under the `cache-correctness` profile is still recommended (persistent storage + `--build`).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (this PR *is* the regression suite for #1611; `test/*` branch)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes