### PR TITLE
fix(incus): honour HTTP Range on image download (resumable large-image downloads)

### DIFF
--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -22,7 +22,7 @@
 
 use axum::body::Body;
 use axum::extract::{DefaultBodyLimit, OriginalUri, Path as AxumPath, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::CONTENT_TYPE;
 use axum::http::{HeaderMap, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, patch, post};
@@ -719,6 +719,7 @@ async fn streams_images(
 
 async fn download_image(
     State(state): State<SharedState>,
+    headers: HeaderMap,
     AxumPath((repo_key, product, version, filename)): AxumPath<(String, String, String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
@@ -784,21 +785,34 @@ async fn download_image(
         }
     })?;
 
-    let content_type = content_type_for_download(&filename);
-    let body =
-        Body::from_stream(stream.map(|r| r.map_err(|e| std::io::Error::other(e.to_string()))));
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, content_type)
-        .header(CONTENT_LENGTH, size_bytes.to_string())
-        .header(
-            "Content-Disposition",
+    // Honour HTTP `Range` so large images are resumable, via the shared
+    // range-aware streaming helper that the generic artifact download uses
+    // (#1847). Previously this handler ignored `Range` and always returned a
+    // full `200`, so a dropped multi-GiB transfer could never resume.
+    let range_header = headers
+        .get(axum::http::header::RANGE)
+        .and_then(|v| v.to_str().ok());
+    let base_headers = vec![
+        (
+            CONTENT_TYPE,
+            content_type_for_download(&filename).to_string(),
+        ),
+        (
+            axum::http::header::CONTENT_DISPOSITION,
             format!("attachment; filename=\"{}\"", filename),
-        )
-        .header("X-Checksum-Sha256", checksum)
-        .body(body)
-        .unwrap())
+        ),
+        (
+            axum::http::header::HeaderName::from_static("x-checksum-sha256"),
+            checksum,
+        ),
+    ];
+    crate::api::handlers::repositories::ranged_stream_response(
+        range_header,
+        size_bytes.max(0) as u64,
+        stream,
+        base_headers,
+    )
+    .map_err(|e| e.into_response())
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3876,6 +3876,56 @@ fn slice_byte_stream(
     stream.boxed()
 }
 
+/// Build a range-aware streaming download response, shared by the generic
+/// artifact download and the format handlers (e.g. incus image download) so
+/// every streaming download path honours HTTP `Range` identically (#1847).
+///
+/// `base_headers` are applied to the `200` and `206` responses; `416` carries
+/// only `Accept-Ranges` and `Content-Range` (no body). The helper always
+/// advertises `Accept-Ranges: bytes`, so clients know they may resume.
+pub(crate) fn ranged_stream_response(
+    range_header: Option<&str>,
+    total: u64,
+    body: futures::stream::BoxStream<'static, Result<Bytes>>,
+    base_headers: Vec<(header::HeaderName, String)>,
+) -> Result<Response> {
+    let build_base = || {
+        let mut b = Response::builder().header(header::ACCEPT_RANGES, "bytes");
+        for (name, value) in &base_headers {
+            b = b.header(name.clone(), value.clone());
+        }
+        b
+    };
+    let mk_err =
+        |e: axum::http::Error| AppError::Internal(format!("failed to build response: {e}"));
+    let response = match parse_byte_range(range_header, total) {
+        RangeOutcome::Satisfiable { start, end } => {
+            let len = end - start + 1;
+            build_base()
+                .status(StatusCode::PARTIAL_CONTENT)
+                .header(header::CONTENT_LENGTH, len.to_string())
+                .header(
+                    header::CONTENT_RANGE,
+                    format!("bytes {}-{}/{}", start, end, total),
+                )
+                .body(Body::from_stream(slice_byte_stream(body, start, end)))
+                .map_err(mk_err)?
+        }
+        RangeOutcome::Unsatisfiable => Response::builder()
+            .status(StatusCode::RANGE_NOT_SATISFIABLE)
+            .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::CONTENT_RANGE, format!("bytes */{}", total))
+            .body(Body::empty())
+            .map_err(mk_err)?,
+        RangeOutcome::Full => build_base()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_LENGTH, total.to_string())
+            .body(Body::from_stream(body))
+            .map_err(mk_err)?,
+    };
+    Ok(response)
+}
+
 /// Download artifact
 #[utoipa::path(
     get,
