### PR TITLE
fix(sso): validate OIDC issuer URL against SSRF policy on config write and discovery fetch

### DIFF
--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -16,6 +16,7 @@ use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
 use crate::api::handlers::auth::set_auth_cookies;
+use crate::api::validation::validate_outbound_url;
 
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -37,6 +38,16 @@ pub fn router() -> Router<SharedState> {
         .route("/saml/:id/login", get(saml_login))
         .route("/saml/:id/acs", post(saml_acs))
         .route("/exchange", post(exchange_code))
+}
+
+/// Re-validate an OIDC endpoint URL against the shared outbound-URL SSRF
+/// guard immediately before the server fetches it as a first hop. The
+/// shared HTTP client's redirect policy only guards redirect hops, never
+/// the initial request, so each server-side fetch target (discovery,
+/// token, JWKS) is checked here. Uses the `Upstream` context, so internal
+/// IdPs are reachable when `UPSTREAM_ALLOW_PRIVATE_IPS` is set.
+fn validate_oidc_fetch_url(url: &str, label: &str) -> Result<()> {
+    validate_outbound_url(url, label)
 }
 
 // ---------------------------------------------------------------------------
@@ -109,6 +120,7 @@ pub async fn oidc_login(
         "{}/.well-known/openid-configuration",
         row.issuer_url.trim_end_matches('/')
     );
+    validate_oidc_fetch_url(&discovery_url, "OIDC discovery URL")?;
 
     let http_client = crate::services::http_client::default_client();
     let discovery: serde_json::Value = http_client
@@ -347,6 +359,7 @@ async fn oidc_callback_inner(
         "{}/.well-known/openid-configuration",
         row.issuer_url.trim_end_matches('/')
     );
+    validate_oidc_fetch_url(&discovery_url, "OIDC discovery URL")?;
 
     let http_client = crate::services::http_client::default_client();
     let discovery: serde_json::Value = http_client
@@ -361,6 +374,7 @@ async fn oidc_callback_inner(
     let token_endpoint = discovery["token_endpoint"]
         .as_str()
         .ok_or_else(|| AppError::Internal("OIDC discovery missing token_endpoint".into()))?;
+    validate_oidc_fetch_url(token_endpoint, "OIDC token endpoint")?;
 
     // 3. Build redirect_uri (must match the one used in the login request)
     let redirect_uri = resolve_oidc_redirect_uri(&row.attribute_mapping, &provider_id, &headers);
@@ -1062,6 +1076,7 @@ async fn validate_id_token(
     let jwks_uri = discovery["jwks_uri"]
         .as_str()
         .ok_or_else(|| AppError::Internal("OIDC discovery missing jwks_uri".into()))?;
+    validate_oidc_fetch_url(jwks_uri, "OIDC JWKS URI")?;
 
     let jwks: serde_json::Value = http_client
         .get(jwks_uri)
@@ -1156,6 +1171,35 @@ mod tests {
         let payload_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(payload).unwrap());
         let signature = URL_SAFE_NO_PAD.encode(b"fake_signature");
         format!("{}.{}.{}", header, payload_b64, signature)
+    }
+
+    // -----------------------------------------------------------------------
+    // validate_oidc_fetch_url (SSRF guard before each server-side first hop)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_oidc_fetch_url_rejects_internal() {
+        // Loopback and cloud-metadata targets must be rejected before the
+        // server issues the discovery/token/jwks fetch.
+        assert!(validate_oidc_fetch_url(
+            "http://127.0.0.1/.well-known/openid-configuration",
+            "OIDC discovery URL"
+        )
+        .is_err());
+        assert!(validate_oidc_fetch_url(
+            "http://169.254.169.254/latest/meta-data",
+            "OIDC token endpoint"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_validate_oidc_fetch_url_accepts_public() {
+        assert!(validate_oidc_fetch_url(
+            "https://idp.example.com/.well-known/openid-configuration",
+            "OIDC discovery URL"
+        )
+        .is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -10,8 +10,17 @@ use sqlx::{FromRow, PgPool};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use crate::api::validation::validate_outbound_url;
 use crate::error::{AppError, Result};
 use crate::services::encryption::{decrypt_credentials, encrypt_credentials};
+
+/// Validate an OIDC `issuer_url` against the shared outbound-URL SSRF guard
+/// before it is persisted. Mirrors the upstream-URL validation in
+/// `repository_service` so the SSO surface enforces the same policy
+/// (honors `UPSTREAM_ALLOW_PRIVATE_IPS` / `AK_SSRF_ALLOW_PRIVATE_CIDRS`).
+fn validate_oidc_issuer(url: &str) -> Result<()> {
+    validate_outbound_url(url, "OIDC issuer URL")
+}
 
 // ---------------------------------------------------------------------------
 // Row structs (mapped directly from database columns)
@@ -501,6 +510,7 @@ impl AuthConfigService {
         pool: &PgPool,
         req: CreateOidcConfigRequest,
     ) -> Result<OidcConfigResponse> {
+        validate_oidc_issuer(&req.issuer_url)?;
         let id = Uuid::new_v4();
         let encrypted = encrypt_credentials(&req.client_secret, &encryption_key());
         let encrypted_hex = hex::encode(&encrypted);
@@ -570,6 +580,7 @@ impl AuthConfigService {
 
         let name = req.name.unwrap_or(existing.name);
         let issuer_url = req.issuer_url.unwrap_or(existing.issuer_url);
+        validate_oidc_issuer(&issuer_url)?;
         let client_id = req.client_id.unwrap_or(existing.client_id);
         let scopes = req.scopes.unwrap_or(existing.scopes);
         // Issue #1191: deep-merge attribute_mapping by default. Callers that
@@ -1612,6 +1623,28 @@ mod tests {
     use serde_json::json;
     #[allow(unused_imports)]
     use uuid::Uuid;
+
+    // -----------------------------------------------------------------------
+    // validate_oidc_issuer() tests (SSRF guard at the config trust boundary)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_oidc_issuer_rejects_metadata_and_internal() {
+        // Cloud metadata, loopback, and a private-IP host must all be
+        // rejected by the shared outbound-URL SSRF guard (IP literals are
+        // classified without DNS, so these are deterministic).
+        assert!(validate_oidc_issuer("http://169.254.169.254/latest/meta-data").is_err());
+        assert!(validate_oidc_issuer("http://127.0.0.1:8080/api/v1/admin/metrics").is_err());
+        assert!(validate_oidc_issuer("http://172.19.0.1:9999/oidc").is_err());
+        // `localhost` is an internal service name in BLOCKED_HOSTS, so it is
+        // rejected regardless of DNS resolution on the test host.
+        assert!(validate_oidc_issuer("http://localhost:5432/").is_err());
+    }
+
+    #[test]
+    fn test_validate_oidc_issuer_accepts_public_idp() {
+        assert!(validate_oidc_issuer("https://idp.example.com").is_ok());
+    }
 
     // -----------------------------------------------------------------------
     // encryption_key() tests


### PR DESCRIPTION
## Summary

Extends the shared outbound-URL SSRF guard (`validate_outbound_url`) to the OIDC
SSO surface, closing a gap where the SSO config and discovery/token/JWKS fetch
paths lacked the protection already applied to remote-repo upstreams
(`repository_service`), webhooks, and remote instances.

The OIDC `issuer_url` was never routed through `validate_outbound_url` at either
the trust boundary (admin config create/update) or before the server-side
discovery fetch. The shared HTTP client's redirect policy only re-validates
redirect hops, never the first request, so the initial server-side GET to the
issuer host was unguarded. The unauthenticated
`GET /api/v1/auth/sso/oidc/{id}/login` route reaches this first-hop fetch, so a
stored issuer pointing at an internal/loopback/metadata address would be fetched
directly by the backend.

Changes:

- `backend/src/services/auth_config_service.rs` — validate `issuer_url` via a thin
  `validate_oidc_issuer` wrapper at the top of `create_oidc` and on the effective
  `issuer_url` in `update_oidc`, mirroring the upstream-URL validation in
  `repository_service`.
- `backend/src/api/handlers/sso.rs` — add a single shared `validate_oidc_fetch_url`
  helper and call it immediately before each server-side first-hop fetch: the
  constructed discovery URL (in `oidc_login` and `oidc_callback_inner`), the
  discovered `token_endpoint` before the token POST, and the `jwks_uri` before the
  JWKS GET.

Both layers reuse the existing public `validate_outbound_url` (Upstream context),
so the same operational knobs already used for internal upstreams
(`UPSTREAM_ALLOW_PRIVATE_IPS`, `AK_SSRF_ALLOW_PRIVATE_CIDRS`) apply. No new env
var, no migration.

The discovered `authorization_endpoint` is intentionally **not** validated: the
login response is a client-side browser redirect (307), not a server fetch, and
legitimate IdPs frequently host the authorize endpoint on a different
host/CDN than the issuer. The `token_endpoint` and `jwks_uri` are validated
because the server fetches them directly as first hops.

### Operational note

Internal/on-prem IdPs on private IP ranges now require `UPSTREAM_ALLOW_PRIVATE_IPS=true`
(or a matching `AK_SSRF_ALLOW_PRIVATE_CIDRS` entry) — the same toggle already used
for internal upstream mirrors. Public IdPs (Okta, Auth0, Google, Keycloak on a
public host) are unaffected. Any already-stored issuer pointing at a private/
loopback/metadata address will start failing login until the operator opts in via
that toggle.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added lib unit tests (no DB):
- `auth_config_service::tests::test_validate_oidc_issuer_rejects_metadata_and_internal`
  and `..._accepts_public_idp` — cover metadata IP, loopback, private IP literal,
  internal service name (reject) and a public IdP (accept).
- `sso::tests::test_validate_oidc_fetch_url_rejects_internal` and
  `..._accepts_public` — cover the fetch-site guard.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full lib suite green (`cargo test --workspace --lib`: 11371 passed), `cargo fmt
--check` clean, `cargo clippy --lib -- -D warnings` clean, duplication on changed
files < 3% (jscpd, no clones). Manual verification on an isolated instance:
admin create with a metadata/loopback issuer → 400 (was 200); unauthenticated
login against a stored internal issuer → 400 with zero outbound fetch; public
issuer create → 200 and, with the private-IP toggle enabled for an internal IdP,
login proceeds to a 307 at the IdP's authorize endpoint.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
