### PR TITLE
fix(security): native middleware default-allowed rule-less private repos (#1802)

### DIFF
--- a/.sqlx/query-0b78b1df55a897dc9f8e28ddf35c97ba8981e294b196da98ff346f31ec4cb4b5.json
+++ b/.sqlx/query-0b78b1df55a897dc9f8e28ddf35c97ba8981e294b196da98ff346f31ec4cb4b5.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT a.name,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.name ILIKE $2\n          AND ($3::text IS NULL OR am.metadata #>> '{composer,type}' = $3)\n        ORDER BY a.name\n        LIMIT $4 OFFSET $5\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "0b78b1df55a897dc9f8e28ddf35c97ba8981e294b196da98ff346f31ec4cb4b5"
+}

--- a/.sqlx/query-67977bf72b8fd610a941dda6fb924373e7542b7e80d7f7c0752b6a86ba786729.json
+++ b/.sqlx/query-67977bf72b8fd610a941dda6fb924373e7542b7e80d7f7c0752b6a86ba786729.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.version as \"version?\", a.path, a.size_bytes,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = ANY($1::uuid[])\n          AND a.is_deleted = false\n          AND LOWER(a.name) = $2\n        ORDER BY a.created_at ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "version?",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "67977bf72b8fd610a941dda6fb924373e7542b7e80d7f7c0752b6a86ba786729"
+}

--- a/.sqlx/query-7341e2eb7cfde437182fb89cb9881700b6f29c9b051d7c98e74db37d6ec1eb8e.json
+++ b/.sqlx/query-7341e2eb7cfde437182fb89cb9881700b6f29c9b051d7c98e74db37d6ec1eb8e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(REPLACE(REPLACE(REPLACE(a.name, '_', '-'), '.', '-'), '--', '-')) = $2\n        ORDER BY a.created_at DESC\n        ",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.created_at,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(REPLACE(REPLACE(REPLACE(a.name, '_', '-'), '.', '-'), '--', '-')) = $2\n        ORDER BY a.created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -35,6 +35,11 @@
       },
       {
         "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
         "name": "metadata?",
         "type_info": "Jsonb"
       }
@@ -52,8 +57,9 @@
       true,
       false,
       false,
+      false,
       false
     ]
   },
-  "hash": "274ebade5ad184e2d9a4c4ff6dd70f7c2f31cd27ea9069d311beee24b3908948"
+  "hash": "7341e2eb7cfde437182fb89cb9881700b6f29c9b051d7c98e74db37d6ec1eb8e"
 }

--- a/.sqlx/query-93b3ad73e22c9ce9d635690b20ef3969b35252376bf90f317ae938b4d3af7d95.json
+++ b/.sqlx/query-93b3ad73e22c9ce9d635690b20ef3969b35252376bf90f317ae938b4d3af7d95.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "93b3ad73e22c9ce9d635690b20ef3969b35252376bf90f317ae938b4d3af7d95"
+}

--- a/.sqlx/query-aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182.json
+++ b/.sqlx/query-aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(DISTINCT a.name)\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND ($2 = '' OR a.name ILIKE '%' || $2 || '%')\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182"
+}

--- a/.sqlx/query-af06d488d04f6fe600a71bd2454a529fae0a3e8624d2478ddc85864980809f72.json
+++ b/.sqlx/query-af06d488d04f6fe600a71bd2454a529fae0a3e8624d2478ddc85864980809f72.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "af06d488d04f6fe600a71bd2454a529fae0a3e8624d2478ddc85864980809f72"
+}

--- a/.sqlx/query-bba5b44be999420534ef47a9aaae58a9297ffa80bb66e56a46ce3818d2e886fe.json
+++ b/.sqlx/query-bba5b44be999420534ef47a9aaae58a9297ffa80bb66e56a46ce3818d2e886fe.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT DISTINCT a.version\n                FROM artifacts a\n                INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id\n                WHERE vrm.virtual_repo_id = $1\n                  AND a.name = $2\n                  AND a.is_deleted = false\n                  AND a.version IS NOT NULL\n                ORDER BY a.version\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "bba5b44be999420534ef47a9aaae58a9297ffa80bb66e56a46ce3818d2e886fe"
+}

--- a/.sqlx/query-c1ac096c425e915cf48ef5d5ac7f2c8238403fe5e4672585cfb6b2a7987f9b4d.json
+++ b/.sqlx/query-c1ac096c425e915cf48ef5d5ac7f2c8238403fe5e4672585cfb6b2a7987f9b4d.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(DISTINCT a.name)\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.name ILIKE $2\n          AND ($3::text IS NULL OR am.metadata #>> '{composer,type}' = $3)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c1ac096c425e915cf48ef5d5ac7f2c8238403fe5e4672585cfb6b2a7987f9b4d"
+}

--- a/.sqlx/query-e9dbc0f5ade116181a1f7aeb39e644a2dddaf0aeb35d58be058dce481a2d52d3.json
+++ b/.sqlx/query-e9dbc0f5ade116181a1f7aeb39e644a2dddaf0aeb35d58be058dce481a2d52d3.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT a.created_at\n                    FROM artifacts a\n                    INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id\n                    WHERE vrm.virtual_repo_id = $1\n                      AND a.name = $2\n                      AND a.version = $3\n                      AND a.is_deleted = false\n                    ORDER BY a.created_at ASC\n                    LIMIT 1\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e9dbc0f5ade116181a1f7aeb39e644a2dddaf0aeb35d58be058dce481a2d52d3"
+}

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -8,8 +8,13 @@ use axum::{
     extract::{Extension, State},
     response::{IntoResponse, Response},
     routing::{delete, get, post},
-    Json, Router,
+    Router,
 };
+// Custom Json extractor: maps malformed/missing-field request bodies to
+// 400 VALIDATION_ERROR (structured envelope) instead of Axum's stock 422
+// + plain-text body. Drop-in for both request extraction and responses
+// (#1783 LOW: POST /auth/login returned 422 for missing `username`).
+use crate::api::extractors::Json;
 use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
@@ -714,6 +719,39 @@ mod tests {
         let json = r#"{"username": "admin"}"#;
         let result = serde_json::from_str::<LoginRequest>(json);
         assert!(result.is_err());
+    }
+
+    /// Regression (#1783 LOW): POST /auth/login with a missing required field
+    /// must surface as HTTP 400 + `{"code":"VALIDATION_ERROR"}`, not Axum's
+    /// stock 422 + plain-text body. The login handler now extracts via the
+    /// custom `crate::api::extractors::Json`; this exercises that exact path
+    /// for the `LoginRequest` shape (missing `username`).
+    #[tokio::test]
+    async fn test_login_missing_username_returns_400_validation_error() {
+        use axum::body::Body;
+        use axum::extract::FromRequest;
+        use axum::http::{header, Request, StatusCode};
+        use axum::response::IntoResponse;
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/v1/auth/login")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(r#"{"password": "Test123!"}"#))
+            .unwrap();
+
+        // `Json` here is the custom extractor (imported at module top).
+        let result = Json::<LoginRequest>::from_request(req, &()).await;
+        let err = result.expect_err("missing username must be rejected");
+        let response = err.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = axum::body::to_bytes(response.into_body(), 65_536)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert_eq!(body["code"], "VALIDATION_ERROR");
+        assert!(body["message"].is_string());
     }
 
     #[test]

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -395,6 +395,26 @@ async fn search_crates(
         .unwrap_or(10)
         .min(100);
 
+    // Total number of distinct crates matching the query. This must be counted
+    // independently of the paginated (LIMIT-truncated) result set, otherwise
+    // `meta.total` reports the page size rather than the real match count and
+    // cargo's search pagination breaks.
+    let total_matches: i64 = sqlx::query_scalar!(
+        r#"
+        SELECT COUNT(DISTINCT a.name)
+        FROM artifacts a
+        WHERE a.repository_id = $1
+          AND a.is_deleted = false
+          AND ($2 = '' OR a.name ILIKE '%' || $2 || '%')
+        "#,
+        repo.id,
+        query,
+    )
+    .fetch_one(&state.db)
+    .await
+    .map_err(map_db_err)?
+    .unwrap_or(0);
+
     // Search for crates matching the query
     let crates = sqlx::query!(
         r#"
@@ -440,18 +460,31 @@ async fn search_crates(
         })
         .collect();
 
-    let response = serde_json::json!({
-        "crates": crate_list,
-        "meta": {
-            "total": crate_list.len(),
-        }
-    });
+    let response = build_search_response(crate_list, total_matches);
 
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/json")
         .body(Body::from(serde_json::to_string(&response).unwrap()))
         .unwrap())
+}
+
+/// Build the cargo search-endpoint JSON body.
+///
+/// `meta.total` is the **total** number of distinct crates matching the query
+/// across all pages — not the length of the (LIMIT-truncated) `crate_list`
+/// for the current page. Cargo relies on `meta.total` for pagination, so it
+/// must be derived from a separate COUNT(*) and not from the page slice.
+fn build_search_response(
+    crate_list: Vec<serde_json::Value>,
+    total_matches: i64,
+) -> serde_json::Value {
+    serde_json::json!({
+        "crates": crate_list,
+        "meta": {
+            "total": total_matches,
+        }
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1558,6 +1591,33 @@ mod tests {
             "links": null,
             "rust_version": "1.70.0"
         })
+    }
+
+    // -----------------------------------------------------------------------
+    // build_search_response — meta.total must reflect the total match count
+    // across all pages, not the (LIMIT-truncated) current page length (#1777)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_search_meta_total_reflects_total_not_page_len() {
+        // One crate on the current page, but 3 total matches across all pages.
+        let page: Vec<serde_json::Value> = vec![serde_json::json!({
+            "name": "alpha-crate",
+            "max_version": "0.1.0",
+            "description": "",
+        })];
+        let resp = build_search_response(page, 3);
+        assert_eq!(resp["crates"].as_array().unwrap().len(), 1);
+        // Regression: previously this used crate_list.len() (== 1) and broke
+        // cargo search pagination. It must be the real total (3).
+        assert_eq!(resp["meta"]["total"], serde_json::json!(3));
+    }
+
+    #[test]
+    fn test_search_meta_total_zero_when_no_matches() {
+        let resp = build_search_response(Vec::new(), 0);
+        assert_eq!(resp["crates"].as_array().unwrap().len(), 0);
+        assert_eq!(resp["meta"]["total"], serde_json::json!(0));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -126,7 +126,14 @@ fn merge_composer_metadata(
 
     for key in COMPOSER_METADATA_KEYS {
         if let Some(val) = composer.get(*key) {
-            version_entry[*key] = val.clone();
+            // Skip JSON null so absent optional fields are omitted from the
+            // version entry rather than serialized as `"field": null`. This
+            // matters for records stored before ComposerJson gained
+            // `skip_serializing_if`, whose metadata still carries null fields
+            // (#1781).
+            if !val.is_null() {
+                version_entry[*key] = val.clone();
+            }
         }
     }
 }
@@ -183,6 +190,86 @@ async fn fetch_composer_artifacts(
             metadata: r.metadata,
         })
         .collect())
+}
+
+/// Row shape for the root `packages.json` index: one row per
+/// (name, version) artifact plus its merged composer metadata.
+struct PackageIndexRow {
+    name: String,
+    version: Option<String>,
+    checksum_sha256: String,
+    metadata: Option<serde_json::Value>,
+}
+
+/// Fetch every (non-deleted) artifact in `repo_id` for the root packages
+/// index. Returning rows (rather than a built map) lets the virtual
+/// `packages_json` fan-out aggregate rows from several members before
+/// rendering (#1781).
+async fn fetch_package_index_rows(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+) -> Result<Vec<PackageIndexRow>, Response> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT DISTINCT a.name, a.version,
+               a.checksum_sha256,
+               am.metadata as "metadata?"
+        FROM artifacts a
+        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
+        WHERE a.repository_id = $1 AND a.is_deleted = false
+        ORDER BY a.name, a.version
+        "#,
+        repo_id
+    )
+    .fetch_all(db)
+    .await
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Database error: {}", e),
+        )
+            .into_response()
+    })?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| PackageIndexRow {
+            name: r.name,
+            version: r.version,
+            checksum_sha256: r.checksum_sha256,
+            metadata: r.metadata,
+        })
+        .collect())
+}
+
+/// Build the `packages` map of the root `packages.json` index from artifact
+/// rows, grouping versions under each package name. `repo_key` is threaded
+/// into the dist URLs so (for virtual repos) downloads route back through the
+/// virtual repo rather than the member. Pure, so it is unit-testable (#1781).
+fn build_packages_index(
+    repo_key: &str,
+    rows: &[PackageIndexRow],
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut by_name: std::collections::HashMap<String, Vec<serde_json::Value>> =
+        std::collections::HashMap::new();
+
+    for row in rows {
+        let version = row.version.as_deref().unwrap_or("dev-main");
+        let entry = build_version_entry(
+            repo_key,
+            &row.name,
+            version,
+            &row.checksum_sha256,
+            row.metadata.as_ref(),
+        );
+        by_name.entry(row.name.clone()).or_default().push(entry);
+    }
+
+    let mut packages_map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    for (name, versions) in by_name {
+        packages_map.insert(name, serde_json::Value::Array(versions));
+    }
+    packages_map
 }
 
 /// Render the Composer v2 "minified" metadata document from a member's
@@ -367,49 +454,28 @@ async fn packages_json(
 ) -> Result<Response, Response> {
     let repo = resolve_composer_repo(&state.db, &repo_key).await?;
 
-    // Get all distinct vendor/package names in this repository
-    let packages = sqlx::query!(
-        r#"
-        SELECT DISTINCT a.name, a.version,
-               a.checksum_sha256,
-               am.metadata as "metadata?"
-        FROM artifacts a
-        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
-        WHERE a.repository_id = $1 AND a.is_deleted = false
-        ORDER BY a.name, a.version
-        "#,
-        repo.id
-    )
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-            .into_response()
-    })?;
+    // Virtual repos aggregate the index from their local/staging members:
+    // collect every member's artifacts and render them under the *virtual*
+    // repo key so dist URLs route back through us. Without this fan-out a
+    // virtual repo returned an empty `{}` even when a member held packages
+    // (#1781). Remote members are not aggregated into the root index (Composer
+    // resolves those per-package via the metadata-url).
+    let rows = if repo.repo_type == RepositoryType::Virtual {
+        let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+        let mut aggregated: Vec<PackageIndexRow> = Vec::new();
+        for member in &members {
+            if member.repo_type == RepositoryType::Local
+                || member.repo_type == RepositoryType::Staging
+            {
+                aggregated.extend(fetch_package_index_rows(&state.db, member.id).await?);
+            }
+        }
+        aggregated
+    } else {
+        fetch_package_index_rows(&state.db, repo.id).await?
+    };
 
