### PR TITLE
ci: fix Check Rust OOM — disable incremental + lower clippy build jobs (#1679)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,16 @@ jobs:
 
       - name: Run Clippy
         # Cap parallel rustc invocations so the lib-test compile doesn't OOM
-        # the ARC runner pod ("sccache: Compile terminated by signal 9", #1515).
-        # 4 is conservative for the runner's memory budget while still keeping
-        # the step under the Tier-1 < 5min target.
+        # the ARC runner pod ("sccache: Compile terminated by signal 9",
+        # #1515/#1594). Lowered 4 → 2 (#1679): under concurrent PR load the
+        # lib-test target still OOM-killed at 4, so fewer parallel codegen
+        # units cut peak RSS further. CARGO_INCREMENTAL=0 disables incremental
+        # codegen (`-C incremental=...`), which was observed ON during the
+        # failing compile and inflates peak memory — incremental is useless in
+        # CI's clean checkout anyway. Lint set is unchanged.
         env:
-          CARGO_BUILD_JOBS: "4"
+          CARGO_BUILD_JOBS: "2"
+          CARGO_INCREMENTAL: "0"
         run: cargo clippy --workspace --all-targets -- -D warnings
 
   test-backend-unit:
@@ -77,6 +82,10 @@ jobs:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
       CARGO_BUILD_JOBS: "4"
+      # Disable incremental codegen (#1679): this job compiles the same
+      # lib-test crate that OOM-killed check-rust, and incremental is useless
+      # in CI's clean checkout while inflating peak RSS.
+      CARGO_INCREMENTAL: "0"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -130,6 +139,11 @@ jobs:
   coverage:
     name: 📊 Code Coverage
     runs-on: ak-ci-runners
+    # Disable incremental codegen (#1679): the coverage build compiles the
+    # same lib-test crate that OOM-killed check-rust. Incremental is useless
+    # in CI's clean checkout and inflates peak RSS.
+    env:
+      CARGO_INCREMENTAL: "0"
     services:
       postgres:
         # Use the GHCR mirror maintained by .github/workflows/mirror-images.yml
@@ -394,6 +408,11 @@ jobs:
     name: 🔗 Backend Integration Tests
     runs-on: ak-ci-runners
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')) && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    # Disable incremental codegen (#1679): consistent with check-rust and the
+    # other heavy Rust compile jobs. Useless in CI's clean checkout, inflates
+    # peak RSS.
+    env:
+      CARGO_INCREMENTAL: "0"
     services:
       postgres:
         # Use the GHCR mirror to avoid Docker Hub anonymous-pull rate limits.


### PR DESCRIPTION
Closes #1679

## Summary
The `🦀 Check Rust` job intermittently OOM-killed (`sccache: Compile terminated by signal 9`, SIGKILL) while clippy compiled the `artifact_keeper_backend (lib test)` target under `--all-targets`. Local clippy passes clean (~5.1GB RSS); CI failed nondeterministically under memory pressure when many PRs compiled concurrently — stalling main **and** the entire PR queue.

This is the same OOM lineage as #1515 / #1594. The existing guards (no debuginfo via `CARGO_PROFILE_DEV_DEBUG=0`/`CARGO_PROFILE_TEST_DEBUG=0`, and `CARGO_BUILD_JOBS=4`) were insufficient on a loaded runner. Diagnosis found `-C incremental=...` was ON during the failing compile, which inflates peak memory.

Targeted, minimal change to cut peak RSS on the confirmed offender (the Check Rust step):
- **`CARGO_INCREMENTAL=0`** — incremental codegen inflates peak memory and is useless in CI's clean checkout (nothing to reuse).
- **`CARGO_BUILD_JOBS` 4 → 2** — fewer parallel codegen units → lower peak RSS.
- **No-debuginfo settings kept** unchanged.
- **Lint set unchanged**: still `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings`. Nothing weakened.

As a clean, low-risk consistency addition, `CARGO_INCREMENTAL=0` is also set on the other heavy Rust compile jobs (Backend Unit Tests, Coverage, Integration), which compile the same lib-test crate.

Local verification with the new env still passes clippy clean under `-D warnings`, and `/usr/bin/time -l` reported ~4.4GB max RSS vs the ~5.1GB baseline — the reduction direction confirms the fix. This PR's own CI runs the workflow from this branch, so the fix applies to its own Check Rust run.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is a CI/workflow change (no application code/logic to cover with a regression test)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=2 cargo clippy --workspace --all-targets -- -D warnings` passes clean; max RSS ~4.4GB)
- [x] No regressions in existing tests (lint set unchanged)

## API Changes
- [x] N/A - no API changes
