### PR TITLE
fix(uploads): enforce repository write authorization on chunked upload sessions

### DIFF
--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -20,6 +20,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::proxy_helpers;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::services::package_service::PackageService;
@@ -153,17 +154,40 @@ async fn create_session(
     // (the soft-delete pattern lives on `artifacts`); the previous
     // `AND is_deleted = false` predicate was a copy-paste from artifact
     // queries that crashed every session create (issue #1168).
-    let repo = sqlx::query_as::<_, (Uuid,)>("SELECT id FROM repositories WHERE key = $1")
-        .bind(&req.repository_key)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?
-        .ok_or_else(|| {
-            map_err(
-                StatusCode::NOT_FOUND,
-                format!("Repository '{}' not found", req.repository_key),
-            )
-        })?;
+    let repo = sqlx::query_as::<_, (Uuid, bool)>(
+        "SELECT id, promotion_only FROM repositories WHERE key = $1",
+    )
+    .bind(&req.repository_key)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?
+    .ok_or_else(|| {
+        map_err(
+            StatusCode::NOT_FOUND,
+            format!("Repository '{}' not found", req.repository_key),
+        )
+    })?;
+    let repo_id = repo.0;
+    let repo_promotion_only = repo.1;
+
+    // Promotion-only gate (#817 parity with the direct upload path).
+    //
+    // A `promotion_only` repository accepts artifacts ONLY via the promotion
+    // path (staging -> promotion -> approval). The direct artifact-write handler
+    // (`repositories::upload_artifact`) already rejects non-admin direct uploads
+    // to such repos; the chunked upload-session API is another direct-write entry
+    // point and must enforce the SAME gate, otherwise a non-admin can sidestep
+    // promotion/approval by opening a session against a release repo.
+    //
+    // This is enforced INDEPENDENTLY of the RBAC permission-rule check below: a
+    // promotion_only repo with no explicit permission rules must still be blocked
+    // for non-admin direct uploads. The promotion service writes through its own
+    // RAW SQL INSERT path (handlers/promotion.rs), which does not pass through
+    // these HTTP handlers, so promotions remain unaffected. Admins are exempt
+    // (break-glass / bootstrap), matching the direct path.
+    if let Some(rejection) = reject_session_if_promotion_only(repo_promotion_only, auth.is_admin) {
+        return Err(rejection);
+    }
 
     // Repository write authorization (#817 parity).
     //
@@ -185,7 +209,7 @@ async fn create_session(
     } else {
         match state
             .permission_service
-            .has_any_rules_for_target("repository", repo.0)
+            .has_any_rules_for_target("repository", repo_id)
             .await
         {
             Ok(v) => v,
@@ -202,12 +226,12 @@ async fn create_session(
         (
             state
                 .permission_service
-                .check_permission(user_id, "repository", repo.0, "write", false)
+                .check_permission(user_id, "repository", repo_id, "write", false)
                 .await
                 .unwrap_or(false),
             state
                 .permission_service
-                .check_permission(user_id, "repository", repo.0, "admin", false)
+                .check_permission(user_id, "repository", repo_id, "admin", false)
                 .await
                 .unwrap_or(false),
         )
@@ -227,7 +251,7 @@ async fn create_session(
         db: &state.db,
         storage_path: &state.config.storage_path,
         user_id,
-        repo_id: repo.0,
+        repo_id,
         repo_key: &req.repository_key,
         artifact_path: &req.artifact_path,
         artifact_name: req.artifact_name.as_deref(),
@@ -659,6 +683,27 @@ fn upload_write_decision(
     has_write || has_admin
 }
 
+/// Build the rejection for a direct upload-session create against a
+/// `promotion_only` repository, or `None` if the upload is permitted.
+///
+/// Mirrors the direct artifact-write path (`repositories::upload_artifact`):
+/// non-admin direct uploads to a promotion-only repo are blocked (`403`) so the
+/// chunked upload-session API cannot be used to sidestep promotion/approval.
+/// Admins are exempt (break-glass / bootstrap), and normal (non-promotion_only)
+/// repositories are never blocked here. The promotion service writes through its
+/// own raw-SQL path and does not pass through this handler, so promotions are
+/// unaffected.
+fn reject_session_if_promotion_only(promotion_only: bool, is_admin: bool) -> Option<Response> {
+    if proxy_helpers::promotion_only_blocks_direct_upload(promotion_only, is_admin) {
+        Some(map_err(
+            StatusCode::FORBIDDEN,
+            "Direct uploads are disabled for this repository; publish via promotion",
+        ))
+    } else {
+        None
+    }
+}
+
 /// Extract a simple artifact name from its path (last path component without extension).
 fn artifact_name_from_path(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
@@ -774,6 +819,35 @@ mod tests {
         // Release/promotion-only repo: rules exist but caller holds neither
         // write nor admin -> denied.
         assert!(!upload_write_decision(false, true, false, false));
+    }
+
+    // -----------------------------------------------------------------------
+    // reject_session_if_promotion_only (#817 parity with direct upload path)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_promotion_only_session_blocks_non_admin() {
+        // Non-admin opening a session against a promotion_only repo is rejected
+        // with 403, mirroring the direct upload path. This is the re-attack:
+        // a promotion_only release repo with NO permission rules must still be
+        // blocked, independent of the RBAC permission-rule check.
+        let rejection = reject_session_if_promotion_only(true, false)
+            .expect("non-admin direct upload session to promotion_only repo must be rejected");
+        assert_eq!(rejection.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_promotion_only_session_admin_allowed() {
+        // Admins are exempt (break-glass / bootstrap): no rejection.
+        assert!(reject_session_if_promotion_only(true, true).is_none());
+    }
+
+    #[test]
+    fn test_promotion_only_session_normal_repo_allowed() {
+        // A normal (non-promotion_only) repo is never blocked here -> no
+        // regression for legitimate uploads by either non-admins or admins.
+        assert!(reject_session_if_promotion_only(false, false).is_none());
+        assert!(reject_session_if_promotion_only(false, true).is_none());
     }
 
     #[test]

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -165,6 +165,62 @@ async fn create_session(
             )
         })?;
 
+    // Repository write authorization (#817 parity).
+    //
+    // The chunked upload-session create path must enforce the same
+    // fine-grained RBAC write gate that `repo_visibility_middleware` applies to
+    // the rest of the artifact-write surface (see middleware/auth.rs): the
+    // /api/v1/uploads router is layered only with `auth_middleware`
+    // (authentication), so without this check any authenticated user could open
+    // a session against a release/promotion-only repository.
+    //
+    // Admins bypass the check. For a non-admin, if any permission rule exists
+    // for this repository the caller must hold the `write` action (or `admin`,
+    // which implies all actions); a repository with no rules falls through
+    // unchanged. A DB error on the rule lookup fails closed (503), mirroring the
+    // middleware. Authorized peer-replication identities hold write/admin on the
+    // target and continue to pass.
+    let has_rules = if auth.is_admin {
+        false
+    } else {
+        match state
+            .permission_service
+            .has_any_rules_for_target("repository", repo.0)
+            .await
+        {
+            Ok(v) => v,
+            Err(_) => {
+                tracing::error!("permission check failed: database unreachable");
+                return Err(map_err(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "permission service temporarily unavailable",
+                ));
+            }
+        }
+    };
+    let (has_write, has_admin) = if !auth.is_admin && has_rules {
+        (
+            state
+                .permission_service
+                .check_permission(user_id, "repository", repo.0, "write", false)
+                .await
+                .unwrap_or(false),
+            state
+                .permission_service
+                .check_permission(user_id, "repository", repo.0, "admin", false)
+                .await
+                .unwrap_or(false),
+        )
+    } else {
+        (false, false)
+    };
+    if !upload_write_decision(auth.is_admin, has_rules, has_write, has_admin) {
+        return Err(map_err(
+            StatusCode::FORBIDDEN,
+            "You do not have permission to perform this action on this repository",
+        ));
+    }
+
     let replication_metadata = replication_session_metadata_from_request(&headers, &req);
 
     let session = UploadService::create_session(upload_service::CreateSessionParams {
@@ -581,6 +637,28 @@ fn map_err(status: StatusCode, e: impl std::fmt::Display) -> Response {
         .into_response()
 }
 
+/// Pure authorization decision for chunked upload-session creation, mirroring
+/// the non-admin RBAC write gate enforced by `repo_visibility_middleware`.
+///
+/// - Admins always pass (any rules state).
+/// - Non-admins on a repository with no permission rules fall through (allowed).
+/// - Non-admins on a rules-bearing repository must hold the `write` action or
+///   the `admin` action (which implies all actions).
+fn upload_write_decision(
+    is_admin: bool,
+    has_rules: bool,
+    has_write: bool,
+    has_admin: bool,
+) -> bool {
+    if is_admin {
+        return true;
+    }
+    if !has_rules {
+        return true;
+    }
+    has_write || has_admin
+}
+
 /// Extract a simple artifact name from its path (last path component without extension).
 fn artifact_name_from_path(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
@@ -661,6 +739,42 @@ mod tests {
     // -----------------------------------------------------------------------
     // artifact_name_from_path
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // upload_write_decision (#817 parity with repo_visibility_middleware)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_upload_write_decision_admin_always_allowed() {
+        // Admins bypass the check regardless of rules/actions.
+        assert!(upload_write_decision(true, false, false, false));
+        assert!(upload_write_decision(true, true, false, false));
+        assert!(upload_write_decision(true, true, true, true));
+    }
+
+    #[test]
+    fn test_upload_write_decision_non_admin_no_rules_allowed() {
+        // A repository with no permission rules falls through unchanged.
+        assert!(upload_write_decision(false, false, false, false));
+    }
+
+    #[test]
+    fn test_upload_write_decision_non_admin_rules_with_write_allowed() {
+        assert!(upload_write_decision(false, true, true, false));
+    }
+
+    #[test]
+    fn test_upload_write_decision_non_admin_rules_with_admin_action_allowed() {
+        // The `admin` action implies all actions (including write).
+        assert!(upload_write_decision(false, true, false, true));
+    }
+
+    #[test]
+    fn test_upload_write_decision_non_admin_rules_neither_denied() {
+        // Release/promotion-only repo: rules exist but caller holds neither
+        // write nor admin -> denied.
+        assert!(!upload_write_decision(false, true, false, false));
+    }
 
     #[test]
     fn test_artifact_name_from_path() {


### PR DESCRIPTION
## Summary

The chunked upload-session create path (`POST /api/v1/uploads`,
`create_session` in `backend/src/api/handlers/upload.rs`) did not perform the
fine-grained repository write-permission check that the rest of the
artifact-write surface enforces. Every other write path passes through
`repo_visibility_middleware` (`backend/src/api/middleware/auth.rs`), which —
for a non-admin user — looks up whether any permission rule exists for the
target repository and, if so, requires the caller to hold the `write` action
(or `admin`, which implies all actions). The `/api/v1/uploads` router is
layered only with `auth_middleware` (authentication), and the handler added no
equivalent authorization, so the RBAC write gate was absent on this one path.

This PR aligns the two paths. After the repository is resolved and before the
upload session is created, `create_session` now applies the same non-admin RBAC
write check the middleware applies:

- Admins bypass the check (unchanged behavior).
- Non-admin callers on a repository with **no** permission rules fall through
  unchanged (no new denials for ordinary uploads).
- Non-admin callers on a repository that **does** carry permission rules must
  hold the `write` or `admin` action, otherwise the request is rejected with
  `403`.
- A database error on the rule lookup fails closed (`503`), mirroring the
  middleware rather than silently allowing the write.

The check is enforced only at session creation; chunk upload and completion
operate on a session the same caller already owns (existing ownership check).
Authorized peer-replication identities authenticate with `write`/`admin` on the
target repository and continue to pass exactly as they do on the existing
middleware-gated surface, so replication is unaffected. No schema or migration
change.

The branch decision is factored into a small pure helper
(`upload_write_decision`) so it can be unit-tested across all branches while the
async permission lookups stay in the handler.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Unit tests cover every branch of the authorization decision: admin always
allowed (any rules state); non-admin no-rules allowed; non-admin rules+write
allowed; non-admin rules+admin-action allowed; non-admin rules with neither
denied.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
