### PR TITLE
fix(quarantine): enforce package age policy on remote/proxy downloads, return setting on read, base window on release date

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -384,6 +384,31 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
             )
                 .into_response()
         }
+        // Package Age Policy (#1770): a quarantine hold is a deliberate
+        // 409 Conflict from the proxy read/write gate, NOT an upstream
+        // failure. It must surface verbatim to the client rather than folding
+        // into the 502 catch-all below (which would mask the policy and, for
+        // the cache-miss path, look like a transient upstream error).
+        crate::error::AppError::Conflict(msg) => {
+            tracing::info!(
+                repo_key = %repo_key,
+                path = %path,
+                "Proxy download blocked by quarantine policy: {}",
+                e
+            );
+            (StatusCode::CONFLICT, msg.clone()).into_response()
+        }
+        // A rejected artifact (failed review) is a 403 Forbidden from the
+        // same quarantine gate; surface it directly for the same reason.
+        crate::error::AppError::Authorization(msg) => {
+            tracing::info!(
+                repo_key = %repo_key,
+                path = %path,
+                "Proxy download forbidden by quarantine policy: {}",
+                e
+            );
+            (StatusCode::FORBIDDEN, msg.clone()).into_response()
+        }
         _ => {
             tracing::warn!(
                 repo_key = %repo_key,
@@ -1084,8 +1109,16 @@ where
                     (proxy_service, member.upstream_url.as_deref())
                 {
                     let repo = build_remote_repo(member.id, &member.key, upstream_url);
-                    if let Ok(result) = proxy.fetch_artifact_streaming(&repo, path).await {
-                        return Ok(result);
+                    match proxy.fetch_artifact_streaming(&repo, path).await {
+                        Ok(result) => return Ok(result),
+                        // Package Age Policy (#1770): a quarantine block from a
+                        // member is a deliberate 409/403, NOT a "member miss".
+                        // Surface it immediately instead of silently trying the
+                        // next member (which would mask the policy and 404).
+                        Err(e) if is_quarantine_block(&e) => {
+                            return Err(map_proxy_error(&member.key, path, e));
+                        }
+                        Err(_) => { /* genuine miss: try the next member */ }
                     }
                 }
             }
@@ -1103,6 +1136,27 @@ where
         "Artifact not found in any member repository",
     )
         .into_response())
+}
+
+/// Whether an [`AppError`] from a proxy member fetch is a deliberate Package
+/// Age Policy / quarantine block (#1770) — a 409 Conflict (held) or 403
+/// Authorization (rejected) — as opposed to an ordinary cache/upstream miss.
+/// Such a block must surface from virtual-repo resolution rather than being
+/// treated as "try the next member".
+fn is_quarantine_block(e: &crate::error::AppError) -> bool {
+    matches!(
+        e,
+        crate::error::AppError::Conflict(_) | crate::error::AppError::Authorization(_)
+    )
+}
+
+/// `Response`-level sibling of [`is_quarantine_block`] for the streaming
+/// virtual-download path, where the member fetch has already mapped its
+/// [`AppError`] to a [`Response`] (#1770). A 409 Conflict (held) or 403
+/// Forbidden (rejected) is a quarantine block that must surface from
+/// virtual-repo resolution rather than fall through to the next member.
+fn is_quarantine_block_response(resp: &Response) -> bool {
+    matches!(resp.status(), StatusCode::CONFLICT | StatusCode::FORBIDDEN)
 }
 
 /// Streaming sibling of [`resolve_virtual_download`] that avoids
@@ -1161,7 +1215,7 @@ where
                 if let (Some(proxy), Some(upstream_url)) =
                     (proxy_service, member.upstream_url.as_deref())
                 {
-                    if let Ok(response) = proxy_fetch_streaming_with_disposition(
+                    match proxy_fetch_streaming_with_disposition(
                         proxy,
                         member.id,
                         &member.key,
@@ -1172,7 +1226,12 @@ where
                     )
                     .await
                     {
-                        return Ok(response);
+                        Ok(response) => return Ok(response),
+                        // Package Age Policy (#1770): a member's quarantine
+                        // block (409/403, already mapped to a Response) must
+                        // surface rather than fall through to the next member.
+                        Err(resp) if is_quarantine_block_response(&resp) => return Err(resp),
+                        Err(_) => { /* genuine miss: try the next member */ }
                     }
                 }
             }
