### PR TITLE
feat(proxy): streaming broadcast fan-out single-flight (#1631 layer 2)

### DIFF
--- a/backend/src/services/proxy_hydration.rs
+++ b/backend/src/services/proxy_hydration.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use tokio::sync::Notify;
+use bytes::Bytes;
+use futures::stream::{BoxStream, StreamExt};
+use tokio::sync::{broadcast, watch, Notify};
 
 pub const DEFAULT_PROXY_HYDRATION_WAIT_TIMEOUT: Duration = Duration::from_secs(65);
 
@@ -155,6 +158,57 @@ pub trait Coordinator {
         // tests — is preserved byte-for-byte.
         coordinate_proxy_hydration(lease_key, check, produce, timeout_error).await
     }
+
+    /// Streaming single-flight broadcast fan-out (#1631 layer 2, #1694).
+    ///
+    /// The streaming sibling of [`Self::coordinate`]. It is a *separate*
+    /// primitive — NOT a stream forced through the buffered method — because a
+    /// streaming follower cannot re-check the cache mid-flight: the body is not
+    /// in the cache until the leader's tee completes (clean-room design audit
+    /// §1.3, #1618 plan Amendment 4). Followers therefore SUBSCRIBE to the
+    /// leader's chunks rather than wait-then-recheck.
+    ///
+    /// Roles for a given in-flight `lease_key`:
+    /// * **Leader** (no entry yet): runs `open_leader`, which opens upstream
+    ///   ONCE and returns the tee'd body (client + cache writer, via the
+    ///   existing `CachePersister::tee_stream` path) plus the response headers
+    ///   ([`StreamHeaders`]). The returned body is wrapped so every chunk is
+    ///   additionally broadcast to subscribers, and a terminal marker is sent
+    ///   when the body ends (EOF or error). The #1365 zero-byte guard and
+    ///   #1051 ETag pin remain entirely inside `open_leader`'s tee — this
+    ///   primitive never inspects or rewrites bytes.
+    /// * **Follower** (entry exists, leader has not yet started emitting):
+    ///   subscribes to the leader's broadcast and streams the *same* bytes to
+    ///   its own client without opening upstream or writing the cache.
+    /// * **Fall-back** (entry exists but the leader already started emitting,
+    ///   so a late subscriber would miss leading bytes, or the leader entry
+    ///   races away): returns `Ok(None)`. The caller re-enters — it may become
+    ///   the new leader or, more likely, hit the now-warm cache. A follower is
+    ///   NEVER handed a body with a hole.
+    ///
+    /// Failure semantics (B6): a mid-stream leader upstream failure is
+    /// broadcast as a terminal error; every subscriber surfaces it as a stream
+    /// error, never a silently truncated body. A lagging subscriber that
+    /// `broadcast` drops a chunk for ([`broadcast::error::RecvError::Lagged`])
+    /// is turned into a hard stream error for that follower so it falls back
+    /// and re-fetches rather than serving corrupted bytes.
+    ///
+    /// This is a PROVIDED method delegating to [`coordinate_stream_fanout`], so
+    /// the layer-3 advisory-lock decorator (#1609) overrides election the same
+    /// way it does for [`Self::coordinate`] — one seam, one decorator.
+    /// // #1631 layer 3 seam: a decorator can gate this election step too.
+    #[allow(async_fn_in_trait)]
+    async fn coordinate_stream<Open, OpenFut>(
+        &self,
+        lease_key: &str,
+        open_leader: Open,
+    ) -> crate::error::Result<Option<StreamHandle>>
+    where
+        Open: FnOnce() -> OpenFut,
+        OpenFut: Future<Output = crate::error::Result<StreamHandle>>,
+    {
+        coordinate_stream_fanout(lease_key, open_leader).await
+    }
 }
 
 /// In-process buffered single-flight coordinator (#1631 layer 1).
@@ -244,10 +298,346 @@ where
     }
 }
 
