### PR TITLE
fix(proxy): page cached-artifact listing without O(N) sidecar loads + guard per_page=0 (#1571)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1892,7 +1892,12 @@ pub async fn list_artifacts(
     Query(query): Query<ListArtifactsQuery>,
 ) -> Result<Json<ArtifactListResponse>> {
     let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(20).min(100);
+    // Clamp per_page to [1, 100]: a `per_page=0` query previously slipped past
+    // the `.min(100)` upper bound and reached the `total_pages` divisions
+    // below as a divide-by-zero, saturating `total_pages` to u32::MAX for any
+    // non-empty repo (#1571). The lower bound makes both the DB and the
+    // proxy-cache listing branches well-defined.
+    let per_page = query.per_page.unwrap_or(20).clamp(1, 100);
     let offset = ((page - 1) * per_page) as i64;
 
     let repo_service = RepositoryService::new(state.db.clone());
@@ -2085,18 +2090,33 @@ async fn list_remote_cached_artifacts(
     page: u32,
     per_page: u32,
 ) -> Result<Json<ArtifactListResponse>> {
-    let entries = match state.proxy_service.as_deref() {
-        Some(proxy) => proxy.list_cached_artifacts(&repo.key).await,
+    // Two-phase listing (#1571): first recover just the cached path strings
+    // (no sidecar reads), filter + slice them to the requested page, and only
+    // then load sidecars for that page. Both listing filters are path-based,
+    // so paging on the paths is exact and avoids the previous O(N) sidecar
+    // read on every request. The trade-off is that `total` counts paths whose
+    // sidecar may since have gone missing (a half-written / legacy cache
+    // write); such a path is still dropped from the returned page, matching
+    // the old per-entry skip, but is no longer pre-excluded from the count —
+    // an acceptable approximation in exchange for O(page) reads.
+    let proxy = state.proxy_service.as_deref();
+    let paths = match proxy {
+        Some(proxy) => proxy.list_cached_paths(&repo.key).await,
         // No proxy service configured (e.g. proxying disabled): nothing cached.
         None => Vec::new(),
     };
 
-    let (page_entries, total) = filter_and_paginate_cached(entries, path_prefix, q, page, per_page);
-    let total_pages = ((total as f64) / (per_page as f64)).ceil() as u32;
+    let (page_paths, total) = filter_and_paginate_paths(paths, path_prefix, q, page, per_page);
+    let total_pages = cached_total_pages(total, per_page);
 
-    let items = page_entries
-        .into_iter()
-        .map(|entry| build_cached_artifact_response(&entry, key))
+    let entries = match proxy {
+        Some(proxy) => proxy.load_cached_entries(&repo.key, &page_paths).await,
+        None => Vec::new(),
+    };
+
+    let items = entries
+        .iter()
+        .map(|entry| build_cached_artifact_response(entry, key))
         .collect();
 
     Ok(Json(ArtifactListResponse {
@@ -2113,50 +2133,59 @@ async fn list_remote_cached_artifacts(
 }
 
 /// Apply the listing's `path_prefix` and `q` filters to the recovered proxy
-/// cache entries, then return the slice for the requested page along with the
-/// total match count.
+/// cache **paths**, then return the slice for the requested page along with
+/// the total match count.
 ///
 /// `path_prefix` matches against the start of the logical path; `q` is a
-/// case-insensitive substring match against the path. Pure so the
-/// filter/paginate logic is unit-testable without a storage backend.
-fn filter_and_paginate_cached(
-    entries: Vec<crate::services::proxy_service::CachedArtifactEntry>,
+/// case-insensitive substring match against the path. Both filters are
+/// purely path-based, so this runs on the path strings alone and the caller
+/// loads sidecars only for the returned page (#1571), instead of loading
+/// every sidecar before slicing. `per_page` is treated as at least 1 so a
+/// `per_page == 0` query cannot wedge pagination. Pure / unit-testable
+/// without a storage backend.
+fn filter_and_paginate_paths(
+    paths: Vec<String>,
     path_prefix: Option<&str>,
     q: Option<&str>,
     page: u32,
     per_page: u32,
-) -> (
-    Vec<crate::services::proxy_service::CachedArtifactEntry>,
-    usize,
-) {
+) -> (Vec<String>, usize) {
     let q_lower = q
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_lowercase);
 
-    let mut matched: Vec<_> = entries
+    let mut matched: Vec<String> = paths
         .into_iter()
-        .filter(|e| match path_prefix {
-            Some(prefix) if !prefix.is_empty() => e.path.starts_with(prefix),
+        .filter(|p| match path_prefix {
+            Some(prefix) if !prefix.is_empty() => p.starts_with(prefix),
             _ => true,
         })
-        .filter(|e| match &q_lower {
-            Some(needle) => e.path.to_lowercase().contains(needle),
+        .filter(|p| match &q_lower {
+            Some(needle) => p.to_lowercase().contains(needle),
             None => true,
         })
         .collect();
 
     // Stable ordering for deterministic pagination across requests.
-    matched.sort_by(|a, b| a.path.cmp(&b.path));
+    matched.sort();
 
     let total = matched.len();
-    let offset = ((page.saturating_sub(1)) as usize).saturating_mul(per_page as usize);
-    let page_items = matched
-        .into_iter()
-        .skip(offset)
-        .take(per_page as usize)
-        .collect();
+    let per_page = (per_page.max(1)) as usize;
+    let offset = (page.saturating_sub(1) as usize).saturating_mul(per_page);
+    let page_items = matched.into_iter().skip(offset).take(per_page).collect();
     (page_items, total)
+}
+
+/// Number of pages for a cached listing of `total` items at `per_page`.
+///
+/// Guards `per_page == 0` (a value a query can supply — the handler only caps
+/// the upper bound) so the count cannot saturate to `u32::MAX` the way the
+/// previous `((total as f64) / (per_page as f64)).ceil() as u32` did for any
+/// non-empty repo (#1571). Pure / unit-testable.
+fn cached_total_pages(total: usize, per_page: u32) -> u32 {
+    let per_page = (per_page.max(1)) as usize;
+    total.div_ceil(per_page) as u32
 }
 
 /// Deterministic artifact id for a proxy-cached object.
@@ -4743,55 +4772,69 @@ mod tests {
         }
     }
 
+    fn paths(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
     #[test]
-    fn test_filter_and_paginate_cached_returns_all_sorted() {
-        let entries = vec![
-            make_cached_entry("lodash/-/lodash-4.17.21.tgz"),
-            make_cached_entry("is-odd/-/is-odd-3.0.1.tgz"),
-        ];
-        let (page, total) = filter_and_paginate_cached(entries, None, None, 1, 20);
+    fn test_filter_and_paginate_paths_returns_all_sorted() {
+        let input = paths(&["lodash/-/lodash-4.17.21.tgz", "is-odd/-/is-odd-3.0.1.tgz"]);
+        let (page, total) = filter_and_paginate_paths(input, None, None, 1, 20);
         assert_eq!(total, 2);
         assert_eq!(page.len(), 2);
         // Sorted by path.
-        assert_eq!(page[0].path, "is-odd/-/is-odd-3.0.1.tgz");
-        assert_eq!(page[1].path, "lodash/-/lodash-4.17.21.tgz");
+        assert_eq!(page[0], "is-odd/-/is-odd-3.0.1.tgz");
+        assert_eq!(page[1], "lodash/-/lodash-4.17.21.tgz");
     }
 
     #[test]
-    fn test_filter_and_paginate_cached_applies_path_prefix() {
-        let entries = vec![
-            make_cached_entry("lodash/-/lodash-4.17.21.tgz"),
-            make_cached_entry("is-odd/-/is-odd-3.0.1.tgz"),
-        ];
-        let (page, total) = filter_and_paginate_cached(entries, Some("lodash/"), None, 1, 20);
+    fn test_filter_and_paginate_paths_applies_path_prefix() {
+        let input = paths(&["lodash/-/lodash-4.17.21.tgz", "is-odd/-/is-odd-3.0.1.tgz"]);
+        let (page, total) = filter_and_paginate_paths(input, Some("lodash/"), None, 1, 20);
         assert_eq!(total, 1);
         assert_eq!(page.len(), 1);
-        assert_eq!(page[0].path, "lodash/-/lodash-4.17.21.tgz");
+        assert_eq!(page[0], "lodash/-/lodash-4.17.21.tgz");
     }
 
     #[test]
-    fn test_filter_and_paginate_cached_applies_case_insensitive_query() {
-        let entries = vec![
-            make_cached_entry("lodash/-/lodash-4.17.21.tgz"),
-            make_cached_entry("is-odd/-/is-odd-3.0.1.tgz"),
-        ];
-        let (page, total) = filter_and_paginate_cached(entries, None, Some("IS-ODD"), 1, 20);
+    fn test_filter_and_paginate_paths_applies_case_insensitive_query() {
+        let input = paths(&["lodash/-/lodash-4.17.21.tgz", "is-odd/-/is-odd-3.0.1.tgz"]);
+        let (page, total) = filter_and_paginate_paths(input, None, Some("IS-ODD"), 1, 20);
         assert_eq!(total, 1);
-        assert_eq!(page[0].path, "is-odd/-/is-odd-3.0.1.tgz");
+        assert_eq!(page[0], "is-odd/-/is-odd-3.0.1.tgz");
     }
 
     #[test]
-    fn test_filter_and_paginate_cached_paginates() {
-        let entries = vec![
-            make_cached_entry("a"),
-            make_cached_entry("b"),
-            make_cached_entry("c"),
-        ];
-        let (page2, total) = filter_and_paginate_cached(entries, None, None, 2, 2);
+    fn test_filter_and_paginate_paths_paginates() {
+        let input = paths(&["a", "b", "c"]);
+        let (page2, total) = filter_and_paginate_paths(input, None, None, 2, 2);
         assert_eq!(total, 3);
         // page size 2, page 2 -> just "c"
         assert_eq!(page2.len(), 1);
-        assert_eq!(page2[0].path, "c");
+        assert_eq!(page2[0], "c");
+    }
+
+    #[test]
+    fn test_filter_and_paginate_paths_per_page_zero_does_not_wedge() {
+        // Regression for #1571: a `per_page=0` query must not panic or produce
+        // a degenerate empty page; per_page is treated as at least 1.
+        let input = paths(&["a", "b", "c"]);
+        let (page1, total) = filter_and_paginate_paths(input, None, None, 1, 0);
+        assert_eq!(total, 3);
+        assert_eq!(page1, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn test_cached_total_pages_guards_per_page_zero() {
+        // Regression for #1571: the previous `(total as f64 / per_page as f64)
+        // .ceil() as u32` returned u32::MAX (saturated infinity) when per_page
+        // was 0 for a non-empty repo. The guarded version returns a sane count.
+        assert_eq!(cached_total_pages(5, 0), 5);
+        assert_eq!(cached_total_pages(0, 0), 0);
+        // Normal ceil-division behaviour is preserved.
+        assert_eq!(cached_total_pages(10, 3), 4);
+        assert_eq!(cached_total_pages(9, 3), 3);
+        assert_eq!(cached_total_pages(0, 20), 0);
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2670,6 +2670,24 @@ impl ProxyService {
     /// `cached_at` come from the sidecar; entries whose sidecar is missing or
     /// unreadable are skipped (a half-written or legacy cache write).
     pub async fn list_cached_artifacts(&self, repo_key: &str) -> Vec<CachedArtifactEntry> {
+        let paths = self.list_cached_paths(repo_key).await;
+        self.load_cached_entries(repo_key, &paths).await
+    }
+
+    /// List the logical paths of every proxy-cached artifact for a repo
+    /// **without** loading any sidecar metadata.
+    ///
+    /// This is the cheap first half of a paginated cached listing (#1571):
+    /// the caller filters + slices these path strings down to the requested
+    /// page (both listing filters — path prefix and substring `q` — are
+    /// purely path-based) and then loads sidecars for just that page via
+    /// [`Self::load_cached_entries`]. That turns a cached listing from O(N)
+    /// sidecar reads on every request into O(page) reads, which is what
+    /// previously made large proxy caches expensive to page through.
+    ///
+    /// Returns paths sorted + deduped (see [`Self::cached_artifact_paths`]),
+    /// or an empty list when the storage backend cannot list the prefix.
+    pub async fn list_cached_paths(&self, repo_key: &str) -> Vec<String> {
         let prefix = format!("proxy-cache/{}/", repo_key);
         let keys = match self.storage.list(Some(&prefix)).await {
             Ok(keys) => keys,
@@ -2684,14 +2702,25 @@ impl ProxyService {
             }
         };
 
-        let logical_paths = Self::cached_artifact_paths(repo_key, keys.iter().map(String::as_str));
+        Self::cached_artifact_paths(repo_key, keys.iter().map(String::as_str))
+    }
 
-        // Load every sidecar concurrently with bounded parallelism instead of
-        // one sequential storage round-trip per path (#1608). `cached_artifact_paths`
-        // already returns paths sorted+deduped, but `buffer_unordered` yields
-        // results out of order, so the collected entries are re-sorted by path
-        // to keep the output deterministic and identical to the sequential path.
-        let mut entries: Vec<CachedArtifactEntry> = futures::stream::iter(logical_paths)
+    /// Load sidecar metadata for a specific, already-paginated set of cached
+    /// `paths`, returning the assembled entries sorted by path.
+    ///
+    /// Pairs with [`Self::list_cached_paths`] so a cached listing only reads
+    /// the sidecars for the requested page rather than every object in the
+    /// cache (#1571). Sidecars are loaded concurrently with bounded
+    /// parallelism (#1608); `buffer_unordered` yields out of order, so the
+    /// collected entries are re-sorted by path to stay deterministic. Paths
+    /// whose sidecar is missing or unreadable are skipped, matching the
+    /// previous whole-cache load.
+    pub async fn load_cached_entries(
+        &self,
+        repo_key: &str,
+        paths: &[String],
+    ) -> Vec<CachedArtifactEntry> {
+        let mut entries: Vec<CachedArtifactEntry> = futures::stream::iter(paths.iter().cloned())
             .map(|path| async move {
                 let metadata_key = Self::cache_metadata_key(repo_key, &path).ok()?;
                 match self.load_cache_metadata(&metadata_key).await {
@@ -7123,6 +7152,126 @@ SHA256:
         assert!(
             service.list_cached_artifacts("npm-remote").await.is_empty(),
             "a storage listing error must yield no cached artifacts"
+        );
+    }
+
+    /// Storage mock that counts every `get` (sidecar read) so a test can
+    /// assert the two-phase cached listing only reads the requested page's
+    /// sidecars rather than every object in the cache (#1571).
+    struct CountingCacheMock {
+        keys: Vec<String>,
+        sidecars: std::collections::HashMap<String, Bytes>,
+        get_count: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for CountingCacheMock {
+        async fn put(&self, _key: &str, _content: Bytes) -> Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            self.get_count
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            match self.sidecars.get(key) {
+                Some(b) => Ok(b.clone()),
+                None => Err(AppError::NotFound(key.to_string())),
+            }
+        }
+        async fn exists(&self, _key: &str) -> Result<bool> {
+            Ok(true)
+        }
+        async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, prefix: Option<&str>) -> Result<Vec<String>> {
+            Ok(match prefix {
+                Some(p) => self
+                    .keys
+                    .iter()
+                    .filter(|k| k.starts_with(p))
+                    .cloned()
+                    .collect(),
+                None => self.keys.clone(),
+            })
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_cached_paths_reads_no_sidecars() {
+        // #1571: recovering the path set must not read a single sidecar, so the
+        // caller can filter + page the paths before paying for any metadata I/O.
+        let repo = "npm-remote";
+        let now = Utc::now();
+        let all = ["a/-/a-1.tgz", "b/-/b-1.tgz", "c/-/c-1.tgz"];
+        let mut sidecars = std::collections::HashMap::new();
+        let mut keys = Vec::new();
+        for p in all {
+            sidecars.insert(
+                meta_key(repo, p),
+                sidecar_bytes(1, &"a".repeat(64), None, now),
+            );
+            keys.push(content_key(repo, p));
+            keys.push(meta_key(repo, p));
+        }
+        let get_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mock = std::sync::Arc::new(CountingCacheMock {
+            keys,
+            sidecars,
+            get_count: get_count.clone(),
+        });
+        let service = build_proxy_service_with_storage(mock);
+
+        let paths = service.list_cached_paths(repo).await;
+        assert_eq!(paths, vec!["a/-/a-1.tgz", "b/-/b-1.tgz", "c/-/c-1.tgz"]);
+        assert_eq!(
+            get_count.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "listing cached paths must not read any sidecar"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_cached_entries_reads_only_requested_paths() {
+        // #1571: loading a single-path page out of a 3-object cache must read
+        // exactly one sidecar, not all three (the old O(N)-per-listing cost).
+        let repo = "npm-remote";
+        let now = Utc::now();
+        let all = ["a/-/a-1.tgz", "b/-/b-1.tgz", "c/-/c-1.tgz"];
+        let mut sidecars = std::collections::HashMap::new();
+        let mut keys = Vec::new();
+        for p in all {
+            sidecars.insert(
+                meta_key(repo, p),
+                sidecar_bytes(7, &"b".repeat(64), None, now),
+            );
+            keys.push(content_key(repo, p));
+            keys.push(meta_key(repo, p));
+        }
+        let get_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let mock = std::sync::Arc::new(CountingCacheMock {
+            keys,
+            sidecars,
+            get_count: get_count.clone(),
+        });
+        let service = build_proxy_service_with_storage(mock);
+
+        let page = vec!["b/-/b-1.tgz".to_string()];
+        let entries = service.load_cached_entries(repo, &page).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].path, "b/-/b-1.tgz");
+        assert_eq!(
+            get_count.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "loading a 1-path page must read exactly one sidecar, not the whole cache"
         );
     }
 


### PR DESCRIPTION
## Summary

The remote-repo **cached-artifact listing** had two defects, both surfaced in #1571:

1. **O(N) sidecar reads per listing.** `ProxyService::list_cached_artifacts` listed the entire `proxy-cache/<repo_key>/` prefix and loaded *every* sidecar into memory before the handler sliced the requested page. A `page=1&per_page=20` request against a 10k-object cache still did ~10k storage reads.
2. **`per_page=0` divide-by-zero.** A `per_page=0` query slipped past the `.min(100)` upper bound and reached `total_pages = ((total as f64) / (per_page as f64)).ceil() as u32`, where `inf as u32` saturates — returning `total_pages = 4294967295` for any non-empty repo (affecting both the DB and cached branches).

**Fix:**
- Two-phase listing: `list_cached_paths` recovers the path set with **zero** sidecar reads; the handler filters + paginates the path strings (both listing filters — `path_prefix` and `q` — are purely path-based); `load_cached_entries` then reads sidecars for **only that page**. Listing is now O(page) reads. `list_cached_artifacts` remains as a thin wrapper for existing callers/tests.
- Clamp `per_page` to `[1, 100]` at the handler and add `cached_total_pages`, a guarded integer ceil-division helper, so neither branch can divide by zero.

Trade-off (documented in code): `total` now counts paths whose sidecar may since have gone missing, instead of paying an O(N) read to pre-exclude them. Such a path is still dropped from the returned page (matching old behavior) — an acceptable approximation in exchange for O(page) reads.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New tests (all pure / no DB):
- `test_cached_total_pages_guards_per_page_zero` — `cached_total_pages(5, 0) == 5` (was `u32::MAX`).
- `test_filter_and_paginate_paths_per_page_zero_does_not_wedge` — `per_page=0` no longer produces a degenerate page.
- `test_list_cached_paths_reads_no_sidecars` — path recovery does 0 sidecar reads (counting storage mock).
- `test_load_cached_entries_reads_only_requested_paths` — a 1-path page reads exactly 1 sidecar out of a 3-object cache (the O(N) regression).
- Migrated the 4 `filter_and_paginate_cached` tests to the path-based `filter_and_paginate_paths`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo test --lib`, `cargo clippy -- -D warnings`, `cargo fmt --check` all pass)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (response shape unchanged; only pagination math + internal read strategy)

Closes #1571