### PR TITLE
fix: replicate hosted Debian packages to peers

### DIFF
--- a/backend/migrations/130_upload_session_replication_metadata.sql
+++ b/backend/migrations/130_upload_session_replication_metadata.sql
@@ -1,0 +1,13 @@
+-- Preserve format-specific metadata across peer replication upload sessions.
+--
+-- Debian/APT repositories need artifact_metadata for Packages/Release index
+-- generation and package catalog metadata for the UI/API package rows. Peer
+-- replication uses the generic resumable upload API, so store the source
+-- metadata on the session and materialize it when the receiver finalizes.
+
+ALTER TABLE upload_sessions
+    ADD COLUMN IF NOT EXISTS artifact_metadata_format TEXT,
+    ADD COLUMN IF NOT EXISTS artifact_metadata JSONB,
+    ADD COLUMN IF NOT EXISTS artifact_metadata_properties JSONB,
+    ADD COLUMN IF NOT EXISTS package_description TEXT,
+    ADD COLUMN IF NOT EXISTS package_metadata JSONB;

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1623,6 +1623,10 @@ fn package_description(control: &DebControl) -> Option<&str> {
         .filter(|description| !description.trim().is_empty())
 }
 
+fn should_enqueue_debian_sync_tasks(headers: &HeaderMap) -> bool {
+    !super::is_replication_request(headers)
+}
+
 async fn persist_debian_upload(
     state: &SharedState,
     repo: &RepoInfo,
@@ -1710,6 +1714,7 @@ async fn pool_upload(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, component, path)): Path<(String, String, String)>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
@@ -1718,7 +1723,15 @@ async fn pool_upload(
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
 
     let upload = prepare_debian_upload(&component, &path, &body)?;
-    persist_debian_upload(&state, &repo, &upload, body, Some(user_id), false).await?;
+    persist_debian_upload(
+        &state,
+        &repo,
+        &upload,
+        body,
+        Some(user_id),
+        should_enqueue_debian_sync_tasks(&headers),
+    )
+    .await?;
 
     info!(
         "Debian upload: {} {} {} to repo {} (component: {})",
@@ -1789,8 +1802,15 @@ async fn upload_raw(
         .unwrap_or(&artifact_path)
         .to_string();
     let upload = prepare_debian_upload(component, &path, &body)?;
-    let artifact =
-        persist_debian_upload(&state, &repo, &upload, body, Some(user_id), false).await?;
+    let artifact = persist_debian_upload(
+        &state,
+        &repo,
+        &upload,
+        body,
+        Some(user_id),
+        should_enqueue_debian_sync_tasks(&headers),
+    )
+    .await?;
 
     info!(
         "Debian upload (raw): {} {} {} to repo {}",
@@ -2917,6 +2937,27 @@ mod upload_db_tests {
         append_ar_member(&mut deb, "control.tar.gz", &control_tar_gz(&control));
         append_ar_member(&mut deb, "data.tar.gz", &empty_data_tar_gz());
         deb
+    }
+
+    fn headers_with_replication(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-artifact-keeper-replication",
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn test_should_enqueue_debian_sync_tasks_for_direct_upload() {
+        assert!(should_enqueue_debian_sync_tasks(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn test_should_enqueue_debian_sync_tasks_skips_peer_replication() {
+        assert!(!should_enqueue_debian_sync_tasks(
+            &headers_with_replication("true")
+        ));
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -1,5 +1,17 @@
 //! HTTP request handlers.
 
+use axum::http::HeaderMap;
+
+/// Request marker set by peer replication writes. Receiving handlers use this
+/// to avoid queuing the replicated write back to the origin peer.
+pub(crate) fn is_replication_request(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-artifact-keeper-replication")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
+        .unwrap_or(false)
+}
+
 /// Remove any soft-deleted artifact at the given `(repository_id, path)` so
 /// that a subsequent INSERT won't violate the UNIQUE constraint.  This is a
 /// fire-and-forget cleanup: if the DELETE fails or finds nothing we just

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -22,6 +22,7 @@ use crate::api::dto::Pagination;
 // `crate::api::extractors`. The wrapper also implements `IntoResponse` so it
 // is a drop-in replacement on response types too.
 use crate::api::extractors::Json;
+use crate::api::handlers::is_replication_request;
 use crate::api::handlers::proxy_helpers;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
@@ -42,14 +43,6 @@ use crate::services::upload_service;
 /// Require that the request is authenticated, returning an error if not.
 fn require_auth(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))
-}
-
-fn is_replication_request(headers: &HeaderMap) -> bool {
-    headers
-        .get("x-artifact-keeper-replication")
-        .and_then(|value| value.to_str().ok())
-        .map(|value| matches!(value.to_ascii_lowercase().as_str(), "true" | "1" | "yes"))
-        .unwrap_or(false)
 }
 
 /// Coerce the requested `is_public` value against the server-wide guest-access

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -63,6 +63,16 @@ pub struct CreateSessionRequest {
     /// Optional for regular client uploads. Peer replication sets this from
     /// the source artifact row so chunked replication preserves metadata.
     pub artifact_version: Option<String>,
+    /// Source artifact metadata format for peer replication.
+    pub artifact_metadata_format: Option<String>,
+    /// Source artifact metadata for peer replication.
+    pub artifact_metadata: Option<serde_json::Value>,
+    /// Source artifact metadata properties for peer replication.
+    pub artifact_metadata_properties: Option<serde_json::Value>,
+    /// Source package description for peer replication.
+    pub package_description: Option<String>,
+    /// Source package catalog metadata for peer replication.
+    pub package_metadata: Option<serde_json::Value>,
     /// Total file size in bytes
     pub total_size: i64,
     /// Expected SHA256 checksum of the complete file
@@ -131,6 +141,7 @@ pub struct CompleteResponse {
 async fn create_session(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
+    headers: HeaderMap,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<Response, Response> {
     let user_id = auth.user_id;
@@ -154,6 +165,8 @@ async fn create_session(
             )
         })?;
 
+    let replication_metadata = replication_session_metadata_from_request(&headers, &req);
+
     let session = UploadService::create_session(upload_service::CreateSessionParams {
         db: &state.db,
         storage_path: &state.config.storage_path,
@@ -163,6 +176,11 @@ async fn create_session(
         artifact_path: &req.artifact_path,
         artifact_name: req.artifact_name.as_deref(),
         artifact_version: req.artifact_version.as_deref(),
+        artifact_metadata_format: replication_metadata.artifact_metadata_format,
+        artifact_metadata: replication_metadata.artifact_metadata,
+        artifact_metadata_properties: replication_metadata.artifact_metadata_properties,
+        package_description: replication_metadata.package_description,
+        package_metadata: replication_metadata.package_metadata,
         total_size: req.total_size,
         chunk_size: req.chunk_size,
         checksum_sha256: &req.checksum_sha256,
@@ -427,6 +445,21 @@ async fn complete(
     .await
     .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
+    if let (Some(format), Some(metadata)) = (
+        session.artifact_metadata_format.as_deref(),
+        session.artifact_metadata.clone(),
+    ) {
+        let properties = session
+            .artifact_metadata_properties
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({}));
+        let artifact_service = state.create_artifact_service(storage.clone());
+        artifact_service
+            .set_metadata(artifact_id, format, metadata, properties)
+            .await
+            .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    }
+
     if let Some((package_name, package_version)) = completed_package_catalog_entry(&session) {
         PackageService::new(state.db.clone())
             .try_create_or_update_from_artifact(
@@ -435,8 +468,8 @@ async fn complete(
                 package_version,
                 session.total_size,
                 &session.checksum_sha256,
-                None,
-                None,
+                completed_package_description(&session),
+                completed_package_metadata(&session),
             )
             .await;
     }
@@ -575,6 +608,47 @@ fn completed_package_catalog_entry(
     Some((completed_artifact_name(session), version))
 }
 
+fn completed_package_description(session: &upload_service::UploadSession) -> Option<&str> {
+    session.package_description.as_deref()
+}
+
+fn completed_package_metadata(
+    session: &upload_service::UploadSession,
+) -> Option<serde_json::Value> {
+    session.package_metadata.clone()
+}
+
+struct ReplicationSessionMetadata<'a> {
+    artifact_metadata_format: Option<&'a str>,
+    artifact_metadata: Option<&'a serde_json::Value>,
+    artifact_metadata_properties: Option<&'a serde_json::Value>,
+    package_description: Option<&'a str>,
+    package_metadata: Option<&'a serde_json::Value>,
+}
+
+fn replication_session_metadata_from_request<'a>(
+    headers: &HeaderMap,
+    req: &'a CreateSessionRequest,
+) -> ReplicationSessionMetadata<'a> {
+    if !super::is_replication_request(headers) {
+        return ReplicationSessionMetadata {
+            artifact_metadata_format: None,
+            artifact_metadata: None,
+            artifact_metadata_properties: None,
+            package_description: None,
+            package_metadata: None,
+        };
+    }
+
+    ReplicationSessionMetadata {
+        artifact_metadata_format: req.artifact_metadata_format.as_deref(),
+        artifact_metadata: req.artifact_metadata.as_ref(),
+        artifact_metadata_properties: req.artifact_metadata_properties.as_ref(),
+        package_description: req.package_description.as_deref(),
+        package_metadata: req.package_metadata.as_ref(),
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -648,6 +722,11 @@ mod tests {
             artifact_path: path.to_string(),
             artifact_name: name.map(str::to_string),
             artifact_version: version.map(str::to_string),
+            artifact_metadata_format: None,
+            artifact_metadata: None,
+            artifact_metadata_properties: None,
+            package_description: None,
+            package_metadata: None,
             content_type: "application/octet-stream".to_string(),
             total_size: 1,
             chunk_size: 1_048_576,
@@ -709,6 +788,79 @@ mod tests {
         assert_eq!(completed_package_catalog_entry(&session), None);
     }
 
+    fn request_with_replication_metadata() -> CreateSessionRequest {
+        CreateSessionRequest {
+            repository_key: "repo".to_string(),
+            artifact_path: "pool/main/a/app/app_1_amd64.deb".to_string(),
+            artifact_name: Some("app".to_string()),
+            artifact_version: Some("1".to_string()),
+            artifact_metadata_format: Some("debian".to_string()),
+            artifact_metadata: Some(serde_json::json!({
+                "format": "debian",
+                "architecture": "amd64"
+            })),
+            artifact_metadata_properties: Some(serde_json::json!({"source": "peer"})),
+            package_description: Some("replicated Debian package".to_string()),
+            package_metadata: Some(serde_json::json!({
+                "format": "debian",
+                "component": "main"
+            })),
+            total_size: 1024,
+            checksum_sha256: "deadbeef".to_string(),
+            chunk_size: None,
+            content_type: None,
+        }
+    }
+
+    fn headers_with_replication(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-artifact-keeper-replication",
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn test_replication_session_metadata_keeps_fields_for_peer_request() {
+        let req = request_with_replication_metadata();
+        let headers = headers_with_replication("true");
+
+        let metadata = replication_session_metadata_from_request(&headers, &req);
+
+        assert_eq!(metadata.artifact_metadata_format, Some("debian"));
+        assert_eq!(
+            metadata.artifact_metadata.unwrap()["architecture"],
+            serde_json::json!("amd64")
+        );
+        assert_eq!(
+            metadata.artifact_metadata_properties.unwrap()["source"],
+            serde_json::json!("peer")
+        );
+        assert_eq!(
+            metadata.package_description,
+            Some("replicated Debian package")
+        );
+        assert_eq!(
+            metadata.package_metadata.unwrap()["component"],
+            serde_json::json!("main")
+        );
+    }
+
+    #[test]
+    fn test_replication_session_metadata_drops_fields_without_peer_marker() {
+        let req = request_with_replication_metadata();
+        let headers = HeaderMap::new();
+
+        let metadata = replication_session_metadata_from_request(&headers, &req);
+
+        assert!(metadata.artifact_metadata_format.is_none());
+        assert!(metadata.artifact_metadata.is_none());
+        assert!(metadata.artifact_metadata_properties.is_none());
+        assert!(metadata.package_description.is_none());
+        assert!(metadata.package_metadata.is_none());
+    }
+
     // -----------------------------------------------------------------------
     // CreateSessionRequest deserialization
     // -----------------------------------------------------------------------
@@ -720,6 +872,11 @@ mod tests {
             "artifact_path": "images/vm.ova",
             "artifact_name": "vm-image",
             "artifact_version": "2026.06.03",
+            "artifact_metadata_format": "debian",
+            "artifact_metadata": {"format": "debian", "architecture": "amd64"},
+            "artifact_metadata_properties": {"source": "peer"},
+            "package_description": "Debian package",
+            "package_metadata": {"format": "debian", "component": "main"},
             "total_size": 21474836480,
             "checksum_sha256": "abc123def456",
             "chunk_size": 16777216,
@@ -730,6 +887,17 @@ mod tests {
         assert_eq!(req.artifact_path, "images/vm.ova");
         assert_eq!(req.artifact_name.as_deref(), Some("vm-image"));
         assert_eq!(req.artifact_version.as_deref(), Some("2026.06.03"));
+        assert_eq!(req.artifact_metadata_format.as_deref(), Some("debian"));
+        assert_eq!(
+            req.artifact_metadata.as_ref().unwrap()["architecture"],
+            "amd64"
+        );
+        assert_eq!(
+            req.artifact_metadata_properties.as_ref().unwrap()["source"],
+            "peer"
+        );
+        assert_eq!(req.package_description.as_deref(), Some("Debian package"));
+        assert_eq!(req.package_metadata.as_ref().unwrap()["component"], "main");
         assert_eq!(req.total_size, 21_474_836_480);
         assert_eq!(req.checksum_sha256, "abc123def456");
         assert_eq!(req.chunk_size, Some(16_777_216));
@@ -749,6 +917,11 @@ mod tests {
         assert_eq!(req.artifact_path, "file.bin");
         assert_eq!(req.artifact_name, None);
         assert_eq!(req.artifact_version, None);
+        assert_eq!(req.artifact_metadata_format, None);
+        assert_eq!(req.artifact_metadata, None);
+        assert_eq!(req.artifact_metadata_properties, None);
+        assert_eq!(req.package_description, None);
+        assert_eq!(req.package_metadata, None);
         assert_eq!(req.total_size, 1024);
         assert_eq!(req.checksum_sha256, "deadbeef");
         assert!(req.chunk_size.is_none());
@@ -1195,6 +1368,11 @@ mod tests {
             artifact_path: "file.bin".into(),
             artifact_name: None,
             artifact_version: None,
+            artifact_metadata_format: None,
+            artifact_metadata: None,
+            artifact_metadata_properties: None,
+            package_description: None,
+            package_metadata: None,
             total_size: 100,
             checksum_sha256: "abc".into(),
             chunk_size: None,
@@ -1533,6 +1711,17 @@ mod tests {
         tdh::post("/".to_string(), "application/json", payload)
     }
 
+    fn create_replication_session_req(
+        body: &serde_json::Value,
+    ) -> axum::http::Request<axum::body::Body> {
+        let mut req = create_session_req(body);
+        req.headers_mut().insert(
+            "x-artifact-keeper-replication",
+            axum::http::HeaderValue::from_static("true"),
+        );
+        req
+    }
+
     /// Wrap the upload router with a bare `Extension(AuthExtension)` layer.
     ///
     /// `tdh::router_with_auth` inserts `Extension::<Option<AuthExtension>>`,
@@ -1732,6 +1921,130 @@ mod tests {
         );
 
         // Clean up everything we wrote.
+        let _ = sqlx::query("DELETE FROM upload_chunks WHERE session_id = $1")
+            .bind(session_id)
+            .execute(&f.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM upload_sessions WHERE id = $1")
+            .bind(session_id)
+            .execute(&f.pool)
+            .await;
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn complete_materializes_replication_metadata() {
+        let Some(f) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let payload: &[u8] = b"replicated-debian-package-bytes";
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        let checksum = hex::encode(hasher.finalize());
+
+        let artifact_path = "pool/main/a/app/app_1_amd64.deb";
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let create_req = create_replication_session_req(&serde_json::json!({
+            "repository_key": f.repo_key,
+            "artifact_path": artifact_path,
+            "artifact_name": "app",
+            "artifact_version": "1",
+            "artifact_metadata_format": "debian",
+            "artifact_metadata": {
+                "format": "debian",
+                "architecture": "amd64",
+                "component": "main"
+            },
+            "artifact_metadata_properties": {"source": "lux"},
+            "package_description": "replicated Debian package",
+            "package_metadata": {
+                "format": "debian",
+                "component": "main"
+            },
+            "total_size": payload.len() as i64,
+            "checksum_sha256": checksum,
+            "chunk_size": 1024 * 1024_i64,
+        }));
+        let (status, body) = tdh::send(app, create_req).await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "create_session must preserve replication metadata; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let create_resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let session_id: Uuid =
+            serde_json::from_value(create_resp["session_id"].clone()).expect("session_id");
+
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri(format!("/{}", session_id))
+            .header(
+                "content-range",
+                format!("bytes 0-{}/{}", payload.len() - 1, payload.len()),
+            )
+            .header("content-type", "application/octet-stream")
+            .body(axum::body::Body::from(payload.to_vec()))
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "chunk PATCH must succeed; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let req = axum::http::Request::builder()
+            .method("PUT")
+            .uri(format!("/{}/complete", session_id))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "complete must succeed; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let artifact_id: Uuid =
+            sqlx::query_scalar("SELECT id FROM artifacts WHERE repository_id = $1 AND path = $2")
+                .bind(f.repo_id)
+                .bind(artifact_path)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query replicated artifact");
+
+        let metadata: (String, serde_json::Value, serde_json::Value) = sqlx::query_as(
+            "SELECT format, metadata, properties FROM artifact_metadata WHERE artifact_id = $1",
+        )
+        .bind(artifact_id)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query replicated artifact metadata");
+        assert_eq!(metadata.0, "debian");
+        assert_eq!(metadata.1["architecture"], "amd64");
+        assert_eq!(metadata.2["source"], "lux");
+
+        let pkg: (String, Option<String>, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT version, description, metadata FROM packages WHERE repository_id = $1 AND name = $2",
+        )
+        .bind(f.repo_id)
+        .bind("app")
+        .fetch_one(&f.pool)
+        .await
+        .expect("query replicated package catalog");
+        assert_eq!(pkg.0, "1");
+        assert_eq!(pkg.1.as_deref(), Some("replicated Debian package"));
+        assert_eq!(pkg.2.expect("package metadata")["component"], "main");
+
         let _ = sqlx::query("DELETE FROM upload_chunks WHERE session_id = $1")
             .bind(session_id)
             .execute(&f.pool)

--- a/backend/src/services/sync_worker.rs
+++ b/backend/src/services/sync_worker.rs
@@ -483,6 +483,11 @@ struct TaskRow {
     artifact_name: String,
     artifact_version: Option<String>,
     artifact_path: String,
+    artifact_metadata_format: Option<String>,
+    artifact_metadata: Option<serde_json::Value>,
+    artifact_metadata_properties: Option<serde_json::Value>,
+    package_description: Option<String>,
+    package_metadata: Option<serde_json::Value>,
     repository_key: String,
     repository_id: Uuid,
     repository_storage_backend: String,
@@ -695,6 +700,17 @@ async fn process_pending_tasks(
                 a.name AS artifact_name,
                 a.version AS artifact_version,
                 a.path AS artifact_path,
+                am.format AS artifact_metadata_format,
+                am.metadata AS artifact_metadata,
+                am.properties AS artifact_metadata_properties,
+                CASE
+                    WHEN p.version = a.version THEN p.description
+                    ELSE NULL
+                END AS package_description,
+                CASE
+                    WHEN p.version = a.version THEN p.metadata
+                    ELSE NULL
+                END AS package_metadata,
                 r.key AS repository_key,
                 r.id AS repository_id,
                 r.storage_backend AS repository_storage_backend,
@@ -708,6 +724,10 @@ async fn process_pending_tasks(
             FROM sync_tasks st
             JOIN artifacts a ON a.id = st.artifact_id
             JOIN repositories r ON r.id = a.repository_id
+            LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
+            LEFT JOIN packages p
+                ON p.repository_id = r.id
+               AND p.name = a.name
             LEFT JOIN peer_repo_subscriptions prs
                 ON prs.peer_instance_id = st.peer_instance_id
                AND prs.repository_id = r.id
@@ -834,9 +854,9 @@ async fn execute_transfer(
     }
 
     // Push flow: decide between single-request upload and chunked transfer
-    // based on the artifact size.
+    // based on the artifact size or the need to preserve metadata.
     let threshold = chunked_threshold_bytes();
-    if should_use_chunked_transfer(task.artifact_size, threshold) {
+    if should_use_chunked_transfer_for_task(task, threshold) {
         return execute_chunked_transfer(
             db,
             client,
@@ -1466,6 +1486,11 @@ fn build_chunked_upload_session_body(task: &TaskRow, chunk_size: i32) -> serde_j
         "artifact_path": task.artifact_path,
         "artifact_name": task.artifact_name,
         "artifact_version": task.artifact_version,
+        "artifact_metadata_format": task.artifact_metadata_format,
+        "artifact_metadata": task.artifact_metadata,
+        "artifact_metadata_properties": task.artifact_metadata_properties,
+        "package_description": task.package_description,
+        "package_metadata": task.package_metadata,
         "total_size": task.artifact_size,
         "checksum_sha256": task.checksum_sha256,
         "chunk_size": chunk_size,
@@ -1602,6 +1627,17 @@ pub(crate) fn sync_chunk_size_bytes() -> i32 {
 /// Decide whether a given artifact size should use chunked transfer.
 pub(crate) fn should_use_chunked_transfer(artifact_size: i64, threshold: i64) -> bool {
     artifact_size >= threshold
+}
+
+fn task_has_replication_metadata(task: &TaskRow) -> bool {
+    (task.artifact_metadata_format.is_some() && task.artifact_metadata.is_some())
+        || task.package_description.is_some()
+        || task.package_metadata.is_some()
+}
+
+fn should_use_chunked_transfer_for_task(task: &TaskRow, threshold: i64) -> bool {
+    should_use_chunked_transfer(task.artifact_size, threshold)
+        || task_has_replication_metadata(task)
 }
 
 /// Compute the list of (chunk_index, byte_offset, byte_length) for a given
@@ -1893,6 +1929,11 @@ mod tests {
             artifact_name: "artifact.bin".to_string(),
             artifact_version: None,
             artifact_path: "path/artifact.bin".to_string(),
+            artifact_metadata_format: None,
+            artifact_metadata: None,
+            artifact_metadata_properties: None,
+            package_description: None,
+            package_metadata: None,
             repository_key: "repo".to_string(),
             repository_id: Uuid::new_v4(),
             repository_storage_backend: storage_backend.to_string(),
@@ -3487,6 +3528,41 @@ mod tests {
         assert!(should_use_chunked_transfer(1, 0));
     }
 
+    #[test]
+    fn test_should_use_chunked_transfer_for_task_uses_size_threshold() {
+        let mut task = test_task("filesystem");
+        task.artifact_size = 100 * 1024 * 1024;
+
+        assert!(should_use_chunked_transfer_for_task(
+            &task,
+            100 * 1024 * 1024
+        ));
+    }
+
+    #[test]
+    fn test_should_use_chunked_transfer_for_task_forces_metadata_tasks() {
+        let mut task = test_task("filesystem");
+        task.artifact_size = 1024;
+        task.artifact_metadata_format = Some("debian".to_string());
+        task.artifact_metadata = Some(serde_json::json!({"format": "debian"}));
+
+        assert!(should_use_chunked_transfer_for_task(
+            &task,
+            100 * 1024 * 1024
+        ));
+    }
+
+    #[test]
+    fn test_should_use_chunked_transfer_for_task_keeps_plain_small_fast_path() {
+        let mut task = test_task("filesystem");
+        task.artifact_size = 1024;
+
+        assert!(!should_use_chunked_transfer_for_task(
+            &task,
+            100 * 1024 * 1024
+        ));
+    }
+
     // ── compute_chunk_ranges ───────────────────────────────────────────
 
     #[test]
@@ -3603,6 +3679,31 @@ mod tests {
         assert_eq!(body["artifact_name"], "name-check");
         assert_eq!(body["artifact_version"], "20260603T072902Z");
         assert_eq!(body["chunk_size"], 52_428_800);
+    }
+
+    #[test]
+    fn test_build_chunked_upload_session_body_preserves_replication_metadata() {
+        let mut task = test_task("filesystem");
+        task.artifact_metadata_format = Some("debian".to_string());
+        task.artifact_metadata = Some(serde_json::json!({
+            "format": "debian",
+            "architecture": "amd64",
+            "component": "main"
+        }));
+        task.artifact_metadata_properties = Some(serde_json::json!({"source": "lux"}));
+        task.package_description = Some("replicated Debian package".to_string());
+        task.package_metadata = Some(serde_json::json!({
+            "format": "debian",
+            "component": "main"
+        }));
+
+        let body = build_chunked_upload_session_body(&task, 52_428_800);
+
+        assert_eq!(body["artifact_metadata_format"], "debian");
+        assert_eq!(body["artifact_metadata"]["architecture"], "amd64");
+        assert_eq!(body["artifact_metadata_properties"]["source"], "lux");
+        assert_eq!(body["package_description"], "replicated Debian package");
+        assert_eq!(body["package_metadata"]["component"], "main");
     }
 
     #[test]

--- a/backend/src/services/upload_service.rs
+++ b/backend/src/services/upload_service.rs
@@ -24,6 +24,11 @@ pub struct UploadSession {
     pub artifact_path: String,
     pub artifact_name: Option<String>,
     pub artifact_version: Option<String>,
+    pub artifact_metadata_format: Option<String>,
+    pub artifact_metadata: Option<serde_json::Value>,
+    pub artifact_metadata_properties: Option<serde_json::Value>,
+    pub package_description: Option<String>,
+    pub package_metadata: Option<serde_json::Value>,
     pub content_type: String,
     pub total_size: i64,
     pub chunk_size: i32,
@@ -171,6 +176,11 @@ pub struct CreateSessionParams<'a> {
     pub artifact_path: &'a str,
     pub artifact_name: Option<&'a str>,
     pub artifact_version: Option<&'a str>,
+    pub artifact_metadata_format: Option<&'a str>,
+    pub artifact_metadata: Option<&'a serde_json::Value>,
+    pub artifact_metadata_properties: Option<&'a serde_json::Value>,
+    pub package_description: Option<&'a str>,
+    pub package_metadata: Option<&'a serde_json::Value>,
     pub total_size: i64,
     pub chunk_size: Option<i32>,
     pub checksum_sha256: &'a str,
@@ -201,6 +211,11 @@ impl UploadService {
         let content_type = p.content_type.unwrap_or("application/octet-stream");
         let artifact_name = normalize_optional_metadata(p.artifact_name);
         let artifact_version = normalize_optional_metadata(p.artifact_version);
+        let artifact_metadata_format = normalize_optional_metadata(p.artifact_metadata_format);
+        let artifact_metadata = p.artifact_metadata.cloned();
+        let artifact_metadata_properties = p.artifact_metadata_properties.cloned();
+        let package_description = normalize_optional_metadata(p.package_description);
+        let package_metadata = p.package_metadata.cloned();
 
         let session_id = Uuid::new_v4();
         let temp_dir = PathBuf::from(p.storage_path).join(".uploads");
@@ -224,9 +239,12 @@ impl UploadService {
             r#"
             INSERT INTO upload_sessions
                 (id, user_id, repository_id, repository_key, artifact_path,
-                 artifact_name, artifact_version, content_type, total_size,
-                 chunk_size, total_chunks, checksum_sha256, temp_file_path)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+                 artifact_name, artifact_version, artifact_metadata_format,
+                 artifact_metadata, artifact_metadata_properties, package_description,
+                 package_metadata, content_type, total_size, chunk_size, total_chunks,
+                 checksum_sha256, temp_file_path)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
+                    $14, $15, $16, $17, $18)
             RETURNING *
             "#,
         )
@@ -237,6 +255,11 @@ impl UploadService {
         .bind(p.artifact_path)
         .bind(artifact_name)
         .bind(artifact_version)
+        .bind(artifact_metadata_format)
+        .bind(artifact_metadata)
+        .bind(artifact_metadata_properties)
+        .bind(package_description)
+        .bind(package_metadata)
         .bind(content_type)
         .bind(p.total_size)
         .bind(chunk_size)
@@ -1340,6 +1363,11 @@ mod tests {
             artifact_path: "path/to/file.bin".into(),
             artifact_name: Some("source-name".into()),
             artifact_version: Some("1.0.0".into()),
+            artifact_metadata_format: None,
+            artifact_metadata: None,
+            artifact_metadata_properties: None,
+            package_description: None,
+            package_metadata: None,
             content_type: "application/octet-stream".into(),
             total_size: 1024,
             chunk_size: DEFAULT_CHUNK_SIZE,
@@ -1369,6 +1397,11 @@ mod tests {
             artifact_path: "file.bin".into(),
             artifact_name: None,
             artifact_version: None,
+            artifact_metadata_format: None,
+            artifact_metadata: None,
+            artifact_metadata_properties: None,
+            package_description: None,
+            package_metadata: None,
             content_type: "application/octet-stream".into(),
             total_size: 100,
             chunk_size: DEFAULT_CHUNK_SIZE,


### PR DESCRIPTION
## Summary

Fixes #1801.

Hosted Debian/APT uploads were persisted locally but never queued for peer replication because the Debian upload handlers always called `persist_debian_upload(..., false)`. This PR makes normal Debian hosted uploads enqueue peer sync tasks while still suppressing fan-out for incoming replication writes marked with `x-artifact-keeper-replication`.

It also carries Debian-specific replication state through the existing chunked upload-session path so a fresh peer materializes the same artifact metadata and package catalog state as the source peer:

- Debian `artifact_metadata` / metadata properties
- package description / package metadata
- artifact name/version for package catalog reconstruction
- package and package-version rows on upload completion

The sync worker forces the chunked upload-session path when replication metadata is present, even for small artifacts, so the receiver can preserve metadata rather than using the metadata-less single PUT path. Storage backend semantics are unchanged; chunked reads continue to use the existing `StorageBackend::get_range` implementations.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added/updated coverage includes:

- direct Debian uploads enqueue sync tasks unless the request is marked as peer replication
- replication-marked upload sessions preserve source artifact/package metadata
- non-replication upload sessions drop replication-only metadata fields
- sync-worker chunked upload session bodies include replication metadata
- metadata-bearing sync tasks force the chunked upload-session path
- upload-session completion materializes artifact metadata and package catalog state

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation run for this branch:

```text
cargo fmt --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --lib
cargo test --lib test_openapi_spec_is_valid
```

The local Rust toolchain was not installed on the host, so these commands were run in a local Docker builder image. `cargo test --workspace --lib` completed with `11238 passed; 0 failed; 4 ignored`.

Manual/live HA validation was also run against two S3-backed peers using Debian/APT hosted repositories:

- checksum-negative Debian uploads rejected with HTTP 400 in both directions
- single Debian package replication succeeded in both directions
- large chunked Debian package replication recovered after a 20-minute target-peer outage
- target peer exposed replicated artifacts through API, DB rows, Debian metadata, and APT install flows
- `artifacts`, `artifact_metadata`, `packages`, and `package_versions` were present after replication settled

GCS/Azure were not live-tested in this PR. This patch does not change storage backend ranged-read behavior; it reuses the existing `get_range` implementations and tests already present on `main`.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

This adds nullable, replication-only metadata fields to the existing upload-session request/body path and nullable columns to `upload_sessions`. Regular client upload sessions ignore these replication metadata fields unless the request carries the peer replication marker.