### PR TITLE
fix(cargo): resolve cargo QA bugs (#1777)

### DIFF
--- a/.sqlx/query-aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182.json
+++ b/.sqlx/query-aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(DISTINCT a.name)\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND ($2 = '' OR a.name ILIKE '%' || $2 || '%')\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182"
+}

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -395,6 +395,26 @@ async fn search_crates(
         .unwrap_or(10)
         .min(100);
 
+    // Total number of distinct crates matching the query. This must be counted
+    // independently of the paginated (LIMIT-truncated) result set, otherwise
+    // `meta.total` reports the page size rather than the real match count and
+    // cargo's search pagination breaks.
+    let total_matches: i64 = sqlx::query_scalar!(
+        r#"
+        SELECT COUNT(DISTINCT a.name)
+        FROM artifacts a
+        WHERE a.repository_id = $1
+          AND a.is_deleted = false
+          AND ($2 = '' OR a.name ILIKE '%' || $2 || '%')
+        "#,
+        repo.id,
+        query,
+    )
+    .fetch_one(&state.db)
+    .await
+    .map_err(map_db_err)?
+    .unwrap_or(0);
+
     // Search for crates matching the query
     let crates = sqlx::query!(
         r#"
@@ -440,18 +460,31 @@ async fn search_crates(
         })
         .collect();
 
-    let response = serde_json::json!({
-        "crates": crate_list,
-        "meta": {
-            "total": crate_list.len(),
-        }
-    });
+    let response = build_search_response(crate_list, total_matches);
 
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/json")
         .body(Body::from(serde_json::to_string(&response).unwrap()))
         .unwrap())
