### PR TITLE
feat(security): add not_applicable terminal scan status (#1470)

### DIFF
--- a/.sqlx/query-4e31f5e596bec0a478cd13c9b5339226edf472ead5acf7c1688ce1eabf9fa297.json
+++ b/.sqlx/query-4e31f5e596bec0a478cd13c9b5339226edf472ead5acf7c1688ce1eabf9fa297.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_results\n            SET status = 'not_applicable', error_message = $2, completed_at = NOW(),\n                started_at = $3\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4e31f5e596bec0a478cd13c9b5339226edf472ead5acf7c1688ce1eabf9fa297"
+}

--- a/.sqlx/query-eb72ac73ee4cd8b20fb35255b4ff30fc3a5798344d4df941969be4108f5c3a8a.json
+++ b/.sqlx/query-eb72ac73ee4cd8b20fb35255b4ff30fc3a5798344d4df941969be4108f5c3a8a.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_results\n                (artifact_id, repository_id, scan_type, status, error_message,\n                 started_at, completed_at, checksum_sha256)\n            VALUES ($1, $2, $3, 'not_applicable', $4, NOW(), NOW(), $5)\n            RETURNING id, artifact_id, repository_id, scan_type, status,\n                      findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                      scanner_version, error_message, started_at, completed_at, created_at,\n                      is_reused, source_scan_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Text",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "eb72ac73ee4cd8b20fb35255b4ff30fc3a5798344d4df941969be4108f5c3a8a"
+}

--- a/backend/migrations/124_scan_results_status_not_applicable.sql
+++ b/backend/migrations/124_scan_results_status_not_applicable.sql
@@ -1,0 +1,81 @@
+-- #1470: add a distinct terminal status for "scanner does not apply to this
+-- artifact format" so those scans stop rendering as `failed`.
+--
+-- Migration 022 created scan_results with
+--   CHECK (status IN ('pending','running','completed','failed'))
+-- and scanner_service::scan_artifact_inner routed the is_applicable()==false
+-- branch through fail_scan(...), persisting `status = 'failed'` with an
+-- error_message containing "does not apply". Promotion gating (#1648) had to
+-- key the "not applicable" distinction off that error_message substring, and
+-- the web UI rendered the row with the same red ❌ used for genuine scanner
+-- crashes (a wall of red on artifacts with several inapplicable scanners).
+--
+-- This relaxes the CHECK to add a fifth terminal value, `not_applicable`, so
+-- the inapplicable-scanner path can persist a benign terminal status that is
+-- neither a pass-with-findings nor a failure. `failed` stays reserved for
+-- "scanner started running and crashed / timed out / errored".
+--
+-- Safe on existing data: no rows currently carry `not_applicable`, so widening
+-- the allowed set never violates the constraint. Historical
+-- `status='failed' + error_message LIKE '%does not apply%'` rows are left as-is
+-- (the substring-based is_not_applicable() classifier keeps recognizing them);
+-- this migration deliberately does NOT backfill them.
+--
+-- Drop and re-add the constraint with the full status set. We prefer the
+-- Postgres default name (scan_results_status_check) which is stable across
+-- versions; only when that exact name is absent do we fall back to a
+-- definition-match search constrained to constraint definitions that reference
+-- the `status` column specifically. The rewrite is skipped entirely when the
+-- existing constraint already permits `'not_applicable'` so reruns and
+-- pre-patched databases don't take an ACCESS EXCLUSIVE lock for nothing.
+
+DO $$
+DECLARE
+    chk_name text;
+    chk_def  text;
+BEGIN
+    -- Pass 1: exact default name.
+    SELECT con.conname, pg_get_constraintdef(con.oid)
+      INTO chk_name, chk_def
+    FROM pg_constraint con
+    JOIN pg_class rel ON rel.oid = con.conrelid
+    WHERE rel.relname = 'scan_results'
+      AND con.contype = 'c'
+      AND con.conname = 'scan_results_status_check'
+    LIMIT 1;
+
+    -- Pass 2: any CHECK constraint on scan_results whose definition references
+    -- the `status` column. ORDER BY + LIMIT 1 makes the choice deterministic
+    -- if multiple candidates exist.
+    IF chk_name IS NULL THEN
+        SELECT con.conname, pg_get_constraintdef(con.oid)
+          INTO chk_name, chk_def
+        FROM pg_constraint con
+        JOIN pg_class rel ON rel.oid = con.conrelid
+        WHERE rel.relname = 'scan_results'
+          AND con.contype = 'c'
+          AND pg_get_constraintdef(con.oid) ~* '\mstatus\M'
+        ORDER BY con.conname
+        LIMIT 1;
+    END IF;
+
+    -- Skip the rewrite when the existing constraint already permits the five
+    -- states we want. Avoids needless ACCESS EXCLUSIVE locking when migration
+    -- 124 is replayed against an already-patched database.
+    IF chk_name IS NOT NULL
+       AND chk_def ILIKE '%pending%'
+       AND chk_def ILIKE '%running%'
+       AND chk_def ILIKE '%completed%'
+       AND chk_def ILIKE '%failed%'
+       AND chk_def ILIKE '%not_applicable%' THEN
+        RETURN;
+    END IF;
+
+    IF chk_name IS NOT NULL THEN
+        EXECUTE format('ALTER TABLE scan_results DROP CONSTRAINT %I', chk_name);
+    END IF;
+
+    ALTER TABLE scan_results
+        ADD CONSTRAINT scan_results_status_check
+        CHECK (status IN ('pending','running','completed','failed','not_applicable'));
+END $$;

--- a/backend/src/models/security.rs
+++ b/backend/src/models/security.rs
@@ -29,6 +29,14 @@ pub enum ScanStatus {
     Running,
     Completed,
     Failed,
+    /// Terminal status for "this scanner does not apply to the artifact's
+    /// format" (#1470). Distinct from `Failed`, which is reserved for a scanner
+    /// that started running and crashed / timed out / errored. A
+    /// `NotApplicable` scan is a benign terminal state: neither a
+    /// pass-with-findings nor a failure, and it must never be treated as an
+    /// error when statuses are interpreted (promotion gating, findings display,
+    /// "did the scan fail" predicates).
+    NotApplicable,
 }
 
 /// Severity of a finding. Ordered from most severe to least.
@@ -288,6 +296,40 @@ mod tests {
     // -----------------------------------------------------------------------
     // Severity
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // ScanStatus (#1470)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_scan_status_not_applicable_serializes_snake_case() {
+        // The DB CHECK constraint (migration 124) and every status-string
+        // consumer use the literal `not_applicable`; the serde wire form must
+        // match so API responses round-trip cleanly.
+        let json = serde_json::to_string(&ScanStatus::NotApplicable).expect("serialize");
+        assert_eq!(json, "\"not_applicable\"");
+    }
+
+    #[test]
+    fn test_scan_status_not_applicable_round_trips() {
+        for status in [
+            ScanStatus::Pending,
+            ScanStatus::Running,
+            ScanStatus::Completed,
+            ScanStatus::Failed,
+            ScanStatus::NotApplicable,
+        ] {
+            let json = serde_json::to_string(&status).expect("serialize");
+            let back: ScanStatus = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(status, back);
+        }
+    }
+
+    #[test]
+    fn test_scan_status_not_applicable_is_distinct_from_failed() {
+        assert_ne!(ScanStatus::NotApplicable, ScanStatus::Failed);
+        assert_ne!(ScanStatus::NotApplicable, ScanStatus::Completed);
+    }
 
     #[test]
     fn test_severity_penalty_weights() {

--- a/backend/src/services/promotion_policy_service.rs
+++ b/backend/src/services/promotion_policy_service.rs
@@ -87,13 +87,18 @@ const OPEN_CVES_SQL: &str = r#"
       AND NOT sf.is_acknowledged
 "#;
 
-/// Sentinel substring written into `scan_results.error_message` when a scanner
-/// reports `is_applicable() == false` for an artifact (see
-/// `scanner_service::scan_artifact_inner`). Until #1470 introduces a dedicated
-/// terminal status, a "scanner does not apply to this format" row is stored as
-/// `status = 'failed'` with this phrase in `error_message`. We key the
-/// "not applicable" distinction off this marker so genuinely-inapplicable scans
-/// are NOT treated as fail-open/unscanned for promotion gating.
+/// Terminal status persisted (#1470) when a scanner reports
+/// `is_applicable() == false` for an artifact (see
+/// `scanner_service::scan_artifact_inner`). A `not_applicable` row means the
+/// scanner genuinely does not apply to the artifact's format; it is NOT a
+/// failure and must NOT be treated as fail-open/unscanned for promotion gating.
+const NOT_APPLICABLE_STATUS: &str = "not_applicable";
+
+/// Sentinel substring written into `scan_results.error_message` on the legacy
+/// (pre-#1470) "does not apply" path, where the row was stored as
+/// `status = 'failed'` with this phrase in `error_message`. We still recognize
+/// it so historical rows persisted before migration 124 keep classifying as
+/// "not applicable" rather than as genuine crashes.
 const NOT_APPLICABLE_MARKER: &str = "does not apply";
 
 /// One `scan_results` row reduced to the only fields that matter for deciding
@@ -107,9 +112,18 @@ struct ScanStateRow {
 }
 
 impl ScanStateRow {
-    /// A `failed` row is "not applicable" (rather than a genuine crash) when its
-    /// error message carries the [`NOT_APPLICABLE_MARKER`] sentinel.
+    /// A row is "not applicable" (the scanner does not apply to this format,
+    /// rather than a genuine crash) when:
+    ///
+    /// * its status is the dedicated `not_applicable` terminal status (#1470,
+    ///   the canonical path for rows persisted from migration 124 onward), or
+    /// * (legacy) its status is `failed` and its error message carries the
+    ///   [`NOT_APPLICABLE_MARKER`] sentinel — historical rows written before the
+    ///   dedicated status existed.
     fn is_not_applicable(&self) -> bool {
+        if self.status == NOT_APPLICABLE_STATUS {
+            return true;
+        }
         self.status == "failed"
             && self
                 .error_message
@@ -193,8 +207,10 @@ fn classify_scan_state(rows: &[ScanStateRow]) -> ScanState {
         return ScanState::InProgress;
     }
     // Remaining rows are terminal-but-not-completed: either genuine failures or
-    // "not applicable" markers. A genuine failure outranks not-applicable
-    // because a crashed scanner means the artifact is NOT vetted.
+    // "not applicable" rows (the dedicated `not_applicable` status from #1470,
+    // or a legacy `failed` row carrying the does-not-apply marker). A genuine
+    // failure outranks not-applicable because a crashed scanner means the
+    // artifact is NOT vetted.
     let has_genuine_failure = rows
         .iter()
         .any(|r| r.status == "failed" && !r.is_not_applicable());
@@ -205,7 +221,7 @@ fn classify_scan_state(rows: &[ScanStateRow]) -> ScanState {
         return ScanState::NeverScanned;
     }
     // Rows exist, none completed, none in-progress, none a genuine failure ->
-    // every row is a "not applicable" marker.
+    // every row is "not applicable".
     ScanState::NotApplicable
 }
 
@@ -2294,6 +2310,50 @@ mod tests {
     fn test_classify_not_applicable_when_all_rows_are_markers() {
         let rows = vec![not_applicable_row(), not_applicable_row()];
         assert_eq!(classify_scan_state(&rows), ScanState::NotApplicable);
+    }
+
+    /// #1470: a row carrying the dedicated `not_applicable` status (no error
+    /// message text required) is recognized as not-applicable, just like the
+    /// legacy `failed` + marker rows.
+    #[test]
+    fn test_is_not_applicable_dedicated_status() {
+        assert!(row("not_applicable", None).is_not_applicable());
+        assert!(row("not_applicable", Some("does not apply")).is_not_applicable());
+    }
+
+    /// #1470: an artifact whose every scan is the dedicated `not_applicable`
+    /// status classifies as NotApplicable (scanned-OK), NOT Failed and NOT
+    /// unscanned. This is the regression guard that such scans no longer block
+    /// promotion under block_unscanned.
+    #[test]
+    fn test_classify_not_applicable_dedicated_status_rows() {
+        let rows = vec![
+            row("not_applicable", Some("Scanner Grype does not apply")),
+            row(
+                "not_applicable",
+                Some("Scanner ImageScanner does not apply"),
+            ),
+        ];
+        assert_eq!(classify_scan_state(&rows), ScanState::NotApplicable);
+    }
+
+    /// #1470: the dedicated status and the legacy marker can coexist (mixed
+    /// historical + fresh rows) and still classify as NotApplicable.
+    #[test]
+    fn test_classify_mixed_dedicated_and_legacy_not_applicable() {
+        let rows = vec![row("not_applicable", None), not_applicable_row()];
+        assert_eq!(classify_scan_state(&rows), ScanState::NotApplicable);
+    }
+
+    /// #1470: a genuine crash still outranks a dedicated `not_applicable` row,
+    /// so a half-vetted artifact is never silently passed.
+    #[test]
+    fn test_classify_genuine_failure_outranks_dedicated_not_applicable() {
+        let rows = vec![
+            row("not_applicable", None),
+            row("failed", Some("OOM killed")),
+        ];
+        assert_eq!(classify_scan_state(&rows), ScanState::Failed);
     }
 
     #[test]

--- a/backend/src/services/scan_result_service.rs
+++ b/backend/src/services/scan_result_service.rs
@@ -1046,6 +1046,77 @@ impl ScanResultService {
         Ok(())
     }
 
+    /// Mark a scan as `not_applicable` (#1470): the scanner does not apply to
+    /// this artifact's format, so it never ran. This is a distinct terminal
+    /// status from `failed` (which is reserved for a scanner that started and
+    /// crashed/errored). The human-readable `reason` is stored in
+    /// `error_message` for display, but consumers must classify the row off the
+    /// `not_applicable` status rather than the message text. No findings or
+    /// counts are written; this row is benign and must not be treated as a
+    /// failure or as a pass-with-findings.
+    pub async fn mark_not_applicable(
+        &self,
+        scan_id: Uuid,
+        reason: &str,
+        started_at: chrono::DateTime<chrono::Utc>,
+    ) -> Result<()> {
+        sqlx::query!(
+            r#"
+            UPDATE scan_results
+            SET status = 'not_applicable', error_message = $2, completed_at = NOW(),
+                started_at = $3
+            WHERE id = $1
+            "#,
+            scan_id,
+            reason,
+            started_at,
+        )
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Create a terminal `not_applicable` scan row for the InsertFresh path
+    /// (#1470, #1648): the auto-scan-on-upload flow has no pre-allocated row, so
+    /// a non-applicable scanner previously wrote nothing and the artifact
+    /// classified as `NeverScanned` (falsely BLOCKED under `block_unscanned`).
+    /// Recording the row here gives a deterministic, benign terminal record
+    /// that promotion gating treats as scanned-OK rather than unscanned.
+    pub async fn create_not_applicable_scan(
+        &self,
+        artifact_id: Uuid,
+        repository_id: Uuid,
+        scan_type: &str,
+        reason: &str,
+        checksum_sha256: Option<&str>,
+    ) -> Result<ScanResult> {
+        let result = sqlx::query_as!(
+            ScanResult,
+            r#"
+            INSERT INTO scan_results
+                (artifact_id, repository_id, scan_type, status, error_message,
+                 started_at, completed_at, checksum_sha256)
+            VALUES ($1, $2, $3, 'not_applicable', $4, NOW(), NOW(), $5)
+            RETURNING id, artifact_id, repository_id, scan_type, status,
+                      findings_count, critical_count, high_count, medium_count, low_count, info_count,
+                      scanner_version, error_message, started_at, completed_at, created_at,
+                      is_reused, source_scan_id
+            "#,
+            artifact_id,
+            repository_id,
+            scan_type,
+            reason,
+            checksum_sha256,
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(result)
+    }
+
     /// Get a scan result by ID.
     pub async fn get_scan(&self, scan_id: Uuid) -> Result<ScanResult> {
         sqlx::query_as!(
@@ -3660,6 +3731,82 @@ mod tests {
                 .bind(&stuck_ids)
                 .execute(&pool)
                 .await;
+            cleanup_repo(&pool, repo_id).await;
+        }
+
+        // ===================================================================
+        // #1470: not-applicable terminal status.
+        // ===================================================================
+
+        /// `mark_not_applicable` transitions a pre-allocated (Reuse-path) row
+        /// to the dedicated `not_applicable` terminal status -- NOT `failed` --
+        /// and records the reason in `error_message` for display. This is the
+        /// regression test for "a scanner that does not apply no longer shows
+        /// as failed."
+        #[tokio::test]
+        async fn mark_not_applicable_persists_not_applicable_status() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let svc = ScanResultService::new(pool.clone());
+            let repo_id = insert_test_repo(&pool).await;
+            let (aid, _) = insert_test_artifact(&pool, repo_id, "na-reuse").await;
+
+            // Pre-allocated `running` row, as the trigger handler would create.
+            let prepared = svc
+                .create_scan_result(aid, repo_id, "image")
+                .await
+                .expect("create pre-allocated scan");
+
+            let reason = "Scanner ImageScanner does not apply to this artifact format";
+            svc.mark_not_applicable(prepared.id, reason, chrono::Utc::now())
+                .await
+                .expect("mark not applicable");
+
+            let row = svc.get_scan(prepared.id).await.expect("get scan");
+            assert_eq!(
+                row.status, "not_applicable",
+                "not-applicable scan must persist the dedicated status, not 'failed'"
+            );
+            assert_ne!(row.status, "failed");
+            assert_eq!(row.error_message.as_deref(), Some(reason));
+            assert!(
+                row.completed_at.is_some(),
+                "a not-applicable scan is terminal and must be completed"
+            );
+            assert_eq!(row.findings_count, 0);
+
+            cleanup_repo(&pool, repo_id).await;
+        }
+
+        /// `create_not_applicable_scan` is the InsertFresh-path counterpart:
+        /// the auto-scan-on-upload flow has no pre-allocated row, so this
+        /// INSERTs a terminal `not_applicable` row directly. Previously the
+        /// scanner wrote nothing and the artifact classified as NeverScanned
+        /// (falsely blocked under block_unscanned). The row must be terminal,
+        /// benign (no findings), and serialize the status verbatim.
+        #[tokio::test]
+        async fn create_not_applicable_scan_inserts_terminal_row() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let svc = ScanResultService::new(pool.clone());
+            let repo_id = insert_test_repo(&pool).await;
+            let (aid, checksum) = insert_test_artifact(&pool, repo_id, "na-fresh").await;
+
+            let reason = "Scanner Grype does not apply to this artifact format";
+            let created = svc
+                .create_not_applicable_scan(aid, repo_id, "dependency", reason, Some(&checksum))
+                .await
+                .expect("create not-applicable scan");
+
+            assert_eq!(created.status, "not_applicable");
+            assert_eq!(created.artifact_id, aid);
+            assert_eq!(created.error_message.as_deref(), Some(reason));
+            assert!(created.completed_at.is_some());
+            assert_eq!(created.findings_count, 0);
+            assert!(!created.is_reused);
+
             cleanup_repo(&pool, repo_id).await;
         }
     }

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -2798,11 +2798,18 @@ impl ScannerService {
             // indistinguishable from a real clean scan and produces the
             // silent-success class behind #961 (scanners running on
             // unsupported formats) and #994 (lodash fixture marked clean in
-            // 2.8ms because ImageScanner short-circuited). If the trigger
-            // handler pre-allocated a row for this scan_type, mark it
-            // failed with a "not applicable" reason so the operator still
-            // sees a deterministic record of the decision rather than a
-            // ghost `pending` row that never transitions.
+            // 2.8ms because ImageScanner short-circuited).
+            //
+            // #1470: persist a distinct `not_applicable` terminal status rather
+            // than routing through fail_scan (which marked the row `failed` and
+            // rendered as a red ❌). On the Reuse path the trigger handler
+            // pre-allocated a row, so we UPDATE it in place. On the InsertFresh
+            // path (auto-scan-on-upload) there is no row yet; previously the
+            // scanner just `continue`d and wrote nothing, so under
+            // `block_unscanned=true` the artifact classified as NeverScanned and
+            // was falsely BLOCKED (#1648). We now INSERT a terminal
+            // `not_applicable` row so the artifact classifies as scanned-OK
+            // (not unscanned) and the operator sees a deterministic record.
             if !scanner.is_applicable_for_target(&target) {
                 info!(
                     "Scanner {} not applicable for artifact {} (content_type={}, path={}), skipping",
@@ -2811,20 +2818,43 @@ impl ScannerService {
                     artifact.content_type,
                     artifact.path,
                 );
-                if let PreparedScanAction::Reuse(target_id) = prepared_action {
-                    let reason = format!(
-                        "Scanner {} does not apply to this artifact format",
-                        scanner.name(),
-                    );
-                    if let Err(e) = self
-                        .scan_result_service
-                        .fail_scan(target_id, &reason, None, chrono::Utc::now())
-                        .await
-                    {
-                        warn!(
-                            "Failed to mark pre-allocated scan {} as not-applicable: {}",
-                            target_id, e
-                        );
+                let reason = format!(
+                    "Scanner {} does not apply to this artifact format",
+                    scanner.name(),
+                );
+                match prepared_action {
+                    PreparedScanAction::Reuse(target_id) => {
+                        if let Err(e) = self
+                            .scan_result_service
+                            .mark_not_applicable(target_id, &reason, chrono::Utc::now())
+                            .await
+                        {
+                            warn!(
+                                "Failed to mark pre-allocated scan {} as not-applicable: {}",
+                                target_id, e
+                            );
+                        }
+                    }
+                    PreparedScanAction::InsertFresh => {
+                        if let Err(e) = self
+                            .scan_result_service
+                            .create_not_applicable_scan(
+                                artifact_id,
+                                artifact.repository_id,
+                                scanner.scan_type(),
+                                &reason,
+                                Some(checksum),
+                            )
+                            .await
+                        {
+                            warn!(
+                                "Failed to record not-applicable scan for artifact {} \
+                                 (scanner {}): {}",
+                                artifact_id,
+                                scanner.name(),
+                                e
+                            );
+                        }
                     }
                 }
                 continue;
@@ -11194,6 +11224,222 @@ mod tests {
             ));
             Ok(ScanOutput::default())
         }
+    }
+
+    /// A scanner that is never applicable to any artifact. Drives the #1470
+    /// not-applicable branch in `scan_artifact_inner` so the orchestration
+    /// records a `not_applicable` terminal row rather than `failed` (Reuse
+    /// path) or no row at all (InsertFresh path). `scan` / `scan_target` panic
+    /// because an inapplicable scanner must never be invoked.
+    struct NeverApplicableScanner;
+
+    #[async_trait]
+    impl Scanner for NeverApplicableScanner {
+        fn name(&self) -> &str {
+            "never-applicable"
+        }
+
+        fn scan_type(&self) -> &str {
+            // Must satisfy scan_results_scan_type_check; "grype" is allowed and
+            // the orchestrator persists a row with this scan_type.
+            "grype"
+        }
+
+        fn is_applicable(&self, _artifact: &Artifact) -> bool {
+            false
+        }
+
+        fn is_applicable_for_target(&self, _target: &ScanTarget<'_>) -> bool {
+            false
+        }
+
+        async fn scan(
+            &self,
+            _artifact: &Artifact,
+            _metadata: Option<&ArtifactMetadata>,
+            _content: &Bytes,
+        ) -> Result<ScanOutput> {
+            panic!("an inapplicable scanner must never be invoked");
+        }
+    }
+
+    /// #1470 regression: on the InsertFresh path (auto-scan-on-upload, no
+    /// pre-allocated row), a scanner that does not apply must persist a single
+    /// terminal `not_applicable` scan_results row -- NOT `failed`, and NOT zero
+    /// rows. Before the fix the scanner `continue`d and wrote nothing, so the
+    /// artifact classified as NeverScanned and was falsely blocked under
+    /// `block_unscanned=true` (#1648).
+    #[tokio::test]
+    async fn test_scan_artifact_inner_records_not_applicable_on_insert_fresh() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return; // skip cleanly when no DATABASE_URL
+        };
+
+        let artifact_id = Uuid::new_v4();
+        let checksum = fresh_checksum();
+        let storage_key = format!("na-insert-fresh/{artifact_id}.bin");
+        fx.state
+            .storage
+            .put(&storage_key, Bytes::from_static(b"data"))
+            .await
+            .expect("store artifact bytes");
+
+        sqlx::query(
+            r#"
+            INSERT INTO artifacts (
+                id, repository_id, name, path, size_bytes, checksum_sha256,
+                content_type, storage_key, is_deleted
+            )
+            VALUES ($1, $2, 'pkg.bin', 'pkg.bin', 4, $3,
+                    'application/octet-stream', $4, false)
+            "#,
+        )
+        .bind(artifact_id)
+        .bind(fx.repo_id)
+        .bind(&checksum)
+        .bind(&storage_key)
+        .execute(&fx.pool)
+        .await
+        .expect("insert artifact");
+
+        let scanner = ScannerService {
+            db: fx.pool.clone(),
+            scanners: vec![Arc::new(NeverApplicableScanner)],
+            scan_result_service: Arc::new(ScanResultService::new(fx.pool.clone())),
+            scan_config_service: Arc::new(ScanConfigService::new(fx.pool.clone())),
+            storage: fx.state.storage.clone(),
+            storage_registry: fx.state.storage_registry.clone(),
+            storage_base_path: fx.storage_dir.to_string_lossy().into_owned(),
+            scan_workspace_path: fx
+                .storage_dir
+                .join("scan-workspace")
+                .to_string_lossy()
+                .into_owned(),
+            dependency_track: None,
+        };
+
+        // prepared=None -> InsertFresh path.
+        scanner
+            .scan_artifact_with_options(artifact_id, true, true)
+            .await
+            .expect("scan orchestration must succeed even when nothing applies");
+
+        let rows: Vec<(String, Option<String>)> =
+            sqlx::query_as("SELECT status, error_message FROM scan_results WHERE artifact_id = $1")
+                .bind(artifact_id)
+                .fetch_all(&fx.pool)
+                .await
+                .expect("read scan rows");
+
+        assert_eq!(rows.len(), 1, "InsertFresh must record exactly one row");
+        assert_eq!(
+            rows[0].0, "not_applicable",
+            "inapplicable scanner must persist not_applicable, never failed"
+        );
+        assert!(
+            rows[0]
+                .1
+                .as_deref()
+                .unwrap_or_default()
+                .contains("does not apply"),
+            "reason text must be preserved for display"
+        );
+
+        cleanup_scan_state(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
+    }
+
+    /// #1470 regression (Reuse path): when the trigger handler pre-allocated a
+    /// `running` scan_results row and the scanner turns out not to apply, the
+    /// orchestration must UPDATE that row to `not_applicable` in place -- never
+    /// `failed`, and never leave it wedged in `running`.
+    #[tokio::test]
+    async fn test_scan_artifact_inner_marks_prepared_row_not_applicable() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return; // skip cleanly when no DATABASE_URL
+        };
+
+        let artifact_id = Uuid::new_v4();
+        let checksum = fresh_checksum();
+        let storage_key = format!("na-reuse/{artifact_id}.bin");
+        fx.state
+            .storage
+            .put(&storage_key, Bytes::from_static(b"data"))
+            .await
+            .expect("store artifact bytes");
+
+        sqlx::query(
+            r#"
+            INSERT INTO artifacts (
+                id, repository_id, name, path, size_bytes, checksum_sha256,
+                content_type, storage_key, is_deleted
+            )
+            VALUES ($1, $2, 'pkg.bin', 'pkg.bin', 4, $3,
+                    'application/octet-stream', $4, false)
+            "#,
+        )
+        .bind(artifact_id)
+        .bind(fx.repo_id)
+        .bind(&checksum)
+        .bind(&storage_key)
+        .execute(&fx.pool)
+        .await
+        .expect("insert artifact");
+
+        let scan_result_service = Arc::new(ScanResultService::new(fx.pool.clone()));
+        // Pre-allocate the `running` row the trigger handler would have created.
+        let prepared_row = scan_result_service
+            .create_scan_result(artifact_id, fx.repo_id, "grype")
+            .await
+            .expect("pre-allocate running scan");
+
+        let scanner = ScannerService {
+            db: fx.pool.clone(),
+            scanners: vec![Arc::new(NeverApplicableScanner)],
+            scan_result_service: scan_result_service.clone(),
+            scan_config_service: Arc::new(ScanConfigService::new(fx.pool.clone())),
+            storage: fx.state.storage.clone(),
+            storage_registry: fx.state.storage_registry.clone(),
+            storage_base_path: fx.storage_dir.to_string_lossy().into_owned(),
+            scan_workspace_path: fx
+                .storage_dir
+                .join("scan-workspace")
+                .to_string_lossy()
+                .into_owned(),
+            dependency_track: None,
+        };
+
+        let mut prepared = HashMap::new();
+        prepared.insert("grype".to_string(), prepared_row.id);
+
+        scanner
+            .scan_artifact_with_prepared(artifact_id, prepared, true, true)
+            .await
+            .expect("scan orchestration must succeed for inapplicable scanner");
+
+        let updated = scan_result_service
+            .get_scan(prepared_row.id)
+            .await
+            .expect("pre-allocated row must still exist");
+        assert_eq!(
+            updated.status, "not_applicable",
+            "pre-allocated row must be updated to not_applicable, not failed/running"
+        );
+        assert!(updated.completed_at.is_some(), "row must be terminal");
+
+        // Exactly one row: the pre-allocated one was UPDATEd, not duplicated.
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM scan_results WHERE artifact_id = $1")
+                .bind(artifact_id)
+                .fetch_one(&fx.pool)
+                .await
+                .expect("count rows");
+        assert_eq!(count, 1);
+
+        cleanup_scan_state(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #1470

## Summary

When a scanner's `is_applicable()` returns false for an artifact's format, `scan_artifact_inner` previously routed through `fail_scan(...)`, persisting `status='failed'` with a `"does not apply"` `error_message`. The web UI rendered those rows with the same red failure treatment as genuine scanner crashes (a wall of red on artifacts with several inapplicable scanners), and promotion gating (#1648) had to detect "not applicable" off the `error_message` substring. On the InsertFresh (auto-scan-on-upload) path the scanner wrote **no row at all**, so under `block_unscanned=true` the artifact classified as `NeverScanned` and was falsely BLOCKED.

This adds a distinct terminal status, **`not_applicable`**, reserving `failed` for "scanner started running and crashed/timed out/errored." A `not_applicable` scan is benign-terminal: neither a pass-with-findings nor a failure.

### New status + migration
- **Status value:** `not_applicable` (matches `ScanStatus`'s `snake_case` serde; the model `ScanStatus` enum gains a `NotApplicable` variant).
- **Migration:** `backend/migrations/124_scan_results_status_not_applicable.sql` relaxes the `scan_results` status CHECK to allow `not_applicable`. Idempotent DROP/ADD (preferring the default constraint name, falling back to a `status`-column definition match), skips the rewrite when already present. Safe on existing data — no rows carry the new value and historical `failed`+marker rows are deliberately **not** backfilled.

### Status-interpretation sites changed
- `backend/src/models/security.rs` — `ScanStatus::NotApplicable` variant (benign-terminal, documented).
- `backend/src/services/scan_result_service.rs` — new `mark_not_applicable()` (Reuse path, UPDATE in place) and `create_not_applicable_scan()` (InsertFresh path, INSERT) persist `status='not_applicable'` with the reason in `error_message` for display.
- `backend/src/services/scanner_service.rs` (`scan_artifact_inner`) — the `is_applicable()==false` branch now writes a `not_applicable` row for **both** the Reuse and InsertFresh paths (InsertFresh previously wrote nothing).
- `backend/src/services/promotion_policy_service.rs` — `is_not_applicable()` now keys off the dedicated `not_applicable` status (keeping backward-compat with legacy `failed`+`"does not apply"` marker rows for pre-migration history); `classify_scan_state` treats it as `ScanState::NotApplicable`.

### Promotion / block_unscanned behavior
A `not_applicable` scan classifies as `ScanState::NotApplicable`, which `is_unscanned()` returns **false** for — so it is treated as scanned-OK and **never blocked**, regardless of the `block_unscanned` toggle (unchanged intent from the in-memory `ScanState::NotApplicable`). It is **not** treated as `Completed` either, so it never satisfies CVE/threshold gates as a clean scan. A genuine scanner crash still **outranks** `not_applicable`, so a half-vetted artifact is never silently passed. The legacy string-based `policy_service` gate also benefits automatically: `not_applicable` is neither `failed` (no `block_on_fail`) nor `completed` (no threshold check).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Regression tests: `test_scan_artifact_inner_records_not_applicable_on_insert_fresh` and `test_scan_artifact_inner_marks_prepared_row_not_applicable` assert an inapplicable scanner persists exactly one `not_applicable` row (never `failed`, never zero rows). On `main` the InsertFresh case wrote no row (false NeverScanned/block) and the Reuse case wrote `failed`.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added unit tests: `ScanStatus` serde round-trip + `not_applicable` snake_case wire form; `is_not_applicable()`/`classify_scan_state` for the dedicated status (including mixed dedicated+legacy and genuine-failure-outranks). Added DB-backed tests: `mark_not_applicable_persists_not_applicable_status`, `create_not_applicable_scan_inserts_terminal_row`, plus the two orchestration integration tests above.

Gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings`, and `cargo test --workspace --lib` all green (two pre-existing failures unrelated to this change are environmental: a network-dependent http_client test and an OCI storage-key test, both fail on pristine `main` in this sandbox). Changed-line coverage 95.8%; jscpd 0.00% on changed files. `.sqlx` regenerated (2 new cache entries for the new queries; orphan deletions restored to keep the diff minimal).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

The `ScanResponse.status` field is a passthrough string, so existing API consumers receive the new `not_applicable` value automatically with no schema change. Migration only widens a CHECK constraint (no data loss; reversible by restoring the four-value constraint).
