### PR TITLE
fix(promotion): repoint open-CVE gate from never-populated cve_history to scan_findings

### DIFF
--- a/backend/src/services/promotion_policy_service.rs
+++ b/backend/src/services/promotion_policy_service.rs
@@ -425,8 +425,27 @@ impl PromotionPolicyService {
             return Ok(None);
         };
 
+        // Open CVEs come from `scan_findings` (the populated source), not the
+        // never-written `cve_history` table. An artifact's open CVEs are the
+        // unacknowledged, cve_id-bearing findings from its latest completed
+        // scan -- the same `scan_findings` shape the SBOM read path uses. The
+        // old `cve_history` read was always empty, so a "block on open CVEs"
+        // gate silently passed (#1620; data source also addresses #1561).
         let cves: Vec<String> = sqlx::query_scalar(
-            r#"SELECT DISTINCT cve_id FROM cve_history WHERE artifact_id = $1 AND status = 'open' AND cve_id IS NOT NULL"#,
+            r#"
+            WITH latest_scan AS (
+                SELECT id
+                FROM scan_results
+                WHERE artifact_id = $1 AND status = 'completed'
+                ORDER BY created_at DESC
+                LIMIT 1
+            )
+            SELECT DISTINCT sf.cve_id
+            FROM scan_findings sf
+            JOIN latest_scan ls ON sf.scan_result_id = ls.id
+            WHERE sf.cve_id IS NOT NULL
+              AND NOT sf.is_acknowledged
+            "#,
         )
         .bind(artifact_id)
         .fetch_all(&self.db)

--- a/backend/src/services/promotion_policy_service.rs
+++ b/backend/src/services/promotion_policy_service.rs
@@ -43,6 +43,64 @@ pub struct LicenseSummary {
     pub unknown_licenses: Vec<String>,
 }
 
