### PR TITLE
feat(repositories): admin endpoints to grant/revoke per-repo user access

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -293,6 +293,14 @@ pub fn router() -> Router<SharedState> {
                 .put(update_virtual_members),
         )
         .route("/:key/members/:member_key", delete(remove_virtual_member))
+        // Per-repo access grants (admin-only): assign/revoke a user a role on a
+        // repository. Backs the per-repo authorization model so existing private
+        // repos can grant access to users other than the owner/admin.
+        .route(
+            "/:key/grants",
+            get(list_repo_grants).post(create_repo_grant),
+        )
+        .route("/:key/grants/:user_id", delete(revoke_repo_grant))
         // Artifact routes nested under repository
         .route(
             "/:key/artifacts",
@@ -1766,6 +1774,194 @@ pub async fn delete_repository(
         "repository.deleted",
         repo.id,
         Some(auth.username.clone()),
+    );
+    Ok(())
+}
+
+// Per-repo access grant handlers (admin-only)
+//
+// Back the per-repo authorization model: after private repos became
+// members-only, the owner auto-grant (on create) and the admin seed were the
+// only writers of `role_assignments`. These admin-only endpoints let an admin
+// assign or revoke a user a role on an existing repository so others can be
+// granted access.
+
+/// A single per-repo grant, as returned by the list endpoint.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RepoGrantResponse {
+    pub user_id: Uuid,
+    pub username: String,
+    pub role_id: Uuid,
+    pub role: String,
+}
+
+/// Wrapper for the grants list response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RepoGrantsListResponse {
+    pub grants: Vec<RepoGrantResponse>,
+}
+
+/// Request body for assigning a user a role on a repository.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateRepoGrantRequest {
+    /// User to grant access to.
+    pub user_id: Uuid,
+    /// Role to assign, scoped to this repository. Defaults to `developer`.
+    #[serde(default = "default_grant_role")]
+    pub role: String,
+}
+
+fn default_grant_role() -> String {
+    "developer".to_string()
+}
+
+/// Roles an admin may assign to a user on a repository via the grants endpoint.
+/// Mirrors the seeded non-admin system roles (`developer`, `reader`); `admin`
+/// is intentionally excluded — repo-scoped admin is not granted here.
+const ASSIGNABLE_GRANT_ROLES: [&str; 2] = ["developer", "reader"];
+
+/// List the per-repo access grants on a repository.
+#[utoipa::path(
+    get,
+    path = "/{key}/grants",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Grants listed", body = RepoGrantsListResponse),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Admin access required"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn list_repo_grants(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(key): Path<String>,
+) -> Result<Json<RepoGrantsListResponse>> {
+    let auth = require_auth(auth)?;
+    auth.require_admin()?;
+    let service = state.create_repository_service();
+    let repo = service.get_by_key(&key).await?;
+    let grants = service
+        .list_repo_grants(repo.id)
+        .await?
+        .into_iter()
+        .map(|g| RepoGrantResponse {
+            user_id: g.user_id,
+            username: g.username,
+            role_id: g.role_id,
+            role: g.role_name,
+        })
+        .collect();
+    Ok(Json(RepoGrantsListResponse { grants }))
+}
+
+/// Assign a user a role on a repository (admin-only).
+#[utoipa::path(
+    post,
+    path = "/{key}/grants",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+    ),
+    request_body = CreateRepoGrantRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Grant created", body = RepoGrantsListResponse),
+        (status = 400, description = "Invalid role"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Admin access required"),
+        (status = 404, description = "Repository or user not found"),
+    )
+)]
+pub async fn create_repo_grant(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(key): Path<String>,
+    Json(payload): Json<CreateRepoGrantRequest>,
+) -> Result<Json<RepoGrantsListResponse>> {
+    let auth = require_auth(auth)?;
+    auth.require_admin()?;
+
+    if !ASSIGNABLE_GRANT_ROLES.contains(&payload.role.as_str()) {
+        return Err(AppError::Validation(format!(
+            "role must be one of: {}",
+            ASSIGNABLE_GRANT_ROLES.join(", ")
+        )));
+    }
+
+    let service = state.create_repository_service();
+    let repo = service.get_by_key(&key).await?;
+    service
+        .grant_repo_role(repo.id, payload.user_id, &payload.role)
+        .await?;
+
+    tracing::info!(
+        actor_user_id = %auth.user_id,
+        actor_username = %auth.username,
+        repo_id = %repo.id,
+        repo_key = %repo.key,
+        target_user_id = %payload.user_id,
+        role = %payload.role,
+        "granted per-repo role assignment"
+    );
+
+    let grants = service
+        .list_repo_grants(repo.id)
+        .await?
+        .into_iter()
+        .map(|g| RepoGrantResponse {
+            user_id: g.user_id,
+            username: g.username,
+            role_id: g.role_id,
+            role: g.role_name,
+        })
+        .collect();
+    Ok(Json(RepoGrantsListResponse { grants }))
+}
+
+/// Revoke a user's access grants on a repository (admin-only).
+#[utoipa::path(
+    delete,
+    path = "/{key}/grants/{user_id}",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+        ("user_id" = Uuid, Path, description = "User whose grants are revoked"),
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Grant revoked"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Admin access required"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn revoke_repo_grant(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path((key, user_id)): Path<(String, Uuid)>,
+) -> Result<()> {
+    let auth = require_auth(auth)?;
+    auth.require_admin()?;
+    let service = state.create_repository_service();
+    let repo = service.get_by_key(&key).await?;
+    let removed = service.revoke_repo_grants(repo.id, user_id).await?;
+
+    tracing::info!(
+        actor_user_id = %auth.user_id,
+        actor_username = %auth.username,
+        repo_id = %repo.id,
+        repo_key = %repo.key,
+        target_user_id = %user_id,
+        removed,
+        "revoked per-repo role assignment(s)"
     );
     Ok(())
 }
