### PR TITLE
fix(signing): require admin to manage repository signing keys

### DIFF
--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -122,6 +122,7 @@ async fn create_key(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateKeyPayload>,
 ) -> Result<Json<SigningKeyPublic>> {
+    auth.require_admin()?;
     let svc = signing_service(&state);
     let key = svc
         .create_key(CreateKeyRequest {
@@ -181,9 +182,10 @@ async fn get_key(
 )]
 async fn delete_key(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
+    auth.require_admin()?;
     let svc = signing_service(&state);
     svc.delete_key(key_id).await?;
     Ok(Json(serde_json::json!({"deleted": true})))
@@ -336,10 +338,11 @@ async fn get_repo_signing_config(
 )]
 async fn update_repo_signing_config(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(repo_id): Path<Uuid>,
     Json(payload): Json<UpdateSigningConfigPayload>,
 ) -> Result<Json<RepositorySigningConfig>> {
+    auth.require_admin()?;
     let svc = signing_service(&state);
 
     // Get existing config to merge with updates
@@ -424,7 +427,64 @@ pub struct SigningApiDoc;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::api::middleware::auth::AuthExtension;
     use serde_json;
+
+    // -----------------------------------------------------------------------
+    // Admin gate on signing-key and repo-config mutation
+    // -----------------------------------------------------------------------
+
+    fn non_admin_jwt() -> AuthExtension {
+        // A non-admin JWT session: `is_api_token = false`, so scope checks do
+        // not apply and the admin gate is the only thing standing between the
+        // caller and a key mint / config write.
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "victor".to_string(),
+            email: "victor@example.com".to_string(),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: None,
+        }
+    }
+
+    fn admin_jwt() -> AuthExtension {
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "admin".to_string(),
+            email: "admin@example.com".to_string(),
+            is_admin: true,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: None,
+        }
+    }
+
+    #[test]
+    fn test_non_admin_blocked_from_managing_signing_keys() {
+        // Regression: minting/deleting a repository signing key or writing the
+        // repo signing config subverts the artifact-signing trust model, so it
+        // must be admin-only. create_key, delete_key, and
+        // update_repo_signing_config all call `auth.require_admin()?` before
+        // touching the service; pin that decision at the predicate level
+        // (no DB needed). A non-admin JWT must be rejected with 403.
+        let ext = non_admin_jwt();
+        match ext.require_admin() {
+            Err(AppError::Authorization(_)) => {}
+            other => panic!("expected 403 Authorization for non-admin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_admin_allowed_to_manage_signing_keys() {
+        // Legitimate use: an admin passes the same gate the three mutation
+        // handlers enforce, so signing-key management still works.
+        let ext = admin_jwt();
+        assert!(ext.require_admin().is_ok());
+    }
 
     // -----------------------------------------------------------------------
     // ListKeysQuery deserialization

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -122,7 +122,7 @@ async fn create_key(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateKeyPayload>,
 ) -> Result<Json<SigningKeyPublic>> {
-    auth.require_admin()?;
+    require_signing_admin(&auth)?;
     let svc = signing_service(&state);
     let key = svc
         .create_key(CreateKeyRequest {
@@ -185,7 +185,7 @@ async fn delete_key(
     Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
-    auth.require_admin()?;
+    require_signing_admin(&auth)?;
     let svc = signing_service(&state);
     svc.delete_key(key_id).await?;
     Ok(Json(serde_json::json!({"deleted": true})))
@@ -292,16 +292,7 @@ async fn get_repo_signing_config(
     let config = svc.get_signing_config(repo_id).await?;
 
     let (signing_key_id, sign_metadata, sign_packages, require_signatures) =
-        if let Some(ref c) = config {
-            (
-                c.signing_key_id,
-                c.sign_metadata,
-                c.sign_packages,
-                c.require_signatures,
-            )
-        } else {
-            (None, false, false, false)
-        };
+        signing_config_fields(config.as_ref());
 
     let key = if let Some(kid) = signing_key_id {
         Some(svc.get_key(kid).await?)
@@ -342,21 +333,12 @@ async fn update_repo_signing_config(
     Path(repo_id): Path<Uuid>,
     Json(payload): Json<UpdateSigningConfigPayload>,
 ) -> Result<Json<RepositorySigningConfig>> {
-    auth.require_admin()?;
+    require_signing_admin(&auth)?;
     let svc = signing_service(&state);
 
     // Get existing config to merge with updates
     let existing = svc.get_signing_config(repo_id).await?;
-    let (cur_key, cur_meta, cur_pkg, cur_req) = if let Some(ref c) = existing {
-        (
-            c.signing_key_id,
-            c.sign_metadata,
-            c.sign_packages,
-            c.require_signatures,
-        )
-    } else {
-        (None, false, false, false)
-    };
+    let (cur_key, cur_meta, cur_pkg, cur_req) = signing_config_fields(existing.as_ref());
 
     let config = svc
         .update_signing_config(
@@ -398,6 +380,32 @@ async fn get_repo_public_key(
 
 fn signing_service(state: &SharedState) -> SigningService {
     SigningService::new(state.db.clone(), &state.config.jwt_secret)
+}
+
+/// Admin gate shared by the signing-key/repo-config mutation handlers.
+///
+/// Minting, deleting, revoking, rotating a repository signing key, or writing
+/// the repo signing config all subvert the artifact-signing trust model, so
+/// they are admin-only. Centralizing the check keeps the policy in one place.
+fn require_signing_admin(auth: &AuthExtension) -> Result<()> {
+    auth.require_admin()
+}
+
+/// Project a repository signing config into its scalar fields, defaulting to
+/// "unconfigured" (no key, nothing signed) when absent. Used by both the read
+/// and the update handler so the defaulting rule lives in one place.
+fn signing_config_fields(
+    config: Option<&RepositorySigningConfig>,
+) -> (Option<Uuid>, bool, bool, bool) {
+    match config {
+        Some(c) => (
+            c.signing_key_id,
+            c.sign_metadata,
+            c.sign_packages,
+            c.require_signatures,
+        ),
+        None => (None, false, false, false),
+    }
 }
 
 #[derive(OpenApi)]
@@ -472,7 +480,7 @@ mod tests {
         // touching the service; pin that decision at the predicate level
         // (no DB needed). A non-admin JWT must be rejected with 403.
         let ext = non_admin_jwt();
-        match ext.require_admin() {
+        match require_signing_admin(&ext) {
             Err(AppError::Authorization(_)) => {}
             other => panic!("expected 403 Authorization for non-admin, got {:?}", other),
         }
@@ -483,7 +491,19 @@ mod tests {
         // Legitimate use: an admin passes the same gate the three mutation
         // handlers enforce, so signing-key management still works.
         let ext = admin_jwt();
-        assert!(ext.require_admin().is_ok());
+        assert!(require_signing_admin(&ext).is_ok());
+    }
+
+    #[test]
+    fn test_signing_config_fields_defaults_when_absent() {
+        // The shared projection helper must treat a missing config as fully
+        // unconfigured (no key, nothing signed) so both the read and update
+        // handlers agree on the default.
+        let (key, meta, pkg, req) = signing_config_fields(None);
+        assert!(key.is_none());
+        assert!(!meta);
+        assert!(!pkg);
+        assert!(!req);
     }
 
     // -----------------------------------------------------------------------
@@ -702,16 +722,7 @@ mod tests {
     fn test_config_extraction_from_none() {
         let config: Option<RepositorySigningConfig> = None;
         let (signing_key_id, sign_metadata, sign_packages, require_signatures) =
-            if let Some(ref c) = config {
-                (
-                    c.signing_key_id,
-                    c.sign_metadata,
-                    c.sign_packages,
-                    c.require_signatures,
-                )
-            } else {
-                (None, false, false, false)
-            };
+            signing_config_fields(config.as_ref());
         assert!(signing_key_id.is_none());
         assert!(!sign_metadata);
         assert!(!sign_packages);
@@ -734,16 +745,7 @@ mod tests {
             updated_at: now,
         });
         let (signing_key_id, sign_metadata, sign_packages, require_signatures) =
-            if let Some(ref c) = config {
-                (
-                    c.signing_key_id,
-                    c.sign_metadata,
-                    c.sign_packages,
-                    c.require_signatures,
-                )
-            } else {
-                (None, false, false, false)
-            };
+            signing_config_fields(config.as_ref());
         assert_eq!(signing_key_id, Some(key_id));
         assert!(sign_metadata);
         assert!(sign_packages);
@@ -763,16 +765,7 @@ mod tests {
             require_signatures: None,
         };
         let existing: Option<RepositorySigningConfig> = None;
-        let (cur_key, cur_meta, cur_pkg, cur_req) = if let Some(ref c) = existing {
-            (
-                c.signing_key_id,
-                c.sign_metadata,
-                c.sign_packages,
-                c.require_signatures,
-            )
-        } else {
-            (None, false, false, false)
-        };
+        let (cur_key, cur_meta, cur_pkg, cur_req) = signing_config_fields(existing.as_ref());
 
         let merged_key = payload.signing_key_id.or(cur_key);
         let merged_meta = payload.sign_metadata.unwrap_or(cur_meta);
@@ -805,16 +798,7 @@ mod tests {
             sign_packages: None,
             require_signatures: None,
         };
-        let (cur_key, cur_meta, cur_pkg, cur_req) = if let Some(ref c) = existing {
-            (
-                c.signing_key_id,
-                c.sign_metadata,
-                c.sign_packages,
-                c.require_signatures,
-            )
-        } else {
-            (None, false, false, false)
-        };
+        let (cur_key, cur_meta, cur_pkg, cur_req) = signing_config_fields(existing.as_ref());
 
         let merged_key = payload.signing_key_id.or(cur_key);
         let merged_meta = payload.sign_metadata.unwrap_or(cur_meta);


### PR DESCRIPTION
## Summary

Require administrator privileges to manage repository signing keys and to write
repository signing configuration.

The signing-key management handlers
(`backend/src/api/handlers/signing.rs`) authenticated the caller but did not
check their role. As a result, any authenticated non-admin user could:

- `POST /api/v1/signing/keys` — mint a repository signing key (returns its
  fingerprint and public-key PEM);
- `DELETE /api/v1/signing/keys/{key_id}` — delete a signing key;
- `POST /api/v1/signing/repositories/{repo_id}/config` — write the repository
  signing configuration (which key the repo signs/verifies against, and whether
  signatures are required).

These operations define the trust root for artifact signing, so they belong to
administrators only — consistent with the other privileged management surfaces
in this codebase (users, permissions, quarantine, peers), which already gate on
`auth.require_admin()?`.

This change adds the same `auth.require_admin()?` gate to the three mutating
handlers, evaluated before any service call or database write. Read endpoints
(list keys, get key, get public key, get signing config) are unchanged. Key
revoke/rotate continue to bind the caller and are out of scope for this change.

Behavior after the fix:
- non-admin → `403 FORBIDDEN` ("Admin access required") on create/delete/config-write;
- admin → unchanged (create/delete/config-write succeed).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Adds two unit tests in `handlers::signing::tests` that pin the admin gate at the
predicate level (no DB required):
- `test_non_admin_blocked_from_managing_signing_keys` — a non-admin JWT session
  (`is_api_token = false`, so scope checks do not apply) is rejected with a 403
  `AppError::Authorization`. This fails without the gate because a non-admin JWT
  would otherwise reach the service call.
- `test_admin_allowed_to_manage_signing_keys` — an admin passes the same gate,
  pinning that legitimate management still works.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated patched instance:
- non-admin `POST /signing/keys`, `POST /signing/repositories/{id}/config`,
  `DELETE /signing/keys/{id}` → all `403`;
- admin `POST /signing/keys` → `200` (returns fingerprint + public key),
  `POST /signing/repositories/{id}/config` → `200`,
  `DELETE /signing/keys/{id}` (standalone key) → `200`.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No new endpoints or schema changes; only an authorization gate is added to
existing handlers. The `403` response is already documented for sibling
admin-gated routes and is the standard `AppError::Authorization` mapping.
