### PR TITLE
fix(security): enforce per-repo authorization on artifact access (private repos members-only)

### DIFF
--- a/backend/migrations/128_repositories_created_by.sql
+++ b/backend/migrations/128_repositories_created_by.sql
@@ -1,0 +1,10 @@
+-- Track the user who created a repository (#authz-private-repo-membership).
+--
+-- New repositories record their creator and auto-grant that user a per-repo
+-- role assignment (owner auto-grant), so the creator retains access once
+-- private repositories are restricted to admins and explicitly-granted users.
+--
+-- Nullable: existing rows predate this column and keep NULL. ON DELETE SET NULL
+-- so removing a user does not block deleting the repositories they created.
+ALTER TABLE repositories
+    ADD COLUMN IF NOT EXISTS created_by UUID REFERENCES users(id) ON DELETE SET NULL;

--- a/backend/src/api/handlers/artifacts.rs
+++ b/backend/src/api/handlers/artifacts.rs
@@ -50,6 +50,20 @@ async fn check_artifact_visibility(
                     "Token does not have access to this repository".to_string(),
                 ));
             }
+            // Per-repo authorization for private repos: admins bypass; every
+            // other caller must hold a role assignment scoped to the repo
+            // (direct or global). NotFound (not Forbidden) avoids leaking the
+            // existence of repositories the caller may not see.
+            if !is_public && !ext.is_admin {
+                let repo_service =
+                    crate::services::repository_service::RepositoryService::new(db.clone());
+                if !repo_service
+                    .user_can_access_repo(repo_id, ext.user_id)
+                    .await?
+                {
+                    return Err(AppError::NotFound("Artifact not found".to_string()));
+                }
+            }
             Ok(())
         }
         None => {

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -7370,6 +7370,75 @@ mod tests {
         }
     }
 