@@ -2813,6 +2872,62 @@ pub(crate) fn build_remote_repo(id: Uuid, key: &str, upstream_url: &str) -> Repo
 mod tests {
     use super::*;
     use axum::http::{HeaderValue, StatusCode};
+
+    // ── Package Age Policy quarantine surfacing (#1770) ──────────────
+
+    #[test]
+    fn test_is_quarantine_block_matches_conflict_and_authorization() {
+        use crate::error::AppError;
+        assert!(is_quarantine_block(&AppError::Conflict("held".into())));
+        assert!(is_quarantine_block(&AppError::Authorization(
+            "rejected".into()
+        )));
+    }
+
+    #[test]
+    fn test_is_quarantine_block_ignores_ordinary_misses() {
+        use crate::error::AppError;
+        assert!(!is_quarantine_block(&AppError::NotFound("gone".into())));
+        assert!(!is_quarantine_block(&AppError::BadGateway(
+            "upstream".into()
+        )));
+        assert!(!is_quarantine_block(&AppError::Storage("io".into())));
+    }
+
+    #[test]
+    fn test_map_proxy_error_surfaces_quarantine_conflict_as_409() {
+        let resp = map_proxy_error(
+            "npm-age",
+            "axios/-/axios-1.6.0.tgz",
+            crate::error::AppError::Conflict(
+                "Artifact is quarantined and pending security review".into(),
+            ),
+        );
+        assert_eq!(resp.status(), StatusCode::CONFLICT);
+        assert!(is_quarantine_block_response(&resp));
+    }
+
+    #[test]
+    fn test_map_proxy_error_surfaces_rejected_as_403() {
+        let resp = map_proxy_error(
+            "npm-age",
+            "axios/-/axios-1.6.0.tgz",
+            crate::error::AppError::Authorization("Artifact was rejected".into()),
+        );
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        assert!(is_quarantine_block_response(&resp));
+    }
+
+    #[test]
+    fn test_map_proxy_error_keeps_transient_failure_as_502() {
+        let resp = map_proxy_error(
+            "npm-age",
+            "axios/-/axios-1.6.0.tgz",
+            crate::error::AppError::Storage("connection reset".into()),
+        );
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        assert!(!is_quarantine_block_response(&resp));
+    }
 
     // ── promotion_only direct-upload gate ───────────────────────────
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -493,6 +493,15 @@ pub struct RepositoryResponse {
     pub upstream_url: Option<String>,
     pub upstream_auth_type: Option<String>,
     pub upstream_auth_configured: bool,
+    /// Whether the Package Age / quarantine policy is enabled for this
+    /// repository, read back from `repository_config` (#1770 B). `None` when
+    /// the repository has no explicit setting (the global default applies).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_enabled: Option<bool>,
+    /// Configured quarantine hold duration in minutes, read back from
+    /// `repository_config` (#1770 B). `None` when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quarantine_duration_minutes: Option<i64>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -523,9 +532,29 @@ fn repo_to_response(
         upstream_url: repo.upstream_url,
         upstream_auth_type: None,
         upstream_auth_configured: false,
+        // Populated by the handlers that have a DB handle (see
+        // `with_quarantine_settings`); `repo_to_response` itself is sync and
+        // db-less, mirroring `upstream_auth_*` above (#1770 B).
+        quarantine_enabled: None,
+        quarantine_duration_minutes: None,
         created_at: repo.created_at,
         updated_at: repo.updated_at,
     }
+}
+
+/// Populate `RepositoryResponse.quarantine_*` from `repository_config` (#1770
+/// B). Split out so the detail and update handlers, which both have a DB
+/// handle, can echo the configured Package Age Policy back to clients. The
+/// listing path stays db-light and omits these per-repo lookups.
+async fn with_quarantine_settings(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    mut response: RepositoryResponse,
+) -> RepositoryResponse {
+    let (enabled, duration) = crate::services::quarantine_service::repo_settings(db, repo_id).await;
+    response.quarantine_enabled = enabled;
+    response.quarantine_duration_minutes = duration;
+    response
 }
 
 /// Validate that a repository key is safe and well-formed.
@@ -1440,9 +1469,11 @@ pub async fn get_repository(
     let auth_type =
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
 
+    let repo_id = repo.id;
     let mut response = repo_to_response(repo, storage_used);
     response.upstream_auth_configured = auth_type.is_some();
     response.upstream_auth_type = auth_type;
+    let response = with_quarantine_settings(&state.db, repo_id, response).await;
     Ok(Json(response))
 }
 
@@ -1616,7 +1647,10 @@ pub async fn update_repository(
         Some(auth.username.clone()),
     );
 
-    Ok(Json(repo_to_response(repo, storage_used)))
+    let repo_id = repo.id;
+    let response = repo_to_response(repo, storage_used);
+    let response = with_quarantine_settings(&state.db, repo_id, response).await;
+    Ok(Json(response))
 }
 
 /// Best-effort purge of a repository's in-flight / abandoned OCI upload temp