-    // Group artifacts by package name
-    let mut by_name: std::collections::HashMap<String, Vec<serde_json::Value>> =
-        std::collections::HashMap::new();
-
-    for row in &packages {
-        let version = row.version.as_deref().unwrap_or("dev-main");
-        let entry = build_version_entry(
-            &repo_key,
-            &row.name,
-            version,
-            &row.checksum_sha256,
-            row.metadata.as_ref(),
-        );
-        by_name.entry(row.name.clone()).or_default().push(entry);
-    }
-
-    let mut packages_map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
-    for (name, versions) in &by_name {
-        packages_map.insert(name.clone(), serde_json::Value::Array(versions.clone()));
-    }
+    let packages_map = build_packages_index(&repo_key, &rows);
 
     let response = serde_json::json!({
         "packages": packages_map,
@@ -713,10 +779,40 @@ struct SearchQuery {
     q: Option<String>,
     #[serde(rename = "type")]
     package_type: Option<String>,
-    #[allow(dead_code)]
     per_page: Option<i64>,
-    #[allow(dead_code)]
     page: Option<i64>,
+}
+
+/// Build the `next` pagination URL for the search response, preserving the
+/// active `per_page` and `type` query parameters so paginated, filtered
+/// searches keep working past page 1 (#1781).
+///
+/// `per_page` is the *raw* request value (`None` when the client did not send
+/// one); we only append it when explicitly provided so default-page links stay
+/// clean. `type_filter` is appended verbatim when set.
+fn build_search_next_url(
+    repo_key: &str,
+    query_str: &str,
+    page: i64,
+    per_page: Option<i64>,
+    type_filter: Option<&str>,
+) -> String {
+    let per_page_param = match per_page {
+        Some(pp) => format!("&per_page={}", pp),
+        None => String::new(),
+    };
+    let type_param = match type_filter {
+        Some(t) => format!("&type={}", t),
+        None => String::new(),
+    };
+    format!(
+        "/composer/{}/search.json?q={}&page={}{}{}",
+        repo_key,
+        query_str,
+        page + 1,
+        per_page_param,
+        type_param,
+    )
 }
 
 async fn search(
@@ -734,6 +830,15 @@ async fn search(
     // Search by name pattern
     let search_pattern = format!("%{}%", query_str);
 
+    // The `type` filter is applied in SQL (against the composer metadata) so
+    // that pagination LIMIT/OFFSET and the total count both see the same
+    // filtered row set. Filtering in Rust *after* LIMIT/OFFSET (the old
+    // behaviour) under-filled pages and, worse, made the total count ignore
+    // `type` entirely — `type=library` returned total=6 with only 4 results
+    // (#1781). `$3::text IS NULL` short-circuits the predicate when no type is
+    // requested.
+    let type_filter = params.package_type.as_deref();
+
     let results = sqlx::query!(
         r#"
         SELECT DISTINCT a.name,
@@ -743,11 +848,13 @@ async fn search(
         WHERE a.repository_id = $1
           AND a.is_deleted = false
           AND a.name ILIKE $2
+          AND ($3::text IS NULL OR am.metadata #>> '{composer,type}' = $3)
         ORDER BY a.name
-        LIMIT $3 OFFSET $4
+        LIMIT $4 OFFSET $5
         "#,
         repo.id,
         search_pattern,
+        type_filter,
         per_page,
         offset
     )
@@ -761,22 +868,8 @@ async fn search(
             .into_response()
     })?;
 
-    // Optionally filter by type from metadata
     let search_results: Vec<serde_json::Value> = results
         .iter()
-        .filter(|r| {
-            if let Some(ref type_filter) = params.package_type {
-                r.metadata
-                    .as_ref()
-                    .and_then(|m| m.get("composer"))
-                    .and_then(|c| c.get("type"))
-                    .and_then(|t| t.as_str())
-                    .map(|t| t == type_filter)
-                    .unwrap_or(false)
-            } else {
-                true
-            }
-        })
         .map(|r| {
             let description = r
                 .metadata
@@ -796,17 +889,21 @@ async fn search(
         })
         .collect();
 
-    // Count total results for pagination
+    // Count total results for pagination — must honor the same `type`
+    // predicate as the page query (#1781).
     let total_count = sqlx::query_scalar!(
         r#"
-        SELECT COUNT(DISTINCT name)
-        FROM artifacts
-        WHERE repository_id = $1
-          AND is_deleted = false
-          AND name ILIKE $2
+        SELECT COUNT(DISTINCT a.name)
+        FROM artifacts a
+        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
+        WHERE a.repository_id = $1
+          AND a.is_deleted = false
+          AND a.name ILIKE $2
+          AND ($3::text IS NULL OR am.metadata #>> '{composer,type}' = $3)
         "#,
         repo.id,
-        search_pattern
+        search_pattern,
+        type_filter
     )
     .fetch_one(&state.db)
     .await
@@ -828,11 +925,12 @@ async fn search(
     });
 
     if has_next {
-        response["next"] = serde_json::Value::String(format!(
-            "/composer/{}/search.json?q={}&page={}",
-            repo_key,
-            query_str,
-            page + 1
+        response["next"] = serde_json::Value::String(build_search_next_url(
+            &repo_key,
+            &query_str,
+            page,
+            params.per_page,
+            type_filter,
         ));
     }
 
@@ -1444,19 +1542,139 @@ mod tests {
 
     #[test]
     fn test_search_next_page_url() {
-        let repo_key = "composer-hosted";
-        let query_str = "monolog";
-        let page = 2i64;
-        let next_url = format!(
-            "/composer/{}/search.json?q={}&page={}",
-            repo_key,
-            query_str,
-            page + 1
-        );
+        // Plain query, default per_page, no type filter: only q + page appear.
+        let next_url = build_search_next_url("composer-hosted", "monolog", 2, None, None);
         assert_eq!(
             next_url,
             "/composer/composer-hosted/search.json?q=monolog&page=3"
         );
+    }
+
+    #[test]
+    fn test_search_next_page_url_preserves_per_page() {
+        // #1781: per_page must survive into the next link so paginated
+        // searches keep the same page size.
+        let next_url = build_search_next_url("repo", "", 1, Some(1), None);
+        assert_eq!(next_url, "/composer/repo/search.json?q=&page=2&per_page=1");
+    }
+
+    #[test]
+    fn test_search_next_page_url_preserves_type() {
+        // #1781: a type-filtered search must keep the type on the next link,
+        // otherwise page 2 silently widens to all packages.
+        let next_url = build_search_next_url("repo", "", 1, None, Some("library"));
+        assert_eq!(
+            next_url,
+            "/composer/repo/search.json?q=&page=2&type=library"
+        );
+    }
+
+    #[test]
+    fn test_search_next_page_url_preserves_per_page_and_type() {
+        // Both active parameters appear together, per_page before type.
+        let next_url = build_search_next_url("repo", "log", 2, Some(5), Some("composer-plugin"));
+        assert_eq!(
+            next_url,
+            "/composer/repo/search.json?q=log&page=3&per_page=5&type=composer-plugin"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // build_packages_index (#1781) — virtual repo packages.json aggregation
+    // -----------------------------------------------------------------------
+
+    fn index_rows() -> Vec<PackageIndexRow> {
+        vec![
+            PackageIndexRow {
+                name: "testvendor/lib1".to_string(),
+                version: Some("1.0.0".to_string()),
+                checksum_sha256: "hash1".to_string(),
+                metadata: Some(serde_json::json!({"composer": {"type": "library"}})),
+            },
+            PackageIndexRow {
+                name: "testvendor/lib1".to_string(),
+                version: Some("1.1.0".to_string()),
+                checksum_sha256: "hash2".to_string(),
+                metadata: None,
+            },
+            PackageIndexRow {
+                name: "testvendor/myplugin".to_string(),
+                version: Some("2.0.0".to_string()),
+                checksum_sha256: "hash3".to_string(),
+                metadata: Some(serde_json::json!({"composer": {"type": "composer-plugin"}})),
+            },
+        ]
+    }
+
+    #[test]
+    fn test_build_packages_index_groups_versions_by_name() {
+        let map = build_packages_index("virt", &index_rows());
+        assert_eq!(map.len(), 2, "two distinct package names");
+        let lib1 = map["testvendor/lib1"].as_array().unwrap();
+        assert_eq!(lib1.len(), 2, "lib1 has two versions");
+        let plugin = map["testvendor/myplugin"].as_array().unwrap();
+        assert_eq!(plugin.len(), 1);
+        assert_eq!(plugin[0]["type"], "composer-plugin");
+    }
+
+    #[test]
+    fn test_build_packages_index_dist_url_uses_repo_key() {
+        // For a virtual repo the index is rendered under the virtual repo key
+        // so dist downloads route back through us, not the member.
+        let map = build_packages_index("vf-virt", &index_rows());
+        let url = map["testvendor/myplugin"][0]["dist"]["url"]
+            .as_str()
+            .unwrap();
+        assert_eq!(
+            url,
+            "/composer/vf-virt/dist/testvendor/myplugin/2.0.0/hash3.zip"
+        );
+    }
+
+    #[test]
+    fn test_build_packages_index_empty_rows_is_empty_map() {
+        let map = build_packages_index("virt", &[]);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn test_build_packages_index_null_version_falls_back_to_dev_main() {
+        let rows = [PackageIndexRow {
+            name: "vendor/pkg".to_string(),
+            version: None,
+            checksum_sha256: "h".to_string(),
+            metadata: None,
+        }];
+        let map = build_packages_index("r", &rows);
+        assert_eq!(map["vendor/pkg"][0]["version"], "dev-main");
+    }
+
+    // -----------------------------------------------------------------------
+    // merge_composer_metadata: JSON null fields are omitted (#1781)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_merge_composer_metadata_skips_json_null() {
+        // Records stored before ComposerJson gained skip_serializing_if carry
+        // explicit nulls for absent optional fields. Those must NOT leak into
+        // the rendered version entry as `"field": null`.
+        let mut entry = serde_json::json!({"name": "vendor/pkg", "version": "1.0.0"});
+        let metadata = serde_json::json!({
+            "composer": {
+                "description": serde_json::Value::Null,
+                "type": "library",
+                "license": serde_json::Value::Null,
+                "require": serde_json::Value::Null,
+            }
+        });
+        merge_composer_metadata(&mut entry, Some(&metadata));
+        assert_eq!(entry["type"], "library");
+        assert!(
+            entry.get("description").is_none(),
+            "null description must be omitted, not serialized as null"
+        );
+        assert!(entry.get("license").is_none());
+        assert!(entry.get("require").is_none());
     }
 
     #[test]
@@ -2415,6 +2633,149 @@ mod metadata_db_tests {
         let (status, _) = tdh::send(app, req).await;
         assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
         vf.teardown().await;
+    }
+
+    // -- Virtual repo: packages.json aggregates from local members (#1781) --
+
+    #[tokio::test]
+    async fn virtual_packages_json_aggregates_member_packages() {
+        let Some(vf) = tdh::Fixture::setup("virtual", "composer").await else {
+            return;
+        };
+        let (member_id, _member_key, member_dir) =
+            tdh::create_repo(&vf.pool, "local", "composer").await;
+        // The member holds two packages; the virtual root index must surface
+        // both (pre-fix it returned an empty `{}`).
+        insert_artifact(
+            &vf.pool,
+            member_id,
+            "testvendor/mypackage",
+            "1.0.0",
+            "aaa111",
+            Some(serde_json::json!({"composer": {"type": "library"}})),
+        )
+        .await;
+        insert_artifact(
+            &vf.pool,
+            member_id,
+            "testvendor/myplugin",
+            "2.0.0",
+            "bbb222",
+            Some(serde_json::json!({"composer": {"type": "composer-plugin"}})),
+        )
+        .await;
+        add_member(&vf.pool, vf.repo_id, member_id, 0).await;
+
+        let app = vf.router_anon(super::router());
+        let req = tdh::get(format!("/{}/packages.json", vf.repo_key));
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let json = body_json(&body).await;
+        let packages = json["packages"].as_object().unwrap();
+        assert_eq!(
+            packages.len(),
+            2,
+            "virtual packages.json must aggregate both member packages (#1781)"
+        );
+        assert!(packages.contains_key("testvendor/mypackage"));
+        assert!(packages.contains_key("testvendor/myplugin"));
+        // dist URLs route back through the virtual repo, not the member.
+        let url = packages["testvendor/mypackage"][0]["dist"]["url"]
+            .as_str()
+            .unwrap();
+        assert!(
+            url.starts_with(&format!("/composer/{}/dist/", vf.repo_key)),
+            "dist url must point at virtual repo, got {}",
+            url
+        );
+
+        tdh::cleanup(&vf.pool, member_id, Uuid::new_v4()).await;
+        let _ = std::fs::remove_dir_all(member_dir);
+        vf.teardown().await;
+    }
+
+    // -- Search: type filter must constrain BOTH results and total (#1781) --
+
+    #[tokio::test]
+    async fn search_type_filter_constrains_total_count() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // Three libraries, one plugin: a `type=composer-plugin` search must
+        // report total=1, not total=4 (the old count ignored `type`).
+        insert_artifact(
+            &f.pool,
+            f.repo_id,
+            "testvendor/lib1",
+            "1.0.0",
+            "h1",
+            Some(serde_json::json!({"composer": {"type": "library"}})),
+        )
+        .await;
+        insert_artifact(
+            &f.pool,
+            f.repo_id,
+            "testvendor/lib2",
+            "1.0.0",
+            "h2",
+            Some(serde_json::json!({"composer": {"type": "library"}})),
+        )
+        .await;
+        insert_artifact(
+            &f.pool,
+            f.repo_id,
+            "testvendor/lib3",
+            "1.0.0",
+            "h3",
+            Some(serde_json::json!({"composer": {"type": "library"}})),
+        )
+        .await;
+        insert_artifact(
+            &f.pool,
+            f.repo_id,
+            "testvendor/myplugin",
+            "1.0.0",
+            "h4",
+            Some(serde_json::json!({"composer": {"type": "composer-plugin"}})),
+        )
+        .await;
+
+        let app = f.router_anon(super::router());
+        let req = tdh::get(format!("/{}/search.json?type=composer-plugin", f.repo_key));
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let json = body_json(&body).await;
+        let results = json["results"].as_array().unwrap();
+        assert_eq!(results.len(), 1, "only the plugin matches");
+        assert_eq!(results[0]["name"], "testvendor/myplugin");
+        assert_eq!(
+            json["total"], 1,
+            "total must honor the type filter, not report all packages (#1781)"
+        );
+
+        // And a type-filtered, paginated search keeps type + per_page on next.
+        let app2 = f.router_anon(super::router());
+        let req2 = tdh::get(format!(
+            "/{}/search.json?type=library&per_page=1&page=1",
+            f.repo_key
+        ));
+        let (status2, body2) = tdh::send(app2, req2).await;
+        assert_eq!(status2, axum::http::StatusCode::OK);
+        let json2 = body_json(&body2).await;
+        assert_eq!(json2["total"], 3, "three libraries");
+        let next = json2["next"].as_str().expect("next link present");
+        assert!(
+            next.contains("type=library"),
+            "next must preserve type filter, got {}",
+            next
+        );
+        assert!(
+            next.contains("per_page=1"),
+            "next must preserve per_page, got {}",
+            next
+        );
+
+        f.teardown().await;
     }
 
     // -- Virtual repo: priority order — first member with the package wins -

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2639,7 +2639,11 @@ fn validate_conda_package(content: &[u8], filename: &str) -> Result<(), String> 
         ));
     }
 
-    // Validate that metadata extraction succeeds and has required fields
+    // Validate that metadata extraction succeeds and has required fields,
+    // and that those fields agree with the uploaded filename. Conda clients
+    // key repodata.json off the filename, so a mismatch between the embedded
+    // index.json and the filename silently publishes a package under the
+    // wrong coordinates (the embedded metadata is discarded). Reject it.
     if let Some(meta) = extract_conda_metadata(content, filename) {
         if meta.get("name").and_then(|v| v.as_str()).is_none() {
             return Err("Invalid package metadata: missing 'name' field".to_string());
@@ -2647,9 +2651,56 @@ fn validate_conda_package(content: &[u8], filename: &str) -> Result<(), String> 
         if meta.get("version").and_then(|v| v.as_str()).is_none() {
             return Err("Invalid package metadata: missing 'version' field".to_string());
         }
+        check_filename_matches_metadata(filename, &meta)?;
     }
     // Note: we don't fail if metadata extraction fails entirely, since
     // the filename already carries name/version info. The package is still usable.
+
+    Ok(())
+}
+
+/// Cross-check the uploaded filename against the embedded `index.json`
+/// metadata. Returns an error string when the filename-derived
+/// `name`/`version`/`build` disagree with the metadata fields.
+///
+/// The `build` is only compared when present in both the filename and the
+/// metadata, since some legacy v1 packages omit a `build` key in index.json.
+/// If the filename cannot be parsed at all, validation is left to the
+/// structural checks above (we do not fail solely on an unparseable name).
+fn check_filename_matches_metadata(
+    filename: &str,
+    meta: &serde_json::Value,
+) -> std::result::Result<(), String> {
+    let Ok((fname, fver, fbuild)) =
+        crate::formats::conda_native::CondaNativeHandler::parse_package_filename(filename)
+    else {
+        return Ok(());
+    };
+
+    if let Some(meta_name) = meta.get("name").and_then(|v| v.as_str()) {
+        if meta_name != fname {
+            return Err(format!(
+                "Package name mismatch: filename declares '{}' but index.json metadata says '{}'",
+                fname, meta_name
+            ));
+        }
+    }
+    if let Some(meta_version) = meta.get("version").and_then(|v| v.as_str()) {
+        if meta_version != fver {
+            return Err(format!(
+                "Package version mismatch: filename declares '{}' but index.json metadata says '{}'",
+                fver, meta_version
+            ));
+        }
+    }
+    if let Some(meta_build) = meta.get("build").and_then(|v| v.as_str()) {
+        if meta_build != fbuild {
+            return Err(format!(
+                "Package build mismatch: filename declares '{}' but index.json metadata says '{}'",
+                fbuild, meta_build
+            ));
+        }
+    }
 
     Ok(())
 }
@@ -4461,6 +4512,68 @@ mod tests {
         assert!(
             result.is_ok(),
             "Valid .tar.bz2 package should pass: {:?}",
+            result
+        );
+    }
+
+    /// Regression (#1782): the uploaded filename must match the embedded
+    /// index.json metadata. Previously a package whose filename declared
+    /// `postpkg-3.0.0-py312_0` while index.json said `name=testpkg,
+    /// version=1.0.0` was accepted and silently published under the
+    /// filename coordinates, discarding the embedded metadata.
+    #[test]
+    fn test_validate_v1_package_filename_metadata_mismatch_name() {
+        let index = serde_json::json!({
+            "name": "testpkg",
+            "version": "1.0.0",
+            "build": "py310_0",
+            "depends": [],
+        });
+        let package = build_test_conda_v1_package(&index);
+        // Filename declares a completely different package than index.json.
+        let result = validate_conda_package(&package, "postpkg-3.0.0-py312_0.tar.bz2");
+        assert!(
+            result.is_err(),
+            "filename/metadata mismatch must be rejected, got Ok"
+        );
+        assert!(
+            result.unwrap_err().contains("name mismatch"),
+            "expected a name-mismatch error"
+        );
+    }
+
+    #[test]
+    fn test_validate_v1_package_filename_metadata_mismatch_version() {
+        let index = serde_json::json!({
+            "name": "testpkg",
+            "version": "1.0.0",
+            "build": "py310_0",
+            "depends": [],
+        });
+        let package = build_test_conda_v1_package(&index);
+        // Same name+build, but the version differs from index.json.
+        let result = validate_conda_package(&package, "testpkg-9.9.9-py310_0.tar.bz2");
+        assert!(result.is_err(), "version mismatch must be rejected, got Ok");
+        assert!(
+            result.unwrap_err().contains("version mismatch"),
+            "expected a version-mismatch error"
+        );
+    }
+
+    #[test]
+    fn test_validate_v1_package_filename_metadata_match_ok() {
+        let index = serde_json::json!({
+            "name": "testpkg",
+            "version": "1.0.0",
+            "build": "py310_0",
+            "depends": [],
+        });
+        let package = build_test_conda_v1_package(&index);
+        // Filename agrees with index.json on name, version, and build.
+        let result = validate_conda_package(&package, "testpkg-1.0.0-py310_0.tar.bz2");
+        assert!(
+            result.is_ok(),
+            "matching filename/metadata must pass: {:?}",
             result
         );
     }

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -442,6 +442,50 @@ async fn list_versions(
         .join("\n");
 
     if body.is_empty() {
+        // Virtual repo: the version list also lives in the artifact tables of
+        // local (non-Remote) member repos, which `try_proxy_go_metadata` does
+        // not consult. Aggregate distinct versions across all members first so
+        // a module stored only in a Local member is listed (#1782).
+        if repo.repo_type == RepositoryType::Virtual {
+            let member_versions: Vec<Option<String>> = sqlx::query_scalar!(
+                r#"
+                SELECT DISTINCT a.version
+                FROM artifacts a
+                INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id
+                WHERE vrm.virtual_repo_id = $1
+                  AND a.name = $2
+                  AND a.is_deleted = false
+                  AND a.version IS NOT NULL
+                ORDER BY a.version
+                "#,
+                repo.id,
+                module
+            )
+            .fetch_all(&state.db)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Database error: {}", e),
+                )
+                    .into_response()
+            })?;
+
+            let member_body = member_versions
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            if !member_body.is_empty() {
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+                    .body(Body::from(member_body))
+                    .unwrap());
+            }
+        }
+
         let encoded = encode_module_path(module);
         let upstream_path = format!("{}/@v/list", encoded);
         if let Ok(resp) =
@@ -505,6 +549,52 @@ async fn version_info(
     let artifact = match artifact {
         Ok(a) => a,
         Err(not_found) => {
+            // Virtual repo: the version may be stored in a local (non-Remote)
+            // member repo whose artifact rows `try_proxy_go_metadata` never
+            // queries. Look across member repos for the earliest matching
+            // artifact before falling through to the upstream proxy (#1782).
+            if repo.repo_type == RepositoryType::Virtual {
+                if let Some(member_row) = sqlx::query!(
+                    r#"
+                    SELECT a.created_at
+                    FROM artifacts a
+                    INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id
+                    WHERE vrm.virtual_repo_id = $1
+                      AND a.name = $2
+                      AND a.version = $3
+                      AND a.is_deleted = false
+                    ORDER BY a.created_at ASC
+                    LIMIT 1
+                    "#,
+                    repo.id,
+                    module,
+                    version
+                )
+                .fetch_optional(&state.db)
+                .await
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("Database error: {}", e),
+                    )
+                        .into_response()
+                })? {
+                    let time_str = member_row
+                        .created_at
+                        .format("%Y-%m-%dT%H:%M:%SZ")
+                        .to_string();
+                    let info = serde_json::json!({
+                        "Version": version,
+                        "Time": time_str,
+                    });
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(CONTENT_TYPE, "application/json")
+                        .body(Body::from(serde_json::to_string(&info).unwrap()))
+                        .unwrap());
+                }
+            }
+
             let encoded = encode_module_path(module);
             let upstream_path = format!("{}/@v/{}.info", encoded, version);
             if let Ok(resp) =
@@ -618,8 +708,8 @@ async fn get_mod_file(
                         let name = module_clone.clone();
                         let ver = version_clone.clone();
                         async move {
-                            proxy_helpers::local_fetch_by_name_version(
-                                &db, &state, member_id, &location, &name, &ver,
+                            proxy_helpers::local_fetch_by_name_version_and_suffix(
+                                &db, &state, member_id, &location, &name, &ver, "%.mod",
                             )
                             .await
                         }
@@ -758,8 +848,8 @@ async fn download_zip(
                         let name = module_clone.clone();
                         let ver = version_clone.clone();
                         async move {
-                            proxy_helpers::local_fetch_by_name_version(
-                                &db, &state, member_id, &location, &name, &ver,
+                            proxy_helpers::local_fetch_by_name_version_and_suffix(
+                                &db, &state, member_id, &location, &name, &ver, "%.zip",
                             )
                             .await
                         }
@@ -1838,5 +1928,162 @@ mod tests {
         assert!(!is_sumdb_host_allowed("sum.golang.org.evil.com"));
         assert!(!is_sumdb_host_allowed("evil.com.sum.golang.org"));
         assert!(!is_sumdb_host_allowed("sum-golang-org.evil.com"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Virtual Go repo over a Local member (#1782).
+    //
+    // Three regressions, all driven end-to-end through the goproxy router with
+    // a virtual repo whose sole member is a Local repo holding a module's
+    // `.mod` and `.zip` (the `.mod` is seeded FIRST so the pre-fix
+    // `local_fetch_by_name_version` would return go.mod bytes for a `.zip`
+    // request):
+    //   1. `/@v/list`  must list the version from the local member (was 404).
+    //   2. `/@v/{v}.info` must return 200 + JSON (was 404).
+    //   3. `/@v/{v}.zip` must return the ZIP bytes, and `/@v/{v}.mod` the
+    //      go.mod bytes — never the same artifact for both.
+    // -----------------------------------------------------------------------
+    #[tokio::test]
+    async fn test_virtual_go_local_member_list_info_zip_mod() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+        use bytes::Bytes;
+        use uuid::Uuid;
+
+        // The fixture repo is the LOCAL member that physically holds the bytes.
+        let Some(fx) = tdh::Fixture::setup("local", "go").await else {
+            return;
+        };
+
+        let module = "example.com/qa-test-module";
+        let version = "v1.0.0";
+        let member = fx.repo_info("local", None);
+
+        // Seed the .mod FIRST, then the .zip — order matters for the bug.
+        let mod_bytes = b"module example.com/qa-test-module\n";
+        let zip_bytes = b"PK\x03\x04 this-is-the-zip-archive-not-the-gomod";
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &member,
+            &format!("go/{}/{}.mod", module, version),
+            &format!("{}/{}/go.mod", module, version),
+            module,
+            version,
+            "text/plain; charset=utf-8",
+            Bytes::from_static(mod_bytes),
+            fx.user_id,
+        )
+        .await;
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &member,
+            &format!("go/{}/{}.zip", module, version),
+            &format!("{}/{}/{}.zip", module, version, version),
+            module,
+            version,
+            "application/zip",
+            Bytes::from_static(zip_bytes),
+            fx.user_id,
+        )
+        .await;
+
+        // Build the virtual repo (shares the fixture's state/storage root so the
+        // local-member fetch can read the seeded bytes back).
+        let virtual_id = Uuid::new_v4();
+        let virtual_key = format!("v-go-1782-{}", virtual_id.simple());
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+             VALUES ($1, $2, $3, $4, 'virtual'::repository_type, 'go'::repository_format)",
+        )
+        .bind(virtual_id)
+        .bind(&virtual_key)
+        .bind(&virtual_key)
+        .bind(fx.storage_dir.to_string_lossy().as_ref())
+        .execute(&fx.pool)
+        .await
+        .expect("insert virtual repo");
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(virtual_id)
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert virtual member");
+
+        let send = |uri: String| {
+            let router = fx.router_with_auth(super::router());
+            async move {
+                let req = Request::builder()
+                    .method("GET")
+                    .uri(uri)
+                    .body(Body::empty())
+                    .unwrap();
+                tdh::send(router, req).await
+            }
+        };
+
+        // 1. /@v/list
+        let (list_status, list_body) = send(format!("/{}/{}/@v/list", virtual_key, module)).await;
+        // 2. /@v/{v}.info
+        let (info_status, _info_body) =
+            send(format!("/{}/{}/@v/{}.info", virtual_key, module, version)).await;
+        // 3a. /@v/{v}.zip
+        let (zip_status, zip_resp) =
+            send(format!("/{}/{}/@v/{}.zip", virtual_key, module, version)).await;
+        // 3b. /@v/{v}.mod
+        let (mod_status, mod_resp) =
+            send(format!("/{}/{}/@v/{}.mod", virtual_key, module, version)).await;
+
+        // Cleanup the virtual repo + members before asserting.
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(virtual_id)
+            .execute(&fx.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(virtual_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+
+        assert_eq!(
+            list_status,
+            StatusCode::OK,
+            "list must resolve from the local member (#1782)"
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&list_body).trim(),
+            version,
+            "list must contain the member's version"
+        );
+        assert_eq!(
+            info_status,
+            StatusCode::OK,
+            "info must resolve from the local member (#1782)"
+        );
+        assert_eq!(
+            zip_status,
+            StatusCode::OK,
+            "zip must resolve from the local member"
+        );
+        assert_eq!(
+            &zip_resp[..],
+            zip_bytes,
+            "zip endpoint must serve the .zip artifact, not go.mod (#1782)"
+        );
+        assert_eq!(
+            mod_status,
+            StatusCode::OK,
+            "mod must resolve from the local member"
+        );
+        assert_eq!(
+            &mod_resp[..],
+            mod_bytes,
+            "mod endpoint must serve the go.mod artifact, not the zip (#1782)"
+        );
     }
 }

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -767,6 +767,94 @@ async fn download(
                         }
                     }
                 }
+
+                // For remote members, proxy the checksum file (or the
+                // metadata file) from upstream. Proxy-cached metadata is not
+                // in the `artifacts` table, so the generation above cannot
+                // serve checksums for a remote member's upstream metadata. The
+                // virtual repo's own (empty) storage probed earlier also misses.
+                for member in &members {
+                    if member.repo_type == RepositoryType::Remote {
+                        if let (Some(upstream_url), Some(ref proxy)) =
+                            (member.upstream_url.as_deref(), &state.proxy_service)
+                        {
+                            // Prefer the upstream checksum file directly.
+                            if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                                proxy,
+                                member.id,
+                                &member.key,
+                                upstream_url,
+                                &path,
+                            )
+                            .await
+                            {
+                                return Ok(Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "text/plain")
+                                    .body(Body::from(content))
+                                    .unwrap());
+                            }
+                            // Otherwise compute it from the upstream metadata file.
+                            if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                                proxy,
+                                member.id,
+                                &member.key,
+                                upstream_url,
+                                base_path,
+                            )
+                            .await
+                            {
+                                let checksum = compute_checksum(&content, checksum_type);
+                                return Ok(Response::builder()
+                                    .status(StatusCode::OK)
+                                    .header(CONTENT_TYPE, "text/plain")
+                                    .body(Body::from(checksum))
+                                    .unwrap());
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Proxy the checksum file from upstream for remote repos, or
+            // compute it from the proxied metadata file. Proxy-cached metadata
+            // is not in the `artifacts` table, so the DB-only generation below
+            // never serves a checksum for a remote repo's upstream metadata.
+            if metadata_checksum_should_proxy_upstream(
+                &repo.repo_type,
+                repo.upstream_url.is_some(),
+                state.proxy_service.is_some(),
+            ) {
+                if let (Some(ref upstream_url), Some(ref proxy)) =
+                    (&repo.upstream_url, &state.proxy_service)
+                {
+                    if let Ok((content, _)) =
+                        proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &path)
+                            .await
+                    {
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "text/plain")
+                            .body(Body::from(content))
+                            .unwrap());
+                    }
+                    if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                        proxy,
+                        repo.id,
+                        &repo_key,
+                        upstream_url,
+                        base_path,
+                    )
+                    .await
+                    {
+                        let checksum = compute_checksum(&content, checksum_type);
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "text/plain")
+                            .body(Body::from(checksum))
+                            .unwrap());
+                    }
+                }
             }
 
             // Fall back to dynamic generation for artifact-level metadata
@@ -1424,6 +1512,24 @@ async fn serve_artifact(
 /// unit-tested without constructing a full repository row.
 fn checksum_compute_eligible(repo_type: &str) -> bool {
     repo_type == RepositoryType::Local || repo_type == RepositoryType::Staging
+}
+
+/// Whether a `maven-metadata.xml.<algo>` checksum request should be served by
+/// proxying upstream (either the upstream checksum file, or computed from the
+/// upstream metadata file).
+///
+/// Remote repos (and remote members of a virtual) cache the upstream
+/// `maven-metadata.xml` in the proxy cache, not the `artifacts` table, so the
+/// DB-only `generate_metadata_for_artifact` path returns no rows and the
+/// request previously 404'd. Proxying is only possible when the repo is
+/// `Remote` and has both an `upstream_url` and a configured proxy service
+/// (#1775).
+fn metadata_checksum_should_proxy_upstream(
+    repo_type: &str,
+    has_upstream_url: bool,
+    has_proxy_service: bool,
+) -> bool {
+    repo_type == RepositoryType::Remote && has_upstream_url && has_proxy_service
 }
 
 async fn serve_computed_checksum(
@@ -2096,6 +2202,53 @@ mod tests {
         assert!(RepositoryType::Staging.is_hosted());
         assert!(!RepositoryType::Remote.is_hosted());
         assert!(!RepositoryType::Virtual.is_hosted());
+    }
+
+    // -----------------------------------------------------------------------
+    // metadata_checksum_should_proxy_upstream (#1775): artifact-level
+    // maven-metadata.xml.<algo> requests against a remote repo (or a remote
+    // member of a virtual) must fall back to proxying upstream instead of
+    // 404'ing, because proxy-cached metadata is not in the `artifacts` table.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_metadata_checksum_proxies_for_remote_with_upstream_and_proxy() {
+        // Regression for #1775: a fully-configured remote repo must proxy the
+        // metadata checksum upstream rather than return 404.
+        assert!(metadata_checksum_should_proxy_upstream(
+            RepositoryType::Remote.as_str(),
+            true,
+            true,
+        ));
+    }
+
+    #[test]
+    fn test_metadata_checksum_no_proxy_when_missing_upstream_or_service() {
+        // Cannot proxy without an upstream URL or a configured proxy service.
+        assert!(!metadata_checksum_should_proxy_upstream(
+            RepositoryType::Remote.as_str(),
+            false,
+            true,
+        ));
+        assert!(!metadata_checksum_should_proxy_upstream(
+            RepositoryType::Remote.as_str(),
+            true,
+            false,
+        ));
+    }
+
+    #[test]
+    fn test_metadata_checksum_no_proxy_for_hosted_or_virtual() {
+        // Hosted repos serve checksums from their own storage / artifact rows;
+        // virtual repos are resolved per-member. Neither proxies at the top
+        // level.
+        for ty in [
+            RepositoryType::Local.as_str(),
+            RepositoryType::Staging.as_str(),
+            RepositoryType::Virtual.as_str(),
+        ] {
+            assert!(!metadata_checksum_should_proxy_upstream(ty, true, true));
+        }
     }
 
     fn sample_coords() -> MavenCoordinates {

--- a/backend/src/api/handlers/monitoring.rs
+++ b/backend/src/api/handlers/monitoring.rs
@@ -3,12 +3,17 @@
 use axum::{
     extract::{Extension, Query, State},
     routing::{get, post},
-    Json, Router,
+    Router,
 };
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 
+// Use the project's custom `Json` extractor so a malformed/incomplete request
+// body (e.g. missing `service_name`) surfaces as the standard 400 +
+// `VALIDATION_ERROR` JSON envelope rather than Axum's stock 422 + text/plain
+// body. Responses are still rendered via `axum::Json` (re-exported below).
+use crate::api::extractors::Json;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -37,6 +42,15 @@ pub struct HealthLogQuery {
     pub limit: Option<i64>,
 }
 
+/// Clamp a caller-supplied `limit` into the `[1, 500]` range.
+///
+/// `None` defaults to 100. Negative or zero values are floored to 1 so the
+/// value handed to `LIMIT` is always a positive integer (a negative `LIMIT`
+/// makes Postgres raise an error, which previously surfaced as a 500).
+fn clamp_health_log_limit(limit: Option<i64>) -> i64 {
+    limit.unwrap_or(100).clamp(1, 500)
+}
+
 /// GET /api/v1/admin/monitoring/health-log
 #[utoipa::path(
     get,
@@ -54,7 +68,11 @@ pub async fn get_health_log(
     Query(query): Query<HealthLogQuery>,
 ) -> Result<Json<Vec<ServiceHealthEntry>>> {
     let monitor = HealthMonitorService::new(state.db.clone(), MonitorConfig::default());
-    let limit = query.limit.unwrap_or(100).min(500);
+    // Clamp to a sane range: a non-positive limit (e.g. `?limit=-1` or `?limit=0`)
+    // must not reach the query, where it would either yield no rows or, for
+    // negative values, trigger a Postgres error (`LIMIT must not be negative`)
+    // that surfaced as a 500. Floor at 1 and cap at 500.
+    let limit = clamp_health_log_limit(query.limit);
     let entries = monitor
         .get_health_log(query.service.as_deref(), limit)
         .await?;
@@ -178,42 +196,35 @@ mod tests {
 
     #[test]
     fn test_limit_default_is_100() {
-        let query = HealthLogQuery {
-            service: None,
-            limit: None,
-        };
-        let limit = query.limit.unwrap_or(100).min(500);
-        assert_eq!(limit, 100);
+        assert_eq!(clamp_health_log_limit(None), 100);
     }
 
     #[test]
     fn test_limit_clamped_to_500() {
-        let query = HealthLogQuery {
-            service: None,
-            limit: Some(1000),
-        };
-        let limit = query.limit.unwrap_or(100).min(500);
-        assert_eq!(limit, 500);
+        assert_eq!(clamp_health_log_limit(Some(1000)), 500);
     }
 
     #[test]
     fn test_limit_below_max_preserved() {
-        let query = HealthLogQuery {
-            service: None,
-            limit: Some(250),
-        };
-        let limit = query.limit.unwrap_or(100).min(500);
-        assert_eq!(limit, 250);
+        assert_eq!(clamp_health_log_limit(Some(250)), 250);
     }
 
     #[test]
     fn test_limit_exactly_500() {
-        let query = HealthLogQuery {
-            service: None,
-            limit: Some(500),
-        };
-        let limit = query.limit.unwrap_or(100).min(500);
-        assert_eq!(limit, 500);
+        assert_eq!(clamp_health_log_limit(Some(500)), 500);
+    }
+
+    // Regression for the 500 returned by `?limit=-1`: a non-positive limit must
+    // be floored to 1 so it never reaches Postgres as a negative `LIMIT`.
+    #[test]
+    fn test_limit_negative_floored_to_1() {
+        assert_eq!(clamp_health_log_limit(Some(-1)), 1);
+        assert_eq!(clamp_health_log_limit(Some(i64::MIN)), 1);
+    }
+
+    #[test]
+    fn test_limit_zero_floored_to_1() {
+        assert_eq!(clamp_health_log_limit(Some(0)), 1);
     }
 
     // ── SuppressRequest deserialization tests ────────────────────────

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -987,6 +987,20 @@ fn build_tarball_response_stream(
     builder.body(Body::from_stream(stream)).unwrap()
 }
 
+/// Decide the `Content-Type` for an npm tarball served from a Virtual repo.
+///
+/// Virtual downloads are satisfied by a member repo's proxy-cache, and the
+/// sidecar records whatever content type the upstream sent — for npm that is
+/// frequently `application/octet-stream` (and occasionally a bogus
+/// text/HTML type on error pages that slipped into cache). npm tarballs are
+/// always gzip, and downstream SBOM/scanner tooling (Trivy, Grype) keys off
+/// the content type, so the virtual path must normalize to `application/gzip`
+/// just like the direct remote-repo path does. We therefore ignore the cached
+/// content type entirely and always return [`NPM_TARBALL_CONTENT_TYPE`].
+fn npm_virtual_tarball_content_type(_cached: Option<String>) -> Option<String> {
+    Some(NPM_TARBALL_CONTENT_TYPE.to_string())
+}
+
 /// Build an OK response with a given content type and body.
 fn build_ok_response(content_type: &str, body: impl Into<Body>) -> Response {
     Response::builder()
@@ -1226,10 +1240,13 @@ async fn serve_tarball(
         )
         .await?;
 
+        // Always serve npm virtual-repo tarballs as `application/gzip`,
+        // overriding whatever content type the proxy-cache sidecar recorded
+        // for the cached member artifact (see `npm_virtual_tarball_content_type`).
         return Ok(build_tarball_response_stream(
             result.body,
             filename,
-            result.content_type,
+            npm_virtual_tarball_content_type(result.content_type),
             result.content_length,
         ));
     }
@@ -3278,6 +3295,49 @@ mod tests {
             Some("application/x-custom")
         );
         assert!(h.get(CONTENT_LENGTH).is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // Regression: virtual-repo tarball content-type override (#1774)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_npm_virtual_tarball_content_type_always_gzip() {
+        // A Virtual npm repo serves tarballs out of a member's proxy cache.
+        // Upstream registries (and stale error-page caches) frequently record
+        // a non-gzip content type; the virtual download path must NOT leak that
+        // through, or downstream SBOM/scanner tooling mis-detects the archive.
+        // Regardless of the cached content type, the served type must be gzip,
+        // matching the direct remote-repo path.
+        for cached in [
+            None,
+            Some("application/octet-stream".to_string()),
+            Some("text/html".to_string()),
+            Some("application/gzip".to_string()),
+        ] {
+            assert_eq!(
+                npm_virtual_tarball_content_type(cached),
+                Some(NPM_TARBALL_CONTENT_TYPE.to_string()),
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_virtual_tarball_response_overrides_octet_stream() {
+        // End-to-end of the helper + response builder: an octet-stream cache
+        // record must be served as application/gzip on the streaming response.
+        let body: futures::stream::BoxStream<'static, crate::error::Result<Bytes>> =
+            Box::pin(futures::stream::once(async {
+                Ok(Bytes::from_static(b"tgz"))
+            }));
+        let ct = npm_virtual_tarball_content_type(Some("application/octet-stream".to_string()));
+        let resp = build_tarball_response_stream(body, "is-array-1.0.1.tgz", ct, Some(3));
+        assert_eq!(
+            resp.headers()
+                .get(CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some(NPM_TARBALL_CONTENT_TYPE),
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -81,6 +81,81 @@ async fn resolve_nuget_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Res
     .await
 }
 
+/// Resolve the set of repository IDs whose local `artifacts` rows should back
+/// a read query for `repo`.
+///
+/// * For a hosted / local repo this is simply `[repo.id]`.
+/// * For a virtual repo it is the IDs of all **non-remote** member repos
+///   (Local / Staging), so local listing/search endpoints federate across
+///   members. Remote members are handled separately via the proxy fallback
+///   because their content is fetched on demand rather than stored locally.
+///
+/// Returns the resolved IDs alongside the list of virtual members (empty for
+/// non-virtual repos) so callers can additionally proxy remote members.
+async fn effective_local_repo_ids(
+    db: &PgPool,
+    repo: &RepoInfo,
+) -> Result<(Vec<uuid::Uuid>, Vec<crate::models::repository::Repository>), Response> {
+    if repo.repo_type != RepositoryType::Virtual {
+        return Ok((vec![repo.id], Vec::new()));
+    }
+
+    let members = proxy_helpers::fetch_virtual_members(db, repo.id).await?;
+    let local_ids: Vec<uuid::Uuid> = members
+        .iter()
+        .filter(|m| m.repo_type != RepositoryType::Remote)
+        .map(|m| m.id)
+        .collect();
+    Ok((local_ids, members))
+}
+
+/// Detect a NuGet pre-release version. Per the SemVer rules NuGet follows, a
+/// pre-release version carries a `-` separated suffix after the version core
+/// (e.g. `2.0.0-beta.1`). Stable versions have no such suffix.
+fn is_prerelease_version(version: &str) -> bool {
+    version.contains('-')
+}
+
+/// Pick the version to surface as "latest" for a package in search results.
+///
+/// When `include_prerelease` is false, the highest **stable** version wins and
+/// pre-release versions are only considered when no stable version exists.
+/// When true, the highest version overall (stable or pre-release) wins.
+/// Returns `"0.0.0"` when `versions` is empty.
+fn select_latest_version(versions: &[String], include_prerelease: bool) -> &str {
+    let highest = |candidates: &[&String]| -> Option<String> {
+        candidates
+            .iter()
+            .max_by(|a, b| version_compare(a, b).cmp(&0))
+            .map(|s| s.to_string())
+    };
+
+    if !include_prerelease {
+        let stable: Vec<&String> = versions
+            .iter()
+            .filter(|v| !is_prerelease_version(v))
+            .collect();
+        if let Some(best) = highest(&stable) {
+            // Return a borrow of the original slice element matching `best`.
+            return versions
+                .iter()
+                .find(|v| **v == best)
+                .map(String::as_str)
+                .unwrap_or("0.0.0");
+        }
+    }
+
+    let all: Vec<&String> = versions.iter().collect();
+    match highest(&all) {
+        Some(best) => versions
+            .iter()
+            .find(|v| **v == best)
+            .map(String::as_str)
+            .unwrap_or("0.0.0"),
+        None => "0.0.0",
+    }
+}
+
 // ---------------------------------------------------------------------------
 // GET /nuget/{repo_key}/v3/index.json — Service index
 // ---------------------------------------------------------------------------
@@ -169,6 +244,7 @@ struct SearchQuery {
 struct SearchPackageRow {
     name: String,
     versions: Vec<String>,
+    description: Option<String>,
 }
 
 async fn search_packages(
@@ -182,7 +258,7 @@ async fn search_packages(
     let query_term = params.q.unwrap_or_default();
     let skip = params.skip.unwrap_or(0);
     let take = params.take.unwrap_or(20).min(100);
-    let _prerelease = params.prerelease.unwrap_or(false);
+    let prerelease = params.prerelease.unwrap_or(false);
 
     // Determine base URL for building resource links.
     let base = format!(
@@ -194,20 +270,37 @@ async fn search_packages(
     // Search distinct package names matching the query term.
     let search_pattern = format!("%{}%", query_term.to_lowercase());
 
+    // Federate over virtual members (local/staging) when the repo is virtual;
+    // otherwise query the repo itself.
+    let (repo_ids, _members) = effective_local_repo_ids(&state.db, &repo).await?;
+
+    // Pull the latest-by-created_at description per package via a LATERAL
+    // join so the search payload carries the package summary instead of a
+    // hardcoded empty string.
     let packages: Vec<SearchPackageRow> = sqlx::query_as(
         r#"
-        SELECT LOWER(name) AS name,
-               ARRAY_AGG(DISTINCT version) FILTER (WHERE version IS NOT NULL) AS versions
-        FROM artifacts
-        WHERE repository_id = $1
-          AND is_deleted = false
-          AND LOWER(name) LIKE $2
-        GROUP BY LOWER(name)
-        ORDER BY LOWER(name)
+        SELECT a.name AS name,
+               ARRAY_AGG(DISTINCT a.version) FILTER (WHERE a.version IS NOT NULL) AS versions,
+               (
+                   SELECT am.metadata->>'description'
+                   FROM artifacts a2
+                   LEFT JOIN artifact_metadata am ON am.artifact_id = a2.id
+                   WHERE a2.repository_id = ANY($1::uuid[])
+                     AND a2.is_deleted = false
+                     AND LOWER(a2.name) = LOWER(a.name)
+                   ORDER BY a2.created_at DESC
+                   LIMIT 1
+               ) AS description
+        FROM artifacts a
+        WHERE a.repository_id = ANY($1::uuid[])
+          AND a.is_deleted = false
+          AND LOWER(a.name) LIKE $2
+        GROUP BY LOWER(a.name), a.name
+        ORDER BY LOWER(a.name)
         LIMIT $3 OFFSET $4
         "#,
     )
-    .bind(repo.id)
+    .bind(&repo_ids)
     .bind(&search_pattern)
     .bind(take)
     .bind(skip)
@@ -222,17 +315,17 @@ async fn search_packages(
     })?;
 
     // Get total count for pagination.
-    let total_count = sqlx::query_scalar!(
+    let total_count: i64 = sqlx::query_scalar(
         r#"
-        SELECT COUNT(DISTINCT LOWER(name))::bigint as "count!"
+        SELECT COUNT(DISTINCT LOWER(name))::bigint
         FROM artifacts
-        WHERE repository_id = $1
+        WHERE repository_id = ANY($1::uuid[])
           AND is_deleted = false
           AND LOWER(name) LIKE $2
         "#,
-        repo.id,
-        search_pattern
     )
+    .bind(&repo_ids)
+    .bind(&search_pattern)
     .fetch_one(&state.db)
     .await
     .map_err(|e| {
@@ -247,12 +340,9 @@ async fn search_packages(
         .iter()
         .map(|p| {
             let id = &p.name;
-            let latest = p
-                .versions
-                .iter()
-                .max_by(|a, b| version_compare(a, b).cmp(&0))
-                .map(String::as_str)
-                .unwrap_or("0.0.0");
+            // When prerelease=false, prefer the highest *stable* version and
+            // only fall back to a pre-release if no stable version exists.
+            let latest = select_latest_version(&p.versions, prerelease);
 
             // Build version list entry for the latest version.
             let versions = vec![serde_json::json!({
@@ -266,7 +356,7 @@ async fn search_packages(
                 "registration": format!("{}/v3/registration/{}/index.json", base, id),
                 "id": id,
                 "version": latest,
-                "description": "",
+                "description": p.description.clone().unwrap_or_default(),
                 "totalDownloads": 0,
                 "versions": versions
             })
@@ -303,19 +393,23 @@ async fn registration_index(
         repo_key
     );
 
-    // Fetch all versions of this package.
+    // Resolve the set of local repo IDs to query: the repo itself, or all
+    // local/staging members for a virtual repo.
+    let (repo_ids, members) = effective_local_repo_ids(&state.db, &repo).await?;
+
+    // Fetch all versions of this package across the effective repo IDs.
     let artifacts = sqlx::query!(
         r#"
         SELECT a.id, a.version as "version?", a.path, a.size_bytes,
                am.metadata as "metadata?"
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
-        WHERE a.repository_id = $1
+        WHERE a.repository_id = ANY($1::uuid[])
           AND a.is_deleted = false
           AND LOWER(a.name) = $2
         ORDER BY a.created_at ASC
         "#,
-        repo.id,
+        &repo_ids,
         package_id_lower
     )
     .fetch_all(&state.db)
@@ -329,6 +423,65 @@ async fn registration_index(
     })?;
 
     if artifacts.is_empty() {
+        // Cache miss: proxy the registration index from upstream.
+        let upstream_path = format!("v3/registration/{}/index.json", package_id_lower);
+
+        // Remote repo: fetch directly from its upstream.
+        if repo.repo_type == RepositoryType::Remote {
+            if let (Some(ref upstream_url), Some(ref proxy)) =
+                (&repo.upstream_url, &state.proxy_service)
+            {
+                let (content, content_type) = proxy_helpers::proxy_fetch(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    &upstream_path,
+                )
+                .await?;
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(
+                        CONTENT_TYPE,
+                        content_type.unwrap_or_else(|| "application/json".to_string()),
+                    )
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+        }
+
+        // Virtual repo: try each remote member's upstream in priority order.
+        if repo.repo_type == RepositoryType::Virtual {
+            if let Some(proxy) = &state.proxy_service {
+                for member in &members {
+                    if member.repo_type != RepositoryType::Remote {
+                        continue;
+                    }
+                    let Some(upstream_url) = member.upstream_url.as_deref() else {
+                        continue;
+                    };
+                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
+                        proxy,
+                        member.id,
+                        &member.key,
+                        upstream_url,
+                        &upstream_path,
+                    )
+                    .await
+                    {
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(
+                                CONTENT_TYPE,
+                                content_type.unwrap_or_else(|| "application/json".to_string()),
+                            )
+                            .body(Body::from(content))
+                            .unwrap());
+                    }
+                }
+            }
+        }
+
         return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
     }
 
@@ -412,17 +565,21 @@ async fn flatcontainer_versions(
     let repo = resolve_nuget_repo(&state.db, &repo_key).await?;
     let package_id_lower = package_id.to_lowercase();
 
+    // Resolve the set of local repo IDs to query: the repo itself, or all
+    // local/staging members for a virtual repo.
+    let (repo_ids, members) = effective_local_repo_ids(&state.db, &repo).await?;
+
     let mut versions: Vec<String> = sqlx::query_scalar(
         r#"
         SELECT DISTINCT version
         FROM artifacts
-        WHERE repository_id = $1
+        WHERE repository_id = ANY($1::uuid[])
           AND is_deleted = false
           AND LOWER(name) = $2
           AND version IS NOT NULL
         "#,
     )
-    .bind(repo.id)
+    .bind(&repo_ids)
     .bind(&package_id_lower)
     .fetch_all(&state.db)
     .await
@@ -441,6 +598,65 @@ async fn flatcontainer_versions(
     });
 
     if versions.is_empty() {
+        // Cache miss: proxy the flatcontainer version index from upstream.
+        let upstream_path = format!("v3/flatcontainer/{}/index.json", package_id_lower);
+
+        // Remote repo: fetch directly from its upstream.
+        if repo.repo_type == RepositoryType::Remote {
+            if let (Some(ref upstream_url), Some(ref proxy)) =
+                (&repo.upstream_url, &state.proxy_service)
+            {
+                let (content, content_type) = proxy_helpers::proxy_fetch(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    &upstream_path,
+                )
+                .await?;
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(
+                        CONTENT_TYPE,
+                        content_type.unwrap_or_else(|| "application/json".to_string()),
+                    )
+                    .body(Body::from(content))
+                    .unwrap());
+            }
+        }
+
+        // Virtual repo: try each remote member's upstream in priority order.
+        if repo.repo_type == RepositoryType::Virtual {
+            if let Some(proxy) = &state.proxy_service {
+                for member in &members {
+                    if member.repo_type != RepositoryType::Remote {
+                        continue;
+                    }
+                    let Some(upstream_url) = member.upstream_url.as_deref() else {
+                        continue;
+                    };
+                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
+                        proxy,
+                        member.id,
+                        &member.key,
+                        upstream_url,
+                        &upstream_path,
+                    )
+                    .await
+                    {
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(
+                                CONTENT_TYPE,
+                                content_type.unwrap_or_else(|| "application/json".to_string()),
+                            )
+                            .body(Body::from(content))
+                            .unwrap());
+                    }
+                }
+            }
+        }
+
         return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
     }
 
@@ -1760,6 +1976,68 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // is_prerelease_version
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_prerelease_version_stable() {
+        assert!(!is_prerelease_version("1.0.0"));
+        assert!(!is_prerelease_version("13.0.1"));
+        assert!(!is_prerelease_version("2.0.0"));
+    }
+
+    #[test]
+    fn test_is_prerelease_version_prerelease() {
+        assert!(is_prerelease_version("2.0.0-beta.1"));
+        assert!(is_prerelease_version("1.0.0-rc1"));
+        assert!(is_prerelease_version("3.1.0-alpha"));
+    }
+
+    // -----------------------------------------------------------------------
+    // select_latest_version
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_select_latest_version_excludes_prerelease_by_default() {
+        // prerelease=false: the stable 1.0.0 wins over 2.0.0-beta.1, matching
+        // the QA finding where prerelease=false wrongly returned 2.0.0-beta.1.
+        let versions = vec!["1.0.0".to_string(), "2.0.0-beta.1".to_string()];
+        assert_eq!(select_latest_version(&versions, false), "1.0.0");
+    }
+
+    #[test]
+    fn test_select_latest_version_includes_prerelease_when_requested() {
+        // prerelease=true: the highest overall version (the beta) wins.
+        let versions = vec!["1.0.0".to_string(), "2.0.0-beta.1".to_string()];
+        assert_eq!(select_latest_version(&versions, true), "2.0.0-beta.1");
+    }
+
+    #[test]
+    fn test_select_latest_version_falls_back_to_prerelease_when_no_stable() {
+        // Only a pre-release exists; even with prerelease=false it must be
+        // surfaced rather than the "0.0.0" placeholder.
+        let versions = vec!["1.0.0-alpha".to_string()];
+        assert_eq!(select_latest_version(&versions, false), "1.0.0-alpha");
+    }
+
+    #[test]
+    fn test_select_latest_version_highest_stable() {
+        let versions = vec![
+            "1.0.0".to_string(),
+            "1.2.0".to_string(),
+            "1.1.0".to_string(),
+        ];
+        assert_eq!(select_latest_version(&versions, false), "1.2.0");
+    }
+
+    #[test]
+    fn test_select_latest_version_empty() {
+        let versions: Vec<String> = vec![];
+        assert_eq!(select_latest_version(&versions, false), "0.0.0");
+        assert_eq!(select_latest_version(&versions, true), "0.0.0");
+    }
+
     #[tokio::test]
     async fn test_flatcontainer_download_remote_arm_routes_through_cached_or_refetch_helper() {
         let Some(fx) = tdh::Fixture::setup("remote", "nuget").await else {
@@ -2168,6 +2446,223 @@ mod push_db_tests {
             desc
         );
 
+        f.teardown().await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DB-backed read-endpoint regression tests (#1778).
+//
+// These cover the QA findings that the search/registration/flatcontainer read
+// endpoints:
+//   * hardcoded an empty `description` in search results,
+//   * ignored the `prerelease` flag,
+//   * returned 404 instead of federating across virtual-repo members.
+//
+// They no-op cleanly when `DATABASE_URL` is unset.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod read_db_tests {
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::http::StatusCode;
+    use std::io::Write;
+    use uuid::Uuid;
+
+    /// Build a minimal valid `.nupkg` (ZIP with a single `.nuspec`).
+    fn build_nupkg(id: &str, version: &str, description: &str) -> Vec<u8> {
+        let buf = Vec::new();
+        let cursor = std::io::Cursor::new(buf);
+        let mut zip = zip::ZipWriter::new(cursor);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file(format!("{}.nuspec", id), options).unwrap();
+        let nuspec = format!(
+            "<?xml version=\"1.0\"?>\n\
+             <package>\n  <metadata>\n\
+             <id>{}</id>\n\
+             <version>{}</version>\n\
+             <description>{}</description>\n\
+             <authors>Test Author</authors>\n\
+             </metadata>\n</package>",
+            id, version, description
+        );
+        zip.write_all(nuspec.as_bytes()).unwrap();
+        let cursor = zip.finish().unwrap();
+        cursor.into_inner()
+    }
+
+    /// Push a package into the repo identified by `repo_key` via the handler.
+    async fn push_pkg(
+        f: &tdh::Fixture,
+        repo_key: &str,
+        id: &str,
+        version: &str,
+        description: &str,
+    ) {
+        let app = f.router_with_auth(super::router());
+        let req = tdh::put(
+            format!("/{}/api/v2/package", repo_key),
+            bytes::Bytes::from(build_nupkg(id, version, description)),
+        );
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "push of {}.{} failed: {} {:?}",
+            id,
+            version,
+            status,
+            String::from_utf8_lossy(&body)
+        );
+    }
+
+    /// GET a NuGet read endpoint anonymously (read paths require no auth).
+    async fn get_json(f: &tdh::Fixture, uri: String) -> (StatusCode, serde_json::Value) {
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(app, tdh::get(uri)).await;
+        let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+        (status, json)
+    }
+
+    // Finding: search always returned a hardcoded empty `description`.
+    #[tokio::test]
+    async fn search_returns_package_description() {
+        let Some(f) = tdh::Fixture::setup("local", "nuget").await else {
+            return;
+        };
+        push_pkg(
+            &f,
+            &f.repo_key,
+            "Qa.DescPkg",
+            "1.0.0",
+            "a documented package",
+        )
+        .await;
+
+        let (status, json) = get_json(&f, format!("/{}/v3/search?q=qa.descpkg", f.repo_key)).await;
+        assert_eq!(status, StatusCode::OK);
+        let data = json["data"].as_array().expect("data array");
+        assert_eq!(data.len(), 1, "expected one hit; body={json}");
+        assert_eq!(
+            data[0]["description"], "a documented package",
+            "search must surface the package description; body={json}"
+        );
+
+        f.teardown().await;
+    }
+
+    // Finding: the `prerelease` flag was parsed but ignored — search always
+    // returned the highest version including pre-releases.
+    #[tokio::test]
+    async fn search_respects_prerelease_flag() {
+        let Some(f) = tdh::Fixture::setup("local", "nuget").await else {
+            return;
+        };
+        push_pkg(&f, &f.repo_key, "Qa.PrerelPkg", "1.0.0", "stable").await;
+        push_pkg(&f, &f.repo_key, "Qa.PrerelPkg", "2.0.0-beta.1", "beta").await;
+
+        // prerelease=false → the stable 1.0.0 must win.
+        let (status, json) = get_json(
+            &f,
+            format!("/{}/v3/search?q=qa.prerelpkg&prerelease=false", f.repo_key),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            json["data"][0]["version"], "1.0.0",
+            "prerelease=false must surface the stable version; body={json}"
+        );
+
+        // prerelease=true → the higher pre-release wins.
+        let (status, json) = get_json(
+            &f,
+            format!("/{}/v3/search?q=qa.prerelpkg&prerelease=true", f.repo_key),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            json["data"][0]["version"], "2.0.0-beta.1",
+            "prerelease=true must surface the pre-release; body={json}"
+        );
+
+        f.teardown().await;
+    }
+
+    /// Create a virtual repo and link `member_id` as its sole member.
+    async fn create_virtual_with_member(pool: &sqlx::PgPool, member_id: Uuid) -> (Uuid, String) {
+        let (vid, vkey, _dir) = tdh::create_repo(pool, "virtual", "nuget").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(vid)
+        .bind(member_id)
+        .execute(pool)
+        .await
+        .expect("link virtual member");
+        (vid, vkey)
+    }
+
+    async fn drop_virtual(pool: &sqlx::PgPool, vid: Uuid) {
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(vid)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(vid)
+            .execute(pool)
+            .await;
+    }
+
+    // Findings: registration/index, flatcontainer/index, and search all
+    // returned 404 / empty instead of federating across virtual members.
+    #[tokio::test]
+    async fn virtual_repo_federates_read_endpoints_over_local_member() {
+        let Some(f) = tdh::Fixture::setup("local", "nuget").await else {
+            return;
+        };
+        // Seed a package into the local member.
+        push_pkg(&f, &f.repo_key, "Qa.FedPkg", "1.0.0", "federated package").await;
+
+        let (vid, vkey) = create_virtual_with_member(&f.pool, f.repo_id).await;
+
+        // registration/index must federate to the member and return 200.
+        let (status, json) = get_json(
+            &f,
+            format!("/{}/v3/registration/qa.fedpkg/index.json", vkey),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "virtual registration must federate; body={json}"
+        );
+        let items = json["items"][0]["items"].as_array().expect("items");
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["catalogEntry"]["version"], "1.0.0");
+
+        // flatcontainer/index must federate to the member and return 200.
+        let (status, json) = get_json(
+            &f,
+            format!("/{}/v3/flatcontainer/qa.fedpkg/index.json", vkey),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "virtual flatcontainer must federate; body={json}"
+        );
+        assert_eq!(json["versions"][0], "1.0.0");
+
+        // search must federate to the member and return the hit.
+        let (status, json) = get_json(&f, format!("/{}/v3/search?q=qa.fed", vkey)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            json["totalHits"], 1,
+            "virtual search must federate over members; body={json}"
+        );
+        assert_eq!(json["data"][0]["id"], "qa.fedpkg");
+
+        drop_virtual(&f.pool, vid).await;
         f.teardown().await;
     }
 }

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -3757,6 +3757,16 @@ async fn handle_start_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
+    // #1776: only repositories that store their own manifests (Local/Staging)
+    // accept pushes. Remote and Virtual repos must reject blob uploads instead
+    // of accepting content that the registry cannot durably own/serve.
+    if !stores_own_manifests(&repo.repo_type) {
+        return oci_error(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "UNSUPPORTED",
+            "pushes are not supported on remote or virtual repositories",
+        );
+    }
     let repo_id = repo.id;
     let location = repo.location;
 
@@ -5894,6 +5904,15 @@ async fn handle_put_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
+    // #1776: only repositories that store their own manifests (Local/Staging)
+    // accept manifest pushes. Remote and Virtual repos must reject the PUT.
+    if !stores_own_manifests(&repo.repo_type) {
+        return oci_error(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "UNSUPPORTED",
+            "pushes are not supported on remote or virtual repositories",
+        );
+    }
     let repo_id = repo.id;
     let image = repo.image;
 
@@ -6061,9 +6080,13 @@ async fn handle_tags_list(
 ) -> Response {
     let host = request_host(headers);
     let scope = pull_scope(image_name);
-    if authenticate_oci(&state.db, &state.config, headers)
-        .await
-        .is_err()
+    // #1776: mirror handle_head_manifest — anonymous tokens are allowed past the
+    // auth gate so a public repository's tags can be listed without credentials.
+    let is_anon = is_anonymous_token(headers);
+    if !is_anon
+        && authenticate_oci(&state.db, &state.config, headers)
+            .await
+            .is_err()
     {
         return unauthorized_challenge_with_scope(&host, Some(&scope));
     }
@@ -6072,6 +6095,11 @@ async fn handle_tags_list(
         Ok(r) => r,
         Err(e) => return e,
     };
+
+    // Anonymous tokens may only list tags on public repositories.
+    if is_anon && !repo.is_public {
+        return unauthorized_challenge_with_scope(&host, Some(&scope));
+    }
 
     let (n, last) = match parse_pagination_params(query) {
         Ok(v) => v,
@@ -6929,44 +6957,84 @@ async fn handle_delete_manifest(
         }
     };
 
-    // Delete all tag rows pointing to this digest within the repository
-    if let Err(e) = sqlx::query!(
-        "DELETE FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2",
+    // Remove tag rows for this delete. A digest reference is a content-address
+    // delete, so every tag pointing at that digest in this repo is removed. A
+    // tag-name reference removes ONLY the named tag row, leaving sibling tags
+    // that happen to share the same manifest digest intact (#1776).
+    let tag_delete = if is_digest_reference(reference) {
+        sqlx::query!(
+            "DELETE FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2",
+            repo.id,
+            digest
+        )
+        .execute(&mut *tx)
+        .await
+    } else {
+        sqlx::query!(
+            "DELETE FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3",
+            repo.id,
+            repo.image,
+            reference
+        )
+        .execute(&mut *tx)
+        .await
+    };
+    if let Err(e) = tag_delete {
+        return oci_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "INTERNAL_ERROR",
+            &e.to_string(),
+        );
+    }
+
+    // A tag-name delete only removes the named tag (#1776). If a sibling tag in
+    // this repo still points at the same manifest digest, the manifest is still
+    // live: skip the ref/blob-ref cleanup so its index edges and blob pins stay
+    // intact. The cleanup only runs once the last tag for the digest is gone (or
+    // for a content-addressed digest delete, which removes every such tag).
+    let digest_still_tagged = match sqlx::query_scalar!(
+        "SELECT EXISTS(SELECT 1 FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2)",
         repo.id,
         digest
     )
-    .execute(&mut *tx)
+    .fetch_one(&mut *tx)
     .await
     {
-        return oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            &e.to_string(),
-        );
-    }
+        Ok(exists) => exists.unwrap_or(false),
+        Err(e) => {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                &e.to_string(),
+            )
+        }
+    };
 
-    // Drop stale index relationships for this digest. Live child edges are
-    // preserved so a still-tagged parent index keeps the child relationship
-    // live and the child's blobs protected.
-    if let Err(e) = clear_repo_manifest_refs(&mut *tx, repo.id, &digest).await {
-        return oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            &e.to_string(),
-        );
-    }
+    if !digest_still_tagged {
+        // Drop stale index relationships for this digest. Live child edges are
+        // preserved so a still-tagged parent index keeps the child relationship
+        // live and the child's blobs protected.
+        if let Err(e) = clear_repo_manifest_refs(&mut *tx, repo.id, &digest).await {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                &e.to_string(),
+            );
+        }
 
-    // #1409: drop the manifest's blob refs so its config + layer blobs become
-    // reclaimable once nothing else references them. Scoped to skip a digest
-    // still referenced as a live per-architecture child of a tagged index
-    // (its blobs are protected ONLY by these rows). After #1681 these rows
-    // also gate digest fallback, so a cleanup error must abort the delete.
-    if let Err(e) = delete_manifest_blob_refs(&mut *tx, repo.id, &digest).await {
-        return oci_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "INTERNAL_ERROR",
-            &e.to_string(),
-        );
+        // #1409: drop the manifest's blob refs so its config + layer blobs
+        // become reclaimable once nothing else references them. Scoped to skip a
+        // digest still referenced as a live per-architecture child of a tagged
+        // index (its blobs are protected ONLY by these rows). After #1681 these
+        // rows also gate digest fallback, so a cleanup error must abort the
+        // delete.
+        if let Err(e) = delete_manifest_blob_refs(&mut *tx, repo.id, &digest).await {
+            return oci_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "INTERNAL_ERROR",
+                &e.to_string(),
+            );
+        }
     }
 
     if let Err(e) = tx.commit().await {
@@ -18807,6 +18875,250 @@ mod cross_repo_session_regression_tests {
         );
 
         cleanup_all(&pool, &[repo_id], user_id, &[storage_dir]).await;
+    }
+
+    /// #1776: create a non-local OCI repo (remote/virtual) marked public, with a
+    /// configured upstream so resolution succeeds. Returns (id, key, dir).
+    async fn create_typed_oci_repo(
+        pool: &PgPool,
+        repo_type: &str,
+        label: &str,
+    ) -> (Uuid, String, std::path::PathBuf) {
+        let id = Uuid::new_v4();
+        let key = format!("ph-test-{}-{}-{}", repo_type, label, id);
+        let storage_dir = std::env::temp_dir().join(format!("ph-test-{}-{}", repo_type, id));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let upstream = if repo_type == "remote" {
+            Some("https://upstream.example.test")
+        } else {
+            None
+        };
+        let sql = format!(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public, upstream_url) \
+             VALUES ($1, $2, $2, $3, '{}'::repository_type, 'docker'::repository_format, true, $4)",
+            repo_type
+        );
+        sqlx::query(&sql)
+            .bind(id)
+            .bind(&key)
+            .bind(storage_dir.to_string_lossy().as_ref())
+            .bind(upstream)
+            .execute(pool)
+            .await
+            .expect("insert typed repo");
+        (id, key, storage_dir)
+    }
+
+    /// #1776: a blob upload POST on a remote repository must be rejected with
+    /// 405 UNSUPPORTED — only Local/Staging repos store their own content.
+    #[tokio::test]
+    async fn handle_start_upload_rejected_on_remote_repo() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username, password) = create_pushable_user(&pool).await;
+        let (repo_id, repo_key, storage_dir) = create_typed_oci_repo(&pool, "remote", "push").await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = basic_auth(&username, &password);
+
+        let body = b"remote-blob".to_vec();
+        let digest = format!("sha256:{}", sha256_hex(&body));
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!(
+                "/{}/myimage/blobs/uploads/?digest={}",
+                repo_key, digest
+            ))
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/octet-stream")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = router().with_state(state).oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "blob upload on a remote repo must be rejected with 405"
+        );
+
+        cleanup_all(&pool, &[repo_id], user_id, &[storage_dir]).await;
+    }
+
+    /// #1776: a manifest PUT on a virtual repository must be rejected with 405
+    /// UNSUPPORTED and must not create an oci_tags row.
+    #[tokio::test]
+    async fn handle_put_manifest_rejected_on_virtual_repo() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username, password) = create_pushable_user(&pool).await;
+        let (repo_id, repo_key, storage_dir) = create_typed_oci_repo(&pool, "virtual", "put").await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = basic_auth(&username, &password);
+
+        let manifest = br#"{"config":{"digest":"sha256:cfg"},"layers":[]}"#.to_vec();
+        let req = Request::builder()
+            .method("PUT")
+            .uri(format!("/{}/myimage/manifests/pushed-tag", repo_key))
+            .header("Authorization", &auth)
+            .header("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+            .body(Body::from(manifest))
+            .unwrap();
+        let resp = router().with_state(state).oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::METHOD_NOT_ALLOWED,
+            "manifest PUT on a virtual repo must be rejected with 405"
+        );
+
+        let tag_rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM oci_tags WHERE repository_id = $1 AND tag = 'pushed-tag'",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(tag_rows, 0, "no tag row may be created on a virtual repo");
+
+        let _ = sqlx::query("DELETE FROM oci_tags WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        cleanup_all(&pool, &[repo_id], user_id, &[storage_dir]).await;
+    }
+
+    /// #1776: anonymous GET /v2/{name}/tags/list on a PUBLIC repo must succeed
+    /// (200), mirroring anonymous manifest reads. Pins the is_anon bypass.
+    #[tokio::test]
+    async fn handle_tags_list_allows_anon_on_public_repo() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // create_docker_repo marks the repo is_public = true.
+        let (repo_id, repo_key, storage_dir) = create_docker_repo(&pool, "anontags").await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        // Seed a tag so the repo is "known" and the list is non-empty.
+        let digest = format!("sha256:{}", "a".repeat(64));
+        sqlx::query(
+            "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type) \
+             VALUES ($1, 'myimage', 'pub1', $2, 'application/vnd.oci.image.manifest.v1+json')",
+        )
+        .bind(repo_id)
+        .bind(&digest)
+        .execute(&pool)
+        .await
+        .expect("seed tag");
+
+        // Anonymous pull token issued by the OCI token endpoint, exactly as a
+        // logged-out Docker/OCI client presents it.
+        let req = Request::builder()
+            .method("GET")
+            .uri(format!("/{}/myimage/tags/list", repo_key))
+            .header("Authorization", "Bearer anonymous")
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = tdh::send(router().with_state(state), req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "anonymous tags/list on a public repo must return 200"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        assert_eq!(json["tags"][0], "pub1", "tag list must include the tag");
+
+        let _ = sqlx::query("DELETE FROM oci_tags WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// #1776: deleting one tag by NAME when a sibling tag shares the same
+    /// manifest digest must leave the sibling tag intact and must NOT reclaim
+    /// the manifest's blob refs (still live via the sibling).
+    #[tokio::test]
+    async fn delete_tag_by_name_preserves_sibling_sharing_digest() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fixture) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+        let repo = fixture.repo_id;
+        let digest = format!("sha256:{}", "7".repeat(64));
+        // Two tags pointing at the same manifest digest.
+        sqlx::query(
+            "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type) \
+             VALUES ($1, 'image2', 'tagA', $2, 'application/vnd.oci.image.manifest.v1+json'), \
+                    ($1, 'image2', 'tagB', $2, 'application/vnd.oci.image.manifest.v1+json')",
+        )
+        .bind(repo)
+        .bind(&digest)
+        .execute(&fixture.pool)
+        .await
+        .expect("seed tags");
+        // Blob refs for the shared manifest.
+        sqlx::query(
+            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind) \
+             VALUES ($1, $1 || ':cfg', $2, 'config'), ($1, $1 || ':l0', $2, 'layer')",
+        )
+        .bind(&digest)
+        .bind(repo)
+        .execute(&fixture.pool)
+        .await
+        .expect("seed blob refs");
+
+        // Emulate the tag-scoped delete path: remove only tagA, then run the
+        // still-tagged guard before any ref cleanup.
+        let mut tx = fixture.pool.begin().await.expect("tx");
+        sqlx::query("DELETE FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3")
+            .bind(repo)
+            .bind("image2")
+            .bind("tagA")
+            .execute(&mut *tx)
+            .await
+            .expect("delete tagA");
+        let still_tagged: Option<bool> = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2)",
+        )
+        .bind(repo)
+        .bind(&digest)
+        .fetch_one(&mut *tx)
+        .await
+        .expect("guard query");
+        assert_eq!(
+            still_tagged,
+            Some(true),
+            "sibling tagB keeps the digest live"
+        );
+        if !still_tagged.unwrap_or(false) {
+            delete_manifest_blob_refs(&mut *tx, repo, &digest)
+                .await
+                .expect("blob refs");
+        }
+        tx.commit().await.expect("commit");
+
+        let remaining_tags: Vec<String> = sqlx::query_scalar(
+            "SELECT tag FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 ORDER BY tag",
+        )
+        .bind(repo)
+        .bind(&digest)
+        .fetch_all(&fixture.pool)
+        .await
+        .expect("remaining tags");
+        let blob_ref_rows: i64 = sqlx::query_scalar(
+            "SELECT count(*) FROM manifest_blob_refs WHERE repository_id = $1 AND manifest_digest = $2",
+        )
+        .bind(repo)
+        .bind(&digest)
+        .fetch_one(&fixture.pool)
+        .await
+        .expect("count blob refs");
+        fixture.teardown().await;
+
+        assert_eq!(remaining_tags, vec!["tagB".to_string()], "tagB preserved");
+        assert_eq!(blob_ref_rows, 2, "blob refs preserved while sibling lives");
     }
 
     /// Successive PATCH chunks must each be appended to the temp file

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1341,6 +1341,12 @@ pub(crate) enum LocalLookup<'a> {
     Path(&'a str),
     /// Match on `name` + `version`.
     NameVersion(&'a str, &'a str),
+    /// Match on `name` + `version` constrained to a trailing `path LIKE`
+    /// pattern (e.g. `%.zip` vs `%.mod`). Needed by the Go proxy where a
+    /// single `(name, version)` pair owns *both* the module `.zip` and the
+    /// `.mod` artifact; the bare `NameVersion` lookup would return whichever
+    /// row was inserted first, serving go.mod bytes for a `.zip` request.
+    NameVersionSuffix(&'a str, &'a str, &'a str),
 }
 
 impl LocalLookup<'_> {
@@ -1361,6 +1367,12 @@ impl LocalLookup<'_> {
                  WHERE repository_id = $1 AND name = $2 AND version = $3 AND is_deleted = false \
                  LIMIT 1"
             }
+            LocalLookup::NameVersionSuffix(_, _, _) => {
+                "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
+                 FROM artifacts \
+                 WHERE repository_id = $1 AND name = $2 AND version = $3 AND path LIKE $4 AND is_deleted = false \
+                 LIMIT 1"
+            }
         }
     }
 
@@ -1372,6 +1384,9 @@ impl LocalLookup<'_> {
         let query = match self {
             LocalLookup::Path(path) => query.bind(*path),
             LocalLookup::NameVersion(name, version) => query.bind(*name).bind(*version),
+            LocalLookup::NameVersionSuffix(name, version, suffix) => {
+                query.bind(*name).bind(*version).bind(*suffix)
+            }
         };
 
         query
@@ -1487,6 +1502,30 @@ pub async fn local_fetch_by_name_version(
         repo_id,
         location,
         LocalLookup::NameVersion(name, version),
+    )
+    .await?;
+    read_local_stream(db, &artifact, &*storage).await
+}
+
+/// Local artifact fetch by `name` + `version` constrained to a trailing
+/// `path LIKE` pattern. Used by the Go proxy's virtual-member fallback so a
+/// `.zip` request resolves the module archive and a `.mod` request resolves
+/// the go.mod, even though both share the same `(name, version)` coordinates.
+pub async fn local_fetch_by_name_version_and_suffix(
+    db: &PgPool,
+    state: &AppState,
+    repo_id: Uuid,
+    location: &StorageLocation,
+    name: &str,
+    version: &str,
+    suffix_pattern: &str,
+) -> Result<StreamingFetchResult, Response> {
+    let (artifact, storage) = local_lookup_artifact(
+        db,
+        state,
+        repo_id,
+        location,
+        LocalLookup::NameVersionSuffix(name, version, suffix_pattern),
     )
     .await?;
     read_local_stream(db, &artifact, &*storage).await
@@ -2656,13 +2695,34 @@ mod tests {
     }
 
     #[test]
+    fn test_local_lookup_name_version_suffix_select_sql() {
+        // Regression (#1782): the Go proxy's virtual fallback uses this
+        // variant so a `.zip` request and a `.mod` request -- which share the
+        // same (name, version) -- resolve to different artifacts. The WHERE
+        // clause MUST add the `path LIKE $4` filter; without it the bare
+        // NameVersion query returns whichever row was inserted first (serving
+        // go.mod bytes for a `.zip` request).
+        let sql = LocalLookup::NameVersionSuffix("pkg", "1.0.0", "%.zip").select_sql();
+        assert!(
+            sql.contains(
+                "WHERE repository_id = $1 AND name = $2 AND version = $3 AND path LIKE $4 AND is_deleted = false"
+            ),
+            "suffix variant must filter on `path LIKE $4`: {sql}"
+        );
+        assert!(sql.contains("LIMIT 1"));
+    }
+
+    #[test]
     fn test_local_lookup_select_columns_identical() {
-        // Both variants select the same LocalArtifactRow columns; only the
+        // All variants select the same LocalArtifactRow columns; only the
         // WHERE clause differs (the whole point of the S6 collapse).
         let cols =
             "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until";
         assert!(LocalLookup::Path("x").select_sql().starts_with(cols));
         assert!(LocalLookup::NameVersion("n", "v")
+            .select_sql()
+            .starts_with(cols));
+        assert!(LocalLookup::NameVersionSuffix("n", "v", "%.mod")
             .select_sql()
             .starts_with(cols));
     }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -147,6 +147,9 @@ struct SimpleProjectArtifact {
     size_bytes: i64,
     checksum_sha256: String,
     metadata: Option<serde_json::Value>,
+    /// Upload timestamp, surfaced as PEP 700 `upload-time` (RFC 3339) in the
+    /// PEP 691 JSON response and `data-upload-time` in the HTML response.
+    upload_time: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -467,10 +470,13 @@ fn build_simple_root_response(
     repo_key: &str,
     packages: &[String],
 ) -> Result<Response, Response> {
-    // Check Accept header for PEP 691 JSON
+    // Content negotiation is driven solely by the Accept header (#1773),
+    // matching `build_simple_project_response`. Previously this also consulted
+    // the request Content-Type, which is the media type of the request *body*,
+    // not a negotiation signal — a client sending `Content-Type: ...+json`
+    // with `Accept: text/html` would wrongly receive JSON.
     let accept = headers
-        .get(CONTENT_TYPE.as_str())
-        .or_else(|| headers.get("accept"))
+        .get("accept")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
@@ -553,6 +559,7 @@ async fn simple_project(
     let artifacts = sqlx::query!(
         r#"
         SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,
+               a.created_at,
                am.metadata as "metadata?"
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
@@ -576,6 +583,7 @@ async fn simple_project(
             size_bytes: a.size_bytes,
             checksum_sha256: a.checksum_sha256,
             metadata: a.metadata,
+            upload_time: Some(a.created_at),
         })
         .collect();
 
@@ -651,6 +659,7 @@ async fn simple_project(
                 let member_rows = sqlx::query!(
                     r#"
         SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,
+               a.created_at,
                am.metadata as "metadata?"
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
@@ -672,6 +681,7 @@ async fn simple_project(
                     size_bytes: a.size_bytes,
                     checksum_sha256: a.checksum_sha256,
                     metadata: a.metadata,
+                    upload_time: Some(a.created_at),
                 }));
             }
 
@@ -837,6 +847,12 @@ fn build_simple_project_response(
                 if let Some(rp) = requires_python {
                     file["requires-python"] = serde_json::Value::String(rp);
                 }
+                // PEP 700: surface the distribution's upload timestamp as an
+                // RFC 3339 / ISO 8601 `upload-time` field (#1773).
+                if let Some(ut) = a.upload_time {
+                    file["upload-time"] =
+                        serde_json::Value::String(ut.format("%Y-%m-%dT%H:%M:%SZ").to_string());
+                }
                 file
             })
             .collect();
@@ -906,9 +922,16 @@ fn build_simple_project_response(
             .map(|rp| format!(" data-requires-python=\"{}\"", html_escape(rp)))
             .unwrap_or_default();
 
+        // PEP 700: expose the upload timestamp as a `data-upload-time` anchor
+        // attribute (RFC 3339) so HTML clients can read it too (#1773).
+        let ut_attr = a
+            .upload_time
+            .map(|ut| format!(" data-upload-time=\"{}\"", ut.format("%Y-%m-%dT%H:%M:%SZ")))
+            .unwrap_or_default();
+
         html.push_str(&format!(
-            "<a href=\"{}\"{}>{}</a><br/>\n",
-            url, rp_attr, filename
+            "<a href=\"{}\"{}{}>{}</a><br/>\n",
+            url, rp_attr, ut_attr, filename
         ));
     }
 
@@ -963,9 +986,14 @@ fn merge_local_into_remote_simple_html(
         let rp_attr = requires_python
             .map(|rp| format!(" data-requires-python=\"{}\"", html_escape(rp)))
             .unwrap_or_default();
+        // PEP 700: include the upload timestamp for spliced local entries (#1773).
+        let ut_attr = a
+            .upload_time
+            .map(|ut| format!(" data-upload-time=\"{}\"", ut.format("%Y-%m-%dT%H:%M:%SZ")))
+            .unwrap_or_default();
         local_lines.push_str(&format!(
-            "<a href=\"{}\"{}>{}</a><br/>\n",
-            url, rp_attr, filename
+            "<a href=\"{}\"{}{}>{}</a><br/>\n",
+            url, rp_attr, ut_attr, filename
         ));
     }
 
@@ -3492,6 +3520,7 @@ mod tests {
             size_bytes: 12345,
             checksum_sha256: "abc123def456".to_string(),
             metadata: None,
+            upload_time: None,
         }];
 
         let headers = HeaderMap::new();
@@ -3521,6 +3550,7 @@ mod tests {
             size_bytes: 5000,
             checksum_sha256: "aaa111bbb222".to_string(),
             metadata: None,
+            upload_time: None,
         }];
 
         let headers = HeaderMap::new();
@@ -3565,6 +3595,7 @@ mod tests {
             size_bytes: 4000,
             checksum_sha256: "deadbeef".to_string(),
             metadata: Some(metadata),
+            upload_time: None,
         }];
 
         let headers = HeaderMap::new();
@@ -3593,6 +3624,7 @@ mod tests {
                 size_bytes: 1000,
                 checksum_sha256: "aaa".to_string(),
                 metadata: None,
+                upload_time: None,
             },
             SimpleProjectArtifact {
                 path: "pkg-2.0.0.tar.gz".to_string(),
@@ -3600,6 +3632,7 @@ mod tests {
                 size_bytes: 2000,
                 checksum_sha256: "bbb".to_string(),
                 metadata: None,
+                upload_time: None,
             },
         ];
 
@@ -3632,6 +3665,7 @@ mod tests {
             size_bytes: 5000,
             checksum_sha256: "abc123".to_string(),
             metadata: None,
+            upload_time: None,
         }];
 
         let mut headers = HeaderMap::new();
@@ -3695,6 +3729,7 @@ mod tests {
             size_bytes: 3000,
             checksum_sha256: "cafe".to_string(),
             metadata: Some(metadata),
+            upload_time: None,
         }];
 
         let mut headers = HeaderMap::new();
@@ -3715,6 +3750,100 @@ mod tests {
 
         let files = json["files"].as_array().unwrap();
         assert_eq!(files[0]["requires-python"], ">=3.9,<4.0");
+    }
+
+    // -----------------------------------------------------------------------
+    // PEP 700 upload-time (#1773)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_simple_project_response_json_emits_upload_time() {
+        // Regression for #1773: the PEP 691 JSON file object must carry the
+        // PEP 700 `upload-time` field, formatted as RFC 3339 (UTC, `Z`).
+        let upload_time = chrono::DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let artifacts = vec![SimpleProjectArtifact {
+            path: "pkg-1.0.0-py3-none-any.whl".to_string(),
+            version: Some("1.0.0".to_string()),
+            size_bytes: 3000,
+            checksum_sha256: "cafe".to_string(),
+            metadata: None,
+            upload_time: Some(upload_time),
+        }];
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "accept",
+            "application/vnd.pypi.simple.v1+json".parse().unwrap(),
+        );
+
+        let result = build_simple_project_response(&headers, "repo", "pkg", &artifacts, &[]);
+        let response = result.unwrap();
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX);
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(body_bytes)
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        let files = json["files"].as_array().unwrap();
+        assert_eq!(files[0]["upload-time"], "2026-01-02T03:04:05Z");
+    }
+
+    #[test]
+    fn test_build_simple_project_response_json_omits_upload_time_when_absent() {
+        let artifacts = vec![SimpleProjectArtifact {
+            path: "pkg-1.0.0.tar.gz".to_string(),
+            version: Some("1.0.0".to_string()),
+            size_bytes: 10,
+            checksum_sha256: "abc".to_string(),
+            metadata: None,
+            upload_time: None,
+        }];
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "accept",
+            "application/vnd.pypi.simple.v1+json".parse().unwrap(),
+        );
+        let response =
+            build_simple_project_response(&headers, "repo", "pkg", &artifacts, &[]).unwrap();
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["files"][0].get("upload-time").is_none());
+    }
+
+    #[test]
+    fn test_build_simple_project_response_html_emits_upload_time() {
+        // Regression for #1773: HTML anchors must carry a `data-upload-time`
+        // attribute when the upload timestamp is known.
+        let upload_time = chrono::DateTime::parse_from_rfc3339("2026-01-02T03:04:05Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        let artifacts = vec![SimpleProjectArtifact {
+            path: "pkg-1.0.0.tar.gz".to_string(),
+            version: Some("1.0.0".to_string()),
+            size_bytes: 10,
+            checksum_sha256: "abc".to_string(),
+            metadata: None,
+            upload_time: Some(upload_time),
+        }];
+        let response =
+            build_simple_project_response(&HeaderMap::new(), "repo", "pkg", &artifacts, &[])
+                .unwrap();
+        let body = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(axum::body::to_bytes(response.into_body(), usize::MAX))
+            .unwrap();
+        let html = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            html.contains("data-upload-time=\"2026-01-02T03:04:05Z\""),
+            "HTML should include data-upload-time, got: {}",
+            html
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -3788,6 +3917,33 @@ mod tests {
         assert_eq!(projects.len(), 2);
         assert_eq!(projects[0]["name"], "flask");
         assert_eq!(projects[1]["name"], "numpy");
+    }
+
+    #[test]
+    fn test_build_simple_root_response_ignores_content_type_for_negotiation() {
+        // Regression for #1773: content negotiation must use ONLY the Accept
+        // header. A request Content-Type of the JSON media type with an
+        // HTML Accept must still yield HTML (the request Content-Type
+        // describes the request body, not the desired response format).
+        let packages = vec!["flask".to_string()];
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_TYPE,
+            "application/vnd.pypi.simple.v1+json".parse().unwrap(),
+        );
+        headers.insert("accept", "text/html".parse().unwrap());
+
+        let response = build_simple_root_response(&headers, "pypi-virtual", &packages).unwrap();
+        let ct = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(
+            ct, "text/html; charset=utf-8",
+            "Content-Type must not drive response negotiation"
+        );
     }
 
     #[test]
@@ -4073,6 +4229,7 @@ mod tests {
             size_bytes: 4096,
             checksum_sha256: "ffeeddccbbaa99887766554433221100".to_string(),
             metadata: None,
+            upload_time: None,
         }];
 
         let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
@@ -4107,6 +4264,7 @@ mod tests {
             checksum_sha256: "0000000000000000000000000000000000000000000000000000000000000000"
                 .to_string(),
             metadata: None,
+            upload_time: None,
         }];
 
         let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
@@ -4140,6 +4298,7 @@ mod tests {
             size_bytes: 256,
             checksum_sha256: "deadbeef".to_string(),
             metadata: Some(metadata),
+            upload_time: None,
         }];
 
         let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);
@@ -4165,6 +4324,7 @@ mod tests {
             size_bytes: 1024,
             checksum_sha256: "cafebabe".to_string(),
             metadata: None,
+            upload_time: None,
         }];
 
         let merged = merge_local_into_remote_simple_html(&remote, "virt", "pkg", &local, &[]);

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -140,6 +140,25 @@ async fn authorize_repo_for_tokens(
         )));
     }
 
+    // Per-repo authorization (mirrors `require_visible` in the repositories
+    // handler). The `can_access_repo` check above only enforces the *token's*
+    // repo scope — a broad `write:repositories` token (`allowed_repo_ids =
+    // None`) passes it for ANY repo. Without this DB-level check, any
+    // authenticated user with the write scope could mint repo-scoped tokens on
+    // a PRIVATE repository they cannot see (#1783). A private repo is visible
+    // only to an admin or a user with a role assignment scoped to it.
+    if !repo.is_public
+        && !auth.is_admin
+        && !repo_service
+            .user_can_access_repo(repo.id, auth.user_id)
+            .await?
+    {
+        return Err(AppError::NotFound(format!(
+            "Repository '{}' not found",
+            key
+        )));
+    }
+
     Ok((auth, repo))
 }
 
@@ -862,6 +881,45 @@ mod admin_scope_policy_tests {
                 String::from_utf8_lossy(&body_bytes),
             );
         }
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
+    /// #1783: a non-admin holding only the broad `write:repositories` scope
+    /// (token `allowed_repo_ids = None`, so `can_access_repo` passes for ANY
+    /// repo) must NOT be able to mint a repo token on a PRIVATE repository it
+    /// has no role on. Before the fix the endpoint returned 200/created; it
+    /// must now 404 (existence-hiding), exactly like `require_visible`.
+    #[tokio::test]
+    async fn non_admin_without_role_cannot_mint_token_on_private_repo() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        // Make the repo private; the user from setup() has no role on it.
+        sqlx::query("UPDATE repositories SET is_public = false WHERE key = $1")
+            .bind(&repo_key)
+            .execute(&pool)
+            .await
+            .expect("set repo private");
+
+        // Non-admin API token with the delegatable write scope but no repo
+        // restriction, requesting a SAFE (non-admin) scope so it clears the
+        // admin-scope gate and reaches the visibility check.
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.scopes = Some(vec!["write:repositories".to_string()]);
+
+        let app = build_app(state, auth);
+        let req = post_repo_token_request(&repo_key, "probe-private", &["read:artifacts"]);
+        let (status, body_bytes) = tdh::send(app, req).await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "non-admin without a role must not mint tokens on a private repo (existence-hiding); got {} body: {}",
+            status,
+            String::from_utf8_lossy(&body_bytes),
+        );
 
         cleanup(&pool, user_id, &repo_key).await;
     }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -514,6 +514,16 @@ fn validate_cache_ttl(secs: i64) -> bool {
     (1..=2_592_000).contains(&secs)
 }
 
+/// Clamp a caller-supplied `per_page` into the valid `[1, 100]` range.
+///
+/// `per_page = 0` (or any value below 1) must NOT pass through: it would reach
+/// the `total_pages = ceil(total / per_page)` division as a divide-by-zero and
+/// saturate `total_pages` to `u32::MAX` for any non-empty listing (#1783 LOW).
+/// `clamp(1, 100)` also caps the page size, matching `list_artifacts`.
+pub(crate) fn clamp_per_page(per_page: Option<u32>) -> u32 {
+    per_page.unwrap_or(20).clamp(1, 100)
+}
+
 /// Reject `POST /api/v1/repositories` requests that create a virtual repo
 /// with no members.
 ///
@@ -1081,7 +1091,7 @@ pub async fn list_repositories(
     Query(query): Query<ListRepositoriesQuery>,
 ) -> Result<Json<RepositoryListResponse>> {
     let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(20).min(100);
+    let per_page = clamp_per_page(query.per_page);
     let offset = ((page - 1) * per_page) as i64;
 
     let format_filter = query.format.as_ref().map(|f| parse_format(f)).transpose()?;
@@ -1094,6 +1104,13 @@ pub async fn list_repositories(
     let visibility = match &auth {
         None => RepoVisibility::PublicOnly,
         Some(a) if a.is_admin => RepoVisibility::All,
+        // Repo-scoped token: the listing must reflect ONLY the token's
+        // allowed repositories, not every repo the owning user can reach.
+        // Checked before the general `User` arm. Admin tokens are handled
+        // above and bypass scope restrictions.
+        Some(a) if a.allowed_repo_ids.is_some() => {
+            RepoVisibility::Ids(a.allowed_repo_ids.clone().unwrap_or_default())
+        }
         Some(a) => RepoVisibility::User(a.user_id),
     };
     let service = RepositoryService::new(state.db.clone());
@@ -7524,6 +7541,44 @@ mod tests {
     #[test]
     fn test_validate_cache_ttl_invalid_very_negative() {
         assert!(!validate_cache_ttl(-86400));
+    }
+
+    // -----------------------------------------------------------------------
+    // clamp_per_page (#1783 LOW: per_page=0 overflowed total_pages to u32::MAX)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_clamp_per_page_zero_becomes_one() {
+        // The core regression: 0 must never reach the total_pages division.
+        assert_eq!(clamp_per_page(Some(0)), 1);
+    }
+
+    #[test]
+    fn test_clamp_per_page_none_uses_default() {
+        assert_eq!(clamp_per_page(None), 20);
+    }
+
+    #[test]
+    fn test_clamp_per_page_within_range_unchanged() {
+        assert_eq!(clamp_per_page(Some(1)), 1);
+        assert_eq!(clamp_per_page(Some(50)), 50);
+        assert_eq!(clamp_per_page(Some(100)), 100);
+    }
+
+    #[test]
+    fn test_clamp_per_page_above_max_capped() {
+        assert_eq!(clamp_per_page(Some(101)), 100);
+        assert_eq!(clamp_per_page(Some(u32::MAX)), 100);
+    }
+
+    #[test]
+    fn test_clamp_per_page_zero_total_pages_is_finite() {
+        // Mirror the handler computation: total_pages = ceil(total / per_page).
+        // With the clamp in place this can never be u32::MAX for per_page=0.
+        let per_page = clamp_per_page(Some(0));
+        let total: i64 = 128;
+        let total_pages = ((total as f64) / (per_page as f64)).ceil() as u32;
+        assert_eq!(total_pages, 128);
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3301,7 +3301,7 @@ pub async fn upload_artifact(
     Path((key, path)): Path<(String, String)>,
     headers: HeaderMap,
     body: Bytes,
-) -> Result<Json<ArtifactResponse>> {
+) -> Result<(StatusCode, Json<ArtifactResponse>)> {
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
 
@@ -3380,14 +3380,17 @@ pub async fn upload_artifact(
         }
     };
 
+    // Content-Type resolution priority:
+    //   1. WASM plugin metadata (format-aware)
+    //   2. the request's declared Content-Type header (honour the client)
+    //   3. mime_guess from the path extension
+    let declared_content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok());
     let content_type = wasm_metadata
         .as_ref()
         .map(|m| m.content_type.clone())
-        .unwrap_or_else(|| {
-            mime_guess::from_path(&path)
-                .first_or_octet_stream()
-                .to_string()
-        });
+        .unwrap_or_else(|| resolve_upload_content_type(declared_content_type, &path));
 
     // Clean up any soft-deleted artifact at the same path so the
     // UNIQUE(repository_id, path) constraint doesn't block re-upload.
@@ -3409,23 +3412,51 @@ pub async fn upload_artifact(
     let downloads = artifact_service.get_download_stats(artifact.id).await?;
     let metadata_json = wasm_metadata.map(|m| m.to_json());
 
-    Ok(Json(ArtifactResponse {
-        id: artifact.id,
-        repository_key: key,
-        path: artifact.path,
-        name: artifact.name,
-        version: artifact.version,
-        size_bytes: artifact.size_bytes,
-        checksum_sha256: artifact.checksum_sha256,
-        content_type: artifact.content_type,
-        download_count: downloads,
-        created_at: artifact.created_at,
-        metadata: metadata_json,
-        // Just-uploaded artifacts have no proxy cache state yet -- the
-        // cache is populated lazily on the first proxy fetch.
-        cache_cached_at: None,
-        cache_expires_at: None,
-    }))
+    Ok((
+        StatusCode::CREATED,
+        Json(ArtifactResponse {
+            id: artifact.id,
+            repository_key: key,
+            path: artifact.path,
+            name: artifact.name,
+            version: artifact.version,
+            size_bytes: artifact.size_bytes,
+            checksum_sha256: artifact.checksum_sha256,
+            content_type: artifact.content_type,
+            download_count: downloads,
+            created_at: artifact.created_at,
+            metadata: metadata_json,
+            // Just-uploaded artifacts have no proxy cache state yet -- the
+            // cache is populated lazily on the first proxy fetch.
+            cache_cached_at: None,
+            cache_expires_at: None,
+        }),
+    ))
+}
+
+/// Resolve the Content-Type for a generic artifact upload.
+///
+/// Honours a client-declared `Content-Type` header when it is a valid,
+/// non-empty MIME type that is not a multipart wrapper (multipart only
+/// describes the request envelope, not the stored object). Otherwise falls
+/// back to guessing from the artifact path's file extension.
+fn resolve_upload_content_type(declared: Option<&str>, path: &str) -> String {
+    if let Some(raw) = declared {
+        let trimmed = raw.trim();
+        // Strip any `; charset=...` parameters for the multipart check, but
+        // preserve the full declared value when we accept it.
+        let base = trimmed.split(';').next().unwrap_or(trimmed).trim();
+        if !base.is_empty()
+            && base.contains('/')
+            && !base.eq_ignore_ascii_case("multipart/form-data")
+            && !base.to_ascii_lowercase().starts_with("multipart/")
+        {
+            return trimmed.to_string();
+        }
+    }
+    mime_guess::from_path(path)
+        .first_or_octet_stream()
+        .to_string()
 }
 
 /// Upload artifact via multipart/form-data POST (with path in URL).
@@ -3438,7 +3469,7 @@ async fn upload_artifact_multipart_with_path(
     Path((key, path)): Path<(String, String)>,
     headers: HeaderMap,
     multipart: Multipart,
-) -> Result<Json<ArtifactResponse>> {
+) -> Result<(StatusCode, Json<ArtifactResponse>)> {
     let (body, filename) = extract_multipart_file(multipart).await?;
     let artifact_path = if path.is_empty() || path == "/" {
         filename
@@ -3472,7 +3503,7 @@ async fn upload_artifact_multipart(
     Path(key): Path<String>,
     headers: HeaderMap,
     multipart: Multipart,
-) -> Result<Json<ArtifactResponse>> {
+) -> Result<(StatusCode, Json<ArtifactResponse>)> {
     let (body, filename, custom_path) = extract_multipart_file_and_path(multipart).await?;
     let artifact_path = compose_artifact_path(custom_path.as_deref(), &filename);
     upload_artifact(
@@ -3601,6 +3632,13 @@ pub async fn download_artifact(
     Path((key, path)): Path<(String, String)>,
     request: axum::http::Request<axum::body::Body>,
 ) -> Result<impl IntoResponse> {
+    // A HEAD request must return identical headers to GET but no body, and it
+    // must close the connection. Without this flag the handler builds a
+    // `Body::from_stream(..)` whose Content-Length advertises the full size
+    // while no bytes are written, so HTTP/1.1 keep-alive clients block waiting
+    // for a body that never arrives (the connection hangs).
+    let is_head = request.method() == axum::http::Method::HEAD;
+
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_visible(&repo, &auth, &repo_service).await?;
@@ -3740,7 +3778,11 @@ pub async fn download_artifact(
                     artifact.checksum_sha256.trim().to_string(),
                 )
                 .header(header::HeaderName::from_static(X_ARTIFACT_STORAGE), "proxy")
-                .body(Body::from_stream(body))
+                .body(if is_head {
+                    Body::empty()
+                } else {
+                    Body::from_stream(body)
+                })
                 .map_err(|e| AppError::Internal(format!("failed to build response: {}", e)))?;
             Ok(response)
         }
@@ -3830,7 +3872,12 @@ pub async fn download_artifact(
             if let Some(size) = result.content_length {
                 builder = builder.header(header::CONTENT_LENGTH, size.to_string());
             }
-            Ok(builder.body(Body::from_stream(result.body)).unwrap())
+            let body = if is_head {
+                Body::empty()
+            } else {
+                Body::from_stream(result.body)
+            };
+            Ok(builder.body(body).unwrap())
         }
         Err(e) => Err(e),
     }
@@ -9046,6 +9093,82 @@ mod tests {
         );
     }
 
+    // Regression (#1782): a HEAD request on the generic download endpoint must
+    // return the GET headers (status, Content-Type, Content-Length) but an
+    // EMPTY body. Previously the handler always attached `Body::from_stream`,
+    // so HTTP/1.1 keep-alive clients blocked waiting for `Content-Length`
+    // bytes that were never written and the connection hung.
+    #[tokio::test]
+    async fn test_download_artifact_head_returns_headers_no_body() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let body_bytes: &[u8] = b"head-request-must-not-return-this-body";
+        let repo = fx.repo_info("local", None);
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &storage_key,
+            "head/probe.bin",
+            "probe",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(body_bytes),
+            fx.user_id,
+        )
+        .await;
+
+        let router = fx.router_with_auth(download_router());
+        let req = axum::http::Request::builder()
+            .method("HEAD")
+            .uri(format!("/{}/download/head/probe.bin", fx.repo_key))
+            .body(Body::empty())
+            .expect("build HEAD request");
+
+        use tower::ServiceExt;
+        let resp = router
+            .oneshot(req)
+            .await
+            .expect("HEAD download must respond");
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let collected = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect HEAD body");
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "HEAD on an existing artifact must return 200"
+        );
+        // Content-Length still advertises the full size (HEAD semantics) ...
+        assert_eq!(
+            headers
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(body_bytes.len().to_string().as_str()),
+            "HEAD must still report the artifact size in Content-Length"
+        );
+        // ... but NO body bytes are written, so the connection can close.
+        assert!(
+            collected.is_empty(),
+            "HEAD must return an empty body, got {} bytes",
+            collected.len()
+        );
+        assert_eq!(
+            headers
+                .get(header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok()),
+            Some("application/x-test"),
+            "HEAD must carry the same Content-Type as GET"
+        );
+    }
+
     #[tokio::test]
     async fn test_download_artifact_local_missing_path_returns_404() {
         let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
@@ -9752,6 +9875,64 @@ mod tests {
                 "artifact_v1.2.3+linux.x86_64.bin"
             ),
             "releases/v1.2.3-rc.1/artifact_v1.2.3+linux.x86_64.bin"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // Generic upload Content-Type resolution (#1782)
+    //
+    // The handler must honour a client-declared `Content-Type` header instead
+    // of always guessing from the file extension. Multipart wrappers describe
+    // the request envelope, not the stored object, so they must NOT win.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_upload_content_type_honours_declared_header() {
+        // A valid declared MIME type wins over the mime_guess of `.bin`
+        // (which would be application/octet-stream).
+        assert_eq!(
+            resolve_upload_content_type(
+                Some("application/vnd.my-company.binary"),
+                "pkg/v1/binary.bin"
+            ),
+            "application/vnd.my-company.binary"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upload_content_type_preserves_charset_params() {
+        assert_eq!(
+            resolve_upload_content_type(Some("text/plain; charset=utf-8"), "x"),
+            "text/plain; charset=utf-8"
+        );
+    }
+
+    #[test]
+    fn test_resolve_upload_content_type_ignores_multipart_wrapper() {
+        // multipart/form-data only describes the upload envelope. Fall back to
+        // mime_guess (here `.txt` -> text/plain).
+        let ct =
+            resolve_upload_content_type(Some("multipart/form-data; boundary=----abc"), "notes.txt");
+        assert!(ct.starts_with("text/plain"), "got {ct}");
+    }
+
+    #[test]
+    fn test_resolve_upload_content_type_falls_back_to_mime_guess() {
+        // No declared header -> guess from extension.
+        let ct = resolve_upload_content_type(None, "archive.json");
+        assert_eq!(ct, "application/json");
+    }
+
+    #[test]
+    fn test_resolve_upload_content_type_ignores_empty_and_invalid() {
+        // Empty / malformed (no slash) declared values fall back to guess.
+        assert_eq!(
+            resolve_upload_content_type(Some("   "), "data.json"),
+            "application/json"
+        );
+        assert_eq!(
+            resolve_upload_content_type(Some("not-a-mime"), "data.json"),
+            "application/json"
         );
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3579,6 +3579,158 @@ async fn extract_multipart_file_and_path(
     }
 }
 
+/// Derive the `Content-Disposition` filename for a downloaded artifact.
+///
+/// The browser-facing filename must be the basename of the requested artifact
+/// path (e.g. `testpkg-1.0.0.tar.gz`), not the artifact's package `name`
+/// (`testpkg`). This mirrors the virtual-repo download path, which already uses
+/// `path.rsplit('/').next()`.
+fn download_filename(path: &str) -> &str {
+    path.rsplit('/')
+        .next()
+        .filter(|s| !s.is_empty())
+        .unwrap_or(path)
+}
+
+/// Outcome of parsing an HTTP `Range` request header against a known total
+/// size. We only support a single `bytes=start-end` range (the common case for
+/// resumable downloads and media seeking); anything more exotic falls back to a
+/// full-body 200 response.
+#[derive(Debug, PartialEq, Eq)]
+enum RangeOutcome {
+    /// No `Range` header, or a header we choose not to honour: serve full 200.
+    Full,
+    /// A satisfiable single range, as inclusive `(start, end)` byte offsets.
+    Satisfiable { start: u64, end: u64 },
+    /// A syntactically valid `bytes=` range that lies outside `[0, total)`:
+    /// the caller must answer 416 Range Not Satisfiable.
+    Unsatisfiable,
+}
+
+/// Parse a single-range HTTP `Range` header value against `total` bytes.
+///
+/// Supports the three RFC 7233 single-range forms:
+/// - `bytes=START-END`   (inclusive)
+/// - `bytes=START-`      (START to end of resource)
+/// - `bytes=-SUFFIX`     (final SUFFIX bytes)
+///
+/// Multi-range (`bytes=0-1,2-3`) and unparseable headers degrade to
+/// [`RangeOutcome::Full`] rather than erroring, which is a valid server choice
+/// per the spec. A `total` of 0 is always served as `Full`.
+fn parse_byte_range(header_value: Option<&str>, total: u64) -> RangeOutcome {
+    let value = match header_value {
+        Some(v) => v.trim(),
+        None => return RangeOutcome::Full,
+    };
+    if total == 0 {
+        return RangeOutcome::Full;
+    }
+    let spec = match value.strip_prefix("bytes=") {
+        Some(s) => s.trim(),
+        None => return RangeOutcome::Full,
+    };
+    // Reject multi-range; we only honour a single range.
+    if spec.contains(',') {
+        return RangeOutcome::Full;
+    }
+    let (start_str, end_str) = match spec.split_once('-') {
+        Some(parts) => parts,
+        None => return RangeOutcome::Full,
+    };
+    let start_str = start_str.trim();
+    let end_str = end_str.trim();
+
+    let last = total - 1;
+    match (start_str.is_empty(), end_str.is_empty()) {
+        // `bytes=-SUFFIX`: final SUFFIX bytes.
+        (true, false) => {
+            let suffix: u64 = match end_str.parse() {
+                Ok(n) => n,
+                Err(_) => return RangeOutcome::Full,
+            };
+            if suffix == 0 {
+                return RangeOutcome::Unsatisfiable;
+            }
+            let len = suffix.min(total);
+            RangeOutcome::Satisfiable {
+                start: total - len,
+                end: last,
+            }
+        }
+        // `bytes=START-`: START to end.
+        (false, true) => {
+            let start: u64 = match start_str.parse() {
+                Ok(n) => n,
+                Err(_) => return RangeOutcome::Full,
+            };
+            if start > last {
+                return RangeOutcome::Unsatisfiable;
+            }
+            RangeOutcome::Satisfiable { start, end: last }
+        }
+        // `bytes=START-END`: explicit inclusive range.
+        (false, false) => {
+            let start: u64 = match start_str.parse() {
+                Ok(n) => n,
+                Err(_) => return RangeOutcome::Full,
+            };
+            let end: u64 = match end_str.parse() {
+                Ok(n) => n,
+                Err(_) => return RangeOutcome::Full,
+            };
+            if start > end || start > last {
+                return RangeOutcome::Unsatisfiable;
+            }
+            RangeOutcome::Satisfiable {
+                start,
+                end: end.min(last),
+            }
+        }
+        // `bytes=-` is malformed.
+        (true, true) => RangeOutcome::Full,
+    }
+}
+
+/// Adapt a byte stream so it yields only the inclusive `[start, end]` window,
+/// skipping leading bytes and truncating trailing ones at chunk boundaries.
+/// Used to satisfy a 206 Partial Content response without buffering the whole
+/// artifact in memory.
+fn slice_byte_stream(
+    body: futures::stream::BoxStream<'static, Result<Bytes>>,
+    start: u64,
+    end: u64,
+) -> futures::stream::BoxStream<'static, Result<Bytes>> {
+    use futures::StreamExt;
+
+    // Number of bytes to emit (inclusive range).
+    let mut remaining = end - start + 1;
+    // Number of leading bytes still to discard before the window begins.
+    let mut to_skip = start;
+
+    let stream = body.filter_map(move |chunk| {
+        let out = match chunk {
+            Ok(mut bytes) => {
+                if to_skip > 0 {
+                    let skip = (to_skip as usize).min(bytes.len());
+                    let _ = bytes.split_to(skip);
+                    to_skip -= skip as u64;
+                }
+                if remaining == 0 || bytes.is_empty() {
+                    None
+                } else {
+                    let take = (remaining as usize).min(bytes.len());
+                    let slice = bytes.split_to(take);
+                    remaining -= take as u64;
+                    Some(Ok(slice))
+                }
+            }
+            Err(e) => Some(Err(e)),
+        };
+        async move { out }
+    });
+    stream.boxed()
+}
+
 /// Download artifact
 #[utoipa::path(
     get,
@@ -3721,27 +3873,68 @@ pub async fn download_artifact(
     match download_result {
         Ok((artifact, body)) => {
             // Stream the body from storage instead of buffering it in memory
-            // (#1608, Core Invariant ①). Headers and status are identical to the
-            // prior buffered path; `size_bytes` gives an accurate Content-Length.
-            let response = Response::builder()
-                .status(StatusCode::OK)
+            // (#1608, Core Invariant ①). `size_bytes` gives an accurate
+            // Content-Length.
+            //
+            // The `Content-Disposition` filename is the basename of the
+            // requested path (e.g. `testpkg-1.0.0.tar.gz`), not the artifact's
+            // package name — matching the virtual-repo download path.
+            let total = artifact.size_bytes.max(0) as u64;
+            let range_header = request
+                .headers()
+                .get(header::RANGE)
+                .and_then(|v| v.to_str().ok());
+            let checksum = artifact.checksum_sha256.trim().to_string();
+            // `artifacts.checksum_sha256` is a CHAR(64) column, so Postgres
+            // blank-pads shorter values on read; trim before emitting so the
+            // header carries the bare checksum.
+
+            let base = Response::builder()
                 .header(header::CONTENT_TYPE, artifact.content_type)
                 .header(
                     header::CONTENT_DISPOSITION,
-                    format!("attachment; filename=\"{}\"", artifact.name),
+                    format!("attachment; filename=\"{}\"", download_filename(&path)),
                 )
-                .header(header::CONTENT_LENGTH, artifact.size_bytes.to_string())
+                // Advertise byte-range support so clients (resumable downloads,
+                // media players) know they may issue `Range` requests.
+                .header(header::ACCEPT_RANGES, "bytes")
                 .header(
                     header::HeaderName::from_static("x-checksum-sha256"),
-                    // `artifacts.checksum_sha256` is a CHAR(64) column, so Postgres
-                    // blank-pads shorter values on read. Trim before emitting so the
-                    // header carries the bare checksum (a real sha256 is exactly 64
-                    // hex chars and is unaffected by the trim).
-                    artifact.checksum_sha256.trim().to_string(),
+                    checksum,
                 )
-                .header(header::HeaderName::from_static(X_ARTIFACT_STORAGE), "proxy")
-                .body(Body::from_stream(body))
-                .map_err(|e| AppError::Internal(format!("failed to build response: {}", e)))?;
+                .header(header::HeaderName::from_static(X_ARTIFACT_STORAGE), "proxy");
+
+            let response = match parse_byte_range(range_header, total) {
+                RangeOutcome::Satisfiable { start, end } => {
+                    let len = end - start + 1;
+                    base.status(StatusCode::PARTIAL_CONTENT)
+                        .header(header::CONTENT_LENGTH, len.to_string())
+                        .header(
+                            header::CONTENT_RANGE,
+                            format!("bytes {}-{}/{}", start, end, total),
+                        )
+                        .body(Body::from_stream(slice_byte_stream(body, start, end)))
+                        .map_err(|e| {
+                            AppError::Internal(format!("failed to build response: {}", e))
+                        })?
+                }
+                RangeOutcome::Unsatisfiable => {
+                    // 416 must carry the resource size via Content-Range and no body.
+                    Response::builder()
+                        .status(StatusCode::RANGE_NOT_SATISFIABLE)
+                        .header(header::ACCEPT_RANGES, "bytes")
+                        .header(header::CONTENT_RANGE, format!("bytes */{}", total))
+                        .body(Body::empty())
+                        .map_err(|e| {
+                            AppError::Internal(format!("failed to build response: {}", e))
+                        })?
+                }
+                RangeOutcome::Full => base
+                    .status(StatusCode::OK)
+                    .header(header::CONTENT_LENGTH, total.to_string())
+                    .body(Body::from_stream(body))
+                    .map_err(|e| AppError::Internal(format!("failed to build response: {}", e)))?,
+            };
             Ok(response)
         }
         Err(AppError::NotFound(_)) if repo.repo_type == RepositoryType::Remote => {
@@ -4797,6 +4990,157 @@ fn format_repo_type(repo_type: &RepositoryType) -> String {
 mod tests {
     use super::*;
     use crate::error::AppError;
+
+    // -----------------------------------------------------------------------
+    // Content-Disposition filename derivation (#1785) — the download filename
+    // must be the basename of the requested path, not the package name.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn download_filename_uses_path_basename() {
+        assert_eq!(
+            download_filename("testpkg/1.0.0/testpkg-1.0.0.tar.gz"),
+            "testpkg-1.0.0.tar.gz"
+        );
+    }
+
+    #[test]
+    fn download_filename_handles_flat_path() {
+        assert_eq!(download_filename("plainfile.bin"), "plainfile.bin");
+    }
+
+    #[test]
+    fn download_filename_handles_trailing_slash() {
+        // A trailing slash would otherwise yield an empty basename; fall back
+        // to the full path rather than emitting an empty filename.
+        assert_eq!(download_filename("a/b/"), "a/b/");
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTP Range parsing (#1785) — `Range: bytes=...` must produce 206 with the
+    // correct window, 416 for out-of-bounds, and degrade to a full 200 for
+    // multi-range / unparseable headers.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn range_none_is_full() {
+        assert_eq!(parse_byte_range(None, 100), RangeOutcome::Full);
+    }
+
+    #[test]
+    fn range_explicit_inclusive() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=0-1023"), 102_624),
+            RangeOutcome::Satisfiable {
+                start: 0,
+                end: 1023
+            }
+        );
+    }
+
+    #[test]
+    fn range_open_ended_start() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=500-"), 1000),
+            RangeOutcome::Satisfiable {
+                start: 500,
+                end: 999
+            }
+        );
+    }
+
+    #[test]
+    fn range_suffix() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=-200"), 1000),
+            RangeOutcome::Satisfiable {
+                start: 800,
+                end: 999
+            }
+        );
+    }
+
+    #[test]
+    fn range_suffix_larger_than_total_clamps() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=-5000"), 1000),
+            RangeOutcome::Satisfiable { start: 0, end: 999 }
+        );
+    }
+
+    #[test]
+    fn range_end_clamped_to_last_byte() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=0-9999"), 1000),
+            RangeOutcome::Satisfiable { start: 0, end: 999 }
+        );
+    }
+
+    #[test]
+    fn range_start_past_end_is_unsatisfiable() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=2000-"), 1000),
+            RangeOutcome::Unsatisfiable
+        );
+        assert_eq!(
+            parse_byte_range(Some("bytes=2000-3000"), 1000),
+            RangeOutcome::Unsatisfiable
+        );
+    }
+
+    #[test]
+    fn range_inverted_is_unsatisfiable() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=500-100"), 1000),
+            RangeOutcome::Unsatisfiable
+        );
+    }
+
+    #[test]
+    fn range_multi_range_degrades_to_full() {
+        assert_eq!(
+            parse_byte_range(Some("bytes=0-10,20-30"), 1000),
+            RangeOutcome::Full
+        );
+    }
+
+    #[test]
+    fn range_unparseable_degrades_to_full() {
+        assert_eq!(
+            parse_byte_range(Some("seconds=0-10"), 1000),
+            RangeOutcome::Full
+        );
+        assert_eq!(
+            parse_byte_range(Some("bytes=abc-def"), 1000),
+            RangeOutcome::Full
+        );
+        assert_eq!(parse_byte_range(Some("bytes=-"), 1000), RangeOutcome::Full);
+    }
+
+    #[test]
+    fn range_on_empty_resource_is_full() {
+        assert_eq!(parse_byte_range(Some("bytes=0-10"), 0), RangeOutcome::Full);
+    }
+
+    #[tokio::test]
+    async fn slice_byte_stream_yields_only_window() {
+        use futures::StreamExt;
+        // Three chunks spanning bytes 0..9: "ab" "cdef" "ghij".
+        let chunks: Vec<Result<Bytes>> = vec![
+            Ok(Bytes::from_static(b"ab")),
+            Ok(Bytes::from_static(b"cdef")),
+            Ok(Bytes::from_static(b"ghij")),
+        ];
+        let body = futures::stream::iter(chunks).boxed();
+        // Request bytes 3..=6 inclusive => "defg".
+        let sliced = slice_byte_stream(body, 3, 6);
+        let collected: Vec<u8> = sliced
+            .filter_map(|r| async move { r.ok() })
+            .collect::<Vec<_>>()
+            .await
+            .concat();
+        assert_eq!(collected, b"defg");
+    }
 
     // -----------------------------------------------------------------------
     // Remote proxy-cache listing (#1548, web #424)
@@ -9043,6 +9387,95 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("proxy"),
             "x-artifact-storage must remain `proxy` for the local-serve path"
+        );
+        // #1785: the Content-Disposition filename must be the basename of the
+        // requested path (`bar.bin`), NOT the artifact's package name (`bar`).
+        assert_eq!(
+            headers
+                .get(header::CONTENT_DISPOSITION)
+                .and_then(|v| v.to_str().ok()),
+            Some("attachment; filename=\"bar.bin\""),
+            "Content-Disposition filename must be the path basename, not the package name"
+        );
+        // #1785: byte-range support must be advertised on every download.
+        assert_eq!(
+            headers
+                .get(header::ACCEPT_RANGES)
+                .and_then(|v| v.to_str().ok()),
+            Some("bytes"),
+            "Accept-Ranges: bytes must be advertised on the local-serve path"
+        );
+    }
+
+    /// #1785: a `Range: bytes=START-END` request against the local-serve path
+    /// must return 206 Partial Content with the correct window, Content-Range,
+    /// and Content-Length — not a 200 with the full body.
+    #[tokio::test]
+    async fn test_download_artifact_local_honours_range_request() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let body_bytes: &[u8] = b"0123456789abcdef";
+        let repo = fx.repo_info("local", None);
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &storage_key,
+            "foo/ranged.bin",
+            "ranged",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(body_bytes),
+            fx.user_id,
+        )
+        .await;
+
+        let router = fx.router_with_auth(download_router());
+        let mut req = tdh::get(format!("/{}/download/foo/ranged.bin", fx.repo_key));
+        req.headers_mut().insert(
+            header::RANGE,
+            axum::http::HeaderValue::from_static("bytes=4-7"),
+        );
+
+        use tower::ServiceExt;
+        let resp = router
+            .oneshot(req)
+            .await
+            .expect("ranged download must respond");
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        let collected = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect partial body");
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            axum::http::StatusCode::PARTIAL_CONTENT,
+            "a satisfiable Range request must return 206"
+        );
+        assert_eq!(
+            &collected[..],
+            b"4567",
+            "the body must contain only the requested byte window"
+        );
+        assert_eq!(
+            headers
+                .get(header::CONTENT_RANGE)
+                .and_then(|v| v.to_str().ok()),
+            Some("bytes 4-7/16"),
+            "Content-Range must report the served window and total size"
+        );
+        assert_eq!(
+            headers
+                .get(header::CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some("4"),
+            "Content-Length must be the size of the partial window"
         );
     }
 

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -83,6 +83,26 @@ async fn resolve_rpm_repo(db: &sqlx::PgPool, repo_key: &str) -> Result<RepoInfo,
     proxy_helpers::resolve_repo_by_key(db, repo_key, &["rpm", "yum"], "an RPM").await
 }
 
+/// Reject RPM uploads to non-hosted (Remote/Virtual) repositories.
+///
+/// `dnf`/`yum` only ever PUT/POST RPMs into hosted repos. Both Remote (proxy)
+/// and Virtual (aggregate) repos must reject the write verb with
+/// `405 Method Not Allowed` so clients receive a consistent, RFC-correct
+/// response. The shared `reject_write_if_not_hosted` helper returns `400` for
+/// Virtual repos (a contract other subsystems depend on), so RPM intercepts
+/// the Virtual case here before delegating the Remote case (#1780).
+#[allow(clippy::result_large_err)]
+fn reject_rpm_write_if_not_hosted(repo_type: &str) -> Result<(), Response> {
+    if repo_type == RepositoryType::Virtual {
+        return Err((
+            StatusCode::METHOD_NOT_ALLOWED,
+            "Cannot publish to a virtual repository",
+        )
+            .into_response());
+    }
+    proxy_helpers::reject_write_if_not_hosted(repo_type)
+}
+
 /// For Remote RPM repos, proxy `upstream_path` from the configured
 /// `upstream_url`. Returns `Ok(Some(response))` on a successful proxy
 /// hit, `Ok(None)` when the repository is not a Remote that can serve
@@ -237,25 +257,60 @@ async fn list_rpm_artifacts(
         .collect())
 }
 
+/// Collect the RPM artifacts a repodata response should describe.
+///
+/// For Hosted (Local/Staging) repos this is just the repo's own artifacts.
+/// For Virtual repos the metadata must reflect the union of every member
+/// repo's packages — otherwise `repomd.xml`/`primary.xml.gz` advertise
+/// `packages="0"` and `dnf` treats the aggregate repo as empty even though
+/// the members hold packages (#1780). We resolve the member repo IDs via
+/// `fetch_virtual_members` and concatenate each member's artifact list.
+async fn collect_repodata_artifacts(
+    db: &sqlx::PgPool,
+    repo: &RepoInfo,
+) -> Result<Vec<RpmArtifact>, Response> {
+    if repo.repo_type != RepositoryType::Virtual {
+        return list_rpm_artifacts(db, repo.id).await;
+    }
+
+    let members = proxy_helpers::fetch_virtual_members(db, repo.id).await?;
+    let mut artifacts = Vec::new();
+    for member in &members {
+        artifacts.extend(list_rpm_artifacts(db, member.id).await?);
+    }
+    Ok(artifacts)
+}
+
 // ---------------------------------------------------------------------------
 // Shared repomd.xml generation
 // ---------------------------------------------------------------------------
 
 fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
-    // Generate primary.xml content and compute its gzipped checksum
+    // Generate primary.xml content and compute both the compressed (gzipped)
+    // and uncompressed (open) sha256 + sizes. DNF/createrepo clients expect a
+    // top-level <revision> plus per-<data> <open-checksum>/<open-size> elements
+    // (#1780); omitting them causes stricter clients to reject the metadata.
     let primary_xml = generate_primary_xml(artifacts);
+    let primary_open_sha256 = sha256_hex(primary_xml.as_bytes());
+    let primary_open_size = primary_xml.len();
     let primary_gz = gzip_bytes(primary_xml.as_bytes());
     let primary_sha256 = sha256_hex(&primary_gz);
 
     let filelists_xml = generate_filelists_xml(artifacts);
+    let filelists_open_sha256 = sha256_hex(filelists_xml.as_bytes());
+    let filelists_open_size = filelists_xml.len();
     let filelists_gz = gzip_bytes(filelists_xml.as_bytes());
     let filelists_sha256 = sha256_hex(&filelists_gz);
 
     let other_xml = generate_other_xml(artifacts);
+    let other_open_sha256 = sha256_hex(other_xml.as_bytes());
+    let other_open_size = other_xml.len();
     let other_gz = gzip_bytes(other_xml.as_bytes());
     let other_sha256 = sha256_hex(&other_gz);
 
     let updateinfo_xml = generate_updateinfo_xml();
+    let updateinfo_open_sha256 = sha256_hex(updateinfo_xml.as_bytes());
+    let updateinfo_open_size = updateinfo_xml.len();
     let updateinfo_gz = gzip_bytes(updateinfo_xml.as_bytes());
     let updateinfo_sha256 = sha256_hex(&updateinfo_gz);
 
@@ -266,42 +321,59 @@ fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
 
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
-<repomd xmlns="http://linux.duke.edu/metadata/repo">
+<repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
+  <revision>{timestamp}</revision>
   <data type="primary">
     <location href="repodata/primary.xml.gz"/>
     <checksum type="sha256">{primary_sha256}</checksum>
+    <open-checksum type="sha256">{primary_open_sha256}</open-checksum>
     <timestamp>{timestamp}</timestamp>
     <size>{primary_size}</size>
+    <open-size>{primary_open_size}</open-size>
   </data>
   <data type="filelists">
     <location href="repodata/filelists.xml.gz"/>
     <checksum type="sha256">{filelists_sha256}</checksum>
+    <open-checksum type="sha256">{filelists_open_sha256}</open-checksum>
     <timestamp>{timestamp}</timestamp>
     <size>{filelists_size}</size>
+    <open-size>{filelists_open_size}</open-size>
   </data>
   <data type="other">
     <location href="repodata/other.xml.gz"/>
     <checksum type="sha256">{other_sha256}</checksum>
+    <open-checksum type="sha256">{other_open_sha256}</open-checksum>
     <timestamp>{timestamp}</timestamp>
     <size>{other_size}</size>
+    <open-size>{other_open_size}</open-size>
   </data>
   <data type="updateinfo">
     <location href="repodata/updateinfo.xml.gz"/>
     <checksum type="sha256">{updateinfo_sha256}</checksum>
+    <open-checksum type="sha256">{updateinfo_open_sha256}</open-checksum>
     <timestamp>{timestamp}</timestamp>
     <size>{updateinfo_size}</size>
+    <open-size>{updateinfo_open_size}</open-size>
   </data>
 </repomd>
 "#,
         primary_sha256 = primary_sha256,
+        primary_open_sha256 = primary_open_sha256,
         filelists_sha256 = filelists_sha256,
+        filelists_open_sha256 = filelists_open_sha256,
         other_sha256 = other_sha256,
+        other_open_sha256 = other_open_sha256,
         updateinfo_sha256 = updateinfo_sha256,
+        updateinfo_open_sha256 = updateinfo_open_sha256,
         timestamp = timestamp,
         primary_size = primary_gz.len(),
+        primary_open_size = primary_open_size,
         filelists_size = filelists_gz.len(),
+        filelists_open_size = filelists_open_size,
         other_size = other_gz.len(),
+        other_open_size = other_open_size,
         updateinfo_size = updateinfo_gz.len(),
+        updateinfo_open_size = updateinfo_open_size,
     )
 }
 
@@ -323,7 +395,7 @@ async fn repomd_xml(
         return Ok(resp);
     }
 
