### PR TITLE
fix(maven): proxy artifact-level maven-metadata.xml checksums upstream (#1775)

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -767,6 +767,94 @@ async fn download(
                         }
                     }
                 }
+
+                // For remote members, proxy the checksum file (or the
+                // metadata file) from upstream. Proxy-cached metadata is not
+                // in the `artifacts` table, so the generation above cannot
+                // serve checksums for a remote member's upstream metadata. The
+                // virtual repo's own (empty) storage probed earlier also misses.
+                for member in &members {
+                    if member.repo_type == RepositoryType::Remote {
+                        if let (Some(upstream_url), Some(ref proxy)) =
+                            (member.upstream_url.as_deref(), &state.proxy_service)
+                        {
+                            // Prefer the upstream checksum file directly.
+                            if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                                proxy,
+                                member.id,
+                                &member.key,
+                                upstream_url,
+                                &path,
+                            )
+                            .await
+                            {
+                                return Ok(Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "text/plain")
+                                    .body(Body::from(content))
+                                    .unwrap());
+                            }
+                            // Otherwise compute it from the upstream metadata file.
+                            if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                                proxy,
+                                member.id,
+                                &member.key,
+                                upstream_url,
+                                base_path,
+                            )
+                            .await
+                            {
+                                let checksum = compute_checksum(&content, checksum_type);
+                                return Ok(Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "text/plain")
+                                    .body(Body::from(checksum))
+                                    .unwrap());
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Proxy the checksum file from upstream for remote repos, or
+            // compute it from the proxied metadata file. Proxy-cached metadata
+            // is not in the `artifacts` table, so the DB-only generation below
+            // never serves a checksum for a remote repo's upstream metadata.
+            if metadata_checksum_should_proxy_upstream(
+                &repo.repo_type,
+                repo.upstream_url.is_some(),
+                state.proxy_service.is_some(),
+            ) {
+                if let (Some(ref upstream_url), Some(ref proxy)) =
+                    (&repo.upstream_url, &state.proxy_service)
+                {
+                    if let Ok((content, _)) =
+                        proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &path)
+                            .await
+                    {
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "text/plain")
+                            .body(Body::from(content))
+                            .unwrap());
+                    }
+                    if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                        proxy,
+                        repo.id,
+                        &repo_key,
+                        upstream_url,
+                        base_path,
+                    )
+                    .await
+                    {
+                        let checksum = compute_checksum(&content, checksum_type);
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "text/plain")
+                            .body(Body::from(checksum))
+                            .unwrap());
+                    }
+                }
             }
 
             // Fall back to dynamic generation for artifact-level metadata
