### PR TITLE
fix(security): SSRF-validate Artifactory downloadUri + fire block_unscanned on failed/pending scans (#1423, #1649)

### DIFF
--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -268,6 +268,15 @@ pub struct PermissionsResponse {
     pub permissions: Vec<PermissionTarget>,
 }
 
+/// Decide whether an Artifactory-supplied `downloadUri` is safe to follow
+/// (#1423). The storage-API `downloadUri` is attacker-influenceable, so it must
+/// pass the same outbound SSRF policy (`validate_outbound_url`) as any other
+/// upstream URL before we issue a request to it. Factored out as a free
+/// function so the guard is unit-testable without a live HTTP client.
+fn download_uri_is_safe_to_follow(download_uri: &str) -> bool {
+    crate::api::validation::validate_outbound_url(download_uri, "Artifactory downloadUri").is_ok()
+}
+
 impl ArtifactoryClient {
     /// Create a new Artifactory client with the given configuration
     pub fn new(config: ArtifactoryClientConfig) -> Result<Self, ArtifactoryError> {
@@ -591,6 +600,25 @@ impl ArtifactoryClient {
             return Ok(response);
         }
 
+        // #1423: `download_uri` comes from the upstream Artifactory storage API
+        // response, which is attacker-influenceable (a hostile or compromised
+        // source instance can point it anywhere). It must pass the outbound
+        // SSRF policy before we issue a request to it. The `download_uri ==
+        // raw_url` check above is a migration-specific constraint, NOT an SSRF
+        // guard: any differing path or port (e.g. the cloud-metadata endpoint
+        // `http://169.254.169.254/...`) sails past it. The shared client's
+        // redirect policy only screens redirect *hops*, not this initial
+        // connection. On rejection, fall back to the original 404 response.
+        if !download_uri_is_safe_to_follow(&download_uri) {
+            tracing::warn!(
+                repo = %repo_key,
+                path = %path,
+                download_uri = %download_uri,
+                "Rejecting Artifactory downloadUri: failed outbound SSRF validation"
+            );
+            return Ok(response);
+        }
+
         tracing::debug!(
             repo = %repo_key,
             path = %path,
@@ -759,6 +787,37 @@ impl crate::services::source_registry::SourceRegistry for ArtifactoryClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_download_uri_ssrf_guard_rejects_dangerous_targets() {
+        // #1423 regression: a malicious/compromised upstream Artifactory can put
+        // an internal or metadata address in the storage-API `downloadUri`. The
+        // guard must refuse to follow it. These targets are hard-blocked
+        // regardless of the private-IP allowlist toggle, so the assertions are
+        // deterministic and require no network/DNS.
+        assert!(
+            !download_uri_is_safe_to_follow("http://169.254.169.254/latest/meta-data/"),
+            "cloud-metadata link-local IP must be rejected"
+        );
+        assert!(
+            !download_uri_is_safe_to_follow("http://metadata.google.internal/computeMetadata/v1/"),
+            "cloud-metadata hostname must be rejected"
+        );
+        assert!(
+            !download_uri_is_safe_to_follow("http://127.0.0.1:8081/artifactory/x/a.jar"),
+            "loopback must be rejected"
+        );
+        assert!(
+            !download_uri_is_safe_to_follow("file:///etc/passwd"),
+            "non-http(s) scheme must be rejected"
+        );
+        // A normal public upstream URL is still followed (no DNS lookup happens
+        // for a non-literal host, so this is offline-deterministic too).
+        assert!(
+            download_uri_is_safe_to_follow("https://repo.example.com/artifactory/libs/a-1.0.jar"),
+            "a public upstream downloadUri must still be allowed"
+        );
+    }
 
     #[test]
     fn test_config_default() {

--- a/backend/src/services/policy_service.rs
+++ b/backend/src/services/policy_service.rs
@@ -5,6 +5,20 @@ use uuid::Uuid;
 
 use crate::error::{AppError, Result};
 use crate::models::security::{PolicyResult, ScanPolicy, Severity};
+use crate::services::scan_state::ScanState;
+
+/// Whether the `block_unscanned` gate should fire for an artifact in the given
+/// aggregate scan state (#1649).
+///
+/// Fires when the policy enables it AND the artifact is "genuinely unscanned"
+/// per [`ScanState::is_unscanned`] — i.e. it has no completed scan and the
+/// reason is not "scanning does not apply". This deliberately fires on
+/// `Failed` / `InProgress` / `NeverScanned`, closing the gap where a `failed`
+/// or `pending` scan row used to satisfy the old `latest_scan.is_none()` check
+/// and let the artifact bypass the gate. Pure / unit-testable.
+fn block_unscanned_violated(block_unscanned: bool, scan_state: ScanState) -> bool {
+    block_unscanned && scan_state.is_unscanned()
+}
 
 pub struct PolicyService {
     db: PgPool,
@@ -78,12 +92,29 @@ impl PolicyService {
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
+        // #1649: classify the artifact's overall scan state from ALL its
+        // scan_results rows (the same precedence the promotion gate uses), not
+        // just whether the latest row exists. A `failed` / `pending` / `running`
+        // scan still means the artifact was never SUCCESSFULLY scanned, so the
+        // `block_unscanned` gate must treat it as unscanned. The old
+        // `latest_scan.is_none()` check let those slip through whenever any scan
+        // row existed, letting a crashed-scanner artifact bypass the gate when
+        // `block_on_fail` was off.
+        let scan_state_rows: Vec<crate::services::scan_state::ScanStateRow> =
+            sqlx::query_as(crate::services::scan_state::SCAN_STATE_SQL)
+                .bind(artifact_id)
+                .fetch_all(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        let scan_state = crate::services::scan_state::classify_scan_state(&scan_state_rows);
+
         for policy in &policies {
             // Check: block_unscanned
-            if policy.block_unscanned && latest_scan.is_none() {
+            if block_unscanned_violated(policy.block_unscanned, scan_state) {
                 violations.push(format!(
-                    "Policy '{}': artifact has not been scanned",
-                    policy.name
+                    "Policy '{}': artifact has not been scanned ({})",
+                    policy.name,
+                    scan_state.reason_token()
                 ));
                 continue;
             }
@@ -290,6 +321,56 @@ impl PolicyService {
 mod tests {
     use super::*;
     use crate::models::security::{PolicyResult, ScanPolicy, Severity};
+
+    // -----------------------------------------------------------------------
+    // block_unscanned gate (#1649)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_block_unscanned_fires_on_failed_or_in_progress_scan() {
+        // #1649 regression: the old `latest_scan.is_none()` check treated ANY
+        // scan row (including a crashed `failed` or still-`pending` one) as
+        // "scanned", so block_unscanned silently passed an un-vetted artifact
+        // whenever block_on_fail happened to be off. The aggregate scan-state
+        // classification must instead fire the gate on every non-completed,
+        // applicable state.
+        assert!(
+            block_unscanned_violated(true, ScanState::Failed),
+            "a crashed scan must trip block_unscanned"
+        );
+        assert!(
+            block_unscanned_violated(true, ScanState::InProgress),
+            "a pending/running scan must trip block_unscanned"
+        );
+        assert!(
+            block_unscanned_violated(true, ScanState::NeverScanned),
+            "no scan at all must trip block_unscanned"
+        );
+    }
+
+    #[test]
+    fn test_block_unscanned_passes_completed_and_not_applicable() {
+        // A completed scan, or a format to which scanning does not apply, must
+        // never be blocked by this gate.
+        assert!(!block_unscanned_violated(true, ScanState::Completed));
+        assert!(!block_unscanned_violated(true, ScanState::NotApplicable));
+    }
+
+    #[test]
+    fn test_block_unscanned_disabled_never_fires() {
+        for state in [
+            ScanState::Failed,
+            ScanState::InProgress,
+            ScanState::NeverScanned,
+            ScanState::Completed,
+            ScanState::NotApplicable,
+        ] {
+            assert!(
+                !block_unscanned_violated(false, state),
+                "gate disabled -> never a violation regardless of scan state"
+            );
+        }
+    }
 
     // -----------------------------------------------------------------------
     // PolicyResult construction


### PR DESCRIPTION
## Summary

Two independent security/correctness gates that were silently not firing.

### #1423 — SSRF: Artifactory `downloadUri` followed without validation
`download_response_with_fallback` (`artifactory_client.rs`) fetches the `downloadUri` returned by the upstream Artifactory storage API — which is attacker-influenceable (a hostile/compromised source instance can point it anywhere). The only pre-flight guard was `download_uri == raw_url` (string equality), which any differing path or port trivially passes while still targeting a blocked address like the cloud-metadata endpoint `http://169.254.169.254/...`. The shared client's redirect policy only screens redirect *hops*, not this initial connection.

**Fix:** validate `downloadUri` with `validate_outbound_url` before following it; on rejection, log and fall back to the original 404 response (no request issued).

### #1649 — `block_unscanned` bypassed by failed/pending scans
`PolicyService::evaluate_artifact` gated on `latest_scan.is_none()`, so the gate only fired when **no** scan row existed. A `failed` (crashed scanner), `pending`, or `running` row made `latest_scan.is_some()` → the gate fell through, and if `block_on_fail` was off the un-vetted artifact was served.

**Fix:** align with the promotion gate — classify the artifact's aggregate scan state via `classify_scan_state(...)` and fire `block_unscanned` whenever it `is_unscanned()` (`Failed` / `InProgress` / `NeverScanned`), never on `Completed` / `NotApplicable`.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Both fixes extract the decision into a **pure helper** with deterministic unit tests (no DB/network):
- `test_download_uri_ssrf_guard_rejects_dangerous_targets` — metadata IP, metadata hostname, loopback, and `file://` rejected; a public upstream URL still allowed. Targets are hard-blocked regardless of the private-IP toggle, so the test can't flake.
- `test_block_unscanned_fires_on_failed_or_in_progress_scan` (+ 2 more) — `block_unscanned_violated` fires on `Failed`/`InProgress`/`NeverScanned`, passes `Completed`/`NotApplicable`, and never fires when disabled.

## Test Checklist
- [x] Unit tests added/updated
- [x] Manually tested locally (`cargo test --lib`, `cargo clippy -- -D warnings`, `cargo fmt --check` all green)
- [x] No regressions in existing tests
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)

## API Changes
- [x] N/A - no API changes (the `block_unscanned` violation message gains a parenthetical scan-state reason token; response shape unchanged)

Closes #1423
Closes #1649