### PR TITLE
feat(proxy): single-flight Coordinator seam (#1631 layer 1)

### DIFF
--- a/backend/src/services/proxy_hydration.rs
+++ b/backend/src/services/proxy_hydration.rs
@@ -79,6 +79,112 @@ fn acquire_local_hydration(key: &str) -> LocalHydrationRole {
     })
 }
 
+/// Single-flight coordination seam for proxy cache hydration (#1631).
+///
+/// This trait is the stable seam that the proxy path elects a leader through.
+/// Layer 1 (#1631) defines it and provides the in-process [`BufferedCoordinator`]
+/// implementation that hosts the existing buffered single-flight behavior
+/// ([`coordinate_proxy_hydration`]) unchanged. Two further layers are designed
+/// to plug in here *without reshaping this method*:
+///
+/// * **Layer 2 — streaming broadcast fan-out (#1631 / #895).** The streaming
+///   proxy path ([`ProxyService::fetch_artifact_streaming`]) has a
+///   fundamentally different follower semantic: followers cannot re-check the
+///   cache mid-flight because the body is not cached until the tee completes,
+///   so they must SUBSCRIBE to the leader's chunks (a `tokio::sync::broadcast`
+///   fan-out) instead of waiting-then-rechecking. That is a *different
+///   primitive*, not a tweak of [`Self::coordinate`]: it will be added as a
+///   SEPARATE method on this trait (e.g. `coordinate_stream`) or a sibling
+///   trait, never by forcing a stream through the buffered method here. See the
+///   clean-room design audit §1.3 and the #1618 plan Amendment 4. The seam is
+///   left deliberately open: do NOT generalize [`Self::coordinate`]'s `T` to
+///   carry a stream — add the streaming entry point alongside it.
+///   // #1631 layer 2 seam: add `coordinate_stream` here.
+///
+/// * **Layer 3 — cross-replica advisory-lock decorator (#1609).** The
+///   leader-election decision (currently [`acquire_local_hydration`], driven
+///   inside [`Self::coordinate`]) must be wrappable so a decorator can gate it
+///   behind `pg_try_advisory_xact_lock(hash(repo_id‖path))`. Because election
+///   is factored behind this trait, a decorator can implement `Coordinator` by
+///   wrapping an inner `Coordinator`, taking the advisory lock around the inner
+///   leader-election step, then delegating. No change to [`Self::coordinate`]'s
+///   signature is required for that.
+///   // #1631 layer 3 seam: an advisory-lock `Coordinator` decorator wraps the
+///   //                     inner coordinator's election step.
+///
+/// The trait is intentionally NOT object-safe (the method is generic over the
+/// caller's closures, mirroring [`coordinate_proxy_hydration`]). It is injected
+/// into `ProxyService` as a concrete field, the same way `CacheStore` (#1618
+/// S7), `UpstreamClient` (S8), and `CachePersister` (S9) are.
+pub trait Coordinator {
+    /// Buffered single-flight coordination for a single cache key.
+    ///
+    /// Contract (preserved byte-for-byte from [`coordinate_proxy_hydration`]):
+    /// the elected leader runs `produce` (which also performs the cache write);
+    /// followers wait on a per-key notify, then re-run `check` to observe the
+    /// leader's result. B6 semantics — a transient cache read error surfaced by
+    /// `check` is the caller's concern (fresh swallows / stale propagates inside
+    /// the closure); this method only loops on `Ok(None)`. `timeout_error`
+    /// builds the error returned when the wait deadline elapses.
+    ///
+    /// Layer 2's streaming fan-out does NOT go through this method (see the
+    /// trait-level docs) — it gets its own entry point. // #1631
+    ///
+    /// This is a PROVIDED method: the default body is the buffered single-flight
+    /// (it delegates to [`coordinate_proxy_hydration`]). [`BufferedCoordinator`]
+    /// uses the default unchanged. A layer-3 advisory-lock decorator (#1609)
+    /// OVERRIDES this to wrap the inner coordinator's leader-election step — the
+    /// provided default is exactly the seam such a decorator wraps. // #1631
+    #[allow(async_fn_in_trait)]
+    async fn coordinate<T, E, Check, CheckFut, Produce, ProduceFut, TimeoutErr>(
+        &self,
+        lease_key: &str,
+        check: Check,
+        produce: Produce,
+        timeout_error: TimeoutErr,
+    ) -> std::result::Result<T, E>
+    where
+        Check: Fn() -> CheckFut,
+        CheckFut: Future<Output = std::result::Result<Option<T>, E>>,
+        Produce: FnOnce() -> ProduceFut,
+        ProduceFut: Future<Output = std::result::Result<T, E>>,
+        TimeoutErr: Fn() -> E,
+    {
+        // Delegate, don't copy: the buffered logic stays in one authoritative
+        // place ([`coordinate_proxy_hydration`]) so behavior — and its unit
+        // tests — is preserved byte-for-byte.
+        coordinate_proxy_hydration(lease_key, check, produce, timeout_error).await
+    }
+}
+
+/// In-process buffered single-flight coordinator (#1631 layer 1).
+///
+/// Zero-sized: the actual coordination state lives in the process-global
+/// [`local_hydration_map`], so this type carries no fields. It is the relocation
+/// target for the existing buffered behavior — [`Coordinator::coordinate`]
+/// delegates to the free function [`coordinate_proxy_hydration`], which is kept
+/// as the implementation body so behavior is preserved exactly (no copy of the
+/// logic, so the leader-produce / follower-re-check / timeout / B6 paths and
+/// their tests stay authoritative in one place).
+///
+/// Layer 3's advisory-lock decorator (#1609) will be a *different*
+/// `Coordinator` impl that wraps this one's election step; it is not built here.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BufferedCoordinator;
+
+impl BufferedCoordinator {
+    /// Construct the in-process buffered coordinator. Mirrors the `::new`
+    /// constructors of the other injected seams (`CacheStore`, `UpstreamClient`,
+    /// `CachePersister`) for a consistent `ProxyService::new` wiring idiom.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+// `BufferedCoordinator` uses the trait's provided buffered default unchanged —
+// no method body to repeat, which keeps the seam free of duplicated signatures.
+impl Coordinator for BufferedCoordinator {}
+
 pub async fn coordinate_proxy_hydration<T, E, Check, CheckFut, Produce, ProduceFut, TimeoutErr>(
     lease_key: &str,
     check: Check,
@@ -227,6 +333,119 @@ mod tests {
             coordinate_proxy_hydration(&key, || async { Ok(None) }, || async { Ok(99) }, || ())
                 .await;
         assert_eq!(result, Ok(99));
+        assert!(!map_contains(&key));
+    }
+
+    // ---- #1631 layer 1: Coordinator trait / BufferedCoordinator ----
+    //
+    // The trait seam must behave identically to the relocated free function.
+    // To prove that WITHOUT copying the free-function test bodies (which would
+    // duplicate logic and trip the jscpd gate), the trait tests drive the same
+    // behavioral assertions through [`Coordinator::coordinate`] but exercise
+    // scenarios distinct from the verbatim free-function cases above:
+    //   * leader-produces + follower-re-check in a single end-to-end flow,
+    //   * the timeout/cancellation slot-reclaim path,
+    //   * producer-error slot release,
+    // each routed through the injectable trait rather than the free function.
+
+    #[tokio::test]
+    async fn buffered_coordinator_leader_produces_then_follower_rechecks() {
+        // End-to-end through the trait: the leader produces + "caches" a value,
+        // then a second caller (follower) observes it on re-check and does NOT
+        // re-run its producer. Covers both the leader-produces and the
+        // follower-re-check semantics in one flow via the injectable seam.
+        let coordinator = BufferedCoordinator::new();
+        let key = format!("test-trait-{}", uuid::Uuid::new_v4());
+        let cache: Arc<Mutex<Option<u32>>> = Arc::new(Mutex::new(None));
+        let produced = Arc::new(AtomicUsize::new(0));
+
+        let check = {
+            let cache = Arc::clone(&cache);
+            move || {
+                let cache = Arc::clone(&cache);
+                async move { Ok::<Option<u32>, ()>(*cache.lock().unwrap()) }
+            }
+        };
+
+        let leader = coordinator
+            .coordinate(
+                &key,
+                check.clone(),
+                {
+                    let cache = Arc::clone(&cache);
+                    let produced = Arc::clone(&produced);
+                    || async move {
+                        produced.fetch_add(1, Ordering::SeqCst);
+                        *cache.lock().unwrap() = Some(123);
+                        Ok(123)
+                    }
+                },
+                || (),
+            )
+            .await;
+        assert_eq!(leader, Ok(123));
+
+        let follower = coordinator
+            .coordinate(
+                &key,
+                check,
+                || async { panic!("follower must not run producer; value is cached") },
+                || (),
+            )
+            .await;
+        assert_eq!(follower, Ok(123));
+        assert_eq!(produced.load(Ordering::SeqCst), 1);
+        assert!(!map_contains(&key));
+    }
+
+    #[tokio::test]
+    async fn buffered_coordinator_timeout_path_drops_leader_slot() {
+        // A leader parked forever inside `produce` occupies the slot. When the
+        // surrounding future is cancelled (request disconnect / wait timeout),
+        // the Drop guard must reclaim the slot through the trait seam, exactly
+        // as the free-function path does. Then a fresh caller wins election.
+        let coordinator = BufferedCoordinator::new();
+        let key = format!("test-trait-timeout-{}", uuid::Uuid::new_v4());
+
+        {
+            let fut = coordinator.coordinate(
+                &key,
+                || async { Ok::<Option<u32>, &'static str>(None) },
+                || async {
+                    futures::future::pending::<()>().await;
+                    unreachable!()
+                },
+                || "timeout",
+            );
+            let _ = tokio::time::timeout(Duration::from_millis(50), fut).await;
+        }
+        assert!(!map_contains(&key));
+
+        let reborn = coordinator
+            .coordinate(
+                &key,
+                || async { Ok(None) },
+                || async { Ok(99u32) },
+                || "timeout",
+            )
+            .await;
+        assert_eq!(reborn, Ok(99));
+        assert!(!map_contains(&key));
+    }
+
+    #[tokio::test]
+    async fn buffered_coordinator_slot_released_after_producer_error() {
+        let coordinator = BufferedCoordinator::new();
+        let key = format!("test-trait-err-{}", uuid::Uuid::new_v4());
+        let result = coordinator
+            .coordinate(
+                &key,
+                || async { Ok::<Option<u32>, &'static str>(None) },
+                || async { Err("boom") },
+                || "timeout",
+            )
+            .await;
+        assert_eq!(result, Err("boom"));
         assert!(!map_contains(&key));
     }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -21,7 +21,7 @@ use uuid::Uuid;
 
 use crate::error::{AppError, Result};
 use crate::models::repository::{Repository, RepositoryFormat, RepositoryType};
-use crate::services::proxy_hydration::coordinate_proxy_hydration;
+use crate::services::proxy_hydration::{BufferedCoordinator, Coordinator};
 use crate::services::storage_service::StorageService;
 
 /// Default cache TTL in seconds (24 hours)
@@ -1578,6 +1578,19 @@ pub struct ProxyService {
     /// delegate here. It holds the shared `http_client` and the bearer
     /// `token_cache` that previously lived directly on `ProxyService`.
     upstream_client: UpstreamClient,
+    /// Single-flight coordinator for proxy cache hydration (#1631 layer 1).
+    /// The buffered slow path (`fetch_artifact_with_cache_path_and_accept`)
+    /// elects a leader through this seam; the leader runs the upstream fetch +
+    /// cache write while followers wait and re-check the cache. Injected as a
+    /// concrete field, mirroring `CacheStore`/`UpstreamClient`/`CachePersister`
+    /// (#1618 S7/S8/S9).
+    ///
+    /// // #1631 layer 2: the streaming path (`fetch_artifact_streaming`) will
+    /// //               coordinate through a streaming entry point on this same
+    /// //               seam (broadcast fan-out, not buffered re-check).
+    /// // #1631 layer 3: a cross-replica advisory-lock decorator (#1609) can
+    /// //               replace this field with a wrapping `Coordinator` impl.
+    coordinator: BufferedCoordinator,
 }
 
 impl ProxyService {
@@ -1604,6 +1617,10 @@ impl ProxyService {
         let cache_store = CacheStore::new(Arc::clone(&storage));
         let cache_persister = CachePersister::new(Arc::clone(&storage));
         let upstream_client = UpstreamClient::new(db.clone(), http_client);
+        // #1631 layer 1: inject the in-process buffered single-flight
+        // coordinator. Layer 3 (#1609) can swap this for an advisory-lock
+        // decorator without touching call sites.
+        let coordinator = BufferedCoordinator::new();
 
         Self {
             db,
@@ -1611,6 +1628,7 @@ impl ProxyService {
             cache_store,
             cache_persister,
             upstream_client,
+            coordinator,
         }
     }
 
@@ -1766,7 +1784,10 @@ impl ProxyService {
         }
 
         let hydration_lease_key = format!("proxy-cache:{}", cache_key);
-        coordinate_proxy_hydration(
+        // #1631 layer 1: buffered single-flight via the injected coordinator
+        // seam (was a direct `coordinate_proxy_hydration` call). The streaming
+        // path below (`fetch_artifact_streaming`) is the layer-2 plug-in point.
+        self.coordinator.coordinate(
             &hydration_lease_key,
             || async { self.get_cached_artifact(&cache_key, &metadata_key).await },
             || async {


### PR DESCRIPTION
Closes #1687

#1631 layer 1 — introduces the single-flight `Coordinator` seam and relocates the existing buffered coordination (`coordinate_proxy_hydration`) behind it. Behavior-preserving: B6 semantics, leader-produce/follower-re-check, and timeout handling all unchanged. Designed to host layer 2 (streaming broadcast fan-out) and layer 3 (#1609 advisory-lock decorator) without reshaping; injection points documented. No migration.

## Summary
- Defines a `Coordinator` trait in `backend/src/services/proxy_hydration.rs` whose **provided** `coordinate(...)` default method *is* the buffered single-flight path — it delegates to the relocated `coordinate_proxy_hydration` free function, so the leader-produce / follower-re-check / timeout / cancellation slot-reclaim / B6 paths are preserved byte-for-byte (no logic copy).
- Adds a zero-sized in-process `BufferedCoordinator` (`impl Coordinator for BufferedCoordinator {}`) that uses the default unchanged.
- Injects `BufferedCoordinator` into `ProxyService` as a concrete field, constructed in `ProxyService::new`, mirroring the S7 `CacheStore` / S8 `UpstreamClient` / S9 `CachePersister` injection idiom.
- Replaces the direct `coordinate_proxy_hydration(...)` call in `fetch_artifact_with_cache_path_and_accept` with `self.coordinator.coordinate(...)`.
- Documents and annotates (`// #1631`) exactly where layer 2 (streaming `fetch_artifact_streaming` broadcast fan-out — a *separate* entry point, not a tweak of the buffered method) and layer 3 (advisory-lock `Coordinator` decorator that overrides the provided method) plug in.

### Seam design (how it accommodates layers 2 & 3 without reshaping)
- **Layer 2 (streaming):** the trait deliberately documents that streaming gets its *own* method (`coordinate_stream`) or a sibling trait — followers subscribe to leader chunks via a broadcast fan-out and cannot re-check the cache mid-flight, a fundamentally different follower semantic. `coordinate`'s `T` is NOT generalized to carry a stream; the streaming entry point is added alongside.
- **Layer 3 (advisory lock, #1609):** because `coordinate` is a provided default, a cross-replica decorator implements `Coordinator` and *overrides* `coordinate` to wrap the inner coordinator's leader-election step with `pg_try_advisory_xact_lock(...)`, then delegates. No signature change required.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added trait/buffered-impl unit tests driving leader-produce + follower-re-check, timeout/cancellation slot-reclaim, and producer-error slot release through the injectable trait. Existing `coordinate_proxy_hydration` unit tests retained and green; the existing `ProxyService` buffered round-trip test exercises the new injected call site end to end.

## API Changes
- [x] N/A - no API changes (no public `ProxyService` signatures changed; no migration / SQL)
