### PR TITLE
feat(oci): manifest_blob_refs table + push-write + startup backfill (#1635)

### DIFF
--- a/backend/migrations/120_manifest_blob_refs.sql
+++ b/backend/migrations/120_manifest_blob_refs.sql
@@ -1,0 +1,53 @@
+-- OCI manifest -> blob reference tracking (artifact-keeper#1635).
+--
+-- GC prerequisite for #1408 / #1610. Today there is no manifest->blob
+-- reference table, so nothing can safely judge an `oci_blobs` row
+-- orphaned: a prior per-`(repo,digest)` heuristic already broke 57
+-- production blobs. Blob deletion MUST NOT ship until these edges exist.
+--
+-- A regular OCI/Docker *image* manifest (content-type
+-- `application/vnd.oci.image.manifest.v1+json` or the Docker equivalent
+-- `application/vnd.docker.distribution.manifest.v2+json`) references the
+-- blobs that make up the image: a single `config` blob plus one
+-- `layers[]` blob per layer. Those layer/config digests live in
+-- `oci_blobs` (storage key `oci-blobs/<digest>`) but nothing currently
+-- records *which* manifest pulled them in, so the storage GC has no safe
+-- reverse lookup from a blob digest back to the manifests that need it.
+--
+-- This table records, for every image manifest pushed through (or
+-- backfilled into) this registry, the (manifest_digest -> blob_digest)
+-- edges, scoped per repository. `kind` distinguishes the config blob
+-- ('config') from layer blobs ('layer') for diagnostics; it is not part
+-- of the primary key because a blob digest can only play one role within
+-- a given manifest.
+--
+-- Image *index* manifests (a.k.a. manifest lists,
+-- `application/vnd.oci.image.index.v1+json` /
+-- `application/vnd.docker.distribution.manifest.list.v2+json`) carry no
+-- blobs of their own -- they reference per-architecture child manifests,
+-- which are tracked separately in `oci_manifest_refs` (#1179). No rows
+-- are written here for index manifests.
+--
+-- Rows are written at manifest-PUT time by the OCI v2 handler. A
+-- one-shot startup backfill walks image manifests reachable via
+-- `oci_tags` / `oci_manifest_refs.child_digest` that have zero rows
+-- here, loads each manifest body from storage, parses it, and inserts the
+-- edges. Both writers use `ON CONFLICT DO NOTHING` so the table is safe
+-- to populate from either source repeatedly.
+--
+-- ADDITIVE ONLY: this migration and its writers make blob references
+-- KNOWABLE. No deletion logic of any kind is added by #1635.
+
+CREATE TABLE manifest_blob_refs (
+    manifest_digest TEXT NOT NULL,
+    blob_digest TEXT NOT NULL,
+    repository_id UUID NOT NULL REFERENCES repositories(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (manifest_digest, blob_digest, repository_id)
+);
+
+-- The GC reverse-lookup hot path keys on blob_digest ("given a blob, is
+-- any manifest still referencing it?"). The primary key leads with
+-- manifest_digest, so that lookup needs its own index.
+CREATE INDEX idx_manifest_blob_refs_blob ON manifest_blob_refs(blob_digest);

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -1568,6 +1568,109 @@ pub(crate) async fn record_oci_manifest_refs(
     Ok(res.rows_affected() as usize)
 }
 
+/// A single (blob_digest, kind) edge extracted from an image manifest.
+/// `kind` is `"config"` for the config blob and `"layer"` for each layer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlobRef {
+    pub digest: String,
+    pub kind: &'static str,
+}
+
+/// Parse an OCI / Docker *image* manifest body and return the blob edges
+/// it pulls in: the single `config.digest` (kind `"config"`) plus every
+/// `layers[].digest` (kind `"layer"`). Used by both the push handler (to
+/// populate `manifest_blob_refs` synchronously) and the startup backfill
+/// (to reconstruct rows for manifests that pre-date this code) for #1635.
+///
+/// Returns an empty vec when the body is not parseable as JSON or carries
+/// no `config`/`layers` blobs. An image *index* (manifest list) has
+/// neither a `config` nor a `layers` array -- it lists child manifests
+/// under `manifests[]` -- so passing an index body here yields an empty
+/// vec. Callers are still expected to gate on [`is_index_content_type`]
+/// so index manifests never reach this path, but the empty-vec behaviour
+/// makes a stray call harmless.
+///
+/// Malformed entries (missing or non-string `digest`) are skipped rather
+/// than erroring, mirroring [`extract_child_digests`]: a single
+/// non-conformant manifest must not block blob-reference recording for
+/// the rest of the corpus.
+pub fn extract_blob_refs(body: &[u8]) -> Vec<BlobRef> {
+    let json: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    let mut refs = Vec::new();
+    if let Some(cfg) = json
+        .get("config")
+        .and_then(|c| c.get("digest"))
+        .and_then(|d| d.as_str())
+    {
+        refs.push(BlobRef {
+            digest: cfg.to_string(),
+            kind: "config",
+        });
+    }
+    if let Some(layers) = json.get("layers").and_then(|l| l.as_array()) {
+        for layer in layers {
+            if let Some(d) = layer.get("digest").and_then(|d| d.as_str()) {
+                refs.push(BlobRef {
+                    digest: d.to_string(),
+                    kind: "layer",
+                });
+            }
+        }
+    }
+    refs
+}
+
+/// Insert (manifest_digest, blob_digest, repository_id, kind) rows into
+/// `manifest_blob_refs` for every config/layer blob of an image manifest.
+/// Idempotent: on conflict the existing row is kept.
+///
+/// Called inline from `handle_put_manifest` and from the startup backfill.
+/// The caller is responsible for verifying that `manifest_body` is a
+/// regular image manifest (NOT an image index -- use
+/// [`is_index_content_type`]); passing an index body just inserts zero
+/// rows because it has no config/layers.
+///
+/// ADDITIVE ONLY (#1635): this records references so a future GC can judge
+/// blob orphanhood safely. It performs no deletion.
+///
+/// Performance: the inserts run as a single round-trip via `UNNEST` so a
+/// manifest with N layers costs one DB call, not N. This matters because
+/// `handle_put_manifest` calls this synchronously on the request hot path.
+pub async fn record_manifest_blob_refs(
+    db: &PgPool,
+    repo_id: Uuid,
+    manifest_digest: &str,
+    manifest_body: &[u8],
+) -> Result<usize, sqlx::Error> {
+    let refs = extract_blob_refs(manifest_body);
+    if refs.is_empty() {
+        return Ok(0);
+    }
+    // Split into parallel arrays so a single UNNEST round-trip can pair
+    // each blob digest with its kind, all against the constant
+    // manifest_digest / repo_id.
+    let blob_digests: Vec<String> = refs.iter().map(|r| r.digest.clone()).collect();
+    let kinds: Vec<String> = refs.iter().map(|r| r.kind.to_string()).collect();
+    let res = sqlx::query(
+        r#"
+        INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
+        SELECT $1, blob, $4, knd
+        FROM UNNEST($2::text[], $3::text[]) AS t(blob, knd)
+        ON CONFLICT (manifest_digest, blob_digest, repository_id) DO NOTHING
+        "#,
+    )
+    .bind(manifest_digest)
+    .bind(&blob_digests)
+    .bind(&kinds)
+    .bind(repo_id)
+    .execute(db)
+    .await?;
+    Ok(res.rows_affected() as usize)
+}
+
 // ---------------------------------------------------------------------------
 // Tags/list and catalog response types
 // ---------------------------------------------------------------------------
@@ -5271,6 +5374,28 @@ async fn handle_put_manifest(
                 error = %e,
                 "Failed to record oci_manifest_refs for index manifest; storage GC may treat \
                  child manifests as orphaned until the next backfill pass runs"
+            );
+        }
+    } else {
+        // For regular (non-index) image manifests, record the
+        // (manifest_digest -> blob_digest) edges (config + layers) so a
+        // future blob GC can safely judge `oci_blobs` orphanhood (#1635).
+        // Image indexes carry no blobs of their own, so they are skipped
+        // here; their child manifests are tracked via oci_manifest_refs
+        // above and each child records its own blob refs on its own PUT.
+        //
+        // Best-effort: a failure to write the refs is logged but does not
+        // fail the push, since the manifest and tag/artifact rows are
+        // already persisted. The startup backfill in main.rs reconstructs
+        // any gaps on the next restart.
+        if let Err(e) = record_manifest_blob_refs(&state.db, repo_id, &digest, &body).await {
+            warn!(
+                image = image_name,
+                reference = reference,
+                manifest_digest = digest.as_str(),
+                error = %e,
+                "Failed to record manifest_blob_refs for image manifest; blob references will \
+                 be reconstructed by the startup backfill on the next restart"
             );
         }
     }
@@ -10364,6 +10489,119 @@ mod oci_manifest_refs_tests {
         }"#;
         let children = extract_child_digests(body);
         assert_eq!(children, vec!["sha256:aaaa", "sha256:bbbb"]);
+    }
+
+    // -- manifest_blob_refs (#1635) blob-edge extraction --------------------
+
+    #[test]
+    fn extract_blob_refs_parses_config_and_layers() {
+        let body = br#"{
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "config": {
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+                "size": 7023,
+                "digest": "sha256:config0"
+            },
+            "layers": [
+                {"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "size": 32654, "digest": "sha256:layer1"},
+                {"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "size": 16724, "digest": "sha256:layer2"}
+            ]
+        }"#;
+        let refs = extract_blob_refs(body);
+        assert_eq!(
+            refs,
+            vec![
+                BlobRef {
+                    digest: "sha256:config0".to_string(),
+                    kind: "config"
+                },
+                BlobRef {
+                    digest: "sha256:layer1".to_string(),
+                    kind: "layer"
+                },
+                BlobRef {
+                    digest: "sha256:layer2".to_string(),
+                    kind: "layer"
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn extract_blob_refs_empty_for_image_index() {
+        // An image index references child manifests, not blobs: it has no
+        // `config` and no `layers`, so it must produce zero blob edges.
+        let body = br#"{
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {"digest": "sha256:childamd64", "platform": {"architecture": "amd64", "os": "linux"}},
+                {"digest": "sha256:childarm64", "platform": {"architecture": "arm64", "os": "linux"}}
+            ]
+        }"#;
+        assert!(
+            extract_blob_refs(body).is_empty(),
+            "image index has no config/layers blobs"
+        );
+    }
+
+    #[test]
+    fn extract_blob_refs_handles_missing_config_or_layers() {
+        // Config present, no layers array.
+        let cfg_only = br#"{"config": {"digest": "sha256:cfg"}}"#;
+        assert_eq!(
+            extract_blob_refs(cfg_only),
+            vec![BlobRef {
+                digest: "sha256:cfg".to_string(),
+                kind: "config"
+            }]
+        );
+        // Layers present, no config.
+        let layers_only = br#"{"layers": [{"digest": "sha256:l1"}]}"#;
+        assert_eq!(
+            extract_blob_refs(layers_only),
+            vec![BlobRef {
+                digest: "sha256:l1".to_string(),
+                kind: "layer"
+            }]
+        );
+    }
+
+    #[test]
+    fn extract_blob_refs_empty_for_malformed_json() {
+        assert!(extract_blob_refs(b"not json").is_empty());
+        assert!(extract_blob_refs(b"").is_empty());
+        assert!(extract_blob_refs(b"{").is_empty());
+        assert!(extract_blob_refs(b"{}").is_empty());
+    }
+
+    #[test]
+    fn extract_blob_refs_skips_layers_missing_digest() {
+        let body = br#"{
+            "config": {"size": 1},
+            "layers": [
+                {"digest": "sha256:l1"},
+                {"size": 5},
+                {"digest": null},
+                {"digest": "sha256:l2"}
+            ]
+        }"#;
+        // Config has no digest -> skipped. Two valid layer digests remain.
+        let refs = extract_blob_refs(body);
+        assert_eq!(
+            refs,
+            vec![
+                BlobRef {
+                    digest: "sha256:l1".to_string(),
+                    kind: "layer"
+                },
+                BlobRef {
+                    digest: "sha256:l2".to_string(),
+                    kind: "layer"
+                },
+            ]
+        );
     }
 }
 

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -1623,6 +1623,28 @@ pub fn extract_blob_refs(body: &[u8]) -> Vec<BlobRef> {
     refs
 }
 
+/// Split a slice of [`BlobRef`] into the two parallel column vectors the
+/// `UNNEST`-based insert in [`record_manifest_blob_refs`] binds: the blob
+/// digests (`$2::text[]`) and their kinds (`$3::text[]`), index-aligned so
+/// row `i` pairs `digests[i]` with `kinds[i]`. Returns `None` when there
+/// is nothing to insert (empty input), letting the caller short-circuit
+/// the DB round-trip.
+///
+/// Pure and DB-free so the array-pairing logic is unit-testable without a
+/// database (the raw `sqlx::query(...).execute()` is exercised only by the
+/// Tier-2 integration tests).
+fn blob_refs_to_columns(refs: &[BlobRef]) -> Option<(Vec<String>, Vec<String>)> {
+    if refs.is_empty() {
+        return None;
+    }
+    // Split into parallel arrays so a single UNNEST round-trip can pair
+    // each blob digest with its kind, all against the constant
+    // manifest_digest / repo_id.
+    let blob_digests: Vec<String> = refs.iter().map(|r| r.digest.clone()).collect();
+    let kinds: Vec<String> = refs.iter().map(|r| r.kind.to_string()).collect();
+    Some((blob_digests, kinds))
+}
+
 /// Insert (manifest_digest, blob_digest, repository_id, kind) rows into
 /// `manifest_blob_refs` for every config/layer blob of an image manifest.
 /// Idempotent: on conflict the existing row is kept.
@@ -1646,14 +1668,10 @@ pub async fn record_manifest_blob_refs(
     manifest_body: &[u8],
 ) -> Result<usize, sqlx::Error> {
     let refs = extract_blob_refs(manifest_body);
-    if refs.is_empty() {
-        return Ok(0);
-    }
-    // Split into parallel arrays so a single UNNEST round-trip can pair
-    // each blob digest with its kind, all against the constant
-    // manifest_digest / repo_id.
-    let blob_digests: Vec<String> = refs.iter().map(|r| r.digest.clone()).collect();
-    let kinds: Vec<String> = refs.iter().map(|r| r.kind.to_string()).collect();
+    let (blob_digests, kinds) = match blob_refs_to_columns(&refs) {
+        Some(cols) => cols,
+        None => return Ok(0),
+    };
     let res = sqlx::query(
         r#"
         INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind)
@@ -10602,6 +10620,77 @@ mod oci_manifest_refs_tests {
                 },
             ]
         );
+    }
+
+    // -- blob_refs_to_columns (#1635) UNNEST column-pairing -----------------
+
+    #[test]
+    fn blob_refs_to_columns_none_for_empty() {
+        // No refs -> no insert; caller short-circuits the DB round-trip.
+        assert!(blob_refs_to_columns(&[]).is_none());
+    }
+
+    #[test]
+    fn blob_refs_to_columns_pairs_digests_and_kinds_in_order() {
+        let refs = vec![
+            BlobRef {
+                digest: "sha256:config0".to_string(),
+                kind: "config",
+            },
+            BlobRef {
+                digest: "sha256:layer1".to_string(),
+                kind: "layer",
+            },
+            BlobRef {
+                digest: "sha256:layer2".to_string(),
+                kind: "layer",
+            },
+        ];
+        let (digests, kinds) =
+            blob_refs_to_columns(&refs).expect("non-empty refs yield Some columns");
+        // The two arrays must be index-aligned: digests[i] pairs kinds[i]
+        // for the UNNEST($2, $3) insert.
+        assert_eq!(
+            digests,
+            vec![
+                "sha256:config0".to_string(),
+                "sha256:layer1".to_string(),
+                "sha256:layer2".to_string(),
+            ]
+        );
+        assert_eq!(
+            kinds,
+            vec![
+                "config".to_string(),
+                "layer".to_string(),
+                "layer".to_string(),
+            ]
+        );
+        assert_eq!(digests.len(), kinds.len());
+    }
+
+    #[test]
+    fn blob_refs_to_columns_round_trips_extracted_refs() {
+        // End-to-end of the pure pipeline: parse a manifest body, then map
+        // it to the two insert columns the UNNEST query binds.
+        let body = br#"{
+            "config": {"digest": "sha256:cfg"},
+            "layers": [{"digest": "sha256:l1"}, {"digest": "sha256:l2"}]
+        }"#;
+        let refs = extract_blob_refs(body);
+        let (digests, kinds) =
+            blob_refs_to_columns(&refs).expect("manifest with blobs yields columns");
+        assert_eq!(digests, vec!["sha256:cfg", "sha256:l1", "sha256:l2"]);
+        assert_eq!(kinds, vec!["config", "layer", "layer"]);
+    }
+
+    #[test]
+    fn blob_refs_to_columns_none_for_blobless_manifest_body() {
+        // An image index has no config/layers -> extract yields nothing ->
+        // columns are None so record_manifest_blob_refs inserts zero rows.
+        let index = br#"{"manifests": [{"digest": "sha256:child"}]}"#;
+        let refs = extract_blob_refs(index);
+        assert!(blob_refs_to_columns(&refs).is_none());
     }
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -487,6 +487,22 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         )
         .await;
 
