### PR TITLE
fix(sso): apply SSRF allowlist to LDAP provider config and connectivity test

### DIFF
--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -282,6 +282,7 @@ pub async fn create_ldap(
     Json(req): Json<CreateLdapConfigRequest>,
 ) -> Result<Json<LdapConfigResponse>> {
     require_admin(&auth)?;
+    crate::api::validation::validate_outbound_ldap_url(&req.server_url, "LDAP server URL")?;
     let result = AuthConfigService::create_ldap(&state.db, req).await?;
     Ok(Json(result))
 }
@@ -310,6 +311,9 @@ pub async fn update_ldap(
     Json(req): Json<UpdateLdapConfigRequest>,
 ) -> Result<Json<LdapConfigResponse>> {
     require_admin(&auth)?;
+    if let Some(server_url) = &req.server_url {
+        crate::api::validation::validate_outbound_ldap_url(server_url, "LDAP server URL")?;
+    }
     let result = AuthConfigService::update_ldap(&state.db, id, req).await?;
     Ok(Json(result))
 }

--- a/backend/src/api/validation.rs
+++ b/backend/src/api/validation.rs
@@ -147,6 +147,75 @@ pub fn validate_outbound_webhook_url(url_str: &str, label: &str) -> Result<()> {
     validate_outbound_url_with(url_str, label, OutboundUrlContext::Webhook)
 }
 
