### PR TITLE
fix(security): cap Helm gzip/tar decompression to prevent DoS (#1806)

### DIFF
--- a/backend/src/formats/helm.rs
+++ b/backend/src/formats/helm.rs
@@ -15,6 +15,39 @@ use crate::error::{AppError, Result};
 use crate::formats::FormatHandler;
 use crate::models::repository::RepositoryFormat;
 
+/// Maximum number of decompressed bytes read from a single tar entry
+/// (e.g. Chart.yaml / values.yaml) before rejecting the upload.
+///
+/// A well-formed Chart.yaml / values.yaml is well under a few hundred KiB.
+/// Capping the per-entry read defends against gzip/tar decompression bombs:
+/// a small compressed payload can otherwise inflate to gigabytes and exhaust
+/// backend memory. The compressed-body limit (axum `DefaultBodyLimit`) only
+/// bounds the COMPRESSED request, not the decompressed output, so an explicit
+/// cap on the inflated stream is required here.
+const MAX_METADATA_ENTRY_BYTES: u64 = 4 * 1024 * 1024; // 4 MiB
+
+/// Read a tar entry into a `String`, capping the decompressed size at
+/// `MAX_METADATA_ENTRY_BYTES`. Rejects gzip/tar decompression bombs by
+/// failing fast once the cap is exceeded, before unbounded buffering.
+fn read_capped_entry_to_string<R: Read>(entry: R, what: &str) -> Result<String> {
+    // Read one extra byte so we can detect "limit exceeded" rather than a
+    // payload that exactly fills the cap.
+    let mut limited = entry.take(MAX_METADATA_ENTRY_BYTES + 1);
+    let mut content = String::new();
+    limited
+        .read_to_string(&mut content)
+        .map_err(|e| AppError::Validation(format!("Failed to read {}: {}", what, e)))?;
+
+    if content.len() as u64 > MAX_METADATA_ENTRY_BYTES {
+        return Err(AppError::Validation(format!(
+            "{} exceeds maximum allowed size of {} bytes",
+            what, MAX_METADATA_ENTRY_BYTES
+        )));
+    }
+
+    Ok(content)
+}
+
 /// Helm format handler
 pub struct HelmHandler;
 
@@ -112,10 +145,7 @@ impl HelmHandler {
 
             // Chart.yaml is typically in <chartname>/Chart.yaml
             if path.ends_with("Chart.yaml") {
-                let mut content = String::new();
-                entry.read_to_string(&mut content).map_err(|e| {
-                    AppError::Validation(format!("Failed to read Chart.yaml: {}", e))
-                })?;
+                let content = read_capped_entry_to_string(&mut entry, "Chart.yaml")?;
 
                 return serde_yaml::from_str(&content)
                     .map_err(|e| AppError::Validation(format!("Invalid Chart.yaml: {}", e)));
@@ -145,10 +175,7 @@ impl HelmHandler {
 
             // values.yaml is typically in <chartname>/values.yaml
             if path.ends_with("values.yaml") {
-                let mut content = String::new();
-                entry.read_to_string(&mut content).map_err(|e| {
-                    AppError::Validation(format!("Failed to read values.yaml: {}", e))
-                })?;
+                let content = read_capped_entry_to_string(&mut entry, "values.yaml")?;
 
                 let values: serde_yaml::Value = serde_yaml::from_str(&content)
                     .map_err(|e| AppError::Validation(format!("Invalid values.yaml: {}", e)))?;
@@ -848,5 +875,75 @@ version: "1.0.0"
         assert_eq!(parsed.chart.name, "test");
         assert_eq!(parsed.urls.len(), 1);
         assert_eq!(parsed.digest, "sha256:abc");
+    }
+
+    // ---- decompression-bomb cap (issue #1806) ----
+
+    /// Build a gzip-compressed tar (`.tgz`) containing a single file at
+    /// `path` whose contents are `body`. Used to construct both a legitimate
+    /// chart and an oversized "bomb" entry.
+    fn build_tgz(path: &str, body: &[u8]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, path, body).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder.write_all(&tar_buf).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    #[test]
+    fn test_extract_chart_yaml_normal_chart_parses() {
+        let body = b"apiVersion: v2\nname: nginx\nversion: 1.2.3\n";
+        let tgz = build_tgz("nginx/Chart.yaml", body);
+        let chart = HelmHandler::extract_chart_yaml(&tgz).unwrap();
+        assert_eq!(chart.name, "nginx");
+        assert_eq!(chart.version, "1.2.3");
+    }
+
+    #[test]
+    fn test_extract_chart_yaml_oversized_entry_rejected() {
+        // A Chart.yaml entry that inflates well past the per-entry cap is a
+        // decompression bomb and must be rejected BEFORE buffering it all.
+        let oversized = vec![b'A'; (MAX_METADATA_ENTRY_BYTES + 1024) as usize];
+        let tgz = build_tgz("bomb/Chart.yaml", &oversized);
+        // The compressed payload is tiny (highly repetitive), proving the cap
+        // bounds the decompressed size, not the request body.
+        assert!(tgz.len() < 64 * 1024);
+
+        let err = HelmHandler::extract_chart_yaml(&tgz).unwrap_err();
+        match err {
+            AppError::Validation(msg) => {
+                assert!(
+                    msg.contains("exceeds maximum allowed size"),
+                    "unexpected error: {msg}"
+                );
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_values_yaml_oversized_entry_rejected() {
+        let oversized = vec![b'A'; (MAX_METADATA_ENTRY_BYTES + 1024) as usize];
+        let tgz = build_tgz("bomb/values.yaml", &oversized);
+        let err = HelmHandler::extract_values_yaml(&tgz).unwrap_err();
+        match err {
+            AppError::Validation(msg) => {
+                assert!(
+                    msg.contains("exceeds maximum allowed size"),
+                    "unexpected error: {msg}"
+                );
+            }
+            other => panic!("expected Validation error, got {other:?}"),
+        }
     }
 }

--- a/backend/src/services/helm_lint_checker.rs
+++ b/backend/src/services/helm_lint_checker.rs
@@ -10,6 +10,16 @@ use tar::Archive;
 
 use crate::models::quality::{QualityCheckOutput, RawQualityIssue};
 
+/// Maximum number of decompressed (inflated tar) bytes the lint checker will
+/// buffer in memory before rejecting the archive.
+///
+/// Without this cap a small, high-ratio gzip payload (a decompression bomb)
+/// can inflate to gigabytes and exhaust backend memory. The compressed request
+/// body limit does not bound the decompressed size, so an explicit cap on the
+/// inflated stream is required. 64 MiB comfortably exceeds any legitimate Helm
+/// chart archive while preventing unbounded allocation.
+const MAX_DECOMPRESSED_TAR_BYTES: u64 = 64 * 1024 * 1024; // 64 MiB
+
 /// Validates Helm chart archives (.tgz) for structural quality.
 ///
 /// Scoring breakdown (100 points total):
@@ -111,25 +121,52 @@ struct TarInventory {
     template_files: Vec<String>,
 }
 
+/// Build a critical-failure `QualityCheckOutput` for a gzip/tar decompression
+/// problem (invalid archive or decompression bomb).
+fn decompress_failure(title: &str, description: String, error: &str) -> QualityCheckOutput {
+    QualityCheckOutput {
+        score: 0,
+        passed: false,
+        issues: vec![RawQualityIssue {
+            severity: "critical".to_string(),
+            category: "helm-structure".to_string(),
+            title: title.to_string(),
+            description: Some(description),
+            location: None,
+        }],
+        details: json!({ "error": error }),
+    }
+}
+
 /// Decompress gzip content, returning the raw tar bytes on success or a
 /// critical-failure `QualityCheckOutput` on error.
+///
+/// The decompressed stream is capped at `MAX_DECOMPRESSED_TAR_BYTES` to defend
+/// against gzip/tar decompression bombs; an archive that inflates beyond the
+/// cap is rejected instead of being buffered in full.
 fn decompress_gzip(content: &Bytes) -> Result<Vec<u8>, QualityCheckOutput> {
-    let mut decoder = GzDecoder::new(content.as_ref());
+    // Read one byte past the cap so an over-limit archive can be detected
+    // rather than silently truncated.
+    let mut decoder = GzDecoder::new(content.as_ref()).take(MAX_DECOMPRESSED_TAR_BYTES + 1);
     let mut tar_bytes = Vec::new();
     if let Err(e) = decoder.read_to_end(&mut tar_bytes) {
-        return Err(QualityCheckOutput {
-            score: 0,
-            passed: false,
-            issues: vec![RawQualityIssue {
-                severity: "critical".to_string(),
-                category: "helm-structure".to_string(),
-                title: "Not a valid gzip archive".to_string(),
-                description: Some(format!("Failed to decompress gzip: {e}")),
-                location: None,
-            }],
-            details: json!({ "error": "Not a valid gzip archive" }),
-        });
+        return Err(decompress_failure(
+            "Not a valid gzip archive",
+            format!("Failed to decompress gzip: {e}"),
+            "Not a valid gzip archive",
+        ));
     }
+
+    if tar_bytes.len() as u64 > MAX_DECOMPRESSED_TAR_BYTES {
+        return Err(decompress_failure(
+            "Decompressed archive too large",
+            format!(
+                "Decompressed archive exceeds maximum allowed size of {MAX_DECOMPRESSED_TAR_BYTES} bytes"
+            ),
+            "Decompressed archive too large",
+        ));
+    }
+
     Ok(tar_bytes)
 }
 
@@ -627,6 +664,26 @@ maintainers:
         assert_eq!(output.issues.len(), 1);
         assert_eq!(output.issues[0].severity, "critical");
         assert_eq!(output.issues[0].category, "helm-structure");
+    }
+
+    #[test]
+    fn test_decompression_bomb_rejected() {
+        // A tiny compressed payload that inflates past MAX_DECOMPRESSED_TAR_BYTES
+        // must be rejected as a critical failure rather than buffered in full.
+        let oversized = vec![b'A'; (MAX_DECOMPRESSED_TAR_BYTES + 1024) as usize];
+        let tgz = build_tgz(&[("bomb/Chart.yaml", &oversized)]);
+        // Highly repetitive content compresses to far below the cap, proving the
+        // guard bounds the decompressed size, not the request body size.
+        assert!(tgz.len() < (MAX_DECOMPRESSED_TAR_BYTES / 16) as usize);
+
+        let checker = HelmLintChecker;
+        let output = checker.check(&tgz);
+
+        assert_eq!(output.score, 0);
+        assert!(!output.passed);
+        assert_eq!(output.issues.len(), 1);
+        assert_eq!(output.issues[0].severity, "critical");
+        assert_eq!(output.issues[0].title, "Decompressed archive too large");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Helm chart upload and the quality-gate Helm lint checker decompressed attacker-controlled gzip/tar into memory with **no decompressed-size cap** (a decompression bomb). A small, high-ratio gzip payload (~510 KB compressed, ~512 MiB inflated, ratio ~1000x) uploaded by any principal holding helm `write` on the target repo inflated to **gigabytes of backend heap** before validation rejected it — verified to push `ak-rt-backend` from ~231 MiB to ~1.3 GiB peak on a single request, enabling OOM / DoS at scale or under concurrency.

The axum `DefaultBodyLimit` only bounds the **compressed** request body, not the inflated output, so it was ineffective against high-ratio bombs.

Root cause (two unbounded sinks):
- `backend/src/formats/helm.rs` — `extract_chart_yaml` / `extract_values_yaml` did `entry.read_to_string(..)` over a tar entry whose declared size is attacker-controlled, with no cap (reached on the authenticated upload path).
- `backend/src/services/helm_lint_checker.rs` — `decompress_gzip` did `GzDecoder::read_to_end(..)` into a `Vec` with no cap.

Fix (minimal, defense-in-depth at each sink):
- `formats/helm.rs`: read each metadata entry through a bounded reader capped at **4 MiB** (`Read::take`), rejecting oversized entries with a `4xx` Validation error **before** buffering. A legitimate Chart.yaml/values.yaml is well under this.
- `helm_lint_checker.rs`: cap the inflated tar stream at **64 MiB** (`Read::take`) and reject over-cap archives as a critical failure.

This is **not** anonymous-reachable — a write-scoped principal on the target repo is required — but it is a real, low-privilege-triggerable DoS. Closes #1806.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New tests build a tiny `.tgz` whose entry inflates just past each cap and assert it is rejected; verified to **fail** without the cap (the unbounded read buffers the full inflated entry) and **pass** with it. A control test confirms a normal chart still parses:
- `formats::helm::tests::test_extract_chart_yaml_oversized_entry_rejected`
- `formats::helm::tests::test_extract_values_yaml_oversized_entry_rejected`
- `formats::helm::tests::test_extract_chart_yaml_normal_chart_parses`
- `services::helm_lint_checker::tests::test_decompression_bomb_rejected`

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
