### PR TITLE
fix(lifecycle): anchor no_downloads_days cascade test download to NOW

### DIFF
--- a/backend/tests/lifecycle_policy_tests.rs
+++ b/backend/tests/lifecycle_policy_tests.rs
@@ -311,6 +311,27 @@ async fn record_download(pool: &PgPool, artifact_id: Uuid, downloaded_at: &str) 
     .expect("failed to record download");
 }
 
+/// Record a download relative to NOW, N days in the past.
+///
+/// Window-based policies such as `no_downloads_days` compare the most recent
+/// download against `NOW() - make_interval(days => N)`. Tests that need a
+/// download to fall *inside* such a window must anchor it to wall-clock NOW,
+/// not a hardcoded calendar date — otherwise the fixture silently rots out of
+/// the window as real time advances and the test starts failing on a date that
+/// has nothing to do with the code under test.
+async fn record_download_days_ago(pool: &PgPool, artifact_id: Uuid, days_ago: i64) {
+    sqlx::query(
+        "INSERT INTO download_statistics (id, artifact_id, downloaded_at) \
+         VALUES ($1, $2, NOW() - make_interval(days => $3::INT))",
+    )
+    .bind(Uuid::new_v4())
+    .bind(artifact_id)
+    .bind(days_ago as i32)
+    .execute(pool)
+    .await
+    .expect("failed to record relative download");
+}
+
 /// Clean up test data including download statistics.
 async fn cleanup_with_downloads(pool: &PgPool, repo_id: Uuid) {
     // Delete download stats for all artifacts in this repo
@@ -1201,9 +1222,11 @@ async fn test_no_downloads_days_cascades_oci_tags() {
     let svc = LifecycleService::new(pool.clone());
 
     // One cold manifest (no downloads, created 30 days ago) plus one warm
-    // one (downloaded yesterday, created 30 days ago). The policy targets
+    // one (downloaded 1 day ago, created 30 days ago). The policy targets
     // anything older than 7 days with no recent downloads, so only the cold
-    // one is soft-deleted.
+    // one is soft-deleted. The warm download is anchored to NOW (1 day ago)
+    // rather than a hardcoded date so it stays inside the 7-day window no
+    // matter when the test runs.
     let cold_digest = "sha256:1407bb00000000000000000000000000000000000000000000000000000001";
     let warm_digest = "sha256:1407bb00000000000000000000000000000000000000000000000000000002";
     let cold_id =
@@ -1223,7 +1246,7 @@ async fn test_no_downloads_days_cascades_oci_tags() {
         .execute(&pool)
         .await
         .unwrap();
-    record_download(&pool, warm_id, "2026-05-28T00:00:00Z").await;
+    record_download_days_ago(&pool, warm_id, 1).await;
 
     let policy = svc
         .create_policy(CreatePolicyRequest {


### PR DESCRIPTION
Closes #1678

Fixes a time-bomb in the integration test `test_no_downloads_days_cascades_oci_tags` that turned `main` red and blocked the merge queue.

## Summary

`backend/tests/lifecycle_policy_tests.rs::test_no_downloads_days_cascades_oci_tags` failed on `main` with `assertion left == right failed / left: 2 / right: 1` (reproduced against a real Postgres 16 DB).

Root cause: the test recorded the "warm" manifest's download at a hardcoded `2026-05-28T00:00:00Z` — one day before the test was added (PR #1513, 2026-05-29). The `no_downloads_days` policy retains an artifact only if it has a download newer than `NOW() - make_interval(days => 7)`. Once wall-clock time advanced past 2026-06-04, that fixed timestamp aged out of the 7-day window, so the "warm" manifest was *also* selected for soft-deletion. `artifacts_removed` became `2` instead of `1`.

This is **not** an `oci_tags` cascade regression. `git log`/`git blame` confirm the `no_downloads_days` selection query (last touched in #1455) and the post-dispatch cascade are unchanged by the recent OCI-touching merges (#1640 promotion, #1641 manifest_blob_refs, #1655 blob GC, #1668 CacheStore). None of those altered tag/blob/manifest selection or download-window logic. The failure is purely the fixture rotting relative to the clock.

Fix: add a `record_download_days_ago` helper that inserts the download at `NOW() - make_interval(days => N)`, and anchor the warm download to `NOW() - 1 day`. This mirrors how the test already sets `created_at` relative to `NOW`, keeps the test's original intent intact (cold manifest evicted, warm manifest kept and its `oci_tags` row surviving the cascade), and guarantees the fixture can never age out of the window again. The expected counts and cascade assertions are unchanged — the test still asserts exactly one removal and verifies the cold tag is cascaded away while the warm tag survives.

Verified against a real Postgres 16 DB (migrations applied via sqlx-cli):
- The previously failing test now passes (`1 passed`).
- Full `lifecycle_policy_tests` integration suite: `19 passed; 0 failed`.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib`: all green.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

The now-passing `test_no_downloads_days_cascades_oci_tags` is the regression test: it fails on `main` (left: 2, right: 1) and passes on this branch. The fix makes the fixture deterministic so it fails only when the cascade behavior is actually wrong, not as a function of the calendar.

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
