### PR TITLE
fix(artifacts): block deletion of immutable released artifacts

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -29,6 +29,7 @@ use crate::error::{AppError, Result};
 use crate::formats::maven::MavenHandler;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::artifact_service::ArtifactService;
+use crate::services::cache_classifier;
 use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
 use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
 use crate::services::repository_service::{
@@ -3792,6 +3793,24 @@ pub async fn download_artifact(
     }
 }
 
+/// Decide whether a delete of `(format, path)` must be refused to preserve
+/// release immutability.
+///
+/// A delete is blocked when the coordinates classify as
+/// [`cache_classifier::Mutability::Immutable`] (the same structural rule the
+/// upload and proxy-cache paths use) and the caller is neither an admin nor an
+/// internal replication request. Admins keep an explicit retraction escape
+/// hatch; replication must be able to mirror upstream deletes; mutable paths
+/// (e.g. Maven SNAPSHOT directories, indexes) are always deletable.
+fn delete_blocked_by_immutability(
+    format: &RepositoryFormat,
+    path: &str,
+    is_admin: bool,
+    is_replication: bool,
+) -> bool {
+    !is_admin && !is_replication && cache_classifier::classify(format, path).is_immutable()
+}
+
 /// Delete artifact
 #[utoipa::path(
     delete,
@@ -3807,6 +3826,7 @@ pub async fn download_artifact(
         (status = 200, description = "Artifact deleted"),
         (status = 401, description = "Authentication required"),
         (status = 404, description = "Artifact not found"),
+        (status = 409, description = "Artifact is immutable (released) and cannot be deleted"),
     )
 )]
 pub async fn delete_artifact(
@@ -3820,6 +3840,24 @@ pub async fn delete_artifact(
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_access(&auth, repo.id)?;
+
+    // Release immutability: a versioned (immutable) artifact must never be
+    // mutated after publication. Deleting one would re-open its coordinates for
+    // a different-bytes re-upload (the upload path already rejects an existing
+    // immutable version at `artifact_service`), so refuse the delete here using
+    // the SAME structural classification the proxy-cache and upload paths use.
+    // Admins retain an explicit escape hatch for genuine retractions; mutable
+    // paths (e.g. Maven SNAPSHOT directories) are unaffected.
+    if delete_blocked_by_immutability(
+        &repo.format,
+        &path,
+        auth.is_admin,
+        is_replication_request(&headers),
+    ) {
+        return Err(AppError::Conflict(
+            "Cannot delete an immutable/released artifact".to_string(),
+        ));
+    }
 
     let storage = state.storage_for_repo(&repo.storage_location())?;
     let artifact_service = state.create_artifact_service(storage);
@@ -10169,6 +10207,65 @@ mod tests {
     // formats that don't normalise, and npm-family repos quietly fall
     // back to the stored path on the second probe.
     // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_delete_blocked_by_immutability_matches_classification() {
+        // A released (versioned) Maven jar is immutable -> a non-admin,
+        // non-replication delete must be refused. This is the soft-delete +
+        // re-upload mutation bypass the gate closes.
+        let immutable_path = "com/acme/widget/3.0.0/widget-3.0.0.jar";
+        assert!(delete_blocked_by_immutability(
+            &RepositoryFormat::Maven,
+            immutable_path,
+            false, // not admin
+            false, // not replication
+        ));
+
+        // Same coordinates: an admin retraction is allowed.
+        assert!(!delete_blocked_by_immutability(
+            &RepositoryFormat::Maven,
+            immutable_path,
+            true,
+            false,
+        ));
+
+        // Same coordinates: an internal replication delete is allowed.
+        assert!(!delete_blocked_by_immutability(
+            &RepositoryFormat::Maven,
+            immutable_path,
+            false,
+            true,
+        ));
+
+        // Mutable coordinates (SNAPSHOT directory metadata, maven-metadata.xml)
+        // are deletable by anyone with the delete scope -> no regression.
+        assert!(!delete_blocked_by_immutability(
+            &RepositoryFormat::Maven,
+            "com/acme/widget/maven-metadata.xml",
+            false,
+            false,
+        ));
+        assert!(!delete_blocked_by_immutability(
+            &RepositoryFormat::Maven,
+            "com/acme/widget/1.0-SNAPSHOT/",
+            false,
+            false,
+        ));
+
+        // The decision tracks the central classifier for other formats too.
+        assert!(delete_blocked_by_immutability(
+            &RepositoryFormat::Npm,
+            "lodash/-/lodash-4.17.21.tgz",
+            false,
+            false,
+        ));
+        assert!(!delete_blocked_by_immutability(
+            &RepositoryFormat::Npm,
+            "lodash",
+            false,
+            false,
+        ));
+    }
 
     #[test]
     fn test_lookup_path_candidates_npm_url_shape_adds_stored_fallback() {


### PR DESCRIPTION
## Summary

Release immutability was only half-enforced. The upload path correctly refuses
to overwrite an existing immutable (version-pinned) artifact — re-`PUT`ting the
same coordinates returns `409 Conflict` ("Artifact version already exists and is
immutable"). The delete path had no matching check: `DELETE
/api/v1/repositories/{key}/artifacts/{path}` only required the `delete` scope and
then removed the row. That left a way to mutate an already-released version:
delete the immutable artifact, then re-upload the same coordinates with different
bytes (the existing row no longer blocks the upload).

This PR closes that gap by applying the **same structural classification** the
upload and proxy-cache paths already use (`services::cache_classifier::classify`)
in the delete handler. If the target coordinates classify as immutable, the
delete is refused with `409 Conflict` ("Cannot delete an immutable/released
artifact").

The check is intentionally narrow:

- **Admins** keep an explicit retraction escape hatch (`is_admin` bypasses the
  guard) for genuine takedowns.
- **Internal replication** requests bypass the guard so a mirrored upstream
  delete still propagates.
- **Mutable** coordinates (Maven `maven-metadata.xml` / `-SNAPSHOT/` directory
  metadata, package indexes, OCI tags, etc.) are unaffected and remain deletable
  by any caller with the `delete` scope.

Because the decision reuses the single central classifier rather than
re-deriving the immutable/mutable rules, the delete gate stays consistent with
upload by construction, with no duplicated rule logic.

### Files changed
- `backend/src/api/handlers/repositories.rs` — add
  `delete_blocked_by_immutability(format, path, is_admin, is_replication)` helper
  and call it at the top of `delete_artifact`; import `cache_classifier`; add the
  `409` response to the handler's OpenAPI doc.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`test_delete_blocked_by_immutability_matches_classification` asserts the gate
decision against the classifier: a released Maven jar is refused for a non-admin
non-replication delete, allowed for an admin, allowed for replication, and not
refused for mutable paths (`maven-metadata.xml`, `-SNAPSHOT/`) or npm packument
metadata. It also confirms an immutable npm tarball is refused. This test fails
against `main` (no guard) and passes here.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification against a freshly built/deployed instance: as a non-admin
developer, uploading a released `maven-releases` jar then `DELETE`-ing it now
returns `409` (was `200`); re-uploading the same coordinates with different bytes
is still rejected `409` and the original bytes remain intact; deleting a mutable
SNAPSHOT-metadata path still returns `200`; an admin can still delete the
immutable artifact (`200`). Full `cargo test --workspace --lib` passes
(11196 tests), `cargo fmt --check` and `cargo clippy --workspace --all-targets
-- -D warnings` are clean, and a jscpd duplication scan of the changed file is
under the 3% threshold.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

`delete_artifact` is an existing endpoint; its `#[utoipa::path]` now documents
the `409` immutable-artifact response. No new endpoints, types, or migrations.
