### PR TITLE
fix(security): enforce per-repo authz on /tree and /search (#1803)

### DIFF
--- a/backend/src/api/handlers/search.rs
+++ b/backend/src/api/handlers/search.rs
@@ -191,7 +191,46 @@ pub(crate) fn resolve_checksum_column(algorithm: &str) -> Result<&'static str> {
 ///
 /// The returned value is passed directly to SearchService methods as the
 /// `accessible_repo_ids` parameter.
+/// Intersect a user-visible repo set with an API token's repository scope
+/// (`allowed_repo_ids`), so a token scoped to repo X cannot enumerate other
+/// repos via search (#1803).
+///
+/// * `visible = None` means "no filter" (admin). A repo-scoped token narrows
+///   this to exactly its scoped ids.
+/// * `visible = Some(ids)` is intersected with the token scope.
+/// * `token_scope = None` (unrestricted / JWT / anonymous) leaves `visible`
+///   unchanged.
+pub(crate) fn intersect_token_scope(
+    visible: Option<Vec<Uuid>>,
+    token_scope: Option<&[Uuid]>,
+) -> Option<Vec<Uuid>> {
+    match token_scope {
+        None => visible,
+        Some(scope) => match visible {
+            // Admin (no filter) restricted to the token's scoped repos.
+            None => Some(scope.to_vec()),
+            Some(ids) => Some(
+                ids.into_iter()
+                    .filter(|id| scope.contains(id))
+                    .collect::<Vec<_>>(),
+            ),
+        },
+    }
+}
+
 async fn resolve_accessible_repos(
+    db: &PgPool,
+    auth: &Option<AuthExtension>,
+) -> Result<Option<Vec<Uuid>>> {
+    let visible = resolve_visible_repos(db, auth).await?;
+    let token_scope = auth.as_ref().and_then(|a| a.allowed_repo_ids.as_deref());
+    Ok(intersect_token_scope(visible, token_scope))
+}
+
+/// Resolve the caller's *visibility* set (public + role grants), ignoring any
+/// API-token repository scope. Token scope is layered on top by
+/// [`resolve_accessible_repos`] via [`intersect_token_scope`].
+async fn resolve_visible_repos(
     db: &PgPool,
     auth: &Option<AuthExtension>,
 ) -> Result<Option<Vec<Uuid>>> {
@@ -1313,6 +1352,50 @@ mod tests {
     fn test_classify_repo_access_anonymous() {
         let auth: Option<AuthExtension> = None;
         assert_eq!(classify_repo_access(&auth), RepoAccessMode::PublicOnly);
+    }
+
+    // intersect_token_scope (pure function) — #1803 search scope tightening
+    #[test]
+    fn test_intersect_unrestricted_token_leaves_visible_unchanged() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let visible = Some(vec![a, b]);
+        assert_eq!(
+            intersect_token_scope(visible.clone(), None),
+            visible,
+            "no token scope means no intersection"
+        );
+        // Admin no-filter stays no-filter when token is unrestricted.
+        assert_eq!(intersect_token_scope(None, None), None);
+    }
+
+    #[test]
+    fn test_intersect_narrows_admin_no_filter_to_token_scope() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        // Admin (None = all repos) with a repo-scoped token is clamped to scope.
+        assert_eq!(intersect_token_scope(None, Some(&[a, b])), Some(vec![a, b]));
+    }
+
+    #[test]
+    fn test_intersect_filters_visible_to_token_scope() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        let c = Uuid::new_v4();
+        // Visible {a,b,c}, token scoped to {a,c}, out-of-scope b dropped.
+        let out = intersect_token_scope(Some(vec![a, b, c]), Some(&[a, c]));
+        assert_eq!(out, Some(vec![a, c]));
+    }
+
+    #[test]
+    fn test_intersect_disjoint_yields_empty() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        // Token scoped to a repo not in the visible set -> nothing visible.
+        assert_eq!(
+            intersect_token_scope(Some(vec![a]), Some(&[b])),
+            Some(vec![])
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/tree.rs
+++ b/backend/src/api/handlers/tree.rs
@@ -24,6 +24,86 @@ pub fn router() -> Router<SharedState> {
         .route("/content", get(get_content))
 }
 
+/// Pure authorization decision for a tree/content read of a single repository.
+///
+/// The tree-browser routes are nested under `optional_auth_middleware` only,
+/// so they never pass through `repo_visibility_middleware` and must enforce
+/// per-repo authorization themselves (#1803). This mirrors the visibility +
+/// token-scope + role-grant logic of `repo_visibility_middleware` /
+/// `RepositoryService::user_can_access_repo`:
+///
+/// * admins always pass;
+/// * a public repo is readable by anyone **whose token scope permits it**
+///   (`token_allows`), including anonymous callers;
+/// * a private repo requires an authenticated caller that holds a role
+///   assignment on the repo (`has_role_grant`) **and** whose token scope
+///   permits it.
+///
+/// `token_allows` already encodes `AuthExtension::can_access_repo` (an
+/// unrestricted token / non-API-token / anonymous caller passes `true`).
+fn tree_access_allowed(
+    is_admin: bool,
+    is_public: bool,
+    is_authed: bool,
+    token_allows: bool,
+    has_role_grant: bool,
+) -> bool {
+    if is_admin {
+        return true;
+    }
+    if !token_allows {
+        return false;
+    }
+    if is_public {
+        return true;
+    }
+    // Private repo: must be authenticated AND hold a role grant on it.
+    is_authed && has_role_grant
+}
+
+/// Resolve and enforce read authorization for a tree/content request against a
+/// single repository, returning the existence-hiding 404 on denial so we never
+/// leak whether a private repo exists (#1803).
+async fn authorize_tree_read(
+    state: &SharedState,
+    auth: &Option<AuthExtension>,
+    repo_id: Uuid,
+    is_public: bool,
+    repo_key: &str,
+) -> Result<()> {
+    let not_found = || AppError::NotFound(format!("Repository '{}' not found", repo_key));
+
+    let is_admin = auth.as_ref().map(|a| a.is_admin).unwrap_or(false);
+    let is_authed = auth.is_some();
+    // Token repo-scope (`allowed_repo_ids`): unrestricted / anonymous => true.
+    let token_allows = auth
+        .as_ref()
+        .map(|a| a.can_access_repo(repo_id))
+        .unwrap_or(true);
+
+    // Only consult role grants when they can actually change the outcome
+    // (private repo, non-admin, authenticated, token-permitted). This avoids
+    // an unnecessary DB round-trip for public reads.
+    let has_role_grant = if !is_admin && !is_public && is_authed && token_allows {
+        match auth.as_ref() {
+            Some(a) => state
+                .create_repository_service()
+                .user_can_access_repo(repo_id, a.user_id)
+                .await
+                .unwrap_or(false),
+            None => false,
+        }
+    } else {
+        false
+    };
+
+    if tree_access_allowed(is_admin, is_public, is_authed, token_allows, has_role_grant) {
+        Ok(())
+    } else {
+        Err(not_found())
+    }
+}
+
 #[derive(Debug, Deserialize, IntoParams)]
 pub struct TreeQuery {
     /// Repository key to browse
@@ -115,13 +195,10 @@ pub async fn get_tree(
     let (repo_id, is_public) = repo_row
         .ok_or_else(|| AppError::NotFound(format!("Repository '{}' not found", repo_key)))?;
 
-    // Private repos require authentication
-    if !is_public && auth.is_none() {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            repo_key
-        )));
-    }
+    // Per-repo read authorization (#1803). These routes bypass
+    // repo_visibility_middleware, so enforce admin / public+token-scope /
+    // role-grant+token-scope here; deny with an existence-hiding 404.
+    authorize_tree_read(&state, &auth, repo_id, is_public, &repo_key).await?;
 
     let prefix = params.path.unwrap_or_default();
     let prefix_depth = if prefix.is_empty() {
@@ -259,13 +336,10 @@ pub async fn get_content(
         AppError::NotFound(format!("Repository '{}' not found", params.repository_key))
     })?;
 