+/// Severity counts from the latest completed scan for an artifact, used to
+/// assemble a [`CveSummary`]. Lifted to module scope (out of the DB-bound
+/// `get_cve_summary` body) so the row -> summary assembly is unit-testable
+/// without a database.
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct ScanRow {
+    critical_count: i32,
+    high_count: i32,
+    medium_count: i32,
+    low_count: i32,
+    findings_count: i32,
+}
+
+/// SQL for the latest completed scan's severity counts for an artifact.
+const LATEST_SCAN_COUNTS_SQL: &str = r#"
+    SELECT critical_count, high_count, medium_count, low_count, findings_count
+    FROM scan_results
+    WHERE artifact_id = $1 AND status = 'completed'
+    ORDER BY created_at DESC
+    LIMIT 1
+"#;
+
+/// SQL for an artifact's open CVEs, sourced from `scan_findings` (the populated
+/// source), not the never-written `cve_history` table. An artifact's open CVEs
+/// are the unacknowledged, cve_id-bearing findings from its latest completed
+/// scan -- the same `scan_findings` shape the SBOM read path uses. The old
+/// `cve_history` read was always empty, so a "block on open CVEs" gate silently
+/// passed (#1620; data source also addresses #1561).
+const OPEN_CVES_SQL: &str = r#"
+    WITH latest_scan AS (
+        SELECT id
+        FROM scan_results
+        WHERE artifact_id = $1 AND status = 'completed'
+        ORDER BY created_at DESC
+        LIMIT 1
+    )
+    SELECT DISTINCT sf.cve_id
+    FROM scan_findings sf
+    JOIN latest_scan ls ON sf.scan_result_id = ls.id
+    WHERE sf.cve_id IS NOT NULL
+      AND NOT sf.is_acknowledged
+"#;
+
+/// Assemble a [`CveSummary`] from a latest-scan [`ScanRow`] and the open-CVE
+/// id list. Pure (no DB): the severity counts come straight from the scan row
+/// and `open_cves` is carried through verbatim. Kept separate from the SQL
+/// execution so the mapping is covered by unit tests.
+fn build_cve_summary(scan: ScanRow, open_cves: Vec<String>) -> CveSummary {
+    CveSummary {
+        critical_count: scan.critical_count,
+        high_count: scan.high_count,
+        medium_count: scan.medium_count,
+        low_count: scan.low_count,
+        total_count: scan.findings_count,
+        open_cves,
+    }
+}
+
 /// Evaluate CVE counts against a severity threshold, returning violations for
 /// any severity level that exceeds the implied limit.
 fn evaluate_cve_thresholds(
@@ -399,66 +457,21 @@ impl PromotionPolicyService {
     }
 
     async fn get_cve_summary(&self, artifact_id: Uuid) -> Result<Option<CveSummary>> {
-        #[derive(sqlx::FromRow)]
-        struct ScanRow {
-            critical_count: i32,
-            high_count: i32,
-            medium_count: i32,
-            low_count: i32,
-            findings_count: i32,
-        }
-
-        let scan: Option<ScanRow> = sqlx::query_as(
-            r#"
-            SELECT critical_count, high_count, medium_count, low_count, findings_count
-            FROM scan_results
-            WHERE artifact_id = $1 AND status = 'completed'
-            ORDER BY created_at DESC
-            LIMIT 1
-            "#,
-        )
-        .bind(artifact_id)
-        .fetch_optional(&self.db)
-        .await?;
+        let scan: Option<ScanRow> = sqlx::query_as(LATEST_SCAN_COUNTS_SQL)
+            .bind(artifact_id)
+            .fetch_optional(&self.db)
+            .await?;
 
         let Some(scan) = scan else {
             return Ok(None);
         };
 
-        // Open CVEs come from `scan_findings` (the populated source), not the
-        // never-written `cve_history` table. An artifact's open CVEs are the
-        // unacknowledged, cve_id-bearing findings from its latest completed
-        // scan -- the same `scan_findings` shape the SBOM read path uses. The
-        // old `cve_history` read was always empty, so a "block on open CVEs"
-        // gate silently passed (#1620; data source also addresses #1561).
-        let cves: Vec<String> = sqlx::query_scalar(
-            r#"
-            WITH latest_scan AS (
-                SELECT id
-                FROM scan_results
-                WHERE artifact_id = $1 AND status = 'completed'
-                ORDER BY created_at DESC
-                LIMIT 1
-            )
-            SELECT DISTINCT sf.cve_id
-            FROM scan_findings sf
-            JOIN latest_scan ls ON sf.scan_result_id = ls.id
-            WHERE sf.cve_id IS NOT NULL
-              AND NOT sf.is_acknowledged
-            "#,
-        )
-        .bind(artifact_id)
-        .fetch_all(&self.db)
-        .await?;
+        let open_cves: Vec<String> = sqlx::query_scalar(OPEN_CVES_SQL)
+            .bind(artifact_id)
+            .fetch_all(&self.db)
+            .await?;
 
-        Ok(Some(CveSummary {
-            critical_count: scan.critical_count,
-            high_count: scan.high_count,
-            medium_count: scan.medium_count,
-            low_count: scan.low_count,
-            total_count: scan.findings_count,
-            open_cves: cves,
-        }))
+        Ok(Some(build_cve_summary(scan, open_cves)))
     }
 
     async fn get_license_summary(&self, artifact_id: Uuid) -> Result<Option<LicenseSummary>> {
@@ -615,6 +628,74 @@ struct LicensePolicyConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // =======================================================================
+    // build_cve_summary tests (row -> summary assembly, no DB)
+    // =======================================================================
+
+    fn scan_row(critical: i32, high: i32, medium: i32, low: i32, findings: i32) -> ScanRow {
+        ScanRow {
+            critical_count: critical,
+            high_count: high,
+            medium_count: medium,
+            low_count: low,
+            findings_count: findings,
+        }
+    }
+
+    #[test]
+    fn test_build_cve_summary_maps_counts_and_carries_open_cves() {
+        let open = vec!["CVE-2021-44228".to_string(), "CVE-2019-10744".to_string()];
+        let summary = build_cve_summary(scan_row(1, 2, 3, 4, 10), open.clone());
+
+        assert_eq!(summary.critical_count, 1);
+        assert_eq!(summary.high_count, 2);
+        assert_eq!(summary.medium_count, 3);
+        assert_eq!(summary.low_count, 4);
+        // total_count maps from the scan row's findings_count, not the open-CVE len.
+        assert_eq!(summary.total_count, 10);
+        assert_eq!(summary.open_cves, open);
+    }
+
+    #[test]
+    fn test_build_cve_summary_empty_open_cves_is_passing_shape() {
+        let summary = build_cve_summary(scan_row(0, 0, 0, 0, 0), Vec::new());
+
+        assert!(summary.open_cves.is_empty());
+        assert_eq!(summary.total_count, 0);
+        // An all-zero summary with no open CVEs must not trip a block-on-CVE gate.
+        let violations = evaluate_cve_thresholds(&summary, "critical", true);
+        assert!(violations.is_empty());
+    }
+
+    #[test]
+    fn test_build_cve_summary_preserves_open_cve_order_and_dupes() {
+        // The helper carries the open-CVE list through verbatim; dedupe/order is
+        // the SQL's responsibility (DISTINCT), not this pure mapper's.
+        let open = vec![
+            "CVE-A".to_string(),
+            "CVE-A".to_string(),
+            "CVE-B".to_string(),
+        ];
+        let summary = build_cve_summary(scan_row(0, 1, 0, 0, 5), open.clone());
+        assert_eq!(summary.open_cves, open);
+    }
+
+    #[test]
+    fn test_open_cves_sql_targets_scan_findings_not_cve_history() {
+        // Guards the #1620 repoint: the query must read unacknowledged,
+        // cve_id-bearing rows from the latest completed scan's scan_findings,
+        // and must NOT touch the dead cve_history table.
+        assert!(OPEN_CVES_SQL.contains("FROM scan_findings"));
+        assert!(OPEN_CVES_SQL.contains("NOT sf.is_acknowledged"));
+        assert!(OPEN_CVES_SQL.contains("sf.cve_id IS NOT NULL"));
+        assert!(OPEN_CVES_SQL.contains("status = 'completed'"));
+        assert!(!OPEN_CVES_SQL.contains("cve_history"));
+
+        // The counts query feeds the same latest-completed-scan contract.
+        assert!(LATEST_SCAN_COUNTS_SQL.contains("FROM scan_results"));
+        assert!(LATEST_SCAN_COUNTS_SQL.contains("status = 'completed'"));
+    }
 
     // =======================================================================
     // evaluate_cve_thresholds tests

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -64,12 +64,14 @@ pub(crate) fn synth_cve_id(artifact_id: Uuid, cve_id: &str) -> Uuid {
 }
 
 /// Collect a case-insensitive (upper-cased) set of CVE identifiers from a
-/// slice of curated `CveHistoryEntry` rows.
+/// slice of `CveHistoryEntry` rows.
 ///
-/// Pulled out of the read paths so the dedupe-by-cve normalization is
-/// covered by unit tests without needing a database. The CVE-history
-/// pipeline calls this once per query to build the `known` set passed to
-/// `build_cve_entries_from_scan_findings`.
+/// Pulled out so the dedupe-by-cve normalization is covered by unit tests
+/// without needing a database. As of #1616/#1620 the read paths source CVE
+/// data solely from `scan_findings` (the `cve_history` reads were dead), so
+/// the production `known` set is always empty; this helper is retained for
+/// the dedupe-contract unit tests of `scan_row_passes_known_filter`.
+#[cfg(test)]
 pub(crate) fn build_known_cve_set(entries: &[CveHistoryEntry]) -> HashSet<String> {
     entries
         .iter()
@@ -557,20 +559,12 @@ FROM (
 ) inner_ranked
 "#;
 
-/// `fixed_cves` count: union of curated `cve_history` rows with status='fixed'
-/// and "fell off on rescan" CVEs, deduped by (artifact_id, cve_id). Repo-
-/// scoped variant. (#1375)
+/// `fixed_cves` count: "fell off on rescan" CVEs, deduped by (artifact_id,
+/// cve_id). Repo-scoped variant. The legacy `curated_fixed` CTE (from the
+/// never-written `cve_history` table) was dropped (#1616/#1620); only the
+/// `disappeared`-from-`scan_findings` half ever contributed real data. (#1375)
 pub(crate) const FIXED_CVES_COUNT_REPO_SQL: &str = r#"
-WITH curated_fixed AS (
-    SELECT DISTINCT ch.artifact_id, LOWER(ch.cve_id) AS cve_id
-    FROM cve_history ch
-    JOIN artifacts a ON ch.artifact_id = a.id
-    WHERE ch.status = 'fixed'
-      AND ch.cve_id IS NOT NULL
-      AND a.repository_id = $1
-      AND NOT a.is_deleted
-),
-latest_scans AS (
+WITH latest_scans AS (
     SELECT DISTINCT ON (sr.artifact_id, sr.scan_type)
         sr.id, sr.artifact_id, sr.scan_type
     FROM scan_results sr
@@ -598,26 +592,15 @@ disappeared AS (
     SELECT e.artifact_id, e.cve_id FROM ever_seen e
     EXCEPT
     SELECT s.artifact_id, s.cve_id FROM still_present s
-),
-unioned AS (
-    SELECT artifact_id, cve_id FROM curated_fixed
-    UNION
-    SELECT artifact_id, cve_id FROM disappeared
 )
-SELECT COUNT(*) FROM unioned
+SELECT COUNT(*) FROM disappeared
 "#;
 
-/// `fixed_cves` count, all-repos variant.
+/// `fixed_cves` count, all-repos variant. The legacy `curated_fixed` CTE
+/// (from the never-written `cve_history` table) was dropped (#1616/#1620);
+/// only the `disappeared`-from-`scan_findings` half ever contributed data.
 pub(crate) const FIXED_CVES_COUNT_ALL_SQL: &str = r#"
-WITH curated_fixed AS (
-    SELECT DISTINCT ch.artifact_id, LOWER(ch.cve_id) AS cve_id
-    FROM cve_history ch
-    JOIN artifacts a ON ch.artifact_id = a.id
-    WHERE ch.status = 'fixed'
-      AND ch.cve_id IS NOT NULL
-      AND NOT a.is_deleted
-),
-latest_scans AS (
+WITH latest_scans AS (
     SELECT DISTINCT ON (sr.artifact_id, sr.scan_type)
         sr.id, sr.artifact_id, sr.scan_type
     FROM scan_results sr
@@ -643,13 +626,8 @@ disappeared AS (
     SELECT e.artifact_id, e.cve_id FROM ever_seen e
     EXCEPT
     SELECT s.artifact_id, s.cve_id FROM still_present s
-),
-unioned AS (
-    SELECT artifact_id, cve_id FROM curated_fixed
-    UNION
-    SELECT artifact_id, cve_id FROM disappeared
 )
-SELECT COUNT(*) FROM unioned
+SELECT COUNT(*) FROM disappeared
 "#;
 
 /// `scan_findings` aggregate keyed on (artifact_id, cve_id), filtered by a
@@ -1006,40 +984,30 @@ impl SbomService {
     }
 
     /// Get CVE history for an artifact.
+    ///
+    /// Sourced entirely from `scan_findings`, the populated source of truth.
+    /// The legacy `cve_history` SELECT was dropped (#1616/#1620): the table is
+    /// never written, so it only ever returned empty rows. We still de-dupe by
+    /// `cve_id` (case-insensitive) for safety. The `cve_history` table itself
+    /// is retained per migration 112 (v1.3.0 owns the drop).
     pub async fn get_cve_history(&self, artifact_id: Uuid) -> Result<Vec<CveHistoryEntry>> {
-        // Primary source: legacy `cve_history` table (manual / promoted entries).
-        let mut entries = sqlx::query_as::<_, CveHistoryEntry>(
-            r#"
-            SELECT * FROM cve_history
-            WHERE artifact_id = $1
-            ORDER BY first_detected_at DESC
-            "#,
-        )
-        .bind(artifact_id)
-        .fetch_all(&self.db)
-        .await?;
-
-        // Fallback / supplement: derive CVE-shaped entries from `scan_findings`
-        // for findings the scanner produced but never wrote into `cve_history`
-        // (see #1375: `record_cve` is presently dead code, so the scan-derived
-        // path is the only source of real CVE data). De-dupe by `cve_id` so a
-        // CVE that exists in both tables surfaces once with the curated row.
-        // Normalize to upper-case so the dedupe is case-insensitive (schema
-        // does not constrain `cve_id` case in either table).
-        let known = build_known_cve_set(&entries);
-        let scan_entries = self
+        // Derive CVE-shaped entries from `scan_findings` -- the only source of
+        // real CVE data (see #1375: `record_cve` is dead code, `cve_history`
+        // has zero writers). Empty known-set: no curated rows to dedupe against.
+        let known = HashSet::new();
+        let mut entries = self
             .build_cve_entries_from_scan_findings(Some(artifact_id), None, &known)
             .await?;
-        entries.extend(scan_entries);
         sort_entries_by_first_detected_desc(&mut entries);
         Ok(entries)
     }
 
     /// Get CVE history for a single CVE identifier across artifacts.
     ///
-    /// Reads from both `cve_history` (curated rows) and `scan_findings` (live
-    /// scanner output) so that callers see the full set of artifacts where
-    /// this CVE has ever been detected.
+    /// Reads from `scan_findings` (live scanner output) so that callers see
+    /// the full set of artifacts where this CVE has ever been detected. The
+    /// legacy `cve_history` read was dropped (#1616/#1620): that table is never
+    /// written, so it only ever returned empty rows.
     ///
     /// # `allowed_repo_ids` contract (ADMIN-ONLY when `None`)
     ///
@@ -1078,60 +1046,23 @@ impl SbomService {
         // upper-cased form for display/known-set dedupe below.
         let cve_id_upper = cve_id.to_ascii_uppercase();
 
-        // 1. Curated rows from cve_history. We join through artifacts so we
-        //    can filter by allowed_repo_ids without a second round-trip.
-        //    LOWER(...)=LOWER(...) so a scanner that wrote lower-case still
-        //    matches an upper-case query (and vice versa).
-        let mut entries: Vec<CveHistoryEntry> = if let Some(repo_ids) = allowed_repo_ids {
-            sqlx::query_as::<_, CveHistoryEntry>(
-                r#"
-                SELECT ch.*
-                FROM cve_history ch
-                JOIN artifacts a ON ch.artifact_id = a.id
-                WHERE LOWER(ch.cve_id) = LOWER($1)
-                  AND a.repository_id = ANY($2)
-                  AND NOT a.is_deleted
-                ORDER BY ch.first_detected_at DESC
-                "#,
-            )
-            .bind(&cve_id_upper)
-            .bind(repo_ids)
-            .fetch_all(&self.db)
-            .await?
-        } else {
-            sqlx::query_as::<_, CveHistoryEntry>(
-                r#"
-                SELECT ch.*
-                FROM cve_history ch
-                JOIN artifacts a ON ch.artifact_id = a.id
-                WHERE LOWER(ch.cve_id) = LOWER($1)
-                  AND NOT a.is_deleted
-                ORDER BY ch.first_detected_at DESC
-                "#,
-            )
-            .bind(&cve_id_upper)
-            .fetch_all(&self.db)
-            .await?
-        };
-
-        // 2. Live findings from scan_findings, skipping cve_ids we already
-        //    surfaced via the curated path. `known` is normalized so the
-        //    dedupe is case-insensitive too.
-        let known = build_known_cve_set(&entries);
+        // Live findings from `scan_findings`, the only populated source. The
+        // legacy `cve_history` SELECT was dropped (#1616/#1620): the table is
+        // never written, so it only ever contributed empty rows. Empty
+        // known-set: no curated rows to dedupe against.
+        let known = HashSet::new();
         let scan_entries = self
             .build_cve_entries_from_scan_findings(None, Some(&cve_id_upper), &known)
             .await?;
-        // For scan-derived entries we additionally enforce the repo filter
-        // (artifact-level lookup already enforced it inside the helper, so
-        // here we only need to re-scope by allowed_repo_ids).
-        let scan_entries = match allowed_repo_ids {
+        // Enforce the repo filter on scan-derived entries (they are synthesized
+        // on the fly, so the filter cannot live in the SQL `WHERE`).
+        let mut entries = match allowed_repo_ids {
             None => scan_entries,
             Some(repo_ids) => {
                 let allowed: HashSet<Uuid> = repo_ids.iter().copied().collect();
                 self.filter_entries_by_repo(scan_entries, &allowed).await?
             }
         };
-        entries.extend(scan_entries);
         sort_entries_by_first_detected_desc(&mut entries);
         Ok(entries)
     }
@@ -1376,15 +1307,12 @@ impl SbomService {
     /// direct equivalent in `scan_findings`. We approximate:
     ///   - open: findings where `NOT is_acknowledged`
     ///   - acknowledged: findings where `is_acknowledged`
-    ///   - fixed: union of two sources, deduped by (artifact_id, cve_id):
-    ///     (a) curated `cve_history` rows with `status='fixed'` (preserves
-    ///     the legacy admin/promotion-policy semantic for the rare callers
-    ///     that write to that table); plus
-    ///     (b) CVEs that appeared in an earlier `scan_findings` row for an
+    ///   - fixed: CVEs that appeared in an earlier `scan_findings` row for an
     ///     artifact but are absent from that artifact's most recent
     ///     `scan_results` (per `scan_type`). "Disappeared on rescan" is the
     ///     closest signal we have to a fixed CVE without a real fixed-at
-    ///     timestamp.
+    ///     timestamp. (#1616/#1620 dropped the dead `cve_history` curated half,
+    ///     which always contributed zero.)
     ///
     /// We dedupe by (artifact_id, cve_id) so multi-scanner overlap doesn't
     /// double-count a single vulnerability.
@@ -1428,13 +1356,10 @@ impl SbomService {
 
         let timeline = project_timeline_rows(&timeline_rows, Utc::now());
 
-        // fixed_cves: union of two definitions, deduped by (artifact_id, cve_id):
-        //   (a) curated `cve_history` rows with status='fixed'
-        //   (b) CVEs present in an earlier scan_findings row for an artifact
-        //       but absent from that artifact's most recent scan_result per
-        //       scan_type (i.e. they "fell off" on rescan)
-        // This avoids the silent-zero regression while still being correct
-        // when no curated rows exist.
+        // fixed_cves: CVEs present in an earlier scan_findings row for an
+        // artifact but absent from that artifact's most recent scan_result per
+        // scan_type (i.e. they "fell off" on rescan). #1616/#1620 dropped the
+        // dead `cve_history` curated-fixed half, which was always empty.
         let fixed_cves: i64 = if let Some(repo_id) = repository_id {
             sqlx::query_scalar(FIXED_CVES_COUNT_REPO_SQL)
                 .bind(repo_id)
@@ -4075,18 +4000,20 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_cves_count_repo_sql_unions_curated_and_disappeared() {
-        // fixed = curated_fixed UNION disappeared (dedup by artifact_id +
-        // cve_id). Losing either CTE would silently zero one of the two
-        // signals.
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("WITH curated_fixed AS"));
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("latest_scans AS"));
+    fn test_fixed_cves_count_repo_sql_counts_disappeared_from_scan_findings() {
+        // fixed = disappeared (ever_seen EXCEPT still_present, from
+        // scan_findings). The legacy `curated_fixed` CTE was dropped
+        // (#1616/#1620): `cve_history` is never written, so it always added
+        // zero. The scan-derived CTE chain must survive.
+        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("WITH latest_scans AS"));
         assert!(FIXED_CVES_COUNT_REPO_SQL.contains("ever_seen AS"));
         assert!(FIXED_CVES_COUNT_REPO_SQL.contains("still_present AS"));
         assert!(FIXED_CVES_COUNT_REPO_SQL.contains("disappeared AS"));
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("SELECT artifact_id, cve_id FROM curated_fixed"));
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("UNION"));
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("SELECT artifact_id, cve_id FROM disappeared"));
+        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("SELECT COUNT(*) FROM disappeared"));
+        // The dead curated path must be gone, not merely unused.
+        assert!(!FIXED_CVES_COUNT_REPO_SQL.contains("curated_fixed"));
+        assert!(!FIXED_CVES_COUNT_REPO_SQL.contains("cve_history"));
+        assert!(!FIXED_CVES_COUNT_REPO_SQL.contains("UNION"));
     }
 
     #[test]
@@ -4115,11 +4042,15 @@ mod tests {
     }
 
     #[test]
-    fn test_fixed_cves_count_repo_sql_curated_fixed_uses_status_fixed() {
-        // Curated fixed rows must filter by status='fixed', not by the
-        // acknowledged column (a different semantic).
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("ch.status = 'fixed'"));
-        assert!(FIXED_CVES_COUNT_ALL_SQL.contains("ch.status = 'fixed'"));
+    fn test_fixed_cves_count_sql_drops_dead_cve_history_curated_path() {
+        // #1616/#1620: the `curated_fixed` CTE read from the never-written
+        // `cve_history` table and always contributed zero. Both variants must
+        // count fixed CVEs solely from the scan-derived `disappeared` CTE.
+        assert!(!FIXED_CVES_COUNT_REPO_SQL.contains("cve_history"));
+        assert!(!FIXED_CVES_COUNT_ALL_SQL.contains("cve_history"));
+        assert!(!FIXED_CVES_COUNT_REPO_SQL.contains("curated_fixed"));
+        assert!(!FIXED_CVES_COUNT_ALL_SQL.contains("curated_fixed"));
+        assert!(FIXED_CVES_COUNT_ALL_SQL.contains("SELECT COUNT(*) FROM disappeared"));
     }
 
     #[test]
@@ -4131,10 +4062,10 @@ mod tests {
 
     #[test]
     fn test_fixed_cves_count_repo_sql_lowercases_cve_id() {
-        // The dedupe is on LOWER(cve_id) so the curated and scan paths
-        // collide regardless of how each side cased the id.
-        assert!(FIXED_CVES_COUNT_REPO_SQL.contains("LOWER(ch.cve_id)"));
+        // The scan-derived CTEs normalize on LOWER(cve_id) so the ever_seen /
+        // still_present EXCEPT collides regardless of how the scanner cased id.
         assert!(FIXED_CVES_COUNT_REPO_SQL.contains("LOWER(sf.cve_id)"));
+        assert!(FIXED_CVES_COUNT_ALL_SQL.contains("LOWER(sf.cve_id)"));
     }
 
     #[test]

--- a/backend/tests/promotion_open_cve_gating_tests.rs
+++ b/backend/tests/promotion_open_cve_gating_tests.rs
@@ -1,0 +1,328 @@
+//! Regression tests for #1620: promotion gating must read open CVEs from the
+//! populated `scan_findings` table, not the never-written `cve_history` table.
+//!
+//! Before the fix, `PromotionPolicyService::get_cve_summary` ran
+//! `SELECT DISTINCT cve_id FROM cve_history WHERE artifact_id = $1 AND
+//! status = 'open'`. `cve_history` has zero writers, so `open_cves` was always
+//! empty and a "block on open CVEs" gate silently passed -- a security gate
+//! that did nothing. The fix repoints the read at `scan_findings` (the source
+//! the scanner pipeline actually writes), so the gate blocks as configured.
+//! This also addresses the #1561 data-source confusion (#1616 umbrella).
+//!
+//! Run with:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test promotion_open_cve_gating_tests -- --ignored
+//! ```
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use artifact_keeper_backend::models::sbom::PolicyAction;
+use artifact_keeper_backend::services::promotion_policy_service::PromotionPolicyService;
+use artifact_keeper_backend::services::sbom_service::SbomService;
+
+async fn create_repo(pool: &PgPool, suffix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let key = format!("test-1620-{}-{}", suffix, id);
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+         VALUES ($1, $2, $3, $4, 'local', 'generic')",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(&key)
+    .bind(format!("/tmp/test-{}", id))
+    .execute(pool)
+    .await
+    .expect("insert repo");
+    id
+}
+
+async fn create_artifact(pool: &PgPool, repo_id: Uuid, name: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let path = format!("{}/{}", repo_id, name);
+    let checksum = format!("{:0>64}", format!("{:x}", id.as_u128() & 0xffff_ffff));
+    sqlx::query(
+        r#"
+        INSERT INTO artifacts (id, repository_id, name, path, size_bytes, checksum_sha256,
+                               content_type, storage_key, is_deleted)
+        VALUES ($1, $2, $3, $4, 1024, $5, 'application/octet-stream', $4, false)
+        "#,
+    )
+    .bind(id)
+    .bind(repo_id)
+    .bind(name)
+    .bind(&path)
+    .bind(&checksum)
+    .execute(pool)
+    .await
+    .expect("insert artifact");
+    id
+}
+
+/// Insert one completed scan, finished `age_seconds` ago, with a single
+/// critical finding carrying `cve_id`. `acknowledged` controls the finding's
+/// `is_acknowledged` flag. Returns the scan_result id.
+async fn insert_scan_with_cve_at(
+    pool: &PgPool,
+    artifact_id: Uuid,
+    repo_id: Uuid,
+    cve_id: &str,
+    acknowledged: bool,
+    age_seconds: i64,
+) -> Uuid {
+    let scan_id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO scan_results (
+            id, artifact_id, repository_id, scan_type, status,
+            findings_count, critical_count, high_count, medium_count, low_count, info_count,
+            started_at, completed_at
+        )
+        VALUES ($1, $2, $3, 'image', 'completed', 1, 1, 0, 0, 0, 0,
+                NOW() - make_interval(secs => $4::double precision),
+                NOW() - make_interval(secs => $4::double precision))
+        "#,
+    )
+    .bind(scan_id)
+    .bind(artifact_id)
+    .bind(repo_id)
+    .bind(age_seconds as f64)
+    .execute(pool)
+    .await
+    .expect("insert scan_result");
+
+    sqlx::query(
+        "INSERT INTO scan_findings \
+         (scan_result_id, artifact_id, severity, title, cve_id, source, is_acknowledged) \
+         VALUES ($1, $2, 'critical', $3, $4, 'test', $5)",
+    )
+    .bind(scan_id)
+    .bind(artifact_id)
+    .bind(format!("Finding for {}", cve_id))
+    .bind(cve_id)
+    .bind(acknowledged)
+    .execute(pool)
+    .await
+    .expect("insert scan_finding");
+
+    scan_id
+}
+
+/// Convenience wrapper: a scan completed "now".
+async fn insert_scan_with_cve(
+    pool: &PgPool,
+    artifact_id: Uuid,
+    repo_id: Uuid,
+    cve_id: &str,
+    acknowledged: bool,
+) -> Uuid {
+    insert_scan_with_cve_at(pool, artifact_id, repo_id, cve_id, acknowledged, 0).await
+}
+
+/// Insert a repo-scoped scan policy that blocks on any CVE at/above critical.
+async fn insert_blocking_policy(pool: &PgPool, repo_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO scan_policies (id, name, repository_id, max_severity, block_on_fail, is_enabled) \
+         VALUES ($1, $2, $3, 'critical', true, true)",
+    )
+    .bind(Uuid::new_v4())
+    .bind("block-on-open-cves")
+    .bind(repo_id)
+    .execute(pool)
+    .await
+    .expect("insert scan_policy");
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid) {
+    sqlx::query("DELETE FROM scan_policies WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query(
+        "DELETE FROM scan_findings WHERE scan_result_id IN \
+         (SELECT id FROM scan_results WHERE repository_id = $1)",
+    )
+    .bind(repo_id)
+    .execute(pool)
+    .await
+    .ok();
+    sqlx::query("DELETE FROM scan_results WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+async fn connect() -> PgPool {
+    PgPool::connect(&std::env::var("DATABASE_URL").expect("DATABASE_URL"))
+        .await
+        .expect("connect")
+}
+
+/// The #1620 regression: an artifact whose only CVE evidence lives in
+/// `scan_findings` (unacknowledged) must surface a NON-EMPTY `open_cves` set
+/// and BLOCK promotion. On `main` (reading the empty `cve_history`) this set
+/// was empty and the gate silently passed.
+#[tokio::test]
+#[ignore]
+async fn test_unacknowledged_scan_finding_blocks_promotion() {
+    let pool = connect().await;
+    let repo_id = create_repo(&pool, "block").await;
+    let artifact_id = create_artifact(&pool, repo_id, "vuln-image").await;
+    insert_scan_with_cve(&pool, artifact_id, repo_id, "CVE-2021-44228", false).await;
+    insert_blocking_policy(&pool, repo_id).await;
+
+    // Sanity: the legacy table the OLD query read is genuinely empty for this
+    // artifact, so the pre-fix code path would have returned `open_cves = []`
+    // and let the artifact through. This proves the test exercises the bug.
+    let legacy_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM cve_history WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count cve_history");
+    assert_eq!(
+        legacy_count.0, 0,
+        "fixture must reproduce #1620: cve_history is empty, so the old read returned no open CVEs"
+    );
+
+    let svc = PromotionPolicyService::new(pool.clone());
+    let result = svc
+        .evaluate_artifact(artifact_id, repo_id)
+        .await
+        .expect("evaluate_artifact");
+
+    let summary = result.cve_summary.expect("cve_summary present");
+    assert_eq!(
+        summary.open_cves,
+        vec!["CVE-2021-44228".to_string()],
+        "open_cves must be sourced from scan_findings, not the empty cve_history (#1620)"
+    );
+    assert!(
+        !result.passed,
+        "promotion must be BLOCKED when an unacknowledged scan_findings CVE exists (#1620)"
+    );
+    assert_eq!(
+        result.action,
+        PolicyAction::Block,
+        "a configured block-on-CVE gate must produce PolicyAction::Block (#1620)"
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+/// An acknowledged finding must NOT count as an open CVE: the repointed query
+/// filters on `NOT is_acknowledged`. With no other open CVEs and no critical
+/// counts in play, `open_cves` is empty.
+#[tokio::test]
+#[ignore]
+async fn test_acknowledged_scan_finding_is_not_open() {
+    let pool = connect().await;
+    let repo_id = create_repo(&pool, "ack").await;
+    let artifact_id = create_artifact(&pool, repo_id, "ack-image").await;
+    insert_scan_with_cve(&pool, artifact_id, repo_id, "CVE-2019-10744", true).await;
+
+    let svc = PromotionPolicyService::new(pool.clone());
+    let result = svc
+        .evaluate_artifact(artifact_id, repo_id)
+        .await
+        .expect("evaluate_artifact");
+
+    let summary = result.cve_summary.expect("cve_summary present");
+    assert!(
+        summary.open_cves.is_empty(),
+        "an acknowledged finding must not appear in open_cves (NOT is_acknowledged filter)"
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+/// Only the LATEST completed scan defines the open-CVE set. A CVE that was
+/// present in an older scan but absent from the newest completed scan must not
+/// surface as open (it "fell off" on rescan).
+#[tokio::test]
+#[ignore]
+async fn test_open_cves_use_latest_completed_scan_only() {
+    let pool = connect().await;
+    let repo_id = create_repo(&pool, "latest").await;
+    let artifact_id = create_artifact(&pool, repo_id, "rescanned-image").await;
+
+    // Older scan (1 hour ago) with a CVE that later gets fixed.
+    insert_scan_with_cve_at(&pool, artifact_id, repo_id, "CVE-2020-0001", false, 3600).await;
+
+    // Newer completed scan (now) with a DIFFERENT, still-open CVE; the old one
+    // is gone from the latest scan.
+    insert_scan_with_cve(&pool, artifact_id, repo_id, "CVE-2022-2222", false).await;
+
+    let svc = PromotionPolicyService::new(pool.clone());
+    let result = svc
+        .evaluate_artifact(artifact_id, repo_id)
+        .await
+        .expect("evaluate_artifact");
+
+    let summary = result.cve_summary.expect("cve_summary present");
+    assert_eq!(
+        summary.open_cves,
+        vec!["CVE-2022-2222".to_string()],
+        "open_cves must reflect the latest completed scan only; the fixed CVE must drop off"
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+/// Companion to the promotion fix: the findings read path (`get_cve_history`)
+/// must return the scan-derived entry for an artifact whose CVE evidence lives
+/// only in `scan_findings`. On `main` this read started from the empty
+/// `cve_history` table; the repointed code derives entries from `scan_findings`
+/// directly (#1561 data source / #1616 umbrella).
+#[tokio::test]
+#[ignore]
+async fn test_get_cve_history_returns_scan_derived_entry() {
+    let pool = connect().await;
+    let repo_id = create_repo(&pool, "history").await;
+    let artifact_id = create_artifact(&pool, repo_id, "history-image").await;
+    insert_scan_with_cve(&pool, artifact_id, repo_id, "CVE-2023-3333", false).await;
+
+    // The legacy table is empty, so any returned entry must come from the
+    // repointed scan_findings read.
+    let legacy_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM cve_history WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count cve_history");
+    assert_eq!(
+        legacy_count.0, 0,
+        "cve_history must be empty for this fixture"
+    );
+
+    let svc = SbomService::new(pool.clone());
+    let entries = svc
+        .get_cve_history(artifact_id)
+        .await
+        .expect("get_cve_history");
+
+    assert_eq!(
+        entries.len(),
+        1,
+        "get_cve_history must surface the scan-derived CVE entry"
+    );
+    assert_eq!(entries[0].cve_id, "CVE-2023-3333");
+    assert_eq!(entries[0].artifact_id, artifact_id);
+
+    cleanup(&pool, repo_id).await;
+}


### PR DESCRIPTION
Closes #1620

## Summary
Promotion quality-gates read open CVEs via `SELECT DISTINCT cve_id FROM cve_history WHERE artifact_id = $1 AND status = 'open'` (`promotion_policy_service.rs`). The `cve_history` table has **zero writers**, so `open_cves` was always empty and a configured "block on open CVEs" gate **silently passed** — a security gate that did nothing.

This repoints the read at `scan_findings`, the populated source of truth. An artifact's open CVEs are now the unacknowledged, cve_id-bearing findings from its latest completed scan (the same `scan_findings` shape the SBOM read path already uses). A configured block-on-CVE gate now actually blocks.

It also repoints the remaining dead `cve_history` reads in `sbom_service.rs` flagged by the decision doc (`docs/audits/decision-cve_history-2026-06-04.md`):
- `get_cve_history` / `get_cve_history_by_cve_id` now derive entries directly from `scan_findings`; the dead `cve_history` SELECT blocks are removed while the dedupe + `filter_entries_by_repo` behavior is retained.
- `FIXED_CVES_COUNT_{REPO,ALL}_SQL` drop the always-empty `curated_fixed` CTE and keep the `disappeared`-from-`scan_findings` half.

This also addresses the data source behind #1561 and is part of the #1616 umbrella.

**Explicitly NOT in scope (reversible, code-only):**
- The `cve_history` table is **not** dropped (retained per migration 112; the DROP is a separate v1.3.0 item with a data-preserving migration).
- `record_cve` and the `POST /sbom/cve/status/:id` route are **not** removed.
- No migration, no route changes, no DTO changes.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The new `backend/tests/promotion_open_cve_gating_tests.rs::test_unacknowledged_scan_finding_blocks_promotion` creates an artifact with an unacknowledged `scan_findings` CVE plus a block-on-CVE policy, asserts `cve_history` is empty (reproducing the bug condition that made the old read pass), then asserts `open_cves` is non-empty and promotion is **BLOCKED** (`PolicyAction::Block`). This fails on `main` and passes here. Companion tests cover acknowledged-finding exclusion, latest-scan-only semantics, and `get_cve_history` returning the scan-derived entry.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes