### PR TITLE
fix(ci): drop suspended backend:-alpine tags from publish/release verify gates (#1572)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -886,11 +886,12 @@ jobs:
           }
 
           # Tags this workflow promises to publish on a tag push. Mirror the
-          # metadata-action `tags:` blocks above. Alpine variant gets the
-          # `-alpine` suffix from the metadata-action `flavor` setting.
+          # metadata-action `tags:` blocks above. The `-alpine` variant is
+          # currently suspended (its build/merge jobs are gated `if: false`),
+          # so it is intentionally absent here — re-add the
+          # `${BACKEND_IMAGE}:${VERSION}-alpine` entry when those jobs return.
           EXPECTED=(
             "${BACKEND_IMAGE}:${VERSION}"
-            "${BACKEND_IMAGE}:${VERSION}-alpine"
             "${OPENSCAP_IMAGE}:${VERSION}"
           )
 
@@ -917,7 +918,7 @@ jobs:
     name: Publish Summary
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [merge-backend, merge-openscap, merge-backend-alpine]
+    needs: [merge-backend, merge-openscap]
     if: always()
     steps:
       - name: Summary
@@ -927,10 +928,6 @@ jobs:
           echo "### Backend" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`docker.io/${{ env.DOCKERHUB_BACKEND }}:latest\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Backend (Alpine)" >> $GITHUB_STEP_SUMMARY
-          echo "- \`${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest-alpine\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`docker.io/${{ env.DOCKERHUB_BACKEND }}:latest-alpine\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### OpenSCAP" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,13 +205,15 @@ jobs:
           # ghcr.io uses the artifact-keeper org / hyphenated names.
           # docker.io uses the artifactkeeper namespace / shorter names.
           # Missing on EITHER registry blocks the release.
+          # The `-alpine` backend variant is currently suspended (its
+          # build/merge jobs in docker-publish.yml are gated `if: false`), so
+          # it is intentionally omitted — re-add the two `${VERSION}-alpine`
+          # entries when that variant is published again.
           IMAGES=(
             "ghcr.io|artifact-keeper/artifact-keeper-backend:${VERSION}"
-            "ghcr.io|artifact-keeper/artifact-keeper-backend:${VERSION}-alpine"
             "ghcr.io|artifact-keeper/artifact-keeper-openscap:${VERSION}"
             "ghcr.io|artifact-keeper/artifact-keeper-web:${VERSION}"
             "docker.io|artifactkeeper/backend:${VERSION}"
-            "docker.io|artifactkeeper/backend:${VERSION}-alpine"
             "docker.io|artifactkeeper/openscap:${VERSION}"
             "docker.io|artifactkeeper/web:${VERSION}"
           )


### PR DESCRIPTION
## Summary

The alpine backend build (`build-backend-alpine`) and multi-arch merge (`merge-backend-alpine`) jobs in `docker-publish.yml` are gated `if: false` — the `-alpine` image is no longer published. But two verify gates still required it:

- `docker-publish.yml` post-publish verify: `EXPECTED` array included `${BACKEND_IMAGE}:${VERSION}-alpine`.
- `release.yml` `verify-images-published`: `IMAGES` array included both the ghcr.io and docker.io `${VERSION}-alpine` entries.

Result: every tag-triggered run failed with `:<v>-alpine is missing` and the release was demoted to a **draft**.

**Fix:** remove the `-alpine` entries from both verify lists, drop the disabled `merge-backend-alpine` job from the `summary` job's `needs`, and remove the stale `latest-alpine` lines from the publish summary. Each edit carries a comment to re-add the entries when the alpine variant is unsuspended.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — workflow-YAML correctness fix; there is no unit harness for the publish/release gates. Verified by inspection (both `-alpine` jobs are `if: false`) and reproducible on any `v*` tag push, where the verify steps fail today and pass with this change.

## Test Checklist
- [x] No regressions in existing tests (YAML parses; no Rust changed)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)

## API Changes
- [x] N/A - no API changes

Closes #1572