-    // Private repos require authentication
-    if !is_public && auth.is_none() {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            params.repository_key
-        )));
-    }
+    // Per-repo read authorization (#1803). These routes bypass
+    // repo_visibility_middleware, so enforce admin / public+token-scope /
+    // role-grant+token-scope here; deny with an existence-hiding 404.
+    authorize_tree_read(&state, &auth, repo_id, is_public, &params.repository_key).await?;
 
     // Look up the artifact by repository_id + path
     #[derive(sqlx::FromRow)]
@@ -709,5 +783,137 @@ mod tests {
         let json = r#"{"repository_key": "x", "path": "y", "max_bytes": 0}"#;
         let q: ContentQuery = serde_json::from_str(json).unwrap();
         assert_eq!(q.max_bytes, Some(0));
+    }
+
+    // ── tree_access_allowed authorization decision (#1803) ───────────────
+
+    #[test]
+    fn test_access_admin_always_allowed_even_private_out_of_scope() {
+        // Admin bypasses visibility, token scope, and role grants.
+        assert!(tree_access_allowed(
+            /* is_admin */ true, /* is_public */ false, /* is_authed */ true,
+            /* token_allows */ false, /* has_role_grant */ false,
+        ));
+    }
+
+    #[test]
+    fn test_access_public_anonymous_allowed() {
+        assert!(tree_access_allowed(false, true, false, true, false));
+    }
+
+    #[test]
+    fn test_access_public_out_of_token_scope_denied() {
+        // Public repo but the token's allowed_repo_ids does not include it.
+        assert!(!tree_access_allowed(false, true, true, false, true));
+    }
+
+    #[test]
+    fn test_access_private_with_grant_and_scope_allowed() {
+        assert!(tree_access_allowed(false, false, true, true, true));
+    }
+
+    #[test]
+    fn test_access_private_zero_grant_denied() {
+        // The exact #1803 exploit shape: non-admin, authed, token scoped to a
+        // public repo (token_allows happens to be true), zero role grants on
+        // the private target -> must be denied.
+        assert!(!tree_access_allowed(false, false, true, true, false));
+    }
+
+    #[test]
+    fn test_access_private_anonymous_denied() {
+        assert!(!tree_access_allowed(false, false, false, true, false));
+    }
+
+    // ── DB-backed handler authorization (#1803) ──────────────────────────
+    //
+    // No-ops when no test DB is configured (`try_pool` returns None).
+
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::http::StatusCode;
+
+    /// A non-admin caller with NO role assignment on a private repo must get a
+    /// 404 (existence-hiding) from GET /tree — not the private tree.
+    #[tokio::test]
+    async fn test_get_tree_private_zero_grant_nonadmin_denied() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        // create_repo defaults to is_public = false (private).
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+
+        let auth = tdh::make_auth(user_id, &username);
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        let app = tdh::router_with_auth(router(), state, auth);
+
+        let uri = format!("/?repository_key={}", repo_key);
+        let (status, _body) = tdh::send(app, tdh::get(uri)).await;
+
+        // Clean up before asserting so a failure does not leak rows.
+        tdh::cleanup(&pool, repo_id, user_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "zero-grant non-admin must be denied (404) on a private repo tree"
+        );
+    }
+
+    /// A non-admin caller WITH a role grant on the private repo is authorized
+    /// and reaches the handler (200 + empty node list for an empty repo).
+    #[tokio::test]
+    async fn test_get_tree_private_with_grant_nonadmin_allowed() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+
+        let auth = tdh::make_auth(user_id, &username);
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        let app = tdh::router_with_auth(router(), state, auth);
+
+        let uri = format!("/?repository_key={}", repo_key);
+        let (status, _body) = tdh::send(app, tdh::get(uri)).await;
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "non-admin with a role grant must be allowed to browse the private tree"
+        );
+    }
+
+    /// A token scoped to a different repo (allowed_repo_ids excludes the
+    /// target) must be denied even though the caller holds a role grant.
+    #[tokio::test]
+    async fn test_get_tree_private_token_out_of_scope_denied() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+
+        // Token scoped to some OTHER repo id only.
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.allowed_repo_ids = Some(vec![Uuid::new_v4()]);
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        let app = tdh::router_with_auth(router(), state, auth);
+
+        let uri = format!("/?repository_key={}", repo_key);
+        let (status, _body) = tdh::send(app, tdh::get(uri)).await;
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "token whose scope excludes the repo must be denied even with a role grant"
+        );
     }
 }


