### PR TITLE
fix(scanning-lifecycle): resolve scanning-lifecycle QA bugs (#1784)

### DIFF
--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -493,8 +493,8 @@ mod tests {
         // that create_key, delete_key, and update_repo_signing_config enforce,
         // letting a non-admin JWT revoke (deactivate) any signing key via
         // POST /api/v1/signing/keys/{id}/revoke and break the trust chain.
-        // revoke_key now calls require_signing_admin(&auth)? first; pin that a
-        // non-admin is rejected with 403 (no DB needed).
+        // revoke_key now calls require_signing_admin(&auth)? first.
+        // (1) sanity: the gate itself rejects a non-admin.
         let ext = non_admin_jwt();
         match require_signing_admin(&ext) {
             Err(AppError::Authorization(_)) => {}
@@ -503,6 +503,24 @@ mod tests {
                 other
             ),
         }
+        // (2) the load-bearing assertion: pin that `revoke_key` ITSELF calls
+        // the gate. A direct `require_signing_admin` check (1) does NOT catch
+        // the gate being dropped from `revoke_key` — which is exactly the
+        // regression that shipped in edbe892d. Assert the gate appears inside
+        // revoke_key's body, so removing it fails the test suite.
+        let src = include_str!("signing.rs");
+        let start = src
+            .find("async fn revoke_key(")
+            .expect("revoke_key handler must exist");
+        let rest = &src[start..];
+        let end = rest[1..]
+            .find("\nasync fn ")
+            .map(|i| i + 1)
+            .unwrap_or(rest.len());
+        assert!(
+            rest[..end].contains("require_signing_admin"),
+            "revoke_key MUST call require_signing_admin (admin gate) — #1784 regression guard"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -212,6 +212,7 @@ async fn revoke_key(
     Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
+    require_signing_admin(&auth)?;
     let svc = signing_service(&state);
     svc.revoke_key(key_id, Some(auth.user_id)).await?;
     Ok(Json(serde_json::json!({"revoked": true})))
@@ -483,6 +484,24 @@ mod tests {
         match require_signing_admin(&ext) {
             Err(AppError::Authorization(_)) => {}
             other => panic!("expected 403 Authorization for non-admin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_non_admin_blocked_from_revoking_signing_key() {
+        // Regression for #1784: revoke_key previously omitted the admin gate
+        // that create_key, delete_key, and update_repo_signing_config enforce,
+        // letting a non-admin JWT revoke (deactivate) any signing key via
+        // POST /api/v1/signing/keys/{id}/revoke and break the trust chain.
+        // revoke_key now calls require_signing_admin(&auth)? first; pin that a
+        // non-admin is rejected with 403 (no DB needed).
+        let ext = non_admin_jwt();
+        match require_signing_admin(&ext) {
+            Err(AppError::Authorization(_)) => {}
+            other => panic!(
+                "expected 403 Authorization for non-admin revoke, got {:?}",
+                other
+            ),
         }
     }
 

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -610,6 +610,15 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
+        // #1784: axum 0.7 nest matches `/sbom` (no slash) against the inner `/`
+        // route but does NOT match the trailing-slash form `/sbom/`, which 404'd
+        // with an empty body instead of behaving like the list endpoint. Add an
+        // explicit redirect from the trailing-slash form to the canonical path
+        // so clients that append a slash still reach the list handler.
+        .route(
+            "/sbom/",
+            get(|| async { axum::response::Redirect::permanent("/api/v1/sbom") }),
+        )
         // Promotion routes with auth middleware (staging -> release workflow)
         .nest(
             "/promotion",
@@ -746,6 +755,30 @@ mod tests {
             incus_count >= 2,
             "expected handlers::incus::router() to be referenced at least \
              twice (once for /incus, once for /lxc); found {incus_count}"
+        );
+    }
+
+    #[test]
+    fn sbom_trailing_slash_is_handled() {
+        // Regression for #1784: axum 0.7's `.nest("/sbom", ...)` resolves the
+        // no-slash form `/sbom` (against the inner `/` route) but 404's the
+        // trailing-slash form `/sbom/` with an empty body. The fix registers an
+        // explicit redirect route for the trailing-slash form. A runtime test
+        // would need full app state + a DB; pin the routing decision in source.
+        assert!(
+            ROUTES_RS_SRC.contains(".nest(\n            \"/sbom\","),
+            "sbom nest registration missing; the trailing-slash redirect test \
+             below would otherwise be vacuously true"
+        );
+        assert!(
+            ROUTES_RS_SRC.contains(".route(\n            \"/sbom/\","),
+            "/sbom/ trailing-slash redirect missing; GET /api/v1/sbom/ will \
+             404 with an empty body instead of reaching the list handler \
+             (regression of #1784)"
+        );
+        assert!(
+            ROUTES_RS_SRC.contains("Redirect::permanent(\"/api/v1/sbom\")"),
+            "/sbom/ route must redirect to the canonical /api/v1/sbom path"
         );
     }
 


### PR DESCRIPTION
Closes #1784

## Summary

Fixes the 2 confirmed scanning-lifecycle QA bugs verified live on `:dev`.

### 1. [HIGH] Non-admin user can revoke signing keys
`revoke_key` (`backend/src/api/handlers/signing.rs`) was missing the
`require_signing_admin(&auth)?;` gate that fix commit `edbe892d` added to
`create_key`, `delete_key`, and `update_repo_signing_config` — `revoke_key`
was omitted from that patch. A non-admin JWT could `POST
/api/v1/signing/keys/{id}/revoke` and deactivate any signing key (HTTP 200
`{"revoked":true}`), subverting the artifact-signing trust model.

**Fix:** Added `require_signing_admin(&auth)?;` as the first statement in
`revoke_key`, mirroring `delete_key`.

**Regression test:**
`api::handlers::signing::tests::test_non_admin_blocked_from_revoking_signing_key`
pins that a non-admin JWT is rejected at the admin predicate (pure unit test,
no DB).

### 2. [LOW] GET /api/v1/sbom/ (trailing slash) returned 404 with empty body
axum 0.7's `.nest("/sbom", ...)` resolves the no-slash form `/sbom` against the
inner `/` route but does NOT match the trailing-slash form `/sbom/`, which
404'd with an empty body.

**Fix:** Added an explicit redirect route in `backend/src/api/routes.rs`
from `/sbom/` to the canonical `/api/v1/sbom`, so clients that append a slash
still reach the list handler.

**Regression test:** `api::routes::tests::sbom_trailing_slash_is_handled`
(source-level meta-test, matching the existing routes.rs test pattern — a
runtime test would need full app state + a DB fixture).

## Test Checklist
- [x] `cargo fmt`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo test -p artifact-keeper-backend --lib api::handlers::signing::` (23 passed)
- [x] `cargo test -p artifact-keeper-backend --lib api::routes::tests::` (4 passed)
- [x] Verified locally against a fresh QA database

## API Changes
- `POST /api/v1/signing/keys/{id}/revoke` now requires admin (returns 403 for non-admin) — security fix, brings it in line with the other key-mutation endpoints.
- `GET /api/v1/sbom/` now 308-redirects to `/api/v1/sbom` instead of 404.

No new migrations. No `sqlx` macros added or changed (offline cache untouched).