@@ -4631,6 +4827,9 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         get_repository,
         update_repository,
         delete_repository,
+        list_repo_grants,
+        create_repo_grant,
+        revoke_repo_grant,
         set_cache_ttl,
         list_pypi_tracks,
         put_pypi_track,
@@ -4658,6 +4857,9 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         UpdateRepositoryRequest,
         RepositoryResponse,
         RepositoryListResponse,
+        RepoGrantResponse,
+        RepoGrantsListResponse,
+        CreateRepoGrantRequest,
         SetCacheTtlRequest,
         CacheTtlResponse,
         InvalidateCacheQuery,
@@ -5611,6 +5813,34 @@ mod tests {
         assert!(req.is_public.is_none());
         assert!(req.upstream_url.is_none());
         assert!(req.quota_bytes.is_none());
+    }
+
+    #[test]
+    fn test_create_repo_grant_request_defaults_to_developer() {
+        // Omitting `role` falls back to the developer default.
+        let json = r#"{"user_id": "11111111-1111-1111-1111-111111111111"}"#;
+        let req: CreateRepoGrantRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.role, "developer");
+        assert_eq!(
+            req.user_id,
+            Uuid::parse_str("11111111-1111-1111-1111-111111111111").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_create_repo_grant_request_explicit_role() {
+        let json = r#"{"user_id": "11111111-1111-1111-1111-111111111111", "role": "reader"}"#;
+        let req: CreateRepoGrantRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.role, "reader");
+    }
+
+    #[test]
+    fn test_assignable_grant_roles_accepts_developer_and_reader() {
+        assert!(ASSIGNABLE_GRANT_ROLES.contains(&"developer"));
+        assert!(ASSIGNABLE_GRANT_ROLES.contains(&"reader"));
+        // `admin` is intentionally not assignable via this endpoint.
+        assert!(!ASSIGNABLE_GRANT_ROLES.contains(&"admin"));
+        assert!(!ASSIGNABLE_GRANT_ROLES.contains(&"owner"));
     }
 
     #[test]

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -48,6 +48,19 @@ pub struct UpdateRepositoryRequest {
     pub upstream_url: Option<String>,
 }
 
+/// A per-repo role assignment (grant) resolved to human-readable names.
+///
+/// Returned by [`RepositoryService::list_repo_grants`] so the admin grants
+/// endpoint can report who holds which role on a repository without the caller
+/// having to resolve user/role ids separately.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct RepoGrant {
+    pub user_id: Uuid,
+    pub username: String,
+    pub role_id: Uuid,
+    pub role_name: String,
+}
+
 /// Controls which repositories a caller can see in listing results.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RepoVisibility {
