### PR TITLE
fix(auth): reconcile env-managed OIDC/LDAP provider on every boot

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1085,29 +1085,41 @@ async fn init_peer_identity(db: &sqlx::PgPool, config: &Config) -> Result<uuid::
 /// env vars (OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, etc.) without
 /// needing admin API access first.
 async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
-    use artifact_keeper_backend::services::auth_config_service::AuthConfigService;
+    use artifact_keeper_backend::services::auth_config_service::{
+        plan_provider_reconcile, AuthConfigService, ReconcileAction,
+    };
 
     let req = match build_oidc_bootstrap_request() {
         Some(r) => r,
         None => return Ok(()),
     };
 
-    // Only bootstrap when no OIDC configs exist in the database
+    // Reconcile the env-managed provider (matched by name) on every boot so
+    // changing OIDC_* env and redeploying takes effect. Other (UI-created)
+    // providers are left untouched.
     let existing = AuthConfigService::list_oidc(db).await?;
-    if !existing.is_empty() {
-        tracing::debug!(
-            "OIDC env vars present but {} config(s) already exist in DB, skipping bootstrap",
-            existing.len()
-        );
-        return Ok(());
-    }
+    let pairs: Vec<(uuid::Uuid, String)> =
+        existing.iter().map(|c| (c.id, c.name.clone())).collect();
 
-    let config = AuthConfigService::create_oidc(db, req).await?;
-    tracing::info!(
-        "Bootstrapped OIDC provider '{}' (id={}) from environment variables",
-        config.name,
-        config.id
-    );
+    match plan_provider_reconcile(&req.name, &pairs) {
+        ReconcileAction::Create => {
+            let config = AuthConfigService::create_oidc(db, req).await?;
+            tracing::info!(
+                "Bootstrapped OIDC provider '{}' (id={}) from environment variables",
+                config.name,
+                config.id
+            );
+        }
+        ReconcileAction::Update(id) => {
+            let name = req.name.clone();
+            let cfg = AuthConfigService::update_oidc(db, id, req.into()).await?;
+            tracing::info!(
+                "Reconciled env-managed OIDC provider '{}' (id={}) from environment variables",
+                name,
+                cfg.id
+            );
+        }
+    }
 
     Ok(())
 }
@@ -1198,29 +1210,41 @@ fn build_oidc_request_from_values(
 /// env vars (LDAP_URL, LDAP_BASE_DN, LDAP_BIND_DN, etc.) without needing admin
 /// API access first.  Mirrors `bootstrap_oidc_from_env` (fixes #1434).
 async fn bootstrap_ldap_from_env(db: &sqlx::PgPool) -> Result<()> {
-    use artifact_keeper_backend::services::auth_config_service::AuthConfigService;
+    use artifact_keeper_backend::services::auth_config_service::{
+        plan_provider_reconcile, AuthConfigService, ReconcileAction,
+    };
 
     let req = match build_ldap_bootstrap_request() {
         Some(r) => r,
         None => return Ok(()),
     };
 
-    // Only bootstrap when no LDAP configs exist in the database
+    // Reconcile the env-managed provider (matched by name) on every boot so
+    // changing LDAP_* env and redeploying takes effect. Other (UI-created)
+    // providers are left untouched.
     let existing = AuthConfigService::list_ldap(db).await?;
-    if !existing.is_empty() {
-        tracing::debug!(
-            "LDAP env vars present but {} config(s) already exist in DB, skipping bootstrap",
-            existing.len()
-        );
-        return Ok(());
-    }
+    let pairs: Vec<(uuid::Uuid, String)> =
+        existing.iter().map(|c| (c.id, c.name.clone())).collect();
 
-    let config = AuthConfigService::create_ldap(db, req).await?;
-    tracing::info!(
-        "Bootstrapped LDAP provider '{}' (id={}) from environment variables",
-        config.name,
-        config.id
-    );
+    match plan_provider_reconcile(&req.name, &pairs) {
+        ReconcileAction::Create => {
+            let config = AuthConfigService::create_ldap(db, req).await?;
+            tracing::info!(
+                "Bootstrapped LDAP provider '{}' (id={}) from environment variables",
+                config.name,
+                config.id
+            );
+        }
+        ReconcileAction::Update(id) => {
+            let name = req.name.clone();
+            let cfg = AuthConfigService::update_ldap(db, id, req.into()).await?;
+            tracing::info!(
+                "Reconciled env-managed LDAP provider '{}' (id={}) from environment variables",
+                name,
+                cfg.id
+            );
+        }
+    }
 
     Ok(())
 }

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -1540,6 +1540,69 @@ impl AuthConfigService {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Env-managed provider reconciliation (issue #1656)
+// ---------------------------------------------------------------------------
+
+/// Outcome of reconciling an env-managed provider against the DB on boot.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReconcileAction {
+    Create,
+    Update(Uuid),
+}
+
+/// Select the env-managed provider by name; UI-created providers with other
+/// names are ignored.
+pub fn plan_provider_reconcile(desired_name: &str, existing: &[(Uuid, String)]) -> ReconcileAction {
+    match existing.iter().find(|(_, name)| name == desired_name) {
+        Some((id, _)) => ReconcileAction::Update(*id),
+        None => ReconcileAction::Create,
+    }
+}
+
+impl From<CreateOidcConfigRequest> for UpdateOidcConfigRequest {
+    fn from(c: CreateOidcConfigRequest) -> Self {
+        UpdateOidcConfigRequest {
+            name: Some(c.name),
+            issuer_url: Some(c.issuer_url),
+            client_id: Some(c.client_id),
+            client_secret: Some(c.client_secret),
+            scopes: c.scopes,
+            attribute_mapping: c.attribute_mapping,
+            // Env is definitive: replace the whole mapping so a key removed
+            // from the environment is cleared from the stored config.
+            attribute_mapping_replace: Some(true),
+            is_enabled: c.is_enabled,
+            auto_create_users: c.auto_create_users,
+            pkce_enabled: c.pkce_enabled,
+            map_groups_to_groups: c.map_groups_to_groups,
+        }
+    }
+}
+
+impl From<CreateLdapConfigRequest> for UpdateLdapConfigRequest {
+    fn from(c: CreateLdapConfigRequest) -> Self {
+        UpdateLdapConfigRequest {
+            name: Some(c.name),
+            server_url: Some(c.server_url),
+            bind_dn: c.bind_dn,
+            bind_password: c.bind_password,
+            user_base_dn: Some(c.user_base_dn),
+            user_filter: c.user_filter,
+            group_base_dn: c.group_base_dn,
+            group_filter: c.group_filter,
+            email_attribute: c.email_attribute,
+            display_name_attribute: c.display_name_attribute,
+            username_attribute: c.username_attribute,
+            groups_attribute: c.groups_attribute,
+            admin_group_dn: c.admin_group_dn,
+            use_starttls: c.use_starttls,
+            is_enabled: c.is_enabled,
+            priority: c.priority,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2234,6 +2297,88 @@ mod tests {
         let patch = serde_json::json!("scalar");
         let out = merge_attribute_mapping(&base, &patch);
         assert_eq!(out, serde_json::json!("scalar"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Env-managed provider reconciliation (issue #1656)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_plan_reconcile_create_when_absent() {
+        let existing: Vec<(Uuid, String)> = vec![];
+        assert_eq!(
+            plan_provider_reconcile("default", &existing),
+            ReconcileAction::Create
+        );
+    }
+
+    #[test]
+    fn test_plan_reconcile_update_when_name_matches() {
+        let id = Uuid::new_v4();
+        let existing = vec![(id, "default".to_string())];
+        assert_eq!(
+            plan_provider_reconcile("default", &existing),
+            ReconcileAction::Update(id)
+        );
+    }
+
+    #[test]
+    fn test_plan_reconcile_create_ignores_other_named_providers() {
+        let other = Uuid::new_v4();
+        let existing = vec![(other, "Corporate SSO".to_string())];
+        assert_eq!(
+            plan_provider_reconcile("default", &existing),
+            ReconcileAction::Create
+        );
+    }
+
+    #[test]
+    fn test_oidc_create_to_update_carries_secret_and_replaces_mapping() {
+        let c = CreateOidcConfigRequest {
+            name: "default".into(),
+            issuer_url: "https://idp".into(),
+            client_id: "c".into(),
+            client_secret: "s".into(),
+            scopes: None,
+            attribute_mapping: None,
+            is_enabled: None,
+            auto_create_users: None,
+            pkce_enabled: None,
+            map_groups_to_groups: None,
+        };
+        let u: UpdateOidcConfigRequest = c.into();
+        assert_eq!(u.issuer_url, Some("https://idp".to_string()));
+        assert_eq!(u.client_id, Some("c".to_string()));
+        assert_eq!(u.client_secret, Some("s".to_string()));
+        assert_eq!(u.attribute_mapping_replace, Some(true));
+    }
+
+    #[test]
+    fn test_ldap_create_to_update_maps_required_fields() {
+        let c = CreateLdapConfigRequest {
+            name: "default".into(),
+            server_url: "ldap://host:389".into(),
+            bind_dn: Some("cn=admin".into()),
+            bind_password: Some("pw".into()),
+            user_base_dn: "ou=users".into(),
+            user_filter: None,
+            group_base_dn: None,
+            group_filter: None,
+            email_attribute: None,
+            display_name_attribute: None,
+            username_attribute: None,
+            groups_attribute: None,
+            admin_group_dn: None,
+            use_starttls: Some(true),
+            is_enabled: Some(true),
+            priority: Some(0),
+        };
+        let u: UpdateLdapConfigRequest = c.into();
+        assert_eq!(u.name, Some("default".to_string()));
+        assert_eq!(u.server_url, Some("ldap://host:389".to_string()));
+        assert_eq!(u.user_base_dn, Some("ou=users".to_string()));
+        assert_eq!(u.bind_dn, Some("cn=admin".to_string()));
+        assert_eq!(u.use_starttls, Some(true));
     }
 
     // =======================================================================


### PR DESCRIPTION
## Summary

`bootstrap_oidc_from_env` / `bootstrap_ldap_from_env` only persisted the env-derived provider when the table was **empty**. After first boot they logged at `debug` and returned, so changing `OIDC_*` / `LDAP_*` in Helm/env and redeploying was a **silent no-op** — surprising operators because the docs present env vars as the configuration path.

This makes the env-managed provider **definitive when set**: on every boot the provider is matched **by name** and **updated** when it already exists, created when absent. Other (UI-created) providers with a different name are never touched. When the env vars are unset, the DB remains the source of truth (UI-managed deployments are unaffected).

The decision is a small pure function (`plan_provider_reconcile`) in the lib crate so it is unit-testable without a database, mirroring the existing `build_oidc_request_from_values` pattern. The `Create -> Update` mapping is a `From<Create…> for Update…` impl placed with the request types (orphan rule). The skip is now an `info`-level reconcile log rather than a silent `debug`.

For OIDC, `attribute_mapping_replace = true` so a key removed from the env clears in the DB (truly env-definitive). Known limitation: `update_ldap` uses `.or(existing)` for `bind_dn` / `group_base_dn` / `group_filter` / `admin_group_dn`, so clearing those four optional LDAP fields via env is not possible — only changed values apply. Fully clearing them would require an `update_ldap` change, out of scope for this minimal fix.

Closes #1656.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_plan_reconcile_update_when_name_matches` is the primary regression test: it asserts that when a provider with the env name already exists the planner returns `Update(id)`. On `main` this symbol does not exist (compile failure) and, behaviourally, the old empty-table-only guard could never produce an update — it could only skip. `test_plan_reconcile_create_ignores_other_named_providers` proves UI-created providers neither block bootstrap nor get targeted.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New unit tests (run under `cargo test --workspace --lib`): `test_plan_reconcile_create_when_absent`, `test_plan_reconcile_update_when_name_matches`, `test_plan_reconcile_create_ignores_other_named_providers`, `test_oidc_create_to_update_carries_secret_and_replaces_mapping`, `test_ldap_create_to_update_maps_required_fields`. Full lib suite: 10796 passed; 0 failed (the one skipped test is a pre-existing flaky loopback-timeout unrelated to this change).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
