### PR TITLE
test: multi-replica single-flight concurrency harness (#1624)

### DIFF
--- a/.github/workflows/concurrency-e2e.yml
+++ b/.github/workflows/concurrency-e2e.yml
@@ -9,6 +9,10 @@
 # weekly schedule so the reproduction stays observable.
 name: Concurrency E2E (single-flight race)
 
+# Least-privilege default for GITHUB_TOKEN across all jobs (CodeQL hardening).
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/concurrency-e2e.yml
+++ b/.github/workflows/concurrency-e2e.yml
@@ -1,0 +1,116 @@
+# Multi-replica single-flight concurrency harness (#1624).
+#
+# Reproduces #1606 (per-process singleflight races across replicas serving
+# partial/truncated artifacts) and is the acceptance gate for #1609.
+#
+# IMPORTANT: this is RED on `main` BY DESIGN until #1609 (cross-process
+# single-flight) lands. It is therefore NOT wired into `pull_request` and must
+# never block the per-PR gate. It runs only on manual dispatch and an optional
+# weekly schedule so the reproduction stays observable.
+name: Concurrency E2E (single-flight race)
+
+on:
+  workflow_dispatch:
+    inputs:
+      replicas:
+        description: "Number of backend replicas"
+        required: false
+        default: "3"
+      concurrency:
+        description: "Number of concurrent GETs"
+        required: false
+        default: "200"
+      latency_ms:
+        description: "Mock upstream per-response latency (ms) to widen the race window"
+        required: false
+        default: "1500"
+      artifact_size_bytes:
+        description: "Mock artifact size in bytes (default 256 MiB)"
+        required: false
+        default: "268435456"
+  schedule:
+    # Weekly, Mondays 06:00 UTC. Keeps the #1606 reproduction observable on main.
+    - cron: "0 6 * * 1"
+
+# Never let this cancel or be cancelled by per-PR runs.
+concurrency:
+  group: concurrency-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  lint:
+    name: Lint harness scripts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: shellcheck
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
+          shellcheck scripts/concurrency/*.sh
+      - name: python syntax check
+        run: python3 -m py_compile scripts/concurrency/mock_upstream.py
+      - name: assert_lib unit tests (no Docker)
+        run: bash scripts/concurrency/test_assert_lib.sh
+      - name: compose config parses
+        run: docker compose -f docker-compose.concurrency-e2e.yml config >/dev/null
+
+  race:
+    name: Run single-flight race (allowed to fail on main)
+    runs-on: ubuntu-latest
+    needs: lint
+    # On `main` this job is EXPECTED to fail (it reproduces #1606). Do not let a
+    # red result mark the whole workflow failed in a way that pages people; the
+    # purpose is observability, not gating. Once #1609 lands, remove this.
+    continue-on-error: true
+    env:
+      REPLICAS: ${{ github.event.inputs.replicas || '3' }}
+      CONCURRENCY: ${{ github.event.inputs.concurrency || '200' }}
+      LATENCY_MS: ${{ github.event.inputs.latency_ms || '1500' }}
+      ARTIFACT_SIZE_BYTES: ${{ github.event.inputs.artifact_size_bytes || '268435456' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build images
+        run: |
+          docker compose -f docker-compose.concurrency-e2e.yml build
+
+      - name: Start stack with N backend replicas
+        run: |
+          # Override the mock upstream latency/size via env so the workflow
+          # inputs take effect.
+          export LATENCY_MS ARTIFACT_SIZE_BYTES
+          docker compose -f docker-compose.concurrency-e2e.yml up -d \
+            --scale backend="${REPLICAS}"
+
+      - name: Wait for the load balancer and replicas to be healthy
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:18080/health >/dev/null 2>&1; then
+              echo "Backend reachable via LB."
+              break
+            fi
+            echo "waiting for stack... ($i)"
+            sleep 5
+          done
+          curl -sf http://localhost:19999/healthz
+
+      - name: Run the single-flight race driver
+        run: |
+          CONCURRENCY="${CONCURRENCY}" bash scripts/concurrency/run-singleflight-race.sh
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: concurrency-results
+          path: /tmp/concurrency-results/
+          if-no-files-found: ignore
+
+      - name: Dump backend logs on failure
+        if: failure() || always()
+        run: |
+          docker compose -f docker-compose.concurrency-e2e.yml logs --no-color > /tmp/concurrency-results/compose.log 2>&1 || true
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.concurrency-e2e.yml down -v || true

--- a/docker-compose.concurrency-e2e.yml
+++ b/docker-compose.concurrency-e2e.yml
@@ -1,0 +1,168 @@
+# Multi-replica single-flight concurrency harness (#1624).
+#
+# Reproduces #1606: per-process singleflight races across replicas serving
+# partial/truncated artifacts. Acceptance gate for #1609.
+#
+# Topology:
+#   postgres        - one shared PostgreSQL (all replicas share metadata)
+#   minio + init    - one shared S3-compatible object store (all replicas share
+#                     blobs, so a blob cached by ONE replica is visible to ALL)
+#   mock-upstream   - controllable upstream serving ONE large artifact with a
+#                     known SHA-256, injectable latency, and a fetch counter
+#   backend         - >=3 replicas (scale via --scale backend=N), all pointed at
+#                     the SAME postgres + minio
+#   lb              - nginx round-robin in front of the backend replicas
+#
+# Usage (see scripts/concurrency/README.md):
+#   docker compose -f docker-compose.concurrency-e2e.yml build
+#   docker compose -f docker-compose.concurrency-e2e.yml up -d \
+#       --scale backend=3
+#   ./scripts/concurrency/run-singleflight-race.sh
+#   docker compose -f docker-compose.concurrency-e2e.yml down -v
+#
+# NOTE: this harness is RED on `main` by design (it reproduces #1606). It is NOT
+# wired into the per-PR gate. It flips green once #1609 (cross-process
+# single-flight) lands and then becomes its regression gate.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: concurrency-e2e-db
+    environment:
+      POSTGRES_USER: registry
+      POSTGRES_PASSWORD: registry
+      POSTGRES_DB: artifact_registry
+    tmpfs:
+      - /var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U registry -d artifact_registry"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+    networks:
+      - concurrency-e2e-network
+
+  minio:
+    image: minio/minio:latest
+    container_name: concurrency-e2e-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    volumes:
+      - concurrency_e2e_minio_data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks:
+      - concurrency-e2e-network
+
+  minio-init:
+    image: minio/mc:latest
+    container_name: concurrency-e2e-minio-init
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb local/artifact-keeper --ignore-existing &&
+      mc anonymous set none local/artifact-keeper &&
+      echo 'Bucket artifact-keeper created'
+      "
+    restart: "no"
+    networks:
+      - concurrency-e2e-network
+
+  mock-upstream:
+    build:
+      context: ./scripts/concurrency
+      dockerfile: Dockerfile.mock-upstream
+    image: ak-concurrency-mock-upstream:test
+    # No container_name: must be scalable-safe and we run a single instance.
+    environment:
+      # 256 MiB artifact, 1.5s latency to widen the race window.
+      ARTIFACT_SIZE_BYTES: "268435456"
+      ARTIFACT_NAME: big-artifact.bin
+      LATENCY_MS: "1500"
+      PORT: "9999"
+      SEED: "1624"
+    ports:
+      - "19999:9999"
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9999/healthz',timeout=2).read()==b'ok' else 1)"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - concurrency-e2e-network
+
+  backend:
+    image: artifact-keeper-backend:test
+    build:
+      context: .
+      dockerfile: docker/Dockerfile.backend
+    # No container_name: compose appends a replica index when scaled.
+    depends_on:
+      postgres:
+        condition: service_healthy
+      minio-init:
+        condition: service_completed_successfully
+      mock-upstream:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://registry:registry@postgres:5432/artifact_registry
+      # SHARED S3 object storage: a blob cached by one replica is visible to all.
+      STORAGE_BACKEND: s3
+      S3_BUCKET: artifact-keeper
+      S3_REGION: us-east-1
+      S3_ENDPOINT: http://minio:9000
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+      STORAGE_PATH: /data/storage
+      BACKUP_PATH: /data/backups
+      PLUGINS_DIR: /data/plugins
+      JWT_SECRET: concurrency-e2e-secret-key-32bytes-long
+      ADMIN_PASSWORD: TestRunner!2026secure
+      ENVIRONMENT: development
+      RUST_LOG: info
+      HOST: 0.0.0.0
+      PORT: "8080"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 10s
+      start_period: 30s
+      retries: 20
+    networks:
+      - concurrency-e2e-network
+
+  lb:
+    image: nginx:alpine
+    container_name: concurrency-e2e-lb
+    depends_on:
+      - backend
+    volumes:
+      - ./scripts/concurrency/nginx-lb.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "18080:8080"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+    networks:
+      - concurrency-e2e-network
+
+networks:
+  concurrency-e2e-network:
+    name: concurrency-e2e-network
+    driver: bridge
+
+volumes:
+  concurrency_e2e_minio_data:

--- a/scripts/concurrency/Dockerfile.mock-upstream
+++ b/scripts/concurrency/Dockerfile.mock-upstream
@@ -1,0 +1,20 @@
+# Mock upstream registry for the multi-replica single-flight race harness (#1624).
+# Dependency-light: stock python slim image, single stdlib script, no pip install.
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY mock_upstream.py /app/mock_upstream.py
+
+# Defaults (overridable via compose `environment:`).
+ENV ARTIFACT_SIZE_BYTES=268435456 \
+    ARTIFACT_NAME=big-artifact.bin \
+    LATENCY_MS=1500 \
+    PORT=9999 \
+    SEED=1624
+
+EXPOSE 9999
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+    CMD python3 -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:9999/healthz',timeout=2).read()==b'ok' else 1)"
+
+CMD ["python3", "/app/mock_upstream.py"]

--- a/scripts/concurrency/README.md
+++ b/scripts/concurrency/README.md
@@ -1,0 +1,141 @@
+# Multi-Replica Single-Flight Concurrency Harness (#1624)
+
+A black-box concurrency harness that runs **≥3 backend replicas** sharing one
+PostgreSQL and one S3-compatible object store (MinIO), behind a round-robin
+load balancer, and fires a storm of concurrent GETs for a single **uncached**
+large artifact through a proxy/remote repository.
+
+It is the **acceptance gate for #1609** and **reproduces #1606** (per-process
+single-flight races across replicas serving partial/truncated artifacts).
+
+> **This harness is RED on `main` by design.** Today's coordinator
+> (`backend/src/services/proxy_hydration.rs`) elects a single-flight *leader*
+> using a process-local `static` map, so it only deduplicates **within one
+> replica**. With the storm spread across replicas, each replica independently
+> fetches the artifact — multiple upstream fetches and, under #1606, torn /
+> truncated bodies. The harness is expected to FAIL here. It flips green once
+> #1609 implements cross-process single-flight, and then becomes its
+> regression gate.
+
+## Components
+
+| File | Purpose |
+| --- | --- |
+| `mock_upstream.py` | Stdlib-only HTTP server: serves ONE large artifact with a fixed SHA-256, injects per-response latency to widen the race window, and exposes a **fetch counter**. |
+| `Dockerfile.mock-upstream` | Containerises the mock upstream on stock `python:3.12-slim` (no pip install). |
+| `nginx-lb.conf` | Round-robin LB that re-resolves the `backend` service via Docker DNS so the storm spreads across all replicas. |
+| `assert_lib.sh` | Pure, side-effect-free assertion helpers (digest match, counter==1, blob count). Unit-tested without Docker. |
+| `run-singleflight-race.sh` | Driver: creates the proxy repo, fires N concurrent GETs, asserts A1/A2/A3, prints a PASS/FAIL summary. |
+| `test_assert_lib.sh` | Unit tests for `assert_lib.sh` + a standalone smoke test of `mock_upstream.py` (no Docker). |
+| `../../docker-compose.concurrency-e2e.yml` | Postgres + MinIO + mock upstream + ≥3 backend replicas + nginx LB. |
+| `../../.github/workflows/concurrency-e2e.yml` | `workflow_dispatch` + weekly schedule. **Not** on `pull_request`. |
+
+## The mock upstream
+
+Serves the artifact at `GET /race/<ARTIFACT_NAME>` and exposes:
+
+- `GET /__digest__` → `{"sha256": "...", "size": N, "name": "..."}` (the published digest)
+- `GET /__count__` → `{"fetches": N}` (how many times the artifact was actually fetched)
+- `POST /__reset__` → resets the counter to 0
+- `GET /healthz` → `ok`
+
+Artifact bytes are generated **deterministically from a fixed seed**, so the
+SHA-256 is stable across restarts without shipping a 256 MiB blob in the image.
+Each served response increments the counter exactly once (counted *before* the
+body is streamed, so a client disconnect still counts as a real upstream hit).
+
+Configurable via env: `ARTIFACT_SIZE_BYTES` (default 256 MiB), `LATENCY_MS`
+(default 1500), `ARTIFACT_NAME`, `SEED`, `PORT`.
+
+## Assertions
+
+| ID | Assertion | The bug it catches |
+| --- | --- | --- |
+| **A1** | mock-upstream fetch counter `== 1` (strict; `FETCH_TOLERANCE` allows a documented passthrough margin) | Cross-process stampede: each replica fetches independently → counter ≫ 1. |
+| **A2** | **every** response is HTTP 200 **and** its SHA-256 == the published digest | Torn / truncated bodies — the #1606 failure. |
+| **A3** | exactly **one** cached blob (`__content__`) under `proxy-cache/<repo>/` in the object store | Duplicate / half-written cache entries from racing writers. |
+
+## How to run
+
+Requires Docker (with the Compose plugin) on a local machine. Building the
+backend image locally is fine — this is a developer machine, **not** cloud
+compute (per repo infra rules, never build on EC2).
+
+```bash
+# From the repo root.
+docker compose -f docker-compose.concurrency-e2e.yml build
+docker compose -f docker-compose.concurrency-e2e.yml up -d --scale backend=3
+
+# Wait for health, then run the storm (default 200 concurrent GETs).
+CONCURRENCY=200 ./scripts/concurrency/run-singleflight-race.sh
+
+# Tear down.
+docker compose -f docker-compose.concurrency-e2e.yml down -v
+```
+
+Tunables (env vars consumed by the driver):
+
+```bash
+CONCURRENCY=200            # number of concurrent GETs
+LB_URL=http://localhost:18080
+MOCK_UPSTREAM_URL=http://localhost:19999
+FETCH_TOLERANCE=0          # allow upstream counter up to 1+tolerance
+```
+
+To widen or narrow the race window, set `LATENCY_MS` / `ARTIFACT_SIZE_BYTES` on
+the `mock-upstream` service before `up` (or via the workflow inputs).
+
+## Run the no-Docker checks
+
+The assertion logic and the mock upstream counter can be validated without the
+full stack:
+
+```bash
+shellcheck scripts/concurrency/*.sh
+python3 -m py_compile scripts/concurrency/mock_upstream.py
+bash scripts/concurrency/test_assert_lib.sh
+docker compose -f docker-compose.concurrency-e2e.yml config >/dev/null
+```
+
+## Expected result on `main`
+
+On current `main` the driver exits **non-zero**. An actual observed run against a
+pre-#1609 backend (3 replicas, shared MinIO, 256 MiB artifact, 1.5 s upstream
+latency, `CONCURRENCY=24`, cold cache) produced:
+
+```
+==> Wiping shared object store for a cold cache ...
+  object store wiped (0 cached blobs)
+...
+==> Reading mock upstream fetch counter...
+  Upstream fetch counter: 24
+==> Counting cached blobs in object store...
+  Cached blob count: 1
+--- A1: exactly one upstream fetch ---
+  FAIL upstream fetch counter is 24 (>1): cross-process single-flight failed (#1606)
+--- A2: every response 200 + correct sha256 ---
+  FAIL of 24 responses: 20 non-200, 0 digest-mismatch
+--- A3: exactly one cached blob ---
+  PASS exactly one cached blob in object store
+RACE HARNESS FAILED (2 assertion(s))
+```
+
+- **A1** fails: the upstream counter is **24** — every cold-cache request fetched
+  upstream independently (a correct cross-process coordinator would fetch once).
+  The mock upstream's per-client access log confirms the fetches are spread
+  across all replica IPs, proving the race is cross-process, not within a
+  single replica.
+- **A2** fails: most responses were **502** (the cold-cache stampede tears the
+  buffered upstream reads — `Failed to read upstream response: error decoding
+  response body` in the backend log). This is the #1606 client-visible failure.
+- **A3** passes once the cache converges to a single blob.
+
+> **Cold cache matters.** A warm shared cache makes every request a cache hit
+> (upstream counter 0, all 200s) and masks the race entirely. The driver wipes
+> the object store before each storm (`WIPE_CACHE=1`, the default). If you run
+> the storm twice without a wipe, the second run will spuriously look "less bad".
+
+That red result is the **correct** outcome for this task — it proves the harness
+reproduces #1606. When #1609 lands, all three assertions pass and the workflow
+turns green, at which point the `continue-on-error` in the workflow's `race`
+job should be removed so it becomes a hard regression gate.

--- a/scripts/concurrency/assert_lib.sh
+++ b/scripts/concurrency/assert_lib.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Pure assertion helpers for the single-flight race harness (#1624).
+#
+# Factored out of run-singleflight-race.sh so the digest/counter/blob-count
+# assertion logic can be unit-tested with a local stub (test_assert_lib.sh)
+# WITHOUT standing up the full multi-container stack. Keep these functions
+# side-effect-free apart from echoing PASS/FAIL/result tokens.
+
+# sha256_of_file <path> -> prints the lowercase hex sha256, or empty on error.
+sha256_of_file() {
+    local f="$1"
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$f" 2>/dev/null | cut -d' ' -f1
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$f" 2>/dev/null | cut -d' ' -f1
+    else
+        echo ""
+    fi
+}
+
+# assert_fetch_counter_one <count> -> "PASS"/"FAIL <reason>"
+# A1: exactly one upstream fetch (strict ==1 unless a documented passthrough
+# tolerance is configured via FETCH_TOLERANCE).
+assert_fetch_counter_one() {
+    local count="$1"
+    local tolerance="${FETCH_TOLERANCE:-0}"
+    local max=$((1 + tolerance))
+    if [ "$count" -lt 1 ]; then
+        echo "FAIL upstream fetch counter is $count (<1): artifact was never fetched"
+        return 1
+    fi
+    if [ "$count" -gt "$max" ]; then
+        echo "FAIL upstream fetch counter is $count (>$max): cross-process single-flight failed (#1606); each replica fetched independently"
+        return 1
+    fi
+    echo "PASS upstream fetch counter == $count (<= $max)"
+    return 0
+}
+
+# assert_all_responses_ok <results_csv> <expected_sha256>
+# A2: EVERY response is HTTP 200 and its sha256 == the published digest.
+# CSV columns: idx,status,sha256,bytes
+assert_all_responses_ok() {
+    local csv="$1" expected="$2"
+    local total=0 bad_status=0 bad_digest=0
+    local idx status sha _bytes
+    while IFS=',' read -r idx status sha _bytes; do
+        [ "$idx" = "idx" ] && continue   # skip header
+        [ -z "$idx" ] && continue
+        total=$((total + 1))
+        if [ "$status" != "200" ]; then
+            bad_status=$((bad_status + 1))
+            continue
+        fi
+        if [ "$sha" != "$expected" ]; then
+            bad_digest=$((bad_digest + 1))
+        fi
+    done < "$csv"
+
+    if [ "$total" -eq 0 ]; then
+        echo "FAIL no responses recorded"
+        return 1
+    fi
+    if [ "$bad_status" -gt 0 ] || [ "$bad_digest" -gt 0 ]; then
+        echo "FAIL of $total responses: $bad_status non-200, $bad_digest digest-mismatch (truncated/torn bodies = #1606)"
+        return 1
+    fi
+    echo "PASS all $total responses HTTP 200 with correct sha256"
+    return 0
+}
+
+# assert_single_cached_blob <count> -> "PASS"/"FAIL"
+# A3: exactly one cached blob object after the storm.
+assert_single_cached_blob() {
+    local count="$1"
+    if [ "$count" = "1" ]; then
+        echo "PASS exactly one cached blob in object store"
+        return 0
+    fi
+    echo "FAIL expected exactly 1 cached blob, found $count"
+    return 1
+}

--- a/scripts/concurrency/mock_upstream.py
+++ b/scripts/concurrency/mock_upstream.py
@@ -36,7 +36,6 @@ Environment
 """
 
 import hashlib
-import io
 import os
 import sys
 import threading
@@ -218,7 +217,7 @@ def main():
     try:
         server.serve_forever()
     except KeyboardInterrupt:
-        pass
+        sys.stderr.write("[mock-upstream] shutting down on interrupt\n")
 
 
 if __name__ == "__main__":

--- a/scripts/concurrency/mock_upstream.py
+++ b/scripts/concurrency/mock_upstream.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Mock upstream registry for the multi-replica single-flight race harness (#1624).
+
+Serves ONE large artifact with a known, fixed SHA-256 and:
+  - injects a configurable per-response latency to widen the race window so
+    that concurrent cold-cache fetches from multiple backend replicas overlap;
+  - counts how many times the artifact was *actually* fetched (the assertion
+    that a correct cross-process single-flight makes exactly one upstream call);
+  - exposes the published digest, size and counter via control endpoints.
+
+This is deliberately dependency-light: Python 3 standard library only, single
+file, so it can run standalone for unit tests AND be containerised with a stock
+`python:3-slim` image (no pip install).
+
+Endpoints
+---------
+  GET  /race/<ARTIFACT_NAME>   -> the large artifact (200), after LATENCY_MS delay.
+                                  Increments the fetch counter exactly once per
+                                  fully-served response start.
+  GET  /__count__              -> JSON: {"fetches": N}
+  GET  /__digest__             -> JSON: {"sha256": "...", "size": N, "name": "..."}
+  POST /__reset__              -> resets the fetch counter to 0 (JSON {"fetches":0})
+  GET  /healthz                -> "ok" (no counter side-effect)
+
+The artifact bytes are generated deterministically from a fixed seed so the
+SHA-256 is stable across container restarts WITHOUT shipping a 256 MB blob in
+the image. We stream it in chunks to keep memory flat.
+
+Environment
+-----------
+  ARTIFACT_SIZE_BYTES  default 268435456 (256 MiB)
+  ARTIFACT_NAME        default big-artifact.bin
+  LATENCY_MS           default 1500  (delay before the body is sent)
+  PORT                 default 9999
+  SEED                 default 1624  (deterministic content seed)
+"""
+
+import hashlib
+import io
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+ARTIFACT_SIZE_BYTES = int(os.environ.get("ARTIFACT_SIZE_BYTES", str(256 * 1024 * 1024)))
+ARTIFACT_NAME = os.environ.get("ARTIFACT_NAME", "big-artifact.bin")
+LATENCY_MS = int(os.environ.get("LATENCY_MS", "1500"))
+PORT = int(os.environ.get("PORT", "9999"))
+SEED = int(os.environ.get("SEED", "1624"))
+
+CHUNK = 1024 * 1024  # 1 MiB streaming chunk
+
+# --- deterministic content generation -------------------------------------------------
+
+def _block(index: int) -> bytes:
+    """Deterministic 1 MiB-ish block derived from (SEED, index).
+
+    Uses repeated SHA-256 expansion so the content is pseudo-random yet fully
+    reproducible. The same (SEED, ARTIFACT_SIZE_BYTES) always yields the same
+    bytes and therefore the same overall digest.
+    """
+    out = bytearray()
+    counter = 0
+    base = f"{SEED}:{index}".encode()
+    while len(out) < CHUNK:
+        out.extend(hashlib.sha256(base + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return bytes(out[:CHUNK])
+
+
+def iter_artifact():
+    """Yield the artifact body in CHUNK-sized pieces, totalling ARTIFACT_SIZE_BYTES."""
+    remaining = ARTIFACT_SIZE_BYTES
+    index = 0
+    while remaining > 0:
+        blk = _block(index)
+        if len(blk) > remaining:
+            blk = blk[:remaining]
+        yield blk
+        remaining -= len(blk)
+        index += 1
+
+
+def compute_digest():
+    """Compute (sha256_hex, size) of the artifact without holding it in memory."""
+    h = hashlib.sha256()
+    size = 0
+    for blk in iter_artifact():
+        h.update(blk)
+        size += len(blk)
+    return h.hexdigest(), size
+
+
+# Computed once at startup; this is the PUBLISHED digest the harness asserts against.
+PUBLISHED_SHA256, PUBLISHED_SIZE = compute_digest()
+
+# --- fetch counter --------------------------------------------------------------------
+
+_counter_lock = threading.Lock()
+_fetch_count = 0
+
+
+def _bump_counter():
+    global _fetch_count
+    with _counter_lock:
+        _fetch_count += 1
+        return _fetch_count
+
+
+def _read_counter():
+    with _counter_lock:
+        return _fetch_count
+
+
+def _reset_counter():
+    global _fetch_count
+    with _counter_lock:
+        _fetch_count = 0
+
+
+# --- HTTP handler ---------------------------------------------------------------------
+
+ARTIFACT_PATH = f"/race/{ARTIFACT_NAME}"
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):  # quieter logs; one line per request
+        sys.stderr.write("[mock-upstream] %s - %s\n" % (self.address_string(), fmt % args))
+
+    def _json(self, code, obj):
+        body = (
+            "{"
+            + ",".join(f'"{k}":{_json_val(v)}' for k, v in obj.items())
+            + "}"
+        ).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/healthz":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", "2")
+            self.end_headers()
+            self.wfile.write(b"ok")
+            return
+        if path == "/__count__":
+            self._json(200, {"fetches": _read_counter()})
+            return
+        if path == "/__digest__":
+            self._json(
+                200,
+                {
+                    "sha256": PUBLISHED_SHA256,
+                    "size": PUBLISHED_SIZE,
+                    "name": ARTIFACT_NAME,
+                },
+            )
+            return
+        if path == ARTIFACT_PATH:
+            self._serve_artifact()
+            return
+        self.send_error(404, "not found")
+
+    def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        if path == "/__reset__":
+            _reset_counter()
+            self._json(200, {"fetches": 0})
+            return
+        self.send_error(404, "not found")
+
+    def _serve_artifact(self):
+        # Count the fetch BEFORE serving so even a client that disconnects
+        # mid-stream is counted as a real upstream hit. This makes the
+        # "exactly one upstream fetch" assertion strict.
+        n = _bump_counter()
+        self.log_message("ARTIFACT FETCH #%d begins (latency=%dms)", n, LATENCY_MS)
+
+        # Widen the race window: delay before sending the body. This is the
+        # critical knob that lets N replica requests pile up on a cold cache.
+        if LATENCY_MS > 0:
+            time.sleep(LATENCY_MS / 1000.0)
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(PUBLISHED_SIZE))
+        self.send_header("X-Mock-Upstream-Fetch", str(n))
+        self.end_headers()
+        try:
+            for blk in iter_artifact():
+                self.wfile.write(blk)
+        except (BrokenPipeError, ConnectionResetError):
+            self.log_message("client disconnected during ARTIFACT FETCH #%d", n)
+
+
+def _json_val(v):
+    if isinstance(v, bool):
+        return "true" if v else "false"
+    if isinstance(v, (int, float)):
+        return str(v)
+    return '"' + str(v).replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def main():
+    sys.stderr.write(
+        "[mock-upstream] artifact=%s size=%d bytes sha256=%s latency=%dms port=%d\n"
+        % (ARTIFACT_NAME, PUBLISHED_SIZE, PUBLISHED_SHA256, LATENCY_MS, PORT)
+    )
+    server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/concurrency/nginx-lb.conf
+++ b/scripts/concurrency/nginx-lb.conf
@@ -1,0 +1,54 @@
+# Round-robin load balancer in front of the backend replicas (#1624).
+#
+# Docker compose's embedded DNS resolves the `backend` service name to ALL
+# replica container IPs. We use nginx with `resolve` + a Docker DNS resolver so
+# the upstream pool tracks every scaled replica, and round-robin spreads the
+# concurrent GET storm across all of them. Spreading the storm across replicas
+# is what exercises the CROSS-PROCESS single-flight path (the #1606 bug): a
+# per-process coordinator only dedupes within one replica.
+
+worker_processes auto;
+events {
+    worker_connections 4096;
+}
+
+http {
+    # Docker's embedded DNS server. 127.0.0.11 is the standard Docker DNS addr.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
+    # Large artifact: do not buffer the whole 256 MB body to disk before
+    # forwarding, and allow long upstream reads while the leader hydrates.
+    proxy_buffering off;
+    proxy_request_buffering off;
+    proxy_max_temp_file_size 0;
+    proxy_read_timeout 300s;
+    proxy_connect_timeout 30s;
+    proxy_send_timeout 300s;
+    client_max_body_size 0;
+
+    # Access log to stdout so `docker compose logs lb` shows which replica
+    # served each request (useful when debugging the spread).
+    log_format lb '$remote_addr -> upstream=$upstream_addr status=$status '
+                  'bytes=$body_bytes_sent rt=$request_time uri=$uri';
+    access_log /dev/stdout lb;
+
+    server {
+        listen 8080;
+
+        # Use a variable so nginx re-resolves `backend` via Docker DNS on each
+        # request instead of caching a single IP at startup (which would pin all
+        # traffic to one replica and hide the cross-process race).
+        set $backend_pool backend;
+
+        location /healthz {
+            return 200 "lb-ok\n";
+        }
+
+        location / {
+            proxy_pass http://$backend_pool:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/scripts/concurrency/run-singleflight-race.sh
+++ b/scripts/concurrency/run-singleflight-race.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# Multi-replica single-flight race driver (#1624).
+#
+# Reproduces #1606: per-process singleflight races across replicas serving
+# partial/truncated artifacts. Acceptance gate for #1609.
+#
+# Mirrors the scripts/stress/ pattern: fire a concurrent storm, capture every
+# response, validate, print a PASS/FAIL summary, exit non-zero on failure.
+#
+# Preconditions: the concurrency-e2e stack is up with >=3 backend replicas:
+#   docker compose -f docker-compose.concurrency-e2e.yml up -d --scale backend=3
+#
+# What it does:
+#   1. Authenticates against the LB.
+#   2. Creates a maven REMOTE (proxy) repo pointed at the mock upstream.
+#   3. Resets the mock upstream fetch counter.
+#   4. Fires N concurrent GETs (default 200) for the SINGLE uncached artifact
+#      through the LB (round-robined across replicas).
+#   5. Asserts:
+#        A1 upstream fetch counter == 1 (modulo FETCH_TOLERANCE)
+#        A2 every response is HTTP 200 with sha256 == the published digest
+#        A3 exactly one cached blob in the object store
+#
+# Environment (with defaults):
+#   LB_URL              http://localhost:18080   load balancer in front of replicas
+#   MOCK_UPSTREAM_URL   http://localhost:19999   mock upstream control plane (host side)
+#   MOCK_UPSTREAM_INTERNAL  http://mock-upstream:9999  what the backend uses to reach upstream
+#   ADMIN_USER          admin
+#   ADMIN_PASS          TestRunner!2026secure
+#   CONCURRENCY         200                      number of concurrent GETs
+#   REPO_KEY            maven-race-proxy
+#   ARTIFACT_PATH       race/big-artifact.bin    path under the proxy repo
+#   RESULTS_DIR         /tmp/concurrency-results
+#   FETCH_TOLERANCE     0                        allow counter up to 1+tolerance
+#   MINIO_ALIAS_CMD     (auto)                   how to count blobs in MinIO
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/concurrency/assert_lib.sh
+. "$SCRIPT_DIR/assert_lib.sh"
+
+LB_URL="${LB_URL:-http://localhost:18080}"
+MOCK_UPSTREAM_URL="${MOCK_UPSTREAM_URL:-http://localhost:19999}"
+MOCK_UPSTREAM_INTERNAL="${MOCK_UPSTREAM_INTERNAL:-http://mock-upstream:9999}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+CONCURRENCY="${CONCURRENCY:-200}"
+REPO_KEY="${REPO_KEY:-maven-race-proxy}"
+ARTIFACT_PATH="${ARTIFACT_PATH:-race/big-artifact.bin}"
+RESULTS_DIR="${RESULTS_DIR:-/tmp/concurrency-results}"
+API_URL="$LB_URL/api/v1"
+MINIO_NETWORK="${MINIO_NETWORK:-concurrency-e2e-network}"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+
+# Run an `mc` command line inside the compose network and stream its stdout to
+# the host. The minio/mc image's ENTRYPOINT is `mc` and it ships NO shell utils
+# (no grep/awk), so we (a) override the entrypoint to /bin/sh and (b) do all
+# text processing on the HOST side. `$1` is the mc command (without the leading
+# `mc`), e.g. mc_in_network "ls -r local/artifact-keeper/".
+mc_in_network() {
+    docker run --rm --network "$MINIO_NETWORK" --entrypoint /bin/sh minio/mc:latest -c \
+        "mc alias set local http://minio:9000 minioadmin minioadmin >/dev/null 2>&1 && mc $1" 2>/dev/null
+}
+
+echo "=============================================="
+echo "Multi-Replica Single-Flight Race (#1624)"
+echo "=============================================="
+echo "LB URL:            $LB_URL"
+echo "Mock upstream:     $MOCK_UPSTREAM_URL (internal: $MOCK_UPSTREAM_INTERNAL)"
+echo "Concurrency:       $CONCURRENCY"
+echo "Proxy repo:        $REPO_KEY (maven, remote)"
+echo "Artifact path:     $ARTIFACT_PATH"
+echo "Results dir:       $RESULTS_DIR"
+echo ""
+
+mkdir -p "$RESULTS_DIR"
+rm -f "$RESULTS_DIR"/*.bin "$RESULTS_DIR"/results.csv "$RESULTS_DIR"/summary.json 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Step 0: published digest from the mock upstream
+# ---------------------------------------------------------------------------
+echo "==> Fetching published digest from mock upstream..."
+DIGEST_JSON=$(curl -sf "$MOCK_UPSTREAM_URL/__digest__" 2>/dev/null) || {
+    echo "ERROR: mock upstream not reachable at $MOCK_UPSTREAM_URL/__digest__"
+    echo "Is the stack up? docker compose -f docker-compose.concurrency-e2e.yml up -d --scale backend=3"
+    exit 2
+}
+EXPECTED_SHA=$(echo "$DIGEST_JSON" | sed -n 's/.*"sha256":"\([0-9a-f]*\)".*/\1/p')
+EXPECTED_SIZE=$(echo "$DIGEST_JSON" | sed -n 's/.*"size":\([0-9]*\).*/\1/p')
+if [ -z "$EXPECTED_SHA" ]; then
+    echo "ERROR: could not parse digest from: $DIGEST_JSON"
+    exit 2
+fi
+echo "  Published sha256: $EXPECTED_SHA"
+echo "  Published size:   $EXPECTED_SIZE bytes"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 1: authenticate against the LB
+# ---------------------------------------------------------------------------
+echo "==> Authenticating against the load balancer..."
+LOGIN_RESP=$(curl -sf -X POST "$API_URL/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}" 2>&1) || {
+    echo "ERROR: failed to authenticate at $API_URL/auth/login. Are the backends healthy?"
+    exit 2
+}
+TOKEN=$(echo "$LOGIN_RESP" | sed -n 's/.*"access_token":"\([^"]*\)".*/\1/p')
+if [ -z "$TOKEN" ]; then
+    echo "ERROR: no access_token in login response: $LOGIN_RESP"
+    exit 2
+fi
+AUTH="Authorization: Bearer $TOKEN"
+echo "  Authenticated."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 2: create the maven remote proxy repo pointed at the mock upstream
+# ---------------------------------------------------------------------------
+# Cold-cache guarantee: a WARM cache hides the race entirely (every request
+# becomes a cache hit, upstream is never touched, and the harness can neither
+# pass nor fail meaningfully). Wipe the shared object store before each storm
+# unless explicitly disabled. Runs `mc` inside the compose network so it works
+# regardless of host port remapping.
+if [ "${WIPE_CACHE:-1}" = "1" ] && docker ps >/dev/null 2>&1; then
+    echo "==> Wiping shared object store for a cold cache (set WIPE_CACHE=0 to skip)..."
+    # Remove every cached object, then confirm the bucket is empty. We delete the
+    # whole proxy-cache prefix recursively. `rm -r --force` on the prefix is the
+    # reliable form against this MinIO (whole-bucket `rb` is flaky here).
+    mc_in_network "rm -r --force local/artifact-keeper/proxy-cache" >/dev/null 2>&1 || true
+    REMAINING=$(mc_in_network "ls -r local/artifact-keeper/" | grep -c '__content__' || true)
+    REMAINING="${REMAINING:-0}"
+    if [ "$REMAINING" = "0" ]; then
+        echo "  object store wiped (0 cached blobs)"
+    else
+        echo "  WARNING: $REMAINING cached blob(s) survived the wipe; the race may be masked by a warm cache"
+    fi
+fi
+
+echo "==> Creating maven remote proxy repo '$REPO_KEY' -> $MOCK_UPSTREAM_INTERNAL ..."
+curl -s -o /dev/null -X DELETE "$API_URL/repositories/$REPO_KEY" -H "$AUTH" 2>/dev/null || true
+CREATE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$API_URL/repositories" \
+    -H "$AUTH" -H 'Content-Type: application/json' \
+    -d "{\"key\":\"$REPO_KEY\",\"name\":\"Maven Race Proxy\",\"format\":\"maven\",\"repo_type\":\"remote\",\"is_public\":true,\"upstream_url\":\"$MOCK_UPSTREAM_INTERNAL\"}")
+if [ "$CREATE_CODE" != "200" ] && [ "$CREATE_CODE" != "201" ]; then
+    echo "ERROR: repo create returned HTTP $CREATE_CODE"
+    exit 2
+fi
+echo "  Repo created (HTTP $CREATE_CODE)."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 3: reset the upstream fetch counter so the count reflects THIS storm
+# ---------------------------------------------------------------------------
+echo "==> Resetting mock upstream fetch counter..."
+curl -s -o /dev/null -X POST "$MOCK_UPSTREAM_URL/__reset__" || true
+PRE_COUNT=$(curl -sf "$MOCK_UPSTREAM_URL/__count__" | sed -n 's/.*"fetches":\([0-9]*\).*/\1/p')
+echo "  Counter reset to: ${PRE_COUNT:-?}"
+echo ""
+
+# Proxy GET URL through the LB. Maven proxy route: GET /maven/<repo>/*path,
+# which maps to upstream <upstream_url>/<path> => mock /race/big-artifact.bin.
+PROXY_GET_URL="$LB_URL/maven/$REPO_KEY/$ARTIFACT_PATH"
+
+# ---------------------------------------------------------------------------
+# Step 4: fire N concurrent GETs for the single uncached artifact
+# ---------------------------------------------------------------------------
+echo "==> Firing $CONCURRENCY concurrent GETs at: $PROXY_GET_URL"
+echo "idx,status,sha256,bytes" > "$RESULTS_DIR/results.csv"
+
+fetch_one() {
+    local idx="$1"
+    local out="$RESULTS_DIR/resp-$idx.bin"
+    local status sha bytes
+    # `--http1.1` + no connection reuse keeps `%{http_code}` to a single value
+    # (otherwise curl can emit the code once per reused/retried connection and
+    # the field becomes e.g. "200200"). Take the LAST 3 digits defensively.
+    status=$(curl -s -o "$out" -w "%{http_code}" --http1.1 -H 'Connection: close' \
+        --max-time 300 "$PROXY_GET_URL" 2>/dev/null || echo "000")
+    status="${status: -3}"
+    sha=$(sha256_of_file "$out")
+    bytes=$(wc -c < "$out" 2>/dev/null | tr -d ' ')
+    echo "$idx,$status,$sha,$bytes" >> "$RESULTS_DIR/results.csv"
+    # Keep only the first few bodies for forensic inspection; delete the rest to
+    # avoid filling the disk with N * 256 MB.
+    if [ "$idx" -gt 5 ]; then rm -f "$out"; fi
+}
+
+START_TIME=$(date +%s)
+PIDS=()
+for i in $(seq 1 "$CONCURRENCY"); do
+    fetch_one "$i" &
+    PIDS+=("$!")
+done
+# Wait for ALL of them so the storm is genuinely concurrent (no batching).
+for pid in "${PIDS[@]}"; do wait "$pid"; done
+END_TIME=$(date +%s)
+echo "  Storm complete in $((END_TIME - START_TIME))s."
+echo ""
+
+# ---------------------------------------------------------------------------
+# Step 5: gather post-storm facts
+# ---------------------------------------------------------------------------
+# Settle window: a leader replica whose client disconnected may still be
+# draining the upstream body after the client-side curl returned. The counter
+# is incremented at fetch START, so this mainly lets any just-started fetches
+# register. Without it the counter can be read a beat too early and under-count.
+SETTLE_SECS="${SETTLE_SECS:-3}"
+sleep "$SETTLE_SECS"
+
+echo "==> Reading mock upstream fetch counter..."
+POST_COUNT=$(curl -sf "$MOCK_UPSTREAM_URL/__count__" | sed -n 's/.*"fetches":\([0-9]*\).*/\1/p')
+POST_COUNT="${POST_COUNT:-0}"
+echo "  Upstream fetch counter: $POST_COUNT"
+echo ""
+
+echo "==> Counting cached blobs in object store..."
+# A3: count cached blob objects under proxy-cache/<repo>/ in MinIO. Each cached
+# artifact has one `__content__` object; we count those. The listing is produced
+# inside the compose network (works regardless of host port remapping) and
+# counted on the HOST (the mc image has no grep). Falls back to "unknown" if
+# docker is unavailable.
+BLOB_COUNT="unknown"
+if docker ps >/dev/null 2>&1; then
+    BLOB_COUNT=$(mc_in_network "ls -r local/artifact-keeper/proxy-cache/$REPO_KEY/" \
+        | grep -c '__content__$' || true)
+    BLOB_COUNT="${BLOB_COUNT:-0}"
+fi
+echo "  Cached blob count: $BLOB_COUNT"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+echo "=============================================="
+echo "Assertions"
+echo "=============================================="
+FAILED=0
+
+echo "--- A1: exactly one upstream fetch ---"
+A1=$(assert_fetch_counter_one "$POST_COUNT"); A1_RC=$?
+if [ "$A1_RC" -eq 0 ]; then echo -e "  ${GREEN}$A1${NC}"; else echo -e "  ${RED}$A1${NC}"; FAILED=$((FAILED+1)); fi
+
+echo "--- A2: every response 200 + correct sha256 ---"
+A2=$(assert_all_responses_ok "$RESULTS_DIR/results.csv" "$EXPECTED_SHA"); A2_RC=$?
+if [ "$A2_RC" -eq 0 ]; then echo -e "  ${GREEN}$A2${NC}"; else echo -e "  ${RED}$A2${NC}"; FAILED=$((FAILED+1)); fi
+
+echo "--- A3: exactly one cached blob ---"
+if [ "$BLOB_COUNT" = "unknown" ]; then
+    echo -e "  ${YELLOW}SKIP could not count blobs (no mc / docker on host)${NC}"
+else
+    A3=$(assert_single_cached_blob "$BLOB_COUNT"); A3_RC=$?
+    if [ "$A3_RC" -eq 0 ]; then echo -e "  ${GREEN}$A3${NC}"; else echo -e "  ${RED}$A3${NC}"; FAILED=$((FAILED+1)); fi
+fi
+echo ""
+
+# Per-status breakdown for the summary.
+OK_COUNT=$(awk -F',' 'NR>1 && $2=="200"{c++} END{print c+0}' "$RESULTS_DIR/results.csv")
+BAD_COUNT=$(awk -F',' 'NR>1 && $2!="200"{c++} END{print c+0}' "$RESULTS_DIR/results.csv")
+DIGEST_OK=$(awk -F',' -v e="$EXPECTED_SHA" 'NR>1 && $3==e{c++} END{print c+0}' "$RESULTS_DIR/results.csv")
+DIGEST_BAD=$(awk -F',' -v e="$EXPECTED_SHA" 'NR>1 && $3!=e{c++} END{print c+0}' "$RESULTS_DIR/results.csv")
+
+cat > "$RESULTS_DIR/summary.json" <<EOF
+{
+  "test": "multireplica_singleflight_race",
+  "issue": 1624,
+  "reproduces": 1606,
+  "gate_for": 1609,
+  "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "config": {
+    "concurrency": $CONCURRENCY,
+    "repo_key": "$REPO_KEY",
+    "artifact_path": "$ARTIFACT_PATH",
+    "expected_sha256": "$EXPECTED_SHA",
+    "expected_size": ${EXPECTED_SIZE:-0},
+    "fetch_tolerance": ${FETCH_TOLERANCE:-0}
+  },
+  "results": {
+    "upstream_fetch_count": $POST_COUNT,
+    "cached_blob_count": "$BLOB_COUNT",
+    "responses_200": $OK_COUNT,
+    "responses_non_200": $BAD_COUNT,
+    "digest_match": $DIGEST_OK,
+    "digest_mismatch": $DIGEST_BAD,
+    "failed_assertions": $FAILED
+  }
+}
+EOF
+
+echo "=============================================="
+echo "Summary"
+echo "=============================================="
+echo "  Concurrency:            $CONCURRENCY"
+echo "  Upstream fetch count:   $POST_COUNT  (expected 1)"
+echo "  Cached blob count:      $BLOB_COUNT  (expected 1)"
+echo "  Responses 200:          $OK_COUNT / $CONCURRENCY"
+echo "  Responses non-200:      $BAD_COUNT"
+echo "  Digest match:           $DIGEST_OK"
+echo "  Digest mismatch:        $DIGEST_BAD"
+echo "  Summary written to:     $RESULTS_DIR/summary.json"
+echo ""
+
+if [ "$FAILED" -gt 0 ]; then
+    echo -e "${RED}=============================================="
+    echo "RACE HARNESS FAILED ($FAILED assertion(s))"
+    echo "==============================================${NC}"
+    echo ""
+    echo "On current 'main' this is the EXPECTED outcome: it reproduces #1606"
+    echo "(per-process single-flight does not coordinate across replicas)."
+    echo "This harness flips green once #1609 lands."
+    exit 1
+fi
+
+echo -e "${GREEN}=============================================="
+echo "RACE HARNESS PASSED"
+echo "==============================================${NC}"
+echo ""
+echo "Cross-process single-flight is holding: one upstream fetch, one cached"
+echo "blob, every client received the full untruncated artifact."

