### PR TITLE
fix(ci): use strong JWT secrets in e2e/test compose so the backend boots under JWT_SECRET hardening

### DIFF
--- a/docker-compose.concurrency-e2e.yml
+++ b/docker-compose.concurrency-e2e.yml
@@ -127,7 +127,7 @@ services:
       STORAGE_PATH: /data/storage
       BACKUP_PATH: /data/backups
       PLUGINS_DIR: /data/plugins
-      JWT_SECRET: concurrency-e2e-secret-key-32bytes-long
+      JWT_SECRET: concurrency-e2e-nonprod-amber-cobalt-river-7391
       ADMIN_PASSWORD: TestRunner!2026secure
       ENVIRONMENT: development
       RUST_LOG: info

--- a/docker-compose.mesh-e2e.yml
+++ b/docker-compose.mesh-e2e.yml
@@ -68,7 +68,7 @@ services:
       STORAGE_PATH: /data/storage
       BACKUP_PATH: /data/backups
       PLUGINS_DIR: /data/plugins
-      JWT_SECRET: mesh-e2e-secret-key-32-bytes-long
+      JWT_SECRET: mesh-e2e-nonprod-saffron-indigo-harbor-7391
       ADMIN_PASSWORD: TestRunner!2026secure
       RUST_LOG: info,artifact_keeper=debug
       HOST: 0.0.0.0
@@ -105,7 +105,7 @@ services:
       STORAGE_PATH: /data/storage
       BACKUP_PATH: /data/backups
       PLUGINS_DIR: /data/plugins
-      JWT_SECRET: mesh-e2e-secret-key-32-bytes-long
+      JWT_SECRET: mesh-e2e-nonprod-saffron-indigo-harbor-7391
       ADMIN_PASSWORD: TestRunner!2026secure
       RUST_LOG: info,artifact_keeper=debug
       HOST: 0.0.0.0

--- a/docker-compose.s3-maven-test.yml
+++ b/docker-compose.s3-maven-test.yml
@@ -81,7 +81,7 @@ services:
       S3_ACCESS_KEY_ID: minioadmin
       S3_SECRET_ACCESS_KEY: minioadmin
       # General config
-      JWT_SECRET: test-secret-for-s3-maven
+      JWT_SECRET: s3-maven-nonprod-crimson-jade-summit-7391
       ADMIN_PASSWORD: admin
       RUST_LOG: info,artifact_keeper=debug,artifact_keeper_backend::storage::s3=trace
       ENVIRONMENT: development

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -60,7 +60,7 @@ services:
       STORAGE_PATH: /data/storage
       BACKUP_PATH: /data/backups
       PLUGINS_DIR: /data/plugins
-      JWT_SECRET: e2e-test-secret-key-32-bytes-long
+      JWT_SECRET: smoke-e2e-nonprod-violet-quartz-meadow-7391
       ADMIN_PASSWORD: TestRunner!2026secure
       RUST_LOG: info
       TRIVY_URL: http://trivy:8090


### PR DESCRIPTION
## Problem

The `🔥 Smoke E2E Tests` job on `main` fails at **Start smoke E2E stack** — `e2e-test-backend` exits (1) on startup, so the stack never comes up.

Root cause: the merged JWT_SECRET strength check rejects weak/placeholder signing secrets at startup in **all** environments. Several e2e/test compose files still set secrets that contain denylisted substrings (`test-secret`, `secret-key`), so the backend refuses to boot:

- `docker-compose.test.yml` → `e2e-test-secret-key-32-bytes-long` (contains `test-secret` **and** `secret-key`)
- `docker-compose.concurrency-e2e.yml` → `concurrency-e2e-secret-key-...` (`secret-key`)
- `docker-compose.mesh-e2e.yml` → `mesh-e2e-secret-key-...` (`secret-key`)
- `docker-compose.s3-maven-test.yml` → `test-secret-for-s3-maven` (`test-secret`)

The unit/coverage jobs pass because `ci.yml` uses a secret without a denylisted substring.

## Fix

Replace those test secrets with strong, readable, non-production values that satisfy the strength check (≥32 chars, no denylisted substring, high distinct-character count) and are not credential-shaped. Verified locally: the backend now passes config validation and boots with the new `docker-compose.test.yml` secret.

These are throwaway CI/e2e values, not production credentials.