+}
+
+/// Build the cargo search-endpoint JSON body.
+///
+/// `meta.total` is the **total** number of distinct crates matching the query
+/// across all pages — not the length of the (LIMIT-truncated) `crate_list`
+/// for the current page. Cargo relies on `meta.total` for pagination, so it
+/// must be derived from a separate COUNT(*) and not from the page slice.
+fn build_search_response(
+    crate_list: Vec<serde_json::Value>,
+    total_matches: i64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "crates": crate_list,
+        "meta": {
+            "total": total_matches,
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1558,6 +1591,33 @@ mod tests {
             "links": null,
             "rust_version": "1.70.0"
         })
+    }
+
+    // -----------------------------------------------------------------------
+    // build_search_response — meta.total must reflect the total match count
+    // across all pages, not the (LIMIT-truncated) current page length (#1777)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_search_meta_total_reflects_total_not_page_len() {
+        // One crate on the current page, but 3 total matches across all pages.
+        let page: Vec<serde_json::Value> = vec![serde_json::json!({
+            "name": "alpha-crate",
+            "max_version": "0.1.0",
+            "description": "",
+        })];
+        let resp = build_search_response(page, 3);
+        assert_eq!(resp["crates"].as_array().unwrap().len(), 1);
+        // Regression: previously this used crate_list.len() (== 1) and broke
+        // cargo search pagination. It must be the real total (3).
+        assert_eq!(resp["meta"]["total"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_search_meta_total_zero_when_no_matches() {
+        let resp = build_search_response(Vec::new(), 0);
+        assert_eq!(resp["crates"].as_array().unwrap().len(), 0);
+        assert_eq!(resp["meta"]["total"], serde_json::json!(0));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -330,6 +330,12 @@ fn extract_token_from_auth_header(auth_header: &str) -> ExtractedToken<'_> {
         .or_else(|| auth_header.strip_prefix("basic "))
     {
         ExtractedToken::Basic(creds)
+    } else if !auth_header.is_empty() && !auth_header.contains(' ') {
+        // The native cargo client's `cargo:token` credential provider sends the
+        // raw token as the Authorization header value with NO scheme prefix
+        // (e.g. `Authorization: <token>`). A scheme-less, single-word value is
+        // therefore treated as a Bearer token so cargo can authenticate.
+        ExtractedToken::Bearer(auth_header)
     } else {
         ExtractedToken::Invalid
     }
@@ -1086,6 +1092,10 @@ fn unauthorized_response() -> Response {
             "WWW-Authenticate",
             "Bearer realm=\"artifact-keeper\", charset=\"UTF-8\"",
         )
+        // Signals cargo 1.67+ to use the Cargo token protocol (sends the token
+        // as the raw Authorization header value) rather than aborting on the
+        // Basic/Bearer challenges it does not understand.
+        .header("WWW-Authenticate", "Cargo")
         .header(axum::http::header::CONTENT_TYPE, "text/plain")
         .body(axum::body::Body::from("Authentication required"))
         .unwrap()
@@ -2138,6 +2148,31 @@ mod tests {
             www_auth_values.iter().any(|v| v.starts_with("Bearer")),
             "expected a Bearer WWW-Authenticate challenge"
         );
+        // Must also include the Cargo challenge so cargo 1.67+ uses the token
+        // protocol instead of aborting on the Basic/Bearer challenges.
+        assert!(
+            www_auth_values.iter().any(|v| v.starts_with("Cargo")),
+            "expected a Cargo WWW-Authenticate challenge"
+        );
+    }
+
+    #[test]
+    fn test_extract_plain_token_treated_as_bearer() {
+        // The native cargo client sends the raw token with no scheme prefix;
+        // a scheme-less single-word value must be accepted as a Bearer token.
+        let result = extract_token_from_auth_header("ak_raw_cargo_token_123");
+        assert!(matches!(
+            result,
+            ExtractedToken::Bearer("ak_raw_cargo_token_123")
+        ));
+    }
+
+    #[test]
+    fn test_extract_plain_token_with_space_is_invalid() {
+        // A multi-word value that matches no known scheme is still invalid
+        // (it is not a raw token).
+        let result = extract_token_from_auth_header("Unknown scheme-value");
+        assert!(matches!(result, ExtractedToken::Invalid));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1777

Fixes the two live-verified cargo QA bugs from the QA fan-out sweep.

**1. [CRITICAL] Native cargo client auth rejected (raw token + missing Cargo challenge)**
The native cargo client's `cargo:token` credential provider sends the raw token as the `Authorization` header value with **no** scheme prefix, but `extract_token_from_auth_header` only handled `Bearer`/`ApiKey`/`Basic` and returned `Invalid` for a scheme-less token, causing a 401. Additionally, `unauthorized_response` only emitted `Basic` and `Bearer` `WWW-Authenticate` challenges, never `Cargo`, so cargo 1.67+ never engaged the token protocol.
- `auth.rs`: a non-empty, single-word (no space) Authorization value is now treated as a `Bearer` token.
- `auth.rs`: `unauthorized_response` now also emits `WWW-Authenticate: Cargo`.

**2. [MEDIUM] Search `meta.total` returned page count, not total match count**
`search_crates` set `meta.total` to `crate_list.len()` — the LIMIT-truncated page slice — which breaks cargo's search pagination. It now runs a separate `COUNT(DISTINCT a.name)` query and reports that as `meta.total`. Response construction was extracted into the pure helper `build_search_response` for testability.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New tests:
- `auth::tests::test_extract_plain_token_treated_as_bearer` and `test_extract_plain_token_with_space_is_invalid` — cover the raw-token acceptance.
- `auth::tests::test_unauthorized_response_has_www_authenticate_headers` extended to assert the `Cargo` challenge.
- `cargo::tests::test_search_meta_total_reflects_total_not_page_len` and `test_search_meta_total_zero_when_no_matches` — assert `meta.total` is the total, not the page length.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (no new endpoints; behavior fixes only)

Verified locally against a fresh DB: `cargo fmt --check`, `SQLX_OFFLINE=true cargo clippy --workspace --all-targets -- -D warnings` (0 warnings), and the cargo + auth module tests (312 passed, 0 failed). `.sqlx` offline cache regenerated for the new COUNT query.