@@ -4041,52 +4091,25 @@ pub async fn download_artifact(
             // blank-pads shorter values on read; trim before emitting so the
             // header carries the bare checksum.
 
-            let base = Response::builder()
-                .header(header::CONTENT_TYPE, artifact.content_type)
-                .header(
+            // Shared range-aware streaming (#1847): one primitive serves the
+            // 200 / 206 / 416 cases for both this generic path and the format
+            // handlers (e.g. incus image download).
+            let base_headers = vec![
+                (header::CONTENT_TYPE, artifact.content_type),
+                (
                     header::CONTENT_DISPOSITION,
                     format!("attachment; filename=\"{}\"", download_filename(&path)),
-                )
-                // Advertise byte-range support so clients (resumable downloads,
-                // media players) know they may issue `Range` requests.
-                .header(header::ACCEPT_RANGES, "bytes")
-                .header(
+                ),
+                (
                     header::HeaderName::from_static("x-checksum-sha256"),
                     checksum,
-                )
-                .header(header::HeaderName::from_static(X_ARTIFACT_STORAGE), "proxy");
-
-            let response = match parse_byte_range(range_header, total) {
-                RangeOutcome::Satisfiable { start, end } => {
-                    let len = end - start + 1;
-                    base.status(StatusCode::PARTIAL_CONTENT)
-                        .header(header::CONTENT_LENGTH, len.to_string())
-                        .header(
-                            header::CONTENT_RANGE,
-                            format!("bytes {}-{}/{}", start, end, total),
-                        )
-                        .body(Body::from_stream(slice_byte_stream(body, start, end)))
-                        .map_err(|e| {
-                            AppError::Internal(format!("failed to build response: {}", e))
-                        })?
-                }
-                RangeOutcome::Unsatisfiable => {
-                    // 416 must carry the resource size via Content-Range and no body.
-                    Response::builder()
-                        .status(StatusCode::RANGE_NOT_SATISFIABLE)
-                        .header(header::ACCEPT_RANGES, "bytes")
-                        .header(header::CONTENT_RANGE, format!("bytes */{}", total))
-                        .body(Body::empty())
-                        .map_err(|e| {
-                            AppError::Internal(format!("failed to build response: {}", e))
-                        })?
-                }
-                RangeOutcome::Full => base
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_LENGTH, total.to_string())
-                    .body(Body::from_stream(body))
-                    .map_err(|e| AppError::Internal(format!("failed to build response: {}", e)))?,
-            };
+                ),
+                (
+                    header::HeaderName::from_static(X_ARTIFACT_STORAGE),
+                    "proxy".to_string(),
+                ),
+            ];
+            let response = ranged_stream_response(range_header, total, body, base_headers)?;
             Ok(response)
         }
         Err(AppError::NotFound(_)) if repo.repo_type == RepositoryType::Remote => {

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -1156,3 +1156,133 @@ async fn test_chunked_upload_cross_repo_session_rejected() {
         .await
         .ok();
 }
+
+// ===========================================================================
+// Range support on download (#1847)
+//
+// The incus image download previously ignored HTTP `Range` and always returned
+// a full `200`, so a dropped multi-GiB transfer could never resume. It now
+// routes through the same range-aware streaming helper as the generic artifact
+// download: a `200` advertises `Accept-Ranges: bytes`, a satisfiable range
+// returns `206` + `Content-Range` + the sliced body, and an unsatisfiable range
+// returns `416`.
+// ===========================================================================
+
+#[tokio::test]
+#[ignore]
+async fn test_incus_download_honours_range() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("incus-range-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "testpass123").await;
+    let (repo_id, storage_path) = create_incus_repo(&pool, "range-test").await;
+    let key = repo_key(&pool, repo_id).await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+
+    let data = test_data(4096);
+    let sha = sha256_hex(&data);
+
+    // Stage the artifact directly (row + stored bytes) so the test isolates the
+    // *download* path rather than exercising the async upload/finalize flow.
+    let repo =
+        artifact_keeper_backend::services::repository_service::RepositoryService::new(pool.clone())
+            .get_by_id(repo_id)
+            .await
+            .unwrap();
+    let storage = state.storage_for_repo(&repo.storage_location()).unwrap();
+    let storage_key = format!("range-test/{}", Uuid::new_v4());
+    storage
+        .put(&storage_key, bytes::Bytes::from(data.clone()))
+        .await
+        .unwrap();
+    sqlx::query(
+        "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by) \
+         VALUES ($1, 'ubuntu/24.04/rootfs.tar.xz', 'rootfs', '24.04', $2, $3, 'application/x-xz', $4, $5)",
+    )
+    .bind(repo_id)
+    .bind(data.len() as i64)
+    .bind(&sha)
+    .bind(&storage_key)
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .expect("insert artifact row");
+
+    let dl_uri = format!("/{}/images/ubuntu/24.04/rootfs.tar.xz", key);
+
+    // (a) No Range -> 200 and Accept-Ranges advertised (regression: was absent).
+    let resp = incus::router()
+        .with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&dl_uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("accept-ranges")
+            .and_then(|v| v.to_str().ok()),
+        Some("bytes"),
+        "200 response must advertise Accept-Ranges: bytes"
+    );
+
+    // (b) bytes=0-1023 -> 206, Content-Range, and exactly the first 1024 bytes.
+    let resp = incus::router()
+        .with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&dl_uri)
+                .header("Range", "bytes=0-1023")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::PARTIAL_CONTENT,
+        "ranged GET must return 206 Partial Content"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("content-range")
+            .and_then(|v| v.to_str().ok()),
+        Some("bytes 0-1023/4096")
+    );
+    let part = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .unwrap();
+    assert_eq!(part.len(), 1024);
+    assert_eq!(&part[..], &data[0..1024]);
+
+    // (c) Unsatisfiable range -> 416 + Content-Range: bytes */<total>.
+    let resp = incus::router()
+        .with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&dl_uri)
+                .header("Range", "bytes=999999-")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    assert_eq!(
+        resp.headers()
+            .get("content-range")
+            .and_then(|v| v.to_str().ok()),
+        Some("bytes */4096")
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}