@@ -619,6 +632,93 @@ impl RepositoryService {
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(granted)
+    }
+
+    /// List the per-repo role assignments (grants) scoped to a repository.
+    ///
+    /// Returns one row per `(user, role)` grant whose `repository_id` matches
+    /// `repo_id` exactly. Global (NULL-scoped) assignments are intentionally
+    /// excluded: they are not repo-scoped grants and are managed elsewhere.
+    /// Ordered by grant creation time for a stable response.
+    pub async fn list_repo_grants(&self, repo_id: Uuid) -> Result<Vec<RepoGrant>> {
+        let grants = sqlx::query_as::<_, RepoGrant>(
+            "SELECT ra.user_id, u.username, ra.role_id, r.name AS role_name \
+             FROM role_assignments ra \
+             JOIN users u ON u.id = ra.user_id \
+             JOIN roles r ON r.id = ra.role_id \
+             WHERE ra.repository_id = $1 \
+             ORDER BY ra.created_at",
+        )
+        .bind(repo_id)
+        .fetch_all(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(grants)
+    }
+
+    /// Grant a user a named role scoped to a repository.
+    ///
+    /// Inserts a `role_assignments` row binding `user_id` to the role named
+    /// `role_name`, scoped to `repo_id`. Idempotent: a duplicate grant is a
+    /// no-op (`ON CONFLICT DO NOTHING`). Validates that the user and the role
+    /// exist, returning `NotFound` otherwise.
+    pub async fn grant_repo_role(
+        &self,
+        repo_id: Uuid,
+        user_id: Uuid,
+        role_name: &str,
+    ) -> Result<()> {
+        // Validate the target user exists so a typo'd id surfaces as 404 rather
+        // than silently inserting nothing.
+        let user_exists: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM users WHERE id = $1)")
+                .bind(user_id)
+                .fetch_one(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        if !user_exists {
+            return Err(AppError::NotFound(format!("User '{}' not found", user_id)));
+        }
+
+        let role_id: Option<Uuid> = sqlx::query_scalar("SELECT id FROM roles WHERE name = $1")
+            .bind(role_name)
+            .fetch_optional(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let role_id =
+            role_id.ok_or_else(|| AppError::NotFound(format!("Role '{}' not found", role_name)))?;
+
+        sqlx::query(
+            "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+             VALUES ($1, $2, $3) \
+             ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+        )
+        .bind(user_id)
+        .bind(role_id)
+        .bind(repo_id)
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Revoke all repo-scoped grants for a user on a repository.
+    ///
+    /// Deletes every `role_assignments` row matching `(user_id, repo_id)` with a
+    /// non-NULL `repository_id`. Global (NULL-scoped) assignments are left
+    /// untouched. Returns the number of rows removed so callers can distinguish
+    /// "revoked" from "nothing to revoke".
+    pub async fn revoke_repo_grants(&self, repo_id: Uuid, user_id: Uuid) -> Result<u64> {
+        let result = sqlx::query(
+            "DELETE FROM role_assignments \
+             WHERE user_id = $1 AND repository_id = $2",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        Ok(result.rows_affected())
     }
 
     /// Get a repository by ID
@@ -2509,6 +2609,96 @@ mod tests {
 
             cleanup_repo(&pool, repo.id).await;
             for uid in [owner_id, other_id] {
+                let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                    .bind(uid)
+                    .execute(&pool)
+                    .await;
+            }
+        }
+
+        /// feat(repo-access-grants): the admin grant/list/revoke service path.
+        ///
+        /// A user with no grant is denied; granting `developer` lists the grant
+        /// and restores access; the grant is idempotent; revoking removes it and
+        /// access is denied again.
+        #[tokio::test]
+        async fn test_grant_list_revoke_repo_role() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+
+            let (owner_id, _) = tdh::create_user(&pool).await;
+            let (target_id, target_name) = tdh::create_user(&pool).await;
+
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let mut req = make_create_req(&suffix, RepositoryFormat::Generic);
+            req.created_by = Some(owner_id);
+            let repo = service.create(req).await.expect("create private repo");
+
+            // Initially the target has no access.
+            assert!(!service
+                .user_can_access_repo(repo.id, target_id)
+                .await
+                .expect("pre-grant access check"));
+
+            // Grant developer -> access restored and listed.
+            service
+                .grant_repo_role(repo.id, target_id, "developer")
+                .await
+                .expect("grant developer");
+            assert!(
+                service
+                    .user_can_access_repo(repo.id, target_id)
+                    .await
+                    .expect("post-grant access check"),
+                "granted user should have access"
+            );
+            let grants = service
+                .list_repo_grants(repo.id)
+                .await
+                .expect("list grants");
+            assert!(
+                grants.iter().any(|g| g.user_id == target_id
+                    && g.role_name == "developer"
+                    && g.username == target_name),
+                "grant should appear in the list with resolved names"
+            );
+
+            // Granting again is idempotent (no duplicate row, no error).
+            service
+                .grant_repo_role(repo.id, target_id, "developer")
+                .await
+                .expect("re-grant is idempotent");
+            let after = service.list_repo_grants(repo.id).await.expect("list again");
+            let target_grants = after.iter().filter(|g| g.user_id == target_id).count();
+            assert_eq!(
+                target_grants, 1,
+                "duplicate grant must not add a second row"
+            );
+
+            // Granting to a non-existent user -> NotFound.
+            let missing = service
+                .grant_repo_role(repo.id, Uuid::new_v4(), "developer")
+                .await;
+            assert!(matches!(missing, Err(AppError::NotFound(_))));
+
+            // Revoke -> access denied again, grant gone.
+            let removed = service
+                .revoke_repo_grants(repo.id, target_id)
+                .await
+                .expect("revoke");
+            assert!(removed >= 1, "revoke should remove at least one row");
+            assert!(
+                !service
+                    .user_can_access_repo(repo.id, target_id)
+                    .await
+                    .expect("post-revoke access check"),
+                "revoked user must lose access"
+            );
+
+            cleanup_repo(&pool, repo.id).await;
+            for uid in [owner_id, target_id] {
                 let _ = sqlx::query("DELETE FROM users WHERE id = $1")
                     .bind(uid)
                     .execute(&pool)


### PR DESCRIPTION
## Summary

Adds admin-only endpoints to manage per-repository access grants, completing the
per-repo authorization model introduced in the base branch.

After per-repo authorization landed, private repositories are members-only: a
caller needs a `role_assignment` scoped to the repository (or a global one, or
admin) to see or use it. The only writers of those assignments so far were the
owner auto-grant on repository create and the admin seed — there was no way for
an admin to grant access to anyone else. As a result, any private repository
created without the new owner-grant path (e.g. pre-existing repos) was reachable
only by admins, with no supported mechanism to add members.

This PR adds the missing management surface, mounted under the existing
repositories router and guarded by `require_admin` (the established codebase
pattern):

- `GET /api/v1/repositories/{key}/grants` — list the repo-scoped grants
  (resolved to usernames and role names).
- `POST /api/v1/repositories/{key}/grants` `{ user_id, role }` — assign a user
  a role on the repository. `role` defaults to `developer`; only the seeded
  non-admin roles `developer` and `reader` are assignable here. Idempotent.
- `DELETE /api/v1/repositories/{key}/grants/{user_id}` — revoke a user's
  repo-scoped grants.

The service layer gains `list_repo_grants`, `grant_repo_role`, and
`revoke_repo_grants`, which write/read `role_assignments` scoped to the
repository and reuse the existing role-by-name lookup. Global (NULL-scoped)
assignments are intentionally left untouched by these operations. Unknown users
or roles return `404`/`400`. The grant/revoke operations are logged via
structured `tracing` for auditability.

No schema change is required — `role_assignments(user_id, role_id,
repository_id)` and the `admin`/`developer`/`reader` roles already exist.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added tests:
- `repositories::tests::test_create_repo_grant_request_defaults_to_developer`,
  `..._explicit_role`, `..._assignable_grant_roles_accepts_developer_and_reader`
  — request defaulting and role-allowlist behavior.
- `repository_service::tests::db::test_grant_list_revoke_repo_role` (DB-backed)
  — grant restores access and appears in the list with resolved names, grants
  are idempotent, granting an unknown user is `NotFound`, and revoke removes
  access again.

Manual verification against a freshly built instance: admin creates a PRIVATE
repo; an ungranted user gets `404` on read/download; the ungranted user gets
`403` on all three grants endpoints; admin `POST` grant → `200` and the user can
then read/upload (`200`); admin `DELETE` grant → user read returns `404` again.
Full `cargo test --workspace --lib` passes (11205 tests), `cargo fmt --check`
and `cargo clippy --workspace --all-targets -- -D warnings` are clean, and
changed-file duplication is under the 3% gate.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes
