### PR TITLE
fix(security): filter packages listing and detail by per-user repository visibility

### DIFF
--- a/backend/src/api/handlers/packages.rs
+++ b/backend/src/api/handlers/packages.rs
@@ -15,6 +15,36 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::curation_service::version_compare;
+use crate::services::repository_service::{
+    build_visibility_clause_for, RepoVisibility, VisibilityBind,
+};
+
+/// Map an optional authenticated principal to the repository visibility scope
+/// used to filter package listings. Mirrors `list_repositories` so that the
+/// packages endpoints enforce the same per-user authorization model
+/// (public repos plus any repo the user holds a role assignment for) instead
+/// of treating every authenticated caller as entitled to all packages.
+fn repo_visibility_for(auth: Option<&AuthExtension>) -> RepoVisibility {
+    match auth {
+        None => RepoVisibility::PublicOnly,
+        Some(a) if a.is_admin => RepoVisibility::All,
+        // Repo-scoped token: restrict strictly to the token's allowed set.
+        Some(a) if a.allowed_repo_ids.is_some() => {
+            RepoVisibility::Ids(a.allowed_repo_ids.clone().unwrap_or_default())
+        }
+        Some(a) => RepoVisibility::User(a.user_id),
+    }
+}
+
+/// Split a [`VisibilityBind`] into the two concrete shapes its parameter can
+/// take (single `user_id` uuid vs `uuid[]`). Exactly one is `Some` per call;
+/// the unused one binds as a typed NULL the clause never references.
+fn split_visibility_bind(bind: VisibilityBind) -> (Option<Uuid>, Option<Vec<Uuid>>) {
+    match bind {
+        VisibilityBind::User(uid) => (uid, None),
+        VisibilityBind::Ids(ids) => (None, Some(ids)),
+    }
+}
 
 /// Check if the packages table exists in the database.
 async fn packages_table_exists(db: &sqlx::PgPool) -> bool {
@@ -118,7 +148,7 @@ pub async fn list_packages(
     Extension(auth): Extension<Option<AuthExtension>>,
     Query(query): Query<ListPackagesQuery>,
 ) -> Result<Json<PackageListResponse>> {
-    let public_only = auth.is_none();
+    let visibility = repo_visibility_for(auth.as_ref());
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(24).min(100);
     let offset = ((page - 1) * per_page) as i64;
@@ -139,7 +169,16 @@ pub async fn list_packages(
         }));
     }
 
