### PR TITLE
fix(security): resolve hostnames in SSRF URL allowlist to block internal targets

### DIFF
--- a/backend/src/api/validation.rs
+++ b/backend/src/api/validation.rs
@@ -217,6 +217,33 @@ fn is_blocked_url_in(url: &reqwest::Url, ctx: OutboundUrlContext) -> Option<Bloc
         if is_blocked_ip_in(ip, ctx) {
             return Some(BlockReason::Ip(ip));
         }
+        // An IP literal carries no DNS resolution step, so once the IP
+        // itself is cleared there is nothing more to check.
+        return None;
+    }
+
+    // The host is a DNS name, not an IP literal. The string-based checks
+    // above (BLOCKED_HOSTS) only catch known service names, so an
+    // arbitrary internal container/service name would otherwise sail
+    // through and the server would issue the request. Resolve the
+    // hostname and re-run the private/internal/loopback/link-local checks
+    // against EVERY resolved address; reject if any one of them is
+    // internal. `(host, 0)` performs a getaddrinfo lookup; the port is
+    // irrelevant to the IP classification.
+    //
+    // Residual gap (see module docs): this resolves at validation time,
+    // so a DNS-rebinding attacker who returns a public IP here and a
+    // private IP at fetch time is not caught by this check alone. Pinning
+    // the resolved address into the request (reqwest `resolve_to_addrs`)
+    // is the follow-up that closes the TOCTOU window.
+    use std::net::ToSocketAddrs;
+    if let Ok(addrs) = (host_normalized, 0u16).to_socket_addrs() {
+        for addr in addrs {
+            let ip = addr.ip();
+            if is_blocked_ip_in(ip, ctx) {
+                return Some(BlockReason::Ip(ip));
+            }
+        }
     }
 
     None
@@ -808,6 +835,35 @@ mod tests {
     #[test]
     fn test_rejects_localhost() {
         assert_blocked_host("http://localhost:8080/api");
+    }
+
+    #[test]
+    fn test_rejects_hostname_resolving_to_internal() {
+        // Regression: a hostname that is NOT in BLOCKED_HOSTS but
+        // resolves (getaddrinfo) to an internal/loopback address must be
+        // rejected. Before the resolution step was added, an arbitrary
+        // internal container/service name sailed past the string checks
+        // and the server issued the outbound request (SSRF).
+        //
+        // `localhost.localdomain` is the test vehicle: it is not a
+        // BLOCKED_HOSTS entry (and does not match the `.localhost`
+        // suffix), yet glibc resolves it to loopback. The assertion is
+        // guarded so the test does not flake on resolver setups that
+        // cannot resolve it — but where it does resolve to an internal
+        // IP, blocking is mandatory.
+        use std::net::ToSocketAddrs;
+        let host = "localhost.localdomain";
+        let resolves_internal = (host, 0u16)
+            .to_socket_addrs()
+            .map(|addrs| {
+                addrs
+                    .into_iter()
+                    .any(|a| is_blocked_ip_in(a.ip(), OutboundUrlContext::Upstream))
+            })
+            .unwrap_or(false);
+        if resolves_internal {
+            assert_blocked_ip(&format!("http://{host}/api"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The shared outbound-URL validator (`backend/src/api/validation.rs`,
`validate_outbound_url` / `validate_outbound_webhook_url`) enforces the
anti-SSRF policy for every server-initiated request: webhook delivery,
remote-instance/proxy fetches, and git plugin installs.

It rejected IP literals (loopback, RFC1918, link-local, unspecified,
broadcast, IPv4-mapped IPv6, decimal/0.0.0.0 forms) and a small list of
known service hostnames (`localhost`, cloud-metadata names, `postgres`,
`redis`, ...). However, when the URL host was a DNS name that was *not* on
that short blocklist, the validator accepted it without resolving it. As a
result an arbitrary internal container/service name resolved and was
contacted by the server, even though the equivalent IP literal was
correctly blocked.

This change closes that gap. After the existing IP-literal and
blocked-hostname checks, the validator now resolves the hostname via
`getaddrinfo` (`(host, 0).to_socket_addrs()`) and re-runs the full
private/internal/loopback/link-local classification against **every**
resolved address, rejecting the URL if any one of them is internal. The
behaviour is shared by all three call paths because they all flow through
the same validator, so one change hardens webhooks, remote-instance
create, and git plugin install together.

Public hostnames that resolve only to public addresses are unaffected and
continue to be accepted.

### Residual gap (documented, follow-up)

This resolves at validation time, so a DNS-rebinding attacker who returns
a public address during validation and a private address at fetch time is
not caught by this check alone. The robust mitigation is to pin the
validated address into the actual request (reqwest `resolve_to_addrs`) so
validation and connection use the same IP; this is noted inline and
tracked as a follow-up. The existing redirect-hop policy already
re-validates each hop, and a cluster-level egress NetworkPolicy remains a
defense-in-depth layer.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added `test_rejects_hostname_resolving_to_internal`: a hostname that is not
on the string blocklist but resolves to an internal/loopback address must
be rejected. This fails on `main` (the resolution step did not exist) and
passes here. The assertion is guarded so it does not flake on resolver
setups that cannot resolve the test name, but where the name does resolve
to an internal IP, blocking is mandatory.

Manual verification on an isolated patched instance:
- `POST /api/v1/webhooks {url: http://ak-bf-db:5432/...}` (arbitrary
  internal container name, not on the blocklist) -> `400 VALIDATION_ERROR`
  "IP '172.20.0.2' is not allowed (private/internal network)" (was 201).
- `POST /api/v1/webhooks {url: http://postgres:5432/...}` -> `400` (name
  blocklist).
- `POST /api/v1/webhooks {url: http://example.com/hook}` (public
  hostname) -> `201 Created` (no regression).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
