### PR TITLE
refactor(proxy): extract UpstreamClient + shared bearer-exchange (#1618 S8)

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -7315,4 +7315,818 @@ SHA256:
             "stale: missing body is a miss, not an error"
         );
     }
+
+    // =======================================================================
+    // UpstreamClient coverage (#1618 S8).
+    //
+    // S8 relocated the upstream-fetch lifecycle (`fetch_buffered`,
+    // `fetch_stream`, `read_upstream_response*`, `exchange_bearer_then`,
+    // `obtain_bearer_token`, `get_cached_token`, `check_etag_changed`) into
+    // `UpstreamClient`. Those network methods load per-repo auth from the DB
+    // before issuing the HTTP request, so the unit tests below drive them end
+    // to end against a `wiremock` upstream with a live `DATABASE_URL` (the
+    // same fixture pattern the rest of this suite uses). They no-op on runners
+    // without a test DB and run in CI's coverage job, which provisions one.
+    //
+    // The `obtain_bearer_token` cache-hit / TTL-cap / eviction decisions and
+    // `get_cached_token` freshness math are pure (no network) and are tested
+    // by constructing an `UpstreamClient` directly and seeding its token cache.
+    // =======================================================================
+
+    /// Build a Remote `Repository` whose `upstream_url` points at `upstream`.
+    /// `repo.id` is random and intentionally absent from the DB: the upstream
+    /// methods only run `load_upstream_auth`, whose query returns no rows
+    /// (`Ok(None)`) for an unknown id and then proceeds to the HTTP request.
+    fn wiremock_remote_repo(key: &str, upstream: &str, storage_path: &str) -> Repository {
+        Repository {
+            id: Uuid::new_v4(),
+            key: key.to_string(),
+            name: key.to_string(),
+            description: None,
+            format: RepositoryFormat::Generic,
+            repo_type: RepositoryType::Remote,
+            storage_backend: "filesystem".to_string(),
+            storage_path: storage_path.to_string(),
+            upstream_url: Some(upstream.to_string()),
+            is_public: true,
+            quota_bytes: None,
+            replication_priority: crate::models::repository::ReplicationPriority::OnDemand,
+            promotion_target_id: None,
+            promotion_policy_id: None,
+            curation_enabled: false,
+            curation_source_repo_id: None,
+            curation_target_repo_id: None,
+            curation_default_action: "allow".to_string(),
+            curation_sync_interval_secs: 3600,
+            curation_auto_fetch: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    // -- get_cached_token: pure TTL-freshness decision -----------------------
+
+    #[tokio::test]
+    async fn test_get_cached_token_returns_fresh_entry_within_90pct_ttl() {
+        // A token cached "just now" with a 1000s TTL is well inside the 90%
+        // freshness window and must be returned verbatim.
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        {
+            let mut cache = client.token_cache.write().await;
+            cache.insert(
+                "k".to_string(),
+                ("tok-fresh".to_string(), Instant::now(), 1000),
+            );
+        }
+        assert_eq!(
+            client.get_cached_token("k").await.as_deref(),
+            Some("tok-fresh"),
+            "a token inside the 90% TTL window is a cache hit",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_cached_token_treats_aged_entry_past_90pct_as_miss() {
+        // created_at far enough in the past that elapsed() >= ttl*9/10. With a
+        // 10s TTL the window is 9s; backdate the entry by 20s so it is stale.
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        {
+            let mut cache = client.token_cache.write().await;
+            let aged = Instant::now()
+                .checked_sub(Duration::from_secs(20))
+                .expect("subtract 20s");
+            cache.insert("k".to_string(), ("tok-old".to_string(), aged, 10));
+        }
+        assert!(
+            client.get_cached_token("k").await.is_none(),
+            "an entry past 90% of its TTL must be treated as a miss",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_cached_token_absent_key_is_miss() {
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        assert!(client.get_cached_token("nope").await.is_none());
+    }
+
+    // -- obtain_bearer_token: cache hit short-circuit (no network) -----------
+
+    #[tokio::test]
+    async fn test_obtain_bearer_token_returns_cached_without_network() {
+        // A fresh cache entry under the exact "{realm}\0{service}\0{scope}"
+        // key must short-circuit before any token-endpoint request. The realm
+        // points at an unroutable host so a network attempt would fail the
+        // test; the cache hit makes it never happen.
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        let realm = "http://127.0.0.1:0/token";
+        let service = "registry.example";
+        let scope = "repository:library/alpine:pull";
+        let key = format!("{}\0{}\0{}", realm, service, scope);
+        {
+            let mut cache = client.token_cache.write().await;
+            cache.insert(key, ("cached-bearer".to_string(), Instant::now(), 1000));
+        }
+        let token = client
+            .obtain_bearer_token(realm, service, scope, &None)
+            .await
+            .expect("cache hit must return Ok without contacting the realm");
+        assert_eq!(token, "cached-bearer");
+    }
+
+    // -- obtain_bearer_token: full token-endpoint exchange via wiremock ------
+
+    #[tokio::test]
+    async fn test_obtain_bearer_token_exchanges_and_caps_ttl() {
+        use wiremock::matchers::{method, path, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // Token endpoint echoes a token and an absurd expires_in; the TTL must
+        // be capped at MAX_TOKEN_TTL_SECS by the caching logic.
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .and(query_param("service", "reg.test"))
+            .and(query_param("scope", "repository:img:pull"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "token": "exchanged-token",
+                "expires_in": 10_000_000u64,
+            })))
+            .mount(&server)
+            .await;
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        let realm = format!("{}/token", server.uri());
+
+        let token = client
+            .obtain_bearer_token(&realm, "reg.test", "repository:img:pull", &None)
+            .await
+            .expect("token exchange against a 200 token endpoint must succeed");
+        assert_eq!(token, "exchanged-token");
+
+        // The entry is now cached with the capped TTL, so a second call is a
+        // cache hit (no second request is registered on the mock).
+        let again = client
+            .obtain_bearer_token(&realm, "reg.test", "repository:img:pull", &None)
+            .await
+            .expect("second call must hit the cache");
+        assert_eq!(again, "exchanged-token");
+
+        let cache = client.token_cache.read().await;
+        let (_, _, ttl) = cache
+            .get(&format!(
+                "{}\0{}\0{}",
+                realm, "reg.test", "repository:img:pull"
+            ))
+            .expect("entry cached");
+        assert_eq!(
+            *ttl, MAX_TOKEN_TTL_SECS,
+            "an oversized expires_in must be capped at MAX_TOKEN_TTL_SECS",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_obtain_bearer_token_uses_access_token_field_and_default_ttl() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // No `service`/`scope` params -> the token URL is the bare realm. The
+        // response uses the `access_token` alias and omits `expires_in`, so the
+        // default TTL applies.
+        Mock::given(method("GET"))
+            .and(path("/realm"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "alias-token",
+            })))
+            .mount(&server)
+            .await;
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        let realm = format!("{}/realm", server.uri());
+
+        let token = client
+            .obtain_bearer_token(&realm, "", "", &None)
+            .await
+            .expect("access_token alias must be accepted");
+        assert_eq!(token, "alias-token");
+
+        let cache = client.token_cache.read().await;
+        let (_, _, ttl) = cache
+            .get(&format!("{}\0\0", realm))
+            .expect("entry cached under empty service/scope");
+        assert_eq!(
+            *ttl, DEFAULT_TOKEN_TTL_SECS,
+            "a missing expires_in must fall back to DEFAULT_TOKEN_TTL_SECS",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_obtain_bearer_token_errors_on_non_success_status() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        let realm = format!("{}/token", server.uri());
+
+        let err = client
+            .obtain_bearer_token(&realm, "", "", &None)
+            .await
+            .expect_err("a 403 from the token endpoint must surface as an error");
+        assert!(
+            matches!(err, AppError::Storage(_)),
+            "non-2xx token endpoint status maps to AppError::Storage, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_obtain_bearer_token_errors_when_response_has_no_token() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/token"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({ "expires_in": 60 })),
+            )
+            .mount(&server)
+            .await;
+
+        let pool = sqlx::PgPool::connect_lazy("postgres://invalid/").unwrap();
+        let client = UpstreamClient::new(pool, Client::new());
+        let realm = format!("{}/token", server.uri());
+
+        let err = client
+            .obtain_bearer_token(&realm, "", "", &None)
+            .await
+            .expect_err("a token response with neither token nor access_token must error");
+        assert!(matches!(err, AppError::Storage(_)));
+    }
+
+    // -- fetch_buffered + read_upstream_response (success / error) -----------
+
+    #[tokio::test]
+    async fn test_fetch_buffered_returns_body_headers_and_etag() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/pkg/file.bin"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .insert_header("etag", "\"v1\"")
+                    .insert_header("link", "<next>; rel=next")
+                    .set_body_bytes(b"buffered-bytes".as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-buf-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/pkg/file.bin", server.uri());
+
+        let resp = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4())
+            .await
+            .expect("buffered fetch of a 200 upstream must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert_eq!(&resp.content[..], b"buffered-bytes");
+        assert_eq!(
+            resp.content_type.as_deref(),
+            Some("application/octet-stream")
+        );
+        assert_eq!(resp.etag.as_deref(), Some("\"v1\""));
+        assert_eq!(resp.link.as_deref(), Some("<next>; rel=next"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_buffered_maps_upstream_404_to_error() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-404-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/missing", server.uri());
+
+        let result = proxy.fetch_from_upstream(&url, Uuid::new_v4()).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(
+            result.is_err(),
+            "a 404 upstream must surface as an error, not a body",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_buffered_maps_upstream_503_to_service_unavailable() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/down"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-503-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/down", server.uri());
+
+        let result = proxy.fetch_from_upstream(&url, Uuid::new_v4()).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+        let err = result
+            .err()
+            .expect("a 5xx upstream must surface as an error");
+        assert!(
+            matches!(err, AppError::ServiceUnavailable(_)),
+            "5xx upstream must map to ServiceUnavailable, got {err:?}",
+        );
+    }
+
+    // -- fetch_upstream_direct(+_with_link): drive fetch_buffered + headers --
+
+    #[tokio::test]
+    async fn test_fetch_upstream_direct_returns_effective_url() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/simple/foo/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_bytes(b"<html/>".as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-direct-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-direct", &server.uri(), tmp.to_str().unwrap());
+
+        let (body, ct, effective) = proxy
+            .fetch_upstream_direct(&repo, "simple/foo/")
+            .await
+            .expect("direct fetch must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(&body[..], b"<html/>");
+        assert_eq!(ct.as_deref(), Some("text/html"));
+        assert!(
+            effective.ends_with("/simple/foo/"),
+            "effective url: {effective}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_upstream_direct_with_link_preserves_link_header() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v2/_catalog"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("link", "</v2/_catalog?last=z>; rel=\"next\"")
+                    .set_body_bytes(b"{}".as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-link-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-link", &server.uri(), tmp.to_str().unwrap());
+
+        let (_body, _ct, link) = proxy
+            .fetch_upstream_direct_with_link(&repo, "v2/_catalog")
+            .await
+            .expect("direct-with-link fetch must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(link.as_deref(), Some("</v2/_catalog?last=z>; rel=\"next\""));
+    }
+
+    // -- fetch_stream + read_upstream_response_streaming ---------------------
+
+    #[tokio::test]
+    async fn test_fetch_artifact_streaming_streams_upstream_body_on_cache_miss() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/blob"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(b"streamed-body".as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-stream-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-stream", &server.uri(), tmp.to_str().unwrap());
+
+        let result = proxy
+            .fetch_artifact_streaming(&repo, "blob")
+            .await
+            .expect("streaming fetch on a cache miss must succeed");
+        assert_eq!(
+            result.content_type.as_deref(),
+            Some("application/octet-stream")
+        );
+
+        let mut collected = Vec::new();
+        let mut body = result.body;
+        while let Some(chunk) = body.next().await {
+            collected.extend_from_slice(&chunk.expect("stream chunk must be Ok"));
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(collected, b"streamed-body");
+    }
+
+    #[tokio::test]
+    async fn test_fetch_artifact_streaming_maps_upstream_5xx_to_error() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/blob"))
+            .respond_with(ResponseTemplate::new(502))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-stream5xx-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-stream5xx", &server.uri(), tmp.to_str().unwrap());
+
+        let err = proxy
+            .fetch_artifact_streaming(&repo, "blob")
+            .await
+            .err()
+            .expect("a 5xx upstream must fail the streaming fetch");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(matches!(err, AppError::ServiceUnavailable(_)), "{err:?}");
+    }
+
+    // -- exchange_bearer_then: OCI 401 Bearer challenge handling -------------
+    //
+    // The full success path (parse challenge -> validate realm -> token
+    // exchange -> bearer retry) cannot be exercised by a unit test: the only
+    // host a wiremock server binds to is loopback, and loopback is a HARD SSRF
+    // block in `validate_outbound_url` that the `UPSTREAM_ALLOW_PRIVATE_IPS`
+    // toggle does NOT relax (api::validation::is_blocked_ipv4). So the realm
+    // validation inside `exchange_bearer_then` rejects a loopback realm before
+    // any token request. The two tests below pin the branches we CAN reach:
+    //   1. a parseable Bearer challenge whose realm is SSRF-blocked surfaces
+    //      the validation error (covers the parse + realm-extract + validate
+    //      path of `exchange_bearer_then`), and
+    //   2. a 401 that is NOT a Bearer challenge returns `Ok(None)` and the
+    //      caller maps it to the original "upstream error status".
+
+    #[tokio::test]
+    async fn test_buffered_fetch_rejects_ssrf_bearer_realm() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A 401 Bearer challenge whose realm points at a metadata/internal
+        // address. `exchange_bearer_then` must parse the challenge, extract the
+        // realm, and reject it via `validate_outbound_url` BEFORE issuing any
+        // outbound token request (the anti-SSRF guard, #1618 S8 doc).
+        Mock::given(method("GET"))
+            .and(path("/v2/lib/img/manifests/latest"))
+            .respond_with(ResponseTemplate::new(401).insert_header(
+                "www-authenticate",
+                "Bearer realm=\"http://169.254.169.254/latest/token\",service=\"reg\",scope=\"pull\"",
+            ))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-ssrf-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/v2/lib/img/manifests/latest", server.uri());
+
+        let err = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4())
+            .await
+            .err()
+            .expect("a Bearer realm pointing at an internal address must be rejected");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(
+            matches!(err, AppError::Validation(_)),
+            "an SSRF-blocked OCI token realm must surface as a validation error, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_buffered_fetch_401_without_bearer_challenge_errors() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A 401 whose WWW-Authenticate is NOT a Bearer challenge: exchange
+        // returns Ok(None) and the caller maps it to the original error.
+        Mock::given(method("GET"))
+            .and(path("/private"))
+            .respond_with(
+                ResponseTemplate::new(401).insert_header("www-authenticate", "Basic realm=\"x\""),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-401basic-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/private", server.uri());
+
+        let err = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4())
+            .await
+            .err()
+            .expect("a non-Bearer 401 must surface as an error");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(matches!(err, AppError::Storage(_)), "{err:?}");
+    }
+
+    // -- check_etag_changed via check_upstream (304 / changed / unchanged) ---
+
+    #[tokio::test]
+    async fn test_check_upstream_etag_304_reports_unchanged() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // Seed the cache by fetching once with an ETag.
+        Mock::given(method("GET"))
+            .and(path("/etagged"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"abc\"")
+                    .set_body_bytes(b"body".as_ref()),
+            )
+            .mount(&server)
+            .await;
+        // HEAD revalidation returns 304 Not Modified.
+        Mock::given(method("HEAD"))
+            .and(path("/etagged"))
+            .respond_with(ResponseTemplate::new(304))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-etag304-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-etag304", &server.uri(), tmp.to_str().unwrap());
+
+        // Prime the cache (writes a metadata sidecar carrying upstream_etag).
+        proxy
+            .fetch_artifact(&repo, "etagged")
+            .await
+            .expect("prime cache");
+
+        let changed = proxy
+            .check_upstream(&repo, "etagged")
+            .await
+            .expect("etag check must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(!changed, "a 304 from the HEAD revalidation means unchanged");
+    }
+
+    #[tokio::test]
+    async fn test_check_upstream_etag_changed_when_head_returns_new_etag() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/etagged2"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("etag", "\"old\"")
+                    .set_body_bytes(b"body".as_ref()),
+            )
+            .mount(&server)
+            .await;
+        // HEAD returns 200 with a different ETag -> changed.
+        Mock::given(method("HEAD"))
+            .and(path("/etagged2"))
+            .respond_with(ResponseTemplate::new(200).insert_header("etag", "\"new\""))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-etagchg-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-etagchg", &server.uri(), tmp.to_str().unwrap());
+
+        proxy
+            .fetch_artifact(&repo, "etagged2")
+            .await
+            .expect("prime cache");
+
+        let changed = proxy
+            .check_upstream(&repo, "etagged2")
+            .await
+            .expect("etag check must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(changed, "a different ETag on the HEAD means changed");
+    }
+
+    // -- fetch_dists_detecting_change: drives buffered fetch + SHA compare ---
+
+    #[tokio::test]
+    async fn test_fetch_dists_detecting_change_reports_changed_on_first_fetch() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/dists/stable/Release"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"Release: v1".as_ref()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-dists-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-dists", &server.uri(), tmp.to_str().unwrap());
+
+        let (content, _ct, changed) = proxy
+            .fetch_dists_detecting_change(&repo, "dists/stable/Release")
+            .await
+            .expect("dists fetch must succeed");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(&content[..], b"Release: v1");
+        assert!(
+            changed,
+            "first fetch with no prior body is always 'changed'"
+        );
+    }
+
+    // -- get_cache_ttl_for_repo: DB lookup with default fallback -------------
+
+    #[tokio::test]
+    async fn test_fetch_artifact_with_cache_path_round_trips_then_serves_from_cache() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // The upstream is only allowed to be hit ONCE: the second request must
+        // be served from the proxy cache, exercising the cache-hit fast path
+        // in fetch_artifact_with_cache_path_and_accept and get_cache_ttl_for_repo.
+        Mock::given(method("GET"))
+            .and(path("/dl/pkg.tgz"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/gzip")
+                    .set_body_bytes(b"tarball".as_ref()),
+            )
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-cachepath-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-cachepath", &server.uri(), tmp.to_str().unwrap());
+
+        let (b1, ct1) = proxy
+            .fetch_artifact_with_cache_path(&repo, "dl/pkg.tgz", "stable/pkg.tgz")
+            .await
+            .expect("first fetch hits upstream and caches");
+        assert_eq!(&b1[..], b"tarball");
+        assert_eq!(ct1.as_deref(), Some("application/gzip"));
+
+        // Second call: upstream mock is exhausted (up_to_n_times(1)); a cache
+        // hit is the only way this can succeed.
+        let (b2, _ct2) = proxy
+            .fetch_artifact_with_cache_path(&repo, "dl/pkg.tgz", "stable/pkg.tgz")
+            .await
+            .expect("second fetch must be served from the proxy cache");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(&b2[..], b"tarball", "cached bytes must match upstream");
+    }
+
+    // -- parse_bearer_challenge: unquoted-value and trailing branches --------
+
+    #[test]
+    fn test_parse_bearer_challenge_unquoted_values() {
+        // Unquoted, comma-separated params exercise the else-branch that reads
+        // up to the next comma (lines around the unquoted-value path).
+        let params = UpstreamClient::parse_bearer_challenge(
+            "Bearer realm=https://auth.example/token,service=reg,scope=pull",
+        );
+        assert_eq!(
+            params.get("realm").map(String::as_str),
+            Some("https://auth.example/token")
+        );
+        assert_eq!(params.get("service").map(String::as_str), Some("reg"));
+        assert_eq!(params.get("scope").map(String::as_str), Some("pull"));
+    }
+
+    #[test]
+    fn test_parse_bearer_challenge_trailing_key_without_value_breaks() {
+        // A dangling key with no '=' after a valid pair: the loop breaks on the
+        // missing '=' so only the first pair is captured.
+        let params = UpstreamClient::parse_bearer_challenge("Bearer realm=\"r\",dangling");
+        assert_eq!(params.get("realm").map(String::as_str), Some("r"));
+        assert!(!params.contains_key("dangling"));
+    }
+
+    #[test]
+    fn test_parse_bearer_challenge_mixed_quoted_then_unquoted_tail() {
+        // Quoted value followed by an unquoted final param (no trailing comma)
+        // covers the `end < remaining.len()` false branch of the unquoted arm.
+        let params =
+            UpstreamClient::parse_bearer_challenge("Bearer realm=\"https://r/\",service=svc");
+        assert_eq!(params.get("realm").map(String::as_str), Some("https://r/"));
+        assert_eq!(params.get("service").map(String::as_str), Some("svc"));
+    }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -902,6 +902,555 @@ impl CacheStore {
     }
 }
 
