### PR TITLE
fix(startup): run manifest_blob_refs backfill in the background (#1642)

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -496,32 +496,46 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     // backends. Failures are logged but do not block startup; on a fresh
     // database or after the first successful run the candidate query
     // returns zero rows and this is a near-instant no-op.
-    let blob_refs_backfill_stats =
-        artifact_keeper_backend::services::manifest_blob_refs_backfill::run_backfill(
-            &db_pool,
-            storage_registry.clone(),
-        )
-        .await;
-    // A failed candidate (body missing from storage, over-cap, DB write
-    // error) leaves that manifest ref-less, which keeps the blob-GC readiness
-    // gate closed — the feature stays OFF. This startup log is the earliest
-    // signal; the scheduler escalates per-tick thereafter (#1409).
-    if blob_refs_backfill_stats.candidates_failed > 0 {
-        tracing::error!(
-            candidates_scanned = blob_refs_backfill_stats.candidates_scanned,
-            edges_inserted = blob_refs_backfill_stats.edges_inserted,
-            candidates_failed = blob_refs_backfill_stats.candidates_failed,
-            "manifest_blob_refs backfill left {} live manifest(s) un-backfilled; \
-             blob GC will stay gated off until they are resolved (re-pushed, or \
-             the offending tag deleted)",
-            blob_refs_backfill_stats.candidates_failed
-        );
-    } else {
-        tracing::info!(
-            candidates_scanned = blob_refs_backfill_stats.candidates_scanned,
-            edges_inserted = blob_refs_backfill_stats.edges_inserted,
-            "manifest_blob_refs backfill complete"
-        );
+    // #1642: run the manifest_blob_refs backfill in the BACKGROUND rather than
+    // awaiting it here. On a large post-upgrade corpus this scans every image
+    // manifest serially (storage GET + parse + INSERT per manifest), which used
+    // to delay the HTTP listener bind below by minutes. Deferring it is safe:
+    // the backfill is additive-only (no deletion), and the blob-GC readiness
+    // gate (`any_live_manifest_missing_refs`) keeps blob GC OFF until every live
+    // manifest has its refs, so GC cannot act on a half-backfilled corpus. The
+    // scheduler escalates any failures per-tick thereafter (#1409).
+    {
+        let db_pool = db_pool.clone();
+        let storage_registry = storage_registry.clone();
+        tokio::spawn(async move {
+            let blob_refs_backfill_stats =
+                artifact_keeper_backend::services::manifest_blob_refs_backfill::run_backfill(
+                    &db_pool,
+                    storage_registry,
+                )
+                .await;
+            // A failed candidate (body missing from storage, over-cap, DB write
+            // error) leaves that manifest ref-less, which keeps the blob-GC
+            // readiness gate closed — the feature stays OFF. This log is the
+            // earliest signal; the scheduler escalates per-tick thereafter.
+            if blob_refs_backfill_stats.candidates_failed > 0 {
+                tracing::error!(
+                    candidates_scanned = blob_refs_backfill_stats.candidates_scanned,
+                    edges_inserted = blob_refs_backfill_stats.edges_inserted,
+                    candidates_failed = blob_refs_backfill_stats.candidates_failed,
+                    "manifest_blob_refs backfill left {} live manifest(s) un-backfilled; \
+                     blob GC will stay gated off until they are resolved (re-pushed, or \
+                     the offending tag deleted)",
+                    blob_refs_backfill_stats.candidates_failed
+                );
+            } else {
+                tracing::info!(
+                    candidates_scanned = blob_refs_backfill_stats.candidates_scanned,
+                    edges_inserted = blob_refs_backfill_stats.edges_inserted,
+                    "manifest_blob_refs backfill complete"
+                );
+            }
+        });
     }
 
     // Initialize security scanner service


### PR DESCRIPTION
## Summary

On a large post-upgrade corpus the `manifest_blob_refs` backfill scans **every** image manifest serially (storage GET + JSON parse + DB INSERT per manifest), and it was `.await`ed at `main.rs:499` **before** the HTTP listener binds (`main.rs` ~930). First boot after the migration-120 upgrade could therefore delay readiness by minutes.

This moves the backfill into a `tokio::spawn` so the HTTP listener binds immediately. Deferring it is safe by construction:

- The backfill is **additive-only** (no deletion).
- The blob-GC readiness gate (`any_live_manifest_missing_refs`) keeps blob GC **OFF** until every live manifest has its refs — so GC cannot act on a half-backfilled corpus.
- Failures continue to be logged and escalated per-tick by the scheduler (#1409).

Part of the Core Invariants epic (#1607).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a **startup-sequencing** change in `main.rs` (binary entrypoint, not unit-testable). The backfill's *correctness* is unchanged and remains covered by the existing `manifest_blob_refs_backfill` tests; the *safety* of deferring is guaranteed by the pre-existing blob-GC readiness gate (unchanged). Verifiable by observing sub-second time-to-first-HTTP-response on a corpus with pending backfill.

## Test Checklist
- [x] No regressions in existing tests (`cargo check`, `cargo clippy -- -D warnings`, `cargo fmt --check` all pass)
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)

## API Changes
- [x] N/A - no API changes

Closes #1642