@@ -6185,6 +6219,8 @@ mod tests {
             upstream_url: None,
             upstream_auth_type: None,
             upstream_auth_configured: false,
+            quarantine_enabled: None,
+            quarantine_duration_minutes: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -7430,6 +7466,43 @@ mod tests {
         assert_eq!(response.storage_used_bytes, 5000);
         assert_eq!(response.quota_bytes, Some(1073741824));
         assert!(response.upstream_url.is_none());
+        // #1770 B: db-less `repo_to_response` leaves quarantine fields unset;
+        // the handlers populate them from `repository_config`. Unset fields
+        // are omitted from the JSON (serde skip).
+        assert!(response.quarantine_enabled.is_none());
+        assert!(response.quarantine_duration_minutes.is_none());
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(!json.contains("quarantine_enabled"));
+        assert!(!json.contains("quarantine_duration_minutes"));
+    }
+
+    #[test]
+    fn test_repository_response_serializes_quarantine_when_set() {
+        // #1770 B: when the handler populates the quarantine settings from
+        // `repository_config`, they appear in the serialized detail response.
+        let resp = RepositoryResponse {
+            id: Uuid::new_v4(),
+            key: "npm-age".to_string(),
+            name: "npm-age".to_string(),
+            description: None,
+            format: "npm".to_string(),
+            repo_type: "remote".to_string(),
+            is_public: true,
+            allow_anonymous_access: true,
+            promotion_only: false,
+            storage_used_bytes: 0,
+            quota_bytes: None,
+            upstream_url: Some("https://registry.npmjs.org".to_string()),
+            upstream_auth_type: None,
+            upstream_auth_configured: false,
+            quarantine_enabled: Some(true),
+            quarantine_duration_minutes: Some(525600),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"quarantine_enabled\":true"));
+        assert!(json.contains("\"quarantine_duration_minutes\":525600"));
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -26,6 +26,7 @@ use crate::services::metrics_service::record_proxy_cache_lookup;
 use crate::services::proxy_hydration::{
     BufferedCoordinator, Coordinator, StreamHandle, StreamHeaders,
 };
+use crate::services::quarantine_service;
 use crate::services::storage_service::StorageService;
 
 /// Default cache TTL in seconds (24 hours)
@@ -423,6 +424,15 @@ pub struct CacheMetadata {
     /// sidecars deserializing.
     #[serde(default)]
     pub negative_cached_until: Option<DateTime<Utc>>,
+    /// Package Age Policy hold for this entry (#1770): when set and in the
+    /// future, reads must respond 409 Conflict (via the pure
+    /// `quarantine_service::check_download_allowed` gate) until the instant
+    /// passes. The window is based on the upstream release date when known
+    /// (#1771). `None` for entries written before this field existed or with
+    /// the policy disabled at write time; `#[serde(default)]` preserves
+    /// wire-compat with pre-existing sidecars.
+    #[serde(default)]
+    pub quarantine_until: Option<DateTime<Utc>>,
     /// When the cache entry expires
     pub expires_at: DateTime<Utc>,
     /// Content type from upstream
@@ -447,6 +457,32 @@ impl CacheMetadata {
             negative_cached_until: self.negative_cached_until,
         }
     }
+}
+
+/// Gate a proxy read on a Package Age Policy hold window (#1770).
+///
+/// Reuses the pure `quarantine_service::check_download_allowed` decision the
+/// hosted download paths already use: a `quarantine_until` in the future
+/// blocks the read with 409 Conflict; an elapsed window or an absent hold
+/// (legacy sidecar, or policy disabled at write time) allows it. The error
+/// MUST propagate to the handler — never be degraded to a cache `Miss`, which
+/// would refetch upstream and loop.
+fn check_quarantine_until(quarantine_until: Option<DateTime<Utc>>) -> Result<()> {
+    match quarantine_until {
+        Some(until) => {
+            quarantine_service::check_download_allowed(Some("quarantined"), Some(until), Utc::now())
+        }
+        None => Ok(()),
+    }
+}
+
+/// Parse an HTTP `Last-Modified` header value (RFC 7231 IMF-fixdate, which is
+/// RFC 2822-compatible) into a UTC timestamp. Returns `None` for absent or
+/// unparseable values so callers fall back to ingestion time (#1771).
+fn parse_http_date(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc2822(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
 }
 
 /// Outcome of the up-front cache read on the buffered proxy path (#1611).
@@ -906,6 +942,7 @@ impl CachePersister {
         ttl_secs: i64,
         repository_id: Uuid,
         artifact_path: &str,
+        quarantine_until: Option<DateTime<Utc>>,
     ) -> Result<()> {
         // #1618 S9 / #1365: never cache a zero-byte body on the buffered
         // path either. An empty upstream response (204 / empty 200) must
@@ -946,6 +983,10 @@ impl CachePersister {
             storage_etag,
             last_modified,
             negative_cached_until: None,
+            // Package Age Policy hold resolved by the caller (#1770): recorded
+            // on the sidecar (NOT the `artifacts` table, per #1278) so every
+            // read path can gate on it.
+            quarantine_until,
             expires_at: now + chrono::Duration::seconds(ttl_secs),
             content_type,
             size_bytes: content.len() as i64,
@@ -1106,6 +1147,10 @@ impl CachePersister {
                         storage_etag,
                         last_modified: template.last_modified,
                         negative_cached_until: None,
+                        // The streaming leader refuses to open upstream at all
+                        // while the repo's Package Age Policy is enabled
+                        // (#1770), so a tee'd entry is never under a hold.
+                        quarantine_until: None,
                         expires_at: now + chrono::Duration::seconds(template.ttl_secs),
                         content_type: template.content_type,
                         size_bytes: result.bytes_written as i64,
@@ -1998,7 +2043,21 @@ impl ProxyService {
         // path below (`fetch_artifact_streaming`) is the layer-2 plug-in point.
         self.coordinator.coordinate(
             &hydration_lease_key,
-            || async { self.get_cached_artifact(&cache_key, &metadata_key).await },
+            || async {
+                let cached = self.get_cached_artifact(&cache_key, &metadata_key).await?;
+                if cached.is_some() {
+                    // Package Age Policy (#1770): a follower re-checking the
+                    // cache must not serve an entry the leader just wrote
+                    // under an active hold. The sidecar load mirrors the
+                    // B6-safe stance (read error -> no hold known).
+                    if let Some(metadata) =
+                        self.load_cache_metadata(&metadata_key).await.unwrap_or(None)
+                    {
+                        check_quarantine_until(metadata.quarantine_until)?;
+                    }
+                }
+                Ok(cached)
+            },
             || async {
                 let full_url = Self::build_upstream_url(upstream_url, fetch_path);
                 let upstream_result = self
@@ -2009,6 +2068,13 @@ impl ProxyService {
                     Ok(resp) => {
                         // #1611: mutability-aware TTL (immutable -> forever).
                         let cache_ttl = self.cache_ttl_for_path(repo, cache_path).await;
+                        // Package Age Policy (#1770): resolve the hold window
+                        // BEFORE caching so the sidecar records it; the window
+                        // is based on the upstream release date when known
+                        // (#1771).
+                        let quarantine_until = self
+                            .quarantine_until_for_new_entry(repo.id, resp.last_modified.as_deref())
+                            .await;
                         // B6 (coalescing 502 leak, remaining path): the upstream fetch
                         // already SUCCEEDED -- `resp.content` is in hand. A failure to
                         // persist the cache entry must NOT fail the client request.
@@ -2034,6 +2100,7 @@ impl ProxyService {
                                 cache_ttl,
                                 repo.id,
                                 cache_path,
+                                quarantine_until,
                             )
                             .await
                         {
@@ -2050,6 +2117,12 @@ impl ProxyService {
                             self.warn_if_proxy_scan_unsupported(repo.id, cache_path)
                                 .await;
                         }
+
+                        // Package Age Policy (#1770): hold the just-fetched
+                        // bytes too — the policy must block the FIRST response,
+                        // not only later cache hits, and must hold even when
+                        // the best-effort cache write above failed.
+                        check_quarantine_until(quarantine_until)?;
 
                         Ok((resp.content, resp.content_type))
                     }
@@ -2242,6 +2315,10 @@ impl ProxyService {
             cache_classifier::Freshness::Fresh => {
                 // Immutable hits reach here and never touch upstream.
                 let metadata = metadata.expect("fresh implies metadata present");
+                // Package Age Policy (#1770): a held entry must 409 — checked
+                // AFTER freshness evaluation; the error propagates and is
+                // never degraded to a Miss (which would refetch upstream).
+                check_quarantine_until(metadata.quarantine_until)?;
                 match self.open_cached_stream(cache_key, &metadata).await? {
                     Some(result) => Ok(StreamingCacheReadOutcome::Hit(result)),
                     None => Ok(StreamingCacheReadOutcome::Miss),
@@ -2256,6 +2333,9 @@ impl ProxyService {
                     // 304 extended the TTL; stream the cached body.
                     RevalidationVerdict::ServeRevalidated
                     | RevalidationVerdict::ServeStaleIfError => {
+                        // Package Age Policy (#1770): gate the revalidated /
+                        // stale-if-error body the same way as a fresh hit.
+                        check_quarantine_until(metadata.quarantine_until)?;
                         match self.open_cached_stream(cache_key, &metadata).await? {
                             Some(result) => Ok(StreamingCacheReadOutcome::Hit(result)),
                             None => Ok(StreamingCacheReadOutcome::Miss),
@@ -2305,6 +2385,19 @@ impl ProxyService {
         cache_key: String,
         metadata_key: String,
     ) -> Result<StreamHandle> {
+        // Package Age Policy (#1770): the streaming path has no buffered
+        // upstream `Last-Modified` to base a release-date hold on (#1771), so
+        // a repo with the policy enabled conservatively refuses to open a new
+        // streaming fetch outright. Entries cached while the policy was off
+        // are unaffected (gated by their sidecar on the hit path above), and
+        // the error propagates as 409 rather than degrading to a fall-back.
+        let quarantine_config = quarantine_service::resolve_config(&self.db, repo.id).await;
+        if quarantine_service::should_quarantine(&quarantine_config) {
+            return Err(AppError::Conflict(
+                "Artifact is quarantined and pending security review".to_string(),
+            ));
+        }
+
         let upstream_url = Self::remote_target(repo)?;
         let full_url = Self::build_upstream_url(upstream_url, path);
         let upstream = match self.fetch_from_upstream_streaming(&full_url, repo.id).await {
@@ -3069,6 +3162,15 @@ impl ProxyService {
             cache_classifier::Freshness::Miss => Ok(CacheReadOutcome::Miss),
             cache_classifier::Freshness::NegativeHit => Ok(CacheReadOutcome::NegativeHit),
             cache_classifier::Freshness::Fresh => {
+                // Package Age Policy (#1770): a held entry must 409 — checked
+                // AFTER freshness evaluation, and the error propagates rather
+                // than degrading to a Miss (which would refetch upstream).
+                check_quarantine_until(
+                    metadata
+                        .as_ref()
+                        .expect("fresh implies metadata present")
+                        .quarantine_until,
+                )?;
                 // Serve the body. Immutable hits reach here and never touch
                 // upstream. `get_cached_artifact` re-verifies checksum + body
                 // presence; a missing/poisoned body degrades to Miss (B6).
@@ -3080,15 +3182,19 @@ impl ProxyService {
                 }
             }
             cache_classifier::Freshness::Stale => {
-                self.revalidate_stale(
-                    repo,
-                    fetch_path,
-                    cache_key,
-                    metadata_key,
-                    // Safe: Stale only arises when metadata is present.
-                    metadata.as_ref().expect("stale implies metadata present"),
-                )
-                .await
+                // Safe: Stale only arises when metadata is present.
+                let stale_metadata = metadata.as_ref().expect("stale implies metadata present");
+                let outcome = self
+                    .revalidate_stale(repo, fetch_path, cache_key, metadata_key, stale_metadata)
+                    .await?;
+                // Package Age Policy (#1770): gate a revalidated /
+                // stale-if-error body the same way as a fresh hit. A Refill
+                // (Miss) is NOT gated here — the upstream refetch records and
+                // enforces its own hold window.
+                if matches!(outcome, CacheReadOutcome::Hit(..)) {
+                    check_quarantine_until(stale_metadata.quarantine_until)?;
+                }
+                Ok(outcome)
             }
         }
     }
@@ -3248,6 +3354,7 @@ impl ProxyService {
             upstream_etag: None,
             storage_etag: None,
             last_modified: None,
+            quarantine_until: None,
             negative_cached_until: Some(now + neg_ttl),
             // expires_at mirrors the negative window so any expiry-only reader
             // also treats it as expired once the window passes.
@@ -3377,6 +3484,7 @@ impl ProxyService {
         ttl_secs: i64,
         repository_id: Uuid,
         artifact_path: &str,
+        quarantine_until: Option<DateTime<Utc>>,
     ) -> Result<()> {
         self.cache_persister
             .write_buffered(
@@ -3389,8 +3497,33 @@ impl ProxyService {
                 ttl_secs,
                 repository_id,
                 artifact_path,
+                quarantine_until,
             )
             .await
+    }
+
+    /// Resolve the Package Age Policy hold window for a newly cached proxy
+    /// entry (#1770). Returns `None` when the repository's quarantine policy
+    /// is disabled. The window is measured from the upstream release date
+    /// (`Last-Modified`) when present and parseable, falling back to the
+    /// ingestion time (#1771): an upstream release older than the configured
+    /// window yields an already-elapsed hold, so old packages are not re-held
+    /// from their first proxy fetch.
+    async fn quarantine_until_for_new_entry(
+        &self,
+        repository_id: Uuid,
+        last_modified: Option<&str>,
+    ) -> Option<DateTime<Utc>> {
+        let config = quarantine_service::resolve_config(&self.db, repository_id).await;
+        if !quarantine_service::should_quarantine(&config) {
+            return None;
+        }
+        let release = last_modified.and_then(parse_http_date);
+        Some(quarantine_service::quarantine_until_from_release(
+            &config,
+            release,
+            Utc::now(),
+        ))
     }
 
     /// Emit a structured warning when a brand-new artifact is cached from
@@ -3553,6 +3686,82 @@ pub(crate) fn build_stale_cache_headers() -> HashMap<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // Package Age Policy on the proxy sidecar (#1770 / #1771)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_check_quarantine_until_none_allows() {
+        assert!(check_quarantine_until(None).is_ok());
+    }
+
+    #[test]
+    fn test_check_quarantine_until_future_blocks_with_conflict() {
+        let until = Utc::now() + chrono::Duration::minutes(30);
+        let err = check_quarantine_until(Some(until)).unwrap_err();
+        match err {
+            AppError::Conflict(_) => {}
+            other => panic!("expected 409 Conflict, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_check_quarantine_until_past_allows() {
+        let until = Utc::now() - chrono::Duration::minutes(1);
+        assert!(check_quarantine_until(Some(until)).is_ok());
+    }
+
+    #[test]
+    fn test_parse_http_date_rfc7231_imf_fixdate() {
+        let parsed = parse_http_date("Tue, 05 May 2026 01:10:54 GMT").expect("parseable");
+        assert_eq!(parsed.to_rfc3339(), "2026-05-05T01:10:54+00:00");
+    }
+
+    #[test]
+    fn test_parse_http_date_rejects_garbage() {
+        assert!(parse_http_date("not-a-date").is_none());
+        assert!(parse_http_date("").is_none());
+    }
+
+    #[test]
+    fn test_legacy_sidecar_without_quarantine_deserializes_to_none() {
+        // A sidecar written before the quarantine field existed (and before
+        // last_modified / negative_cached_until / storage_etag) must still
+        // deserialize, with quarantine_until defaulting to None.
+        let legacy = r#"{
+            "cached_at": "2026-01-01T00:00:00Z",
+            "upstream_etag": null,
+            "expires_at": "2030-01-01T00:00:00Z",
+            "content_type": "application/octet-stream",
+            "size_bytes": 10,
+            "checksum_sha256": "abc"
+        }"#;
+        let meta: CacheMetadata = serde_json::from_str(legacy).expect("legacy sidecar parses");
+        assert!(meta.quarantine_until.is_none());
+        assert!(check_quarantine_until(meta.quarantine_until).is_ok());
+    }
+
+    #[test]
+    fn test_sidecar_round_trips_quarantine_until() {
+        let until = Utc::now() + chrono::Duration::minutes(120);
+        let meta = CacheMetadata {
+            cached_at: Utc::now(),
+            upstream_etag: None,
+            storage_etag: None,
+            last_modified: None,
+            quarantine_until: Some(until),
+            negative_cached_until: None,
+            expires_at: Utc::now() + chrono::Duration::hours(24),
+            content_type: Some("application/octet-stream".to_string()),
+            size_bytes: 10,
+            checksum_sha256: "abc".to_string(),
+        };
+        let json = serde_json::to_vec(&meta).unwrap();
+        let back: CacheMetadata = serde_json::from_slice(&json).unwrap();
+        assert_eq!(back.quarantine_until, Some(until));
+        assert!(check_quarantine_until(back.quarantine_until).is_err());
+    }
 
     // -----------------------------------------------------------------------
     // should_warn_proxy_scan_skipped — scan-on-proxy gap warning gate (#1274)
@@ -4225,6 +4434,7 @@ mod tests {
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: Utc::now() + chrono::Duration::hours(24),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: 1024,
@@ -4248,6 +4458,7 @@ mod tests {
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now + chrono::Duration::seconds(3600),
             content_type: None,
             size_bytes: 0,
@@ -4272,6 +4483,7 @@ mod tests {
             storage_etag: Some("\"storage-etag\"".to_string()),
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: expires,
             content_type: Some("application/json".to_string()),
             size_bytes: 4096,
@@ -4293,6 +4505,7 @@ mod tests {
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: Utc::now() + chrono::Duration::hours(1),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: i64::MAX,
@@ -4335,6 +4548,7 @@ mod tests {
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now - chrono::Duration::hours(1),
             content_type: None,
             size_bytes: 100,
@@ -4352,6 +4566,7 @@ mod tests {
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now + chrono::Duration::hours(23),
             content_type: None,
             size_bytes: 100,
@@ -4677,6 +4892,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now - chrono::Duration::hours(1),
             content_type: Some("application/java-archive".to_string()),
             size_bytes: 2048,
@@ -4700,6 +4916,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now + chrono::Duration::hours(23),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: 512,
@@ -4719,6 +4936,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now - chrono::Duration::seconds(1),
             content_type: Some("application/gzip".to_string()),
             size_bytes: 4096,
@@ -5323,6 +5541,7 @@ SHA256:
             storage_etag,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: Utc::now() + chrono::Duration::hours(1),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: 42,
@@ -5338,6 +5557,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: Utc::now() - chrono::Duration::seconds(1),
             content_type: None,
             size_bytes: 0,
@@ -6469,6 +6689,7 @@ SHA256:
                 3600,
                 Uuid::nil(),
                 "repo/path",
+                None,
             )
             .await
             .expect("write_buffered should succeed");
@@ -6906,6 +7127,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: cached_at + chrono::Duration::hours(1),
             content_type: content_type.map(|s| s.to_string()),
             size_bytes: size,
@@ -6930,6 +7152,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now + chrono::Duration::hours(1),
             content_type: Some("application/gzip".to_string()),
             size_bytes: 789,
@@ -6957,6 +7180,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now + chrono::Duration::hours(1),
             content_type: None,
             size_bytes: 1,
@@ -8044,6 +8268,7 @@ SHA256:
                 DEFAULT_CACHE_TTL_SECS,
                 Uuid::new_v4(),
                 cache_path,
+                None,
             )
             .await
             .expect("cache_artifact must succeed on a healthy filesystem backend");
@@ -8471,6 +8696,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at,
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: body.len() as i64,
@@ -9560,6 +9786,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             // Already expired -> Stale for a mutable path.
             expires_at: now - chrono::Duration::seconds(1),
             content_type: Some("application/octet-stream".to_string()),
@@ -9830,6 +10057,7 @@ SHA256:
             storage_etag: None,
             last_modified: None,
             negative_cached_until: None,
+            quarantine_until: None,
             expires_at: now + chrono::Duration::seconds(ttl_secs),
             content_type: Some("application/octet-stream".to_string()),
             size_bytes: body.len() as i64,
@@ -9848,6 +10076,7 @@ SHA256:
             upstream_etag: None,
             storage_etag: None,
             last_modified: None,
+            quarantine_until: None,
             negative_cached_until: Some(now + neg_ttl),
             expires_at: now + neg_ttl,
             content_type: None,

--- a/backend/src/services/quarantine_service.rs
+++ b/backend/src/services/quarantine_service.rs
@@ -67,6 +67,22 @@ pub fn quarantine_until(config: &QuarantineConfig, now: DateTime<Utc>) -> DateTi
     now + Duration::minutes(config.duration_minutes)
 }
 
+/// Calculate the quarantine expiry from the upstream release date.
+///
+/// The Package Age Policy holds an artifact for `duration_minutes` measured
+/// from when it was *released* upstream, not from when this instance first
+/// ingested it (#1771). A release date older than the configured window
+/// therefore yields an already-elapsed expiry, so an old upstream package is
+/// not re-held from its first proxy fetch. Falls back to `now` (matching
+/// [`quarantine_until`]) when no release date is known.
+pub fn quarantine_until_from_release(
+    config: &QuarantineConfig,
+    release_date: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+) -> DateTime<Utc> {
+    release_date.unwrap_or(now) + Duration::minutes(config.duration_minutes)
+}
+
 /// Decide whether a download should be blocked based on quarantine state.
 ///
 /// Returns `Ok(())` if the download is allowed, or `Err` with a 409 Conflict
@@ -114,6 +130,46 @@ pub fn status_after_scan(has_findings: bool) -> QuarantineState {
 // Database helpers (I/O layer)
 // ---------------------------------------------------------------------------
 
+/// Read the raw per-repository quarantine settings from `repository_config`.
+///
+/// Unlike [`resolve_config`], this does NOT merge global env defaults: it
+/// returns exactly what is stored for the repository (`None` when a key is
+/// unset or unparseable) so the repository API can echo the configured policy
+/// back to clients (#1770 B).
+pub async fn repo_settings(db: &PgPool, repository_id: Uuid) -> (Option<bool>, Option<i64>) {
+    let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+        "SELECT key, value FROM repository_config \
+         WHERE repository_id = $1 AND key IN ('quarantine_enabled', 'quarantine_duration_minutes')",
+    )
+    .bind(repository_id)
+    .fetch_all(db)
+    .await
+    .unwrap_or_default();
+
+    let mut enabled = None;
+    let mut duration = None;
+
+    for (key, value) in &rows {
+        match key.as_str() {
+            "quarantine_enabled" => {
+                if let Some(v) = value {
+                    enabled = Some(v == "true" || v == "1");
+                }
+            }
+            "quarantine_duration_minutes" => {
+                if let Some(v) = value {
+                    if let Ok(d) = v.parse::<i64>() {
+                        duration = Some(d);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    (enabled, duration)
+}
+
 /// Resolve the effective quarantine config for a repository.
 ///
 /// Checks `repository_config` first, then falls back to env vars, then defaults.
@@ -127,40 +183,12 @@ pub async fn resolve_config(db: &PgPool, repository_id: Uuid) -> QuarantineConfi
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_DURATION_MINUTES);
 
-    // Try per-repo overrides from repository_config
-    let rows: Vec<(String, Option<String>)> = sqlx::query_as(
-        "SELECT key, value FROM repository_config \
-         WHERE repository_id = $1 AND key IN ('quarantine_enabled', 'quarantine_duration_minutes')",
-    )
-    .bind(repository_id)
-    .fetch_all(db)
-    .await
-    .unwrap_or_default();
-
-    let mut enabled = global_enabled;
-    let mut duration = global_duration;
-
-    for (key, value) in &rows {
-        match key.as_str() {
-            "quarantine_enabled" => {
-                if let Some(v) = value {
-                    enabled = v == "true" || v == "1";
-                }
-            }
-            "quarantine_duration_minutes" => {
-                if let Some(v) = value {
-                    if let Ok(d) = v.parse::<i64>() {
-                        duration = d;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
+    // Per-repo overrides from repository_config take precedence.
+    let (enabled, duration) = repo_settings(db, repository_id).await;
 
     QuarantineConfig {
-        enabled,
-        duration_minutes: validate_duration(duration),
+        enabled: enabled.unwrap_or(global_enabled),
+        duration_minutes: validate_duration(duration.unwrap_or(global_duration)),
     }
 }
 
@@ -219,11 +247,15 @@ pub async fn transition(db: &PgPool, artifact_id: Uuid, new_status: QuarantineSt
     Ok(())
 }
 
-/// Fetch the current quarantine status and expiry for an artifact.
-pub async fn get_status(
+/// Fetch the raw `(quarantine_status, quarantine_until)` for a live artifact.
+///
+/// Returns `Ok(None)` when no matching (non-deleted) row exists. Shared by
+/// [`get_status`] and [`check_artifact_download`] so the identical SELECT is
+/// expressed once.
+async fn fetch_quarantine_fields(
     db: &PgPool,
     artifact_id: Uuid,
-) -> Result<(Option<String>, Option<DateTime<Utc>>)> {
+) -> Result<Option<(Option<String>, Option<DateTime<Utc>>)>> {
     #[derive(sqlx::FromRow)]
     struct Row {
         quarantine_status: Option<String>,
@@ -236,10 +268,19 @@ pub async fn get_status(
     .bind(artifact_id)
     .fetch_optional(db)
     .await
-    .map_err(|e| AppError::Database(e.to_string()))?
-    .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+    .map_err(|e| AppError::Database(e.to_string()))?;
 
-    Ok((row.quarantine_status, row.quarantine_until))
+    Ok(row.map(|r| (r.quarantine_status, r.quarantine_until)))
+}
+
+/// Fetch the current quarantine status and expiry for an artifact.
+pub async fn get_status(
+    db: &PgPool,
+    artifact_id: Uuid,
+) -> Result<(Option<String>, Option<DateTime<Utc>>)> {
+    fetch_quarantine_fields(db, artifact_id)
+        .await?
+        .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))
 }
 
 /// Fetch quarantine status along with the artifact's repository_id.
@@ -279,26 +320,8 @@ pub async fn get_status_with_repo(
 /// artifact's quarantine fields and returns an error if the artifact is
 /// quarantined (409 Conflict) or rejected (403 Forbidden).
 pub async fn check_artifact_download(db: &PgPool, artifact_id: Uuid) -> Result<()> {
-    #[derive(sqlx::FromRow)]
-    struct Row {
-        quarantine_status: Option<String>,
-        quarantine_until: Option<DateTime<Utc>>,
-    }
-
-    let row = sqlx::query_as::<_, Row>(
-        "SELECT quarantine_status, quarantine_until FROM artifacts WHERE id = $1 AND is_deleted = false",
-    )
-    .bind(artifact_id)
-    .fetch_optional(db)
-    .await
-    .map_err(|e| AppError::Database(e.to_string()))?;
-
-    if let Some(row) = row {
-        check_download_allowed(
-            row.quarantine_status.as_deref(),
-            row.quarantine_until,
-            Utc::now(),
-        )?;
+    if let Some((status, until)) = fetch_quarantine_fields(db, artifact_id).await? {
+        check_download_allowed(status.as_deref(), until, Utc::now())?;
     }
 
     Ok(())
@@ -362,6 +385,51 @@ mod tests {
         };
         let until = quarantine_until(&config, now);
         assert_eq!(until, now);
+    }
+
+    // -----------------------------------------------------------------------
+    // quarantine_until_from_release
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_quarantine_until_from_release_recent_release_in_future() {
+        let now = Utc::now();
+        let config = QuarantineConfig {
+            enabled: true,
+            duration_minutes: 120,
+        };
+        let release = now - Duration::minutes(30);
+        let until = quarantine_until_from_release(&config, Some(release), now);
+        assert_eq!(until, release + Duration::minutes(120));
+        assert!(until > now, "recent release must still be held");
+        // The held window composes with check_download_allowed -> blocked.
+        assert!(check_download_allowed(Some("quarantined"), Some(until), now).is_err());
+    }
+
+    #[test]
+    fn test_quarantine_until_from_release_old_release_already_expired() {
+        let now = Utc::now();
+        let config = QuarantineConfig {
+            enabled: true,
+            duration_minutes: 60,
+        };
+        // Released long before the window: the hold has already elapsed.
+        let release = now - Duration::days(365);
+        let until = quarantine_until_from_release(&config, Some(release), now);
+        assert!(until < now, "old release must yield an elapsed window");
+        // And composes with check_download_allowed -> downloadable.
+        assert!(check_download_allowed(Some("quarantined"), Some(until), now).is_ok());
+    }
+
+    #[test]
+    fn test_quarantine_until_from_release_falls_back_to_now() {
+        let now = Utc::now();
+        let config = QuarantineConfig {
+            enabled: true,
+            duration_minutes: 45,
+        };
+        let until = quarantine_until_from_release(&config, None, now);
+        assert_eq!(until, quarantine_until(&config, now));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Enforce the per-repository Package Age / quarantine policy on remote and proxy
downloads, return the configured policy on repository reads, and base the
quarantine hold window on the upstream release date.

Three related gaps existed for `remote` (pull-through cache) and proxy repos:

- **A — proxy downloads were never quarantined.** The quarantine gate
  (`quarantine_service::check_download_allowed`) only runs for artifacts that
  have a row in the `artifacts` table. Proxy-cached items deliberately have no
  such row (the cache write omits the `artifacts` insert, enforced by a
  meta-test in `proxy_service.rs`), and no quarantine state was stored on the
  cache sidecar, so a tarball fetched through a remote repo with the policy
  enabled returned `200` instead of `409`. This change stores the hold window
  on the `CacheMetadata` sidecar at cache-write time and gates on the
  `ProxyService` read paths (buffered + streaming, fresh + revalidated + just
  fetched), reusing the existing pure `check_download_allowed`. No
  `artifacts` insert is added, so the existing meta-test stays green.
- **B — the configured policy was not returned on repository reads.**
  `update_repository` upserts `quarantine_enabled` /
  `quarantine_duration_minutes` into `repository_config`, but
  `RepositoryResponse` had no fields for them and `repo_to_response` never read
  them back, so `GET /repositories/{key}` omitted the setting and UI toggles
  reset to off. The response type now carries both fields, populated from
  `repository_config` by the detail and update handlers.
- **C — the hold window was measured from ingestion time.** The window is now
  computed from the upstream `Last-Modified` (release date) when present,
  falling back to ingestion time, so an old upstream package is not re-held
  with a fresh full window from its first proxy fetch.

Quarantine blocks (held = `409`, rejected = `403`) propagate as deliberate
status codes through the proxy error mapper and through virtual-repo
resolution (a quarantined member surfaces the block rather than falling through
to the next member / a `404`).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests:
- `quarantine_service`: `quarantine_until_from_release` (recent release held,
  old release already expired, fallback to now).
- `proxy_service`: sidecar gate (`check_quarantine_until` none/future/past),
  HTTP-date parsing, legacy sidecar (no quarantine field) deserializes to
  `None`, and a sidecar round-trips a quarantine window.
- `proxy_helpers`: `map_proxy_error` surfaces a quarantine `Conflict` as `409`
  and a rejection as `403` while keeping transient failures `502`; the
  quarantine-block predicates used by virtual-repo resolution.
- `repositories`: `repo_to_response` leaves the quarantine fields unset
  (db-less) and they are omitted from JSON; a populated response serializes
  both fields.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on a rebuilt instance (remote npm repo `npm-age`,
upstream `registry.npmjs.org`):
- `PATCH quarantine_enabled=true, quarantine_duration_minutes=525600` → `200`;
  `GET` then shows both values (B).
- `GET axios-1.6.0.tgz` with the policy on → `409` on cold cache (451075-byte
  body withheld) and `409` again on warm cache (A).
- Disable the policy + invalidate the cache + refetch → `200` with the full
  451075-byte gzip body (legitimate use intact).
- Release basis (C): with a one-year window, a recent release
  (`axios-1.6.0`, upstream `Last-Modified` 2026-05) is held `409` while an old
  release (`left-pad-1.3.0`, 2018) is served `200`.
- A virtual repo whose member is the quarantined remote returns `409`, not a
  `404` fall-through.

Full backend lib suite: `11453 passed; 0 failed`. fmt + clippy
(`-D warnings`) clean. Duplication check on changed files: 0%.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no migration
- [ ] N/A - no API changes

`RepositoryResponse` gains two additive, optional fields
(`quarantine_enabled`, `quarantine_duration_minutes`), omitted from JSON when
unset, so existing clients are unaffected. No schema migration is required;
the quarantine state for proxy entries lives on the existing cache sidecar
(`#[serde(default)]` keeps pre-existing sidecars deserializing).

## Notes for reviewers
- Local and hosted (`artifacts`-row) download paths are unchanged; they keep
  using `check_artifact_download`.
- The `cache_artifact` path still performs no `artifacts` insert; the
  meta-test that guards this remains green.
- The streaming proxy path has no buffered upstream `Last-Modified` to base a
  release window on, so a repo with the policy enabled conservatively refuses
  to open a new streaming fetch (entries cached while the policy was off remain
  gated by their own sidecar). Sourcing the exact registry publish timestamp
  (e.g. npm `time.<version>`) for the streaming path is a possible follow-up.
