### PR TITLE
test(auth): pin credential-change session invalidation on HTTP + gRPC (#1636)

### DIFF
--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -3441,6 +3441,110 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Credential-change session invalidation — HTTP plane (issue #1636,
+    // regression of #505). The HTTP auth middleware validates every request
+    // through `validate_access_token_async`, which shares the
+    // `invalidate_user_tokens` watermark map with the synchronous
+    // `validate_access_token` exercised here. A password change calls
+    // `invalidate_user_tokens(user_id)` (see
+    // `api::handlers::users::change_password`), so a JWT minted before that
+    // call MUST be rejected and a JWT minted after it MUST be accepted.
+    //
+    // This pins the invariant at the public `AuthService` token-validation
+    // surface so a refactor that drops the `is_token_invalidated` consult
+    // from `validate_access_token` is caught even when the lower-level
+    // `is_token_invalidated` unit tests still pass against the orphaned
+    // helper.
+    // -----------------------------------------------------------------------
+
+    /// Build a `super-secret`-keyed `AuthService` over a lazy (never-connected)
+    /// pool. The sync `validate_access_token` path performs no DB I/O, so the
+    /// lazy pool is sufficient and keeps this a pure unit test.
+    fn invalidation_test_service() -> (AuthService, Arc<Config>) {
+        let cfg = make_test_config();
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid:invalid@127.0.0.1:1/invalid")
+            .expect("connect_lazy never errors on construction");
+        (AuthService::new(pool, cfg.clone()), cfg)
+    }
+
+    /// Mint an access JWT for `user` with an explicit `iat` (seconds), signed
+    /// with the service's configured secret — exactly the shape the HTTP
+    /// middleware decodes.
+    fn mint_access_token_at(cfg: &Config, user: &User, iat: i64) -> String {
+        let claims = Claims {
+            sub: user.id,
+            username: user.username.clone(),
+            email: user.email.clone(),
+            is_admin: user.is_admin,
+            iat,
+            exp: iat + 3600,
+            token_type: "access".to_string(),
+            jti: None,
+            family_id: None,
+        };
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(cfg.jwt_secret.as_bytes()),
+        )
+        .expect("encode access token")
+    }
+
+    // `#[tokio::test]`: `connect_lazy` defers connection but its pool
+    // machinery still requires a Tokio reactor in scope on first touch. The
+    // sync `validate_access_token` performs no DB I/O, so no real connection
+    // is ever opened — the runtime is only needed for the lazy pool's
+    // construction guard.
+    #[tokio::test]
+    async fn test_http_token_minted_before_password_change_is_rejected() {
+        let (service, cfg) = invalidation_test_service();
+        let user = make_test_user();
+
+        // A token minted strictly before the credential change. We backdate
+        // `iat` by 10 s so the invalidation watermark (now, or now+1) lands
+        // strictly after it regardless of sub-second timing.
+        let pre_change_iat = Utc::now().timestamp() - 10;
+        let pre_change_token = mint_access_token_at(&cfg, &user, pre_change_iat);
+
+        // Before the password change the token is accepted on the HTTP plane.
+        assert!(
+            service.validate_access_token(&pre_change_token).is_ok(),
+            "freshly minted pre-change token should validate before invalidation"
+        );
+
+        // Password change fires `invalidate_user_tokens(user_id)`.
+        invalidate_user_tokens(user.id);
+
+        // The previously-valid token is now rejected — the #505 regression.
+        let err = service
+            .validate_access_token(&pre_change_token)
+            .expect_err("pre-change token MUST be rejected after credential change");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "rejection must be an authentication failure, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_http_token_minted_after_password_change_is_accepted() {
+        let (service, cfg) = invalidation_test_service();
+        let user = make_test_user();
+
+        // Credential change happens first.
+        invalidate_user_tokens(user.id);
+
+        // A token minted at least one whole second after the invalidation.
+        // The watermark is `now + 1` (#1436), so `now + 2` is strictly newer.
+        let post_change_iat = Utc::now().timestamp() + 2;
+        let post_change_token = mint_access_token_at(&cfg, &user, post_change_iat);
+
+        assert!(
+            service.validate_access_token(&post_change_token).is_ok(),
+            "a token minted after the credential change MUST be accepted"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // API-token cache invalidation on user deactivation (issue #931)
     // -----------------------------------------------------------------------
 

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -250,3 +250,130 @@ fn regression_ghsa_m597_h769_6qgp_gitlfs_list_locks_auth() {
         "challenge must echo the realm passed by the caller; got {challenge}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Bug — Credential-change session invalidation on the gRPC plane (#1636,
+//        original #505; gRPC gap tracked as #549/#551).
+// Class:  Session/JWT not invalidated after credential change.
+// Seam:   `grpc::auth_interceptor::AuthInterceptor::intercept` — the single
+//         token-validation entry point every gRPC request traverses.
+// What:   A password change calls
+//         `auth_service::invalidate_user_tokens(user_id)`, which bumps the
+//         per-user invalidation watermark consulted by BOTH transports: the
+//         HTTP middleware (via `validate_access_token_async`) and the gRPC
+//         interceptor here (via `is_token_invalidated[_replica_safe]`). Before
+//         the watermark existed, a JWT minted before the change kept
+//         authenticating on the gRPC plane until it expired.
+// Asserts: (1) a pre-change admin token is accepted by the interceptor;
+//          (2) after `invalidate_user_tokens`, the SAME token is rejected with
+//              `Unauthenticated` ("revoked"); and (3) a token minted after the
+//              change is accepted again. The HTTP-plane counterpart of this
+//              invariant is pinned by the lib unit tests
+//              `test_http_token_minted_before_password_change_is_rejected` /
+//              `..._after_..._is_accepted` in `services::auth_service`.
+//
+// The interceptor is constructed with `db = None`, which exercises the
+// in-memory fast-path (`is_token_invalidated`). That is the same map
+// `invalidate_user_tokens` writes and the same map the replica-safe DB path
+// serves as its cache, so this no-DB seam faithfully pins the cross-transport
+// invariant without requiring a live database (matching this file's
+// pure-helper testing contract).
+// ---------------------------------------------------------------------------
+mod credential_change_grpc {
+    use artifact_keeper_backend::grpc::auth_interceptor::AuthInterceptor;
+    use artifact_keeper_backend::services::auth_service::{invalidate_user_tokens, Claims};
+    use jsonwebtoken::{encode, EncodingKey, Header};
+    use tonic::Request;
+    use uuid::Uuid;
+
+    const SECRET: &str = "grpc-credential-change-regression-secret";
+
+    /// Mint an admin access JWT for `user_id` with an explicit `iat` (seconds),
+    /// signed with `SECRET` — the exact shape the interceptor decodes.
+    fn admin_token_at(user_id: Uuid, iat: i64) -> String {
+        let claims = Claims {
+            sub: user_id,
+            username: "grpc-user".to_string(),
+            email: "grpc-user@test.local".to_string(),
+            is_admin: true,
+            iat,
+            exp: iat + 3600,
+            token_type: "access".to_string(),
+            jti: None,
+            family_id: None,
+        };
+        encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(SECRET.as_bytes()),
+        )
+        .expect("encode admin access token")
+    }
+
+    fn request_with(token: &str) -> Request<()> {
+        let mut req = Request::new(());
+        req.metadata_mut()
+            .insert("authorization", format!("Bearer {token}").parse().unwrap());
+        req
+    }
+
+    #[test]
+    fn regression_1636_grpc_token_rejected_after_credential_change() {
+        // A distinct user per test run so the process-wide invalidation map
+        // never collides with a parallel test.
+        let user_id = Uuid::new_v4();
+        // Backdate `iat` 10 s so the invalidation watermark (now / now+1)
+        // lands strictly after the token regardless of sub-second timing.
+        let pre_change_iat = chrono::Utc::now().timestamp() - 10;
+        let pre_change_token = admin_token_at(user_id, pre_change_iat);
+
+        let interceptor = AuthInterceptor::new(SECRET, None);
+
+        // 1) Before the credential change the gRPC interceptor accepts it.
+        assert!(
+            interceptor
+                .intercept(request_with(&pre_change_token))
+                .is_ok(),
+            "pre-change admin token must be accepted before invalidation"
+        );
+
+        // 2) Password change fires `invalidate_user_tokens(user_id)`.
+        invalidate_user_tokens(user_id);
+
+        // 3) The SAME token is now rejected on the gRPC plane (#505/#549/#551).
+        let err = interceptor
+            .intercept(request_with(&pre_change_token))
+            .expect_err("pre-change token MUST be rejected after credential change");
+        assert_eq!(
+            err.code(),
+            tonic::Code::Unauthenticated,
+            "revoked token must surface as Unauthenticated, got {err:?}"
+        );
+        assert!(
+            err.message().contains("revoked"),
+            "rejection message must indicate revocation; got {}",
+            err.message()
+        );
+    }
+
+    #[test]
+    fn regression_1636_grpc_token_minted_after_change_is_accepted() {
+        let user_id = Uuid::new_v4();
+
+        // Credential change happens first.
+        invalidate_user_tokens(user_id);
+
+        // The watermark is `now + 1` (#1436); a token minted at `now + 2` is
+        // strictly newer and must be honoured.
+        let post_change_iat = chrono::Utc::now().timestamp() + 2;
+        let post_change_token = admin_token_at(user_id, post_change_iat);
+
+        let interceptor = AuthInterceptor::new(SECRET, None);
+        assert!(
+            interceptor
+                .intercept(request_with(&post_change_token))
+                .is_ok(),
+            "a token minted after the credential change MUST be accepted on gRPC"
+        );
+    }
+}


### PR DESCRIPTION
Closes #1636

## Summary

#1636 reports that sessions/JWTs are not invalidated after a credential change (orig #505), with the gRPC interceptor having the same gap (#549/#551). I investigated the current auth model before changing anything.

**Investigation finding: the invalidation mechanism is already implemented and wired on BOTH transports.** A per-user credential-change watermark is the single point both planes consult:

- **Tokens minted:** `AuthService::generate_tokens` (login) and refresh/OCI token-exchange embed `iat` (seconds) in the JWT `Claims`. There is no separate user-epoch claim; the floor lives server-side.
- **HTTP validation:** `auth_middleware` validates every request via `AuthService::validate_access_token_async` -> `is_token_invalidated_replica_safe` (DB-backed `password_changed_at`/`totp_verified_at` watermark, with a short in-memory cache).
- **gRPC validation:** `grpc::auth_interceptor::AuthInterceptor::intercept` consults the SAME `is_token_invalidated_replica_safe` (with DB) / `is_token_invalidated` (no-DB fast path) helpers.
- **Password change:** `change_password`, `reset_password`, and `force_password_change` all set `password_changed_at = NOW()`, call `invalidate_user_tokens(id)` (bumps the watermark), and revoke refresh-token families. `authenticate()` reads `password_hash` fresh from the DB on every login, so an old password cannot work after a change.

So the active defect described in #1636 is closed in mechanism by the chain of prior PRs (#931, #1023/#1027, #1173/#1190, #1174, #1248/#1265/#1436). **What was genuinely missing is regression coverage** that pins the cross-transport invariant so a future refactor cannot silently drop the check from one transport's public surface. Per the "stop before over-building" guidance, I did NOT add a parallel watermark or refactor the `TokenIat`/watermark model -- that consolidation is explicitly owned by #1394.

### What this PR adds

- **HTTP plane** (lib unit tests in `services::auth_service`): a JWT minted *before* `invalidate_user_tokens` is rejected by `validate_access_token`; one minted *after* is accepted. This is the regression that would have caught the original "old token still works" bug on the HTTP plane.
- **gRPC plane** (`tests/security_regression_tests.rs`, driving the real public `AuthInterceptor::intercept`): a pre-change admin token is accepted, then rejected with `Unauthenticated` ("revoked") after `invalidate_user_tokens`, and a post-change token is accepted again.

No schema, migration, sqlx-query, or mechanism changes.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`regression_1636_grpc_token_rejected_after_credential_change`, `regression_1636_grpc_token_minted_after_change_is_accepted` (gRPC), and `test_http_token_minted_before_password_change_is_rejected` / `test_http_token_minted_after_password_change_is_accepted` (HTTP) pin the invariant on both transports.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verification (in an isolated clone):
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean (exit 0)
- `cargo test --workspace --lib`: 10714 passed; the only failure is the pre-existing sandbox-only `services::http_client::tests::test_large_object_client_builder_does_not_apply_total_timeout` (network timeout, unrelated to this change).
- New gRPC regression tests: 7 passed in `security_regression_tests`.

## API Changes
- [x] N/A - no API changes