### PR TITLE
fix(sbom): legacy CVE-status ack falls back to scan_findings (#1561)

### DIFF
--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -1007,8 +1007,21 @@ async fn update_cve_status(
     // sqlx::Error::RowNotFound as 500 DATABASE_ERROR. Map it explicitly to
     // 404 so the client can distinguish bad input from server failure. All
     // other sqlx errors continue to flow through the default mapping.
+    //
+    // #1561: the read paths now project synthetic ids out of `scan_findings`
+    // (the never-written `cve_history` table is empty in production), so a
+    // plain `cve_history` UPDATE 404'd for every id the read side emits. The
+    // service now falls back to resolving the synth id and acknowledging the
+    // underlying `scan_findings` rows. We pass `auth.allowed_repo_ids` so the
+    // synth-id resolution is scoped to repositories this caller can access.
     let entry = service
-        .update_cve_status(id, status, Some(auth.user_id), body.reason.as_deref())
+        .update_cve_status(
+            id,
+            status,
+            Some(auth.user_id),
+            body.reason.as_deref(),
+            auth.allowed_repo_ids.as_deref(),
+        )
         .await
         .map_err(|e| match e {
             AppError::Sqlx(sqlx::Error::RowNotFound) => {

--- a/backend/src/grpc/sbom_server.rs
+++ b/backend/src/grpc/sbom_server.rs
@@ -312,7 +312,10 @@ impl CveHistoryServiceTrait for CveHistoryGrpcServer {
 
         let entry = self
             .service
-            .update_cve_status(id, status, None, Some(&req.reason))
+            // `None` repo scope: the gRPC surface is an admin/system path
+            // (no per-call repo restriction), so synth-id resolution (#1561)
+            // runs unrestricted, matching the admin-when-`None` contract.
+            .update_cve_status(id, status, None, Some(&req.reason), None)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -63,6 +63,25 @@ pub(crate) fn synth_cve_id(artifact_id: Uuid, cve_id: &str) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
+/// Find the `(artifact_id, cve_id)` pair in `pairs` whose synthetic id
+/// (see [`synth_cve_id`]) equals `target`.
+///
+/// The synthetic id is a one-way SHA-256 hash of `(artifact_id, cve_id)`, so
+/// it cannot be reversed arithmetically. To resolve a synth id back to its
+/// originating pair we recompute the hash for every candidate pair and look
+/// for the match. `pairs` is the set of distinct `(artifact_id, cve_id)`
+/// tuples drawn from `scan_findings` (already repo-scoped by the caller).
+///
+/// Pure: no DB, no I/O. Extracted from [`SbomService::resolve_synth_cve_id`]
+/// so the round-trip (`synth_cve_id` -> `match_synth_cve_id`) is unit-testable
+/// without a Postgres pool. (#1561)
+pub(crate) fn match_synth_cve_id(target: Uuid, pairs: &[(Uuid, String)]) -> Option<(Uuid, String)> {
+    pairs
+        .iter()
+        .find(|(artifact_id, cve_id)| synth_cve_id(*artifact_id, cve_id) == target)
+        .cloned()
+}
+
 /// Collect a case-insensitive (upper-cased) set of CVE identifiers from a
 /// slice of `CveHistoryEntry` rows.
 ///
@@ -1144,15 +1163,42 @@ impl SbomService {
         Ok(project_scan_rows_to_entries(rows, known))
     }
 
-    /// Update CVE status.
+    /// Update CVE status by legacy `cve_history` id, falling back to the
+    /// `scan_findings` acknowledge path for synthetic ids.
+    ///
+    /// History (#1561): this endpoint (`POST /sbom/cve/status/{id}`) used to
+    /// only `UPDATE cve_history WHERE id = $1`. Because the scanner pipeline
+    /// never writes `cve_history` and the *read* paths now project synthetic
+    /// ids out of `scan_findings` (#1616/#1620, [`synth_cve_id`]), every ack
+    /// against an id the read path actually emits returned 404 -- the table
+    /// has no such row. We now:
+    ///
+    ///   1. Try the legacy `cve_history` UPDATE first. If a real curated row
+    ///      exists (rare admin/promotion-policy data), it wins and behaviour
+    ///      is unchanged.
+    ///   2. On `RowNotFound`, attempt to resolve `id` as a synthetic id back
+    ///      to its `(artifact_id, cve_id)` pair (scoped to `allowed_repo_ids`)
+    ///      and delegate to [`Self::update_cve_status_by_artifact_cve`], which
+    ///      mutates `scan_findings`. This is the path the read side emits, so
+    ///      the ack now persists and returns the synth aggregate instead of
+    ///      404.
+    ///   3. If neither matches, surface the original `RowNotFound` so the
+    ///      handler still maps a genuinely-unknown id to 404.
+    ///
+    /// `allowed_repo_ids` follows the same admin-when-`None` contract as
+    /// [`Self::get_cve_history_by_cve_id`]: `None` means no repo restriction
+    /// (admin/system callers); `Some(&[...])` scopes the synth-id resolution
+    /// to those repositories so a non-admin caller cannot acknowledge a CVE on
+    /// an artifact they cannot see.
     pub async fn update_cve_status(
         &self,
         id: Uuid,
         status: CveStatus,
         user_id: Option<Uuid>,
         reason: Option<&str>,
+        allowed_repo_ids: Option<&[Uuid]>,
     ) -> Result<CveHistoryEntry> {
-        let entry = sqlx::query_as::<_, CveHistoryEntry>(
+        let curated = sqlx::query_as::<_, CveHistoryEntry>(
             r#"
             UPDATE cve_history SET
                 status = $2,
@@ -1168,10 +1214,73 @@ impl SbomService {
         .bind(status.as_str())
         .bind(user_id)
         .bind(reason)
-        .fetch_one(&self.db)
+        .fetch_optional(&self.db)
         .await?;
 
-        Ok(entry)
+        if let Some(entry) = curated {
+            return Ok(entry);
+        }
+
+        // No curated `cve_history` row: treat `id` as a synthetic id derived
+        // from `scan_findings` and resolve it back to (artifact_id, cve_id).
+        if let Some((artifact_id, cve_id)) = self.resolve_synth_cve_id(id, allowed_repo_ids).await?
+        {
+            return self
+                .update_cve_status_by_artifact_cve(artifact_id, &cve_id, status, user_id, reason)
+                .await;
+        }
+
+        // Neither a curated row nor a resolvable synth id: genuinely unknown.
+        // Preserve the legacy 404 contract (handler maps RowNotFound -> 404).
+        Err(AppError::Sqlx(sqlx::Error::RowNotFound))
+    }
+
+    /// Resolve a synthetic CVE id (see [`synth_cve_id`]) back to the
+    /// `(artifact_id, cve_id)` pair it was derived from, by recomputing the
+    /// hash for every distinct `scan_findings` pair and matching `id`.
+    ///
+    /// The synth id is a one-way hash, so reversal is by recomputation, not
+    /// arithmetic. `allowed_repo_ids` scopes the candidate set to artifacts in
+    /// the listed repositories (`None` = no restriction; admin-only, same
+    /// contract as [`Self::get_cve_history_by_cve_id`]). Returns `None` when
+    /// no `scan_findings` pair hashes to `id`. (#1561)
+    pub(crate) async fn resolve_synth_cve_id(
+        &self,
+        id: Uuid,
+        allowed_repo_ids: Option<&[Uuid]>,
+    ) -> Result<Option<(Uuid, String)>> {
+        let pairs: Vec<(Uuid, String)> = match allowed_repo_ids {
+            None => {
+                sqlx::query_as(
+                    r#"
+                SELECT DISTINCT sf.artifact_id, sf.cve_id
+                FROM scan_findings sf
+                JOIN artifacts a ON sf.artifact_id = a.id
+                WHERE sf.cve_id IS NOT NULL
+                  AND NOT a.is_deleted
+                "#,
+                )
+                .fetch_all(&self.db)
+                .await?
+            }
+            Some(repo_ids) => {
+                sqlx::query_as(
+                    r#"
+                SELECT DISTINCT sf.artifact_id, sf.cve_id
+                FROM scan_findings sf
+                JOIN artifacts a ON sf.artifact_id = a.id
+                WHERE sf.cve_id IS NOT NULL
+                  AND NOT a.is_deleted
+                  AND a.repository_id = ANY($1)
+                "#,
+                )
+                .bind(repo_ids)
+                .fetch_all(&self.db)
+                .await?
+            }
+        };
+
+        Ok(match_synth_cve_id(id, &pairs))
     }
 
     /// Update CVE status for an (artifact, cve) pair by mutating the
@@ -3020,6 +3129,67 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // match_synth_cve_id: reverse-resolve a synthetic id to its (artifact,
+    // cve) pair by recomputing the hash. This is the pure half of the #1561
+    // fix -- it proves the read-side `synth_cve_id` round-trips back to the
+    // pair the legacy ack path needs, the exact thing whose absence made
+    // `POST /sbom/cve/status/{synth_id}` 404.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_match_synth_cve_id_round_trips_from_synth_cve_id() {
+        // The read path emits `synth_cve_id(artifact, cve)`. Feeding that id
+        // back through `match_synth_cve_id` against the candidate pair set
+        // (what `resolve_synth_cve_id` pulls from `scan_findings`) must
+        // recover the original pair -- otherwise the ack falls back to 404.
+        let a1 = Uuid::new_v4();
+        let a2 = Uuid::new_v4();
+        let pairs = vec![
+            (a1, "CVE-2019-10744".to_string()),
+            (a2, "CVE-2024-12345".to_string()),
+            (a1, "CVE-2024-12345".to_string()),
+        ];
+        let target = synth_cve_id(a1, "CVE-2024-12345");
+        let resolved = match_synth_cve_id(target, &pairs);
+        assert_eq!(resolved, Some((a1, "CVE-2024-12345".to_string())));
+    }
+
+    #[test]
+    fn test_match_synth_cve_id_returns_none_when_no_pair_matches() {
+        // A genuinely unknown id (no scan_findings pair hashes to it) must
+        // resolve to None so the service can preserve the legacy 404.
+        let pairs = vec![(Uuid::new_v4(), "CVE-2019-10744".to_string())];
+        assert_eq!(match_synth_cve_id(Uuid::new_v4(), &pairs), None);
+        assert_eq!(match_synth_cve_id(Uuid::nil(), &[]), None);
+    }
+
+    #[test]
+    fn test_match_synth_cve_id_distinguishes_pairs_sharing_a_field() {
+        // Two pairs differing only by artifact (same CVE) must resolve to the
+        // correct artifact, and two differing only by CVE (same artifact) to
+        // the correct CVE -- the hash binds both fields.
+        let a1 = Uuid::new_v4();
+        let a2 = Uuid::new_v4();
+        let pairs = vec![
+            (a1, "CVE-2019-10744".to_string()),
+            (a2, "CVE-2019-10744".to_string()),
+        ];
+        assert_eq!(
+            match_synth_cve_id(synth_cve_id(a2, "CVE-2019-10744"), &pairs),
+            Some((a2, "CVE-2019-10744".to_string()))
+        );
+
+        let pairs2 = vec![
+            (a1, "CVE-2019-10744".to_string()),
+            (a1, "CVE-2024-12345".to_string()),
+        ];
+        assert_eq!(
+            match_synth_cve_id(synth_cve_id(a1, "CVE-2024-12345"), &pairs2),
+            Some((a1, "CVE-2024-12345".to_string()))
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Pure-logic helpers extracted from the DB-coupled CVE history paths.
     // These are the cases the inline coverage gate counts; the SQL queries
     // they wrap are unreachable without a live PostgreSQL, so we exercise
@@ -4582,5 +4752,146 @@ mod tests {
         assert_eq!(acked.0, 2, "both scan_findings rows must be acknowledged");
 
         teardown(&pool, repo_id).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // update_cve_status synth-id fallback (#1561)
+    //
+    // The reported bug: `POST /sbom/cve/status/{id}` -> `update_cve_status`
+    // ran `UPDATE cve_history WHERE id = $1`, but `cve_history` is never
+    // written in production and the read path emits SHA-256 synth ids derived
+    // from `scan_findings`. Every ack against an id the read side actually
+    // returns 404'd. These DB-backed tests prove the fallback: the same synth
+    // id now resolves and persists the ack on `scan_findings`.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_update_cve_status_synth_id_falls_back_to_scan_findings() {
+        // Regression for #1561: the EXACT reported flow. Take the synth id the
+        // read path emits for a scan-derived CVE, call the legacy
+        // `update_cve_status` with it, and assert it now succeeds (was 404).
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let repo_id = seed_repo(&pool).await;
+        let artifact_id = seed_artifact(&pool, repo_id).await;
+        let scan_id = seed_scan_result(&pool, artifact_id, repo_id).await;
+        seed_finding(&pool, scan_id, artifact_id, "CVE-2024-8888", "high").await;
+
+        let service = SbomService::new(pool.clone());
+
+        // The id the read path hands clients for this (artifact, cve) pair.
+        let synth_id = synth_cve_id(artifact_id, "CVE-2024-8888");
+
+        // Before the fix this returned AppError::Sqlx(RowNotFound) -> 404.
+        let entry = service
+            .update_cve_status(
+                synth_id,
+                CveStatus::Acknowledged,
+                None,
+                Some("ack via legacy synth-id endpoint"),
+                None,
+            )
+            .await
+            .expect("synth-id ack must succeed via scan_findings fallback");
+
+        assert_eq!(entry.cve_id.to_ascii_uppercase(), "CVE-2024-8888");
+        assert_eq!(entry.status, "acknowledged");
+        // The synth aggregate the response carries must keep the same id.
+        assert_eq!(entry.id, synth_id);
+
+        // And the ack must actually be persisted on the source table.
+        let (ack, _, _, _) = read_ack(&pool, artifact_id, "CVE-2024-8888")
+            .await
+            .expect("finding row present");
+        assert!(ack, "scan_findings.is_acknowledged must be persisted");
+
+        teardown(&pool, repo_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_update_cve_status_unknown_id_still_returns_not_found() {
+        // The fallback must NOT mask genuinely-unknown ids: an id that is
+        // neither a curated cve_history row nor a resolvable synth id must
+        // still surface RowNotFound (handler -> 404).
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let repo_id = seed_repo(&pool).await;
+        let artifact_id = seed_artifact(&pool, repo_id).await;
+        let scan_id = seed_scan_result(&pool, artifact_id, repo_id).await;
+        seed_finding(&pool, scan_id, artifact_id, "CVE-2024-9090", "low").await;
+
+        let service = SbomService::new(pool.clone());
+        let err = service
+            .update_cve_status(
+                Uuid::new_v4(), // random id: no cve_history row, no synth match
+                CveStatus::Acknowledged,
+                None,
+                Some("nope"),
+                None,
+            )
+            .await
+            .expect_err("unknown id must 404");
+
+        assert!(
+            matches!(err, AppError::Sqlx(sqlx::Error::RowNotFound)),
+            "unknown id must surface RowNotFound (handler maps to 404), got {err:?}"
+        );
+
+        teardown(&pool, repo_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_update_cve_status_synth_id_respects_repo_scope() {
+        // Resolution must honour allowed_repo_ids: a synth id for an artifact
+        // in repo A must NOT resolve when the caller is scoped to repo B
+        // (returns 404 rather than acknowledging an unauthorized CVE).
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let repo_a = seed_repo(&pool).await;
+        let repo_b = seed_repo(&pool).await;
+        let artifact_a = seed_artifact(&pool, repo_a).await;
+        let scan_a = seed_scan_result(&pool, artifact_a, repo_a).await;
+        seed_finding(&pool, scan_a, artifact_a, "CVE-2024-7001", "high").await;
+
+        let service = SbomService::new(pool.clone());
+        let synth_id = synth_cve_id(artifact_a, "CVE-2024-7001");
+
+        // Scoped to repo_b only: the artifact lives in repo_a, so no match.
+        let err = service
+            .update_cve_status(
+                synth_id,
+                CveStatus::Acknowledged,
+                None,
+                Some("cross-repo attempt"),
+                Some(&[repo_b]),
+            )
+            .await
+            .expect_err("synth id outside repo scope must 404");
+        assert!(matches!(err, AppError::Sqlx(sqlx::Error::RowNotFound)));
+
+        // The finding must remain unacknowledged.
+        let (ack, _, _, _) = read_ack(&pool, artifact_a, "CVE-2024-7001")
+            .await
+            .expect("finding present");
+        assert!(!ack, "ack must not persist for out-of-scope caller");
+
+        // Scoped to repo_a: now it resolves and persists.
+        let entry = service
+            .update_cve_status(
+                synth_id,
+                CveStatus::Acknowledged,
+                None,
+                Some("in-scope ack"),
+                Some(&[repo_a]),
+            )
+            .await
+            .expect("in-scope synth id must resolve");
+        assert_eq!(entry.status, "acknowledged");
+
+        teardown(&pool, repo_a).await;
+        teardown(&pool, repo_b).await;
     }
 }


### PR DESCRIPTION
Closes #1561

## Summary
The legacy CVE-status acknowledge endpoint `POST /sbom/cve/status/{id}` (`SbomService::update_cve_status`) ran `UPDATE cve_history WHERE id = $1 ... fetch_one`. But `cve_history` is never written in production, and after #1616/#1620 the CVE-history **read** paths project synthetic IDs derived from `scan_findings` via `synth_cve_id(artifact_id, cve_id)` = first 16 bytes of `SHA-256(artifact_id || 0x00 || cve_id)`. So every ack against an id the read side actually emits hit a non-existent `cve_history` row and 404'd.

The synthetic id is a one-way hash, so it cannot be reversed arithmetically. `update_cve_status` now:
1. Tries the curated `cve_history` UPDATE first (unchanged behaviour for any real legacy/admin row).
2. On miss, resolves the id back to `(artifact_id, cve_id)` by recomputing `synth_cve_id` over the distinct `(artifact_id, cve_id)` pairs in `scan_findings` (scoped to the caller's `allowed_repo_ids`) and delegates to the existing working `update_cve_status_by_artifact_cve`, which mutates `scan_findings`.
3. If neither matches, surfaces `RowNotFound` so genuinely-unknown ids still map to 404.

The round-trip logic is extracted into a pure, DB-free helper `match_synth_cve_id` so it is unit-testable. No migration; `cve_history` is retained untouched per migration 112 (v1.3.0 owns the drop).

Files changed: `backend/src/services/sbom_service.rs` (helper + resolver + fallback + tests), `backend/src/api/handlers/sbom.rs` (pass `allowed_repo_ids` through), `backend/src/grpc/sbom_server.rs` (pass `None` admin scope).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The DB-backed `test_update_cve_status_synth_id_falls_back_to_scan_findings` reproduces the exact reported flow: it seeds a `scan_findings` row, computes the synth id the read path emits for that `(artifact, cve)` pair, calls `update_cve_status` with it, and asserts success + persisted ack. On `main` this returns `AppError::Sqlx(RowNotFound)` → 404; on this branch it returns the synth aggregate (200) and writes `scan_findings.is_acknowledged`. Companion tests cover unknown-id (still 404) and repo-scope enforcement; pure tests cover the `synth_cve_id` → `match_synth_cve_id` round-trip.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