+    // One-shot backfill of manifest_blob_refs for image manifests that
+    // pre-date migration 120 (artifact-keeper#1635). GC prerequisite for
+    // #1408 / #1610: reconstructs the (manifest -> blob) edges for the
+    // existing corpus so a future blob GC can judge oci_blobs orphanhood
+    // safely. ADDITIVE ONLY -- no deletion. Runs after the storage
+    // registry is wired up because it reads manifest bodies from per-repo
+    // backends. Failures are logged but do not block startup; on a fresh
+    // database or after the first successful run the candidate query
+    // returns zero rows and this is a near-instant no-op.
+    let _blob_refs_backfill_stats =
+        artifact_keeper_backend::services::manifest_blob_refs_backfill::run_backfill(
+            &db_pool,
+            storage_registry.clone(),
+        )
+        .await;
+
     // Initialize security scanner service
     let advisory_client = Arc::new(AdvisoryClient::new(std::env::var("GITHUB_TOKEN").ok()));
     let scan_result_service = Arc::new(ScanResultService::new(db_pool.clone()));

--- a/backend/src/services/manifest_blob_refs_backfill.rs
+++ b/backend/src/services/manifest_blob_refs_backfill.rs
@@ -1,0 +1,253 @@
+//! One-shot backfill for `manifest_blob_refs` (artifact-keeper#1635).
+//!
+//! GC prerequisite for #1408 / #1610. The push handler in
+//! `api::handlers::oci_v2` populates `manifest_blob_refs` eagerly whenever
+//! a regular (non-index) image manifest is committed. That covers every
+//! push that lands after the upgrade to a release containing migration
+//! 120, but it does not cover image manifests that were pushed before the
+//! upgrade and are still reachable: those manifests exist in storage (and
+//! are referenced from `oci_tags` and/or `oci_manifest_refs.child_digest`)
+//! with no corresponding rows in `manifest_blob_refs`.
+//!
+//! This module walks the image manifests reachable via `oci_tags`
+//! (directly tagged manifests whose content-type is NOT an image index)
+//! and via `oci_manifest_refs.child_digest` (the per-architecture child
+//! manifests of multi-arch image indexes, which are always image
+//! manifests) that have zero `manifest_blob_refs` rows, loads each
+//! manifest body from storage, parses the JSON, and inserts the
+//! (manifest, blob, repo, kind) edges. The backfill is idempotent
+//! (`ON CONFLICT DO NOTHING`) and best-effort: a missing storage file or
+//! a malformed manifest is logged at WARN and skipped; it does not stop
+//! the backfill or fail startup.
+//!
+//! Called once from `main.rs` after migrations run. On the next restart
+//! the same query returns zero rows and the backfill is effectively a
+//! no-op SQL query. This reconstructs blob references for the existing
+//! corpus so a future blob GC can judge `oci_blobs` orphanhood safely.
+//!
+//! ADDITIVE ONLY (#1635): this backfill only makes blob references
+//! KNOWABLE. It performs no deletion of any kind.
+
+use std::sync::Arc;
+
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use crate::storage::{StorageLocation, StorageRegistry};
+
+/// Result of a backfill pass. Returned for tracing and tests.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BackfillStats {
+    /// Number of (manifest_digest, repository_id) candidates we tried to
+    /// process. Equals the number of distinct image manifests visited.
+    pub candidates_scanned: usize,
+    /// Number of edges (manifest -> blob) inserted into the table.
+    pub edges_inserted: usize,
+    /// Number of candidates we could not process (manifest missing from
+    /// storage, malformed JSON, DB write failure). These are logged at
+    /// WARN level but otherwise ignored; the next restart re-tries.
+    pub candidates_failed: usize,
+}
+
+/// Run the one-shot backfill. Returns a stats struct; never errors at the
+/// function boundary (backfill failures are logged and counted in
+/// `candidates_failed`). Server startup must not be blocked by a single
+/// corrupted manifest.
+pub async fn run_backfill(db: &PgPool, registry: Arc<StorageRegistry>) -> BackfillStats {
+    let candidates = match select_unbackfilled_manifests(db).await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "manifest_blob_refs backfill: failed to scan candidates; skipping"
+            );
+            return BackfillStats::default();
+        }
+    };
+
+    let mut stats = BackfillStats {
+        candidates_scanned: candidates.len(),
+        ..BackfillStats::default()
+    };
+
+    if candidates.is_empty() {
+        return stats;
+    }
+
+    tracing::info!(
+        candidate_count = candidates.len(),
+        "manifest_blob_refs backfill: processing image manifests"
+    );
+
+    for candidate in candidates {
+        match process_candidate(db, &registry, &candidate).await {
+            Ok(inserted) => stats.edges_inserted += inserted,
+            Err(e) => {
+                tracing::warn!(
+                    manifest_digest = candidate.manifest_digest.as_str(),
+                    repository_id = %candidate.repository_id,
+                    error = %e,
+                    "manifest_blob_refs backfill: skipped image manifest"
+                );
+                stats.candidates_failed += 1;
+            }
+        }
+    }
+
+    tracing::info!(
+        candidates_scanned = stats.candidates_scanned,
+        edges_inserted = stats.edges_inserted,
+        candidates_failed = stats.candidates_failed,
+        "manifest_blob_refs backfill: complete"
+    );
+    stats
+}
+
+#[derive(Debug)]
+struct BackfillCandidate {
+    manifest_digest: String,
+    repository_id: Uuid,
+    storage_backend: String,
+    storage_path: String,
+}
+
+/// Select the distinct (manifest_digest, repository_id) tuples for image
+/// manifests that have zero rows in `manifest_blob_refs`. Two reachability
+/// sources are unioned:
+///
+///   1. `oci_tags` rows whose content-type is NOT an image index -- these
+///      are directly tagged image manifests.
+///   2. `oci_manifest_refs.child_digest` -- the per-architecture child
+///      manifests of multi-arch image indexes. These never appear in
+///      `oci_tags` directly but are image manifests with their own blobs.
+///
+/// We pull `storage_backend` / `storage_path` from the repositories table
+/// along the way so the per-candidate work can resolve the correct backend
+/// without a second query. `DISTINCT ON` deduplicates a digest that is
+/// tagged under multiple names (or is both tagged and an index child) in
+/// the same repository; the first row wins, and since all rows for the
+/// same (digest, repo) point at the same manifest body, that is fine.
+async fn select_unbackfilled_manifests(db: &PgPool) -> sqlx::Result<Vec<BackfillCandidate>> {
+    let rows = sqlx::query(
+        r#"
+        SELECT DISTINCT ON (c.manifest_digest, c.repository_id)
+            c.manifest_digest AS manifest_digest,
+            c.repository_id AS repository_id,
+            r.storage_backend AS storage_backend,
+            r.storage_path AS storage_path
+        FROM (
+            SELECT ot.manifest_digest AS manifest_digest,
+                   ot.repository_id AS repository_id
+            FROM oci_tags ot
+            WHERE ot.manifest_content_type NOT IN (
+                    'application/vnd.oci.image.index.v1+json',
+                    'application/vnd.docker.distribution.manifest.list.v2+json'
+                )
+            UNION
+            SELECT omr.child_digest AS manifest_digest,
+                   omr.repository_id AS repository_id
+            FROM oci_manifest_refs omr
+        ) AS c
+        JOIN repositories r ON r.id = c.repository_id
+        WHERE NOT EXISTS (
+                SELECT 1 FROM manifest_blob_refs mbr
+                WHERE mbr.manifest_digest = c.manifest_digest
+                  AND mbr.repository_id = c.repository_id
+          )
+        "#,
+    )
+    .fetch_all(db)
+    .await?;
+
+    let candidates = rows
+        .into_iter()
+        .map(|r| BackfillCandidate {
+            manifest_digest: r.try_get("manifest_digest").unwrap_or_default(),
+            repository_id: r.try_get("repository_id").unwrap_or_default(),
+            storage_backend: r.try_get("storage_backend").unwrap_or_default(),
+            storage_path: r.try_get("storage_path").unwrap_or_default(),
+        })
+        .collect();
+    Ok(candidates)
+}
+
+/// Hard cap on the manifest body size we are willing to load and parse
+/// during backfill. OCI image manifests are tiny in practice (one JSON
+/// entry per layer, a few hundred bytes each); a 4 MiB ceiling is far
+/// above legitimate sizes and prevents a corrupted or malicious storage
+/// key from OOMing startup. If a body exceeds this, we log at WARN and
+/// skip the candidate; its blobs just stay unreferenced (same state as
+/// before this PR) until the manifest is re-pushed through the live
+/// handler.
+pub(crate) const MAX_IMAGE_MANIFEST_BYTES: usize = 4 * 1024 * 1024;
+
+/// Load one image manifest from storage, parse it, and insert the
+/// resulting (manifest, blob, repo, kind) edges into `manifest_blob_refs`.
+async fn process_candidate(
+    db: &PgPool,
+    registry: &StorageRegistry,
+    candidate: &BackfillCandidate,
+) -> Result<usize, String> {
+    let location = StorageLocation {
+        backend: candidate.storage_backend.clone(),
+        path: candidate.storage_path.clone(),
+    };
+    let storage = registry
+        .backend_for(&location)
+        .map_err(|e| format!("resolve storage backend: {}", e))?;
+
+    let storage_key = format!("oci-manifests/{}", candidate.manifest_digest);
+    let body = storage
+        .get(&storage_key)
+        .await
+        .map_err(|e| format!("read manifest from storage: {}", e))?;
+
+    if body.len() > MAX_IMAGE_MANIFEST_BYTES {
+        return Err(format!(
+            "image manifest body exceeds {} bytes (got {}); skipping JSON parse",
+            MAX_IMAGE_MANIFEST_BYTES,
+            body.len()
+        ));
+    }
+
+    let inserted = crate::api::handlers::oci_v2::record_manifest_blob_refs(
+        db,
+        candidate.repository_id,
+        &candidate.manifest_digest,
+        &body,
+    )
+    .await
+    .map_err(|e| format!("insert manifest_blob_refs rows: {}", e))?;
+
+    Ok(inserted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backfill_stats_default_is_zero() {
+        let s = BackfillStats::default();
+        assert_eq!(s.candidates_scanned, 0);
+        assert_eq!(s.edges_inserted, 0);
+        assert_eq!(s.candidates_failed, 0);
+    }
+
+    #[test]
+    fn backfill_stats_is_copy() {
+        // Compile-time only: confirms BackfillStats stays Copy so it can
+        // be returned across async boundaries cheaply.
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<BackfillStats>();
+    }
+
+    // The cap exists to protect startup from a corrupted/malicious body.
+    // Real OCI image manifests are well under 1 MiB; a 4 MiB ceiling is
+    // far above legitimate sizes but small enough that a single bad blob
+    // cannot exhaust process memory. Asserted at compile time so a future
+    // bump out of the safe range fails the build rather than a single test
+    // invocation.
+    const _SANE_LOWER: () = assert!(MAX_IMAGE_MANIFEST_BYTES >= 64 * 1024);
+    const _SANE_UPPER: () = assert!(MAX_IMAGE_MANIFEST_BYTES <= 16 * 1024 * 1024);
+}

--- a/backend/src/services/manifest_blob_refs_backfill.rs
+++ b/backend/src/services/manifest_blob_refs_backfill.rs
@@ -49,6 +49,31 @@ pub struct BackfillStats {
     pub candidates_failed: usize,
 }
 
+impl BackfillStats {
+    /// Initial stats for a pass over `n` candidates: `candidates_scanned`
+    /// is fixed up front (it equals the number of distinct manifests we
+    /// will visit), the per-candidate counters start at zero. Pure so the
+    /// initialization is unit-testable without a DB scan.
+    fn for_candidates(n: usize) -> Self {
+        Self {
+            candidates_scanned: n,
+            ..Self::default()
+        }
+    }
+
+    /// Fold one candidate's outcome into the running totals: a success adds
+    /// its inserted-edge count, a failure bumps `candidates_failed`.
+    /// `candidates_scanned` is untouched (it is fixed by
+    /// [`for_candidates`]). Pure so the loop's accounting is unit-testable
+    /// without exercising the DB-backed `process_candidate`.
+    fn record_candidate_result(&mut self, outcome: &Result<usize, String>) {
+        match outcome {
+            Ok(inserted) => self.edges_inserted += inserted,
+            Err(_) => self.candidates_failed += 1,
+        }
+    }
+}
+
 /// Run the one-shot backfill. Returns a stats struct; never errors at the
 /// function boundary (backfill failures are logged and counted in
 /// `candidates_failed`). Server startup must not be blocked by a single
@@ -65,10 +90,7 @@ pub async fn run_backfill(db: &PgPool, registry: Arc<StorageRegistry>) -> Backfi
         }
     };
 
