### PR TITLE
fix(plugins): require admin for plugin install and lifecycle routes

### DIFF
--- a/backend/src/api/handlers/plugins.rs
+++ b/backend/src/api/handlers/plugins.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     extract::{Extension, Multipart, Path, Query, State},
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use serde::{Deserialize, Serialize};
@@ -23,18 +23,32 @@ fn wasm_service(state: &SharedState) -> Result<&WasmPluginService> {
         .ok_or_else(|| AppError::Internal("WASM plugin service not available".to_string()))
 }
 
-/// Create plugin routes
+/// Create plugin read-only routes (list, get, config, events).
+///
+/// These are mounted under the standard auth middleware so any authenticated
+/// user may inspect installed plugins.
 pub fn router() -> Router<SharedState> {
     Router::new()
-        .route("/", get(list_plugins).post(install_plugin))
-        .route("/:id", get(get_plugin).delete(uninstall_plugin))
-        .route("/:id/enable", post(enable_plugin))
-        .route("/:id/disable", post(disable_plugin))
+        .route("/", get(list_plugins))
+        .route("/:id", get(get_plugin))
         .route(
             "/:id/config",
             get(get_plugin_config).post(update_plugin_config),
         )
         .route("/:id/events", get(get_plugin_events))
+}
+
+/// Create plugin admin routes (install + lifecycle).
+///
+/// Installing a plugin loads arbitrary WASM code and enabling/disabling or
+/// uninstalling a plugin changes the running plugin set, so these routes are
+/// mounted under the admin middleware (requires `is_admin`).
+pub fn admin_router() -> Router<SharedState> {
+    Router::new()
+        .route("/", post(install_plugin))
+        .route("/:id", delete(uninstall_plugin))
+        .route("/:id/enable", post(enable_plugin))
+        .route("/:id/disable", post(disable_plugin))
         // WASM plugin endpoints
         .route("/install/git", post(install_from_git))
         .route("/install/zip", post(install_from_zip))

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -536,12 +536,20 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 admin_middleware,
             )),
         )
-        // Plugin routes with auth middleware
+        // Plugin read-only routes with auth middleware
         .nest(
             "/plugins",
             handlers::plugins::router().layer(middleware::from_fn_with_state(
                 auth_service.clone(),
                 auth_middleware,
+            )),
+        )
+        // Plugin install + lifecycle routes require admin (loads arbitrary WASM)
+        .nest(
+            "/plugins",
+            handlers::plugins::admin_router().layer(middleware::from_fn_with_state(
+                auth_service.clone(),
+                admin_middleware,
             )),
         )
         // Format handler read-only routes (list, get) with optional auth
@@ -738,6 +746,29 @@ mod tests {
             incus_count >= 2,
             "expected handlers::incus::router() to be referenced at least \
              twice (once for /incus, once for /lxc); found {incus_count}"
+        );
+    }
+
+    #[test]
+    fn plugin_install_and_lifecycle_require_admin() {
+        // Installing a plugin loads arbitrary WASM, and enabling/disabling or
+        // uninstalling one changes the running plugin set. These routes must be
+        // mounted via `plugins::admin_router` under `admin_middleware`, not the
+        // plain `auth_middleware` (which any authenticated user passes). A
+        // regression here re-opens the supply-chain path where a non-admin can
+        // drive the WASM plugin installer.
+        let admin_nest = ROUTES_RS_SRC
+            .split("handlers::plugins::admin_router()")
+            .nth(1)
+            .expect("plugins::admin_router() must be nested under /plugins");
+        // The nest immediately following admin_router() must wire admin_middleware.
+        let next_middleware = admin_nest
+            .split("from_fn_with_state")
+            .nth(1)
+            .expect("admin_router() nest must attach a middleware layer");
+        assert!(
+            next_middleware.contains("admin_middleware"),
+            "plugin install + lifecycle routes must be gated by admin_middleware"
         );
     }
 }


### PR DESCRIPTION
## Summary

Plugin installation and lifecycle endpoints were mounted under the standard
authentication middleware, which any authenticated user passes. That meant a
non-admin user could drive the WASM plugin installer (`/plugins/install/git`,
`/plugins/install/zip`, `/plugins/install/local`, `POST /plugins`) and the
plugin lifecycle (`enable` / `disable` / `uninstall` / `reload`). Because
installing a plugin loads arbitrary WASM code into the server, this is a
privileged operation and should be restricted to administrators — consistent
with how the mutating format-handler routes already require admin.

This PR splits the plugin router into two:

- `plugins::router()` — read-only routes (list, get, config read/update,
  events) remain under `auth_middleware`, so any authenticated user can still
  inspect installed plugins.
- `plugins::admin_router()` — install + lifecycle routes are mounted under
  `admin_middleware`, which returns `403 Forbidden` for non-admin callers.

This mirrors the existing `format_router()` / `format_admin_router()` split in
the same handler module, so no new authorization pattern is introduced.

Behavior after the change (verified against a freshly built/deployed instance,
seeded company data):

- Non-admin `POST /plugins/install/git|zip|local`, `POST /plugins`,
  `POST /plugins/{id}/enable|disable|reload`, `DELETE /plugins/{id}` -> `403`
- Non-admin `GET /plugins` -> `200` (read access unchanged)
- Admin `POST /plugins/install/git` -> reaches install logic (clone/validation,
  not a `403`); admin `DELETE /plugins/{id}` -> `404` for a missing id (handler
  reached)

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added `plugin_install_and_lifecycle_require_admin` in `routes.rs`, following the
existing source-level meta-test convention in that file. It asserts the
`plugins::admin_router()` nest is wired through `admin_middleware`, and fails if
a future refactor drops the admin gate (re-opening the non-admin install path).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (routes unchanged; only the authorization layer differs)
