### PR TITLE
chore(ci): cache Rust deps + run coverage via nextest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,12 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # Cache the dependency build so only the workspace crate recompiles.
+      # ~635 deps are byte-identical run-to-run; cold compile was ~9m.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: clippy
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -123,6 +129,12 @@ jobs:
           --health-retries 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      # Separate cache key from check-rust: same target dir but a different
+      # build profile (test vs clippy), so they must not share a cache.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          shared-key: unit
 
       # Catch migration-slot collisions before they reach the e2e/nightly job.
       # The nightly run on 2026-05-09 (#1128) crashed at startup with
@@ -258,6 +270,22 @@ jobs:
             echo "### Coverage: skipped (no Rust source changes in this PR)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
+      # Distinct cache key: the instrumented coverage build is incompatible
+      # with the clippy/unit profiles, and cargo-llvm-cov builds into
+      # target/llvm-cov-target, so point rust-cache there or it caches an
+      # empty target/ and silently no-ops.
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        if: steps.detect.outputs.rust_changed == 'true'
+        with:
+          shared-key: coverage
+          workspaces: ". -> target/llvm-cov-target"
+
+      - name: Install cargo-nextest
+        if: steps.detect.outputs.rust_changed == 'true'
+        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2.81.5
+        with:
+          tool: nextest
+
       - name: Run database migrations
         if: steps.detect.outputs.rust_changed == 'true'
         run: sqlx migrate run --source backend/migrations
@@ -277,7 +305,10 @@ jobs:
           # paths in coverage. The encryption_key panic-when-unset test
           # explicitly skips when this is set.
           JWT_SECRET: ci-coverage-secret-at-least-32-bytes-long-for-tests
-        run: cargo llvm-cov --workspace --lib --lcov --output-path lcov.info
+        # nextest runs each test in its own process for faster scheduling.
+        # Cap test concurrency to 4 so parallel test processes don't OOM the
+        # memory-limited ARC runner (cf. the #1515 compile OOM).
+        run: cargo llvm-cov nextest --workspace --lib --lcov --output-path lcov.info --test-threads 4
 
       - name: Coverage summary and gate
         if: steps.detect.outputs.rust_changed == 'true'


### PR DESCRIPTION
Closes #1672

## Summary
The `coverage` job dominates CI at ~12-13m, almost entirely in one step (`cargo llvm-cov --workspace --lib`): ~9.5m recompiling 636 dependency crates from cold (there is no Rust build cache anywhere in CI) and ~2.5m running the unit tests in a single process.

This PR attacks both phases without sharding or extra runners:

- **Dependency build cache** (`Swatinem/rust-cache`) on `check-rust`, `test-backend-unit` and `coverage`. `cargo-llvm-cov` only instruments workspace crates, so the ~635-dep build is identical run-to-run and fully cacheable. Each job gets a distinct `shared-key` (`clippy` / `unit` / `coverage`) because the build profiles differ; the coverage cache is pointed at `target/llvm-cov-target` (where `cargo-llvm-cov` actually builds) so it doesn't silently cache an empty `target/`.
- **`cargo-nextest`** as the coverage test executor for process-level parallelism, capped at `--test-threads 4` to stay within the memory-limited ARC runner (cf. the #1515 compile OOM).

Expected warm-cache `coverage` runtime **~3-3.5m** on a single runner. `check-rust` and `test-backend-unit` also drop from cold-compile-bound to ~1-2m.

The downstream "Coverage summary and gate" step (`cargo llvm-cov --no-run --summary-only` / `--fail-under-lines`) reads nextest-collected profile data unchanged — `--lib` carries no doctests and the build profile matches, so no change is needed there.

All actions are pinned to a commit SHA with a version comment, matching the existing convention in this workflow.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

<!-- Validation is in CI itself: the second run on this branch exercises the warm cache and should show the coverage job dropping from ~13m to ~3-3.5m. The coverage/duplication/audit gates run unchanged. -->

## API Changes
- [x] N/A - no API changes