-    let mut stats = BackfillStats {
-        candidates_scanned: candidates.len(),
-        ..BackfillStats::default()
-    };
+    let mut stats = BackfillStats::for_candidates(candidates.len());
 
     if candidates.is_empty() {
         return stats;
@@ -80,18 +102,16 @@ pub async fn run_backfill(db: &PgPool, registry: Arc<StorageRegistry>) -> Backfi
     );
 
     for candidate in candidates {
-        match process_candidate(db, &registry, &candidate).await {
-            Ok(inserted) => stats.edges_inserted += inserted,
-            Err(e) => {
-                tracing::warn!(
-                    manifest_digest = candidate.manifest_digest.as_str(),
-                    repository_id = %candidate.repository_id,
-                    error = %e,
-                    "manifest_blob_refs backfill: skipped image manifest"
-                );
-                stats.candidates_failed += 1;
-            }
+        let outcome = process_candidate(db, &registry, &candidate).await;
+        if let Err(e) = &outcome {
+            tracing::warn!(
+                manifest_digest = candidate.manifest_digest.as_str(),
+                repository_id = %candidate.repository_id,
+                error = %e,
+                "manifest_blob_refs backfill: skipped image manifest"
+            );
         }
+        stats.record_candidate_result(&outcome);
     }
 
     tracing::info!(
@@ -103,12 +123,82 @@ pub async fn run_backfill(db: &PgPool, registry: Arc<StorageRegistry>) -> Backfi
     stats
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct BackfillCandidate {
     manifest_digest: String,
     repository_id: Uuid,
     storage_backend: String,
     storage_path: String,
+}
+
+impl BackfillCandidate {
+    /// Build a candidate from the four scalar columns of the selection
+    /// query. Pure (no DB row coupling) so the field wiring is unit-
+    /// testable; `select_unbackfilled_manifests` calls this once per row.
+    fn new(
+        manifest_digest: String,
+        repository_id: Uuid,
+        storage_backend: String,
+        storage_path: String,
+    ) -> Self {
+        Self {
+            manifest_digest,
+            repository_id,
+            storage_backend,
+            storage_path,
+        }
+    }
+
+    /// The storage key under which an OCI image manifest body is stored.
+    /// Kept here (next to its only consumer) and pure so the key layout is
+    /// pinned by a unit test rather than only exercised by Tier-2 storage
+    /// reads.
+    fn storage_key(&self) -> String {
+        format!("oci-manifests/{}", self.manifest_digest)
+    }
+
+    /// The [`StorageLocation`] used to resolve this candidate's backend.
+    fn location(&self) -> StorageLocation {
+        StorageLocation {
+            backend: self.storage_backend.clone(),
+            path: self.storage_path.clone(),
+        }
+    }
+}
+
+/// Reject a manifest body that exceeds [`MAX_IMAGE_MANIFEST_BYTES`] before
+/// it is parsed, returning the WARN-level skip reason. Pure size check,
+/// split out so the cap behaviour is unit-testable without storage.
+fn check_manifest_size(len: usize) -> Result<(), String> {
+    if len > MAX_IMAGE_MANIFEST_BYTES {
+        return Err(format!(
+            "image manifest body exceeds {} bytes (got {}); skipping JSON parse",
+            MAX_IMAGE_MANIFEST_BYTES, len
+        ));
+    }
+    Ok(())
+}
+
+/// The skip reason recorded when a candidate's storage backend cannot be
+/// resolved. Pure formatter so the message is unit-testable without a
+/// `StorageRegistry`; `process_candidate` maps the backend-resolution
+/// error through it.
+fn backend_resolve_error(e: impl std::fmt::Display) -> String {
+    format!("resolve storage backend: {}", e)
+}
+
+/// The skip reason recorded when the manifest body cannot be read from
+/// storage (missing key, IO failure). Pure formatter, mapped from the
+/// storage `get` error in `process_candidate`.
+fn storage_read_error(e: impl std::fmt::Display) -> String {
+    format!("read manifest from storage: {}", e)
+}
+
+/// The skip reason recorded when the `manifest_blob_refs` insert fails.
+/// Pure formatter, mapped from the `record_manifest_blob_refs` DB error in
+/// `process_candidate`.
+fn insert_rows_error(e: impl std::fmt::Display) -> String {
+    format!("insert manifest_blob_refs rows: {}", e)
 }
 
 /// Select the distinct (manifest_digest, repository_id) tuples for image
@@ -161,11 +251,13 @@ async fn select_unbackfilled_manifests(db: &PgPool) -> sqlx::Result<Vec<Backfill
 
     let candidates = rows
         .into_iter()
-        .map(|r| BackfillCandidate {
-            manifest_digest: r.try_get("manifest_digest").unwrap_or_default(),
-            repository_id: r.try_get("repository_id").unwrap_or_default(),
-            storage_backend: r.try_get("storage_backend").unwrap_or_default(),
-            storage_path: r.try_get("storage_path").unwrap_or_default(),
+        .map(|r| {
+            BackfillCandidate::new(
+                r.try_get("manifest_digest").unwrap_or_default(),
+                r.try_get("repository_id").unwrap_or_default(),
+                r.try_get("storage_backend").unwrap_or_default(),
+                r.try_get("storage_path").unwrap_or_default(),
+            )
         })
         .collect();
     Ok(candidates)
@@ -188,27 +280,16 @@ async fn process_candidate(
     registry: &StorageRegistry,
     candidate: &BackfillCandidate,
 ) -> Result<usize, String> {
-    let location = StorageLocation {
-        backend: candidate.storage_backend.clone(),
-        path: candidate.storage_path.clone(),
-    };
     let storage = registry
-        .backend_for(&location)
-        .map_err(|e| format!("resolve storage backend: {}", e))?;
+        .backend_for(&candidate.location())
+        .map_err(backend_resolve_error)?;
 
-    let storage_key = format!("oci-manifests/{}", candidate.manifest_digest);
     let body = storage
-        .get(&storage_key)
+        .get(&candidate.storage_key())
         .await
-        .map_err(|e| format!("read manifest from storage: {}", e))?;
+        .map_err(storage_read_error)?;
 
-    if body.len() > MAX_IMAGE_MANIFEST_BYTES {
-        return Err(format!(
-            "image manifest body exceeds {} bytes (got {}); skipping JSON parse",
-            MAX_IMAGE_MANIFEST_BYTES,
-            body.len()
-        ));
-    }
+    check_manifest_size(body.len())?;
 
     let inserted = crate::api::handlers::oci_v2::record_manifest_blob_refs(
         db,
@@ -217,7 +298,7 @@ async fn process_candidate(
         &body,
     )
     .await
-    .map_err(|e| format!("insert manifest_blob_refs rows: {}", e))?;
+    .map_err(insert_rows_error)?;
 
     Ok(inserted)
 }
@@ -250,4 +331,127 @@ mod tests {
     // invocation.
     const _SANE_LOWER: () = assert!(MAX_IMAGE_MANIFEST_BYTES >= 64 * 1024);
     const _SANE_UPPER: () = assert!(MAX_IMAGE_MANIFEST_BYTES <= 16 * 1024 * 1024);
+
+    // -- BackfillStats accounting helpers -----------------------------------
+
+    #[test]
+    fn for_candidates_fixes_scanned_and_zeroes_counters() {
+        let s = BackfillStats::for_candidates(7);
+        assert_eq!(s.candidates_scanned, 7);
+        assert_eq!(s.edges_inserted, 0);
+        assert_eq!(s.candidates_failed, 0);
+    }
+
+    #[test]
+    fn for_candidates_zero_is_all_zero() {
+        let s = BackfillStats::for_candidates(0);
+        assert_eq!(s.candidates_scanned, 0);
+        assert_eq!(s.edges_inserted, 0);
+        assert_eq!(s.candidates_failed, 0);
+    }
+
+    #[test]
+    fn record_candidate_result_accumulates_inserted_edges() {
+        let mut s = BackfillStats::for_candidates(3);
+        s.record_candidate_result(&Ok(2));
+        s.record_candidate_result(&Ok(5));
+        assert_eq!(s.edges_inserted, 7);
+        assert_eq!(s.candidates_failed, 0);
+        // candidates_scanned is fixed up front, never touched by folding.
+        assert_eq!(s.candidates_scanned, 3);
+    }
+
+    #[test]
+    fn record_candidate_result_counts_failures() {
+        let mut s = BackfillStats::for_candidates(3);
+        s.record_candidate_result(&Err("boom".to_string()));
+        s.record_candidate_result(&Ok(4));
+        s.record_candidate_result(&Err("missing".to_string()));
+        assert_eq!(s.candidates_failed, 2);
+        assert_eq!(s.edges_inserted, 4);
+        assert_eq!(s.candidates_scanned, 3);
+    }
+
+    #[test]
+    fn record_candidate_result_ok_zero_is_noop_on_counts() {
+        // A successfully-processed manifest that contributed no new edges
+        // (e.g. all rows already present) must not be counted as a failure.
+        let mut s = BackfillStats::for_candidates(1);
+        s.record_candidate_result(&Ok(0));
+        assert_eq!(s.edges_inserted, 0);
+        assert_eq!(s.candidates_failed, 0);
+    }
+
+    // -- BackfillCandidate pure derivations ---------------------------------
+
+    fn sample_candidate() -> BackfillCandidate {
+        BackfillCandidate::new(
+            "sha256:abc123".to_string(),
+            Uuid::nil(),
+            "filesystem".to_string(),
+            "/var/lib/ak/repo".to_string(),
+        )
+    }
+
+    #[test]
+    fn candidate_new_wires_all_fields() {
+        let c = sample_candidate();
+        assert_eq!(c.manifest_digest, "sha256:abc123");
+        assert_eq!(c.repository_id, Uuid::nil());
+        assert_eq!(c.storage_backend, "filesystem");
+        assert_eq!(c.storage_path, "/var/lib/ak/repo");
+    }
+
+    #[test]
+    fn candidate_storage_key_prefixes_oci_manifests() {
+        assert_eq!(
+            sample_candidate().storage_key(),
+            "oci-manifests/sha256:abc123"
+        );
+    }
+
+    #[test]
+    fn candidate_location_carries_backend_and_path() {
+        let loc = sample_candidate().location();
+        assert_eq!(loc.backend, "filesystem");
+        assert_eq!(loc.path, "/var/lib/ak/repo");
+    }
+
+    // -- check_manifest_size cap --------------------------------------------
+
+    #[test]
+    fn check_manifest_size_accepts_small_and_boundary_bodies() {
+        assert!(check_manifest_size(0).is_ok());
+        assert!(check_manifest_size(1024).is_ok());
+        // Exactly at the cap is allowed; only strictly-larger is rejected.
+        assert!(check_manifest_size(MAX_IMAGE_MANIFEST_BYTES).is_ok());
+    }
+
+    #[test]
+    fn check_manifest_size_rejects_oversized_body() {
+        let err = check_manifest_size(MAX_IMAGE_MANIFEST_BYTES + 1)
+            .expect_err("body over the cap must be rejected");
+        assert!(err.contains("exceeds"));
+        assert!(err.contains(&(MAX_IMAGE_MANIFEST_BYTES + 1).to_string()));
+    }
+
+    // -- per-stage skip-reason formatters -----------------------------------
+
+    #[test]
+    fn backend_resolve_error_describes_stage_and_cause() {
+        let msg = backend_resolve_error("no such backend 's3'");
+        assert_eq!(msg, "resolve storage backend: no such backend 's3'");
+    }
+
+    #[test]
+    fn storage_read_error_describes_stage_and_cause() {
+        let msg = storage_read_error("key not found");
+        assert_eq!(msg, "read manifest from storage: key not found");
+    }
+
+    #[test]
+    fn insert_rows_error_describes_stage_and_cause() {
+        let msg = insert_rows_error("connection reset");
+        assert_eq!(msg, "insert manifest_blob_refs rows: connection reset");
+    }
 }

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -22,6 +22,7 @@ pub mod http_client;
 pub mod image_scanner;
 pub mod incus_scanner;
 pub mod ldap_service;
+pub mod manifest_blob_refs_backfill;
 pub mod metadata_checker;
 pub mod migration_service;
 pub mod migration_worker;

--- a/backend/tests/manifest_blob_refs_tests.rs
+++ b/backend/tests/manifest_blob_refs_tests.rs
@@ -1,0 +1,165 @@
+//! Integration tests for `manifest_blob_refs` push-time writes (#1635).
+//!
+//! These tests require a PostgreSQL database with migrations applied
+//! (including migration 120). Set DATABASE_URL and run:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test manifest_blob_refs_tests -- --ignored
+//! ```
+//!
+//! ADDITIVE ONLY (#1635): these tests only exercise reference recording.
+//! No deletion path exists or is tested here.
+
+use sqlx::{PgPool, Row};
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::oci_v2::record_manifest_blob_refs;
+
+/// Create a test repository and return its ID.
+async fn create_test_repo(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    let key = format!("test-{}", id);
+    let storage_path = format!("/tmp/test-artifacts/{}", id);
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+         VALUES ($1, $2, $2, $3, 'local', 'oci')",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(&storage_path)
+    .execute(pool)
+    .await
+    .expect("failed to create test repository");
+    id
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid) {
+    sqlx::query("DELETE FROM manifest_blob_refs WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+/// Fetch (blob_digest, kind) edges for a manifest, ordered by blob_digest.
+async fn fetch_edges(pool: &PgPool, repo_id: Uuid, manifest_digest: &str) -> Vec<(String, String)> {
+    sqlx::query(
+        "SELECT blob_digest, kind FROM manifest_blob_refs \
+         WHERE repository_id = $1 AND manifest_digest = $2 ORDER BY blob_digest",
+    )
+    .bind(repo_id)
+    .bind(manifest_digest)
+    .fetch_all(pool)
+    .await
+    .expect("failed to query manifest_blob_refs")
+    .into_iter()
+    .map(|r| (r.get("blob_digest"), r.get("kind")))
+    .collect()
+}
+
+async fn connect() -> PgPool {
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL must be set for these tests");
+    PgPool::connect(&url)
+        .await
+        .expect("failed to connect to test database")
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL with migrations applied"]
+async fn image_manifest_writes_config_and_layer_edges() {
+    let pool = connect().await;
+    let repo_id = create_test_repo(&pool).await;
+
+    let manifest_digest = "sha256:manifest0";
+    let body = br#"{
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {"size": 7023, "digest": "sha256:config0"},
+        "layers": [
+            {"size": 32654, "digest": "sha256:layer1"},
+            {"size": 16724, "digest": "sha256:layer2"}
+        ]
+    }"#;
+
+    let inserted = record_manifest_blob_refs(&pool, repo_id, manifest_digest, body)
+        .await
+        .expect("record_manifest_blob_refs failed");
+    assert_eq!(inserted, 3, "expected one config + two layer edges");
+
+    let edges = fetch_edges(&pool, repo_id, manifest_digest).await;
+    assert_eq!(
+        edges,
+        vec![
+            ("sha256:config0".to_string(), "config".to_string()),
+            ("sha256:layer1".to_string(), "layer".to_string()),
+            ("sha256:layer2".to_string(), "layer".to_string()),
+        ]
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL with migrations applied"]
+async fn index_manifest_writes_no_blob_edges() {
+    let pool = connect().await;
+    let repo_id = create_test_repo(&pool).await;
+
+    let manifest_digest = "sha256:index0";
+    // An image index has no config/layers, so no blob edges must be written
+    // even if (defensively) it is passed to the writer.
+    let body = br#"{
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {"digest": "sha256:childamd64", "platform": {"architecture": "amd64", "os": "linux"}},
+            {"digest": "sha256:childarm64", "platform": {"architecture": "arm64", "os": "linux"}}
+        ]
+    }"#;
+
+    let inserted = record_manifest_blob_refs(&pool, repo_id, manifest_digest, body)
+        .await
+        .expect("record_manifest_blob_refs failed");
+    assert_eq!(inserted, 0, "image index must produce zero blob edges");
+    assert!(fetch_edges(&pool, repo_id, manifest_digest)
+        .await
+        .is_empty());
+
+    cleanup(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore = "requires PostgreSQL with migrations applied"]
+async fn recording_is_idempotent() {
+    let pool = connect().await;
+    let repo_id = create_test_repo(&pool).await;
+
+    let manifest_digest = "sha256:manifestidem";
+    let body = br#"{
+        "config": {"digest": "sha256:cfg"},
+        "layers": [{"digest": "sha256:l1"}]
+    }"#;
+
+    let first = record_manifest_blob_refs(&pool, repo_id, manifest_digest, body)
+        .await
+        .expect("first record failed");
+    assert_eq!(first, 2);
+
+    // Second call must insert nothing (ON CONFLICT DO NOTHING) and leave
+    // exactly the same rows.
+    let second = record_manifest_blob_refs(&pool, repo_id, manifest_digest, body)
+        .await
+        .expect("second record failed");
+    assert_eq!(second, 0, "re-recording the same manifest inserts no rows");
+
+    let edges = fetch_edges(&pool, repo_id, manifest_digest).await;
+    assert_eq!(edges.len(), 2);
+
+    cleanup(&pool, repo_id).await;
+}


### PR DESCRIPTION
Closes #1635

GC prerequisite for #1408 / #1610.

## Summary
Adds an **additive** manifest→blob reference table so a future OCI blob GC can safely judge `oci_blobs` orphanhood. Today there is no manifest→blob reference table, so nothing can decide whether a blob row is unreferenced (a prior per-`(repo,digest)` heuristic broke 57 production blobs). This PR only makes blob references **knowable**.

**ADDITIVE ONLY — no deletion logic of any kind.** No `run_blob_gc`, no advisory-lock sweep, no reclaimable-report changes. Those land in a later PR once these edges are verified.

What's included:
- **Migration `120_manifest_blob_refs.sql`** — `manifest_blob_refs(manifest_digest TEXT, blob_digest TEXT, repository_id UUID, kind TEXT, created_at TIMESTAMPTZ DEFAULT now())`, PK `(manifest_digest, blob_digest, repository_id)`, plus `CREATE INDEX ON manifest_blob_refs(blob_digest)` for the GC reverse-lookup hot path.
- **Push-time write** — in `handle_put_manifest`, for non-index manifests, parse `config.digest` + every `layers[].digest` and batch-insert the edges via a single `UNNEST` insert with `ON CONFLICT DO NOTHING` (mirrors `record_oci_manifest_refs`). Image-index manifests carry no blobs of their own and are skipped.
- **Startup backfill** — new `services::manifest_blob_refs_backfill`, mirroring the `oci_manifest_refs` backfill. Walks image manifests reachable via `oci_tags` (non-index content-type) and via `oci_manifest_refs.child_digest` that have zero `manifest_blob_refs` rows, loads each manifest body from storage, parses it, and inserts edges. Idempotent and best-effort; never blocks startup.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (additive feature; GC prerequisite for #1408)

## Test Checklist
- [x] Unit tests added/updated — `extract_blob_refs` parsing → edges (config + layers extracted; index manifest yields no blob edges; malformed/partial bodies handled)
- [x] Integration tests added/updated (if applicable) — DB-gated tests for the push-time writer (`backend/tests/manifest_blob_refs_tests.rs`, run with `--ignored`)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo build`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace --lib` all pass (the pre-existing `http_client` timeout test failure is sandbox-only and also fails on clean `main`)
- [x] No regressions in existing tests

## API Changes
- [x] Migration is reversible (if applicable) — additive table + index; safe to drop
- [x] N/A - no API changes (no new HTTP endpoints or schemas)
