### PR TITLE
refactor(proxy): collapse cache invalidation into shared helper (#1618 S3)

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1085,14 +1085,7 @@ impl ProxyService {
 
     /// Invalidate cached artifact
     pub async fn invalidate_cache(&self, repo: &Repository, path: &str) -> Result<()> {
-        let cache_key = Self::cache_storage_key(&repo.key, path)?;
-        let metadata_key = Self::cache_metadata_key(&repo.key, path)?;
-
-        // Delete both content and metadata
-        let _ = self.storage.delete(&cache_key).await;
-        let _ = self.storage.delete(&metadata_key).await;
-
-        Ok(())
+        self.invalidate_cache_keys(&repo.key, path).await
     }
 
     /// Invalidate cached artifact by repo key alone.
@@ -1102,10 +1095,22 @@ impl ProxyService {
     /// `RepoInfo` and need to evict sibling cache entries (e.g. APT
     /// invalidating stale Packages indices when Release changes, #1147).
     pub async fn invalidate_cache_by_key(&self, repo_key: &str, path: &str) -> Result<()> {
-        let cache_key = Self::cache_storage_key(repo_key, path)?;
-        let metadata_key = Self::cache_metadata_key(repo_key, path)?;
-        let _ = self.storage.delete(&cache_key).await;
-        let _ = self.storage.delete(&metadata_key).await;
+        self.invalidate_cache_keys(repo_key, path).await
+    }
+
+    /// Shared invalidation core for [`Self::invalidate_cache`] (keyed off
+    /// `repo.key`) and [`Self::invalidate_cache_by_key`] (keyed off a bare
+    /// `repo_key`). The two public methods differ only in how they obtain the
+    /// repo key; the eviction itself — derive both cache keys, then delete the
+    /// content and metadata blobs in that order, ignoring delete errors — is
+    /// identical, so it lives here as a single source of truth (#1618 S3).
+    async fn invalidate_cache_keys(&self, repo_key: &str, path: &str) -> Result<()> {
+        let keys = CacheKeys::derive(repo_key, path)?;
+
+        // Delete both content and metadata
+        let _ = self.storage.delete(&keys.content).await;
+        let _ = self.storage.delete(&keys.metadata).await;
+
         Ok(())
     }
 


### PR DESCRIPTION
Closes #1632

## Summary

Step **S3** of the #1618 proxy refactor: collapse the two byte-identical cache-invalidation methods on `ProxyService` into one shared private helper, shim-first and strictly behavior-preserving.

`invalidate_cache(&self, repo, path)` and `invalidate_cache_by_key(&self, repo_key, path)` had byte-identical bodies apart from how they obtained the repo key (`repo.key` vs the `repo_key` arg): derive both cache keys, then delete the content and metadata blobs in that order, ignoring delete errors. Review confirmed no divergence in logging, error handling, or delete ordering.

This PR introduces a private `invalidate_cache_keys(repo_key, path)` helper that derives the keys via `CacheKeys::derive` (the S1 single source of truth) and performs the two deletes. Both public methods become thin shims over it. Signatures, visibility, and **all call sites are unchanged**; behavior is preserved exactly (same two deletes, same order, same error handling). This reduces duplication.

Diff: 1 file, +17/-12 — only the two methods plus the new shared helper. No call-site edits, no renames.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (refactor)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Existing `proxy_service` unit tests already exercise the new shared helper: `test_invalidate_cache_by_key_deletes_both_content_and_metadata` covers the success path (both keys deleted, correct keys) and `test_invalidate_cache_by_key_rejects_invalid_path` covers the error path (`CacheKeys::derive` returns `Err` before any delete fires). Both pass; no new test required.

Local checks (green): `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` (10705 passed; the only failure is the pre-existing `services::http_client::tests::test_large_object_client_builder_does_not_apply_total_timeout`, which also fails on clean `main` in sandboxes lacking localhost networking and is unrelated to this change).

## API Changes
- [x] N/A - no API changes