-    let artifacts = list_rpm_artifacts(&state.db, repo.id).await?;
+    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
     let xml = generate_repomd_xml_content(&artifacts);
 
     Ok(Response::builder()
@@ -355,7 +427,7 @@ async fn repomd_xml_asc(
         return Ok(resp);
     }
 
-    let artifacts = list_rpm_artifacts(&state.db, repo.id).await?;
+    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
     let repomd_content = generate_repomd_xml_content(&artifacts);
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
@@ -470,7 +542,7 @@ async fn primary_xml_gz(
         return Ok(resp);
     }
 
-    let artifacts = list_rpm_artifacts(&state.db, repo.id).await?;
+    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
 
     let primary_xml = generate_primary_xml(&artifacts);
     let gz = gzip_bytes(primary_xml.as_bytes());
@@ -504,7 +576,7 @@ async fn filelists_xml_gz(
         return Ok(resp);
     }
 
-    let artifacts = list_rpm_artifacts(&state.db, repo.id).await?;
+    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
 
     let filelists_xml = generate_filelists_xml(&artifacts);
     let gz = gzip_bytes(filelists_xml.as_bytes());
@@ -533,7 +605,7 @@ async fn other_xml_gz(
         return Ok(resp);
     }
 
-    let artifacts = list_rpm_artifacts(&state.db, repo.id).await?;
+    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
 
     let other_xml = generate_other_xml(&artifacts);
     let gz = gzip_bytes(other_xml.as_bytes());
@@ -760,7 +832,7 @@ async fn upload_package_put(
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = require_auth_basic_scope(auth, "rpm", "write")?.user_id;
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
-    proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    reject_rpm_write_if_not_hosted(&repo.repo_type)?;
 
     let filename = pkg_path.rsplit('/').next().unwrap_or(&pkg_path).to_string();
 
@@ -785,7 +857,7 @@ async fn upload_package_post(
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = require_auth_basic_scope(auth, "rpm", "write")?.user_id;
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
-    proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    reject_rpm_write_if_not_hosted(&repo.repo_type)?;
 
     // Try to get filename from Content-Disposition header, fall back to a hash-based name
     let filename = headers
@@ -2431,5 +2503,167 @@ mod tests {
         );
         // seed_artifact stores checksum "test-seed"; verify it is surfaced.
         assert_eq!(checksum_header.as_deref(), Some("test-seed"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #1780: repomd.xml must carry <revision>, <open-checksum>, <open-size>
+    // so stricter DNF/createrepo clients accept the metadata.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_generate_repomd_xml_content_has_revision_and_open_metadata() {
+        let xml = generate_repomd_xml_content(&[]);
+        // Top-level revision element present exactly once.
+        assert!(xml.contains("<revision>"), "missing <revision>: {xml}");
+        // Each of the four <data> blocks gets open-checksum + open-size.
+        assert_eq!(
+            xml.matches("<open-checksum type=\"sha256\">").count(),
+            4,
+            "expected 4 <open-checksum> elements: {xml}"
+        );
+        assert_eq!(
+            xml.matches("<open-size>").count(),
+            4,
+            "expected 4 <open-size> elements: {xml}"
+        );
+    }
+
+    #[test]
+    fn test_generate_repomd_open_checksum_matches_uncompressed_primary() {
+        // The primary <open-checksum> must equal sha256 of the *uncompressed*
+        // primary.xml, while the regular <checksum> hashes the gzipped blob.
+        let xml = generate_repomd_xml_content(&[]);
+        let primary_xml = generate_primary_xml(&[]);
+        let expected_open = sha256_hex(primary_xml.as_bytes());
+        assert!(
+            xml.contains(&format!(
+                "<open-checksum type=\"sha256\">{expected_open}</open-checksum>"
+            )),
+            "primary open-checksum should hash the uncompressed primary.xml"
+        );
+        // And the compressed checksum must differ from the open one.
+        let primary_gz_sha = sha256_hex(&gzip_bytes(primary_xml.as_bytes()));
+        assert_ne!(expected_open, primary_gz_sha);
+        assert!(xml.contains(&format!(
+            "<checksum type=\"sha256\">{primary_gz_sha}</checksum>"
+        )));
+    }
+
+    // -----------------------------------------------------------------------
+    // #1780: PUT/POST to a virtual RPM repo must return 405 (not 400), to
+    // match the remote-repo response.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reject_rpm_write_virtual_returns_405() {
+        let err = reject_rpm_write_if_not_hosted("virtual").unwrap_err();
+        assert_eq!(err.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[test]
+    fn test_reject_rpm_write_remote_returns_405() {
+        let err = reject_rpm_write_if_not_hosted("remote").unwrap_err();
+        assert_eq!(err.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[test]
+    fn test_reject_rpm_write_local_is_ok() {
+        assert!(reject_rpm_write_if_not_hosted("local").is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_rpm_upload_virtual_405() {
+        let Some(f) = tdh::Fixture::setup("virtual", "rpm").await else {
+            return;
+        };
+        let app = f.router_with_auth(super::router());
+        let req = tdh::put(
+            format!("/{}/packages/foo-1.0-1.x86_64.rpm", f.repo_key),
+            bytes::Bytes::from_static(b"data"),
+        );
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #1780: Virtual repo repodata must aggregate member packages instead of
+    // reporting packages="0".
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_rpm_virtual_repomd_aggregates_member_packages() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let Some(f) = tdh::Fixture::setup("virtual", "rpm").await else {
+            return;
+        };
+
+        // Create a hosted member repo and seed an RPM artifact into it.
+        let (member_id, _member_key, _member_dir) = tdh::create_repo(&f.pool, "local", "rpm").await;
+        let member_repo =
+            tdh::make_repo_info(member_id, "rpm-virt-member", &f.storage_dir, "local", None);
+        tdh::seed_artifact(
+            &f.state,
+            &f.pool,
+            &member_repo,
+            "rpm/member/agg-1.0-1.x86_64.rpm",
+            "packages/agg-1.0-1.x86_64.rpm",
+            "agg",
+            "1.0-1",
+            "application/x-rpm",
+            bytes::Bytes::from_static(b"member-rpm-bytes"),
+            f.user_id,
+        )
+        .await;
+
+        // Wire the membership: virtual (f.repo_id) -> member.
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 0)",
+        )
+        .bind(f.repo_id)
+        .bind(member_id)
+        .execute(&f.pool)
+        .await
+        .expect("insert virtual member");
+
+        // primary.xml.gz must report 1 package (decompress and inspect).
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/repodata/primary.xml.gz", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let mut decoder = GzDecoder::new(&body[..]);
+        let mut primary = String::new();
+        decoder
+            .read_to_string(&mut primary)
+            .expect("decompress primary.xml.gz");
+        assert!(
+            primary.contains("packages=\"1\""),
+            "virtual primary.xml should aggregate the member package, got: {primary}"
+        );
+        assert!(primary.contains("<name>agg</name>"));
+
+        // Cleanup the extra member repo + membership.
+        sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(f.repo_id)
+            .execute(&f.pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+            .bind(member_id)
+            .execute(&f.pool)
+            .await
+            .ok();
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(member_id)
+            .execute(&f.pool)
+            .await
+            .ok();
+        f.teardown().await;
     }
 }

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -212,6 +212,7 @@ async fn revoke_key(
     Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
+    require_signing_admin(&auth)?;
     let svc = signing_service(&state);
     svc.revoke_key(key_id, Some(auth.user_id)).await?;
     Ok(Json(serde_json::json!({"revoked": true})))
@@ -483,6 +484,24 @@ mod tests {
         match require_signing_admin(&ext) {
             Err(AppError::Authorization(_)) => {}
             other => panic!("expected 403 Authorization for non-admin, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_non_admin_blocked_from_revoking_signing_key() {
+        // Regression for #1784: revoke_key previously omitted the admin gate
+        // that create_key, delete_key, and update_repo_signing_config enforce,
+        // letting a non-admin JWT revoke (deactivate) any signing key via
+        // POST /api/v1/signing/keys/{id}/revoke and break the trust chain.
+        // revoke_key now calls require_signing_admin(&auth)? first; pin that a
+        // non-admin is rejected with 403 (no DB needed).
+        let ext = non_admin_jwt();
+        match require_signing_admin(&ext) {
+            Err(AppError::Authorization(_)) => {}
+            other => panic!(
+                "expected 403 Authorization for non-admin revoke, got {:?}",
+                other
+            ),
         }
     }
 

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -205,7 +205,9 @@ pub async fn list_users(
     // if someone moves it between routers in the future. See #1257.
     auth.require_admin()?;
     let page = query.page.unwrap_or(1).max(1);
-    let per_page = query.per_page.unwrap_or(20).min(100);
+    // Shared clamp: per_page=0 would otherwise divide by zero in total_pages
+    // and saturate to u32::MAX (#1783 LOW). See clamp_per_page docs.
+    let per_page = crate::api::handlers::repositories::clamp_per_page(query.per_page);
     let offset = ((page - 1) * per_page) as i64;
 
     let search_pattern = query.search.as_ref().map(|s| format!("%{}%", s));

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -330,6 +330,12 @@ fn extract_token_from_auth_header(auth_header: &str) -> ExtractedToken<'_> {
         .or_else(|| auth_header.strip_prefix("basic "))
     {
         ExtractedToken::Basic(creds)
+    } else if !auth_header.is_empty() && !auth_header.contains(' ') {
+        // The native cargo client's `cargo:token` credential provider sends the
+        // raw token as the Authorization header value with NO scheme prefix
+        // (e.g. `Authorization: <token>`). A scheme-less, single-word value is
+        // therefore treated as a Bearer token so cargo can authenticate.
+        ExtractedToken::Bearer(auth_header)
     } else {
         ExtractedToken::Invalid
     }
@@ -1086,6 +1092,10 @@ fn unauthorized_response() -> Response {
             "WWW-Authenticate",
             "Bearer realm=\"artifact-keeper\", charset=\"UTF-8\"",
         )
+        // Signals cargo 1.67+ to use the Cargo token protocol (sends the token
+        // as the raw Authorization header value) rather than aborting on the
+        // Basic/Bearer challenges it does not understand.
+        .header("WWW-Authenticate", "Cargo")
         .header(axum::http::header::CONTENT_TYPE, "text/plain")
         .body(axum::body::Body::from("Authentication required"))
         .unwrap()
@@ -2138,6 +2148,31 @@ mod tests {
             www_auth_values.iter().any(|v| v.starts_with("Bearer")),
             "expected a Bearer WWW-Authenticate challenge"
         );
+        // Must also include the Cargo challenge so cargo 1.67+ uses the token
+        // protocol instead of aborting on the Basic/Bearer challenges.
+        assert!(
+            www_auth_values.iter().any(|v| v.starts_with("Cargo")),
+            "expected a Cargo WWW-Authenticate challenge"
+        );
+    }
+
+    #[test]
+    fn test_extract_plain_token_treated_as_bearer() {
+        // The native cargo client sends the raw token with no scheme prefix;
+        // a scheme-less single-word value must be accepted as a Bearer token.
+        let result = extract_token_from_auth_header("ak_raw_cargo_token_123");
+        assert!(matches!(
+            result,
+            ExtractedToken::Bearer("ak_raw_cargo_token_123")
+        ));
+    }
+
+    #[test]
+    fn test_extract_plain_token_with_space_is_invalid() {
+        // A multi-word value that matches no known scheme is still invalid
+        // (it is not a raw token).
+        let result = extract_token_from_auth_header("Unknown scheme-value");
+        assert!(matches!(result, ExtractedToken::Invalid));
     }
 
     #[test]

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1142,6 +1142,18 @@ fn forbidden_permission_response() -> Response {
         .unwrap()
 }
 
+/// Build a 404 response that hides the existence of a private repository the
+/// caller is not authorized to see. Mirrors the REST `require_visible` helper
+/// (which returns `NotFound`) so the native-protocol and REST paths give the
+/// same existence-hiding answer for an inaccessible private repo.
+fn not_found_response() -> Response {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .header(axum::http::header::CONTENT_TYPE, "text/plain")
+        .body(axum::body::Body::from("Repository not found"))
+        .unwrap()
+}
+
 /// Map an HTTP method to a permission action string.
 ///
 /// Used by [`repo_visibility_middleware`] to determine the required permission
@@ -1402,6 +1414,43 @@ pub async fn repo_visibility_middleware(
 
                 if !allowed {
                     return forbidden_permission_response();
+                }
+            } else if !is_public {
+                // A private repo with NO fine-grained permission rules must
+                // still not be readable by every authenticated user. Mirror
+                // the REST `require_visible` model: a non-admin needs a role
+                // assignment scoped to this repo (or a global assignment).
+                //
+                // Without this branch the native-protocol path default-ALLOWED
+                // rule-less private repos to any authenticated principal, while
+                // the REST download path denied the same caller (404) — a
+                // cross-tenant private-artifact leak (red-team round 2).
+                //
+                // Uses sqlx::query_scalar (not the macro) so no new entry in
+                // the sqlx offline-query cache is required, matching the rest
+                // of this middleware. Same predicate as
+                // RepositoryService::user_can_access_repo.
+                let granted = sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS ( \
+                         SELECT 1 FROM role_assignments ra \
+                         WHERE ra.user_id = $1 \
+                           AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
+                     )",
+                )
+                .bind(ext.user_id)
+                .bind(repo.id)
+                .fetch_one(&vis_state.db)
+                .await;
+
+                match granted {
+                    Ok(true) => {}
+                    // Existence-hiding 404, matching REST `require_visible`.
+                    Ok(false) => return not_found_response(),
+                    Err(_) => {
+                        // DB error on access check: fail closed.
+                        tracing::error!("repo access check failed: database unreachable");
+                        return service_unavailable_response();
+                    }
                 }
             }
         }
@@ -3694,5 +3743,139 @@ mod tests {
             .unwrap();
         let resp = run_through_visibility(state, req).await;
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Regression (red-team round 2): a PRIVATE repo with NO fine-grained
+    /// permission rules must NOT be readable by an authenticated non-admin who
+    /// holds no role assignment for it. The native-protocol middleware must
+    /// match the REST `require_visible` model (existence-hiding 404), not
+    /// default-allow to any authenticated principal.
+    ///
+    /// DB-backed: no-ops when `DATABASE_URL` is unset; runs for real in the CI
+    /// coverage job (which seeds Postgres before `cargo llvm-cov --lib`).
+    #[tokio::test]
+    async fn test_private_repo_without_rules_denies_unassigned_nonadmin() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::models::user::{AuthProvider, User};
+        use crate::services::permission_service::PermissionService;
+        use std::sync::Arc;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (user_id, username) = tdh::create_user(&pool).await; // non-admin
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "local", "pypi").await; // is_public defaults false
+
+        // Mint a real access JWT for this non-admin user. AuthService is built
+        // on the real pool so the replica-safe invalidation check succeeds.
+        let auth_service = Arc::new(AuthService::new(
+            pool.clone(),
+            make_test_config_for_middleware(),
+        ));
+        let now = chrono::Utc::now();
+        let user = User {
+            id: user_id,
+            username: username.clone(),
+            email: format!("{}@test.local", username),
+            password_hash: None,
+            auth_provider: AuthProvider::Local,
+            external_id: None,
+            display_name: None,
+            is_active: true,
+            is_admin: false,
+            is_service_account: false,
+            must_change_password: false,
+            totp_secret: None,
+            totp_enabled: false,
+            totp_backup_codes: None,
+            totp_verified_at: None,
+            failed_login_attempts: 0,
+            locked_until: None,
+            last_failed_login_at: None,
+            password_changed_at: now,
+            last_login_at: Some(now),
+            created_at: now,
+            updated_at: now,
+        };
+        let bearer = format!(
+            "Bearer {}",
+            auth_service.generate_tokens(&user).unwrap().access_token
+        );
+
+        // Fresh state per request: a pre-populated cache so the middleware skips
+        // the DB repo lookup, with the private repo's real id so the
+        // role_assignments query resolves against it.
+        async fn mk_state(
+            pool: &sqlx::PgPool,
+            auth: Arc<AuthService>,
+            repo_key: &str,
+            repo_id: Uuid,
+            storage_path: String,
+        ) -> RepoVisibilityState {
+            let cache: RepoCache =
+                Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+            let entry = CachedRepo {
+                id: repo_id,
+                format: "pypi".to_string(),
+                repo_type: "local".to_string(),
+                upstream_url: None,
+                storage_path,
+                storage_backend: "filesystem".to_string(),
+                is_public: false,
+                index_upstream_url: None,
+            };
+            cache
+                .write()
+                .await
+                .insert(repo_key.to_string(), (entry, std::time::Instant::now()));
+            RepoVisibilityState {
+                auth_service: auth,
+                db: pool.clone(),
+                repo_cache: cache,
+                permission_service: Arc::new(PermissionService::new(pool.clone())),
+            }
+        }
+
+        let req = || {
+            axum::http::Request::builder()
+                .method(Method::GET)
+                .uri(format!("/pypi/{}/simple/", repo_key))
+                .header("Authorization", &bearer)
+                .body(axum::body::Body::empty())
+                .unwrap()
+        };
+        let storage = storage_dir.to_string_lossy().into_owned();
+
+        // 1) No role assignment -> existence-hiding 404 (the fix). Without the
+        //    fix this returned 200 and leaked the private repo's contents.
+        let state = mk_state(
+            &pool,
+            auth_service.clone(),
+            &repo_key,
+            repo_id,
+            storage.clone(),
+        )
+        .await;
+        let resp = run_through_visibility(state, req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "authenticated non-admin without a role assignment must NOT read a \
+             rule-less private repo via the native path"
+        );
+
+        // 2) Grant a role assignment -> access restored (parity with REST).
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = mk_state(&pool, auth_service, &repo_key, repo_id, storage).await;
+        let resp = run_through_visibility(state, req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "a role assignment must restore native-path access to the private repo"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
     }
 }

--- a/backend/src/api/middleware/security_headers.rs
+++ b/backend/src/api/middleware/security_headers.rs
@@ -22,12 +22,19 @@ pub async fn security_headers_middleware(request: Request, next: Next) -> Respon
         "permissions-policy",
         "camera=(), microphone=(), geolocation=()".parse().unwrap(),
     );
-    headers.insert(
-        "content-security-policy",
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
-            .parse()
-            .unwrap(),
-    );
+    // Only set the global default CSP when the handler did not already set a
+    // tighter, route-specific policy. Using `entry().or_insert()` (rather than
+    // `insert()`, which unconditionally overwrites) preserves a per-handler CSP
+    // such as the restrictive `default-src 'none'` the PyPI simple-index
+    // handler emits, while still providing a safe default for every other
+    // route (#1773).
+    headers
+        .entry("content-security-policy")
+        .or_insert(
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+                .parse()
+                .unwrap(),
+        );
 
     response
 }
@@ -137,6 +144,41 @@ mod tests {
         assert_eq!(resp.status(), axum::http::StatusCode::OK);
         // We verify the status code is OK, which confirms the handler ran.
         // Body consumption requires http-body-util which is not a direct dependency.
+    }
+
+    #[tokio::test]
+    async fn test_security_headers_preserves_handler_set_csp() {
+        // Regression for #1773: a handler that sets its own (tighter) CSP must
+        // not have it clobbered by the global default. The middleware should
+        // only fill in the default CSP when none is already present.
+        async fn tight_csp_handler() -> axum::response::Response {
+            axum::response::Response::builder()
+                .header(
+                    "content-security-policy",
+                    "default-src 'none'; style-src 'unsafe-inline'",
+                )
+                .body(Body::from("OK"))
+                .unwrap()
+        }
+
+        let app = Router::new()
+            .route("/tight", get(tight_csp_handler))
+            .layer(middleware::from_fn(security_headers_middleware));
+        let request = Request::builder()
+            .uri("/tight")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(request).await.unwrap();
+
+        let csp = resp
+            .headers()
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(csp, "default-src 'none'; style-src 'unsafe-inline'");
+        // The other security headers must still be applied.
+        assert!(resp.headers().get("x-frame-options").is_some());
     }
 
     #[tokio::test]

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -610,6 +610,15 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
+        // #1784: axum 0.7 nest matches `/sbom` (no slash) against the inner `/`
+        // route but does NOT match the trailing-slash form `/sbom/`, which 404'd
+        // with an empty body instead of behaving like the list endpoint. Add an
+        // explicit redirect from the trailing-slash form to the canonical path
+        // so clients that append a slash still reach the list handler.
+        .route(
+            "/sbom/",
+            get(|| async { axum::response::Redirect::permanent("/api/v1/sbom") }),
+        )
         // Promotion routes with auth middleware (staging -> release workflow)
         .nest(
             "/promotion",
@@ -746,6 +755,30 @@ mod tests {
             incus_count >= 2,
             "expected handlers::incus::router() to be referenced at least \
              twice (once for /incus, once for /lxc); found {incus_count}"
+        );
+    }
+
+    #[test]
+    fn sbom_trailing_slash_is_handled() {
+        // Regression for #1784: axum 0.7's `.nest("/sbom", ...)` resolves the
+        // no-slash form `/sbom` (against the inner `/` route) but 404's the
+        // trailing-slash form `/sbom/` with an empty body. The fix registers an
+        // explicit redirect route for the trailing-slash form. A runtime test
+        // would need full app state + a DB; pin the routing decision in source.
+        assert!(
+            ROUTES_RS_SRC.contains(".nest(\n            \"/sbom\","),
+            "sbom nest registration missing; the trailing-slash redirect test \
+             below would otherwise be vacuously true"
+        );
+        assert!(
+            ROUTES_RS_SRC.contains(".route(\n            \"/sbom/\","),
+            "/sbom/ trailing-slash redirect missing; GET /api/v1/sbom/ will \
+             404 with an empty body instead of reaching the list handler \
+             (regression of #1784)"
+        );
+        assert!(
+            ROUTES_RS_SRC.contains("Redirect::permanent(\"/api/v1/sbom\")"),
+            "/sbom/ route must redirect to the canonical /api/v1/sbom path"
         );
     }
 

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -205,25 +205,29 @@ pub enum ComposerPathKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComposerJson {
     pub name: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
-    #[serde(rename = "type", default)]
+    #[serde(rename = "type", default, skip_serializing_if = "Option::is_none")]
     pub package_type: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub license: Option<serde_json::Value>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub require: Option<HashMap<String, String>>,
-    #[serde(rename = "require-dev", default)]
+    #[serde(
+        rename = "require-dev",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub require_dev: Option<HashMap<String, String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub autoload: Option<serde_json::Value>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub authors: Option<Vec<ComposerAuthor>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub homepage: Option<String>,
 }
 
@@ -544,5 +548,48 @@ mod tests {
         assert_eq!(parsed.name, "vendor/pkg");
         assert_eq!(parsed.version, Some("1.0.0".to_string()));
         assert_eq!(parsed.package_type, Some("library".to_string()));
+    }
+
+    // #1781: a minimal composer.json (only name + version) must NOT serialize
+    // absent optional fields as JSON null. The Packagist/Composer spec omits
+    // them; serializing `"description": null` etc. pollutes stored metadata.
+    #[test]
+    fn test_composer_json_omits_none_fields_on_serialize() {
+        let cj = ComposerJson {
+            name: "vendor/minimal".to_string(),
+            description: None,
+            version: Some("1.0.0".to_string()),
+            package_type: None,
+            license: None,
+            require: None,
+            require_dev: None,
+            autoload: None,
+            authors: None,
+            keywords: None,
+            homepage: None,
+        };
+        let value = serde_json::to_value(&cj).unwrap();
+        let obj = value.as_object().unwrap();
+        // Only the fields that are Some are present.
+        assert_eq!(obj.len(), 2, "only name + version should be serialized");
+        assert!(obj.contains_key("name"));
+        assert!(obj.contains_key("version"));
+        for absent in [
+            "description",
+            "type",
+            "license",
+            "require",
+            "require-dev",
+            "autoload",
+            "authors",
+            "keywords",
+            "homepage",
+        ] {
+            assert!(
+                !obj.contains_key(absent),
+                "absent optional field `{}` must be omitted, not null",
+                absent
+            );
+        }
     }
 }

--- a/backend/src/formats/conda_native.rs
+++ b/backend/src/formats/conda_native.rs
@@ -86,6 +86,24 @@ impl CondaNativeHandler {
         }
     }
 
+    /// Parse a bare Conda package filename (no subdir prefix) into its
+    /// `(name, version, build)` coordinates. Accepts both `.conda` and
+    /// `.tar.bz2` extensions. Used by the upload validator to cross-check the
+    /// filename against the embedded `index.json` metadata.
+    pub fn parse_package_filename(filename: &str) -> Result<(String, String, String)> {
+        let stem = if let Some(s) = filename.strip_suffix(".conda") {
+            s
+        } else if let Some(s) = filename.strip_suffix(".tar.bz2") {
+            s
+        } else {
+            return Err(AppError::Validation(format!(
+                "Invalid Conda package: {}",
+                filename
+            )));
+        };
+        Self::parse_conda_filename(stem)
+    }
+
     /// Parse Conda package filename: `<name>-<version>-<build_string>`
     fn parse_conda_filename(stem: &str) -> Result<(String, String, String)> {
         // Split from the right: build is last, version is second-to-last
@@ -232,5 +250,27 @@ mod tests {
         let info = CondaNativeHandler::parse_path("channeldata.json").unwrap();
         assert!(info.is_index);
         assert!(info.subdir.is_none());
+    }
+
+    #[test]
+    fn test_parse_package_filename_v1_and_v2() {
+        // Bare filename parse used by the upload validator (#1782).
+        let (name, version, build) =
+            CondaNativeHandler::parse_package_filename("testpkg-1.0.0-py310_0.tar.bz2").unwrap();
+        assert_eq!(name, "testpkg");
+        assert_eq!(version, "1.0.0");
+        assert_eq!(build, "py310_0");
+
+        let (name, version, build) =
+            CondaNativeHandler::parse_package_filename("numpy-1.26.4-py312h02b7e37_0.conda")
+                .unwrap();
+        assert_eq!(name, "numpy");
+        assert_eq!(version, "1.26.4");
+        assert_eq!(build, "py312h02b7e37_0");
+    }
+
+    #[test]
+    fn test_parse_package_filename_rejects_unknown_extension() {
+        assert!(CondaNativeHandler::parse_package_filename("pkg-1.0-0.zip").is_err());
     }
 }

--- a/backend/src/formats/helm.rs
+++ b/backend/src/formats/helm.rs
@@ -59,39 +59,64 @@ impl HelmHandler {
         )))
     }
 
