### PR TITLE
fix(ci): serialize storage_gc DB tests under nextest to fully restore the coverage gate (#1753)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,24 +1,34 @@
 # cargo-nextest configuration.
 #
 # The coverage CI job runs the suite via `cargo llvm-cov nextest`, which
-# executes each test in its OWN PROCESS. That breaks the in-process
-# `CLEANUP_TEST_LOCK` (`backend/src/services/scan_result_service.rs`) that the
-# `cleanup_stuck_scans_*` DB tests use to serialize: under nextest they run
-# concurrently across processes and contend on the GLOBAL
-# `pg_try_advisory_xact_lock(STUCK_SCAN_LOCK_ID)` and the global stuck-scan reap
-# query. One tick then observes the lock held by a sibling test and reaps 0,
-# failing `assert!(reaped >= 1)` and aborting the whole instrumented run so no
-# `lcov.info` is produced (#1753). The plain `cargo test --workspace --lib`
-# unit-test job runs them in a single process, so the in-process mutex still
-# works there — which is why that gate stays green while coverage fails.
+# executes each test in its OWN PROCESS. Several DB integration tests serialize
+# themselves with an *in-process* `tokio::Mutex` because they mutate GLOBAL,
+# cluster-wide state and assert on exact results:
 #
-# Pin these tests to a single-threaded test group so nextest never runs two of
-# them at once, restoring the cross-process serialization the in-process mutex
-# cannot provide. Add new tests that take STUCK_SCAN_LOCK_ID to the same group.
+#   * `scan_result_service.rs` `CLEANUP_TEST_LOCK` — the `cleanup_stuck_scans_*`
+#     tests share the global stuck-scan reap query + `pg_try_advisory_xact_lock(
+#     STUCK_SCAN_LOCK_ID)`. Concurrent ticks see the lock held by a sibling and
+#     reap 0, failing `assert!(reaped >= 1)`.
+#   * `storage_gc_service.rs` `STORAGE_GC_TEST_LOCK` (via `storage_gc_test_guard`)
+#     — the `test_run_gc_*` tests run a cluster-wide GC reap and assert on the
+#     exact set of keys collected. A concurrent GC test reaps another's fixtures
+#     first, failing e.g. "GC result should include the upload temp and part keys".
+#
+# Under nextest's process-per-test model those in-process mutexes do NOT
+# serialize across the suite, so the tests interfere nondeterministically, fail,
+# and abort the instrumented run before `lcov.info` is written — leaving the
+# Code Coverage gate red (#1753). The plain `cargo test --workspace --lib`
+# unit-test job runs every test in a single process, so the in-process mutexes
+# still work there — which is why that gate stays green while coverage fails.
+#
+# Pin every test that mutates this shared DB state to a single-threaded test
+# group so nextest never runs two of them at once, restoring the serialization
+# the in-process mutexes provide under `cargo test`. Add new tests that take
+# STUCK_SCAN_LOCK_ID or `storage_gc_test_guard()` to the matching filter below.
 
 [test-groups]
-stuck-scan-cleanup = { max-threads = 1 }
+db-serial = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'test(cleanup_stuck_scans)'
-test-group = 'stuck-scan-cleanup'
+filter = 'test(cleanup_stuck_scans) | test(storage_gc_service::tests)'
+test-group = 'db-serial'


### PR DESCRIPTION
## Summary

Follow-up to #1754. That PR serialized the `cleanup_stuck_scans_*` tests, but the **Code Coverage** gate is still red — a sibling DB test fails under nextest for the *same* root cause:

```
FAIL services::storage_gc_service::tests::test_run_gc_removes_abandoned_oci_upload_session_storage
panicked: "GC result should include the upload temp and part keys"  → nextest exit 100, no lcov.info
```

The `test_run_gc_*` tests run a **cluster-wide GC reap** and assert on the exact set of collected keys. They serialize via the in-process `STORAGE_GC_TEST_LOCK` / `storage_gc_test_guard()` (`storage_gc_service.rs:1670`), which — like `CLEANUP_TEST_LOCK` — does nothing across nextest's per-test **processes**. So concurrent GC tests reap each other's fixtures and the exact-result assertions fail nondeterministically.

**Fix:** generalize the nextest test-group to a single `db-serial` group covering **both** the `cleanup_stuck_scans_*` and `storage_gc_service::tests` suites, so no two cluster-wide-state DB tests ever run concurrently under nextest.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — fixes **test-harness scheduling**, not product code. **Verified locally:** the 91 affected tests pass under `cargo nextest run --lib --test-threads 4` (CI's mode) with this config — serialized — against a real Postgres; they flaked before. (I installed nextest + ran a local Postgres to confirm, since this can only be reproduced under nextest + DB.)

## Test Checklist
- [x] No regressions (config-only; affects only nextest scheduling in the coverage job; `cargo test` unit job unaffected; locally verified green under nextest)

## API Changes
- [x] N/A

Closes #1753