+    /// Admin variant of [`make_auth_ext`]: an authenticated admin with no
+    /// repository-scope restriction. Admins bypass per-repo authorization.
+    fn make_admin_auth_ext() -> AuthExtension {
+        let mut ext = make_auth_ext(None);
+        ext.is_admin = true;
+        ext
+    }
+
+    #[tokio::test]
+    async fn test_require_visible_private_admin_bypasses_grant() {
+        // Admins bypass the per-repo grant lookup, so this short-circuits
+        // before any DB access and remains DB-free.
+        let repo = make_repo(false);
+        let auth = Some(make_admin_auth_ext());
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        assert!(
+            require_visible(&repo, &auth, &svc).await.is_ok(),
+            "admin must see a private repo without an explicit grant"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // require_repo_write_access (authz-private-repo-membership)
+    //
+    // Write/delete authorization on a repository. The public-repo and admin
+    // arms short-circuit before the grant lookup, so they are DB-free. The
+    // private + non-admin grant lookup is covered by
+    // `repository_service::tests::test_user_can_access_repo_private_grant_enforced`.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_require_repo_write_access_public_ok() {
+        let repo = make_repo(true);
+        let auth = make_auth_ext(None);
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        assert!(
+            require_repo_write_access(&auth, &repo, &svc).await.is_ok(),
+            "any authenticated caller may write to a public repo"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_repo_write_access_admin_ok() {
+        let repo = make_repo(false);
+        let auth = make_admin_auth_ext();
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        assert!(
+            require_repo_write_access(&auth, &repo, &svc).await.is_ok(),
+            "admin may write to a private repo without an explicit grant"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_repo_write_access_token_scope_denied() {
+        // The token-scope check runs first and rejects a repository-scoped
+        // token that does not list this repo, before the grant lookup, so this
+        // remains DB-free.
+        let repo = make_repo(false);
+        let other_repo_id = Uuid::new_v4();
+        let auth = make_auth_ext(Some(vec![other_repo_id]));
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        let result = require_repo_write_access(&auth, &repo, &svc).await;
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            AppError::Authorization(msg) => assert!(msg.contains("does not have access")),
+            other => panic!("Expected Authorization error, got: {:?}", other),
+        }
+    }
+
     // -----------------------------------------------------------------------
     // validate_cache_ttl
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -93,30 +93,70 @@ fn require_repo_access(auth: &AuthExtension, repo_id: Uuid) -> Result<()> {
     }
 }
 
+/// Authorize a write/delete operation against a repository.
+///
+/// Enforces both the token-scope check (`require_repo_access`) and, for private
+/// repositories, per-repo authorization: admins bypass; every other caller must
+/// hold a role assignment scoped to the repo (direct or global). Public repos
+/// keep their existing behavior (token-scope only).
+async fn require_repo_write_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_access(auth, repo.id)?;
+    if repo.is_public || auth.is_admin {
+        return Ok(());
+    }
+    if repo_service
+        .user_can_access_repo(repo.id, auth.user_id)
+        .await?
+    {
+        Ok(())
+    } else {
+        Err(AppError::Authorization(
+            "You do not have access to this repository".to_string(),
+        ))
+    }
+}
+
 /// Ensure a repository is visible to the current user.
-/// Public repos are visible to everyone. Private repos require authentication.
-fn require_visible(
+///
+/// Public repos are visible to everyone. Private repos require authentication
+/// AND per-repo authorization: the caller must be an admin or hold a role
+/// assignment scoped to the repository (direct or global). The token-scope
+/// check (`can_access_repo`) is also enforced for repository-scoped API tokens.
+///
+/// Denials on private repos return `NotFound` (not `Forbidden`) to avoid
+/// leaking the existence of repositories the caller may not see.
+async fn require_visible(
     repo: &crate::models::repository::Repository,
     auth: &Option<AuthExtension>,
+    repo_service: &RepositoryService,
 ) -> Result<()> {
     if repo.is_public {
         return Ok(());
     }
+    let not_found = || AppError::NotFound(format!("Repository '{}' not found", repo.key));
     match auth {
         Some(a) => {
-            if a.can_access_repo(repo.id) {
+            // Repository-scoped API tokens must still allow this repo.
+            if !a.can_access_repo(repo.id) {
+                return Err(not_found());
+            }
+            // Per-repo authorization: admins bypass; everyone else needs a
+            // role assignment scoped to this repo (or a global assignment).
+            if a.is_admin
+                || repo_service
+                    .user_can_access_repo(repo.id, a.user_id)
+                    .await?
+            {
                 Ok(())
             } else {
-                Err(AppError::NotFound(format!(
-                    "Repository '{}' not found",
-                    repo.key
-                )))
+                Err(not_found())
             }
         }
-        None => Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            repo.key
-        ))),
+        None => Err(not_found()),
     }
 }
 
@@ -1234,6 +1274,9 @@ pub async fn create_repository(
             // in the payload: when a WASM plugin format was resolved above,
             // `plugin_format_key` carries the canonical handler name.
             format_key: plugin_format_key.or(payload.format_key),
+            // Owner auto-grant: record the creator and grant them per-repo
+            // access so they retain access under per-repo authorization.
+            created_by: Some(auth.user_id),
         })
         .await?;
 