-    /// Parse chart filename to extract name and version
-    /// Format: <name>-<version>.tgz
+    /// Returns true if `segment` looks like a chart version token.
+    ///
+    /// Accepts plain semver (`1.24.0`) as well as OCI-style `v`-prefixed tags
+    /// (`v1.14.0`). To avoid mistaking a chart-name segment such as `2nd` for a
+    /// version, the leading numeric run (after an optional `v`/`V`) must be
+    /// followed by a version-structural character (`.`, `-`, `+`) or the end of
+    /// the token — not an alphabetic continuation like `nd`.
+    fn looks_like_version_start(segment: &str) -> bool {
+        let bytes = segment.as_bytes();
+        let mut i = 0;
+        // Optional leading v / V (OCI-style tag).
+        if matches!(bytes.first(), Some(b'v') | Some(b'V')) {
+            i = 1;
+        }
+        // Require at least one digit.
+        let digits_start = i;
+        while i < bytes.len() && bytes[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == digits_start {
+            return false;
+        }
+        // The numeric run must end the token or be followed by version syntax.
+        matches!(bytes.get(i), None | Some(b'.') | Some(b'-') | Some(b'+'))
+    }
+
+    /// Parse chart filename to extract name and version.
+    ///
+    /// Format: `<name>-<version>.tgz`
+    ///
+    /// The version may contain hyphens itself (semver pre-release / build
+    /// metadata such as `1.24.0-rc.1` or `1.0.0-alpha.1+build.5`), so we cannot
+    /// simply split on the last hyphen. Instead we scan hyphen boundaries from
+    /// left to right and pick the FIRST one whose right-hand side looks like the
+    /// start of a version (leading digit, or `v`/`V` + digit). This keeps the
+    /// chart name greedy while still capturing the full version, including
+    /// pre-release suffixes that the naive last-hyphen split would truncate.
     fn parse_chart_filename(filename: &str) -> Result<(String, String)> {
-        let name = filename.trim_end_matches(".tgz");
+        let stem = filename.trim_end_matches(".tgz");
 
-        // Find the last hyphen that separates name from version
-        // Version starts with a digit
-        let parts: Vec<&str> = name.rsplitn(2, '-').collect();
-
-        if parts.len() != 2 {
-            return Err(AppError::Validation(format!(
-                "Invalid Helm chart filename: {}",
-                filename
-            )));
+        // Candidate split points: every hyphen that is not the first character.
+        // Walk left-to-right so the chart name stays as long as possible and the
+        // version captures any embedded pre-release hyphens.
+        for (idx, _) in stem.match_indices('-') {
+            if idx == 0 {
+                continue;
+            }
+            let chart_name = &stem[..idx];
+            let version = &stem[idx + 1..];
+            if !version.is_empty() && Self::looks_like_version_start(version) {
+                return Ok((chart_name.to_string(), version.to_string()));
+            }
         }
 
-        let version = parts[0];
-        let chart_name = parts[1];
-
-        // Validate version starts with a digit (semver)
-        if !version
-            .chars()
-            .next()
-            .map(|c| c.is_ascii_digit())
-            .unwrap_or(false)
-        {
-            return Err(AppError::Validation(format!(
-                "Invalid Helm chart version in filename: {}",
-                filename
-            )));
-        }
-
-        Ok((chart_name.to_string(), version.to_string()))
+        Err(AppError::Validation(format!(
+            "Invalid Helm chart filename: {}",
+            filename
+        )))
     }
 
     /// Extract Chart.yaml from chart package
@@ -266,29 +291,29 @@ pub struct ChartYaml {
     pub api_version: String,
     pub name: String,
     pub version: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub kube_version: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[serde(default, rename = "type")]
+    #[serde(default, rename = "type", skip_serializing_if = "Option::is_none")]
     pub chart_type: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub keywords: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub home: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sources: Option<Vec<String>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub dependencies: Option<Vec<ChartDependency>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maintainers: Option<Vec<ChartMaintainer>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub icon: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub app_version: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deprecated: Option<bool>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub annotations: Option<HashMap<String, String>>,
 }
 
@@ -297,15 +322,19 @@ pub struct ChartYaml {
 pub struct ChartDependency {
     pub name: String,
     pub version: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub condition: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
-    #[serde(default, rename = "import-values")]
+    #[serde(
+        default,
+        rename = "import-values",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub import_values: Option<Vec<serde_yaml::Value>>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
 }
 
@@ -313,9 +342,9 @@ pub struct ChartDependency {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChartMaintainer {
     pub name: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
 }
 
@@ -422,6 +451,63 @@ mod tests {
         // "chart-.tgz" -> version is empty, first char check fails
         let result = HelmHandler::parse_chart_filename("chart-.tgz");
         assert!(result.is_err());
+    }
+
+    // ---- parse_chart_filename: pre-release & v-prefixed versions (#1779) ----
+
+    #[test]
+    fn test_parse_chart_filename_prerelease_suffix() {
+        // Regression (#1779): a semver pre-release suffix contains its own
+        // hyphen. The naive last-hyphen split truncated the version to "rc.1";
+        // the version must be captured in full.
+        let (name, version) = HelmHandler::parse_chart_filename("nginx-1.24.0-rc.1.tgz").unwrap();
+        assert_eq!(name, "nginx");
+        assert_eq!(version, "1.24.0-rc.1");
+    }
+
+    #[test]
+    fn test_parse_chart_filename_prerelease_with_build_metadata() {
+        let (name, version) =
+            HelmHandler::parse_chart_filename("my-chart-1.0.0-alpha.1+build.5.tgz").unwrap();
+        assert_eq!(name, "my-chart");
+        assert_eq!(version, "1.0.0-alpha.1+build.5");
+    }
+
+    #[test]
+    fn test_parse_chart_filename_v_prefixed_version() {
+        // Regression (#1779): OCI-style v-prefixed tags were rejected because
+        // the version did not start with a digit.
+        let (name, version) =
+            HelmHandler::parse_chart_filename("cert-manager-v1.14.0.tgz").unwrap();
+        assert_eq!(name, "cert-manager");
+        assert_eq!(version, "v1.14.0");
+    }
+
+    #[test]
+    fn test_parse_chart_filename_v_prefixed_prerelease() {
+        let (name, version) = HelmHandler::parse_chart_filename("nginx-v1.24.0-rc.1.tgz").unwrap();
+        assert_eq!(name, "nginx");
+        assert_eq!(version, "v1.24.0-rc.1");
+    }
+
+    #[test]
+    fn test_parse_chart_filename_digit_leading_name_segment() {
+        // A chart-name segment that merely starts with a digit (e.g. "2nd")
+        // must NOT be mistaken for the version. Only a proper version token
+        // (digit run ending in '.', '-', '+', or end-of-token) splits.
+        let (name, version) = HelmHandler::parse_chart_filename("my-2nd-chart-1.0.0.tgz").unwrap();
+        assert_eq!(name, "my-2nd-chart");
+        assert_eq!(version, "1.0.0");
+    }
+
+    #[test]
+    fn test_parse_path_chart_prerelease_roundtrip() {
+        // The download handler relies on parse_path succeeding so it can fall
+        // through to the upstream-index proxy lookup (#1779).
+        let info = HelmHandler::parse_path("charts/nginx-1.24.0-rc.1.tgz").unwrap();
+        assert_eq!(info.name, Some("nginx".to_string()));
+        assert_eq!(info.version, Some("1.24.0-rc.1".to_string()));
+        assert!(!info.is_index);
     }
 
     // ---- parse_path: index.yaml ----
@@ -621,6 +707,102 @@ annotations:
 
         let ann = chart.annotations.unwrap();
         assert_eq!(ann.get("category"), Some(&"database".to_string()));
+    }
+
+    // ---- index.yaml serialization: omit unset optional fields (#1779) ----
+
+    #[test]
+    fn test_chart_yaml_minimal_serializes_without_nulls() {
+        // Regression (#1779): a minimal chart (apiVersion/name/version only)
+        // must NOT emit explicit `null` for every unset optional field, which
+        // violates the ChartMuseum/Helm index.yaml convention.
+        let chart = ChartYaml {
+            api_version: "v2".to_string(),
+            name: "mini".to_string(),
+            version: "0.1.0".to_string(),
+            kube_version: None,
+            description: None,
+            chart_type: None,
+            keywords: None,
+            home: None,
+            sources: None,
+            dependencies: None,
+            maintainers: None,
+            icon: None,
+            app_version: None,
+            deprecated: None,
+            annotations: None,
+        };
+
+        let yaml = serde_yaml::to_string(&chart).unwrap();
+        assert!(!yaml.contains("null"), "unexpected null in:\n{}", yaml);
+        for absent in [
+            "kubeVersion",
+            "description",
+            "type",
+            "keywords",
+            "home",
+            "sources",
+            "dependencies",
+            "maintainers",
+            "icon",
+            "appVersion",
+            "deprecated",
+            "annotations",
+        ] {
+            assert!(
+                !yaml.contains(absent),
+                "field `{}` should be omitted, got:\n{}",
+                absent,
+                yaml
+            );
+        }
+        // Required fields are still present.
+        assert!(yaml.contains("apiVersion: v2"));
+        assert!(yaml.contains("name: mini"));
+        assert!(yaml.contains("version: 0.1.0"));
+
+        // JSON serialization is also clean (used by API metadata paths).
+        let json = serde_json::to_value(&chart).unwrap();
+        let obj = json.as_object().unwrap();
+        assert!(!obj.values().any(|v| v.is_null()));
+        assert_eq!(obj.len(), 3);
+    }
+
+    #[test]
+    fn test_chart_maintainer_minimal_serializes_without_nulls() {
+        let m = ChartMaintainer {
+            name: "Dev".to_string(),
+            email: None,
+            url: None,
+        };
+        let yaml = serde_yaml::to_string(&m).unwrap();
+        assert!(!yaml.contains("null"), "unexpected null in:\n{}", yaml);
+        assert!(!yaml.contains("email"));
+        assert!(!yaml.contains("url"));
+        assert!(yaml.contains("name: Dev"));
+    }
+
+    #[test]
+    fn test_chart_dependency_minimal_serializes_without_nulls() {
+        let dep = ChartDependency {
+            name: "dep".to_string(),
+            version: "1.0.0".to_string(),
+            repository: None,
+            condition: None,
+            tags: None,
+            import_values: None,
+            alias: None,
+        };
+        let yaml = serde_yaml::to_string(&dep).unwrap();
+        assert!(!yaml.contains("null"), "unexpected null in:\n{}", yaml);
+        for absent in ["repository", "condition", "tags", "import-values", "alias"] {
+            assert!(
+                !yaml.contains(absent),
+                "field `{}` should be omitted",
+                absent
+            );
+        }
     }
 
     // ---- ChartDependency serde ----

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -58,6 +58,24 @@ pub enum RepoVisibility {
     /// Authenticated non-admin caller: public repositories plus any private
     /// repositories where the user holds a role assignment (direct or global).
     User(Uuid),
+    /// Repo-scoped API token: visibility is restricted to exactly the set of
+    /// repository IDs the token is allowed to access. Unlike [`Self::User`],
+    /// this does NOT widen to public repos or to all of the owner's grants —
+    /// the listing must reflect only the token's scope. The IDs were already
+    /// validated against the owner's access when the token was minted.
+    Ids(Vec<Uuid>),
+}
+
+/// Value bound at the visibility parameter (`$3`) of repository listing
+/// queries. The concrete type depends on the [`RepoVisibility`] variant:
+/// `PublicOnly`/`All` bind NULL, `User` binds a single `Uuid`, and `Ids`
+/// binds a `Uuid[]` array.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum VisibilityBind {
+    /// Bind a single user id (or NULL when `None`).
+    User(Option<Uuid>),
+    /// Bind an array of repository ids.
+    Ids(Vec<Uuid>),
 }
 
 // ---------------------------------------------------------------------------
@@ -163,10 +181,11 @@ pub(crate) fn build_search_pattern(query: Option<&str>) -> Option<String> {
 /// - `PublicOnly` -> only public repos, user_id bound as NULL.
 /// - `All`        -> no visibility restriction (always true), user_id bound as NULL.
 /// - `User(id)`   -> public repos OR repos the user has a role_assignment for.
-pub(crate) fn build_visibility_clause(visibility: &RepoVisibility) -> (String, Option<Uuid>) {
+/// - `Ids(ids)`   -> only repos whose id is in `ids` (repo-scoped token).
+pub(crate) fn build_visibility_clause(visibility: &RepoVisibility) -> (String, VisibilityBind) {
     match visibility {
-        RepoVisibility::PublicOnly => ("is_public = true".to_string(), None),
-        RepoVisibility::All => ("true".to_string(), None),
+        RepoVisibility::PublicOnly => ("is_public = true".to_string(), VisibilityBind::User(None)),
+        RepoVisibility::All => ("true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::User(user_id) => {
             let clause = r#"(
                 is_public = true
@@ -177,7 +196,16 @@ pub(crate) fn build_visibility_clause(visibility: &RepoVisibility) -> (String, O
                 )
             )"#
             .to_string();
-            (clause, Some(*user_id))
+            (clause, VisibilityBind::User(Some(*user_id)))
+        }
+        RepoVisibility::Ids(ids) => {
+            // Restrict strictly to the token's allowed set. An empty set must
+            // match no rows (not "all rows") — `id = ANY('{}')` is correctly
+            // false for every row in Postgres.
+            (
+                "repositories.id = ANY($3)".to_string(),
+                VisibilityBind::Ids(ids.clone()),
+            )
         }
     }
 }
@@ -562,15 +590,24 @@ impl RepositoryService {
                 repo
             }
             Err(e) if is_duplicate_key_error(&e.to_string()) => {
-                // Another request created this repo concurrently. Roll back
-                // our (failed) INSERT and return the existing row so callers
-                // see a successful, idempotent result instead of a 409.
+                // A repository with this key already exists. Roll back our
+                // (failed) INSERT and surface a 409 Conflict. Previously this
+                // path silently returned the existing row with HTTP 200, which
+                // masked the conflict: a second POST with a *different* payload
+                // (name/format/type) appeared to succeed while its payload was
+                // discarded. 409 is the correct semantics for both sequential
+                // duplicate requests and the concurrent-insert race (the unique
+                // constraint still serializes concurrent creators; the loser
+                // now gets a clean conflict instead of a phantom success).
                 tracing::debug!(
                     key = %req.key,
-                    "Concurrent insert detected, returning existing repository"
+                    "Duplicate repository key on create, returning 409 Conflict"
                 );
                 let _ = tx.rollback().await;
-                self.get_by_key(&req.key).await?
+                return Err(AppError::Conflict(format!(
+                    "Repository with key '{}' already exists",
+                    req.key
+                )));
             }
             Err(e) => {
                 let _ = tx.rollback().await;
@@ -695,7 +732,15 @@ impl RepositoryService {
         search_query: Option<&str>,
     ) -> Result<(Vec<Repository>, i64)> {
         let search_pattern = build_search_pattern(search_query);
-        let (visibility_clause, user_id) = build_visibility_clause(&visibility);
+        let (visibility_clause, visibility_bind) = build_visibility_clause(&visibility);
+
+        // Split the visibility bind into the two concrete `$3` shapes. Exactly
+        // one is `Some` per call; the unused one stays `None` and binds as a
+        // typed NULL, which the clause never references.
+        let (user_id_bind, ids_bind): (Option<Uuid>, Option<Vec<Uuid>>) = match visibility_bind {
+            VisibilityBind::User(uid) => (uid, None),
+            VisibilityBind::Ids(ids) => (None, Some(ids)),
+        };
 
         // -- fetch page --
         let select_sql = format!(
@@ -721,10 +766,15 @@ impl RepositoryService {
             "#
         );
 
-        let repos = sqlx::query_as::<_, Repository>(&select_sql)
+        let page_query = sqlx::query_as::<_, Repository>(&select_sql)
             .bind(format_filter.clone())
-            .bind(type_filter.clone())
-            .bind(user_id)
+            .bind(type_filter.clone());
+        // $3 shape depends on the visibility variant (single uuid vs uuid[]).
+        let page_query = match &ids_bind {
+            Some(ids) => page_query.bind(ids.clone()),
+            None => page_query.bind(user_id_bind),
+        };
+        let repos = page_query
             .bind(search_pattern.clone())
             .bind(offset)
             .bind(limit)
@@ -744,10 +794,14 @@ impl RepositoryService {
             "#
         );
 
-        let total: i64 = sqlx::query_scalar::<_, i64>(&count_sql)
+        let count_query = sqlx::query_scalar::<_, i64>(&count_sql)
             .bind(format_filter)
-            .bind(type_filter)
-            .bind(user_id)
+            .bind(type_filter);
+        let count_query = match &ids_bind {
+            Some(ids) => count_query.bind(ids.clone()),
+            None => count_query.bind(user_id_bind),
+        };
+        let total: i64 = count_query
             .bind(search_pattern)
             .fetch_one(&self.db)
             .await
@@ -1864,26 +1918,48 @@ mod tests {
 
     #[test]
     fn test_visibility_public_only_returns_is_public_clause() {
-        let (clause, user_id) = build_visibility_clause(&RepoVisibility::PublicOnly);
+        let (clause, bind) = build_visibility_clause(&RepoVisibility::PublicOnly);
         assert_eq!(clause, "is_public = true");
-        assert!(user_id.is_none());
+        assert_eq!(bind, VisibilityBind::User(None));
     }
 
     #[test]
     fn test_visibility_all_returns_true_clause() {
-        let (clause, user_id) = build_visibility_clause(&RepoVisibility::All);
+        let (clause, bind) = build_visibility_clause(&RepoVisibility::All);
         assert_eq!(clause, "true");
-        assert!(user_id.is_none());
+        assert_eq!(bind, VisibilityBind::User(None));
     }
 
     #[test]
     fn test_visibility_user_returns_subquery_and_user_id() {
         let uid = Uuid::new_v4();
-        let (clause, user_id) = build_visibility_clause(&RepoVisibility::User(uid));
+        let (clause, bind) = build_visibility_clause(&RepoVisibility::User(uid));
         assert!(clause.contains("is_public = true"));
         assert!(clause.contains("role_assignments"));
         assert!(clause.contains("$3"));
-        assert_eq!(user_id, Some(uid));
+        assert_eq!(bind, VisibilityBind::User(Some(uid)));
+    }
+
+    #[test]
+    fn test_visibility_ids_restricts_to_id_set_only() {
+        // Repo-scoped token: the clause must filter strictly on the allowed id
+        // set ($3 = uuid[]) and must NOT widen to public repos or role grants.
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let (clause, bind) = build_visibility_clause(&RepoVisibility::Ids(vec![a, b]));
+        assert_eq!(clause, "repositories.id = ANY($3)");
+        assert!(!clause.contains("is_public"));
+        assert!(!clause.contains("role_assignments"));
+        assert_eq!(bind, VisibilityBind::Ids(vec![a, b]));
+    }
+
+    #[test]
+    fn test_visibility_ids_empty_set_matches_no_rows() {
+        // An empty allowed set must not degrade to "all rows". The clause is
+        // `id = ANY('{}')`, which Postgres evaluates to false for every row.
+        let (clause, bind) = build_visibility_clause(&RepoVisibility::Ids(vec![]));
+        assert_eq!(clause, "repositories.id = ANY($3)");
+        assert_eq!(bind, VisibilityBind::Ids(vec![]));
     }
 
     #[test]
@@ -2420,10 +2496,12 @@ mod tests {
             cleanup_repo(&pool, repo.id).await;
         }
 
-        /// Duplicate key: the second `create` rolls back its own (failed)
-        /// INSERT and returns the row created by the first.
+        /// Regression (#1783 HIGH): a duplicate key on create must roll back the
+        /// failed INSERT and return `409 Conflict`, NOT a silent 200 echoing the
+        /// existing row. A second create with a DIFFERENT payload must not be
+        /// reported as success while its payload is discarded.
         #[tokio::test]
-        async fn test_create_duplicate_key_returns_existing_via_rollback() {
+        async fn test_create_duplicate_key_returns_conflict() {
             let Some(pool) = tdh::try_pool().await else {
                 return;
             };
@@ -2434,14 +2512,25 @@ mod tests {
                 .await
                 .expect("first create");
 
+            // Second create with the same key but a deliberately different
+            // format — the old code returned 200 with the first row's payload.
             let second = service
-                .create(make_create_req(&suffix, RepositoryFormat::Generic))
-                .await
-                .expect("duplicate create should idempotently return existing");
-            assert_eq!(
-                second.id, first.id,
-                "duplicate-key path must return the row created by the first call"
-            );
+                .create(make_create_req(&suffix, RepositoryFormat::Pypi))
+                .await;
+            match second {
+                Err(AppError::Conflict(msg)) => {
+                    assert!(
+                        msg.contains(&suffix),
+                        "conflict message should name the duplicate key, got: {msg}"
+                    );
+                }
+                other => panic!("expected 409 Conflict on duplicate key, got: {other:?}"),
+            }
+
+            // The original row is untouched (payload not silently overwritten).
+            let fetched = service.get_by_key(&first.key).await.expect("fetch first");
+            assert_eq!(fetched.id, first.id);
+            assert_eq!(fetched.format, RepositoryFormat::Generic);
 
             cleanup_repo(&pool, first.id).await;
         }
@@ -2514,6 +2603,91 @@ mod tests {
                     .execute(&pool)
                     .await;
             }
+        }
+
+        /// Regression (#1783 MEDIUM): `list` with `RepoVisibility::Ids` (the
+        /// shape a repo-scoped token produces) must return ONLY the repos in
+        /// the allowed id set — not every repo the owning user can reach.
+        ///
+        /// Before the fix, the list handler mapped any authenticated principal
+        /// (including scoped tokens) to `RepoVisibility::User`, so a token
+        /// scoped to repo A still listed repo B when the owner had access to B.
+        #[tokio::test]
+        async fn test_list_ids_visibility_restricts_to_allowed_set() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+
+            let (owner_id, _) = tdh::create_user(&pool).await;
+
+            // Two PRIVATE repos, both owned (granted) by the same user.
+            let tag = format!("{}", uuid::Uuid::new_v4().simple());
+            let mut req_a = make_create_req(&format!("{tag}a"), RepositoryFormat::Pypi);
+            req_a.created_by = Some(owner_id);
+            let repo_a = service.create(req_a).await.expect("create repo a");
+            let mut req_b = make_create_req(&format!("{tag}b"), RepositoryFormat::Npm);
+            req_b.created_by = Some(owner_id);
+            let repo_b = service.create(req_b).await.expect("create repo b");
+
+            let search = Some(format!("acs-repo-{tag}"));
+
+            // Sanity: as the owning user, BOTH repos are visible.
+            let (user_repos, user_total) = service
+                .list(
+                    0,
+                    50,
+                    None,
+                    None,
+                    RepoVisibility::User(owner_id),
+                    search.as_deref(),
+                )
+                .await
+                .expect("user list");
+            assert_eq!(user_total, 2, "owner should see both private repos");
+            assert_eq!(user_repos.len(), 2);
+
+            // Scoped to repo_a only: repo_b must NOT appear.
+            let (ids_repos, ids_total) = service
+                .list(
+                    0,
+                    50,
+                    None,
+                    None,
+                    RepoVisibility::Ids(vec![repo_a.id]),
+                    search.as_deref(),
+                )
+                .await
+                .expect("ids list");
+            assert_eq!(ids_total, 1, "scoped token must see only the allowed repo");
+            assert_eq!(ids_repos.len(), 1);
+            assert_eq!(ids_repos[0].id, repo_a.id);
+            assert!(
+                !ids_repos.iter().any(|r| r.id == repo_b.id),
+                "repo outside allowed_repo_ids must not leak into the listing"
+            );
+
+            // Empty allowed set: matches no rows (must not degrade to "all").
+            let (empty_repos, empty_total) = service
+                .list(
+                    0,
+                    50,
+                    None,
+                    None,
+                    RepoVisibility::Ids(vec![]),
+                    search.as_deref(),
+                )
+                .await
+                .expect("empty ids list");
+            assert_eq!(empty_total, 0);
+            assert!(empty_repos.is_empty());
+
+            cleanup_repo(&pool, repo_a.id).await;
+            cleanup_repo(&pool, repo_b.id).await;
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(owner_id)
+                .execute(&pool)
+                .await;
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes a critical broken-access-control hole found by the internal red-team and reproduced live: the native-protocol `repo_visibility_middleware` treated a **private** repository with **no fine-grained permission rules** as readable by **any authenticated user**.

`should_allow_repo_access(is_public=false, has_auth=true)` returns `true`, and the `#817` fine-grained block is gated on `has_any_rules_for_target(...)`. When a private repo has no rules, that block was skipped and the request fell through to the format handler — so `/maven`, `/cargo`, `/helm`, `/pypi`, … were strictly more permissive than the REST download path (`require_visible` → `user_can_access_repo`), which denied the same caller with 404.

A brand-new, zero-grant, non-admin user could read private cross-team artifacts (including a credentials file): native maven path returned `200` + the secret, while REST returned `404` for the same user + artifact.

### Fix
For a non-admin on a **private** repo with **no fine-grained rules**, require a role assignment (mirroring `require_visible`) before falling through; deny with an existence-hiding `404` otherwise. Public repos, admins, and repos governed by fine-grained rules are unaffected. Uses `sqlx::query_scalar` (runtime, no offline-cache entry), same predicate as `RepositoryService::user_can_access_repo`.

Closes #1802.

## Test Checklist
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (changed crate, clean)
- [x] `cargo test --workspace --lib` (auth middleware module: 185 passed)
- [x] New DB-backed regression test: non-admin without a role assignment → `404`; granting the role → `200`. Runs in the CI coverage job (seeds Postgres).

## API Changes
None. Behavior change only: native-protocol reads of a rule-less private repo by a non-admin without a role assignment now return `404` (existence-hiding), matching the REST download path. This is a security tightening, not an API surface change.
