### PR TITLE
fix(docker): pull el9_8 z-stream errata in openscap rootfs (#1544)

### DIFF
--- a/docker/Dockerfile.openscap
+++ b/docker/Dockerfile.openscap
@@ -9,14 +9,27 @@ RUN ARCH=$(uname -m) && \
 # Install OpenSCAP, SCAP content, and Python into a clean rootfs.
 # Then remove pip/setuptools wheel packages from RPM database (not needed
 # at runtime) and strip the bundled ensurepip module to eliminate pip CVEs.
+#
+# --refresh forces fresh repo metadata and the follow-up upgrade pulls
+# z-stream errata (e.g. el9_8 security fixes for glibc, openssl-libs, krb5,
+# python3, systemd, glib2, libcap, p11-kit) that the install step alone may
+# miss when the cache is stale or the base image tag lags the latest
+# z-stream. The reposdir override is required on the upgrade step because
+# once the installroot has a populated /etc, dnf reads repos from inside it
+# (which is empty) instead of falling back to the host's /etc/yum.repos.d.
+# Mirrors the rootfs-builder upgrade step in Dockerfile.backend. See
+# artifact-keeper#1544 (weekly container scan findings).
 RUN mkdir -p /mnt/rootfs && \
-    dnf install --installroot /mnt/rootfs --releasever 9 \
+    dnf install --installroot /mnt/rootfs --releasever 9 --refresh \
+        --setopt=reposdir=/etc/yum.repos.d/ \
         --setopt install_weak_deps=0 --nodocs --nogpgcheck -y \
         glibc-minimal-langpack \
         ca-certificates \
         openscap-scanner \
         scap-security-guide \
         python3 \
+    && dnf --installroot /mnt/rootfs --releasever 9 \
+        --setopt=reposdir=/etc/yum.repos.d/ --nogpgcheck upgrade -y \
     && rpm --root /mnt/rootfs -e --nodeps python3-pip-wheel python3-setuptools-wheel \
     && rm -rf /mnt/rootfs/usr/lib/python3.9/ensurepip \
     && dnf --installroot /mnt/rootfs clean all \


### PR DESCRIPTION
## Summary

Addresses part of the weekly container scan findings in #1544.

The OpenSCAP image (`docker/Dockerfile.openscap`) builds a minimal rootfs with `dnf install` but, unlike `Dockerfile.backend`, **never ran a `dnf upgrade`**. As a result the published image shipped `el9_7`-vintage packages even though fixed `el9_8` z-stream errata are already available upstream. Trivy (`ignore-unfixed: true`) flagged **50 fixable CRITICAL/HIGH OS-package findings** for this image: glibc, openssl-libs, krb5-libs, python3, systemd, glib2, libcap, p11-kit, libssh.

This change adds `--refresh` to the install and a follow-up `dnf upgrade` against the host `reposdir`, mirroring the proven rootfs-builder pattern in `Dockerfile.backend`. It pulls current z-stream security errata at build time so the published image no longer ships outdated packages.

### Scope / coordination with the rest of #1544

The 223 scan findings break down as:

| Image | Go (trivy/grype CLIs) | OS packages |
|---|---|---|
| Backend | 61 | 37 (UBI9) |
| Backend Alpine | 61 | 14 (Alpine curl) |
| OpenSCAP | 0 | 50 (UBI9) |

- **Go findings (122, ~55%)** — stdlib, docker, buildkit, containerd, grpc, otel, helm, go-git, etc. These are NOT in our Rust app; they come from the embedded **trivy 0.70** and **grype 0.112** CLI binaries. Covered by dependabot **#1605** (trivy 0.71) and **#1603** (grype 0.113) — not duplicated here.
- **Backend UBI9 (37) and Alpine (14) OS findings** — `Dockerfile.backend` already runs `dnf upgrade`; Alpine already uses `apk add --upgrade`. These resolve on the next rebuild against fresh repos.
- **OpenSCAP (50)** — the only image missing an upgrade step. **This PR fixes that gap.**
- **#1604** (rust 1.95→1.96-bookworm) only touches `Dockerfile.backend.dev`, which is not scanned/published — no overlap.

Validated with `docker build --check -f docker/Dockerfile.openscap .` (syntax check only, no image layers built per the repo cost rule). CI will rebuild and the next weekly scan will confirm the reduced finding count.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix
<!-- This is a Dockerfile hardening change; the "regression test" is the weekly
container scan (.github/workflows/scheduled-container-scan.yml), which will
report the reduced OpenSCAP finding count on the next rebuild. No unit/
integration/E2E test applies to base-image errata. -->

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`docker build --check` passes; images not built per cost rule)
- [x] No regressions in existing tests (Dockerfile-only change)

## API Changes
- [x] N/A - no API changes