### PR DESCRIPTION
## Summary

The incus image download handler (`download_image`,
`backend/src/api/handlers/incus.rs`) ignored the request's HTTP `Range` header and
always returned a full `200 OK` with no `Accept-Ranges`, so a client whose
connection dropped partway through a multi-GiB image (behind a load balancer /
gateway timeout) could never resume — every retry restarted at byte 0. The
generic artifact download (`download_artifact`) gained full RFC 7233 range support
in #1785, but it was never carried over to the incus handler.

This extracts a shared `ranged_stream_response` helper and routes **both**
`download_image` and `download_artifact`'s streaming branch through it:

- `200 OK` now advertises `Accept-Ranges: bytes`,
- a satisfiable range returns `206 Partial Content` + `Content-Range` + the sliced body,
- an unsatisfiable range returns `416 Range Not Satisfiable` + `Content-Range: bytes */<total>`.

The previously-duplicated 200/206/416 block in `download_artifact` is collapsed
into the helper.

## Regression test (required for `fix/*` PRs)

`tests/incus_upload_tests::test_incus_download_honours_range` (DB-backed,
`--ignored`): against a staged incus image, a `Range: bytes=0-1023` GET returns
`206` with `Content-Range: bytes 0-1023/4096` and exactly the first 1024 bytes; a
no-range GET returns `200` with `Accept-Ranges: bytes`; an unsatisfiable range
returns `416` with `Content-Range: bytes */4096`. Verified **failing on `main`**
(the `200` path lacked `Accept-Ranges`) and **passing** with this change.

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (local Postgres; also confirmed pre-fix against a deployed instance: a `Range: bytes=0-1023` GET of a multi-GiB image returned `200` with the full `Content-Length`)
- [x] No regressions in existing tests (range unit tests + existing incus upload tests pass; clippy clean)

## API Changes
- [x] N/A — no API changes (adds `Range` handling + `Accept-Ranges` to an existing endpoint; full `200` responses are unchanged for clients that don't send `Range`)

Closes #1847