@@ -1424,6 +1512,24 @@ async fn serve_artifact(
 /// unit-tested without constructing a full repository row.
 fn checksum_compute_eligible(repo_type: &str) -> bool {
     repo_type == RepositoryType::Local || repo_type == RepositoryType::Staging
+}
+
+/// Whether a `maven-metadata.xml.<algo>` checksum request should be served by
+/// proxying upstream (either the upstream checksum file, or computed from the
+/// upstream metadata file).
+///
+/// Remote repos (and remote members of a virtual) cache the upstream
+/// `maven-metadata.xml` in the proxy cache, not the `artifacts` table, so the
+/// DB-only `generate_metadata_for_artifact` path returns no rows and the
+/// request previously 404'd. Proxying is only possible when the repo is
+/// `Remote` and has both an `upstream_url` and a configured proxy service
+/// (#1775).
+fn metadata_checksum_should_proxy_upstream(
+    repo_type: &str,
+    has_upstream_url: bool,
+    has_proxy_service: bool,
+) -> bool {
+    repo_type == RepositoryType::Remote && has_upstream_url && has_proxy_service
 }
 
 async fn serve_computed_checksum(
@@ -2096,6 +2202,53 @@ mod tests {
         assert!(RepositoryType::Staging.is_hosted());
         assert!(!RepositoryType::Remote.is_hosted());
         assert!(!RepositoryType::Virtual.is_hosted());
+    }
+
+    // -----------------------------------------------------------------------
+    // metadata_checksum_should_proxy_upstream (#1775): artifact-level
+    // maven-metadata.xml.<algo> requests against a remote repo (or a remote
+    // member of a virtual) must fall back to proxying upstream instead of
+    // 404'ing, because proxy-cached metadata is not in the `artifacts` table.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_metadata_checksum_proxies_for_remote_with_upstream_and_proxy() {
+        // Regression for #1775: a fully-configured remote repo must proxy the
+        // metadata checksum upstream rather than return 404.
+        assert!(metadata_checksum_should_proxy_upstream(
+            RepositoryType::Remote.as_str(),
+            true,
+            true,
+        ));
+    }
+
+    #[test]
+    fn test_metadata_checksum_no_proxy_when_missing_upstream_or_service() {
+        // Cannot proxy without an upstream URL or a configured proxy service.
+        assert!(!metadata_checksum_should_proxy_upstream(
+            RepositoryType::Remote.as_str(),
+            false,
+            true,
+        ));
+        assert!(!metadata_checksum_should_proxy_upstream(
+            RepositoryType::Remote.as_str(),
+            true,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_metadata_checksum_no_proxy_for_hosted_or_virtual() {
+        // Hosted repos serve checksums from their own storage / artifact rows;
+        // virtual repos are resolved per-member. Neither proxies at the top
+        // level.
+        for ty in [
+            RepositoryType::Local.as_str(),
+            RepositoryType::Staging.as_str(),
+            RepositoryType::Virtual.as_str(),
+        ] {
+            assert!(!metadata_checksum_should_proxy_upstream(ty, true, true));
+        }
     }
 
     fn sample_coords() -> MavenCoordinates {


### PR DESCRIPTION
## Summary

Closes #1775

Artifact-level `maven-metadata.xml.{md5,sha1,sha256,sha512}` checksum requests against a **remote** repo (and against a **virtual** repo with a remote member) returned `404 NOT_FOUND` even though the `maven-metadata.xml` itself proxied fine.

Root cause: in `download()` (`backend/src/api/handlers/maven.rs`), the metadata-checksum branch (`is_metadata(base_path)`) probed the repo's own storage, then virtual-member storage, then fell straight through to the DB-only `generate_metadata_for_artifact(repo.id, ...)`. For a remote repo the upstream metadata is cached in the proxy cache, not the `artifacts` table, so generation produced no rows and the handler 404'd. The regular metadata GET (lines 815-829) and the stored-file checksum branch (lines 1027-1041) already had an upstream proxy fallback; the metadata-checksum branch did not.

Fix:
- Remote repo: added an upstream proxy fallback that first fetches the upstream checksum file directly, and if that is unavailable computes the checksum from the proxied `maven-metadata.xml`. Gated by a new pure helper `metadata_checksum_should_proxy_upstream(repo_type, has_upstream_url, has_proxy_service)`.
- Virtual repo: in the virtual-member loop, for `Remote` members proxy the upstream checksum file (or compute from the proxied metadata file), mirroring the existing stored-file virtual logic.

No new `sqlx` macros, migrations, or API surface — pure handler logic plus reuse of `proxy_helpers::proxy_fetch` and `compute_checksum`.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added three unit tests guarding the proxy-decision helper:
- `test_metadata_checksum_proxies_for_remote_with_upstream_and_proxy`
- `test_metadata_checksum_no_proxy_when_missing_upstream_or_service`
- `test_metadata_checksum_no_proxy_for_hosted_or_virtual`

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified locally against a fresh DB: `cargo fmt --check`, `SQLX_OFFLINE=true cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test -p artifact-keeper-backend --lib api::handlers::maven` (124 passed).

## API Changes
- [x] N/A - no API changes