@@ -1325,7 +1368,7 @@ pub async fn get_repository(
 ) -> Result<Json<RepositoryResponse>> {
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_visible(&repo, &auth)?;
+    require_visible(&repo, &auth, &service).await?;
     let storage_used = service.get_storage_usage(repo.id).await?;
     let auth_type =
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
@@ -1902,7 +1945,7 @@ pub async fn list_artifacts(
 
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_visible(&repo, &auth)?;
+    require_visible(&repo, &auth, &repo_service).await?;
 
     let storage = state.storage_for_repo(&repo.storage_location())?;
     let artifact_service = ArtifactService::new(state.db.clone(), storage);
@@ -3086,7 +3129,7 @@ pub async fn get_artifact_metadata(
 ) -> Result<Response> {
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_visible(&repo, &auth)?;
+    require_visible(&repo, &auth, &repo_service).await?;
 
     let storage = state.storage_for_repo(&repo.storage_location())?;
     let artifact_service = ArtifactService::new(state.db.clone(), storage);
@@ -3272,7 +3315,7 @@ pub async fn upload_artifact(
 
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
 
     // Verify declared checksums against actual content before storing anything.
     let declared_sha256 = headers
@@ -3559,7 +3602,7 @@ pub async fn download_artifact(
 ) -> Result<impl IntoResponse> {
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_visible(&repo, &auth)?;
+    require_visible(&repo, &auth, &repo_service).await?;
 
     // Check quarantine status before serving the artifact.
     // If the artifact is quarantined or rejected, return 409 Conflict.
@@ -3819,7 +3862,7 @@ pub async fn delete_artifact(
     auth.require_scope("delete")?;
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
 
     let storage = state.storage_for_repo(&repo.storage_location())?;
     let artifact_service = state.create_artifact_service(storage);
@@ -7276,23 +7319,34 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_require_visible_public_no_auth() {
+    // NOTE: `require_visible` is now async and consults the per-repo grant
+    // model (role_assignments) for private repositories, so the cases that
+    // exercise the DB grant lookup (private + authenticated non-admin) are
+    // covered by integration/live verification rather than these pure tests.
+    // The cases below short-circuit BEFORE any DB access (public repos, the
+    // anonymous-on-private denial, and the token-scope mismatch denial) and so
+    // remain DB-free; we drive them with an unused pool handle.
+
+    #[tokio::test]
+    async fn test_require_visible_public_no_auth() {
         let repo = make_repo(true);
-        assert!(require_visible(&repo, &None).is_ok());
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        assert!(require_visible(&repo, &None, &svc).await.is_ok());
     }
 
-    #[test]
-    fn test_require_visible_public_with_auth() {
+    #[tokio::test]
+    async fn test_require_visible_public_with_auth() {
         let repo = make_repo(true);
         let auth = Some(make_auth_ext(None));
-        assert!(require_visible(&repo, &auth).is_ok());
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        assert!(require_visible(&repo, &auth, &svc).await.is_ok());
     }
 
-    #[test]
-    fn test_require_visible_private_no_auth() {
+    #[tokio::test]
+    async fn test_require_visible_private_no_auth() {
         let repo = make_repo(false);
-        let result = require_visible(&repo, &None);
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        let result = require_visible(&repo, &None, &svc).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppError::NotFound(msg) => assert!(msg.contains("test-repo")),
@@ -7300,26 +7354,15 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_require_visible_private_with_unrestricted_auth() {
-        let repo = make_repo(false);
-        let auth = Some(make_auth_ext(None));
-        assert!(require_visible(&repo, &auth).is_ok());
-    }
-
-    #[test]
-    fn test_require_visible_private_with_allowed_repo() {
-        let repo = make_repo(false);
-        let auth = Some(make_auth_ext(Some(vec![repo.id])));
-        assert!(require_visible(&repo, &auth).is_ok());
-    }
-
-    #[test]
-    fn test_require_visible_private_with_different_repo_restriction() {
+    #[tokio::test]
+    async fn test_require_visible_private_with_different_repo_restriction() {
+        // Token-scope mismatch is rejected before the grant lookup, so this
+        // remains DB-free.
         let repo = make_repo(false);
         let other_repo_id = Uuid::new_v4();
         let auth = Some(make_auth_ext(Some(vec![other_repo_id])));
-        let result = require_visible(&repo, &auth);
+        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+        let result = require_visible(&repo, &auth, &svc).await;
         assert!(result.is_err());
         match result.unwrap_err() {
             AppError::NotFound(msg) => assert!(msg.contains("test-repo")),

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -237,7 +237,29 @@ pub async fn send(app: Router, req: Request<Body>) -> (StatusCode, Bytes) {
     (status, body)
 }
 
+/// Grant `user_id` the `developer` role scoped to `repo_id`, mirroring the
+/// owner auto-grant that `RepositoryService::create` performs for real
+/// callers. Handler smoke tests authenticate as the fixture user, so without
+/// this grant the per-repo authorization check in `require_visible` /
+/// `require_repo_write_access` would reject them on private repositories.
+pub async fn grant_repo_access(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+         SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+         ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+    )
+    .bind(user_id)
+    .bind(repo_id)
+    .execute(pool)
+    .await
+    .expect("grant developer role");
+}
+
 pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await;
     let _ = sqlx::query(
         "DELETE FROM artifact_metadata WHERE artifact_id IN \
          (SELECT id FROM artifacts WHERE repository_id = $1)",
@@ -379,6 +401,11 @@ impl Fixture {
         let pool = try_pool().await?;
         let (user_id, username) = create_user(&pool).await;
         let (repo_id, repo_key, storage_dir) = create_repo(&pool, repo_type, format).await;
+        // Owner auto-grant: the fixture user is the de-facto owner of the
+        // fixture repo, so grant them per-repo access. This keeps the
+        // authenticated-router smoke tests valid under per-repo authorization
+        // (private repos now require a role assignment, not just a token).
+        grant_repo_access(&pool, repo_id, user_id).await;
         let state = build_state(pool.clone(), storage_dir.to_str().unwrap());
         Some(Self {
             pool,

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -40,6 +40,17 @@ pub async fn try_pool() -> Option<PgPool> {
         .ok()
 }
 
+/// Build a lazily-connecting pool that never actually opens a connection
+/// unless a query is issued. Useful for DB-free unit tests of code paths that
+/// short-circuit before touching the database.
+pub fn lazy_pool() -> PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://invalid:invalid@127.0.0.1:1/none".to_string());
+    sqlx::postgres::PgPoolOptions::new()
+        .connect_lazy(&url)
+        .expect("lazy pool")
+}
+
 fn cfg(storage_path: &str) -> Config {
     Config {
         database_url: std::env::var("DATABASE_URL").unwrap_or_default(),

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -30,6 +30,11 @@ pub struct CreateRepositoryRequest {
     pub quota_bytes: Option<i64>,
     /// Custom format key for WASM plugin handlers (e.g. "rpm-custom").
     pub format_key: Option<String>,
+    /// User who is creating this repository. When set, the repository records
+    /// this user as `created_by` and the creator is auto-granted the
+    /// `developer` role scoped to the new repository (owner auto-grant), so the
+    /// creator retains access under per-repo authorization.
+    pub created_by: Option<Uuid>,
 }
 
 /// Request to update a repository
@@ -529,6 +534,28 @@ impl RepositoryService {
                         .await
                         .map_err(|e| AppError::Database(e.to_string()))?;
                 }
+                // Owner auto-grant: record the creator and grant them the
+                // `developer` role scoped to this repository, so the creator
+                // retains access under per-repo authorization. Runs inside the
+                // same tx as the INSERT so creator-grant is atomic with create.
+                if let Some(creator_id) = req.created_by {
+                    sqlx::query("UPDATE repositories SET created_by = $1 WHERE id = $2")
+                        .bind(creator_id)
+                        .bind(repo.id)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| AppError::Database(e.to_string()))?;
+                    sqlx::query(
+                        "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+                         SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+                         ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+                    )
+                    .bind(creator_id)
+                    .bind(repo.id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+                }
                 tx.commit()
                     .await
                     .map_err(|e| AppError::Database(e.to_string()))?;
@@ -567,6 +594,31 @@ impl RepositoryService {
         }
 
         Ok(repo)
+    }
+
+    /// Check whether a single user may access a private repository.
+    ///
+    /// Mirrors the `RepoVisibility::User` branch of [`build_visibility_clause`]
+    /// for one repository: the user has access if they hold any role assignment
+    /// scoped to that repository OR a global (NULL-scoped) role assignment.
+    ///
+    /// This is the per-repo authorization predicate. Callers are responsible for
+    /// short-circuiting the cases this method does NOT cover: admins bypass it
+    /// entirely and public repositories are accessible to everyone.
+    pub async fn user_can_access_repo(&self, repo_id: Uuid, user_id: Uuid) -> Result<bool> {
+        let granted: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM role_assignments ra \
+                 WHERE ra.user_id = $1 \
+                   AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
+             )",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(granted)
     }
 
     /// Get a repository by ID
@@ -1356,6 +1408,7 @@ mod tests {
             is_public: true,
             quota_bytes: Some(1_000_000_000),
             format_key: None,
+            created_by: None,
         };
         assert_eq!(req.key, "my-repo");
         assert_eq!(req.format, RepositoryFormat::Maven);
@@ -1378,6 +1431,7 @@ mod tests {
             is_public: false,
             quota_bytes: None,
             format_key: None,
+            created_by: None,
         };
         assert_eq!(
             req.upstream_url,
@@ -2306,6 +2360,7 @@ mod tests {
                 is_public: false,
                 quota_bytes: None,
                 format_key: None,
+                created_by: None,
             }
         }
 
@@ -2389,6 +2444,76 @@ mod tests {
             );
 
             cleanup_repo(&pool, first.id).await;
+        }
+
+        /// Regression (authz-private-repo-membership): per-repo authorization
+        /// for a PRIVATE repository.
+        ///
+        /// Before the fix, any authenticated user could access any private
+        /// repository (the handlers never consulted the grant model). This
+        /// asserts the corrected predicate: the owner (auto-granted on create)
+        /// can access the repo, while a different user with no grant cannot —
+        /// and that an explicit grant restores access.
+        #[tokio::test]
+        async fn test_user_can_access_repo_private_grant_enforced() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+
+            let (owner_id, _) = tdh::create_user(&pool).await;
+            let (other_id, _) = tdh::create_user(&pool).await;
+
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let mut req = make_create_req(&suffix, RepositoryFormat::Generic);
+            // Owner auto-grant: the creator is recorded and granted access.
+            req.created_by = Some(owner_id);
+            let repo = service.create(req).await.expect("create private repo");
+
+            // Owner (auto-granted developer role scoped to the repo) -> allowed.
+            assert!(
+                service
+                    .user_can_access_repo(repo.id, owner_id)
+                    .await
+                    .expect("owner access check"),
+                "owner should retain access via auto-grant"
+            );
+
+            // Different user with no grant -> denied (this is the bug being fixed).
+            assert!(
+                !service
+                    .user_can_access_repo(repo.id, other_id)
+                    .await
+                    .expect("other access check"),
+                "ungranted user must NOT access a private repo"
+            );
+
+            // Explicit grant scoped to the repo -> access restored.
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+                 SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+                 ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+            )
+            .bind(other_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("grant developer role");
+            assert!(
+                service
+                    .user_can_access_repo(repo.id, other_id)
+                    .await
+                    .expect("granted access check"),
+                "explicitly granted user should now have access"
+            );
+
+            cleanup_repo(&pool, repo.id).await;
+            for uid in [owner_id, other_id] {
+                let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                    .bind(uid)
+                    .execute(&pool)
+                    .await;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Enforce per-repository authorization on artifact access so that **private
repositories are restricted to admins and explicitly-granted users**.

Previously, artifact read/download/upload/delete handlers authorized access
to a private repository (`is_public = false`) using only:

- the global `is_admin` flag,
- the API token's repository scope (`allowed_repo_ids`), and
- the `is_public` flag (for anonymous callers).

They never consulted the per-repository grant model (`role_assignments`). As a
result, any authenticated user could read, download, upload, and delete
artifacts in a private repository regardless of whether they had been granted
access to it. The grant predicate already existed and was used for repository
**listing/search** (`build_visibility_clause`), but the per-artifact handlers
did not apply it.

This PR closes that gap by applying the same grant predicate on the
single-repository access paths, on both reads and writes.

### What changed

- **New migration** `128_repositories_created_by.sql`: adds a nullable
  `created_by UUID REFERENCES users(id) ON DELETE SET NULL` column to
  `repositories`.
- **Owner auto-grant on create** (`RepositoryService::create` +
  `create_repository` handler): a newly created repository records its creator
  in `created_by` and inserts a `role_assignments` row granting the creator the
  built-in `developer` role scoped to that repository, inside the same
  transaction as the `INSERT`. This is the first place the application writes
  `role_assignments`; it mirrors how `user_roles` are seeded elsewhere.
- **New predicate** `RepositoryService::user_can_access_repo(repo_id, user_id)`:
  the single-repository sibling of the existing `build_visibility_clause`
  `User` branch (`EXISTS` over `role_assignments` matching the repo directly or
  a global, NULL-scoped assignment).
- **Enforcement on reads**: `require_visible` (repository-nested
  read/download/metadata) and `check_artifact_visibility` (standalone
  artifact-by-id) now require, for private repos, `is_admin` **or** a matching
  grant. The existing token-scope check is retained as an additional condition
  for repository-scoped tokens. Denials use `NotFound` (not `Forbidden`),
  matching the existing convention, to avoid leaking repository existence.
- **Enforcement on writes/deletes**: `upload_artifact` and `delete_artifact`
  now go through `require_repo_write_access`, which combines the existing
  token-scope check with the per-repo grant check for private repos.

Public repositories and anonymous-on-public access are unchanged.

### Rollout note — existing private repositories

Existing private repositories were created before this change and therefore
have **no grants recorded**. On rollout, those repositories become accessible
to **admins and explicitly-granted users only**. Newly created repositories are
unaffected because the creator is auto-granted access on create.

Restoring access for additional users to a pre-existing private repository
requires assigning them a role scoped to that repository. An
admin-facing "assign user to repository" endpoint is a tracked follow-up; until
it ships, admins can grant access via a role assignment. This is the intended,
documented consequence of moving private repositories onto an explicit
grant model.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added `repository_service::tests::db::test_user_can_access_repo_private_grant_enforced`
(DB-backed, runs in the coverage CI job that provisions Postgres): creates a
private repo with owner auto-grant, asserts the **owner is allowed**, a
**different ungranted user is denied** (the exact bug), and that an **explicit
grant restores access**. This test fails against the pre-fix predicate (which
had no per-repo grant check) and passes here.

Also updated the DB-free `require_visible` unit tests for the new async,
grant-aware signature (public, anonymous-on-private, and token-scope-mismatch
cases, all of which short-circuit before any DB access).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification against an isolated patched instance, seeded with the
standard company fixture:

| Scenario | Before | After |
| --- | --- | --- |
| Owner (admin) GET download of own private repo | 200 | 200 |
| Different non-admin GET download of that private repo | 200 | 404 |
| Different non-admin PUT upload to that private repo | 200 | 403 |
| Different non-admin DELETE in that private repo | 200 | 403 |
| Standalone `GET /artifacts/{id}` of private artifact (ungranted user) | 200 | 404 |
| Explicitly-granted non-admin GET/PUT on that private repo | n/a | 200 |
| Authenticated user GET download of a **public** repo | 200 | 200 |
| Anonymous GET download of a public (allow-anonymous) repo | 200 | 200 |

Full `cargo test --workspace --lib` passes (11197 tests). `cargo fmt --check`
and `cargo clippy --workspace --all-targets -- -D warnings` are clean.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

No new endpoints or request/response schema changes. Migration `128` adds a
nullable column with a foreign key (`ON DELETE SET NULL`) and is safe to apply
to a populated table; it can be reversed with `ALTER TABLE repositories DROP
COLUMN created_by`.
