### PR TITLE
fix(pypi): local-precedence for virtual simple index to close dependency-confusion (#1600)

### DIFF
--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -608,12 +608,18 @@ async fn simple_project(
             let mut local_artifacts: Vec<SimpleProjectArtifact> = Vec::new();
             let mut remote_response: Option<(Bytes, Option<String>)> = None;
 
+            // First pass: collect distributions from every local (hosted /
+            // staging) member. We must know whether a local member owns the
+            // name BEFORE deciding to fetch any remote index, because members
+            // are iterated in priority order and a remote can precede a local.
             for member in &members {
-                if member.repo_type == RepositoryType::Local
-                    || member.repo_type == RepositoryType::Staging
+                if member.repo_type != RepositoryType::Local
+                    && member.repo_type != RepositoryType::Staging
                 {
-                    let member_rows = sqlx::query!(
-                        r#"
+                    continue;
+                }
+                let member_rows = sqlx::query!(
+                    r#"
         SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,
                am.metadata as "metadata?"
         FROM artifacts a
@@ -623,25 +629,39 @@ async fn simple_project(
           AND LOWER(REPLACE(REPLACE(REPLACE(a.name, '_', '-'), '.', '-'), '--', '-')) = $2
         ORDER BY a.created_at DESC
         "#,
-                        member.id,
-                        normalized
-                    )
-                    .fetch_all(&state.db)
-                    .await
-                    .map_err(map_db_err)?;
+                    member.id,
+                    normalized
+                )
+                .fetch_all(&state.db)
+                .await
+                .map_err(map_db_err)?;
 
-                    local_artifacts.extend(member_rows.into_iter().map(|a| {
-                        SimpleProjectArtifact {
-                            path: a.path,
-                            version: a.version,
-                            size_bytes: a.size_bytes,
-                            checksum_sha256: a.checksum_sha256,
-                            metadata: a.metadata,
-                        }
-                    }));
-                    continue;
+                local_artifacts.extend(member_rows.into_iter().map(|a| SimpleProjectArtifact {
+                    path: a.path,
+                    version: a.version,
+                    size_bytes: a.size_bytes,
+                    checksum_sha256: a.checksum_sha256,
+                    metadata: a.metadata,
+                }));
+            }
+
+            // Ownership / dependency-confusion guard (#1600). When a local
+            // member owns this PEP 503 name, the virtual serves ONLY that
+            // member's distributions for the name — in both the simple index
+            // and the download — rather than unioning the remote's versions for
+            // it. Unioning an unrelated public package that merely shares the
+            // name is a supply-chain hole (`pip` prefers the higher public
+            // version) AND makes the index inconsistent with the download path,
+            // which is also local-precedence-by-name and 404s for any version
+            // only the remote has. Local precedence is the PEP 708-aligned
+            // default for a locally-owned name. Second pass: fetch a remote
+            // index only when no local member owns the name.
+            let suppress_remote = virtual_simple_suppress_remote(local_artifacts.len());
+
+            for member in &members {
+                if suppress_remote {
+                    break;
                 }
-
                 if member.repo_type != RepositoryType::Remote {
                     continue;
                 }
@@ -838,6 +858,23 @@ fn build_simple_project_response(
         .unwrap())
 }
 
+/// Ownership / dependency-confusion policy for a virtual PyPI simple index
+/// (#1600). Returns `true` when a local (hosted/staging) member owns the
+/// requested PEP 503 name — in which case the virtual must serve ONLY that
+/// member's distributions and must NOT union or proxy a remote member's
+/// versions for the name.
+///
+/// `local_artifact_count` is the number of distributions the virtual's local
+/// members hold for the normalized name. A non-zero count means the name is
+/// locally owned. Unioning an unrelated public package that merely shares the
+/// name is a supply-chain hole (`pip` would prefer the higher public version)
+/// and makes the simple index inconsistent with the download path — which is
+/// also local-precedence-by-name and 404s for any version only the remote has.
+/// Local precedence is the PEP 708-aligned default for a locally-owned name.
+fn virtual_simple_suppress_remote(local_artifact_count: usize) -> bool {
+    local_artifact_count > 0
+}
+
 /// Splice local-member entries into a remote-member PEP 503 HTML response so
 /// the union is visible through the virtual repo. Entries already present in
 /// the remote response (matched by filename, the anchor's inner text per
@@ -1002,16 +1039,21 @@ async fn serve_file(
                     .into_response());
                 }
 
-                // Supply-chain shadowing guard (#1217 follow-up, ak-hv3s).
-                // Version-aware: suppress the proxy only when a local member
-                // owns the requested version, not any version of the name (#1582).
+                // Supply-chain shadowing / ownership guard (#1217, #1600).
+                // Local-precedence-by-name: when a local (hosted/staging) member
+                // owns the PEP 503 name, suppress every remote member for this
+                // download regardless of the requested version. This keeps the
+                // download consistent with the simple index, which is also
+                // local-precedence-by-name (#1600): if the index won't list an
+                // unrelated public version for a locally-owned name, the
+                // download must not serve it either. It also closes the
+                // dependency-confusion hole where a higher public version of an
+                // internally-owned name would resolve through the virtual.
                 let normalized_project = PypiHandler::normalize_name(project);
-                let requested_version = PypiHandler::version_from_filename(filename);
-                let suppress_remote_members = proxy_helpers::virtual_non_remote_owns_name_version(
+                let suppress_remote_members = proxy_helpers::virtual_non_remote_owns_name(
                     &state.db,
                     repo.id,
                     &normalized_project,
-                    requested_version.as_deref(),
                 )
                 .await?;
 
@@ -4014,6 +4056,27 @@ mod tests {
         let remote = remote_html_with(&[("pkg-1.0.0.tar.gz", None)]);
         let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &[]);
         assert_eq!(merged, remote);
+    }
+
+    // -----------------------------------------------------------------------
+    // virtual_simple_suppress_remote — #1600 ownership / dependency-confusion
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_virtual_simple_suppress_remote_local_owns_name() {
+        // #1600: when a local member holds any distribution for the name, the
+        // virtual must NOT union/proxy the remote's versions — local precedence.
+        // This keeps the simple index consistent with the local-precedence
+        // download path and closes the dependency-confusion hole.
+        assert!(virtual_simple_suppress_remote(1));
+        assert!(virtual_simple_suppress_remote(5));
+    }
+
+    #[test]
+    fn test_virtual_simple_suppress_remote_name_not_owned_locally() {
+        // No local distributions for the name: the virtual falls through to the
+        // remote member (general proxy behavior for names a local doesn't own).
+        assert!(!virtual_simple_suppress_remote(0));
     }
 
     #[test]


### PR DESCRIPTION
Closes #1600

## Summary

A PyPI **virtual** repo with a local member and a remote (pypi.org proxy) member unioned the remote's versions into `/simple/<name>/` even when a local member owned the name. When an *unrelated* public package happened to share the name, the index advertised the public distributions, but the download path (already local-precedence by name) then **404'd** for any version only the remote had.

Net effect: an **index/download inconsistency** plus a **dependency-confusion hole** — with an unpinned `pip install <name>`, pip picks the highest version (the public one), then fails to download it through the virtual.

**Root cause:**
- `simple_project` (index) in `backend/src/api/handlers/pypi.rs` unconditionally unioned a remote member's `/simple/<name>/` into the response whenever it was fetched, ignoring local ownership.
- `serve_file` (download) used the *version-aware* guard (`virtual_non_remote_owns_name_version`), suppressing the remote only when a local member owned the exact requested version — so a public-only version fell through to a download that 404'd against the local member, disagreeing with the index.

**Fix — PEP 708-aligned local precedence (ownership-aware):** when a local (hosted/staging) member owns the PEP 503 name, the virtual serves **only that member's distributions** for the name in **both** the index and the download, and does not union/proxy the remote's versions for that name. Names a local member does not own still proxy from the remote as before.

- `simple_project`: collect local members in a first pass, then fetch a remote index only when no local member owns the name (members are priority-ordered, so a remote can precede a local — the decision must be made up front).
- `serve_file`: use the name-only ownership guard so the download agrees with the index.
- Extracted `virtual_simple_suppress_remote()` policy helper with unit tests.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added `test_virtual_simple_suppress_remote_local_owns_name` and `test_virtual_simple_suppress_remote_name_not_owned_locally` covering the index ownership policy.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib` all green (the single `test_large_object_client_builder_does_not_apply_total_timeout` failure is a pre-existing environmental TCP-timeout test that also fails on clean `main`). jscpd on the changed file: no clones above the 3% threshold.

## API Changes
- [x] N/A - no API changes
