### PR TITLE
test: pin token-minting endpoint surface (#1315)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,15 @@ jobs:
       - name: No legacy admin scope check
         run: ./scripts/ci/check-no-legacy-admin-scope.sh
 
+      # Token-minting surface pin (#1315, epic #1617 -> #1615): every handler
+      # that calls AuthService::generate_api_token must be in the reviewed set
+      # and carry its reject rule (enforce_admin_only_scopes or require_admin).
+      # A new token-minting endpoint added without updating the pinned list
+      # fails the build, forcing a deliberate review of the privilege-escalation
+      # surface.
+      - name: Pin token-minting endpoint surface
+        run: ./scripts/ci/check-token-mint-surface.sh
+
       - name: Run Clippy
         # Cap parallel rustc invocations so the lib-test compile doesn't OOM
         # the ARC runner pod ("sccache: Compile terminated by signal 9",

--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -1008,4 +1008,146 @@ mod tests {
         assert!(json["user_id"].is_null());
         assert_eq!(json["error"], "Token expired");
     }
+
+    // -----------------------------------------------------------------------
+    // Token-minting endpoint surface pin (issue #1315, epic #1617 -> #1615)
+    //
+    // WHY THIS CONSTANT PIN IS LOAD-BEARING
+    // -------------------------------------
+    // Every token-minting HTTP handler ultimately calls the single mint
+    // primitive `AuthService::generate_api_token`. Each such handler MUST,
+    // before minting, refuse admin-class scopes from a non-admin caller --
+    // either by funnelling the requested scopes through
+    // `enforce_admin_only_scopes` (self-or-admin endpoints), or by gating the
+    // whole handler behind `require_admin` (admin-only endpoints).
+    //
+    // PRs #1261 and #1306 patched the scope-content policy on each existing
+    // endpoint individually. The structural risk #1315 guards against is that
+    // a future, additional token-minting endpoint silently re-opens the
+    // privilege-escalation hole because the author forgot the reject rule.
+    //
+    // This test re-derives the set of production token-minting handlers
+    // straight from source (every `generate_api_token` call site in
+    // `api/handlers`, excluding `#[cfg(test)]` modules) and asserts it equals
+    // the reviewed `EXPECTED` set below. Adding a new token-minting endpoint
+    // fails this test until `EXPECTED` is updated -- forcing a deliberate,
+    // reviewed change. It also asserts each pinned handler still references its
+    // required reject rule, so the guard cannot be quietly removed.
+    //
+    // This runs in `cargo test --lib` (no database needed) and is the Rust-side
+    // companion to the CI grep gate at
+    // `scripts/ci/check-token-mint-surface.sh`.
+    // -----------------------------------------------------------------------
+
+    /// Strip `#[cfg(test)]` module bodies so only production source remains.
+    /// Mirrors the cfg(test)-skipping logic in the CI gate.
+    fn strip_test_modules(src: &str) -> String {
+        let mut out = String::new();
+        let mut in_test = false;
+        let mut test_depth: i32 = 0;
+        let mut depth: i32 = 0;
+        let mut pending_cfg_test = false;
+        for line in src.lines() {
+            let stripped = line.trim();
+            let braces =
+                |s: &str| -> i32 { s.matches('{').count() as i32 - s.matches('}').count() as i32 };
+            if !in_test {
+                if stripped.starts_with("#[cfg(test)]") {
+                    pending_cfg_test = true;
+                } else if pending_cfg_test && stripped.contains("mod ") {
+                    if line.contains('{') {
+                        in_test = true;
+                        test_depth = depth;
+                        depth += braces(line);
+                        pending_cfg_test = false;
+                        continue;
+                    }
+                } else if !stripped.is_empty()
+                    && !stripped.starts_with("//")
+                    && pending_cfg_test
+                    && !stripped.contains("mod ")
+                {
+                    pending_cfg_test = false;
+                }
+            }
+            if in_test {
+                depth += braces(line);
+                if depth <= test_depth {
+                    in_test = false;
+                }
+                continue;
+            }
+            depth += braces(line);
+            // Drop trailing line comments so a `// generate_api_token` note
+            // never counts as a mint site.
+            let code = line.split("//").next().unwrap_or("");
+            out.push_str(code);
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn token_mint_endpoint_surface_is_pinned() {
+        use std::collections::BTreeMap;
+
+        // The reviewed set: handler file -> required reject-rule marker.
+        //   enforce_admin_only_scopes => self-or-admin endpoint that screens
+        //                                requested scopes.
+        //   require_admin             => admin-only endpoint (mint unreachable
+        //                                by non-admins).
+        // To add a token-minting endpoint, add it here in the same PR that
+        // adds the route -- the deliberate review #1315 requires.
+        let expected: BTreeMap<&str, &str> = BTreeMap::from([
+            ("auth.rs", "enforce_admin_only_scopes"), // POST /api/v1/auth/tokens
+            ("profile.rs", "enforce_admin_only_scopes"), // POST /api/v1/profile/access-tokens
+            ("users.rs", "enforce_admin_only_scopes"), // POST /api/v1/users/:id/tokens
+            ("repo_tokens.rs", "enforce_admin_only_scopes"), // POST /api/v1/repositories/:key/tokens
+            ("service_accounts.rs", "require_admin"), // POST /api/v1/service-accounts/:id/tokens
+        ]);
+
+        let handlers_dir =
+            std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/api/handlers");
+
+        // Derive production mint sites straight from source.
+        let mut found: BTreeMap<String, String> = BTreeMap::new();
+        for entry in std::fs::read_dir(&handlers_dir).expect("read handlers dir") {
+            let path = entry.expect("dir entry").path();
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .expect("file name")
+                .to_string();
+            let raw = std::fs::read_to_string(&path).expect("read handler");
+            let production = strip_test_modules(&raw);
+            if production.contains("generate_api_token") {
+                found.insert(name, raw);
+            }
+        }
+
+        let found_names: Vec<&str> = found.keys().map(String::as_str).collect();
+        let expected_names: Vec<&str> = expected.keys().copied().collect();
+        assert_eq!(
+            found_names, expected_names,
+            "token-minting endpoint surface drift (#1315): the set of handlers \
+             calling generate_api_token changed. If you added a new \
+             token-minting endpoint, add it to `expected` here AND to \
+             scripts/ci/check-token-mint-surface.sh, and ensure it enforces a \
+             reject rule. If you removed one, drop it from both."
+        );
+
+        // Each pinned handler must still carry its required reject rule.
+        for (name, raw) in &found {
+            let marker = expected[name.as_str()];
+            assert!(
+                raw.contains(marker),
+                "token-minting endpoint {name} is pinned to use `{marker}` but \
+                 that reject rule is absent -- the privilege-escalation guard \
+                 appears to have been removed or weakened (#1315)."
+            );
+        }
+    }
 }

--- a/scripts/ci/check-token-mint-surface.sh
+++ b/scripts/ci/check-token-mint-surface.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# CI gate for issue #1315 (epic #1617 -> #1615 auth consolidation):
+# pin the exact set of token-minting endpoints in the API tree.
+#
+# WHY THIS PIN IS LOAD-BEARING
+# ----------------------------
+# Every token-minting HTTP handler ultimately calls the single mint
+# primitive `AuthService::generate_api_token`. Each such handler must, BEFORE
+# minting, refuse to grant admin-class scopes to a non-admin caller -- either
+# by routing the requested scopes through
+# `token_service::enforce_admin_only_scopes` (self-or-admin endpoints), or by
+# gating the whole handler behind `require_admin` (admin-only endpoints).
+#
+# PRs #1261 and #1306 patched the scope-content policy on each existing
+# endpoint individually. The structural risk (issue #1315) is that a 6th
+# token-minting endpoint added later silently re-opens the
+# privilege-escalation hole because the author forgot the reject rule.
+#
+# This gate enumerates every PRODUCTION call site of `generate_api_token` in
+# `backend/src/api/handlers` (excluding `#[cfg(test)]` modules) and asserts the
+# set is EXACTLY the reviewed list below. Adding a new token-minting endpoint
+# fails this gate until the author updates `EXPECTED` here -- forcing a
+# deliberate, reviewed change. The gate additionally verifies that each owning
+# handler file references a reject rule (`enforce_admin_only_scopes` or
+# `require_admin`), so a new mint site cannot land without an authz guard.
+#
+# Mirrors the style of `scripts/ci/check-no-legacy-admin-scope.sh` (#1316) and
+# the "Lint migration slots are unique" CI step.
+#
+# Exits non-zero (failing the build) on any drift.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HANDLERS_DIR="${1:-$ROOT/backend/src/api/handlers}"
+
+python3 - "$HANDLERS_DIR" <<'PY'
+import os
+import sys
+
+handlers_dir = sys.argv[1]
+
+# ---------------------------------------------------------------------------
+# THE PINNED SET. Each entry is a production token-minting handler:
+#   relative file (under handlers/)  ->  reject rule it MUST enforce.
+#
+# "scopes"  => the handler funnels requested scopes through
+#              token_service::enforce_admin_only_scopes (self-or-admin
+#              endpoints: a non-admin may mint a token, but never one bearing
+#              an admin-class scope).
+# "admin"   => the whole handler is gated by require_admin (admin-only
+#              endpoint: only an admin can reach the mint at all).
+#
+# To add a new token-minting endpoint you MUST add it here in the same PR
+# that adds the route -- that is the deliberate, reviewed change #1315 wants.
+# ---------------------------------------------------------------------------
+EXPECTED = {
+    "auth.rs": "scopes",              # POST /api/v1/auth/tokens
+    "profile.rs": "scopes",           # POST /api/v1/profile/access-tokens
+    "users.rs": "scopes",             # POST /api/v1/users/:id/tokens (self-or-admin)
+    "repo_tokens.rs": "scopes",       # POST /api/v1/repositories/:key/tokens
+    "service_accounts.rs": "admin",   # POST /api/v1/service-accounts/:id/tokens
+}
+
+REJECT_MARKERS = {
+    "scopes": "enforce_admin_only_scopes",
+    "admin": "require_admin",
+}
+
+
+def production_lines(path):
+    """Yield (lineno, code) for source lines OUTSIDE any #[cfg(test)] module."""
+    in_test = False
+    test_depth = 0
+    depth = 0
+    pending_cfg_test = False
+    with open(path, encoding="utf-8") as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.rstrip("\n")
+            stripped = line.strip()
+            if not in_test:
+                if stripped.startswith("#[cfg(test)]"):
+                    pending_cfg_test = True
+                elif pending_cfg_test and "mod " in stripped:
+                    if "{" in line:
+                        in_test = True
+                        test_depth = depth
+                        depth += line.count("{") - line.count("}")
+                        pending_cfg_test = False
+                        continue
+                elif stripped and not stripped.startswith("//"):
+                    if pending_cfg_test and "mod " not in stripped:
+                        pending_cfg_test = False
+            if in_test:
+                depth += line.count("{") - line.count("}")
+                if depth <= test_depth:
+                    in_test = False
+                continue
+            depth += line.count("{") - line.count("}")
+            code = line.split("//", 1)[0]
+            yield lineno, code
+
+
+# Discover every production mint site.
+found = {}        # filename -> [linenos]
+file_text = {}    # filename -> full source (for reject-marker check)
+for name in os.listdir(handlers_dir):
+    if not name.endswith(".rs"):
+        continue
+    path = os.path.join(handlers_dir, name)
+    with open(path, encoding="utf-8") as fh:
+        file_text[name] = fh.read()
+    for lineno, code in production_lines(path):
+        if "generate_api_token" in code:
+            found.setdefault(name, []).append(lineno)
+
+errors = []
+
+found_set = set(found)
+expected_set = set(EXPECTED)
+
+unreviewed = sorted(found_set - expected_set)
+for name in unreviewed:
+    sites = ", ".join(str(n) for n in found[name])
+    errors.append(
+        f"NEW token-minting endpoint detected in handlers/{name} (line(s) {sites}) "
+        f"that is NOT in the pinned set. If this is a legitimate new endpoint, add "
+        f"it to EXPECTED in scripts/ci/check-token-mint-surface.sh AND ensure it "
+        f"enforces a reject rule (enforce_admin_only_scopes or require_admin). "
+        f"This is the deliberate review #1315 requires."
+    )
+
+missing = sorted(expected_set - found_set)
+for name in missing:
+    errors.append(
+        f"Pinned token-minting endpoint handlers/{name} no longer calls "
+        f"generate_api_token. If the endpoint was removed, delete it from EXPECTED "
+        f"in scripts/ci/check-token-mint-surface.sh."
+    )
+
+# Verify each pinned handler still carries its required reject rule.
+for name in sorted(expected_set & found_set):
+    kind = EXPECTED[name]
+    marker = REJECT_MARKERS[kind]
+    if marker not in file_text[name]:
+        errors.append(
+            f"Token-minting endpoint handlers/{name} is pinned to use '{marker}' "
+            f"({kind} reject rule) but that marker is absent -- the "
+            f"privilege-escalation guard appears to have been removed/weakened."
+        )
+
+if errors:
+    sys.stderr.write(
+        "ERROR: token-minting endpoint surface drift detected (issue #1315).\n\n"
+    )
+    for e in errors:
+        sys.stderr.write(f"  - {e}\n\n")
+    sys.exit(1)
+
+print(
+    f"OK: token-minting endpoint surface matches the pinned set "
+    f"({len(expected_set)} endpoints), each with its reject rule intact."
+)
+PY


### PR DESCRIPTION
Closes #1315

Part of #1617 → #1615 (auth consolidation epic).

## Summary

Pins the exact set of token-minting endpoints and their reject rules so a new one cannot be added (or an existing one weakened) without a deliberate, reviewed change.

**Background.** Every token-minting HTTP handler funnels through the single mint primitive `AuthService::generate_api_token` and must refuse admin-class scopes from a non-admin caller — either by routing requested scopes through `token_service::enforce_admin_only_scopes` (self-or-admin endpoints) or by gating the whole handler behind `require_admin` (admin-only endpoints). PRs #1261 and #1306 patched the scope-content policy on each endpoint individually; the structural risk #1315 guards against is a future endpoint silently re-opening the privilege-escalation hole because the author forgot the reject rule.

**The pinned set (5 endpoints).** The issue text said 4; that was stale — the repo-scoped minter is also in the surface:

| Endpoint | Handler | Reject rule |
|---|---|---|
| `POST /api/v1/auth/tokens` | `auth.rs::create_api_token` | `enforce_admin_only_scopes` |
| `POST /api/v1/profile/access-tokens` | `profile.rs::create_access_token` | `enforce_admin_only_scopes` |
| `POST /api/v1/users/:id/tokens` | `users.rs::create_api_token` | `enforce_admin_only_scopes` |
| `POST /api/v1/repositories/:key/tokens` | `repo_tokens.rs::create_repo_token` | `enforce_admin_only_scopes` |
| `POST /api/v1/service-accounts/:id/tokens` | `service_accounts.rs::create_token` | `require_admin` |

**Mechanism (two complementary pins).**
1. **CI grep gate** `scripts/ci/check-token-mint-surface.sh` — enumerates every production `generate_api_token` call site under `backend/src/api/handlers` (excluding `#[cfg(test)]` modules), asserts the set equals the reviewed list, and verifies each owning handler still references its reject-rule marker. Wired into `ci.yml` right next to the #1316 legacy-admin-scope gate, mirroring its style.
2. **Rust unit test** `token_service::tests::token_mint_endpoint_surface_is_pinned` — DB-free; re-derives the same set from source and asserts it matches a pinned constant, so `cargo test --lib` also catches drift. A code comment documents why the constant pin is load-bearing.

**Proof it catches drift.** Injecting a 6th `generate_api_token` site into a non-pinned handler fails both the gate and the unit test; stripping `enforce_admin_only_scopes` from a pinned handler fails both. Verified locally.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a hardening/test PR (`test/*`), not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes