### PR TITLE
fix(promotion): enforce admin authorization on direct artifact promotion

### DIFF
--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -417,6 +417,25 @@ async fn enforce_release_target_link(
     Ok(())
 }
 
+/// Authorize a direct promotion request.
+///
+/// Promoting an artifact into a release repository is an admin-only action,
+/// matching the authorization on the approval workflow's
+/// `POST /api/v1/approval/{id}/approve` endpoint. Without this gate the
+/// approval/governance workflow could be bypassed by promoting directly via
+/// the `/promote` routes.
+///
+/// Split into a pure helper so the admin-gate decision is shared by the single
+/// and bulk promote handlers and can be unit tested without a DB or storage.
+fn ensure_promotion_authorized(is_admin: bool) -> Result<()> {
+    if !is_admin {
+        return Err(AppError::Authorization(
+            "Only admins can promote artifacts".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 fn failed_response(source: String, target: String, message: String) -> PromotionResponse {
     PromotionResponse {
         promoted: false,
@@ -452,6 +471,8 @@ pub async fn promote_artifact(
     Path((repo_key, artifact_id)): Path<(String, Uuid)>,
     Json(req): Json<PromoteArtifactRequest>,
 ) -> Result<Json<PromotionResponse>> {
+    ensure_promotion_authorized(auth.is_admin)?;
+
     let repo_service = RepositoryService::new(state.db.clone());
 
     let source_repo = repo_service.get_by_key(&repo_key).await?;
@@ -703,6 +724,8 @@ pub async fn promote_artifacts_bulk(
     Path(repo_key): Path<String>,
     Json(req): Json<BulkPromoteRequest>,
 ) -> Result<Json<BulkPromotionResponse>> {
+    ensure_promotion_authorized(auth.is_admin)?;
+
     let repo_service = RepositoryService::new(state.db.clone());
 
     let source_repo = repo_service.get_by_key(&repo_key).await?;
@@ -1327,6 +1350,29 @@ pub struct PromotionApiDoc;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // ensure_promotion_authorized (admin-only gate on /promote routes)
+    //
+    // Regression for the direct-promotion authorization bug: a non-admin
+    // caller could promote artifacts straight into a release repository via
+    // the `/promote` routes, bypassing the admin-gated approval workflow.
+    // The single and bulk promote handlers now both call this helper.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_ensure_promotion_authorized_admin_ok() {
+        assert!(ensure_promotion_authorized(true).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_promotion_authorized_non_admin_denied() {
+        let err = ensure_promotion_authorized(false).unwrap_err();
+        // Non-admin promotion is an authorization failure (HTTP 403), matching
+        // the approval workflow's approve/reject endpoints.
+        assert!(matches!(err, AppError::Authorization(_)));
+        assert!(err.to_string().contains("admin"));
+    }
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (moved into test module)


### PR DESCRIPTION
## Summary

The direct artifact promotion endpoints did not enforce any role check, so any
authenticated user could promote artifacts from a staging repository into a
release (local) repository:

- `POST /api/v1/promotion/repositories/{key}/artifacts/{artifact_id}/promote`
- `POST /api/v1/promotion/repositories/{key}/promote` (bulk)

The promotion approval workflow already restricts the equivalent privileged
action — `POST /api/v1/approval/{id}/approve` — to admins, but the direct
`/promote` routes bypassed that governance entirely, allowing a non-admin to
land artifacts in a release repo without an approval.

This change adds the same admin authorization to both `/promote` handlers,
matching the approval workflow's gate. The check is factored into a small
shared `ensure_promotion_authorized` helper used by the single and bulk
handlers, returning `AppError::Authorization` (HTTP 403) for non-admin callers.
Existing authentication (the `/promotion` auth middleware) is unchanged, so
anonymous callers continue to receive 401.

Behavior after this change:
- non-admin (single or bulk) promote -> `403 Forbidden`
- admin promote -> `200 { "promoted": true }` (unchanged)
- anonymous promote -> `401 Unauthorized` (unchanged)

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added `test_ensure_promotion_authorized_non_admin_denied` and
`test_ensure_promotion_authorized_admin_ok`, which pin the admin-only decision
shared by both promote handlers. The non-admin test fails against the previous
behavior (no gate) and passes with this change.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated patched instance: non-admin users (single
and bulk) receive 403, an admin promotion still returns 200 `promoted:true`,
and anonymous requests still return 401. `cargo fmt --check`, `cargo clippy
--workspace --all-targets -- -D warnings`, and `cargo test --workspace --lib`
all pass.

## API Changes
- [x] N/A - no API changes

No new endpoints, request/response types, or migrations. The authorization
response codes for the existing `/promote` routes are tightened (403 for
non-admins).
