### PR TITLE
fix(download): stream the generic local-serve artifact path

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3449,7 +3449,11 @@ pub async fn download_artifact(
                 .header(header::CONTENT_LENGTH, artifact.size_bytes.to_string())
                 .header(
                     header::HeaderName::from_static("x-checksum-sha256"),
-                    artifact.checksum_sha256,
+                    // `artifacts.checksum_sha256` is a CHAR(64) column, so Postgres
+                    // blank-pads shorter values on read. Trim before emitting so the
+                    // header carries the bare checksum (a real sha256 is exactly 64
+                    // hex chars and is unaffected by the trim).
+                    artifact.checksum_sha256.trim().to_string(),
                 )
                 .header(header::HeaderName::from_static(X_ARTIFACT_STORAGE), "proxy")
                 .body(Body::from_stream(body))

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3425,7 +3425,7 @@ pub async fn download_artifact(
     let artifact_service = ArtifactService::new(state.db.clone(), storage);
 
     let download_result = artifact_service
-        .download(
+        .download_stream(
             repo.id,
             &path,
             auth.map(|a| a.user_id),
@@ -3435,26 +3435,27 @@ pub async fn download_artifact(
         .await;
 
     match download_result {
-        Ok((artifact, content)) => Ok((
-            [
-                (header::CONTENT_TYPE, artifact.content_type),
-                (
+        Ok((artifact, body)) => {
+            // Stream the body from storage instead of buffering it in memory
+            // (#1608, Core Invariant ①). Headers and status are identical to the
+            // prior buffered path; `size_bytes` gives an accurate Content-Length.
+            let response = Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, artifact.content_type)
+                .header(
                     header::CONTENT_DISPOSITION,
                     format!("attachment; filename=\"{}\"", artifact.name),
-                ),
-                (header::CONTENT_LENGTH, artifact.size_bytes.to_string()),
-                (
+                )
+                .header(header::CONTENT_LENGTH, artifact.size_bytes.to_string())
+                .header(
                     header::HeaderName::from_static("x-checksum-sha256"),
                     artifact.checksum_sha256,
-                ),
-                (
-                    header::HeaderName::from_static(X_ARTIFACT_STORAGE),
-                    "proxy".to_string(),
-                ),
-            ],
-            content,
-        )
-            .into_response()),
+                )
+                .header(header::HeaderName::from_static(X_ARTIFACT_STORAGE), "proxy")
+                .body(Body::from_stream(body))
+                .map_err(|e| AppError::Internal(format!("failed to build response: {}", e)))?;
+            Ok(response)
+        }
         Err(AppError::NotFound(_)) if repo.repo_type == RepositoryType::Remote => {
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
@@ -8531,6 +8532,142 @@ mod tests {
         );
 
         fx.teardown().await;
+    }
+
+    // ---------------------------------------------------------------------
+    // download_artifact: local-serve streaming happy path (#1608, epic #1607).
+    //
+    // The generic `/:key/download/*path` handler used to buffer the WHOLE
+    // local artifact body into memory (`ArtifactService::download` ->
+    // `storage.get()` -> `Bytes`) before responding, an OOM/pod-eviction
+    // risk for large artifacts -- the same class #1393 fixed for the
+    // per-format handlers. #1608 converts this path to
+    // `ArtifactService::download_stream` + `Body::from_stream`. These tests
+    // pin the new contract end-to-end:
+    //
+    //   1. seed a local artifact and download it -> 200 with the exact
+    //      bytes, Content-Type, Content-Length (from `size_bytes`),
+    //      x-checksum-sha256, and x-artifact-storage: proxy headers
+    //   2. a missing path on a Local repo still maps to 404 (the
+    //      NotFound contract the Remote/Virtual fallback arms key on)
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_download_artifact_local_streams_body_with_headers() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let body_bytes: &[u8] = b"the-streamed-local-artifact-body-bytes";
+        let repo = fx.repo_info("local", None);
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &storage_key,
+            "foo/bar.bin",
+            "bar",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(body_bytes),
+            fx.user_id,
+        )
+        .await;
+
+        let router = fx.router_with_auth(download_router());
+        let req = tdh::get(format!("/{}/download/foo/bar.bin", fx.repo_key));
+
+        // Send manually so we can inspect headers before draining the body.
+        use tower::ServiceExt;
+        let resp = router
+            .oneshot(req)
+            .await
+            .expect("download_artifact local-serve must respond");
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let collected = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect streamed body");
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "local-serve happy path must stream a 200"
+        );
+        assert_eq!(
+            &collected[..],
+            body_bytes,
+            "streamed body bytes must round-trip identically to the stored object"
+        );
+        assert_eq!(
+            headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/x-test"),
+            "Content-Type must come from the artifact row"
+        );
+        assert_eq!(
+            headers
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(body_bytes.len().to_string().as_str()),
+            "Content-Length must be the artifact's size_bytes (#1608 streamed path)"
+        );
+        assert_eq!(
+            headers
+                .get("x-checksum-sha256")
+                .and_then(|v| v.to_str().ok()),
+            Some("test-seed"),
+            "x-checksum-sha256 header must be preserved"
+        );
+        assert_eq!(
+            headers
+                .get(X_ARTIFACT_STORAGE)
+                .and_then(|v| v.to_str().ok()),
+            Some("proxy"),
+            "x-artifact-storage must remain `proxy` for the local-serve path"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_download_artifact_local_missing_path_returns_404() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        // No proxy_service wired and no upstream: a Local repo with a missing
+        // path must surface the NotFound contract as a 404, not a 500.
+        let router = fx.router_with_auth(download_router());
+        let req = tdh::get(format!("/{}/download/does/not/exist.bin", fx.repo_key));
+        let (status, _body) = tdh::send(router, req).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::NOT_FOUND,
+            "missing local artifact must map to 404 (NotFound contract preserved by #1608)"
+        );
+    }
+
+    // Source-level pin (#1608, epic #1607): the local-serve happy path in
+    // `download_artifact` MUST stream via `ArtifactService::download_stream`
+    // and `Body::from_stream`, never the buffered `.download(` -> `Bytes`
+    // path. A silent revert would re-introduce the OOM regression this fix
+    // closes (same class as #1393 for the per-format handlers).
+    #[test]
+    fn test_repositories_download_artifact_local_streams_1608() {
+        let src = include_str!("repositories.rs");
+        assert!(
+            src.contains(".download_stream("),
+            "`repositories::download_artifact` MUST call \
+             `ArtifactService::download_stream(` for the local-serve download \
+             (#1608). A revert to the buffered `.download(` helper would \
+             re-introduce the large-body OOM regression."
+        );
     }
 
     #[tokio::test]

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -5,6 +5,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use futures::stream::BoxStream;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tracing::warn;
@@ -661,15 +662,19 @@ impl ArtifactService {
         Ok(artifact)
     }
 
-    /// Download an artifact
-    pub async fn download(
+    /// Shared download preamble: look up the artifact row, enforce quarantine,
+    /// and run BeforeDownload hooks (which may reject the download). Returns the
+    /// resolved [`Artifact`] so both the buffered ([`download`]) and streaming
+    /// ([`download_stream`]) paths share one source of truth for the
+    /// NotFound/quarantine/hook contract.
+    ///
+    /// [`download`]: Self::download
+    /// [`download_stream`]: Self::download_stream
+    async fn prepare_download(
         &self,
         repository_id: Uuid,
         path: &str,
-        user_id: Option<Uuid>,
-        ip_address: Option<String>,
-        user_agent: Option<&str>,
-    ) -> Result<(Artifact, Bytes)> {
+    ) -> Result<(Artifact, ArtifactInfo)> {
         // Find artifact
         let artifact = sqlx::query_as!(
             Artifact,
@@ -703,18 +708,29 @@ impl ArtifactService {
         self.trigger_hook(PluginEventType::BeforeDownload, &artifact_info)
             .await?;
 
-        // Get content from storage
-        let content = self.storage.get(&artifact.storage_key).await?;
+        Ok((artifact, artifact_info))
+    }
 
+    /// Shared download epilogue: record best-effort download statistics and fire
+    /// the (non-blocking) AfterDownload hooks. Used by both the buffered and
+    /// streaming download paths.
+    async fn finish_download(
+        &self,
+        artifact_id: Uuid,
+        artifact_info: &ArtifactInfo,
+        user_id: Option<Uuid>,
+        ip_address: Option<&str>,
+        user_agent: Option<&str>,
+    ) {
         // Record download statistics
         sqlx::query!(
             r#"
             INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent)
             VALUES ($1, $2, $3, $4)
             "#,
-            artifact.id,
+            artifact_id,
             user_id,
-            ip_address.as_deref(),
+            ip_address,
             user_agent
         )
         .execute(&self.db)
@@ -722,10 +738,82 @@ impl ArtifactService {
         .ok(); // Ignore stats errors
 
         // Trigger AfterDownload hooks (non-blocking)
-        self.trigger_hook_non_blocking(PluginEventType::AfterDownload, &artifact_info)
+        self.trigger_hook_non_blocking(PluginEventType::AfterDownload, artifact_info)
             .await;
+    }
+
+    /// Download an artifact, buffering the full body into memory.
+    ///
+    /// Prefer [`download_stream`] for serving artifact bodies over HTTP so large
+    /// artifacts are never fully resident in memory. This buffered variant is
+    /// retained for callers that genuinely need the bytes in hand.
+    ///
+    /// [`download_stream`]: Self::download_stream
+    pub async fn download(
+        &self,
+        repository_id: Uuid,
+        path: &str,
+        user_id: Option<Uuid>,
+        ip_address: Option<String>,
+        user_agent: Option<&str>,
+    ) -> Result<(Artifact, Bytes)> {
+        let (artifact, artifact_info) = self.prepare_download(repository_id, path).await?;
+
+        // Get content from storage
+        let content = self.storage.get(&artifact.storage_key).await?;
+
+        self.finish_download(
+            artifact.id,
+            &artifact_info,
+            user_id,
+            ip_address.as_deref(),
+            user_agent,
+        )
+        .await;
 
         Ok((artifact, content))
+    }
+
+    /// Stream an artifact body from storage without buffering it in memory.
+    ///
+    /// Behaviorally identical to [`download`] (same NotFound/quarantine/hook
+    /// contract, same best-effort stats and AfterDownload hooks) except the body
+    /// is returned as a [`BoxStream`] instead of an in-memory [`Bytes`]. This is
+    /// the streaming sibling that closes the last large-body buffer on the
+    /// generic local-serve path (Core Invariant ①, #1608) — mirroring what
+    /// #1393 did for the per-format handlers.
+    ///
+    /// The returned [`Artifact`] still carries `size_bytes` so callers can set
+    /// an accurate `Content-Length`. A storage miss surfaces as
+    /// [`AppError::NotFound`] exactly as the buffered path did, preserving the
+    /// handler's Remote/Virtual fallback contract.
+    ///
+    /// [`download`]: Self::download
+    pub async fn download_stream(
+        &self,
+        repository_id: Uuid,
+        path: &str,
+        user_id: Option<Uuid>,
+        ip_address: Option<String>,
+        user_agent: Option<&str>,
+    ) -> Result<(Artifact, BoxStream<'static, Result<Bytes>>)> {
+        let (artifact, artifact_info) = self.prepare_download(repository_id, path).await?;
+
+        // Open the body as a stream so large artifacts never buffer in memory.
+        // `get_stream` resolves a missing key eagerly to `AppError::NotFound`,
+        // matching the buffered `get` path's NotFound contract.
+        let body = self.storage.get_stream(&artifact.storage_key).await?;
+
+        self.finish_download(
+            artifact.id,
+            &artifact_info,
+            user_id,
+            ip_address.as_deref(),
+            user_agent,
+        )
+        .await;
+
+        Ok((artifact, body))
     }
 
     /// Get artifact by ID


### PR DESCRIPTION
Closes #1712

Part of #1608 → #1607.

## Summary

The generic `/:key/download/*path` handler served **local** artifacts through `ArtifactService::download`, which reads the entire artifact body into memory (`storage.get()` → `Bytes`) before responding. For large artifacts this is an OOM / pod-eviction risk — the same class of bug #1393 fixed for the per-format handlers. This was the last remaining buffered-artifact-body offender on the generic serve path (Core Invariant ①, epic #1607).

This PR adds `ArtifactService::download_stream`, the streaming sibling of `download`:
- The lookup / quarantine / `BeforeDownload`-hook preamble and the stats / `AfterDownload`-hook epilogue are extracted into `prepare_download` / `finish_download` so both paths share one source of truth (no duplication).
- `download_stream` opens the body via `storage.get_stream()` and returns a `BoxStream` instead of `Bytes`.
- The handler serves it via `Body::from_stream` with `Content-Length` derived from `size_bytes`.

Behavior is identical to the buffered path — same headers (Content-Type, Content-Disposition, Content-Length, x-checksum-sha256, x-artifact-storage: proxy), same status codes, same content — only the memory profile changes. A storage miss still surfaces as `AppError::NotFound`, preserving the handler’s Remote/Virtual fallback contract. The buffered `download` is retained as a documented in-memory variant.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Tests added:
- `test_download_artifact_local_streams_body_with_headers` — seeds a local artifact, downloads it, asserts 200 + exact bytes + Content-Type/Content-Length(from size_bytes)/x-checksum-sha256/x-artifact-storage headers.
- `test_download_artifact_local_missing_path_returns_404` — missing local path still maps to 404 (NotFound contract).
- `test_repositories_download_artifact_local_streams_1608` — source-level pin guarding the `download_stream` call against a silent revert to the buffered helper.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (response headers/status/content unchanged; only the body is streamed instead of buffered)
