### PR TITLE
fix(maven): serve group-level plugin-prefix maven-metadata.xml through virtual repositories

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1000,6 +1000,56 @@ async fn download(
                         .body(Body::from(xml))
                         .unwrap());
                 }
+
+                // Group-level plugin-prefix metadata (#1595). A path like
+                // `org/apache/maven/plugins/maven-metadata.xml` matches
+                // parse_metadata_path but carries <plugins> entries instead
+                // of a <versions> block, so the version merge above yields
+                // nothing. Collect each member's plugin-prefix metadata
+                // (stored file first, upstream for remote members) and serve
+                // the union of <plugin> entries deduped by <prefix>.
+                let mut member_docs: Vec<String> = Vec::new();
+                for member in &members {
+                    let member_storage_key = format!("maven/{}", path);
+                    if let Ok(member_storage) = state.storage_for_repo(&member.storage_location()) {
+                        if let Ok(content) = member_storage.get(&member_storage_key).await {
+                            if let Ok(xml_str) = std::str::from_utf8(&content) {
+                                member_docs.push(xml_str.to_string());
+                                continue;
+                            }
+                        }
+                    }
+
+                    if member.repo_type == RepositoryType::Remote {
+                        if let (Some(upstream_url), Some(ref proxy)) =
+                            (member.upstream_url.as_deref(), &state.proxy_service)
+                        {
+                            if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                                proxy,
+                                member.id,
+                                &member.key,
+                                upstream_url,
+                                &path,
+                            )
+                            .await
+                            {
+                                if let Ok(xml_str) = std::str::from_utf8(&content) {
+                                    member_docs.push(xml_str.to_string());
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if let Some(xml) = crate::formats::maven::merge_plugin_prefix_metadata(&member_docs)
+                {
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(CONTENT_TYPE, "text/xml")
+                        .header(CONTENT_LENGTH, xml.len().to_string())
+                        .body(Body::from(xml))
+                        .unwrap());
+                }
             }
 
             // Virtual repo: SNAPSHOT version-level metadata (#839).

--- a/backend/src/formats/maven.rs
+++ b/backend/src/formats/maven.rs
@@ -418,6 +418,124 @@ pub fn parse_metadata_versions(xml: &str) -> Option<(String, String, Vec<String>
     Some((group_id, artifact_id, versions))
 }
 
+/// A `<plugin>` entry from a group-level plugin-prefix maven-metadata.xml
+/// (e.g. `org/apache/maven/plugins/maven-metadata.xml`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PluginPrefixEntry {
+    pub name: Option<String>,
+    pub prefix: String,
+    pub artifact_id: String,
+}
+
+/// Minimal XML text escaping for re-emitting merged metadata values.
+fn xml_escape_text(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+/// Minimal XML text unescaping for values read from member metadata.
+fn xml_unescape_text(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+/// Extract the text of a direct child element from an XML fragment.
+fn extract_element_text(fragment: &str, tag: &str) -> Option<String> {
+    let open = format!("<{}>", tag);
+    let close = format!("</{}>", tag);
+    let text = fragment
+        .split(open.as_str())
+        .nth(1)?
+        .split(close.as_str())
+        .next()?
+        .trim();
+    if text.is_empty() {
+        None
+    } else {
+        Some(xml_unescape_text(text))
+    }
+}
+
+/// Parse the `<plugins>` block of a group-level plugin-prefix
+/// maven-metadata.xml. Returns an empty Vec for documents without plugin
+/// entries (such as artifact-level metadata carrying a `<versions>` block).
+pub fn parse_plugin_prefix_entries(xml: &str) -> Vec<PluginPrefixEntry> {
+    let mut entries = Vec::new();
+    let plugins_block = match xml.split("<plugins>").nth(1) {
+        Some(block) => block,
+        None => return entries,
+    };
+    let plugins_block = match plugins_block.split("</plugins>").next() {
+        Some(block) => block,
+        None => return entries,
+    };
+    for segment in plugins_block.split("<plugin>").skip(1) {
+        let plugin = match segment.split("</plugin>").next() {
+            Some(plugin) => plugin,
+            None => continue,
+        };
+        if let (Some(prefix), Some(artifact_id)) = (
+            extract_element_text(plugin, "prefix"),
+            extract_element_text(plugin, "artifactId"),
+        ) {
+            entries.push(PluginPrefixEntry {
+                name: extract_element_text(plugin, "name"),
+                prefix,
+                artifact_id,
+            });
+        }
+    }
+    entries
+}
+
+/// Merge group-level plugin-prefix metadata documents from the members of a
+/// virtual repository. `<plugin>` entries are deduped by `<prefix>` with
+/// first-writer-wins order. Returns `None` when no document contributes any
+/// plugin entry (e.g. all documents are artifact-level version metadata),
+/// so callers can fall through to their not-found handling.
+pub fn merge_plugin_prefix_metadata(docs: &[String]) -> Option<String> {
+    let mut merged: Vec<PluginPrefixEntry> = Vec::new();
+    for doc in docs {
+        for entry in parse_plugin_prefix_entries(doc) {
+            if !merged.iter().any(|e| e.prefix == entry.prefix) {
+                merged.push(entry);
+            }
+        }
+    }
+    if merged.is_empty() {
+        return None;
+    }
+
+    let mut plugins_xml = String::new();
+    for entry in &merged {
+        plugins_xml.push_str("    <plugin>\n");
+        if let Some(ref name) = entry.name {
+            plugins_xml.push_str(&format!("      <name>{}</name>\n", xml_escape_text(name)));
+        }
+        plugins_xml.push_str(&format!(
+            "      <prefix>{}</prefix>\n",
+            xml_escape_text(&entry.prefix)
+        ));
+        plugins_xml.push_str(&format!(
+            "      <artifactId>{}</artifactId>\n",
+            xml_escape_text(&entry.artifact_id)
+        ));
+        plugins_xml.push_str("    </plugin>\n");
+    }
+
+    Some(format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <plugins>
+{}  </plugins>
+</metadata>
+"#,
+        plugins_xml
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -630,5 +748,130 @@ mod tests {
         assert_eq!(g, "com.example");
         assert_eq!(a, "my-lib");
         assert_eq!(versions, vec!["1.0.0", "1.1.0"]);
+    }
+
+    const PLUGIN_PREFIX_DOC_A: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <plugins>
+    <plugin>
+      <name>Apache Maven Compiler Plugin</name>
+      <prefix>compiler</prefix>
+      <artifactId>maven-compiler-plugin</artifactId>
+    </plugin>
+    <plugin>
+      <name>Apache Maven Deploy Plugin</name>
+      <prefix>deploy</prefix>
+      <artifactId>maven-deploy-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>
+"#;
+
+    const PLUGIN_PREFIX_DOC_B: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <plugins>
+    <plugin>
+      <name>Other Compiler Plugin</name>
+      <prefix>compiler</prefix>
+      <artifactId>other-compiler-plugin</artifactId>
+    </plugin>
+    <plugin>
+      <name>Versions Maven Plugin</name>
+      <prefix>versions</prefix>
+      <artifactId>versions-maven-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>
+"#;
+
+    #[test]
+    fn test_parse_plugin_prefix_entries() {
+        let entries = parse_plugin_prefix_entries(PLUGIN_PREFIX_DOC_A);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].prefix, "compiler");
+        assert_eq!(entries[0].artifact_id, "maven-compiler-plugin");
+        assert_eq!(
+            entries[0].name.as_deref(),
+            Some("Apache Maven Compiler Plugin")
+        );
+        assert_eq!(entries[1].prefix, "deploy");
+        assert_eq!(entries[1].artifact_id, "maven-deploy-plugin");
+        assert_eq!(
+            entries[1].name.as_deref(),
+            Some("Apache Maven Deploy Plugin")
+        );
+    }
+
+    #[test]
+    fn test_parse_plugin_prefix_entries_versions_doc_is_empty() {
+        let xml = generate_metadata_xml(
+            "com.example",
+            "my-lib",
+            &["1.0.0".into(), "1.1.0".into()],
+            "1.1.0",
+            Some("1.1.0"),
+        );
+        assert!(parse_plugin_prefix_entries(&xml).is_empty());
+    }
+
+    #[test]
+    fn test_merge_plugin_prefix_metadata_union_dedup_by_prefix() {
+        let merged = merge_plugin_prefix_metadata(&[
+            PLUGIN_PREFIX_DOC_A.to_string(),
+            PLUGIN_PREFIX_DOC_B.to_string(),
+        ])
+        .unwrap();
+        // Single <plugins> block.
+        assert_eq!(merged.matches("<plugins>").count(), 1);
+        assert_eq!(merged.matches("</plugins>").count(), 1);
+        // Union of distinct prefixes from both members.
+        assert!(merged.contains("<prefix>compiler</prefix>"));
+        assert!(merged.contains("<prefix>deploy</prefix>"));
+        assert!(merged.contains("<prefix>versions</prefix>"));
+        assert!(merged.contains("<artifactId>maven-deploy-plugin</artifactId>"));
+        assert!(merged.contains("<artifactId>versions-maven-plugin</artifactId>"));
+        // Deduped by prefix, first-writer-wins: doc A's compiler entry kept,
+        // doc B's overlapping compiler entry dropped.
+        assert_eq!(merged.matches("<prefix>compiler</prefix>").count(), 1);
+        assert!(merged.contains("<artifactId>maven-compiler-plugin</artifactId>"));
+        assert!(!merged.contains("other-compiler-plugin"));
+        // First-writer-wins order: compiler (doc A) before versions (doc B).
+        assert!(
+            merged.find("<prefix>compiler</prefix>").unwrap()
+                < merged.find("<prefix>versions</prefix>").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_merge_plugin_prefix_metadata_none_for_no_plugins() {
+        assert!(merge_plugin_prefix_metadata(&[]).is_none());
+        let versions_doc = generate_metadata_xml(
+            "com.example",
+            "my-lib",
+            &["1.0.0".into()],
+            "1.0.0",
+            Some("1.0.0"),
+        );
+        assert!(merge_plugin_prefix_metadata(&[versions_doc, "<metadata/>".to_string()]).is_none());
+    }
+
+    #[test]
+    fn test_merge_plugin_prefix_metadata_escapes_ampersand() {
+        let doc = r#"<metadata>
+  <plugins>
+    <plugin>
+      <name>Build &amp; Release Plugin</name>
+      <prefix>build</prefix>
+      <artifactId>build-release-plugin</artifactId>
+    </plugin>
+  </plugins>
+</metadata>
+"#
+        .to_string();
+        let entries = parse_plugin_prefix_entries(&doc);
+        assert_eq!(entries[0].name.as_deref(), Some("Build & Release Plugin"));
+        let merged = merge_plugin_prefix_metadata(&[doc]).unwrap();
+        assert!(merged.contains("<name>Build &amp; Release Plugin</name>"));
+        assert!(!merged.contains("& Release"));
     }
 }


### PR DESCRIPTION
## Summary

Virtual Maven repositories returned 404 for group-level plugin-prefix metadata
(e.g. `org/apache/maven/plugins/maven-metadata.xml`), which breaks
`mvn <prefix>:<goal>` resolution (such as `mvn versions:display-dependency-updates`)
when the client resolves plugins through a virtual repository. The same path
served fine through a plain remote repository, which raw-proxies the upstream
bytes.

Root cause: a group-level plugin-prefix path matches `parse_metadata_path`
(`groupId=org.apache.maven`, `artifactId=plugins`) and enters the virtual
version-merge loop in `backend/src/api/handlers/maven.rs`, which only extracts
`<versions>` entries. Plugin-prefix metadata carries `<plugins><plugin>`
entries and no `<versions>` block, so the merged version list stays empty and
the request falls through to the catch-all "Metadata not found" 404.

This PR makes virtual repositories merge and serve group-level plugin-prefix
metadata from their members:

- `backend/src/formats/maven.rs`: new pure helpers
  `parse_plugin_prefix_entries` (extracts `<plugin>` name/prefix/artifactId
  entries; returns empty for version-style metadata) and
  `merge_plugin_prefix_metadata` (unions entries across member documents,
  deduped by `<prefix>` with first-writer-wins order; returns `None` when no
  document contributes a plugin entry so callers keep their not-found
  behavior). `parse_metadata_versions` is intentionally untouched to keep its
  other callers unaffected.
- `backend/src/api/handlers/maven.rs`: in the virtual metadata branch, after
  the version merge produces nothing for a `parse_metadata_path`-matched path,
  collect each member's plugin-prefix metadata (stored file first, upstream
  proxy for remote members) and return the merged document. Artifact-level
  and SNAPSHOT version-level virtual metadata paths return earlier or get
  `None` from the merge, so they are unchanged; genuinely missing metadata
  still 404s.

Verified locally against an isolated instance with a remote member proxying
`repo1.maven.org/maven2` and a virtual repo on top:

- `GET /maven/mv/org/apache/maven/plugins/maven-metadata.xml` → 200 (was 404),
  body contains a `<plugins>` block including `maven-compiler-plugin`
- `GET /maven/mv/org/codehaus/mojo/maven-metadata.xml` → 200 (was 404)
- Regression: `GET /maven/mv/org/apache/commons/commons-lang3/maven-metadata.xml`
  → still 200 with a `<versions>` block
- Direct member unchanged: `GET /maven/mr/org/apache/maven/plugins/maven-metadata.xml` → 200

Closes #1595

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