--- a/scripts/concurrency/test_assert_lib.sh
+++ b/scripts/concurrency/test_assert_lib.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Unit tests for assert_lib.sh and a standalone smoke test of mock_upstream.py.
+#
+# Runs WITHOUT Docker or the full stack. Validates the digest/counter/blob-count
+# assertion logic against local stubs so the harness's pass/fail decisions are
+# trustworthy independent of a real multi-container run.
+#
+# Usage: ./scripts/concurrency/test_assert_lib.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/concurrency/assert_lib.sh
+. "$SCRIPT_DIR/assert_lib.sh"
+
+PASS=0; FAIL=0
+ok()   { echo "  ok   - $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL - $1"; FAIL=$((FAIL+1)); }
+
+check_rc() { # desc expected_rc actual_rc
+    if [ "$2" = "$3" ]; then ok "$1 (rc=$3)"; else bad "$1 (expected rc=$2, got $3)"; fi
+}
+
+expect_eq() { # desc expected actual
+    if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+echo "== assert_fetch_counter_one =="
+assert_fetch_counter_one 1 >/dev/null 2>&1; rc=$?; check_rc "count==1 passes" 0 "$rc"
+assert_fetch_counter_one 8 >/dev/null 2>&1; rc=$?; check_rc "count==8 fails (the #1606 multi-fetch)" 1 "$rc"
+assert_fetch_counter_one 0 >/dev/null 2>&1; rc=$?; check_rc "count==0 fails (never fetched)" 1 "$rc"
+FETCH_TOLERANCE=2 assert_fetch_counter_one 3 >/dev/null 2>&1; rc=$?; check_rc "count==3 passes with tolerance=2" 0 "$rc"
+FETCH_TOLERANCE=2 assert_fetch_counter_one 4 >/dev/null 2>&1; rc=$?; check_rc "count==4 fails with tolerance=2" 1 "$rc"
+
+echo "== assert_single_cached_blob =="
+assert_single_cached_blob 1 >/dev/null 2>&1; rc=$?; check_rc "blob count 1 passes" 0 "$rc"
+assert_single_cached_blob 3 >/dev/null 2>&1; rc=$?; check_rc "blob count 3 fails" 1 "$rc"
+assert_single_cached_blob 0 >/dev/null 2>&1; rc=$?; check_rc "blob count 0 fails" 1 "$rc"
+
+echo "== sha256_of_file =="
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+printf 'hello' > "$TMP/h.txt"
+EXPECT="2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+GOT=$(sha256_of_file "$TMP/h.txt")
+if [ "$GOT" = "$EXPECT" ]; then ok "sha256('hello') correct"; else bad "sha256('hello') got $GOT"; fi
+
+echo "== assert_all_responses_ok =="
+GOOD_SHA="$EXPECT"
+# All-good CSV: every response 200 with the right digest.
+cat > "$TMP/good.csv" <<EOF
+idx,status,sha256,bytes
+1,200,$GOOD_SHA,5
+2,200,$GOOD_SHA,5
+3,200,$GOOD_SHA,5
+EOF
+assert_all_responses_ok "$TMP/good.csv" "$GOOD_SHA" >/dev/null 2>&1; rc=$?; check_rc "all-200 correct-digest passes" 0 "$rc"
+
+# Truncated/torn body: one response has a different (truncated) digest -> the #1606 failure.
+cat > "$TMP/torn.csv" <<EOF
+idx,status,sha256,bytes
+1,200,$GOOD_SHA,5
+2,200,deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef,3
+3,200,$GOOD_SHA,5
+EOF
+assert_all_responses_ok "$TMP/torn.csv" "$GOOD_SHA" >/dev/null 2>&1; rc=$?; check_rc "truncated body fails (#1606)" 1 "$rc"
+
+# Non-200 response (e.g. a 502 leak under stampede).
+cat > "$TMP/err.csv" <<EOF
+idx,status,sha256,bytes
+1,200,$GOOD_SHA,5
+2,502,,0
+3,200,$GOOD_SHA,5
+EOF
+assert_all_responses_ok "$TMP/err.csv" "$GOOD_SHA" >/dev/null 2>&1; rc=$?; check_rc "non-200 response fails" 1 "$rc"
+
+# Empty CSV (no responses).
+echo "idx,status,sha256,bytes" > "$TMP/empty.csv"
+assert_all_responses_ok "$TMP/empty.csv" "$GOOD_SHA" >/dev/null; rc=$?; check_rc "no responses fails" 1 "$rc"
+
+echo "== mock_upstream.py standalone (counter + digest stability) =="
+if command -v python3 >/dev/null 2>&1; then
+    # Tiny artifact + zero latency so the test is fast.
+    PORT=$(( (RANDOM % 2000) + 21000 ))
+    ARTIFACT_SIZE_BYTES=4096 LATENCY_MS=0 PORT=$PORT SEED=1624 \
+        python3 "$SCRIPT_DIR/mock_upstream.py" >/dev/null 2>&1 &
+    MOCK_PID=$!
+    # Wait for it to come up.
+    up=0
+    for _ in $(seq 1 50); do
+        if curl -sf "http://127.0.0.1:$PORT/healthz" >/dev/null 2>&1; then up=1; break; fi
+        sleep 0.1
+    done
+    if [ "$up" != "1" ]; then
+        bad "mock upstream did not start on port $PORT"
+    else
+        # Counter starts at 0.
+        c0=$(curl -sf "http://127.0.0.1:$PORT/__count__" | sed -n 's/.*"fetches":\([0-9]*\).*/\1/p')
+        expect_eq "counter starts at 0" "0" "$c0"
+
+        # Two fetches -> counter == 2; both bodies have the SAME (stable) digest
+        # equal to the published digest.
+        PUB=$(curl -sf "http://127.0.0.1:$PORT/__digest__" | sed -n 's/.*"sha256":"\([0-9a-f]*\)".*/\1/p')
+        curl -sf "http://127.0.0.1:$PORT/race/big-artifact.bin" -o "$TMP/a1.bin"
+        curl -sf "http://127.0.0.1:$PORT/race/big-artifact.bin" -o "$TMP/a2.bin"
+        c2=$(curl -sf "http://127.0.0.1:$PORT/__count__" | sed -n 's/.*"fetches":\([0-9]*\).*/\1/p')
+        expect_eq "counter == 2 after two fetches" "2" "$c2"
+
+        s1=$(sha256_of_file "$TMP/a1.bin"); s2=$(sha256_of_file "$TMP/a2.bin")
+        expect_eq "fetch 1 digest matches published" "$PUB" "$s1"
+        expect_eq "two fetches byte-identical (deterministic content)" "$s1" "$s2"
+
+        sz=$(wc -c < "$TMP/a1.bin" | tr -d ' ')
+        expect_eq "artifact size honoured (4096 bytes)" "4096" "$sz"
+
+        # Reset returns counter to 0.
+        curl -sf -X POST "http://127.0.0.1:$PORT/__reset__" >/dev/null
+        cr=$(curl -sf "http://127.0.0.1:$PORT/__count__" | sed -n 's/.*"fetches":\([0-9]*\).*/\1/p')
+        expect_eq "counter resets to 0" "0" "$cr"
+    fi
+    kill "$MOCK_PID" >/dev/null 2>&1 || true
+    wait "$MOCK_PID" 2>/dev/null || true
+else
+    echo "  SKIP - python3 not available for mock_upstream standalone test"
+fi
+
+echo ""
+echo "=============================================="
+echo "assert_lib unit tests: PASS=$PASS FAIL=$FAIL"
+echo "=============================================="
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Adds a **multi-replica single-flight concurrency harness** (`scripts/concurrency/`) that reproduces **#1606** (per-process single-flight races across replicas serving partial/truncated artifacts) and is the **acceptance gate for #1609** (cross-process single-flight).

It mirrors the existing `scripts/stress/` pattern but targets the cold-cache proxy stampede across replicas:

- **Mock upstream** (`mock_upstream.py`, stdlib-only, containerised on `python:3.12-slim`): serves ONE deterministic 256 MiB artifact with a fixed SHA-256, injects per-response latency to widen the race window, and exposes a **fetch counter** (`/__count__`), the published digest (`/__digest__`), and `/__reset__`.
- **docker-compose.concurrency-e2e.yml**: one Postgres + one MinIO (shared S3 object store) + the mock upstream + **>=3 backend replicas** (`--scale backend=N`) + an nginx round-robin LB. All replicas share the same Postgres and S3, so a blob cached by one is visible to all.
- **Driver** (`run-singleflight-race.sh`): creates a maven remote/proxy repo pointed at the mock upstream, **wipes the shared cache for a cold start**, fires N concurrent GETs (default 200) for the single uncached artifact through the LB, and asserts:
  - **A1**: mock-upstream fetch counter `== 1` (strict; `FETCH_TOLERANCE` allows a documented passthrough margin).
  - **A2**: EVERY response is HTTP 200 and its SHA-256 == the published digest (no torn/truncated bodies — the #1606 failure).
  - **A3**: exactly one cached blob (`__content__`) under `proxy-cache/<repo>/` in the object store.
- **Workflow** (`.github/workflows/concurrency-e2e.yml`): `workflow_dispatch` + weekly schedule only — **NOT** `pull_request`, since this harness is **RED on `main` by design** until #1609 lands. The `race` job is `continue-on-error` for observability; remove it once #1609 makes the harness green so it becomes a hard regression gate.
- **No-Docker unit tests** (`test_assert_lib.sh`): cover the digest/counter/blob-count assertion logic and run a standalone smoke test of the mock upstream's counter — so the harness's pass/fail decisions are trustworthy without standing up the full stack.

### Observed reproduction (this is the point)

Ran locally against a pre-#1609 backend (3 replicas, shared MinIO, 256 MiB artifact, 1.5 s latency, cold cache):

```
Upstream fetch counter: 24        (expected 1)   -> A1 FAIL
Responses 200: 4 / 24             20x HTTP 502    -> A2 FAIL
Cached blob count: 1              (expected 1)    -> A3 PASS
RACE HARNESS FAILED (2 assertion(s))
```

The mock upstream's per-client access log shows the 24 cold-cache fetches spread across all replica IPs, proving the race is **cross-process** (each replica's process-local coordinator in `proxy_hydration.rs` elects its own leader). The backend logs the #1606 symptom directly: `Failed to read upstream response: error decoding response body -> 502`. A red result here is the expected/correct outcome.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (it is the acceptance-gate test harness for #1609)

## Test Checklist
- [x] Unit tests added/updated (`test_assert_lib.sh`, 19 cases, no Docker — all pass)
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (the concurrency harness itself)
- [x] Manually tested locally (full `docker compose` stack scaled to 3 backends; reproduced #1606 as shown above)
- [x] No regressions in existing tests (new files only; `shellcheck -x`, `py_compile`, `docker compose config` all clean)

## API Changes
- [x] N/A - no API changes

---

Closes #1624. References #1606 and #1609.

**Notes for reviewers**
- The harness is intentionally **not** wired into the per-PR gate; it lives behind `workflow_dispatch` + a weekly cron.
- A **warm** shared cache hides the race entirely (all 200s, 0 upstream fetches), so the driver wipes the object store before each storm (`WIPE_CACHE=1` default). This is documented in `scripts/concurrency/README.md`.
- Local verification used the prebuilt `artifact-keeper-backend:dev` (v1.1.2) image tagged as `:test` to skip a from-scratch Rust release build; that image predates #1609 just like `main`. CI builds the image from source via the compose `build` step.