### PR DESCRIPTION
## Summary

**Critical broken access control.** `/api/v1/tree`, `/api/v1/tree/content` and `/api/v1/search/*` are nested under `optional_auth_middleware` only, so they never pass through `repo_visibility_middleware`. The tree handlers gated access with just `if !is_public && auth.is_none()`, so **any authenticated principal** — including a non-admin, repo-scoped API token with zero role assignments — could enumerate and download the contents of **any private repository**, ignoring both the token's repo scope (`allowed_repo_ids`) and per-user role grants. The anonymous control on the same URLs correctly returns 404, confirming this is an authorization bypass.

This PR adds real per-repo read authorization in `get_tree` and `get_content` via a shared `authorize_tree_read` helper that mirrors `repo_visibility_middleware` / `RepositoryService::user_can_access_repo`:

- admin → allow;
- public repo AND token scope permits it → allow (incl. anonymous);
- private repo → require an authenticated caller who holds a role assignment on the repo **and** whose token scope permits it.

Denials use an existence-hiding 404 (never leaking whether a private repo exists).

It also tightens search: `resolve_accessible_repos` now intersects the user-visible repo set with the token's `allowed_repo_ids` (`intersect_token_scope`), so a token scoped to one repo cannot enumerate others via search results/facets.

Closes #1803

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

DB-backed tree tests: zero-grant non-admin → 404, granted user → 200, out-of-scope token → 404 (these fail on `main`, where the handler returns 200). Plus pure unit tests for the authorization decision (`tree_access_allowed`) and the search scope intersection (`intersect_token_scope`).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes