### PR TITLE
fix(ci): serialize cleanup_stuck_scans DB tests under nextest to restore the coverage gate (#1753)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,24 @@
+# cargo-nextest configuration.
+#
+# The coverage CI job runs the suite via `cargo llvm-cov nextest`, which
+# executes each test in its OWN PROCESS. That breaks the in-process
+# `CLEANUP_TEST_LOCK` (`backend/src/services/scan_result_service.rs`) that the
+# `cleanup_stuck_scans_*` DB tests use to serialize: under nextest they run
+# concurrently across processes and contend on the GLOBAL
+# `pg_try_advisory_xact_lock(STUCK_SCAN_LOCK_ID)` and the global stuck-scan reap
+# query. One tick then observes the lock held by a sibling test and reaps 0,
+# failing `assert!(reaped >= 1)` and aborting the whole instrumented run so no
+# `lcov.info` is produced (#1753). The plain `cargo test --workspace --lib`
+# unit-test job runs them in a single process, so the in-process mutex still
+# works there — which is why that gate stays green while coverage fails.
+#
+# Pin these tests to a single-threaded test group so nextest never runs two of
+# them at once, restoring the cross-process serialization the in-process mutex
+# cannot provide. Add new tests that take STUCK_SCAN_LOCK_ID to the same group.
+
+[test-groups]
+stuck-scan-cleanup = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'test(cleanup_stuck_scans)'
+test-group = 'stuck-scan-cleanup'


### PR DESCRIPTION
## Summary

The **📊 Code Coverage** CI job has been failing on `main` (and on every Rust PR) — exit 100, no `lcov.info` produced, so the new-code coverage gate is unenforceable.

**Root cause (diagnosed from the failed run logs, not a guess):**
- The coverage job runs `cargo llvm-cov nextest`, and **nextest executes each test in its own process**.
- The four `cleanup_stuck_scans_*` DB tests (`scan_result_service.rs`) share a **global** `pg_try_advisory_xact_lock(STUCK_SCAN_LOCK_ID)` and a global reap query. They serialize via `CLEANUP_TEST_LOCK` — an **in-process** `tokio::Mutex`, which does nothing across separate nextest processes.
- So `cleanup_stuck_scans_skips_when_advisory_lock_held` holds the advisory lock while, concurrently, `cleanup_stuck_scans_writes_audit_row_in_same_transaction` calls the janitor → `pg_try_advisory_xact_lock` fails → returns `0 reaped` → `assert!(reaped >= 1)` panics → **nextest exits 100 → no `lcov.info`**.
- The `cargo test --workspace --lib` unit-test job runs in a single process, so the in-process mutex works there — which is why **that** required gate stayed green while coverage failed. This regressed when coverage moved to nextest (#1673).

Evidence from the failed main run (`27157410246`):
```
1 failed: services::scan_result_service::tests::db::cleanup_stuck_scans_writes_audit_row_in_same_transaction
panicked at scan_result_service.rs:3528 (assert!(reaped >= 1))
Summary: 9041 passed, 1 failed → error: test run failed (exit status: 100)
```

**Fix:** add `.config/nextest.toml` with a single-threaded `stuck-scan-cleanup` test group matching `test(cleanup_stuck_scans)`, so nextest never runs two of these tests at once — restoring the serialization the in-process mutex provided under `cargo test`.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this fixes **test-harness scheduling**, not product code. There is no product behaviour to add a test for; the "test" is the existing `cleanup_stuck_scans_*` suite, which now passes deterministically under nextest. Verification: the next coverage run on a Rust-touching change must go green (this PR itself touches no `.rs`, so the coverage job correctly skips it).

## Test Checklist
- [x] No regressions (config-only; `.config/nextest.toml` validated; affects only nextest scheduling in the coverage job — the `cargo test` unit job is unaffected)
- [ ] Unit/Integration/E2E tests added (N/A)

## API Changes
- [x] N/A - no API changes

Closes #1753