### PR TITLE
fix(swift): resolve virtual repo package lookups across members (#1554)

### DIFF
--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -202,7 +202,53 @@ async fn list_releases(
 
     let package_id = format!("{}.{}", scope, name);
 
-    let artifacts = sqlx::query!(
+    // Virtual repos own no artifacts: fan out across members (issue #1554).
+    let versions = if repo.repo_type == RepositoryType::Virtual {
+        query_release_versions_virtual(&state.db, repo.id, &package_id).await?
+    } else {
+        query_release_versions(&state.db, repo.id, &package_id).await?
+    };
+
+    if versions.is_empty() {
+        return Err(swift_error_response(
+            StatusCode::NOT_FOUND,
+            &format!("Package {}.{} not found", scope, name),
+        ));
+    }
+
+    Ok(swift_json_response(
+        StatusCode::OK,
+        build_releases_body(&repo_key, &scope, &name, &versions),
+    ))
+}
+
+/// Build the `{ "releases": { version: { url } } }` body for `list_releases`.
+/// Pure (no I/O) so the response shape has at-rest unit coverage.
+fn build_releases_body(
+    repo_key: &str,
+    scope: &str,
+    name: &str,
+    versions: &[String],
+) -> serde_json::Value {
+    let mut releases = serde_json::Map::new();
+    for version in versions {
+        let url = format!("/swift/{}/{}/{}/{}", repo_key, scope, name, version);
+        releases.insert(version.clone(), serde_json::json!({ "url": url }));
+    }
+    serde_json::json!({ "releases": releases })
+}
+
+/// Query the release versions of a Swift package in a single (non-virtual)
+/// repository, newest first.
+async fn query_release_versions(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+    package_id: &str,
+) -> Result<Vec<String>, Response> {
+    // NOTE: the SELECT list is kept byte-identical to the pre-#1554 query so
+    // the committed `.sqlx` offline cache entry still matches; `checksum_sha256`
+    // is selected but unused.
+    let rows = sqlx::query!(
         r#"
         SELECT a.version, a.checksum_sha256
         FROM artifacts a
@@ -211,10 +257,10 @@ async fn list_releases(
           AND LOWER(a.name) = LOWER($2)
         ORDER BY a.created_at DESC
         "#,
-        repo.id,
+        repo_id,
         package_id
     )
-    .fetch_all(&state.db)
+    .fetch_all(db)
     .await
     .map_err(|e| {
         swift_error_response(
@@ -223,31 +269,34 @@ async fn list_releases(
         )
     })?;
 
-    if artifacts.is_empty() {
-        return Err(swift_error_response(
-            StatusCode::NOT_FOUND,
-            &format!("Package {}.{} not found", scope, name),
-        ));
+    Ok(rows
+        .into_iter()
+        .map(|r| r.version.unwrap_or_default())
+        .collect())
+}
+
+/// Fan out a `list_releases` lookup across the members of a virtual repo,
+/// returning the versions from the first member that owns the package
+/// (members are returned in priority order). Remote members are not consulted
+/// for listing because their upstream listing shape is format-specific; the
+/// `.zip`/metadata endpoints proxy them on demand.
+pub async fn query_release_versions_virtual(
+    db: &PgPool,
+    virtual_repo_id: uuid::Uuid,
+    package_id: &str,
+) -> Result<Vec<String>, Response> {
+    let members = proxy_helpers::fetch_virtual_members(db, virtual_repo_id).await?;
+    for member in &members {
+        if member.repo_type != RepositoryType::Local && member.repo_type != RepositoryType::Staging
+        {
+            continue;
+        }
+        let versions = query_release_versions(db, member.id, package_id).await?;
+        if !versions.is_empty() {
+            return Ok(versions);
+        }
     }
-
-    // Build releases object: version -> { url }
-    let mut releases = serde_json::Map::new();
-    for artifact in &artifacts {
-        let version = artifact.version.clone().unwrap_or_default();
-        let url = format!("/swift/{}/{}/{}/{}", repo_key, scope, name, version);
-        releases.insert(
-            version,
-            serde_json::json!({
-                "url": url,
-            }),
-        );
-    }
-
-    let body = serde_json::json!({
-        "releases": releases,
-    });
-
-    Ok(swift_json_response(StatusCode::OK, body))
+    Ok(Vec::new())
 }
 
 // ---------------------------------------------------------------------------
@@ -280,17 +329,23 @@ async fn version_path_handler(
 // GET /swift/:repo_key/:scope/:name/:version -- Get release metadata
 // ---------------------------------------------------------------------------
 
-async fn get_release_metadata(
-    state: SharedState,
-    repo_key: &str,
-    scope: &str,
-    name: &str,
-    version: &str,
-) -> Result<Response, Response> {
-    let repo = resolve_swift_repo(&state.db, repo_key).await?;
-    let package_id = format!("{}.{}", scope, name);
+/// Minimal release row used to build the metadata response.
+pub struct ReleaseRow {
+    pub checksum_sha256: String,
+    pub metadata: Option<serde_json::Value>,
+}
 
-    let artifact = sqlx::query!(
+/// Query a single Swift release's metadata row from one (non-virtual) repo.
+async fn query_release_metadata(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+    package_id: &str,
+    version: &str,
+) -> Result<Option<ReleaseRow>, Response> {
+    // NOTE: the SELECT list is kept byte-identical to the pre-#1554 query so
+    // the committed `.sqlx` offline cache entry still matches; only
+    // `checksum_sha256` and `metadata` are consumed here.
+    let row = sqlx::query!(
         r#"
         SELECT a.id, a.version, a.size_bytes, a.checksum_sha256,
                am.metadata as "metadata?"
@@ -302,30 +357,61 @@ async fn get_release_metadata(
           AND a.version = $3
         LIMIT 1
         "#,
-        repo.id,
+        repo_id,
         package_id,
         version
     )
-    .fetch_optional(&state.db)
+    .fetch_optional(db)
     .await
     .map_err(|e| {
         swift_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             &format!("Database error: {}", e),
         )
-    })?
-    .ok_or_else(|| swift_error_response(StatusCode::NOT_FOUND, "Release not found"))?;
+    })?;
 
-    let archive_url = format!("/swift/{}/{}/{}/{}.zip", repo_key, scope, name, version);
+    Ok(row.map(|r| ReleaseRow {
+        checksum_sha256: r.checksum_sha256,
+        metadata: r.metadata,
+    }))
+}
 
+/// Fan out a release-metadata lookup across the Local/Staging members of a
+/// virtual repo, returning the first hit in priority order (issue #1554).
+pub async fn query_release_metadata_virtual(
+    db: &PgPool,
+    virtual_repo_id: uuid::Uuid,
+    package_id: &str,
+    version: &str,
+) -> Result<Option<ReleaseRow>, Response> {
+    let members = proxy_helpers::fetch_virtual_members(db, virtual_repo_id).await?;
+    for member in &members {
+        if member.repo_type != RepositoryType::Local && member.repo_type != RepositoryType::Staging
+        {
+            continue;
+        }
+        if let Some(row) = query_release_metadata(db, member.id, package_id, version).await? {
+            return Ok(Some(row));
+        }
+    }
+    Ok(None)
+}
+
+/// Build the release-metadata JSON body. Pure (no I/O) so the response shape
+/// (resources list, manifest presence, embedded swift metadata) is unit-tested.
+fn build_release_metadata_body(
+    scope: &str,
+    name: &str,
+    version: &str,
+    row: &ReleaseRow,
+) -> serde_json::Value {
     let mut resources = vec![serde_json::json!({
         "name": "source-archive",
         "type": "application/zip",
-        "checksum": artifact.checksum_sha256.clone(),
+        "checksum": row.checksum_sha256.clone(),
     })];
 
-    // Check if a manifest exists in metadata
-    let has_manifest = artifact
+    let has_manifest = row
         .metadata
         .as_ref()
         .and_then(|m| m.get("manifest"))
@@ -338,12 +424,38 @@ async fn get_release_metadata(
         }));
     }
 
-    let body = serde_json::json!({
+    serde_json::json!({
         "id": format!("{}.{}", scope, name),
         "version": version,
         "resources": resources,
-        "metadata": artifact.metadata.clone().and_then(|m| m.get("swift_metadata").cloned()).unwrap_or(serde_json::json!({})),
-    });
+        "metadata": row
+            .metadata
+            .clone()
+            .and_then(|m| m.get("swift_metadata").cloned())
+            .unwrap_or(serde_json::json!({})),
+    })
+}
+
+async fn get_release_metadata(
+    state: SharedState,
+    repo_key: &str,
+    scope: &str,
+    name: &str,
+    version: &str,
+) -> Result<Response, Response> {
+    let repo = resolve_swift_repo(&state.db, repo_key).await?;
+    let package_id = format!("{}.{}", scope, name);
+
+    // Virtual repos own no artifacts: fan out across members (issue #1554).
+    let row = if repo.repo_type == RepositoryType::Virtual {
+        query_release_metadata_virtual(&state.db, repo.id, &package_id, version).await?
+    } else {
+        query_release_metadata(&state.db, repo.id, &package_id, version).await?
+    }
+    .ok_or_else(|| swift_error_response(StatusCode::NOT_FOUND, "Release not found"))?;
+
+    let archive_url = format!("/swift/{}/{}/{}/{}.zip", repo_key, scope, name, version);
+    let body = build_release_metadata_body(scope, name, version, &row);
 
     let mut response = swift_json_response(StatusCode::OK, body);
     response.headers_mut().insert(
@@ -503,17 +615,16 @@ async fn download_archive(
 // GET /swift/:repo_key/:scope/:name/:version/Package.swift -- Fetch manifest
 // ---------------------------------------------------------------------------
 
-async fn fetch_manifest(
-    state: SharedState,
-    repo_key: &str,
-    scope: &str,
-    name: &str,
+/// Look up the cached manifest text (if any) for a release in one repo.
+/// Returns `Ok(None)` when the release does not exist in this repo, and
+/// `Ok(Some(None))` when the release exists but has no cached manifest.
+async fn query_manifest(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+    package_id: &str,
     version: &str,
-) -> Result<Response, Response> {
-    let repo = resolve_swift_repo(&state.db, repo_key).await?;
-    let package_id = format!("{}.{}", scope, name);
-
-    let artifact = sqlx::query!(
+) -> Result<Option<Option<String>>, Response> {
+    let row = sqlx::query!(
         r#"
         SELECT am.metadata as "metadata?"
         FROM artifacts a
@@ -524,31 +635,81 @@ async fn fetch_manifest(
           AND a.version = $3
         LIMIT 1
         "#,
-        repo.id,
+        repo_id,
         package_id,
         version
     )
-    .fetch_optional(&state.db)
+    .fetch_optional(db)
     .await
     .map_err(|e| {
         swift_error_response(
             StatusCode::INTERNAL_SERVER_ERROR,
             &format!("Database error: {}", e),
         )
-    })?
-    .ok_or_else(|| swift_error_response(StatusCode::NOT_FOUND, "Release not found"))?;
+    })?;
 
-    // Prefer the cached manifest from artifact_metadata. When that is missing
-    // (legacy uploads predating issue #1100, or publishes that bypassed the
-    // header path), parse the source archive on demand so SwiftPM dependency
-    // resolution still succeeds.
-    let cached_manifest = artifact
-        .metadata
-        .as_ref()
-        .and_then(|m| m.get("manifest"))
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    Ok(row.map(|r| {
+        r.metadata
+            .as_ref()
+            .and_then(|m| m.get("manifest"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    }))
+}
 
+/// Resolve which repo owns a Swift release for manifest fetching. For a
+/// virtual repo this fans out across Local/Staging members in priority order
+/// and returns the first that owns the release (issue #1554); for any other
+/// repo type it returns the repo itself. The returned tuple carries the
+/// owning repo's id, its storage location, and the cached manifest (if any).
+async fn resolve_manifest_owner(
+    db: &PgPool,
+    repo: &RepoInfo,
+    package_id: &str,
+    version: &str,
+) -> Result<(uuid::Uuid, crate::storage::StorageLocation, Option<String>), Response> {
+    if repo.repo_type == RepositoryType::Virtual {
+        let members = proxy_helpers::fetch_virtual_members(db, repo.id).await?;
+        for member in &members {
+            if member.repo_type != RepositoryType::Local
+                && member.repo_type != RepositoryType::Staging
+            {
+                continue;
+            }
+            if let Some(cached) = query_manifest(db, member.id, package_id, version).await? {
+                return Ok((member.id, member.storage_location(), cached));
+            }
+        }
+        return Err(swift_error_response(
+            StatusCode::NOT_FOUND,
+            "Release not found",
+        ));
+    }
+
+    let cached = query_manifest(db, repo.id, package_id, version)
+        .await?
+        .ok_or_else(|| swift_error_response(StatusCode::NOT_FOUND, "Release not found"))?;
+    Ok((repo.id, repo.storage_location(), cached))
+}
+
+async fn fetch_manifest(
+    state: SharedState,
+    repo_key: &str,
+    scope: &str,
+    name: &str,
+    version: &str,
+) -> Result<Response, Response> {
+    let repo = resolve_swift_repo(&state.db, repo_key).await?;
+    let package_id = format!("{}.{}", scope, name);
+
+    // Resolve the owning repo (handles virtual fan-out), preferring the cached
+    // manifest from artifact_metadata.
+    let (owner_id, owner_location, cached_manifest) =
+        resolve_manifest_owner(&state.db, &repo, &package_id, version).await?;
+
+    // When the cache is missing (legacy uploads predating issue #1100, or
+    // publishes that bypassed the header path), parse the source archive on
+    // demand so SwiftPM dependency resolution still succeeds.
     let manifest = match cached_manifest {
         Some(m) => m,
         None => {
@@ -559,7 +720,7 @@ async fn fetch_manifest(
                  WHERE repository_id = $1 AND is_deleted = false \
                  AND LOWER(name) = LOWER($2) AND version = $3 LIMIT 1",
             )
-            .bind(repo.id)
+            .bind(owner_id)
             .bind(&package_id)
             .bind(version)
             .fetch_one(&state.db)
@@ -571,7 +732,7 @@ async fn fetch_manifest(
                 )
             })?;
             let storage = state
-                .storage_for_repo(&repo.storage_location())
+                .storage_for_repo(&owner_location)
                 .map_err(|e| e.into_response())?;
             let zip_bytes = storage.get(&storage_key).await.map_err(|e| {
                 swift_error_response(
@@ -1033,6 +1194,86 @@ mod tests {
             writer.finish().unwrap();
         }
         buf
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression: issue #1554 -- virtual repo response builders
+    //
+    // These cover the pure response-shape logic for the three read endpoints
+    // (list_releases / get_release_metadata / fetch_manifest). The DB fan-out
+    // across virtual members is exercised by the `--ignored` integration tests
+    // in tests/swift_virtual_tests.rs; here we lock the JSON shapes that the
+    // virtual path feeds the same builders so the contract stays stable.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn build_releases_body_maps_versions_to_member_urls() {
+        let versions = vec!["1.0.0".to_string(), "1.2.0".to_string()];
+        let body = build_releases_body("swift-virtual", "macos", "lib", &versions);
+        let releases = body.get("releases").unwrap().as_object().unwrap();
+        assert_eq!(releases.len(), 2);
+        // URLs must point at the *virtual* repo key, not a member key, so the
+        // client keeps talking to the virtual repo on follow-up requests.
+        assert_eq!(
+            releases
+                .get("1.2.0")
+                .and_then(|v| v.get("url"))
+                .and_then(|v| v.as_str()),
+            Some("/swift/swift-virtual/macos/lib/1.2.0")
+        );
+        assert!(releases.contains_key("1.0.0"));
+    }
+
+    #[test]
+    fn build_releases_body_empty_when_no_versions() {
+        let body = build_releases_body("v", "s", "n", &[]);
+        assert!(body
+            .get("releases")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn build_release_metadata_body_without_manifest_has_only_archive() {
+        let row = ReleaseRow {
+            checksum_sha256: "abc123".to_string(),
+            metadata: None,
+        };
+        let body = build_release_metadata_body("apple", "swift-log", "1.5.0", &row);
+        assert_eq!(body.get("id").unwrap(), "apple.swift-log");
+        assert_eq!(body.get("version").unwrap(), "1.5.0");
+        let resources = body.get("resources").unwrap().as_array().unwrap();
+        assert_eq!(resources.len(), 1);
+        assert_eq!(resources[0].get("name").unwrap(), "source-archive");
+        assert_eq!(resources[0].get("checksum").unwrap(), "abc123");
+        // No swift_metadata -> empty object, not null.
+        assert_eq!(body.get("metadata").unwrap(), &serde_json::json!({}));
+    }
+
+    #[test]
+    fn build_release_metadata_body_with_manifest_adds_package_swift_resource() {
+        let row = ReleaseRow {
+            checksum_sha256: "deadbeef".to_string(),
+            metadata: Some(serde_json::json!({
+                "manifest": "// swift-tools-version:5.9",
+                "swift_metadata": { "scope": "apple", "name": "swift-nio" },
+            })),
+        };
+        let body = build_release_metadata_body("apple", "swift-nio", "2.40.0", &row);
+        let resources = body.get("resources").unwrap().as_array().unwrap();
+        assert_eq!(resources.len(), 2);
+        assert!(resources
+            .iter()
+            .any(|r| r.get("name").and_then(|n| n.as_str()) == Some("Package.swift")));
+        // Embedded swift_metadata is surfaced under "metadata".
+        assert_eq!(
+            body.get("metadata")
+                .and_then(|m| m.get("name"))
+                .and_then(|n| n.as_str()),
+            Some("swift-nio")
+        );
     }
 
     #[test]

--- a/backend/tests/swift_virtual_lookup_tests.rs
+++ b/backend/tests/swift_virtual_lookup_tests.rs
@@ -1,0 +1,234 @@
+//! Integration test: Swift virtual repositories must resolve package lookups
+//! across their members.
+//!
+//! Regression test for #1554. The read endpoints `list_releases`,
+//! `get_release_metadata`, and `fetch_manifest` previously queried the
+//! `artifacts` table using the *virtual* repo's own id. Virtual repos own no
+//! artifacts, so every lookup returned 404 even when a member served the
+//! package. The fix fans out across Local/Staging members in priority order
+//! and returns the first hit.
+//!
+//! Requires a PostgreSQL database with migrations applied. Run with:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test swift_virtual_lookup_tests -- --ignored
+//! ```
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::swift::{
+    query_release_metadata_virtual, query_release_versions_virtual,
+};
+
+async fn pool() -> PgPool {
+    PgPool::connect(
+        &std::env::var("DATABASE_URL")
+            .expect("DATABASE_URL must be set to run this integration test"),
+    )
+    .await
+    .expect("connect")
+}
+
+async fn insert_repo(pool: &PgPool, key: &str, repo_type: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let storage_path = format!("/tmp/test-artifacts/{}", id);
+    let upstream_url: Option<String> = if repo_type == "remote" {
+        Some("https://example.invalid/test".to_string())
+    } else {
+        None
+    };
+    sqlx::query(
+        r#"
+        INSERT INTO repositories (id, key, name, format, repo_type, storage_path, upstream_url)
+        VALUES ($1, $2, $2, 'swift'::repository_format, $3::repository_type, $4, $5)
+        "#,
+    )
+    .bind(id)
+    .bind(key)
+    .bind(repo_type)
+    .bind(&storage_path)
+    .bind(&upstream_url)
+    .execute(pool)
+    .await
+    .expect("failed to insert test repository");
+    id
+}
+
+async fn add_virtual_member(pool: &PgPool, virtual_id: Uuid, member_id: Uuid, priority: i32) {
+    sqlx::query(
+        "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+         VALUES ($1, $2, $3)",
+    )
+    .bind(virtual_id)
+    .bind(member_id)
+    .bind(priority)
+    .execute(pool)
+    .await
+    .expect("failed to insert virtual member");
+}
+
+/// Insert a Swift artifact row the way `publish_release` stores it: `name` is
+/// the `scope.name` package id and `metadata.manifest` holds the manifest text.
+async fn insert_swift_artifact(
+    pool: &PgPool,
+    repo_id: Uuid,
+    package_id: &str,
+    version: &str,
+    manifest: Option<&str>,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO artifacts (
+            id, repository_id, path, name, version,
+            size_bytes, checksum_sha256, content_type, storage_key
+        )
+        VALUES ($1, $2, $3, $4, $5, 0, $6, 'application/zip', $7)
+        "#,
+    )
+    .bind(id)
+    .bind(repo_id)
+    .bind(format!("{}/{}/pkg.zip", package_id, version))
+    .bind(package_id)
+    .bind(version)
+    .bind(format!("test-{}", id))
+    .bind(format!("artifacts/{}", id))
+    .execute(pool)
+    .await
+    .expect("failed to insert test artifact");
+
+    let meta = serde_json::json!({
+        "manifest": manifest,
+        "swift_metadata": { "package_id": package_id, "version": version },
+    });
+    sqlx::query(
+        "INSERT INTO artifact_metadata (artifact_id, format, metadata) \
+         VALUES ($1, 'swift', $2)",
+    )
+    .bind(id)
+    .bind(meta)
+    .execute(pool)
+    .await
+    .expect("failed to insert artifact metadata");
+    id
+}
+
+async fn cleanup(pool: &PgPool, virtual_id: Uuid, member_ids: &[Uuid]) {
+    sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+        .bind(virtual_id)
+        .execute(pool)
+        .await
+        .ok();
+    for &m in member_ids {
+        // artifact_metadata rows cascade via artifact_id FK; delete artifacts.
+        sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+            .bind(m)
+            .execute(pool)
+            .await
+            .ok();
+    }
+    let mut ids = member_ids.to_vec();
+    ids.push(virtual_id);
+    sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+        .bind(&ids)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+/// Core #1554 regression: a package owned by a Local member must be found
+/// through the virtual repo's list + metadata lookups.
+#[tokio::test]
+#[ignore]
+async fn swift_virtual_resolves_release_from_local_member() {
+    let pool = pool().await;
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("sw-virt-{}", suffix), "virtual").await;
+    let local_id = insert_repo(&pool, &format!("sw-local-{}", suffix), "local").await;
+    add_virtual_member(&pool, virtual_id, local_id, 1).await;
+
+    let package_id = "macos.lib";
+    insert_swift_artifact(&pool, local_id, package_id, "12.5.2", Some("// manifest")).await;
+
+    // list_releases fan-out
+    let versions = query_release_versions_virtual(&pool, virtual_id, package_id)
+        .await
+        .expect("virtual list lookup must succeed");
+    assert_eq!(
+        versions,
+        vec!["12.5.2".to_string()],
+        "virtual repo must surface the local member's release versions (#1554)"
+    );
+
+    // get_release_metadata fan-out
+    let row = query_release_metadata_virtual(&pool, virtual_id, package_id, "12.5.2")
+        .await
+        .expect("virtual metadata lookup must succeed")
+        .expect("release must be found via the member");
+    assert!(!row.checksum_sha256.is_empty());
+    assert!(row
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("manifest"))
+        .is_some());
+
+    cleanup(&pool, virtual_id, &[local_id]).await;
+}
+
+/// Priority ordering: the first member (by priority) that owns the package wins.
+#[tokio::test]
+#[ignore]
+async fn swift_virtual_returns_first_member_hit_by_priority() {
+    let pool = pool().await;
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("sw-virt-prio-{}", suffix), "virtual").await;
+    let local_a = insert_repo(&pool, &format!("sw-a-{}", suffix), "local").await;
+    let local_b = insert_repo(&pool, &format!("sw-b-{}", suffix), "local").await;
+    // local_b has higher priority value but later position; local_a is first.
+    add_virtual_member(&pool, virtual_id, local_a, 1).await;
+    add_virtual_member(&pool, virtual_id, local_b, 2).await;
+
+    let package_id = "apple.swift-log";
+    insert_swift_artifact(&pool, local_a, package_id, "1.0.0", None).await;
+    insert_swift_artifact(&pool, local_b, package_id, "9.9.9", None).await;
+
+    let versions = query_release_versions_virtual(&pool, virtual_id, package_id)
+        .await
+        .expect("lookup must succeed");
+    assert_eq!(
+        versions,
+        vec!["1.0.0".to_string()],
+        "the highest-priority member that owns the package must win"
+    );
+
+    cleanup(&pool, virtual_id, &[local_a, local_b]).await;
+}
+
+/// Negative: a package no member owns yields an empty list / None, which the
+/// handlers map to 404 (matching the direct-repo behavior).
+#[tokio::test]
+#[ignore]
+async fn swift_virtual_missing_package_returns_empty() {
+    let pool = pool().await;
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("sw-virt-miss-{}", suffix), "virtual").await;
+    let local_id = insert_repo(&pool, &format!("sw-local-miss-{}", suffix), "local").await;
+    add_virtual_member(&pool, virtual_id, local_id, 1).await;
+
+    let versions = query_release_versions_virtual(&pool, virtual_id, "nope.absent")
+        .await
+        .expect("lookup must succeed");
+    assert!(
+        versions.is_empty(),
+        "unknown package must yield no versions"
+    );
+
+    let row = query_release_metadata_virtual(&pool, virtual_id, "nope.absent", "1.0.0")
+        .await
+        .expect("lookup must succeed");
+    assert!(row.is_none(), "unknown release must yield None");
+
+    cleanup(&pool, virtual_id, &[local_id]).await;
+}


### PR DESCRIPTION
Closes #1554

## Summary
Swift **virtual** repositories returned `404 Package not found` for every read endpoint because each query bound `$1` to the *virtual* repo's own id, and virtual repos own no artifacts. The three affected handlers were `list_releases`, `get_release_metadata`, and `fetch_manifest`. Only `download_archive` already handled the virtual case (via `resolve_virtual_download`).

**Root cause:** `backend/src/api/handlers/swift.rs` — `list_releases` (~line 205), `get_release_metadata` (~line 393), and `fetch_manifest` (~line 447) ran `SELECT ... FROM artifacts WHERE repository_id = repo.id` against the virtual repo, which never owns rows.

**Fix:** Mirror the established virtual fan-out pattern used by `npm.rs`. For a `Virtual` repo, iterate `Local`/`Staging` members in priority order (`proxy_helpers::fetch_virtual_members`) and return the first member that owns the package; otherwise 404. Non-virtual (Local/Remote/Staging) behavior is unchanged. The per-function SQL was factored into reusable `query_*` helpers parameterized by `repository_id`, and the JSON response shapes into pure `build_*` helpers with at-rest unit coverage. SELECT lists were kept byte-identical to the originals so the committed `.sqlx` offline cache entries still match (no DB regeneration needed).

Scope note: Remote-member listing/metadata fan-out is intentionally out of scope here (upstream list/metadata shapes are format-specific); the `.zip` download path already proxies Remote members. This matches the issue's reproduction (a member-served package 404ing through the virtual repo).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Regression coverage:
- Unit tests for the pure response builders (`build_releases_body`, `build_release_metadata_body`) in `swift.rs`.
- DB-backed integration tests in `backend/tests/swift_virtual_lookup_tests.rs` (`--ignored`): member resolution, priority ordering (first owning member wins), and the missing-package path.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

---
Local gates (`SQLX_OFFLINE=true`): `cargo fmt --check` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo test --workspace --lib` green (one pre-existing flaky timeout test unrelated to this change passes in isolation). jscpd: changed files are exempt (`swift.rs` is in the `.jscpd.json` format-handler ignore list; the new test lives under `tests/`).
