### PR TITLE
fix(ci): resolve clippy -D warnings lints that fail on current stable

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -9098,7 +9098,7 @@ mod tests {
 
     #[test]
     fn test_anonymous_token_is_non_empty() {
-        assert!(!ANONYMOUS_TOKEN.is_empty());
+        assert_eq!(ANONYMOUS_TOKEN, "anonymous");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`main` does not pass `cargo clippy --workspace --all-targets -- -D warnings` on the current stable toolchain — two warn-by-default lints fail under `-D warnings`:

- `backend/src/storage/azure.rs:1208` — `clippy::collapsible_else_if`
- `backend/src/api/handlers/oci_v2.rs:8712` — `clippy::const_is_empty` (`assert!(!ANONYMOUS_TOKEN.is_empty())`)

Because the `🦀 Check Rust` job uses unpinned `dtolnay/rust-toolchain@stable` + `sccache`, these only surface on a **cold** compile of those files, so `Check Rust` passes or fails on cache state for otherwise-identical `main`-based code (observed across two unrelated PRs).

This collapses the `else if` in `azure.rs` and changes the `oci_v2.rs` test to `assert_eq!(ANONYMOUS_TOKEN, "anonymous")` — asserting the constant's real value, which is the test's actual intent, and sidestepping `const_is_empty`. Both changes are behaviour-preserving. After this, `clippy -D warnings` is clean on a cold checkout.

See #1669 for the full analysis, including the recommended follow-up to **pin the CI toolchain** (out of scope here — maintainer policy decision).

Closes #1669.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is a lint/CI fix. The bug is a clippy gate failure, not runtime behaviour, so the "test" is the clippy gate itself going green on a cold compile (verified locally: `cargo clippy --workspace --all-targets -- -D warnings` → 0 warnings on a clean target). The existing `test_anonymous_token_is_non_empty` and the `azure::tests::*` `put_stream` tests guard that the touched code's behaviour is unchanged (all pass).

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --all -- --check` clean; `cargo clippy --workspace --all-targets -- -D warnings` clean (was 2 errors on cold compile before this change); affected lib tests (`anonymous_token`, `azure`) 77 passed / 0 failed.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