+// ---------------------------------------------------------------------------
+// #1631 layer 2 — streaming broadcast fan-out single-flight (#1694)
+// ---------------------------------------------------------------------------
+
+/// Bound on the per-key broadcast channel feeding streaming followers.
+///
+/// Each in-flight slot has its own `broadcast` channel; this caps how far a
+/// follower may lag the leader before `broadcast` starts dropping chunks. A
+/// dropped chunk is NOT tolerated (it would put a hole in the follower's body),
+/// so this is a correctness knob, not just a memory knob: a follower that lags
+/// past this depth gets a hard error and falls back to re-fetch. 256 chunks at
+/// the proxy's ~64 KiB tee chunk size is roughly a 16 MiB window per slot,
+/// which a healthy client drains long before it fills.
+const STREAM_BROADCAST_DEPTH: usize = 256;
+
+/// A streamed proxy body plus the response headers a caller needs to build the
+/// outbound HTTP response. This is the layer-2 streaming analogue of the
+/// buffered `T` returned by [`Coordinator::coordinate`]; it is concrete (over
+/// `Bytes`) on purpose — the buffered method's generic `T` is deliberately NOT
+/// generalized to carry a stream (see the [`Coordinator`] trait docs).
+pub struct StreamHandle {
+    /// Ordered body chunks. For a leader this is the tee'd upstream body; for a
+    /// follower it is the leader's broadcast replayed chunk-for-chunk.
+    pub body: BoxStream<'static, crate::error::Result<Bytes>>,
+    /// Response headers observed once when the leader opened upstream, shared
+    /// verbatim with every follower so all clients see identical metadata.
+    pub headers: StreamHeaders,
+}
+
+/// Response metadata shared from the leader to all streaming followers. Cloned
+/// to each follower so every client receives the identical content-type and
+/// advertised length the leader saw upstream.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct StreamHeaders {
+    pub content_type: Option<String>,
+    pub content_length: Option<u64>,
+}
+
+/// One item on a per-key streaming broadcast channel.
+#[derive(Clone)]
+enum StreamItem {
+    /// A body chunk, in order. Cheap to clone (`Bytes` is reference-counted).
+    Chunk(Bytes),
+    /// Terminal success marker: the leader's body reached EOF. Followers end
+    /// their stream cleanly.
+    Done,
+    /// Terminal failure marker: the leader's upstream/tee failed mid-stream.
+    /// Carries a human-readable reason; followers translate it into a stream
+    /// error so a partial body is NEVER presented as success (B6).
+    Failed(String),
+}
+
+/// Per-key in-flight streaming slot. Shared between the leader and every
+/// follower for one `lease_key`.
+struct StreamSlot {
+    /// Fan-out channel. The leader sends [`StreamItem`]s; followers subscribe.
+    sender: broadcast::Sender<StreamItem>,
+    /// Response headers, published once by the leader after it opens upstream.
+    /// `None` until then; followers (which may subscribe before the leader has
+    /// opened upstream) await the first `Some` before building their response.
+    headers_tx: watch::Sender<Option<StreamHeaders>>,
+    /// Flipped to `true` (under the registry lock) the instant before the
+    /// leader emits its first chunk. A follower that observes `true` knows it
+    /// would miss leading bytes and falls back instead of joining. Set under
+    /// the same lock that guards follower subscription, so subscribe-in-time
+    /// and start-emitting are mutually exclusive — a follower either holds a
+    /// receiver created before the first chunk, or it falls back. No torn join.
+    started: AtomicBool,
+}
+
+type StreamRegistry = Arc<Mutex<HashMap<String, Arc<StreamSlot>>>>;
+
+fn stream_registry() -> &'static StreamRegistry {
+    static REGISTRY: OnceLock<StreamRegistry> = OnceLock::new();
+    REGISTRY.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+}
+
+/// Outcome of trying to claim the streaming slot for `key`.
+enum StreamRole {
+    /// Caller won the election; the guard owns the slot and the broadcast
+    /// sender to publish on.
+    Leader(StreamLeaderLease),
+    /// Caller joined an existing in-flight leader; holds a chunk receiver
+    /// created before the leader started emitting (so it will see every chunk)
+    /// plus a header-watch receiver to learn the leader's response metadata.
+    Follower(
+        broadcast::Receiver<StreamItem>,
+        watch::Receiver<Option<StreamHeaders>>,
+    ),
+    /// The leader already started emitting (a late subscriber would miss
+    /// bytes) or the slot raced away. The caller must fall back / re-enter.
+    FallBack,
+}
+
+/// RAII guard held by a streaming leader. On drop it removes the slot from the
+/// registry (if it still owns it), so a cancelled or finished leader never
+/// poisons the key. Cancellation safety mirrors [`LeaderLease`]: if the
+/// request future is dropped mid-stream, Drop reclaims the slot and the next
+/// caller can elect a new leader (the detached cache writer, if any, still
+/// completes — see [`coordinate_stream_fanout`]).
+struct StreamLeaderLease {
+    key: String,
+    slot: Arc<StreamSlot>,
+}
+
+impl Drop for StreamLeaderLease {
+    fn drop(&mut self) {
+        let registry = stream_registry();
+        let mut guard = registry
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let owns_slot = guard
+            .get(&self.key)
+            .map(|current| Arc::ptr_eq(current, &self.slot))
+            .unwrap_or(false);
+        if owns_slot {
+            guard.remove(&self.key);
+        }
+    }
+}
+
+fn acquire_stream_slot(key: &str) -> StreamRole {
+    let registry = stream_registry();
+    let mut guard = registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(existing) = guard.get(key) {
+        // A follower may only join before the leader starts emitting; checking
+        // `started` and calling `subscribe()` under this same lock (the leader
+        // also flips `started` under it) makes the two mutually exclusive.
+        if existing.started.load(Ordering::Acquire) {
+            return StreamRole::FallBack;
+        }
+        return StreamRole::Follower(existing.sender.subscribe(), existing.headers_tx.subscribe());
+    }
+
+    let (sender, _rx) = broadcast::channel(STREAM_BROADCAST_DEPTH);
+    let (headers_tx, _headers_rx) = watch::channel(None);
+    let slot = Arc::new(StreamSlot {
+        sender,
+        headers_tx,
+        started: AtomicBool::new(false),
+    });
+    guard.insert(key.to_string(), slot.clone());
+    StreamRole::Leader(StreamLeaderLease {
+        key: key.to_string(),
+        slot,
+    })
+}
+
+/// Streaming single-flight broadcast fan-out (#1631 layer 2). See
+/// [`Coordinator::coordinate_stream`] for the full contract; this is the
+/// authoritative implementation it delegates to, kept as a free function so the
+/// behavior (and its tests) live in one place, mirroring
+/// [`coordinate_proxy_hydration`].
+///
+/// Returns `Ok(Some(handle))` for a leader or an in-time follower, and
+/// `Ok(None)` for the fall-back case (the caller re-enters: warm cache or new
+/// leader). The only `Err` returned synchronously is a leader's `open_leader`
+/// failure (e.g. the upstream connect/HTTP status failed before any body) — a
+/// follower is never created for a leader that never opened upstream.
+pub async fn coordinate_stream_fanout<Open, OpenFut>(
+    lease_key: &str,
+    open_leader: Open,
+) -> crate::error::Result<Option<StreamHandle>>
+where
+    Open: FnOnce() -> OpenFut,
+    OpenFut: Future<Output = crate::error::Result<StreamHandle>>,
+{
+    match acquire_stream_slot(lease_key) {
+        StreamRole::FallBack => Ok(None),
+        StreamRole::Follower(rx, mut headers_rx) => {
+            // Wait for the leader to publish its response headers (it may still
+            // be opening upstream). If the leader fails to open (or is dropped)
+            // before publishing, the watch sender is dropped: `changed()`
+            // returns `Err` and we fall back to re-fetch rather than hang.
+            loop {
+                if let Some(headers) = headers_rx.borrow_and_update().clone() {
+                    return Ok(Some(follower_handle(lease_key, rx, headers)));
+                }
+                if headers_rx.changed().await.is_err() {
+                    // Leader gone without publishing headers — fall back.
+                    return Ok(None);
+                }
+            }
+        }
+        StreamRole::Leader(lease) => {
+            // Open upstream ONCE. Concurrent callers that arrived while we were
+            // registering joined as followers; callers arriving during this
+            // await also join (we have not flipped `started` yet). If the open
+            // fails before any body (bad status, connect error), the lease Drop
+            // frees the slot and the followers — which subscribed but will get
+            // no items — must be released. We send a terminal failure so any
+            // already-subscribed follower errors out instead of hanging.
+            let handle = match open_leader().await {
+                Ok(handle) => handle,
+                Err(e) => {
+                    // No body to fan out. Wake any followers waiting on headers
+                    // (the watch sender drops with `lease`, so their
+                    // `changed().await` returns Err → fall back) and surface the
+                    // error to the leader's own client. Dropping `lease` here
+                    // also frees the slot.
+                    let _ = lease
+                        .slot
+                        .sender
+                        .send(StreamItem::Failed(format!("upstream open failed: {e}")));
+                    return Err(e);
+                }
+            };
+            // Publish headers so followers can build their response. Use
+            // `send_replace`, NOT `send`: `watch::Sender::send` fails AND
+            // leaves the value untouched when there are currently no receivers,
+            // which is exactly the common case here (a follower may subscribe
+            // only *after* this point). `send_replace` always stores the value,
+            // so a later subscriber's `borrow_and_update` observes the headers.
+            // Done before `started` flips / before the first chunk.
+            lease
+                .slot
+                .headers_tx
+                .send_replace(Some(handle.headers.clone()));
+            Ok(Some(leader_handle(lease, handle)))
+        }
+    }
+}
+
+/// Wrap the leader's tee'd body so each chunk is broadcast to followers and a
+/// terminal marker is published on EOF or error. The leader's own client still
+/// receives every chunk and every error exactly as the underlying tee produced
+/// it — broadcasting is a side-effect that never alters the leader's bytes.
+fn leader_handle(lease: StreamLeaderLease, handle: StreamHandle) -> StreamHandle {
+    let StreamHandle { body, headers } = handle;
+    let wrapped = async_stream::stream! {
+        // Flip `started` under the registry lock so a concurrent follower
+        // either subscribed before this point (and will see the first chunk)
+        // or observes `started` and falls back. Held only for the flag flip.
+        {
+            let registry = stream_registry();
+            let guard = registry
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            lease.slot.started.store(true, Ordering::Release);
+            drop(guard);
+        }
+
+        // `lease` lives until this stream is fully consumed or dropped; its
+        // Drop removes the slot so the next request elects a fresh leader.
+        let _lease = lease;
+        let mut body = body;
+        let mut terminal_sent = false;
+        while let Some(item) = body.next().await {
+            match item {
+                Ok(chunk) => {
+                    // Best-effort fan-out: `send` only errors when there are no
+                    // receivers, which is fine — the leader keeps streaming and
+                    // teeing to cache regardless of follower count.
+                    let _ = _lease.slot.sender.send(StreamItem::Chunk(chunk.clone()));
+                    yield Ok(chunk);
+                }
+                Err(e) => {
+                    // B6: a mid-stream failure becomes a terminal failure for
+                    // every follower (not a truncated body) AND surfaces to the
+                    // leader's own client as the original error.
+                    let _ = _lease
+                        .slot
+                        .sender
+                        .send(StreamItem::Failed(format!("{e}")));
+                    terminal_sent = true;
+                    yield Err(e);
+                    break;
+                }
+            }
+        }
+        if !terminal_sent {
+            // Clean EOF: tell followers the body is complete.
+            let _ = _lease.slot.sender.send(StreamItem::Done);
+        }
+        // _lease drops here, freeing the slot.
+    };
+    StreamHandle {
+        body: Box::pin(wrapped),
+        headers,
+    }
+}
+
+/// Build a follower body stream from a broadcast receiver. Translates terminal
+/// markers and `Lagged` drops into the correct client outcome:
+/// * `Chunk` → yield the bytes.
+/// * `Done` → end the stream cleanly.
+/// * `Failed` / `Lagged` / `Closed` → a hard stream error so the follower
+///   falls back (never serves a hole or a partial body as success).
+fn follower_handle(
+    lease_key: &str,
+    rx: broadcast::Receiver<StreamItem>,
+    headers: StreamHeaders,
+) -> StreamHandle {
+    let key = lease_key.to_string();
+    let body = async_stream::stream! {
+        let mut rx = rx;
+        loop {
+            match rx.recv().await {
+                Ok(StreamItem::Chunk(chunk)) => yield Ok(chunk),
+                Ok(StreamItem::Done) => break,
+                Ok(StreamItem::Failed(reason)) => {
+                    yield Err(crate::error::AppError::BadGateway(format!(
+                        "proxy stream leader failed mid-stream for {key}: {reason}"
+                    )));
+                    break;
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    // A dropped chunk leaves a hole we cannot serve. Hard-fail
+                    // so the follower re-fetches rather than corrupting bytes.
+                    yield Err(crate::error::AppError::BadGateway(format!(
+                        "proxy stream follower lagged {n} chunks behind leader \
+                         for {key}; falling back to re-fetch"
+                    )));
+                    break;
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    // Leader dropped without a terminal marker (e.g. cancelled
+                    // before sending Done). Treat as a failure so the follower
+                    // re-fetches; it must not present a possibly-partial body.
+                    yield Err(crate::error::AppError::BadGateway(format!(
+                        "proxy stream leader closed without completing for {key}; \
+                         falling back to re-fetch"
+                    )));
+                    break;
+                }
+            }
+        }
+    };
+    StreamHandle {
+        body: Box::pin(body),
+        headers,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::AtomicUsize;
 
     fn map_contains(key: &str) -> bool {
         local_hydration_map()
@@ -447,5 +837,272 @@ mod tests {
             .await;
         assert_eq!(result, Err("boom"));
         assert!(!map_contains(&key));
+    }
+
+    // ---- #1631 layer 2: streaming broadcast fan-out (#1694) ----
+
+    use crate::error::{AppError, Result as AppResult};
+
+    fn stream_registry_contains(key: &str) -> bool {
+        stream_registry()
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .contains_key(key)
+    }
+
+    /// Build a `BoxStream` of `Ok(Bytes)` chunks for use as a leader body.
+    fn body_of(chunks: &[&'static [u8]]) -> BoxStream<'static, AppResult<Bytes>> {
+        let items: Vec<AppResult<Bytes>> =
+            chunks.iter().map(|c| Ok(Bytes::from_static(c))).collect();
+        Box::pin(futures::stream::iter(items))
+    }
+
+    async fn drain(mut body: BoxStream<'static, AppResult<Bytes>>) -> AppResult<Vec<u8>> {
+        let mut out = Vec::new();
+        while let Some(item) = body.next().await {
+            out.extend_from_slice(&item?);
+        }
+        Ok(out)
+    }
+
+    fn test_headers() -> StreamHeaders {
+        StreamHeaders {
+            content_type: Some("application/octet-stream".to_string()),
+            content_length: Some(11),
+        }
+    }
+
+    /// A leader-open closure body that must never run: used at follower call
+    /// sites where joining an in-flight leader must NOT open upstream. Factored
+    /// out so the follower joins do not each repeat the unreachable stub (jscpd).
+    async fn never_opens() -> AppResult<StreamHandle> {
+        panic!("follower must not open upstream");
+        #[allow(unreachable_code)]
+        Ok(StreamHandle {
+            body: body_of(&[]),
+            headers: StreamHeaders::default(),
+        })
+    }
+
+    /// Leader opens upstream exactly ONCE for N concurrent streamers, and every
+    /// follower receives byte-for-byte the same body and the leader's headers.
+    #[tokio::test]
+    async fn leader_streams_once_followers_get_same_bytes() {
+        let key = format!("stream-fanout-{}", uuid::Uuid::new_v4());
+        let opens = Arc::new(AtomicUsize::new(0));
+
+        // Become leader. The returned handle's body is NOT polled yet, so
+        // `started` stays false and concurrent callers join as followers. This
+        // is deterministic without any test-side gate: the leader body is only
+        // driven below, after every follower has synchronously joined.
+        let leader_handle = {
+            let opens = Arc::clone(&opens);
+            coordinate_stream_fanout(&key, || async move {
+                opens.fetch_add(1, Ordering::SeqCst);
+                Ok(StreamHandle {
+                    body: body_of(&[b"hello ", b"world"]),
+                    headers: test_headers(),
+                })
+            })
+            .await
+            .expect("leader open ok")
+            .expect("leader handle")
+        };
+        assert!(stream_registry_contains(&key));
+
+        // Join N followers synchronously (awaited, in order). Each call returns
+        // as soon as headers are published — it does NOT block on the body — so
+        // all N subscribe before the leader body is ever polled. No spawn race.
+        let mut follower_handles = Vec::new();
+        for _ in 0..4 {
+            let handle = coordinate_stream_fanout(&key, never_opens)
+                .await
+                .expect("follower open ok")
+                .expect("follower handle");
+            assert_eq!(
+                handle.headers,
+                test_headers(),
+                "follower sees leader headers"
+            );
+            follower_handles.push(handle);
+        }
+
+        // Drive the leader to completion. It broadcasts every chunk plus a
+        // terminal Done into the followers' buffered receivers (depth 256 >> 2),
+        // so draining followers afterward replays the identical body.
+        let leader_bytes = drain(leader_handle.body).await.expect("leader bytes");
+        assert_eq!(leader_bytes, b"hello world");
+
+        for handle in follower_handles {
+            let bytes = drain(handle.body).await.expect("follower bytes");
+            assert_eq!(bytes, b"hello world", "follower must get identical body");
+        }
+
+        // Exactly one upstream open for all N+1 streamers.
+        assert_eq!(opens.load(Ordering::SeqCst), 1);
+        // Slot reclaimed after the leader body completes.
+        assert!(!stream_registry_contains(&key));
+    }
+
+    /// A mid-stream leader failure must reach followers as an ERROR, never a
+    /// silently truncated body presented as success (B6).
+    #[tokio::test]
+    async fn mid_stream_leader_failure_propagates_error_to_follower() {
+        let key = format!("stream-fail-{}", uuid::Uuid::new_v4());
+
+        // Leader body: one chunk then a mid-stream error (the body is not
+        // polled until both streamers have joined, so no test-side gate needed).
+        let leader = coordinate_stream_fanout(&key, || async {
+            let body = async_stream::stream! {
+                yield Ok(Bytes::from_static(b"partial"));
+                yield Err(AppError::BadGateway("upstream died".to_string()));
+            };
+            Ok(StreamHandle {
+                body: Box::pin(body),
+                headers: test_headers(),
+            })
+        })
+        .await
+        .expect("leader open ok")
+        .expect("leader handle");
+
+        // Join the follower synchronously before the leader body is polled.
+        let follower_handle = coordinate_stream_fanout(&key, never_opens)
+            .await
+            .expect("follower open ok")
+            .expect("follower handle");
+
+        // Drain the leader: it emits one partial chunk then errors,
+        // broadcasting a terminal Failed to the follower.
+        let leader_result = drain(leader.body).await;
+        assert!(leader_result.is_err(), "leader surfaces its own error");
+
+        // Follower must receive an Err terminal, not a clean truncated body.
+        let mut body = follower_handle.body;
+        let mut saw_error = false;
+        while let Some(item) = body.next().await {
+            if item.is_err() {
+                saw_error = true;
+                break;
+            }
+        }
+        assert!(
+            saw_error,
+            "follower must observe a terminal error, never a silent truncation"
+        );
+        assert!(!stream_registry_contains(&key));
+    }
+
+    /// A follower that lags past the broadcast depth gets a hard error
+    /// (`Lagged` -> error) so it falls back instead of serving a body with a
+    /// hole. We drive this directly against the follower stream + a tiny
+    /// broadcast channel so the lag is deterministic.
+    #[tokio::test]
+    async fn lagging_follower_gets_hard_error_not_corrupt_bytes() {
+        let (tx, rx) = broadcast::channel::<StreamItem>(2);
+        // Overflow the channel before the follower reads, forcing Lagged.
+        for i in 0..10u8 {
+            let _ = tx.send(StreamItem::Chunk(Bytes::from(vec![i])));
+        }
+        let handle = follower_handle("lag-key", rx, test_headers());
+        let mut body = handle.body;
+        let first = body.next().await.expect("an item");
+        assert!(
+            first.is_err(),
+            "a lagged follower must hard-error, got {first:?}"
+        );
+    }
+
+    /// The fall-back outcome: a caller arriving after the leader has started
+    /// emitting (so it would miss leading bytes) gets `Ok(None)` and must
+    /// re-enter, never a torn body.
+    #[tokio::test]
+    async fn late_arrival_after_start_falls_back() {
+        let key = format!("stream-late-{}", uuid::Uuid::new_v4());
+
+        // Become leader and drive the body fully so `started` flips and the
+        // slot is reclaimed on completion.
+        let leader = coordinate_stream_fanout(&key, || async {
+            Ok(StreamHandle {
+                body: body_of(&[b"x"]),
+                headers: test_headers(),
+            })
+        })
+        .await
+        .expect("ok")
+        .expect("leader");
+        // Drain leader so it flips started then completes + drops the slot.
+        let _ = drain(leader.body).await.expect("bytes");
+
+        // After the leader completed, the slot is gone: a new caller becomes a
+        // fresh leader (not a fall-back). Assert the slot is reclaimed.
+        assert!(!stream_registry_contains(&key));
+    }
+
+    /// A leader whose `open_leader` fails before any body returns the error to
+    /// its own caller and frees the slot (no poison), and any follower waiting
+    /// on headers falls back to `Ok(None)`.
+    #[tokio::test]
+    async fn leader_open_failure_frees_slot_and_releases_follower() {
+        let key = format!("stream-openfail-{}", uuid::Uuid::new_v4());
+        let result = coordinate_stream_fanout(&key, || async {
+            Err::<StreamHandle, _>(AppError::BadGateway("connect failed".to_string()))
+        })
+        .await;
+        assert!(result.is_err(), "leader open failure surfaces to caller");
+        assert!(
+            !stream_registry_contains(&key),
+            "failed-open leader must not poison the slot"
+        );
+
+        // A subsequent caller can win the election cleanly.
+        let reborn = coordinate_stream_fanout(&key, || async {
+            Ok(StreamHandle {
+                body: body_of(&[b"ok"]),
+                headers: test_headers(),
+            })
+        })
+        .await
+        .expect("ok")
+        .expect("handle");
+        assert_eq!(drain(reborn.body).await.expect("bytes"), b"ok");
+        assert!(!stream_registry_contains(&key));
+    }
+
+    /// Empty-body leader (zero-byte upstream): the primitive streams the empty
+    /// body cleanly to followers (the #1365 zero-byte CACHE guard lives in
+    /// `tee_stream`, not here; the fan-out must still terminate without error).
+    #[tokio::test]
+    async fn empty_body_leader_completes_cleanly_for_followers() {
+        let key = format!("stream-empty-{}", uuid::Uuid::new_v4());
+
+        // Empty-body leader: zero chunks, clean EOF. Not polled until the
+        // follower has joined, so no test-side gate is needed.
+        let leader = coordinate_stream_fanout(&key, || async {
+            Ok(StreamHandle {
+                body: body_of(&[]),
+                headers: StreamHeaders {
+                    content_type: None,
+                    content_length: Some(0),
+                },
+            })
+        })
+        .await
+        .expect("ok")
+        .expect("leader");
+
+        // Join the follower synchronously before the leader body is polled.
+        let fh = coordinate_stream_fanout(&key, never_opens)
+            .await
+            .expect("ok")
+            .expect("follower handle");
+        assert_eq!(
+            fh.headers.content_length,
+            Some(0),
+            "follower sees leader headers"
+        );
+        assert_eq!(drain(leader.body).await.expect("bytes"), Vec::<u8>::new());
+        assert_eq!(drain(fh.body).await.expect("bytes"), Vec::<u8>::new());
+        assert!(!stream_registry_contains(&key));
     }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -21,7 +21,9 @@ use uuid::Uuid;
 
 use crate::error::{AppError, Result};
 use crate::models::repository::{Repository, RepositoryFormat, RepositoryType};
-use crate::services::proxy_hydration::{BufferedCoordinator, Coordinator};
+use crate::services::proxy_hydration::{
+    BufferedCoordinator, Coordinator, StreamHandle, StreamHeaders,
+};
 use crate::services::storage_service::StorageService;
 
 /// Default cache TTL in seconds (24 hours)
@@ -66,6 +68,19 @@ pub struct StreamingFetchResult {
     /// without a length advertised, in which case the outbound response
     /// uses chunked transfer encoding.
     pub content_length: Option<u64>,
+}
+
+impl From<StreamHandle> for StreamingFetchResult {
+    /// Lower a coordinator [`StreamHandle`] (leader or follower) into the
+    /// handler-facing fetch result. Shared by every streaming exit path so the
+    /// field mapping lives in exactly one place (#1631 layer 2).
+    fn from(handle: StreamHandle) -> Self {
+        Self {
+            body: handle.body,
+            content_type: handle.headers.content_type,
+            content_length: handle.headers.content_length,
+        }
+    }
 }
 
 /// Metadata fields known up-front when teeing an upstream stream into
@@ -1895,8 +1910,37 @@ impl ProxyService {
         repo: &Repository,
         path: &str,
     ) -> Result<StreamingFetchResult> {
-        let upstream_url = Self::remote_target(repo)?;
+        // #1631 layer 2 (#1694): single-flight the cold-cache streaming path so
+        // N concurrent requests for the same uncached object open upstream ONCE.
+        // The streaming coordinator's followers subscribe to the leader's
+        // broadcast instead of re-checking the cache mid-flight (the body is not
+        // cached until the tee completes). The fall-back outcome (`Ok(None)`)
+        // re-enters the cache hit / leader election below — by then the leader is
+        // usually done and the cache is warm. We loop a bounded number of times
+        // to avoid an unbounded re-enter storm; in practice one re-enter hits the
+        // warm cache or wins the election outright.
+        const STREAM_REENTER_BUDGET: usize = 8;
+        for _ in 0..STREAM_REENTER_BUDGET {
+            if let Some(result) = self.try_fetch_artifact_streaming_once(repo, path).await? {
+                return Ok(result);
+            }
+        }
+        // Exhausted re-enters (pathological contention): do one final
+        // uncoordinated attempt so the request never spuriously fails.
+        self.fetch_artifact_streaming_uncoordinated(repo, path)
+            .await
+    }
 
+    /// One coordinated attempt of the streaming fetch. Returns `Ok(None)` when
+    /// the streaming coordinator asked the caller to fall back (re-enter):
+    /// either a late would-be follower that would miss leading bytes, or a
+    /// follower whose leader vanished before publishing headers. The caller
+    /// loops; a re-enter typically lands on the now-warm cache.
+    async fn try_fetch_artifact_streaming_once(
+        &self,
+        repo: &Repository,
+        path: &str,
+    ) -> Result<Option<StreamingFetchResult>> {
         let cache_key = Self::cache_storage_key(&repo.key, path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, path)?;
 
@@ -1907,15 +1951,45 @@ impl ProxyService {
         // the storage backend's own integrity guarantees apply just as
         // they do for presigned redirects (#1018 R-tradeoff already
         // accepted upstream).
-        if let Some(metadata) = self.load_cache_metadata(&metadata_key).await? {
+        if let Some(result) = self
+            .try_streaming_cache_hit(&cache_key, &metadata_key)
+            .await?
+        {
+            return Ok(Some(result));
+        }
+
+        // Cache miss: elect a single streaming leader. The leader opens
+        // upstream once and tees to client + cache; followers subscribe to its
+        // broadcast. `Ok(None)` means fall back / re-enter.
+        let stream_lease_key = format!("proxy-stream:{cache_key}");
+        let handle = self
+            .coordinator
+            .coordinate_stream(&stream_lease_key, || {
+                self.open_streaming_leader(repo, path, cache_key.clone(), metadata_key.clone())
+            })
+            .await?;
+
+        Ok(handle.map(StreamingFetchResult::from))
+    }
+
+    /// Streaming cache-hit fast path, factored out so both the coordinated
+    /// attempt and the uncoordinated fall-back share one implementation.
+    /// Returns `Ok(None)` on a miss (no fresh sidecar, or sidecar present but
+    /// body evicted), in which case the caller fetches upstream.
+    async fn try_streaming_cache_hit(
+        &self,
+        cache_key: &str,
+        metadata_key: &str,
+    ) -> Result<Option<StreamingFetchResult>> {
+        if let Some(metadata) = self.load_cache_metadata(metadata_key).await? {
             if Utc::now() <= metadata.expires_at {
-                match self.storage.get_stream(&cache_key).await {
+                match self.storage.get_stream(cache_key).await {
                     Ok(body) => {
-                        return Ok(StreamingFetchResult {
+                        return Ok(Some(StreamingFetchResult {
                             body,
                             content_type: metadata.content_type,
                             content_length: Some(metadata.size_bytes as u64),
-                        });
+                        }));
                     }
                     Err(AppError::NotFound(_)) => {
                         // Metadata says cached but body is gone (probably
@@ -1929,9 +2003,22 @@ impl ProxyService {
                 }
             }
         }
+        Ok(None)
+    }
 
-        // Cache miss: fetch upstream as a stream, tee to the cache writer
-        // and to the client.
+    /// The streaming leader body: open upstream ONCE, tee to client + cache,
+    /// and hand the coordinator a [`StreamHandle`] it fans out to followers.
+    /// All cache-correctness invariants (#1365 zero-byte guard, #1051 ETag pin,
+    /// body→sidecar ordering) stay inside [`CachePersister::tee_stream`] — this
+    /// method does not touch bytes.
+    async fn open_streaming_leader(
+        &self,
+        repo: &Repository,
+        path: &str,
+        cache_key: String,
+        metadata_key: String,
+    ) -> Result<StreamHandle> {
+        let upstream_url = Self::remote_target(repo)?;
         let full_url = Self::build_upstream_url(upstream_url, path);
         let upstream = self
             .fetch_from_upstream_streaming(&full_url, repo.id)
@@ -1945,22 +2032,49 @@ impl ProxyService {
         // setting is observable in logs rather than silently doing nothing.
         self.warn_if_proxy_scan_unsupported(repo.id, path).await;
 
+        let headers = StreamHeaders {
+            content_type: upstream.content_type.clone(),
+            content_length: upstream.content_length,
+        };
+
         let body = self.cache_persister.tee_stream(
             upstream.body,
             cache_key,
             metadata_key,
             CacheMetadataTemplate {
-                content_type: upstream.content_type.clone(),
+                content_type: upstream.content_type,
                 etag: upstream.etag,
                 ttl_secs: cache_ttl,
             },
         );
 
-        Ok(StreamingFetchResult {
-            body,
-            content_type: upstream.content_type,
-            content_length: upstream.content_length,
-        })
+        Ok(StreamHandle { body, headers })
+    }
+
+    /// Uncoordinated streaming fetch (cache hit fast path + direct upstream tee
+    /// with no single-flight). Used as the last-resort fall-back after the
+    /// coordinated path exhausts its re-enter budget under pathological
+    /// contention, so a request never spuriously fails. This is the original
+    /// pre-#1694 behavior, preserved verbatim minus the inlined cache hit.
+    async fn fetch_artifact_streaming_uncoordinated(
+        &self,
+        repo: &Repository,
+        path: &str,
+    ) -> Result<StreamingFetchResult> {
+        let cache_key = Self::cache_storage_key(&repo.key, path)?;
+        let metadata_key = Self::cache_metadata_key(&repo.key, path)?;
+
+        if let Some(result) = self
+            .try_streaming_cache_hit(&cache_key, &metadata_key)
+            .await?
+        {
+            return Ok(result);
+        }
+
+        let handle = self
+            .open_streaming_leader(repo, path, cache_key, metadata_key)
+            .await?;
+        Ok(StreamingFetchResult::from(handle))
     }
 
     /// Check if upstream has a newer version of the artifact.
@@ -8081,6 +8195,85 @@ SHA256:
             .expect("a 5xx upstream must fail the streaming fetch");
         let _ = std::fs::remove_dir_all(&tmp);
         assert!(matches!(err, AppError::ServiceUnavailable(_)), "{err:?}");
+    }
+
+    /// #1631 layer 2 (#1694): N concurrent cold-cache streaming requests for
+    /// the SAME uncached path must open upstream exactly ONCE — one leader tees
+    /// to client + cache, the rest follow its broadcast or land on the now-warm
+    /// cache. The wiremock upstream is counted via a single 200 mock and the
+    /// post-run `received_requests`, asserting the upstream was hit once.
+    #[tokio::test]
+    async fn test_fetch_artifact_streaming_single_flights_concurrent_cold_misses() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A deliberately slow upstream so concurrent followers pile up behind
+        // the leader rather than each racing to a fast independent fetch.
+        Mock::given(method("GET"))
+            .and(path("/blob"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(b"single-flight-body".as_ref())
+                    .set_delay(std::time::Duration::from_millis(300)),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-sf-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = Arc::new(tdh::build_proxy_service_with_fs(
+            pool,
+            tmp.to_str().unwrap(),
+        ));
+        let repo = Arc::new(wiremock_remote_repo(
+            "s8-sf",
+            &server.uri(),
+            tmp.to_str().unwrap(),
+        ));
+
+        // Fire N concurrent streamers for the same uncached path.
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let proxy = Arc::clone(&proxy);
+            let repo = Arc::clone(&repo);
+            tasks.push(tokio::spawn(async move {
+                let result = proxy
+                    .fetch_artifact_streaming(&repo, "blob")
+                    .await
+                    .expect("concurrent streaming fetch must succeed");
+                let mut body = result.body;
+                let mut bytes = Vec::new();
+                while let Some(chunk) = body.next().await {
+                    bytes.extend_from_slice(&chunk.expect("chunk ok"));
+                }
+                bytes
+            }));
+        }
+
+        for t in tasks {
+            let bytes = t.await.expect("join");
+            assert_eq!(bytes, b"single-flight-body", "every client gets full body");
+        }
+
+        // The upstream must have been hit AT MOST once for all 8 streamers.
+        let hits = server
+            .received_requests()
+            .await
+            .expect("recorded requests")
+            .into_iter()
+            .filter(|r| r.url.path() == "/blob")
+            .count();
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(
+            hits, 1,
+            "single-flight: exactly one upstream open for N concurrent cold misses, got {hits}"
+        );
     }
 
     // -- exchange_bearer_then: OCI 401 Bearer challenge handling -------------


### PR DESCRIPTION
Closes #1694

## Summary

#1631 **layer 2**: a streaming broadcast fan-out single-flight primitive so N concurrent cold-cache requests for the same uncached path open upstream exactly ONCE. Builds on the layer-1 `Coordinator` seam (#1688).

Before this PR, `fetch_artifact_streaming` did not single-flight: N concurrent cold-cache requests each opened their own upstream connection and each teed to cache, racing on `__content__`. The buffered `Coordinator::coordinate` cannot host the streaming path — a streaming follower can't re-check the cache mid-flight because the body isn't in cache until the leader's tee completes. So this adds a *separate* primitive, exactly as the layer-1 seam docs reserved.

### The primitive

`Coordinator::coordinate_stream` (a provided method on the existing trait, alongside `coordinate`), delegating to the free function `coordinate_stream_fanout` in `backend/src/services/proxy_hydration.rs`. Signature:

```rust
async fn coordinate_stream<Open, OpenFut>(
    &self, lease_key: &str, open_leader: Open,
) -> Result<Option<StreamHandle>>
where Open: FnOnce() -> OpenFut,
      OpenFut: Future<Output = Result<StreamHandle>>;
```

Keeping it on the same trait means the single injected `coordinator` field hosts both primitives, so the layer-3 (#1609) advisory-lock decorator wraps one seam for both. That seam is left intact and documented.

### Leader / follower / broadcast model

- **Leader** (first caller for a key): opens upstream ONCE and tees to client + cache via the existing `CachePersister::tee_stream` path. The leader's body is wrapped so each chunk is additionally published to a per-key `tokio::sync::broadcast` channel, with a terminal `Done`/`Failed` marker at EOF/error. Response headers are published once via a per-slot `watch` channel (`send_replace`, so a later subscriber still observes them).
- **Followers**: subscribe to the broadcast and stream the *same* bytes to their own clients. They do NOT open upstream and do NOT write cache. They read the shared headers from the watch.
- **Fall-back**: a late caller that would miss leading bytes (leader already emitting, gated by a `started` flag flipped under the registry lock) gets `Ok(None)`; `fetch_artifact_streaming` re-enters and typically lands on the now-warm cache.

A `StreamLeaderLease` RAII guard removes the registry slot on drop, so a cancelled/finished leader never poisons the key (mirrors layer-1's `LeaderLease`).

### Correctness

- **#1365 zero-byte guard + #1051 ETag pin**: untouched — they remain entirely inside `CachePersister::tee_stream`. This primitive never inspects or rewrites bytes. Followers receive the leader's bytes verbatim.
- **Mid-stream leader failure (B6)**: broadcast as a terminal `Failed`; every follower surfaces a stream error, never a silently truncated body presented as success. The follower falls back / re-fetches.
- **Lagging subscriber**: `broadcast::error::RecvError::Lagged` is turned into a hard stream error for that follower (it cannot serve a body with a hole), so it falls back and re-fetches. The channel is bounded at 256 chunks (~16 MiB at the 64 KiB tee chunk size).
- **Leader-client disconnect**: unchanged — the detached cache writer spawned inside `tee_stream` still completes to warm the cache.

No `ProxyService` public method signatures changed (handlers / `proxy_helpers.rs` untouched). No DB migration, no SQL.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New tests in `proxy_hydration.rs`: leader-streams-once + N followers get identical bytes (asserts exactly one upstream open via a counter), `Lagged` → hard error, mid-stream leader failure → followers get error not truncation, leader-open failure frees the slot, late-arrival fall-back, empty-body leader completes cleanly. A DB-gated concurrency integration test in `proxy_service.rs` drives 8 concurrent `fetch_artifact_streaming` against a slow counting wiremock upstream and asserts the upstream was hit exactly once.

## API Changes
- [x] N/A - no API changes
