### PR TITLE
fix(auth): preserve 503 ServiceUnavailable on the API-token auth branch under bcrypt saturation

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -480,14 +480,19 @@ pub async fn auth_middleware(
                 }
                 Err(_) => match validate_api_token_with_scopes(&auth_service, token).await {
                     Ok(ext) => Ok((ext, None)),
-                    Err(_) => Err("Invalid or expired token"),
+                    // Same transient bcrypt-capacity shed as the Basic branch
+                    // below: a saturated cap is "retry shortly", not "wrong
+                    // token". See `TokenAuthError::Overloaded`.
+                    Err(TokenAuthError::Overloaded) => return service_unavailable_response(),
+                    Err(TokenAuthError::Invalid) => Err("Invalid or expired token"),
                 },
             }
         }
         ExtractedToken::ApiKey(token) => {
             match validate_api_token_with_scopes(&auth_service, token).await {
                 Ok(ext) => Ok((ext, None)),
-                Err(_) => Err("Invalid or expired API token"),
+                Err(TokenAuthError::Overloaded) => return service_unavailable_response(),
+                Err(TokenAuthError::Invalid) => Err("Invalid or expired API token"),
             }
         }
         ExtractedToken::Basic(encoded) => match decode_basic_credentials(encoded) {
@@ -596,15 +601,48 @@ pub async fn auth_middleware(
     (StatusCode::UNAUTHORIZED, message).into_response()
 }
 
+/// Why an API-token validation attempt did not produce an [`AuthExtension`].
+///
+/// Two outcomes matter to the middleware: the token is genuinely bad
+/// (unknown, expired, revoked, deactivated owner — answer with 401), or
+/// validation could not be completed because the process-wide bcrypt
+/// concurrency cap is saturated (`AppError::ServiceUnavailable` from
+/// `auth_service::acquire_auth_permit_for_bcrypt` — answer with a retryable
+/// 503, exactly like the username/password branch). Flattening both into a
+/// unit error is what made cargo/twine API-token clients receive a spurious
+/// 401 under a concurrent burst; they retry on 503 but abort on 401.
+#[derive(Debug, PartialEq, Eq)]
+enum TokenAuthError {
+    /// The credential failed validation; the caller owes the client a 401.
+    Invalid,
+    /// The bcrypt-bound auth-concurrency cap is saturated; the caller must
+    /// surface a retryable 503 (see [`service_unavailable_response`]), never
+    /// a 401.
+    Overloaded,
+}
+
+/// Classify a `validate_api_token` error into the two outcomes the
+/// middleware distinguishes. Only the transient bcrypt-capacity shed
+/// (`AppError::ServiceUnavailable`) maps to [`TokenAuthError::Overloaded`];
+/// everything else (authentication, unauthorized, database, internal) is a
+/// genuine validation failure and stays [`TokenAuthError::Invalid`] so the
+/// existing 401 behaviour is preserved.
+fn classify_token_validation_err(err: AppError) -> TokenAuthError {
+    match err {
+        AppError::ServiceUnavailable(_) => TokenAuthError::Overloaded,
+        _ => TokenAuthError::Invalid,
+    }
+}
+
 /// Validate an API token and create an AuthExtension with scopes and repo restrictions.
 async fn validate_api_token_with_scopes(
     auth_service: &AuthService,
     token: &str,
-) -> Result<AuthExtension, ()> {
+) -> Result<AuthExtension, TokenAuthError> {
     let validation = auth_service
         .validate_api_token(token)
         .await
-        .map_err(|_| ())?;
+        .map_err(classify_token_validation_err)?;
 
     Ok(AuthExtension {
         user_id: validation.user.id,
@@ -706,8 +744,12 @@ pub(crate) async fn try_resolve_auth_outcome(
             if let Ok(claims) = auth_service.validate_access_token_async(token).await {
                 return AuthOutcome::Resolved(AuthExtension::from(claims));
             }
-            if let Ok(ext) = validate_api_token_with_scopes(auth_service, token).await {
-                return AuthOutcome::Resolved(ext);
+            match validate_api_token_with_scopes(auth_service, token).await {
+                Ok(ext) => return AuthOutcome::Resolved(ext),
+                // A transient bcrypt-capacity shed must surface as 503, not
+                // 401. See `AuthOutcome::Overloaded`.
+                Err(TokenAuthError::Overloaded) => return AuthOutcome::Overloaded,
+                Err(TokenAuthError::Invalid) => {}
             }
             // Some package managers (npm, cargo, goproxy) send Bearer tokens
             // that are base64-encoded `username:password` rather than JWTs or
@@ -726,7 +768,10 @@ pub(crate) async fn try_resolve_auth_outcome(
         ExtractedToken::ApiKey(token) => {
             match validate_api_token_with_scopes(auth_service, token).await {
                 Ok(ext) => AuthOutcome::Resolved(ext),
-                Err(()) => AuthOutcome::InvalidCredential,
+                // See `AuthOutcome::Overloaded`: saturated bcrypt cap is a
+                // retryable 503, never a 401.
+                Err(TokenAuthError::Overloaded) => AuthOutcome::Overloaded,
+                Err(TokenAuthError::Invalid) => AuthOutcome::InvalidCredential,
             }
         }
         ExtractedToken::Basic(encoded) => {
@@ -748,7 +793,12 @@ pub(crate) async fn try_resolve_auth_outcome(
             // pip netrc / Artifactory-style `token:<api_token>` credential format
             match validate_api_token_with_scopes(auth_service, &password).await {
                 Ok(ext) => AuthOutcome::Resolved(ext),
-                Err(()) => AuthOutcome::InvalidCredential,
+                // The token fallback also burns a bcrypt verify under the
+                // same process-wide cap; preserve the shed as Overloaded so
+                // pip-netrc-style `token:<api_token>` clients get the
+                // retryable 503, not a spurious 401.
+                Err(TokenAuthError::Overloaded) => AuthOutcome::Overloaded,
+                Err(TokenAuthError::Invalid) => AuthOutcome::InvalidCredential,
             }
         }
         ExtractedToken::None => AuthOutcome::NoCredential,
@@ -1057,7 +1107,10 @@ pub async fn admin_middleware(
                 Ok(claims) => AuthExtension::from(claims),
                 Err(_) => match validate_api_token_with_scopes(&auth_service, token).await {
                     Ok(ext) => ext,
-                    Err(_) => {
+                    // A saturated bcrypt cap is a retryable 503, never a 401.
+                    // See `TokenAuthError::Overloaded`.
+                    Err(TokenAuthError::Overloaded) => return service_unavailable_response(),
+                    Err(TokenAuthError::Invalid) => {
                         return (StatusCode::UNAUTHORIZED, "Invalid or expired token")
                             .into_response()
                     }
@@ -1067,7 +1120,8 @@ pub async fn admin_middleware(
         ExtractedToken::ApiKey(token) => {
             match validate_api_token_with_scopes(&auth_service, token).await {
                 Ok(ext) => ext,
-                Err(_) => {
+                Err(TokenAuthError::Overloaded) => return service_unavailable_response(),
+                Err(TokenAuthError::Invalid) => {
                     return (StatusCode::UNAUTHORIZED, "Invalid or expired API token")
                         .into_response()
                 }
@@ -3573,6 +3627,41 @@ mod tests {
                 .and_then(|v| v.to_str().ok()),
             Some("1")
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // classify_token_validation_err: the API-token branch must preserve the
+    // bcrypt-capacity shed (`AppError::ServiceUnavailable`) as Overloaded so
+    // every token call site surfaces a retryable 503, while every other
+    // validation failure stays Invalid (401). This mapping is what stops a
+    // saturated auth cap from being misreported to cargo/twine/pip API-token
+    // clients as "invalid credentials".
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_classify_token_validation_err_service_unavailable_is_overloaded() {
+        assert_eq!(
+            classify_token_validation_err(AppError::ServiceUnavailable(
+                "Authentication service is at capacity, retry shortly".to_string()
+            )),
+            TokenAuthError::Overloaded
+        );
+    }
+
+    #[test]
+    fn test_classify_token_validation_err_genuine_failures_stay_invalid() {
+        // Genuinely bad tokens (unknown, expired, revoked, deactivated owner)
+        // and infrastructure errors must keep producing 401 from the token
+        // call sites — only the transient capacity shed maps to Overloaded.
+        for err in [
+            AppError::Authentication("Invalid API token".to_string()),
+            AppError::Authentication("API token expired".to_string()),
+            AppError::Unauthorized("Token has been revoked".to_string()),
+            AppError::Database("connection refused".to_string()),
+            AppError::Internal("bcrypt failure".to_string()),
+        ] {
+            assert_eq!(classify_token_validation_err(err), TokenAuthError::Invalid);
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The bcrypt-bound auth-concurrency cap (`auth_service::acquire_auth_permit_for_bcrypt`) sheds load by returning `AppError::ServiceUnavailable` — a transient, retryable signal — when too many credential verifications run concurrently. The username/password branch already surfaces that shed correctly as `503 Service Unavailable` with `Retry-After: 1`, so well-behaved clients back off and retry instead of treating it as a credential failure.

The **API-token** branch did not. `validate_api_token_with_scopes` returned `Result<AuthExtension, ()>` and flattened every error — including `ServiceUnavailable` — into a unit `()`. As a result, all seven token call sites (Bearer-as-API-token and ApiKey in `auth_middleware`, the same two plus the `Basic user:token` fallback in `try_resolve_auth_outcome`, and the Bearer/ApiKey arms of `admin_middleware`) misreported a saturated cap as `401 Unauthorized`. Under a concurrent burst, API-token clients (cargo index lookups, twine, pip with a `token:<api_token>` netrc entry, `ApiKey`/`X-API-Key`) received a spurious `401` and aborted — those clients retry on `503` but not on `401`.

This change propagates the overload signal on the API-token branch so it behaves like the already-correct password branch:

- Introduce a private two-variant enum `TokenAuthError { Invalid, Overloaded }` and a small pure helper `classify_token_validation_err(AppError) -> TokenAuthError` that maps `AppError::ServiceUnavailable` to `Overloaded` and everything else (authentication, unauthorized, database, internal) to `Invalid`.
- Change `validate_api_token_with_scopes` to return `Result<AuthExtension, TokenAuthError>`.
- Update all seven call sites to route `Overloaded` to the existing 503 path (`service_unavailable_response()` in `auth_middleware`/`admin_middleware`, `AuthOutcome::Overloaded` in `try_resolve_auth_outcome`) while `Invalid` keeps the existing `401`.

The exhaustive match forces every token call site to distinguish a transient shed from a genuine bad credential, so the contract is self-documenting and cannot silently regress. `optional_auth_middleware` and both `repo_visibility_middleware` branches already handle `AuthOutcome::Overloaded`; they self-correct once `try_resolve_auth_outcome` emits it and need no change.

Genuine invalid / expired / revoked / deactivated API tokens still return `401`, valid API-token auth still returns `200`, and no DB migration or data change is involved. Single file touched: `backend/src/api/middleware/auth.rs`.

Refs #1839.

Follow-up (out of scope here, noted for tracking): `admin_middleware`'s `Basic` arm and `require_auth_with_bearer_fallback` still flatten `authenticate()`'s `ServiceUnavailable` into `401` on the username/password path. Those are a separate branch from the API-token path this PR targets and should be addressed in a follow-up.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New/updated unit tests in `backend/src/api/middleware/auth.rs`:
- `test_classify_token_validation_err_service_unavailable_is_overloaded` — the bcrypt-capacity shed maps to `Overloaded` (the bug: it was discarded).
- `test_classify_token_validation_err_genuine_failures_stay_invalid` — authentication/unauthorized/database/internal errors stay `Invalid` so genuine bad tokens still produce `401`.
- Existing `test_service_unavailable_response_is_503_with_retry_after`, the bad-ApiKey / unparseable-Basic 401 tests, and the `try_resolve_auth_outcome` tri-state tests remain green, pinning that genuine-invalid still returns `401`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