+/// Owns the upstream HTTP fetch + OCI bearer-token-exchange lifecycle
+/// (#1618 S8 — the highest-risk structural extraction).
+///
+/// This is a pure structural relocation of the upstream-facing methods that
+/// previously lived directly on [`ProxyService`]: the buffered fetch
+/// (`fetch_buffered` ← `fetch_from_upstream_with_accept`), the streaming fetch
+/// (`fetch_stream` ← `fetch_from_upstream_streaming`), the ETag revalidation
+/// HEAD (`check_etag_changed`), and the OCI bearer-token cache
+/// (`obtain_bearer_token` / `get_cached_token` / `parse_bearer_challenge`).
+/// [`ProxyService`] now holds an `UpstreamClient` and the corresponding methods
+/// delegate here; no behavior, logging, error type, ordering, header set, or
+/// call-site signature changed in the move.
+///
+/// Holds the same `http_client`, the bearer `token_cache`, and a `db` handle
+/// (used only to load per-repo upstream auth via
+/// `upstream_auth::load_upstream_auth`) that [`ProxyService`] used before.
+///
+/// The two fetch paths each previously inlined an identical 401 Bearer
+/// state machine; it is now extracted ONCE into [`Self::exchange_bearer_then`].
+/// The caller-supplied `build_request` closure is what preserves the
+/// **intentional OCI `Accept`-header asymmetry** — see that method's doc.
+pub(crate) struct UpstreamClient {
+    db: PgPool,
+    http_client: Client,
+    /// In-memory cache for OCI registry bearer tokens.
+    /// Key: "{realm}\0{service}\0{scope}", Value: (token, created_at, ttl_secs)
+    token_cache: RwLock<HashMap<String, (String, Instant, u64)>>,
+}
+
+impl UpstreamClient {
+    /// Construct an `UpstreamClient` over the given HTTP client and db handle.
+    /// Starts with an empty bearer-token cache (matching the previous
+    /// `ProxyService::new` initialization exactly).
+    pub(crate) fn new(db: PgPool, http_client: Client) -> Self {
+        Self {
+            db,
+            http_client,
+            token_cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Buffered upstream fetch. Relocated verbatim from
+    /// `ProxyService::fetch_from_upstream_with_accept`.
+    ///
+    /// Variant of the plain fetch that adds an `Accept` header to BOTH the
+    /// initial request and the post-token-exchange retry.
+    ///
+    /// OCI manifest fetches need this so the upstream registry returns the
+    /// content type the caller actually understands. Without an `Accept`
+    /// header Docker Hub picks a default representation (typically the
+    /// OCI image index for multi-arch images) but other registries respond
+    /// with 404 / 406 / a legacy v1 manifest the client cannot consume.
+    /// Mirroring the client's `Accept` upstream removes that source of
+    /// silent content-type mismatches and the spurious 404s they trigger.
+    async fn fetch_buffered(
+        &self,
+        url: &str,
+        repo_id: Uuid,
+        accept: Option<&str>,
+    ) -> Result<UpstreamResponse> {
+        tracing::info!(
+            "Fetching artifact from upstream: {} (accept={:?})",
+            url,
+            accept
+        );
+
+        let upstream_auth =
+            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
+
+        let mut request = self.http_client.get(url);
+        if let Some(ref auth) = upstream_auth {
+            request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
+        }
+        // BUFFERED path sets `Accept` on the INITIAL request. The streaming
+        // path deliberately does NOT — see `exchange_bearer_then` /
+        // `fetch_stream` for why this asymmetry is intentional (#1618 S8).
+        if let Some(accept_value) = accept {
+            request = request.header(ACCEPT, accept_value);
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to fetch from upstream: {}", e)))?;
+
+        let status = response.status();
+
+        // Handle 401 with bearer token exchange (required by Docker Hub and
+        // other OCI registries, even for anonymous/public pulls).
+        if status == StatusCode::UNAUTHORIZED {
+            // The buffered closure RE-ADDS `Accept` on the bearer retry,
+            // mirroring the initial request. The bearer-exchange helper itself
+            // never touches `Accept`; the closure owns that decision so the
+            // buffered/streaming asymmetry is preserved (#1618 S8).
+            if let Some(retry_response) = self
+                .exchange_bearer_then(response, url, &upstream_auth, |req| {
+                    if let Some(accept_value) = accept {
+                        req.header(ACCEPT, accept_value)
+                    } else {
+                        req
+                    }
+                })
+                .await?
+            {
+                return Self::read_upstream_response(retry_response, url).await;
+            }
+
+            return Err(AppError::Storage(format!(
+                "Upstream returned error status {}: {}",
+                status, url
+            )));
+        }
+
+        Self::read_upstream_response(response, url).await
+    }
+
+    /// Extract content, content-type, etag, effective URL, and Link header from
+    /// an upstream HTTP response. Callers are responsible for handling 401 before
+    /// invoking. Relocated verbatim from `ProxyService::read_upstream_response`.
+    async fn read_upstream_response(
+        response: reqwest::Response,
+        url: &str,
+    ) -> Result<UpstreamResponse> {
+        let status = response.status();
+        let effective_url = response.url().to_string();
+
+        // Centralise the 404/4xx/5xx classification through
+        // `validate_upstream_status` (#1445) so the buffered fetch path
+        // gets the same 5xx -> ServiceUnavailable mapping the streaming
+        // path does. Previously this inlined a "non-2xx -> Storage" rule
+        // that surfaced raw upstream 502/503/504 to clients as 502.
+        validate_upstream_status(status, url)?;
+
+        let content_type = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let etag = response
+            .headers()
+            .get(ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let link = response
+            .headers()
+            .get("link")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+
+        let content = response
+            .bytes()
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?;
+
+        tracing::info!(
+            "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?}, link: {:?})",
+            content.len(),
+            content_type,
+            etag,
+            link
+        );
+
+        Ok(UpstreamResponse {
+            content,
+            content_type,
+            etag,
+            effective_url,
+            link,
+        })
+    }
+
+    /// Streaming upstream fetch. Relocated verbatim from
+    /// `ProxyService::fetch_from_upstream_streaming` (#895).
+    ///
+    /// Returns the upstream body as a stream of `Bytes` chunks instead of
+    /// buffering the whole body into memory. Used by the OOM-mitigation path
+    /// that tees the upstream stream simultaneously to the client and to the
+    /// storage cache.
+    ///
+    /// Auth handling (Basic + OCI bearer token exchange) mirrors the
+    /// buffered variant; only the body extraction differs — and, critically,
+    /// the streaming path sets NO `Accept` header anywhere (see below).
+    async fn fetch_stream(&self, url: &str, repo_id: Uuid) -> Result<UpstreamStream> {
+        tracing::info!("Fetching artifact from upstream (streaming): {}", url);
+
+        let upstream_auth =
+            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
+
+        let mut request = self.http_client.get(url);
+        if let Some(ref auth) = upstream_auth {
+            request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
+        }
+        // NOTE: the streaming path intentionally sets NO `Accept` header on the
+        // initial request, in contrast to the buffered path which sets it on
+        // both the initial request and the retry. This asymmetry is deliberate
+        // and MUST NOT be "unified" — do not add `Accept` here (#1618 S8 review).
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to fetch from upstream: {}", e)))?;
+
+        let status = response.status();
+
+        if status == StatusCode::UNAUTHORIZED {
+            // The streaming closure is the IDENTITY transform: it adds NO
+            // `Accept` header on the bearer retry, preserving the asymmetry
+            // with the buffered path (#1618 S8).
+            if let Some(retry_response) = self
+                .exchange_bearer_then(response, url, &upstream_auth, |req| req)
+                .await?
+            {
+                return Self::read_upstream_response_streaming(retry_response, url);
+            }
+
+            return Err(AppError::Storage(format!(
+                "Upstream returned error status {}: {}",
+                status, url
+            )));
+        }
+
+        Self::read_upstream_response_streaming(response, url)
+    }
+
+    /// Shared OCI 401 Bearer-challenge state machine, extracted ONCE from the
+    /// previously copy-pasted blocks in the buffered and streaming fetch paths
+    /// (#1618 S8).
+    ///
+    /// Given the upstream's 401 `response`, this:
+    /// 1. parses the `WWW-Authenticate: Bearer ...` challenge,
+    /// 2. validates the advertised realm against SSRF rules
+    ///    (`validate_outbound_url`) BEFORE any outbound request,
+    /// 3. obtains a bearer token (cache hit or token-endpoint exchange), and
+    /// 4. rebuilds a fresh GET via the caller-supplied `build_request` closure
+    ///    (already carrying `bearer_auth(token)`), sends it, and returns the
+    ///    RAW [`reqwest::Response`].
+    ///
+    /// Returns `Ok(Some(response))` when the 401 carried a usable Bearer
+    /// challenge and the retry was issued; `Ok(None)` when the response was not
+    /// a parseable Bearer challenge (the caller then maps that to the original
+    /// "Upstream returned error status" error, exactly as before).
+    ///
+    /// CRITICAL — this helper deliberately returns the raw response and does
+    /// NOT read the body: the caller picks `read_upstream_response` (buffered,
+    /// fully buffered) vs `read_upstream_response_streaming` (streaming, bounded
+    /// memory). Reading the body here would collapse streaming into buffering
+    /// and break its bounded-memory guarantee (#1618 S8 review).
+    ///
+    /// CRITICAL — this helper NEVER sets an `Accept` header. The OCI `Accept`
+    /// asymmetry between the buffered and streaming paths is intentional and is
+    /// owned entirely by the caller's `build_request` closure: the buffered
+    /// caller re-adds `Accept` on the retry, the streaming caller adds nothing.
+    /// Do NOT "helpfully" add `Accept` here (#1618 S8 review).
+    async fn exchange_bearer_then<F>(
+        &self,
+        response: reqwest::Response,
+        url: &str,
+        upstream_auth: &Option<crate::services::upstream_auth::UpstreamAuthType>,
+        build_request: F,
+    ) -> Result<Option<reqwest::Response>>
+    where
+        F: FnOnce(reqwest::RequestBuilder) -> reqwest::RequestBuilder,
+    {
+        let challenge = response
+            .headers()
+            .get(WWW_AUTHENTICATE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .to_string();
+
+        if challenge.starts_with("Bearer ") {
+            let params = Self::parse_bearer_challenge(&challenge);
+            if let Some(realm) = params.get("realm") {
+                let scope = params.get("scope").cloned().unwrap_or_default();
+                let service = params.get("service").cloned().unwrap_or_default();
+
+                // Validate the realm URL against SSRF rules before making
+                // any outbound request. A malicious upstream could set
+                // realm to an internal address.
+                crate::api::validation::validate_outbound_url(realm, "OCI token realm")?;
+
+                let token = self
+                    .obtain_bearer_token(realm, &service, &scope, upstream_auth)
+                    .await?;
+
+                // Retry with the bearer token only. The original upstream
+                // Basic credentials were already forwarded to the token
+                // endpoint in obtain_bearer_token(); adding them here
+                // would produce two Authorization headers.
+                //
+                // The caller's `build_request` closure decides whether to
+                // re-add `Accept` (buffered: yes; streaming: no) — see the
+                // method doc on the intentional asymmetry (#1618 S8).
+                let retry_request = build_request(self.http_client.get(url).bearer_auth(&token));
+
+                let retry_response = retry_request.send().await.map_err(|e| {
+                    AppError::Storage(format!(
+                        "Failed to fetch from upstream after token exchange: {}",
+                        e
+                    ))
+                })?;
+
+                return Ok(Some(retry_response));
+            }
+        }
+
+        Ok(None)
+    }
+
+    /// Stream the upstream HTTP response body without buffering. Mirrors
+    /// the shape of [`Self::read_upstream_response`] but returns the body
+    /// as a stream. Status/header validation happens up front; the
+    /// stream itself yields one [`Bytes`] chunk per `reqwest` body
+    /// frame. Relocated verbatim from
+    /// `ProxyService::read_upstream_response_streaming`.
+    fn read_upstream_response_streaming(
+        response: reqwest::Response,
+        url: &str,
+    ) -> Result<UpstreamStream> {
+        validate_upstream_status(response.status(), url)?;
+        let (content_type, etag, content_length) = extract_streaming_headers(response.headers());
+
+        let body = response.bytes_stream().map(|r| {
+            r.map_err(|e| AppError::Storage(format!("Failed to read upstream stream: {}", e)))
+        });
+
+        Ok(UpstreamStream {
+            body: Box::pin(body),
+            content_type,
+            etag,
+            content_length,
+        })
+    }
+
+    /// Obtain a bearer token for an OCI registry, using the in-memory cache
+    /// when possible. Relocated verbatim from
+    /// `ProxyService::obtain_bearer_token`.
+    async fn obtain_bearer_token(
+        &self,
+        realm: &str,
+        service: &str,
+        scope: &str,
+        upstream_auth: &Option<crate::services::upstream_auth::UpstreamAuthType>,
+    ) -> Result<String> {
+        let cache_key = format!("{}\0{}\0{}", realm, service, scope);
+
+        if let Some(token) = self.get_cached_token(&cache_key).await {
+            return Ok(token);
+        }
+
+        // Build token request URL with query parameters.
+        let token_url = {
+            let mut parts = Vec::new();
+            if !service.is_empty() {
+                parts.push(format!("service={}", urlencoding::encode(service)));
+            }
+            if !scope.is_empty() {
+                parts.push(format!("scope={}", urlencoding::encode(scope)));
+            }
+            if parts.is_empty() {
+                realm.to_string()
+            } else {
+                let sep = if realm.contains('?') { "&" } else { "?" };
+                format!("{}{}{}", realm, sep, parts.join("&"))
+            }
+        };
+        let mut token_request = self.http_client.get(&token_url);
+
+        // Forward configured Basic credentials for private registries.
+        if let Some(crate::services::upstream_auth::UpstreamAuthType::Basic {
+            username,
+            password,
+        }) = upstream_auth
+        {
+            token_request = token_request.basic_auth(username, Some(password));
+        }
+
+        tracing::debug!("Requesting bearer token from {} (scope={})", realm, scope);
+
+        let token_response = token_request.send().await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to request bearer token from {}: {}",
+                realm, e
+            ))
+        })?;
+
+        if !token_response.status().is_success() {
+            return Err(AppError::Storage(format!(
+                "Token endpoint {} returned status {}",
+                realm,
+                token_response.status()
+            )));
+        }
+
+        let body: RegistryTokenResponse = token_response.json().await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to parse token response from {}: {}",
+                realm, e
+            ))
+        })?;
+
+        let token = body
+            .token
+            .or(body.access_token)
+            .ok_or_else(|| AppError::Storage("Token endpoint returned no token".to_string()))?;
+
+        // Cap TTL to prevent overflow and unreasonably long cache entries.
+        let ttl = body
+            .expires_in
+            .unwrap_or(DEFAULT_TOKEN_TTL_SECS)
+            .min(MAX_TOKEN_TTL_SECS);
+
+        // Cache the token, evicting expired entries to prevent unbounded growth.
+        {
+            let mut cache = self.token_cache.write().await;
+            cache.retain(|_, (_, created_at, entry_ttl)| {
+                created_at.elapsed() < Duration::from_secs(*entry_ttl)
+            });
+            cache.insert(cache_key, (token.clone(), Instant::now(), ttl));
+        }
+
+        Ok(token)
+    }
+
+    /// Return a cached bearer token if present and not expired. Relocated
+    /// verbatim from `ProxyService::get_cached_token`.
+    async fn get_cached_token(&self, cache_key: &str) -> Option<String> {
+        let cache = self.token_cache.read().await;
+        let (token, created_at, ttl_secs) = cache.get(cache_key)?;
+        if created_at.elapsed() < Duration::from_secs(ttl_secs.saturating_mul(9) / 10) {
+            Some(token.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Parse a `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`
+    /// header into a map of key-value pairs. Relocated verbatim from
+    /// `ProxyService::parse_bearer_challenge`.
+    fn parse_bearer_challenge(header: &str) -> HashMap<String, String> {
+        let mut params = HashMap::new();
+        let bearer_params = match header.strip_prefix("Bearer ") {
+            Some(p) => p,
+            None => return params,
+        };
+
+        let mut remaining = bearer_params.trim();
+        while !remaining.is_empty() {
+            let eq_pos = match remaining.find('=') {
+                Some(p) => p,
+                None => break,
+            };
+            let key = remaining[..eq_pos].trim().to_lowercase();
+            remaining = remaining[eq_pos + 1..].trim();
+
+            let value;
+            if remaining.starts_with('"') {
+                remaining = &remaining[1..];
+                let end = remaining.find('"').unwrap_or(remaining.len());
+                value = remaining[..end].to_string();
+                remaining = if end + 1 < remaining.len() {
+                    remaining[end + 1..].trim_start_matches(',').trim()
+                } else {
+                    ""
+                };
+            } else {
+                let end = remaining.find(',').unwrap_or(remaining.len());
+                value = remaining[..end].trim().to_string();
+                remaining = if end < remaining.len() {
+                    remaining[end + 1..].trim()
+                } else {
+                    ""
+                };
+            }
+
+            params.insert(key, value);
+        }
+
+        params
+    }
+
+    /// Check if upstream ETag has changed (returns true if changed/newer).
+    /// Relocated verbatim from `ProxyService::check_etag_changed`.
+    async fn check_etag_changed(
+        &self,
+        url: &str,
+        cached_etag: &str,
+        repo_id: Uuid,
+    ) -> Result<bool> {
+        let upstream_auth =
+            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
+
+        let mut request = self
+            .http_client
+            .head(url)
+            .header(IF_NONE_MATCH, cached_etag);
+        if let Some(ref auth) = upstream_auth {
+            request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
+        }
+
+        let response = request.send().await.map_err(|e| {
+            AppError::Storage(format!("Failed to check upstream for changes: {}", e))
+        })?;
+
+        match response.status() {
+            StatusCode::NOT_MODIFIED => {
+                tracing::debug!("Upstream unchanged (304 Not Modified) for {}", url);
+                Ok(false)
+            }
+            StatusCode::OK => {
+                // Check if ETag in response differs
+                let new_etag = response.headers().get(ETAG).and_then(|v| v.to_str().ok());
+
+                match new_etag {
+                    Some(etag) if etag == cached_etag => {
+                        tracing::debug!("Upstream ETag unchanged for {}", url);
+                        Ok(false)
+                    }
+                    _ => {
+                        tracing::debug!("Upstream has newer content for {}", url);
+                        Ok(true)
+                    }
+                }
+            }
+            StatusCode::UNAUTHORIZED => {
+                // OCI registries require bearer token exchange even for HEAD
+                // requests. Rather than duplicating the token exchange here,
+                // treat this as "needs re-fetch" and let fetch_from_upstream
+                // handle the full 401 flow on the next access.
+                tracing::debug!(
+                    "Upstream returned 401 for ETag check on {}, will re-fetch with token exchange",
+                    url
+                );
+                Ok(true)
+            }
+            status => {
+                tracing::warn!(
+                    "Unexpected status {} checking upstream {}, assuming changed",
+                    status,
+                    url
+                );
+                Ok(true)
+            }
+        }
+    }
+}
+
 /// Proxy service for fetching and caching artifacts from upstream repositories
 pub struct ProxyService {
     db: PgPool,
@@ -909,10 +1458,12 @@ pub struct ProxyService {
     /// Owns the cache body/metadata/invalidate/freshness lifecycle (#1618 S7).
     /// The cache-facing public methods on `ProxyService` delegate here.
     cache_store: CacheStore,
-    http_client: Client,
-    /// In-memory cache for OCI registry bearer tokens.
-    /// Key: "{realm}\0{service}\0{scope}", Value: (token, created_at, ttl_secs)
-    token_cache: RwLock<HashMap<String, (String, Instant, u64)>>,
+    /// Owns the upstream HTTP fetch + OCI bearer-token-exchange lifecycle
+    /// (#1618 S8). The upstream-facing methods on `ProxyService`
+    /// (`fetch_from_upstream*`, `check_etag_changed`, `parse_bearer_challenge`)
+    /// delegate here. It holds the shared `http_client` and the bearer
+    /// `token_cache` that previously lived directly on `ProxyService`.
+    upstream_client: UpstreamClient,
 }
 
 impl ProxyService {
@@ -937,13 +1488,13 @@ impl ProxyService {
             .expect("Failed to create HTTP client");
 
         let cache_store = CacheStore::new(Arc::clone(&storage));
+        let upstream_client = UpstreamClient::new(db.clone(), http_client);
 
         Self {
             db,
             storage,
             cache_store,
-            http_client,
-            token_cache: RwLock::new(HashMap::new()),
+            upstream_client,
         }
     }
 
@@ -1865,387 +2416,47 @@ impl ProxyService {
     /// Variant of [`Self::fetch_from_upstream`] that adds an `Accept` header
     /// to both the initial request and the post-token-exchange retry.
     ///
-    /// OCI manifest fetches need this so the upstream registry returns the
-    /// content type the caller actually understands. Without an `Accept`
-    /// header Docker Hub picks a default representation (typically the
-    /// OCI image index for multi-arch images) but other registries respond
-    /// with 404 / 406 / a legacy v1 manifest the client cannot consume.
-    /// Mirroring the client's `Accept` upstream removes that source of
-    /// silent content-type mismatches and the spurious 404s they trigger.
+    /// Thin delegation to [`UpstreamClient::fetch_buffered`] (#1618 S8). The
+    /// buffered path's OCI `Accept` semantics (set on the initial request AND
+    /// re-added on the bearer retry) live there; this signature and every
+    /// external call site are unchanged.
     async fn fetch_from_upstream_with_accept(
         &self,
         url: &str,
         repo_id: Uuid,
         accept: Option<&str>,
     ) -> Result<UpstreamResponse> {
-        tracing::info!(
-            "Fetching artifact from upstream: {} (accept={:?})",
-            url,
-            accept
-        );
-
-        let upstream_auth =
-            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
-
-        let mut request = self.http_client.get(url);
-        if let Some(ref auth) = upstream_auth {
-            request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
-        }
-        if let Some(accept_value) = accept {
-            request = request.header(ACCEPT, accept_value);
-        }
-
-        let response = request
-            .send()
+        self.upstream_client
+            .fetch_buffered(url, repo_id, accept)
             .await
-            .map_err(|e| AppError::Storage(format!("Failed to fetch from upstream: {}", e)))?;
-
-        let status = response.status();
-
-        // Handle 401 with bearer token exchange (required by Docker Hub and
-        // other OCI registries, even for anonymous/public pulls).
-        if status == StatusCode::UNAUTHORIZED {
-            let challenge = response
-                .headers()
-                .get(WWW_AUTHENTICATE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("")
-                .to_string();
-
-            if challenge.starts_with("Bearer ") {
-                let params = Self::parse_bearer_challenge(&challenge);
-                if let Some(realm) = params.get("realm") {
-                    let scope = params.get("scope").cloned().unwrap_or_default();
-                    let service = params.get("service").cloned().unwrap_or_default();
-
-                    // Validate the realm URL against SSRF rules before making
-                    // any outbound request. A malicious upstream could set
-                    // realm to an internal address.
-                    crate::api::validation::validate_outbound_url(realm, "OCI token realm")?;
-
-                    let token = self
-                        .obtain_bearer_token(realm, &service, &scope, &upstream_auth)
-                        .await?;
-
-                    // Retry with the bearer token only. The original upstream
-                    // Basic credentials were already forwarded to the token
-                    // endpoint in obtain_bearer_token(); adding them here
-                    // would produce two Authorization headers.
-                    let mut retry_request = self.http_client.get(url).bearer_auth(&token);
-                    if let Some(accept_value) = accept {
-                        retry_request = retry_request.header(ACCEPT, accept_value);
-                    }
-
-                    let retry_response = retry_request.send().await.map_err(|e| {
-                        AppError::Storage(format!(
-                            "Failed to fetch from upstream after token exchange: {}",
-                            e
-                        ))
-                    })?;
-
-                    return Self::read_upstream_response(retry_response, url).await;
-                }
-            }
-
-            return Err(AppError::Storage(format!(
-                "Upstream returned error status {}: {}",
-                status, url
-            )));
-        }
-
-        Self::read_upstream_response(response, url).await
-    }
-
-    /// Extract content, content-type, etag, effective URL, and Link header from
-    /// an upstream HTTP response. Callers are responsible for handling 401 before
-    /// invoking.
-    async fn read_upstream_response(
-        response: reqwest::Response,
-        url: &str,
-    ) -> Result<UpstreamResponse> {
-        let status = response.status();
-        let effective_url = response.url().to_string();
-
-        // Centralise the 404/4xx/5xx classification through
-        // `validate_upstream_status` (#1445) so the buffered fetch path
-        // gets the same 5xx -> ServiceUnavailable mapping the streaming
-        // path does. Previously this inlined a "non-2xx -> Storage" rule
-        // that surfaced raw upstream 502/503/504 to clients as 502.
-        validate_upstream_status(status, url)?;
-
-        let content_type = response
-            .headers()
-            .get(CONTENT_TYPE)
-            .and_then(|v| v.to_str().ok())
-            .map(String::from);
-
-        let etag = response
-            .headers()
-            .get(ETAG)
-            .and_then(|v| v.to_str().ok())
-            .map(String::from);
-
-        let link = response
-            .headers()
-            .get("link")
-            .and_then(|v| v.to_str().ok())
-            .map(String::from);
-
-        let content = response
-            .bytes()
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?;
-
-        tracing::info!(
-            "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?}, link: {:?})",
-            content.len(),
-            content_type,
-            etag,
-            link
-        );
-
-        Ok(UpstreamResponse {
-            content,
-            content_type,
-            etag,
-            effective_url,
-            link,
-        })
     }
 
     /// Streaming variant of [`Self::fetch_from_upstream`] used by the
     /// proxy slow path (#895). Returns the upstream body as a stream of
     /// `Bytes` chunks instead of buffering the whole body into memory.
-    /// Used by the OOM-mitigation path that tees the upstream stream
-    /// simultaneously to the client and to the storage cache.
     ///
-    /// Auth handling (Basic + OCI bearer token exchange) mirrors the
-    /// buffered variant; only the body extraction differs.
+    /// Thin delegation to [`UpstreamClient::fetch_stream`] (#1618 S8). The
+    /// streaming path deliberately sets NO `Accept` header (the intentional
+    /// asymmetry with the buffered path); that decision lives there.
     async fn fetch_from_upstream_streaming(
         &self,
         url: &str,
         repo_id: Uuid,
     ) -> Result<UpstreamStream> {
-        tracing::info!("Fetching artifact from upstream (streaming): {}", url);
-
-        let upstream_auth =
-            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
-
-        let mut request = self.http_client.get(url);
-        if let Some(ref auth) = upstream_auth {
-            request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
-        }
-
-        let response = request
-            .send()
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to fetch from upstream: {}", e)))?;
-
-        let status = response.status();
-
-        if status == StatusCode::UNAUTHORIZED {
-            let challenge = response
-                .headers()
-                .get(WWW_AUTHENTICATE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("")
-                .to_string();
-
-            if challenge.starts_with("Bearer ") {
-                let params = Self::parse_bearer_challenge(&challenge);
-                if let Some(realm) = params.get("realm") {
-                    let scope = params.get("scope").cloned().unwrap_or_default();
-                    let service = params.get("service").cloned().unwrap_or_default();
-                    crate::api::validation::validate_outbound_url(realm, "OCI token realm")?;
-                    let token = self
-                        .obtain_bearer_token(realm, &service, &scope, &upstream_auth)
-                        .await?;
-                    let retry_request = self.http_client.get(url).bearer_auth(&token);
-                    let retry_response = retry_request.send().await.map_err(|e| {
-                        AppError::Storage(format!(
-                            "Failed to fetch from upstream after token exchange: {}",
-                            e
-                        ))
-                    })?;
-                    return Self::read_upstream_response_streaming(retry_response, url);
-                }
-            }
-
-            return Err(AppError::Storage(format!(
-                "Upstream returned error status {}: {}",
-                status, url
-            )));
-        }
-
-        Self::read_upstream_response_streaming(response, url)
-    }
-
-    /// Stream the upstream HTTP response body without buffering. Mirrors
-    /// the shape of [`Self::read_upstream_response`] but returns the body
-    /// as a stream. Status/header validation happens up front; the
-    /// stream itself yields one [`Bytes`] chunk per `reqwest` body
-    /// frame.
-    fn read_upstream_response_streaming(
-        response: reqwest::Response,
-        url: &str,
-    ) -> Result<UpstreamStream> {
-        validate_upstream_status(response.status(), url)?;
-        let (content_type, etag, content_length) = extract_streaming_headers(response.headers());
-
-        let body = response.bytes_stream().map(|r| {
-            r.map_err(|e| AppError::Storage(format!("Failed to read upstream stream: {}", e)))
-        });
-
-        Ok(UpstreamStream {
-            body: Box::pin(body),
-            content_type,
-            etag,
-            content_length,
-        })
-    }
-
-    /// Obtain a bearer token for an OCI registry, using the in-memory cache
-    /// when possible.
-    async fn obtain_bearer_token(
-        &self,
-        realm: &str,
-        service: &str,
-        scope: &str,
-        upstream_auth: &Option<crate::services::upstream_auth::UpstreamAuthType>,
-    ) -> Result<String> {
-        let cache_key = format!("{}\0{}\0{}", realm, service, scope);
-
-        if let Some(token) = self.get_cached_token(&cache_key).await {
-            return Ok(token);
-        }
-
-        // Build token request URL with query parameters.
-        let token_url = {
-            let mut parts = Vec::new();
-            if !service.is_empty() {
-                parts.push(format!("service={}", urlencoding::encode(service)));
-            }
-            if !scope.is_empty() {
-                parts.push(format!("scope={}", urlencoding::encode(scope)));
-            }
-            if parts.is_empty() {
-                realm.to_string()
-            } else {
-                let sep = if realm.contains('?') { "&" } else { "?" };
-                format!("{}{}{}", realm, sep, parts.join("&"))
-            }
-        };
-        let mut token_request = self.http_client.get(&token_url);
-
-        // Forward configured Basic credentials for private registries.
-        if let Some(crate::services::upstream_auth::UpstreamAuthType::Basic {
-            username,
-            password,
-        }) = upstream_auth
-        {
-            token_request = token_request.basic_auth(username, Some(password));
-        }
-
-        tracing::debug!("Requesting bearer token from {} (scope={})", realm, scope);
-
-        let token_response = token_request.send().await.map_err(|e| {
-            AppError::Storage(format!(
-                "Failed to request bearer token from {}: {}",
-                realm, e
-            ))
-        })?;
-
-        if !token_response.status().is_success() {
-            return Err(AppError::Storage(format!(
-                "Token endpoint {} returned status {}",
-                realm,
-                token_response.status()
-            )));
-        }
-
-        let body: RegistryTokenResponse = token_response.json().await.map_err(|e| {
-            AppError::Storage(format!(
-                "Failed to parse token response from {}: {}",
-                realm, e
-            ))
-        })?;
-
-        let token = body
-            .token
-            .or(body.access_token)
-            .ok_or_else(|| AppError::Storage("Token endpoint returned no token".to_string()))?;
-
-        // Cap TTL to prevent overflow and unreasonably long cache entries.
-        let ttl = body
-            .expires_in
-            .unwrap_or(DEFAULT_TOKEN_TTL_SECS)
-            .min(MAX_TOKEN_TTL_SECS);
-
-        // Cache the token, evicting expired entries to prevent unbounded growth.
-        {
-            let mut cache = self.token_cache.write().await;
-            cache.retain(|_, (_, created_at, entry_ttl)| {
-                created_at.elapsed() < Duration::from_secs(*entry_ttl)
-            });
-            cache.insert(cache_key, (token.clone(), Instant::now(), ttl));
-        }
-
-        Ok(token)
-    }
-
-    /// Return a cached bearer token if present and not expired.
-    async fn get_cached_token(&self, cache_key: &str) -> Option<String> {
-        let cache = self.token_cache.read().await;
-        let (token, created_at, ttl_secs) = cache.get(cache_key)?;
-        if created_at.elapsed() < Duration::from_secs(ttl_secs.saturating_mul(9) / 10) {
-            Some(token.clone())
-        } else {
-            None
-        }
+        self.upstream_client.fetch_stream(url, repo_id).await
     }
 
     /// Parse a `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`
     /// header into a map of key-value pairs.
+    ///
+    /// Thin delegation to [`UpstreamClient::parse_bearer_challenge`] (#1618 S8);
+    /// retained on `ProxyService` so the existing bearer-challenge-parse unit
+    /// tests keep calling `ProxyService::parse_bearer_challenge` unchanged.
+    /// The runtime callers now use [`UpstreamClient::parse_bearer_challenge`]
+    /// directly, so this wrapper exists only for the test oracle.
+    #[cfg(test)]
     fn parse_bearer_challenge(header: &str) -> HashMap<String, String> {
-        let mut params = HashMap::new();
-        let bearer_params = match header.strip_prefix("Bearer ") {
-            Some(p) => p,
-            None => return params,
-        };
-
-        let mut remaining = bearer_params.trim();
-        while !remaining.is_empty() {
-            let eq_pos = match remaining.find('=') {
-                Some(p) => p,
-                None => break,
-            };
-            let key = remaining[..eq_pos].trim().to_lowercase();
-            remaining = remaining[eq_pos + 1..].trim();
-
-            let value;
-            if remaining.starts_with('"') {
-                remaining = &remaining[1..];
-                let end = remaining.find('"').unwrap_or(remaining.len());
-                value = remaining[..end].to_string();
-                remaining = if end + 1 < remaining.len() {
-                    remaining[end + 1..].trim_start_matches(',').trim()
-                } else {
-                    ""
-                };
-            } else {
-                let end = remaining.find(',').unwrap_or(remaining.len());
-                value = remaining[..end].trim().to_string();
-                remaining = if end < remaining.len() {
-                    remaining[end + 1..].trim()
-                } else {
-                    ""
-                };
-            }
-
-            params.insert(key, value);
-        }
-
-        params
+        UpstreamClient::parse_bearer_challenge(header)
     }
 
     /// Cache artifact content and metadata, and record the artifact in the
@@ -2291,68 +2502,18 @@ impl ProxyService {
         self.get_cached(cache_key, metadata_key, true).await
     }
 
-    /// Check if upstream ETag has changed (returns true if changed/newer)
+    /// Check if upstream ETag has changed (returns true if changed/newer).
+    ///
+    /// Thin delegation to [`UpstreamClient::check_etag_changed`] (#1618 S8).
     async fn check_etag_changed(
         &self,
         url: &str,
         cached_etag: &str,
         repo_id: Uuid,
     ) -> Result<bool> {
-        let upstream_auth =
-            crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
-
-        let mut request = self
-            .http_client
-            .head(url)
-            .header(IF_NONE_MATCH, cached_etag);
-        if let Some(ref auth) = upstream_auth {
-            request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
-        }
-
-        let response = request.send().await.map_err(|e| {
-            AppError::Storage(format!("Failed to check upstream for changes: {}", e))
-        })?;
-
-        match response.status() {
-            StatusCode::NOT_MODIFIED => {
-                tracing::debug!("Upstream unchanged (304 Not Modified) for {}", url);
-                Ok(false)
-            }
-            StatusCode::OK => {
-                // Check if ETag in response differs
-                let new_etag = response.headers().get(ETAG).and_then(|v| v.to_str().ok());
-
-                match new_etag {
-                    Some(etag) if etag == cached_etag => {
-                        tracing::debug!("Upstream ETag unchanged for {}", url);
-                        Ok(false)
-                    }
-                    _ => {
-                        tracing::debug!("Upstream has newer content for {}", url);
-                        Ok(true)
-                    }
-                }
-            }
-            StatusCode::UNAUTHORIZED => {
-                // OCI registries require bearer token exchange even for HEAD
-                // requests. Rather than duplicating the token exchange here,
-                // treat this as "needs re-fetch" and let fetch_from_upstream
-                // handle the full 401 flow on the next access.
-                tracing::debug!(
-                    "Upstream returned 401 for ETag check on {}, will re-fetch with token exchange",
-                    url
-                );
-                Ok(true)
-            }
-            status => {
-                tracing::warn!(
-                    "Unexpected status {} checking upstream {}, assuming changed",
-                    status,
-                    url
-                );
-                Ok(true)
-            }
-        }
+        self.upstream_client
+            .check_etag_changed(url, cached_etag, repo_id)
+            .await
     }
 }
 


### PR DESCRIPTION
Closes #1674

## Summary

Step S8 of the #1618 proxy refactor — the highest-risk structural extraction. This is a strictly behavior-preserving cut/paste into a new `UpstreamClient` struct plus extraction of ONE shared OCI 401 Bearer-exchange helper. No logic edits; no public signatures or external call sites changed.

**What moved into `UpstreamClient`** (owns `http_client`, the bearer `token_cache`, and a `db` handle used only for `load_upstream_auth`):
- `fetch_buffered` ← `fetch_from_upstream_with_accept`
- `fetch_stream` ← `fetch_from_upstream_streaming`
- `check_etag_changed` (HEAD revalidation)
- `obtain_bearer_token` / `get_cached_token` / `parse_bearer_challenge`
- `read_upstream_response` / `read_upstream_response_streaming`

`ProxyService` now holds an `UpstreamClient` (built in `new()` from the same `http_client`/`token_cache`) and the existing methods delegate to it. `parse_bearer_challenge` is retained as a `#[cfg(test)]` wrapper on `ProxyService` so the existing bearer-challenge-parse unit tests keep calling `ProxyService::parse_bearer_challenge` unchanged.

**Shared bearer helper.** The 401 Bearer state machine (parse challenge → `validate_outbound_url` SSRF guard → `obtain_bearer_token` → rebuild & retry request) was copy-pasted across the buffered and streaming paths. It is now extracted ONCE into `UpstreamClient::exchange_bearer_then(response, url, upstream_auth, build_request)`. This collapses the two duplicated 401 blocks into one (reduces duplication).

- **The helper returns the RAW `reqwest::Response` and never reads the body** — the caller picks `read_upstream_response` (buffered) vs `read_upstream_response_streaming` (streaming), preserving streaming's bounded-memory guarantee.
- **OCI `Accept`-header asymmetry preserved (buffered adds / streaming omits).** The buffered path sets `Accept` on the initial request, and its `build_request` closure re-adds `Accept` on the bearer retry. The streaming path sets `Accept` nowhere and its closure is the identity transform. The helper itself never touches `Accept`. The asymmetry is annotated with comments citing #1618 S8 so a future editor doesn't "fix" it.

`validate_outbound_url` (SSRF), token-cache hit/expiry/eviction, bearer-challenge parsing, and error handling are all relocated verbatim.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

The existing token-cache, bearer-challenge-parse, SSRF/`validate_outbound_url`, ETag, and streaming proxy tests are the oracle for this refactor — all 185 `proxy_service::tests` pass, and the full `cargo test --workspace --lib` is green except the pre-existing sandbox-only `http_client` total-timeout test (network connect blocked in sandbox; unrelated to this change). `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