+/// Validate an LDAP server URL (`ldap://` or `ldaps://`) against the SSRF
+/// allowlist, reusing the same blocked-host / private-IP rules as
+/// [`validate_outbound_url`]. Split out because the shared validator
+/// rejects any non-http(s) scheme (so the LDAP schemes cannot be passed
+/// through it) and because LDAP uses the `Upstream` context so the
+/// existing `UPSTREAM_ALLOW_PRIVATE_IPS` / `AK_SSRF_ALLOW_PRIVATE_CIDRS`
+/// operator escape hatches relax it uniformly.
+///
+/// This checks the string / literal-IP form (and, for DNS names, the
+/// resolution at validation time, like [`is_blocked_url_in`]). The
+/// connect-time resolved-IP re-check is done by the connectivity probe
+/// via [`is_blocked_resolved_ip`] so already-stored configs and the
+/// DNS-rebind window are also covered.
+pub fn validate_outbound_ldap_url(url_str: &str, label: &str) -> Result<()> {
+    let remainder = if let Some(rest) = url_str.strip_prefix("ldaps://") {
+        rest
+    } else if let Some(rest) = url_str.strip_prefix("ldap://") {
+        rest
+    } else {
+        return Err(AppError::Validation(format!(
+            "{} must use ldap or ldaps",
+            label
+        )));
+    };
+
+    // Keep only the authority (drop any path/query/fragment and userinfo),
+    // then extract the host (bracket-aware for IPv6 literals).
+    let authority = remainder.split(['/', '?', '#']).next().unwrap_or(remainder);
+    let authority = authority.rsplit('@').next().unwrap_or(authority);
+    let host = ldap_authority_host(authority);
+    if host.is_empty() {
+        return Err(AppError::Validation(format!("{} must have a host", label)));
+    }
+
+    if let Some(reason) = is_blocked_host_str(host, OutboundUrlContext::Upstream) {
+        record_block(label, &reason);
+        return Err(block_reason_to_error(label, reason));
+    }
+
+    Ok(())
+}
+
+/// Extract the host portion (keeping IPv6 brackets) from an LDAP
+/// `host[:port]` authority. Bracket-aware so `[::1]:389` yields `[::1]`
+/// rather than splitting inside the address.
+fn ldap_authority_host(authority: &str) -> &str {
+    if authority.starts_with('[') {
+        // IPv6 literal: host runs up to and including the closing bracket.
+        if let Some(end) = authority.find(']') {
+            return &authority[..=end];
+        }
+        return authority;
+    }
+    match authority.rsplit_once(':') {
+        Some((h, _)) => h,
+        None => authority,
+    }
+}
+
+/// True when a resolved IP must not be contacted from the server in the
+/// upstream context (honors `UPSTREAM_ALLOW_PRIVATE_IPS` /
+/// `AK_SSRF_ALLOW_PRIVATE_CIDRS`). Used by the LDAP `/test` connectivity
+/// probe to re-check the resolved address before opening a socket, which
+/// closes the literal-IP and hostname-resolution (DNS) port-scan oracle
+/// for already-stored configs.
+pub fn is_blocked_resolved_ip(ip: std::net::IpAddr) -> bool {
+    is_blocked_ip_in(ip, OutboundUrlContext::Upstream)
+}
+
 /// Common implementation shared by the per-context validators. The
 /// `ctx` selects which env var the private-IP relaxation toggle reads.
 fn validate_outbound_url_with(url_str: &str, label: &str, ctx: OutboundUrlContext) -> Result<()> {
@@ -167,18 +236,26 @@ fn validate_outbound_url_with(url_str: &str, label: &str, ctx: OutboundUrlContex
 
     if let Some(reason) = is_blocked_url_in(&parsed, ctx) {
         record_block(label, &reason);
-        return Err(match reason {
-            BlockReason::Hostname(host) => {
-                AppError::Validation(format!("{} host '{}' is not allowed", label, host))
-            }
-            BlockReason::Ip(ip) => AppError::Validation(format!(
-                "{} IP '{}' is not allowed (private/internal network)",
-                label, ip
-            )),
-        });
+        return Err(block_reason_to_error(label, reason));
     }
 
     Ok(())
+}
+
+/// Map a [`BlockReason`] to the user-facing [`AppError::Validation`] with
+/// the standard message wording. Shared by [`validate_outbound_url_with`]
+/// and [`validate_outbound_ldap_url`] so the host/IP messages stay
+/// identical across surfaces.
+fn block_reason_to_error(label: &str, reason: BlockReason) -> AppError {
+    match reason {
+        BlockReason::Hostname(host) => {
+            AppError::Validation(format!("{} host '{}' is not allowed", label, host))
+        }
+        BlockReason::Ip(ip) => AppError::Validation(format!(
+            "{} IP '{}' is not allowed (private/internal network)",
+            label, ip
+        )),
+    }
 }
 
 /// Decide whether a parsed URL targets a blocked address. Used by the
@@ -197,6 +274,16 @@ pub(crate) fn is_blocked_url(url: &reqwest::Url) -> Option<BlockReason> {
 /// means the request must not be issued for the given context.
 fn is_blocked_url_in(url: &reqwest::Url, ctx: OutboundUrlContext) -> Option<BlockReason> {
     let host = url.host_str()?;
+    is_blocked_host_str(host, ctx)
+}
+
+/// Decide whether a host string (a DNS name or an IP literal, possibly
+/// bracketed for IPv6 like `[::1]`) targets a blocked address for the
+/// given context. Factored out of [`is_blocked_url_in`] so the
+/// `BLOCKED_HOSTS` list, literal-IP rules, and hostname-resolution step
+/// live in one place and are shared by [`validate_outbound_ldap_url`]
+/// (which cannot reuse the http(s)-only [`validate_outbound_url`]).
+fn is_blocked_host_str(host: &str, ctx: OutboundUrlContext) -> Option<BlockReason> {
     let host_lower = host.to_lowercase();
     // Strip a trailing dot so `localhost.` is treated like `localhost`.
     let host_normalized = host_lower.trim_end_matches('.');
@@ -1513,5 +1600,125 @@ mod tests {
         assert!(webhook_allow_private_ips_enabled());
         std::env::set_var("WEBHOOK_ALLOW_PRIVATE_IPS", "maybe");
         assert!(!webhook_allow_private_ips_enabled());
+    }
+
+    // -----------------------------------------------------------------------
+    // LDAP outbound URL validation (validate_outbound_ldap_url). Reuses the
+    // same blocked-host / private-IP rules as validate_outbound_url but
+    // accepts the ldap:// / ldaps:// schemes (which the http(s)-only
+    // validator rejects).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_ldap_allows_public_ldaps_with_port() {
+        assert!(
+            validate_outbound_ldap_url("ldaps://ldap.example.com:636", "LDAP server URL").is_ok()
+        );
+    }
+
+    #[test]
+    fn test_ldap_allows_public_ldap_default_port() {
+        assert!(validate_outbound_ldap_url("ldap://ldap.example.com", "LDAP server URL").is_ok());
+    }
+
+    #[test]
+    fn test_ldap_rejects_private_ip() {
+        let _g = AllowlistGuard::new();
+        let err = validate_outbound_ldap_url("ldap://10.0.0.1", "LDAP server URL")
+            .expect_err("private IP must be rejected");
+        assert!(err.to_string().contains("private/internal network"));
+    }
+
+    #[test]
+    fn test_ldap_rejects_ipv6_loopback() {
+        let err = validate_outbound_ldap_url("ldap://[::1]:389", "LDAP server URL")
+            .expect_err("ipv6 loopback must be rejected");
+        assert!(err.to_string().contains("private/internal network"));
+    }
+
+    #[test]
+    fn test_ldap_rejects_localhost() {
+        let err = validate_outbound_ldap_url("ldap://localhost", "LDAP server URL")
+            .expect_err("localhost must be rejected");
+        assert!(err.to_string().contains("is not allowed"));
+    }
+
+    #[test]
+    fn test_ldap_rejects_docker_service_host() {
+        // BLOCKED_HOSTS entry — the string check catches it with no DNS.
+        let err = validate_outbound_ldap_url("ldaps://postgres", "LDAP server URL")
+            .expect_err("internal docker host must be rejected");
+        assert!(err.to_string().contains("is not allowed"));
+    }
+
+    #[test]
+    fn test_ldap_rejects_non_ldap_scheme() {
+        assert!(validate_outbound_ldap_url("http://ldap.example.com", "LDAP server URL").is_err());
+        assert!(validate_outbound_ldap_url("https://ldap.example.com", "LDAP server URL").is_err());
+        assert!(validate_outbound_ldap_url("ldap.example.com:389", "LDAP server URL").is_err());
+    }
+
+    #[test]
+    fn test_ldap_rejects_hostname_resolving_to_internal() {
+        // Mirror of test_rejects_hostname_resolving_to_internal: a non-listed
+        // hostname that resolves to an internal IP must be rejected by the
+        // resolution step. Guarded so it does not flake where the name does
+        // not resolve (e.g. ak-rt-db is a Docker-network-only name).
+        use std::net::ToSocketAddrs;
+        let host = "localhost.localdomain";
+        let resolves_internal = (host, 0u16)
+            .to_socket_addrs()
+            .map(|addrs| {
+                addrs
+                    .into_iter()
+                    .any(|a| is_blocked_ip_in(a.ip(), OutboundUrlContext::Upstream))
+            })
+            .unwrap_or(false);
+        if resolves_internal {
+            let err = validate_outbound_ldap_url(&format!("ldap://{host}"), "LDAP server URL")
+                .expect_err("internal-resolving host must be rejected");
+            assert!(err.to_string().contains("private/internal network"));
+        }
+    }
+
+    #[test]
+    fn test_ldap_allow_private_ips_toggle_unblocks() {
+        // The existing Upstream escape hatch relaxes LDAP too (no new env var).
+        let _g = AllowlistGuard::new();
+        std::env::set_var("UPSTREAM_ALLOW_PRIVATE_IPS", "true");
+        assert!(
+            validate_outbound_ldap_url("ldap://10.0.0.5:389", "LDAP server URL").is_ok(),
+            "private LDAP host must be allowed when UPSTREAM_ALLOW_PRIVATE_IPS=true"
+        );
+    }
+
+    #[test]
+    fn test_ldap_cidr_allowlist_relaxes_private() {
+        let _g = AllowlistGuard::new();
+        std::env::set_var("AK_SSRF_ALLOW_PRIVATE_CIDRS", "10.0.0.0/8");
+        assert!(validate_outbound_ldap_url("ldap://10.1.2.3", "LDAP server URL").is_ok());
+        // Outside the allowlisted CIDR — still blocked.
+        assert!(validate_outbound_ldap_url("ldap://192.168.1.1", "LDAP server URL").is_err());
+    }
+
+    #[test]
+    fn test_ldap_allow_private_ips_still_blocks_metadata_and_loopback() {
+        // Even with the blanket toggle, metadata and loopback stay blocked.
+        let _g = AllowlistGuard::new();
+        std::env::set_var("UPSTREAM_ALLOW_PRIVATE_IPS", "true");
+        assert!(validate_outbound_ldap_url("ldap://169.254.169.254", "LDAP server URL").is_err());
+        assert!(validate_outbound_ldap_url("ldaps://127.0.0.1:636", "LDAP server URL").is_err());
+    }
+
+    #[test]
+    fn test_is_blocked_resolved_ip_contract() {
+        let _g = AllowlistGuard::new();
+        // Loopback / private / metadata are blocked by default.
+        assert!(is_blocked_resolved_ip("127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_resolved_ip("10.0.0.1".parse().unwrap()));
+        assert!(is_blocked_resolved_ip("169.254.169.254".parse().unwrap()));
+        assert!(is_blocked_resolved_ip("::1".parse().unwrap()));
+        // A public IP passes.
+        assert!(!is_blocked_resolved_ip("93.184.216.34".parse().unwrap()));
     }
 }

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -975,22 +975,64 @@ impl AuthConfigService {
         .map_err(|e| AppError::Internal(format!("Failed to get LDAP config: {e}")))?
         .ok_or_else(|| AppError::NotFound(format!("LDAP config {id} not found")))?;
 
-        let start = std::time::Instant::now();
-
         // Parse host and port from server_url (e.g. ldap://host:389 or ldaps://host:636)
         let url = &row.server_url;
         let (host, port) = Self::parse_ldap_url(url)?;
 
-        let addr = format!("{host}:{port}");
+        Self::probe_ldap_endpoint(&host, port).await
+    }
+
+    /// Resolve, SSRF-vet, and probe a TCP connection to `host:port`.
+    ///
+    /// The connectivity test is the only outbound surface that opens a raw
+    /// socket to an operator-supplied target, so it re-checks the resolved
+    /// IP against the SSRF allowlist before connecting (covering configs
+    /// stored before write-time validation and the DNS-resolution oracle),
+    /// connects to the vetted `SocketAddr` directly, and returns only a
+    /// generic outcome — never the raw OS error or a refused-vs-filtered
+    /// timing distinction — so it cannot be used as an internal port-scan
+    /// oracle. Details are logged server-side via `tracing`.
+    async fn probe_ldap_endpoint(host: &str, port: u16) -> Result<LdapTestResult> {
+        let start = std::time::Instant::now();
         let timeout = std::time::Duration::from_secs(5);
 
-        let result = tokio::time::timeout(timeout, tokio::net::TcpStream::connect(&addr)).await;
+        // Resolve the host. Honor the operator escape hatches via the
+        // Upstream context (UPSTREAM_ALLOW_PRIVATE_IPS / AK_SSRF_ALLOW_PRIVATE_CIDRS).
+        let resolved: Vec<std::net::SocketAddr> = match tokio::net::lookup_host((host, port)).await
+        {
+            Ok(addrs) => addrs.collect(),
+            Err(e) => {
+                tracing::warn!(target: "security", error = %e, "LDAP test: host resolution failed");
+                return Ok(LdapTestResult {
+                    success: false,
+                    message: "Connection failed".to_string(),
+                    response_time_ms: start.elapsed().as_millis() as u64,
+                });
+            }
+        };
+
+        // Reject if every resolved address is an internal/private target;
+        // otherwise pin the first vetted address (do not re-resolve, to
+        // avoid a TOCTOU / DNS-rebind window).
+        let vetted = resolved
+            .into_iter()
+            .find(|sa| !crate::api::validation::is_blocked_resolved_ip(sa.ip()));
+        let Some(vetted) = vetted else {
+            return Err(AppError::Validation(
+                "LDAP server URL is not allowed (private/internal network)".to_string(),
+            ));
+        };
+
+        let result = tokio::time::timeout(timeout, tokio::net::TcpStream::connect(&vetted)).await;
         let elapsed = start.elapsed().as_millis() as u64;
 
         let (success, message) = match result {
-            Ok(Ok(_)) => (true, format!("Successfully connected to {addr}")),
-            Ok(Err(e)) => (false, format!("Connection to {addr} failed: {e}")),
-            Err(_) => (false, format!("Connection to {addr} timed out after 5s")),
+            Ok(Ok(_)) => (true, format!("Successfully connected to {host}:{port}")),
+            Ok(Err(e)) => {
+                tracing::warn!(target: "security", error = %e, "LDAP test: connection failed");
+                (false, "Connection failed".to_string())
+            }
+            Err(_) => (false, "Connection timed out".to_string()),
         };
 
         Ok(LdapTestResult {
@@ -1873,6 +1915,47 @@ mod tests {
     fn test_parse_ldap_url_invalid_port() {
         let result = AuthConfigService::parse_ldap_url("ldap://myhost:notaport");
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // probe_ldap_endpoint: SSRF-vets the resolved IP before connecting and
+    // returns only a generic outcome (no raw OS error / port-scan oracle).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_probe_ldap_rejects_loopback_before_connect() {
+        // Loopback is hard-blocked regardless of env, so this is stable even
+        // if a parallel test toggles the private-IP allowlist env vars.
+        let err = AuthConfigService::probe_ldap_endpoint("127.0.0.1", 9999)
+            .await
+            .expect_err("loopback must be rejected before any TCP connect");
+        assert!(
+            err.to_string().contains("private/internal network"),
+            "expected a private/internal rejection, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_probe_ldap_rejects_metadata_ip_before_connect() {
+        let err = AuthConfigService::probe_ldap_endpoint("169.254.169.254", 80)
+            .await
+            .expect_err("metadata IP must be rejected before connect");
+        assert!(err.to_string().contains("private/internal network"));
+    }
+
+    #[tokio::test]
+    async fn test_probe_ldap_generic_message_on_resolution_failure() {
+        // `.invalid` never resolves (RFC 6761), so this is deterministic and
+        // offline. The failure message must be generic — no OS error echoed.
+        let res = AuthConfigService::probe_ldap_endpoint("nonexistent.invalid", 389)
+            .await
+            .expect("resolution failure returns a generic result, not an error");
+        assert!(!res.success);
+        assert_eq!(res.message, "Connection failed");
+        assert!(
+            !res.message.contains("os error"),
+            "failure message must not leak the OS error string"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The SSO LDAP provider config path is the only outbound surface that does not
go through the centralized SSRF guard. `AuthConfigService::test_ldap_connection`
(`backend/src/services/auth_config_service.rs`) parsed `host:port` from the
stored `server_url` and opened a raw `tokio::net::TcpStream::connect`, then
returned the verbatim outcome — `"Successfully connected to {addr}"`,
`"Connection to {addr} failed: {e}"` (echoing the OS error), or
`"... timed out after 5s"`. Because `create_ldap` / `update_ldap` stored the
operator-supplied `server_url` with no validation, an admin-authenticated
caller could point the probe at arbitrary internal `host:port` targets and use
the distinct open / refused / filtered responses as an internal port-scan
oracle. The other outbound paths already enforce the guard
(`validate_outbound_url` for remote instances, `validate_outbound_webhook_url`
for webhooks, the shared SSRF-guarded HTTP client for OIDC/SAML).

This change applies the same outbound-URL allowlist to LDAP:

- **`api/validation.rs`** — adds `validate_outbound_ldap_url`, which accepts the
  `ldap://` / `ldaps://` schemes (the existing `validate_outbound_url` rejects
  any non-http(s) scheme) and runs the host through the *same* blocked-host /
  private-IP rules via a shared `is_blocked_host_str` helper. Adds
  `is_blocked_resolved_ip` for the connect-time check. Uses the existing
  `Upstream` context, so the existing operator escape hatches
  (`UPSTREAM_ALLOW_PRIVATE_IPS`, `AK_SSRF_ALLOW_PRIVATE_CIDRS`) relax LDAP too —
  no new env var, no new docs.
- **`api/handlers/sso_admin.rs`** — `create_ldap` and `update_ldap` validate the
  supplied `server_url` before persisting (rejecting internal targets at write
  time).
- **`services/auth_config_service.rs`** — the connectivity probe now resolves
  the host, rejects the request if every resolved IP is internal/private
  (closing both the literal-IP and the hostname-resolution leak, and protecting
  rows stored before this change), connects to the vetted `SocketAddr`, and
  returns only generic messages (`"Connection failed"` / `"Connection timed
  out"`). The detailed error is logged via `tracing` instead of being echoed in
  the response, removing the refused-vs-filtered-vs-open distinction.

The real LDAP authentication flow (`ldap_service::connect_and_bind`) is
intentionally untouched to avoid regressing real logins; defense-in-depth there
is a separate follow-up. No DB migration is required.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added tests:
- `api/validation.rs`: `validate_outbound_ldap_url` accepts public
  `ldaps://ldap.example.com:636`, rejects `ldap://10.0.0.1`, `ldap://[::1]`,
  `ldap://localhost`, `ldaps://postgres`, and non-ldap schemes; the
  `UPSTREAM_ALLOW_PRIVATE_IPS` / `AK_SSRF_ALLOW_PRIVATE_CIDRS` escape hatches
  relax a private host; metadata/loopback stay blocked; `is_blocked_resolved_ip`
  contract.
- `services/auth_config_service.rs`: `probe_ldap_endpoint` rejects loopback /
  metadata IPs before any TCP connect, and returns a generic message (no OS
  error string) on resolution failure. Existing `parse_ldap_url` tests unchanged.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

The `LdapTestResult` response shape is unchanged; only the `message` content on
failure becomes generic. No new endpoints or types.