-    let packages: Vec<PackageRow> = sqlx::query_as(
+    // Per-user repository visibility. The page query binds the visibility
+    // parameter at $6 (after repository_key/format/search/offset/limit); the
+    // count query binds it at $4 (after repository_key/format/search). The
+    // generated `$N` MUST line up with the `.bind()` order below.
+    let (page_clause, page_bind) = build_visibility_clause_for(&visibility, "r", 6);
+    let (count_clause, count_bind) = build_visibility_clause_for(&visibility, "r", 4);
+    let (page_user_id, page_ids) = split_visibility_bind(page_bind);
+    let (count_user_id, count_ids) = split_visibility_bind(count_bind);
+
+    let page_sql = format!(
         r#"
         SELECT p.id, r.key as repository_key, p.name, p.version, r.format::text as format,
                p.description, p.size_bytes, p.download_count, p.created_at, p.updated_at,
@@ -149,23 +188,29 @@ pub async fn list_packages(
         WHERE ($1::text IS NULL OR r.key = $1)
           AND ($2::text IS NULL OR r.format::text = $2)
           AND ($3::text IS NULL OR p.name ILIKE $3)
-          AND ($6::bool = false OR r.is_public = true)
+          AND ({page_clause})
         ORDER BY p.updated_at DESC
         OFFSET $4
         LIMIT $5
-        "#,
-    )
-    .bind(&query.repository_key)
-    .bind(&query.format)
-    .bind(&search_pattern)
-    .bind(offset)
-    .bind(per_page as i64)
-    .bind(public_only)
-    .fetch_all(&state.db)
-    .await
-    .map_err(|e| AppError::Database(e.to_string()))?;
+        "#
+    );
+    let page_query = sqlx::query_as::<_, PackageRow>(&page_sql)
+        .bind(&query.repository_key)
+        .bind(&query.format)
+        .bind(&search_pattern)
+        .bind(offset)
+        .bind(per_page as i64);
+    // $6 shape depends on the visibility variant (single uuid vs uuid[]).
+    let page_query = match &page_ids {
+        Some(ids) => page_query.bind(ids.clone()),
+        None => page_query.bind(page_user_id),
+    };
+    let packages: Vec<PackageRow> = page_query
+        .fetch_all(&state.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
 
-    let total: i64 = sqlx::query_scalar(
+    let count_sql = format!(
         r#"
         SELECT COUNT(*)
         FROM packages p
@@ -173,16 +218,19 @@ pub async fn list_packages(
         WHERE ($1::text IS NULL OR r.key = $1)
           AND ($2::text IS NULL OR r.format::text = $2)
           AND ($3::text IS NULL OR p.name ILIKE $3)
-          AND ($4::bool = false OR r.is_public = true)
-        "#,
-    )
-    .bind(&query.repository_key)
-    .bind(&query.format)
-    .bind(&search_pattern)
-    .bind(public_only)
-    .fetch_one(&state.db)
-    .await
-    .unwrap_or(0);
+          AND ({count_clause})
+        "#
+    );
+    let count_query = sqlx::query_scalar::<_, i64>(&count_sql)
+        .bind(&query.repository_key)
+        .bind(&query.format)
+        .bind(&search_pattern);
+    // $4 shape depends on the visibility variant (single uuid vs uuid[]).
+    let count_query = match &count_ids {
+        Some(ids) => count_query.bind(ids.clone()),
+        None => count_query.bind(count_user_id),
+    };
+    let total: i64 = count_query.fetch_one(&state.db).await.unwrap_or(0);
 
     let total_pages = ((total as f64) / (per_page as f64)).ceil() as u32;
 
@@ -218,7 +266,7 @@ pub async fn get_package(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<PackageResponse>> {
-    let public_only = auth.is_none();
+    let visibility = repo_visibility_for(auth.as_ref());
 
     let table_exists = packages_table_exists(&state.db).await;
 
@@ -226,7 +274,11 @@ pub async fn get_package(
         return Err(AppError::NotFound("Package not found".to_string()));
     }
 
-    let package: PackageRow = sqlx::query_as(
+    // The visibility parameter is bound at $2 (after the package id at $1).
+    let (clause, bind) = build_visibility_clause_for(&visibility, "r", 2);
+    let (user_id, ids) = split_visibility_bind(bind);
+
+    let sql = format!(
         r#"
         SELECT p.id, r.key as repository_key, p.name, p.version, r.format::text as format,
                p.description, p.size_bytes, p.download_count, p.created_at, p.updated_at,
@@ -234,15 +286,20 @@ pub async fn get_package(
         FROM packages p
         JOIN repositories r ON r.id = p.repository_id
         WHERE p.id = $1
-          AND ($2::bool = false OR r.is_public = true)
-        "#,
-    )
-    .bind(id)
-    .bind(public_only)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|e| AppError::Database(e.to_string()))?
-    .ok_or_else(|| AppError::NotFound("Package not found".to_string()))?;
+          AND ({clause})
+        "#
+    );
+    let query = sqlx::query_as::<_, PackageRow>(&sql).bind(id);
+    // $2 shape depends on the visibility variant (single uuid vs uuid[]).
+    let query = match &ids {
+        Some(ids) => query.bind(ids.clone()),
+        None => query.bind(user_id),
+    };
+    let package: PackageRow = query
+        .fetch_optional(&state.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?
+        .ok_or_else(|| AppError::NotFound("Package not found".to_string()))?;
 
     Ok(Json(PackageResponse::from(package)))
 }
@@ -303,7 +360,7 @@ pub async fn get_package_versions(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<PackageVersionsResponse>> {
-    let public_only = auth.is_none();
+    let visibility = repo_visibility_for(auth.as_ref());
 
     let table_exists = packages_table_exists(&state.db).await;
 
@@ -311,22 +368,28 @@ pub async fn get_package_versions(
         return Err(AppError::NotFound("Package not found".to_string()));
     }
 
-    // Verify the package exists and belongs to a visible repository
-    let package_exists: bool = sqlx::query_scalar(
+    // Verify the package exists and belongs to a repository visible to the
+    // caller. The visibility parameter is bound at $2 (after the id at $1).
+    let (clause, bind) = build_visibility_clause_for(&visibility, "r", 2);
+    let (user_id, ids) = split_visibility_bind(bind);
+
+    let exists_sql = format!(
         r#"
         SELECT EXISTS(
             SELECT 1 FROM packages p
             JOIN repositories r ON r.id = p.repository_id
             WHERE p.id = $1
-              AND ($2::bool = false OR r.is_public = true)
+              AND ({clause})
         )
-        "#,
-    )
-    .bind(id)
-    .bind(public_only)
-    .fetch_one(&state.db)
-    .await
-    .unwrap_or(false);
+        "#
+    );
+    let exists_query = sqlx::query_scalar::<_, bool>(&exists_sql).bind(id);
+    // $2 shape depends on the visibility variant (single uuid vs uuid[]).
+    let exists_query = match &ids {
+        Some(ids) => exists_query.bind(ids.clone()),
+        None => exists_query.bind(user_id),
+    };
+    let package_exists: bool = exists_query.fetch_one(&state.db).await.unwrap_or(false);
 
     if !package_exists {
         return Err(AppError::NotFound("Package not found".to_string()));
@@ -405,6 +468,76 @@ mod tests {
             updated_at: now,
             metadata: Some(serde_json::json!({"license": "MIT"})),
         }
+    }
+
+    fn make_auth(user_id: Uuid, is_admin: bool, allowed: Option<Vec<Uuid>>) -> AuthExtension {
+        AuthExtension {
+            user_id,
+            username: "tester".to_string(),
+            email: "tester@example.com".to_string(),
+            is_admin,
+            is_api_token: allowed.is_some(),
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: allowed,
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // repo_visibility_for: per-user authorization mapping (mirrors list_repositories)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_visibility_anonymous_is_public_only() {
+        assert_eq!(repo_visibility_for(None), RepoVisibility::PublicOnly);
+    }
+
+    #[test]
+    fn test_visibility_admin_is_all() {
+        let auth = make_auth(Uuid::new_v4(), true, None);
+        assert_eq!(repo_visibility_for(Some(&auth)), RepoVisibility::All);
+    }
+
+    #[test]
+    fn test_visibility_authenticated_non_admin_is_user_scope() {
+        let uid = Uuid::new_v4();
+        let auth = make_auth(uid, false, None);
+        assert_eq!(repo_visibility_for(Some(&auth)), RepoVisibility::User(uid));
+    }
+
+    #[test]
+    fn test_visibility_scoped_token_is_ids() {
+        let repo = Uuid::new_v4();
+        let auth = make_auth(Uuid::new_v4(), false, Some(vec![repo]));
+        assert_eq!(
+            repo_visibility_for(Some(&auth)),
+            RepoVisibility::Ids(vec![repo])
+        );
+    }
+
+    #[test]
+    fn test_visibility_admin_scoped_token_still_all() {
+        // Admin bypasses scope restrictions, matching list_repositories.
+        let auth = make_auth(Uuid::new_v4(), true, Some(vec![Uuid::new_v4()]));
+        assert_eq!(repo_visibility_for(Some(&auth)), RepoVisibility::All);
+    }
+
+    #[test]
+    fn test_split_visibility_bind_user_and_ids() {
+        let uid = Uuid::new_v4();
+        assert_eq!(
+            split_visibility_bind(VisibilityBind::User(Some(uid))),
+            (Some(uid), None)
+        );
+        assert_eq!(
+            split_visibility_bind(VisibilityBind::User(None)),
+            (None, None)
+        );
+        let a = Uuid::new_v4();
+        assert_eq!(
+            split_visibility_bind(VisibilityBind::Ids(vec![a])),
+            (None, Some(vec![a]))
+        );
     }
 
     fn make_version_row() -> PackageVersionRow {

--- a/backend/src/api/handlers/packages.rs
+++ b/backend/src/api/handlers/packages.rs
@@ -827,4 +827,158 @@ mod tests {
         assert_eq!(json["pagination"]["per_page"], 24);
         assert_eq!(json["pagination"]["total"], 0);
     }
+
+    // -----------------------------------------------------------------------
+    // DB-backed visibility tests: the listing/detail/versions endpoints must
+    // enforce per-user repository visibility (skip cleanly without
+    // DATABASE_URL, same as the other handler suites).
+    // -----------------------------------------------------------------------
+    mod visibility_db {
+        use super::*;
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        /// Insert a minimal `packages` row in `repo_id` and return its id.
+        async fn seed_package(pool: &sqlx::PgPool, repo_id: Uuid) -> Uuid {
+            sqlx::query_scalar(
+                "INSERT INTO packages (repository_id, name, version, size_bytes) \
+                 VALUES ($1, 'vis-test-pkg', '1.0.0', 1) RETURNING id",
+            )
+            .bind(repo_id)
+            .fetch_one(pool)
+            .await
+            .expect("seed package")
+        }
+
+        async fn set_repo_public(pool: &sqlx::PgPool, repo_id: Uuid) {
+            sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+                .bind(repo_id)
+                .execute(pool)
+                .await
+                .expect("set is_public");
+        }
+
+        /// Build the packages router with `auth` injected (None = anonymous).
+        fn app_for(f: &tdh::Fixture, auth: Option<AuthExtension>) -> axum::Router {
+            match auth {
+                Some(a) => tdh::router_with_auth(router(), f.state.clone(), a),
+                None => f.router_anon(router()),
+            }
+        }
+
+        /// How many packages of the fixture repo the caller can see in the
+        /// listing (filtered by repository_key so parallel tests don't leak in).
+        async fn visible_total(f: &tdh::Fixture, auth: Option<AuthExtension>) -> i64 {
+            let (status, body) = tdh::send(
+                app_for(f, auth),
+                tdh::get(format!("/?repository_key={}", f.repo_key)),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            let json: serde_json::Value = serde_json::from_slice(&body).expect("listing json");
+            json["pagination"]["total"].as_i64().expect("total")
+        }
+
+        /// Status the caller gets for a packages-router GET (detail/versions).
+        async fn status_of(
+            f: &tdh::Fixture,
+            auth: Option<AuthExtension>,
+            path: String,
+        ) -> StatusCode {
+            let (status, _) = tdh::send(app_for(f, auth), tdh::get(path)).await;
+            status
+        }
+
+        #[tokio::test]
+        async fn test_private_repo_packages_hidden_without_access() {
+            // create_repo leaves is_public at its default (false): private.
+            let Some(f) = tdh::Fixture::setup("local", "npm").await else {
+                return;
+            };
+            let pkg = seed_package(&f.pool, f.repo_id).await;
+            // A user with no role assignment on the repo.
+            let outsider = || Some(make_auth(Uuid::new_v4(), false, None));
+
+            assert_eq!(visible_total(&f, None).await, 0);
+            assert_eq!(visible_total(&f, outsider()).await, 0);
+            assert_eq!(
+                status_of(&f, None, format!("/{pkg}")).await,
+                StatusCode::NOT_FOUND
+            );
+            assert_eq!(
+                status_of(&f, outsider(), format!("/{pkg}")).await,
+                StatusCode::NOT_FOUND
+            );
+            assert_eq!(
+                status_of(&f, outsider(), format!("/{pkg}/versions")).await,
+                StatusCode::NOT_FOUND
+            );
+            f.teardown().await;
+        }
+
+        #[tokio::test]
+        async fn test_private_repo_packages_visible_with_grant_or_admin() {
+            let Some(f) = tdh::Fixture::setup("local", "npm").await else {
+                return;
+            };
+            let pkg = seed_package(&f.pool, f.repo_id).await;
+            // Fixture::setup grants the fixture user a repo-scoped role.
+            let granted = || Some(make_auth(f.user_id, false, None));
+            let admin = || Some(make_auth(Uuid::new_v4(), true, None));
+
+            assert_eq!(visible_total(&f, granted()).await, 1);
+            assert_eq!(visible_total(&f, admin()).await, 1);
+            assert_eq!(
+                status_of(&f, granted(), format!("/{pkg}")).await,
+                StatusCode::OK
+            );
+            assert_eq!(
+                status_of(&f, admin(), format!("/{pkg}")).await,
+                StatusCode::OK
+            );
+            assert_eq!(
+                status_of(&f, granted(), format!("/{pkg}/versions")).await,
+                StatusCode::OK
+            );
+            f.teardown().await;
+        }
+
+        #[tokio::test]
+        async fn test_public_repo_packages_visible_to_anonymous() {
+            let Some(f) = tdh::Fixture::setup("local", "npm").await else {
+                return;
+            };
+            let pkg = seed_package(&f.pool, f.repo_id).await;
+            set_repo_public(&f.pool, f.repo_id).await;
+
+            assert_eq!(visible_total(&f, None).await, 1);
+            assert_eq!(status_of(&f, None, format!("/{pkg}")).await, StatusCode::OK);
+            f.teardown().await;
+        }
+
+        #[tokio::test]
+        async fn test_repo_scoped_token_limited_to_allowed_repos() {
+            let Some(f) = tdh::Fixture::setup("local", "npm").await else {
+                return;
+            };
+            let pkg = seed_package(&f.pool, f.repo_id).await;
+            let scoped_to = |ids: Vec<Uuid>| Some(make_auth(f.user_id, false, Some(ids)));
+
+            // Token scoped to a different repository: nothing visible, even
+            // though the underlying user holds a grant on the fixture repo.
+            assert_eq!(visible_total(&f, scoped_to(vec![Uuid::new_v4()])).await, 0);
+            assert_eq!(
+                status_of(&f, scoped_to(vec![Uuid::new_v4()]), format!("/{pkg}")).await,
+                StatusCode::NOT_FOUND
+            );
+
+            // Token scoped to the fixture repository: visible.
+            assert_eq!(visible_total(&f, scoped_to(vec![f.repo_id])).await, 1);
+            assert_eq!(
+                status_of(&f, scoped_to(vec![f.repo_id]), format!("/{pkg}")).await,
+                StatusCode::OK
+            );
+            f.teardown().await;
+        }
+    }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -188,19 +188,43 @@ pub(crate) fn build_search_pattern(query: Option<&str>) -> Option<String> {
 /// - `User(id)`   -> public repos OR repos the user has a role_assignment for.
 /// - `Ids(ids)`   -> only repos whose id is in `ids` (repo-scoped token).
 pub(crate) fn build_visibility_clause(visibility: &RepoVisibility) -> (String, VisibilityBind) {
+    // Canonical instantiation for repository listing: the `repositories` table
+    // is referenced unaliased and the visibility parameter is bound at `$3`.
+    build_visibility_clause_for(visibility, "repositories", 3)
+}
+
+/// Alias- and parameter-index-aware variant of [`build_visibility_clause`].
+///
+/// Produces the same per-user grant predicate but lets the caller control:
+/// - `table_alias`: the alias under which the `repositories` table is referenced
+///   (e.g. `r` when the table is joined into a packages query); only the `.id`
+///   references in the `User`/`Ids` arms are qualified, since `is_public` is
+///   unique to `repositories` and resolves unambiguously even in a join.
+/// - `user_param`: the positional bind index (`$N`) for the `user_id`/`ids`
+///   value, so the generated `$N` lines up with the caller's `.bind()` order
+///   (this differs per query).
+///
+/// [`build_visibility_clause`] is the canonical `("repositories", $3)`
+/// instantiation used by repository listing.
+pub(crate) fn build_visibility_clause_for(
+    visibility: &RepoVisibility,
+    table_alias: &str,
+    user_param: usize,
+) -> (String, VisibilityBind) {
     match visibility {
         RepoVisibility::PublicOnly => ("is_public = true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::All => ("true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::User(user_id) => {
-            let clause = r#"(
+            let clause = format!(
+                r#"(
                 is_public = true
                 OR EXISTS (
                     SELECT 1 FROM role_assignments ra
-                    WHERE ra.user_id = $3
-                      AND (ra.repository_id = repositories.id OR ra.repository_id IS NULL)
+                    WHERE ra.user_id = ${user_param}
+                      AND (ra.repository_id = {table_alias}.id OR ra.repository_id IS NULL)
                 )
             )"#
-            .to_string();
+            );
             (clause, VisibilityBind::User(Some(*user_id)))
         }
         RepoVisibility::Ids(ids) => {
@@ -208,7 +232,7 @@ pub(crate) fn build_visibility_clause(visibility: &RepoVisibility) -> (String, V
             // match no rows (not "all rows") — `id = ANY('{}')` is correctly
             // false for every row in Postgres.
             (
-                "repositories.id = ANY($3)".to_string(),
+                format!("{table_alias}.id = ANY(${user_param})"),
                 VisibilityBind::Ids(ids.clone()),
             )
         }
@@ -1985,6 +2009,64 @@ mod tests {
         assert!(clause.contains("ra.repository_id = repositories.id"));
         // Global assignment (repository_id IS NULL)
         assert!(clause.contains("ra.repository_id IS NULL"));
+    }
+
+    // -----------------------------------------------------------------------
+    // build_visibility_clause_for tests (alias + param-index aware variant)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_visibility_for_delegates_match_canonical_wrapper() {
+        // The wrapper must be an exact ("repositories", 3) instantiation of the
+        // variant, so the two agree for every arm.
+        let uid = Uuid::new_v4();
+        for v in [
+            RepoVisibility::PublicOnly,
+            RepoVisibility::All,
+            RepoVisibility::User(uid),
+            RepoVisibility::Ids(vec![Uuid::new_v4()]),
+        ] {
+            assert_eq!(
+                build_visibility_clause(&v),
+                build_visibility_clause_for(&v, "repositories", 3)
+            );
+        }
+    }
+
+    #[test]
+    fn test_visibility_for_applies_alias_and_param_index() {
+        let uid = Uuid::new_v4();
+        let (clause, bind) = build_visibility_clause_for(&RepoVisibility::User(uid), "r", 6);
+        // Alias is applied to the `.id` reference in the EXISTS subquery.
+        assert!(clause.contains("ra.repository_id = r.id"));
+        assert!(!clause.contains("repositories.id"));
+        // Global assignments still honoured.
+        assert!(clause.contains("ra.repository_id IS NULL"));
+        // user_id bound at the requested positional index.
+        assert!(clause.contains("ra.user_id = $6"));
+        assert!(!clause.contains("$3"));
+        // is_public stays unqualified (unique to repositories, unambiguous in a join).
+        assert!(clause.contains("is_public = true"));
+        assert_eq!(bind, VisibilityBind::User(Some(uid)));
+    }
+
+    #[test]
+    fn test_visibility_for_public_only_and_all_ignore_alias_and_param() {
+        let (clause, bind) = build_visibility_clause_for(&RepoVisibility::PublicOnly, "r", 6);
+        assert_eq!(clause, "is_public = true");
+        assert_eq!(bind, VisibilityBind::User(None));
+
+        let (clause, bind) = build_visibility_clause_for(&RepoVisibility::All, "r", 6);
+        assert_eq!(clause, "true");
+        assert_eq!(bind, VisibilityBind::User(None));
+    }
+
+    #[test]
+    fn test_visibility_for_ids_uses_alias_and_param_index() {
+        let a = Uuid::new_v4();
+        let (clause, bind) = build_visibility_clause_for(&RepoVisibility::Ids(vec![a]), "r", 2);
+        assert_eq!(clause, "r.id = ANY($2)");
+        assert_eq!(bind, VisibilityBind::Ids(vec![a]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Filter the `/api/v1/packages` listing and detail endpoints by per-user repository
visibility.

The authenticated packages endpoints (`list_packages`, `get_package`,
`get_package_versions` in `backend/src/api/handlers/packages.rs`) computed
visibility as a binary `public_only = auth.is_none()` flag and bound it into the
SQL guard as `($N::bool = false OR r.is_public = true)`. For any authenticated
caller `public_only` is `false`, so the guard collapses to `true` and every
package in every repository is returned — including private and cross-tenant
repositories the caller has no grant to. Anonymous callers were filtered
correctly, so the over-exposure only affected logged-in users. The leaked data
includes package names, versions, sizes, and SHA256 checksums.

The repository listing endpoint already implements the correct model:
`list_repositories` derives a three-way `RepoVisibility`
(`PublicOnly` / `All` / `User(user_id)` / `Ids` for scoped tokens) and
`repository_service::build_visibility_clause` translates `User(id)` into a
predicate that consults `role_assignments` (public repos OR repos the user holds
a direct or global grant for). This PR adopts that same model in all three
packages handlers, reusing the canonical grant predicate instead of duplicating
it:

- Added `build_visibility_clause_for(visibility, table_alias, user_param)` to
  `repository_service.rs` — an alias- and parameter-index-aware variant of the
  existing helper, so the joined packages queries can reference the repositories
  table as `r` and bind the visibility parameter at the correct positional index
  (which differs per query: `$6` for the listing page query, `$4` for its count
  query, `$2` for the detail and versions queries).
- `build_visibility_clause` is now a thin wrapper that delegates with
  `("repositories", 3)`, so repository listing behavior and its unit tests are
  unchanged.
- `packages.rs` maps the authenticated principal to `RepoVisibility` (mirroring
  `list_repositories`) via a small pure helper and applies the generated clause
  to the three queries.

No schema or migration change: `role_assignments` already holds the grant data.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added unit tests:
- `repository_service.rs`: `build_visibility_clause_for` alias/param-index
  substitution, delegation parity with the canonical wrapper, and the
  `PublicOnly` / `All` / `User` / `Ids` arms.
- `packages.rs`: `repo_visibility_for` arm mapping (anonymous → `PublicOnly`,
  admin → `All`, non-admin → `User`, scoped token → `Ids`, admin-scoped → `All`)
  and `split_visibility_bind`.

Manual verification on an isolated instance with one public repo, one private
repo with no grant, and one private repo granted to a non-admin user:
- Non-admin list returns only the public and granted packages; the ungranted
  private package is absent (was previously returned).
- Non-admin `GET /packages/{ungranted-private-id}` → 404 (was 200).
- Non-admin `GET /packages/{ungranted-private-id}/versions` → 404 (was 200,
  leaking the version checksum).
- Non-admin still sees the granted private package by list, by id, and by
  versions.
- Anonymous list still returns only public packages.
- Admin list still returns all packages.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
