### PR TITLE
feat(oidc): add OIDC_DEFAULT_ROLE and wire OIDC_GROUP_ROLE_MAP into admin check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -252,6 +252,8 @@ JWT_EXPIRATION_SECS=86400
 # OIDC_USERNAME_CLAIM=preferred_username
 # OIDC_EMAIL_CLAIM=email
 # OIDC_ADMIN_GROUP=artifact-admins
+# OIDC_DEFAULT_ROLE=user
+# OIDC_GROUP_ROLE_MAP=engineers:user;security-team:viewer
 
 # --- LDAP (optional) ---
 # When LDAP_URL and LDAP_BASE_DN are set, the backend seeds an enabled LDAP

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -38,6 +38,8 @@ pub struct OidcConfig {
     pub groups_claim: String,
     /// Group name for admin role
     pub admin_group: Option<String>,
+    /// Default role for all OIDC users (OIDC_DEFAULT_ROLE, defaults to "user").
+    pub default_role: String,
 }
 
 impl OidcConfig {
@@ -64,6 +66,7 @@ impl OidcConfig {
             groups_claim: std::env::var("OIDC_GROUPS_CLAIM")
                 .unwrap_or_else(|_| "groups".to_string()),
             admin_group: std::env::var("OIDC_ADMIN_GROUP").ok(),
+            default_role: std::env::var("OIDC_DEFAULT_ROLE").unwrap_or_else(|_| "user".to_string()),
         })
     }
 }
@@ -600,15 +603,31 @@ impl OidcService {
         }
     }
 
-    /// Check if user is admin based on group memberships
     fn is_admin_from_groups(&self, groups: &[String]) -> bool {
         if let Some(admin_group) = &self.config.admin_group {
-            groups
+            if groups
                 .iter()
                 .any(|g| g.to_lowercase() == admin_group.to_lowercase())
-        } else {
-            false
+            {
+                return true;
+            }
         }
+
+        if let Ok(mappings) = std::env::var("OIDC_GROUP_ROLE_MAP") {
+            for mapping in mappings.split(';') {
+                if let Some((group, role)) = mapping.split_once(':') {
+                    if role.trim().to_lowercase() == "admin"
+                        && groups
+                            .iter()
+                            .any(|g| g.to_lowercase() == group.trim().to_lowercase())
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        self.config.default_role.to_lowercase() == "admin"
     }
 
     /// Extract group memberships for role mapping
@@ -616,24 +635,21 @@ impl OidcService {
         oidc_user.groups.clone()
     }
 
-    /// Map OIDC groups to application roles
     pub fn map_groups_to_roles(&self, groups: &[String]) -> Vec<String> {
-        let mut roles = vec!["user".to_string()];
+        let mut roles = vec![self.config.default_role.clone()];
 
         if self.is_admin_from_groups(groups) {
             roles.push("admin".to_string());
         }
 
-        // Additional role mappings from environment
-        // OIDC_GROUP_ROLE_MAP=developers:developer;admins:admin
         if let Ok(mappings) = std::env::var("OIDC_GROUP_ROLE_MAP") {
             for mapping in mappings.split(';') {
                 if let Some((group, role)) = mapping.split_once(':') {
                     if groups
                         .iter()
-                        .any(|g| g.to_lowercase() == group.to_lowercase())
+                        .any(|g| g.to_lowercase() == group.trim().to_lowercase())
                     {
-                        roles.push(role.to_string());
+                        roles.push(role.trim().to_string());
                     }
                 }
             }


### PR DESCRIPTION
Closes #1746

## What

- Adds `OIDC_DEFAULT_ROLE` env var (defaults to `"user"`) to `OidcConfig`, letting operators set a fallback role for all authenticated OIDC users.
- Wires `OIDC_GROUP_ROLE_MAP` into `is_admin_from_groups` so that mapping a group to `admin` actually promotes the user — previously the map was parsed in `map_groups_to_roles` but never consulted when computing `is_admin` on the user record.

## Why

`OIDC_GROUP_ROLE_MAP` existed but was effectively dead: it populated `map_groups_to_roles` return values that aren't used in the login/user-creation path. Only `is_admin_from_groups` gates the DB write, and it only checked `OIDC_ADMIN_GROUP`. This made it impossible to assign non-admin roles to specific OIDC groups, mirroring what `SAML_GROUP_ROLE_MAP` already supports for SAML.

## Behaviour

| Env var | Effect |
|---|---|
| `OIDC_DEFAULT_ROLE=user` (default) | No change from current behaviour |
| `OIDC_DEFAULT_ROLE=admin` | All OIDC users get admin (use with caution) |
| `OIDC_GROUP_ROLE_MAP=engineers:user;admins:admin` | `admins` group → admin; explicit mapping respected in both role list and `is_admin` |

## Notes

`OIDC_GROUP_ROLE_MAP` is read from env on each call to `is_admin_from_groups` / `map_groups_to_roles`, consistent with the existing pattern in `saml_service.rs`. A follow-up could parse it once at config construction, but that's a separate concern.