### PR TITLE
fix: replicate hosted PyPI packages to peers

### DIFF
--- a/backend/migrations/134_upload_session_replication_flag.sql
+++ b/backend/migrations/134_upload_session_replication_flag.sql
@@ -1,0 +1,23 @@
+-- Mark upload sessions created by peer replication.
+--
+-- The generic resumable upload API is also used by inter-peer replication.
+-- Keeping this flag lets retry/recovery cleanup remove only replication-owned
+-- leftovers without touching ordinary client resumable uploads.
+
+ALTER TABLE upload_sessions
+    ADD COLUMN IF NOT EXISTS is_replication BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE upload_sessions
+SET is_replication = true
+WHERE is_replication = false
+  AND (
+      artifact_metadata_format IS NOT NULL
+      OR artifact_metadata IS NOT NULL
+      OR artifact_metadata_properties IS NOT NULL
+      OR package_description IS NOT NULL
+      OR package_metadata IS NOT NULL
+  );
+
+CREATE INDEX IF NOT EXISTS idx_upload_sessions_replication_path
+    ON upload_sessions (repository_id, artifact_path)
+    WHERE is_replication = true;

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1569,6 +1569,7 @@ async fn upload(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(repo_key): Path<String>,
+    headers: HeaderMap,
     mut multipart: Multipart,
 ) -> Result<Response, Response> {
     // Authenticate
@@ -1717,21 +1718,12 @@ async fn upload(
         return Err(AppError::Conflict("File already exists".to_string()).into_response());
     }
 
-    // Store the file
-    let storage_key = format!("pypi/{}/{}/{}", normalized, pkg_version, filename);
-    let storage = state
-        .storage_for_repo(&repo.storage_location())
-        .map_err(|e| e.into_response())?;
-    storage
-        .put(&storage_key, content.clone())
-        .await
-        .map_err(map_storage_err)?;
-
     // Build metadata JSON
     let mut pkg_metadata = serde_json::json!({
-        "name": pkg_name,
-        "version": pkg_version,
-        "filename": filename,
+        "name": &pkg_name,
+        "normalized_name": &normalized,
+        "version": &pkg_version,
+        "filename": &filename,
     });
     if let Some(rp) = &requires_python {
         pkg_metadata["pkg_info"] = serde_json::json!({
@@ -1739,10 +1731,15 @@ async fn upload(
         });
     }
     if let Some(s) = &summary {
-        pkg_metadata["pkg_info"]
-            .as_object_mut()
-            .get_or_insert(&mut serde_json::Map::new())
-            .insert("summary".to_string(), serde_json::Value::String(s.clone()));
+        if !pkg_metadata["pkg_info"].is_object() {
+            pkg_metadata["pkg_info"] = serde_json::json!({});
+        }
+        if let Some(pkg_info) = pkg_metadata["pkg_info"].as_object_mut() {
+            pkg_info.insert("summary".to_string(), serde_json::Value::String(s.clone()));
+        }
+    }
+    if !metadata_fields.is_empty() {
+        pkg_metadata["upload_metadata"] = serde_json::Value::Object(metadata_fields);
     }
 
     let content_type = pypi_content_type(&filename);
@@ -1752,42 +1749,28 @@ async fn upload(
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
 
-    // Insert artifact record
-    let artifact_id = sqlx::query_scalar!(
-        r#"
-        INSERT INTO artifacts (
-            repository_id, path, name, version, size_bytes,
-            checksum_sha256, content_type, storage_key, uploaded_by
+    let storage = state
+        .storage_for_repo(&repo.storage_location())
+        .map_err(|e| e.into_response())?;
+    let artifact_service = state.create_artifact_service(storage);
+    let artifact = artifact_service
+        .upload_with_sync_options(
+            repo.id,
+            &artifact_path,
+            &normalized,
+            Some(&pkg_version),
+            content_type,
+            content,
+            Some(user_id),
+            should_enqueue_pypi_sync_tasks(&headers),
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-        RETURNING id
-        "#,
-        repo.id,
-        artifact_path,
-        normalized,
-        pkg_version,
-        size_bytes,
-        computed_sha256,
-        content_type,
-        storage_key,
-        user_id,
-    )
-    .fetch_one(&state.db)
-    .await
-    .map_err(map_db_err)?;
+        .await
+        .map_err(|e| e.into_response())?;
 
-    // Store metadata
-    let _ = sqlx::query!(
-        r#"
-        INSERT INTO artifact_metadata (artifact_id, format, metadata)
-        VALUES ($1, 'pypi', $2)
-        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2
-        "#,
-        artifact_id,
-        pkg_metadata,
-    )
-    .execute(&state.db)
-    .await;
+    artifact_service
+        .set_metadata(artifact.id, "pypi", pkg_metadata, serde_json::json!({}))
+        .await
+        .map_err(|e| e.into_response())?;
 
     // Update repository timestamp
     let _ = sqlx::query!(
@@ -1806,9 +1789,12 @@ async fn upload(
                 &normalized,
                 &pkg_version,
                 size_bytes,
-                &computed_sha256,
+                &artifact.checksum_sha256,
                 summary.as_deref(),
-                Some(serde_json::json!({ "format": "pypi" })),
+                Some(build_pypi_package_catalog_metadata(
+                    &filename,
+                    requires_python.as_deref(),
+                )),
             )
             .await;
     }
@@ -1827,6 +1813,24 @@ async fn upload(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+fn should_enqueue_pypi_sync_tasks(headers: &HeaderMap) -> bool {
+    !super::is_replication_request(headers)
+}
+
+fn build_pypi_package_catalog_metadata(
+    filename: &str,
+    requires_python: Option<&str>,
+) -> serde_json::Value {
+    let mut metadata = serde_json::json!({
+        "format": "pypi",
+        "filename": filename,
+    });
+    if let Some(rp) = requires_python.filter(|value| !value.trim().is_empty()) {
+        metadata["requires_python"] = serde_json::Value::String(rp.to_string());
+    }
+    metadata
+}
 
 /// Determine the Content-Type for a PyPI filename based on its extension.
 fn pypi_content_type(filename: &str) -> &'static str {
@@ -1992,6 +1996,65 @@ fn rewrite_upstream_urls(html: &str, repo_key: &str, project: &str) -> String {
 mod tests {
     use super::*;
 
+    fn headers_with_replication(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-artifact-keeper-replication",
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        headers
+    }
+
+    fn pypi_upload_multipart(
+        project: &str,
+        version: &str,
+        filename: &str,
+        content: &[u8],
+        summary: &str,
+        requires_python: &str,
+    ) -> (String, Bytes) {
+        let mut hasher = Sha256::new();
+        hasher.update(content);
+        let sha256 = format!("{:x}", hasher.finalize());
+        let boundary = format!("ak-pypi-test-{}", project.replace('-', "_"));
+        let fields = [
+            (":action", "file_upload"),
+            ("protocol_version", "1"),
+            ("metadata_version", "2.1"),
+            ("name", project),
+            ("version", version),
+            ("summary", summary),
+            ("sha256_digest", sha256.as_str()),
+            ("filetype", "bdist_wheel"),
+            ("pyversion", "py3"),
+            ("requires_python", requires_python),
+        ];
+        let mut body = Vec::new();
+        for (name, value) in fields {
+            body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+            body.extend_from_slice(
+                format!("Content-Disposition: form-data; name=\"{name}\"\r\n\r\n").as_bytes(),
+            );
+            body.extend_from_slice(value.as_bytes());
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!(
+                "Content-Disposition: form-data; name=\"content\"; filename=\"{filename}\"\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: application/zip\r\n\r\n");
+        body.extend_from_slice(content);
+        body.extend_from_slice(b"\r\n");
+        body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+        (
+            format!("multipart/form-data; boundary={boundary}"),
+            Bytes::from(body),
+        )
+    }
+
     // -----------------------------------------------------------------------
     // pypi_upstream_url_and_path (#1130)
     // -----------------------------------------------------------------------
@@ -2048,6 +2111,18 @@ mod tests {
         let (url, path) = pypi_upstream_url_and_path("/simple/", "flask/");
         assert_eq!(url, "/");
         assert_eq!(path, "simple/flask/");
+    }
+
+    #[test]
+    fn test_should_enqueue_pypi_sync_tasks_for_direct_upload() {
+        assert!(should_enqueue_pypi_sync_tasks(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn test_should_enqueue_pypi_sync_tasks_skips_peer_replication() {
+        assert!(!should_enqueue_pypi_sync_tasks(&headers_with_replication(
+            "true"
+        )));
     }
 
     #[test]
@@ -3417,6 +3492,201 @@ mod tests {
         );
 
         cleanup().await;
+    }
+
+    #[tokio::test]
+    async fn pypi_upload_queues_sync_tasks_and_preserves_replication_metadata() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::peer_instance_service::{
+            PeerInstanceService, RegisterPeerInstanceRequest, ReplicationMode,
+        };
+
+        async fn sync_task_count(pool: &sqlx::PgPool, repo_id: uuid::Uuid, path: &str) -> i64 {
+            sqlx::query_scalar::<_, i64>(
+                r#"
+                SELECT COUNT(*)
+                FROM sync_tasks st
+                JOIN artifacts a ON a.id = st.artifact_id
+                WHERE a.repository_id = $1
+                  AND a.path = $2
+                "#,
+            )
+            .bind(repo_id)
+            .bind(path)
+            .fetch_one(pool)
+            .await
+            .expect("count sync tasks")
+        }
+
+        async fn wait_for_sync_task_count(
+            pool: &sqlx::PgPool,
+            repo_id: uuid::Uuid,
+            path: &str,
+            expected: i64,
+        ) -> i64 {
+            for _ in 0..40 {
+                let count = sync_task_count(pool, repo_id, path).await;
+                if count == expected {
+                    return count;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+            }
+            sync_task_count(pool, repo_id, path).await
+        }
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let peer_service = PeerInstanceService::new(fx.pool.clone());
+        let peer = peer_service
+            .register(RegisterPeerInstanceRequest {
+                name: format!("pypi-repl-peer-{}", fx.repo_id),
+                endpoint_url: "https://peer.example.test".to_string(),
+                region: None,
+                cache_size_bytes: 1024 * 1024,
+                sync_filter: None,
+                api_key: "peer-key".to_string(),
+            })
+            .await
+            .expect("register test peer");
+        peer_service
+            .assign_repository(
+                peer.id,
+                fx.repo_id,
+                true,
+                Some(ReplicationMode::Mirror),
+                None,
+                None,
+            )
+            .await
+            .expect("assign repo to peer");
+
+        let project = "ak-pypi-replication-smoke";
+        let version = "0.1.0";
+        let filename = "ak_pypi_replication_smoke-0.1.0-py3-none-any.whl";
+        let artifact_path = format!("{project}/{version}/{filename}");
+        let payload = b"fake-wheel-bytes-for-replication";
+        let (content_type, body) = pypi_upload_multipart(
+            project,
+            version,
+            filename,
+            payload,
+            "PyPI peer replication smoke package",
+            ">=3.8",
+        );
+        let app = fx.router_with_auth(super::router());
+        let req = tdh::post(format!("/{}/", fx.repo_key), &content_type, body);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "PyPI upload must succeed; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        assert_eq!(
+            wait_for_sync_task_count(&fx.pool, fx.repo_id, &artifact_path, 1).await,
+            1,
+            "direct PyPI upload must queue exactly one peer sync task"
+        );
+
+        let metadata: (String, serde_json::Value) = sqlx::query_as(
+            r#"
+            SELECT am.format, am.metadata
+            FROM artifact_metadata am
+            JOIN artifacts a ON a.id = am.artifact_id
+            WHERE a.repository_id = $1
+              AND a.path = $2
+            "#,
+        )
+        .bind(fx.repo_id)
+        .bind(&artifact_path)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("query PyPI artifact metadata");
+        assert_eq!(metadata.0, "pypi");
+        assert_eq!(metadata.1["filename"], filename);
+        assert_eq!(metadata.1["pkg_info"]["requires_python"], ">=3.8");
+        assert_eq!(
+            metadata.1["pkg_info"]["summary"],
+            "PyPI peer replication smoke package"
+        );
+        assert_eq!(metadata.1["upload_metadata"]["metadata_version"], "2.1");
+
+        let package: (Option<String>, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT description, metadata FROM packages WHERE repository_id = $1 AND name = $2",
+        )
+        .bind(fx.repo_id)
+        .bind(project)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("query package catalog row");
+        assert_eq!(
+            package.0.as_deref(),
+            Some("PyPI peer replication smoke package")
+        );
+        let package_metadata = package.1.expect("package metadata");
+        assert_eq!(package_metadata["format"], "pypi");
+        assert_eq!(package_metadata["filename"], filename);
+        assert_eq!(package_metadata["requires_python"], ">=3.8");
+
+        let version_rows: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM package_versions pv
+            JOIN packages p ON p.id = pv.package_id
+            WHERE p.repository_id = $1
+              AND p.name = $2
+              AND pv.version = $3
+            "#,
+        )
+        .bind(fx.repo_id)
+        .bind(project)
+        .bind(version)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("query package version row");
+        assert_eq!(version_rows, 1);
+
+        let replicated_project = "ak-pypi-replication-incoming";
+        let replicated_version = "0.2.0";
+        let replicated_filename = "ak_pypi_replication_incoming-0.2.0-py3-none-any.whl";
+        let replicated_path =
+            format!("{replicated_project}/{replicated_version}/{replicated_filename}");
+        let (content_type, body) = pypi_upload_multipart(
+            replicated_project,
+            replicated_version,
+            replicated_filename,
+            b"incoming-replication-wheel",
+            "Incoming replicated PyPI package",
+            ">=3.9",
+        );
+        let app = fx.router_with_auth(super::router());
+        let mut req = tdh::post(format!("/{}/", fx.repo_key), &content_type, body);
+        req.headers_mut().insert(
+            "x-artifact-keeper-replication",
+            axum::http::HeaderValue::from_static("true"),
+        );
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "replication-marked PyPI upload must persist; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(
+            sync_task_count(&fx.pool, fx.repo_id, &replicated_path).await,
+            0,
+            "incoming peer replication writes must not requeue back to peers"
+        );
+
+        let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+            .bind(peer.id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -258,7 +258,12 @@ async fn create_session(
         ));
     }
 
+    let is_replication = super::is_replication_request(&headers);
     let replication_metadata = replication_session_metadata_from_request(&headers, &req);
+
+    if is_replication {
+        cleanup_stale_replication_upload_sessions(&state.db, repo.0, &req.artifact_path).await;
+    }
 
     let session = UploadService::create_session(upload_service::CreateSessionParams {
         db: &state.db,
@@ -274,6 +279,7 @@ async fn create_session(
         artifact_metadata_properties: replication_metadata.artifact_metadata_properties,
         package_description: replication_metadata.package_description,
         package_metadata: replication_metadata.package_metadata,
+        is_replication,
         total_size: req.total_size,
         chunk_size: req.chunk_size,
         checksum_sha256: &req.checksum_sha256,
@@ -465,9 +471,11 @@ async fn get_session_status(
 async fn complete(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
+    headers: HeaderMap,
     Path(session_id): Path<Uuid>,
 ) -> Result<Response, Response> {
     let user_id = auth.user_id;
+    let is_replication_request = super::is_replication_request(&headers);
 
     // C3: Verify user owns this session
     let session = UploadService::complete_session(&state.db, session_id, user_id)
@@ -574,6 +582,10 @@ async fn complete(
         session.total_size,
         &session.checksum_sha256[..12.min(session.checksum_sha256.len())]
     );
+
+    if is_replication_request || session.is_replication {
+        cleanup_completed_upload_session(&state.db, session_id).await;
+    }
 
     Ok(Json(CompleteResponse {
         artifact_id,
@@ -709,6 +721,71 @@ fn completed_package_metadata(
     session: &upload_service::UploadSession,
 ) -> Option<serde_json::Value> {
     session.package_metadata.clone()
+}
+
+async fn cleanup_completed_upload_session(db: &sqlx::PgPool, session_id: Uuid) {
+    match sqlx::query("DELETE FROM upload_sessions WHERE id = $1 AND status = 'completed'")
+        .bind(session_id)
+        .execute(db)
+        .await
+    {
+        Ok(result) if result.rows_affected() == 0 => {
+            tracing::warn!(
+                %session_id,
+                "Completed upload session cleanup did not remove a row"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(
+                %session_id,
+                error = %e,
+                "Failed to clean up completed upload session"
+            );
+        }
+    }
+}
+
+async fn cleanup_stale_replication_upload_sessions(
+    db: &sqlx::PgPool,
+    repository_id: Uuid,
+    artifact_path: &str,
+) {
+    let stale = match sqlx::query_as::<_, (Uuid, String)>(
+        r#"
+        DELETE FROM upload_sessions
+        WHERE repository_id = $1
+          AND artifact_path = $2
+          AND is_replication = true
+        RETURNING id, temp_file_path
+        "#,
+    )
+    .bind(repository_id)
+    .bind(artifact_path)
+    .fetch_all(db)
+    .await
+    {
+        Ok(stale) => stale,
+        Err(e) => {
+            tracing::warn!(
+                %repository_id,
+                artifact_path = %artifact_path,
+                error = %e,
+                "Failed to clean up stale replication upload sessions"
+            );
+            return;
+        }
+    };
+
+    for (session_id, temp_file_path) in &stale {
+        let _ = tokio::fs::remove_file(temp_file_path).await;
+        tracing::info!(
+            %session_id,
+            %repository_id,
+            artifact_path = %artifact_path,
+            "Removed stale replication upload session before retry"
+        );
+    }
 }
 
 struct ReplicationSessionMetadata<'a> {
@@ -889,6 +966,7 @@ mod tests {
             artifact_metadata_properties: None,
             package_description: None,
             package_metadata: None,
+            is_replication: false,
             content_type: "application/octet-stream".to_string(),
             total_size: 1,
             chunk_size: 1_048_576,
@@ -2024,6 +2102,123 @@ mod tests {
             .await;
     }
 
+    async fn upload_session_row_counts(pool: &sqlx::PgPool, session_id: Uuid) -> (i64, i64) {
+        let sessions =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM upload_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(pool)
+                .await
+                .expect("count upload session rows");
+        let chunks = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM upload_chunks WHERE session_id = $1",
+        )
+        .bind(session_id)
+        .fetch_one(pool)
+        .await
+        .expect("count upload chunk rows");
+        (sessions, chunks)
+    }
+
+    #[tokio::test]
+    async fn create_replication_session_removes_stale_replication_session_for_same_path() {
+        let Some(f) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let artifact_path = "torch/2.0.0/torch-2.0.0-cp311-cp311-win_amd64.whl";
+        let stale_session_id = Uuid::new_v4();
+        let stale_temp = f
+            .storage_dir
+            .join(".uploads")
+            .join(stale_session_id.to_string());
+        tokio::fs::create_dir_all(stale_temp.parent().expect("stale temp parent"))
+            .await
+            .expect("create stale temp dir");
+        tokio::fs::write(&stale_temp, b"partial replication bytes")
+            .await
+            .expect("write stale temp file");
+
+        sqlx::query(
+            r#"
+            INSERT INTO upload_sessions
+                (id, user_id, repository_id, repository_key, artifact_path,
+                 content_type, total_size, chunk_size, total_chunks,
+                 completed_chunks, bytes_received, checksum_sha256, temp_file_path,
+                 status, is_replication)
+            VALUES ($1, $2, $3, $4, $5, 'application/zip', 172305868, 52428800, 4,
+                    2, 104857600, $6, $7, 'in_progress', true)
+            "#,
+        )
+        .bind(stale_session_id)
+        .bind(f.user_id)
+        .bind(f.repo_id)
+        .bind(&f.repo_key)
+        .bind(artifact_path)
+        .bind("2802f84f021907deee7e9470ed10c0e78af7457ac9a08a6cd7d55adef835fede")
+        .bind(stale_temp.to_string_lossy().as_ref())
+        .execute(&f.pool)
+        .await
+        .expect("insert stale replication session");
+
+        sqlx::query(
+            "INSERT INTO upload_chunks (session_id, chunk_index, byte_offset, byte_length, status) \
+             VALUES ($1, 0, 0, 52428800, 'completed')",
+        )
+        .bind(stale_session_id)
+        .execute(&f.pool)
+        .await
+        .expect("insert stale chunk row");
+
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let req = create_replication_session_req(&serde_json::json!({
+            "repository_key": f.repo_key,
+            "artifact_path": artifact_path,
+            "artifact_name": "torch",
+            "artifact_version": "2.0.0",
+            "artifact_metadata_format": "pypi",
+            "artifact_metadata": {"format": "pypi", "filename": "torch-2.0.0-cp311-cp311-win_amd64.whl"},
+            "package_metadata": {"format": "pypi", "filename": "torch-2.0.0-cp311-cp311-win_amd64.whl"},
+            "total_size": 172305868_i64,
+            "checksum_sha256": "2802f84f021907deee7e9470ed10c0e78af7457ac9a08a6cd7d55adef835fede",
+            "chunk_size": 52428800_i64,
+        }));
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "retry create_session must succeed; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        assert_eq!(
+            upload_session_row_counts(&f.pool, stale_session_id).await,
+            (0, 0),
+            "retrying peer replication must remove stale upload session/chunk rows"
+        );
+        assert!(
+            !stale_temp.exists(),
+            "retry cleanup should remove the stale replication temp file"
+        );
+
+        let create_resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let new_session_id: Uuid =
+            serde_json::from_value(create_resp["session_id"].clone()).expect("session_id");
+        let is_replication: bool =
+            sqlx::query_scalar("SELECT is_replication FROM upload_sessions WHERE id = $1")
+                .bind(new_session_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query new upload session");
+        assert!(
+            is_replication,
+            "new peer-created upload session must be marked as replication"
+        );
+
+        cleanup_created_session(&f.pool, &body).await;
+        f.teardown().await;
+    }
+
     #[tokio::test]
     async fn create_session_allows_non_admin_with_write_grant() {
         // (a) Non-admin holding a fine-grained `write` rule on the target repo
@@ -2196,6 +2391,11 @@ mod tests {
             "complete must succeed; body: {}",
             String::from_utf8_lossy(&body)
         );
+        assert_eq!(
+            upload_session_row_counts(&f.pool, session_id).await,
+            (1, 1),
+            "regular completed upload sessions remain queryable for client status"
+        );
 
         // 4) The new path uses content-addressable storage under the
         //    repo-scoped backend. Verify the bytes are there at the expected
@@ -2320,6 +2520,7 @@ mod tests {
         let req = axum::http::Request::builder()
             .method("PUT")
             .uri(format!("/{}/complete", session_id))
+            .header("x-artifact-keeper-replication", "true")
             .body(axum::body::Body::empty())
             .unwrap();
         let (status, body) = tdh::send(app, req).await;
@@ -2328,6 +2529,11 @@ mod tests {
             StatusCode::OK,
             "complete must succeed; body: {}",
             String::from_utf8_lossy(&body)
+        );
+        assert_eq!(
+            upload_session_row_counts(&f.pool, session_id).await,
+            (0, 0),
+            "replication upload complete must not leave stale upload session/chunk rows"
         );
 
         let artifact_id: Uuid =

--- a/backend/src/services/package_service.rs
+++ b/backend/src/services/package_service.rs
@@ -110,7 +110,11 @@ impl PackageService {
             existing.0
         };
 
-        // Upsert into `package_versions`
+        // Keep `package_versions` deterministic when a package format (PyPI in
+        // particular) publishes multiple distributions for the same version.
+        // Different peers may process wheel/sdist artifacts in different
+        // orders during replication recovery, so "last writer wins" makes
+        // otherwise-equivalent repositories diverge at the DB row level.
         sqlx::query(
             r#"
             INSERT INTO package_versions (package_id, version, size_bytes, checksum_sha256)
@@ -118,6 +122,8 @@ impl PackageService {
             ON CONFLICT (package_id, version) DO UPDATE SET
                 size_bytes      = EXCLUDED.size_bytes,
                 checksum_sha256 = EXCLUDED.checksum_sha256
+            WHERE (EXCLUDED.checksum_sha256, EXCLUDED.size_bytes)
+                < (package_versions.checksum_sha256, package_versions.size_bytes)
             "#,
         )
         .bind(package_id)
@@ -159,6 +165,17 @@ impl PackageService {
             );
         }
     }
+}
+
+#[cfg(test)]
+fn should_replace_package_version(
+    existing_checksum_sha256: &str,
+    existing_size_bytes: i64,
+    candidate_checksum_sha256: &str,
+    candidate_size_bytes: i64,
+) -> bool {
+    (candidate_checksum_sha256, candidate_size_bytes)
+        < (existing_checksum_sha256, existing_size_bytes)
 }
 
 #[cfg(test)]
@@ -209,6 +226,19 @@ mod tests {
         assert!(metadata["authors"].is_array());
         assert_eq!(metadata["authors"].as_array().unwrap().len(), 2);
         assert_eq!(metadata["dependencies"]["serde"], "1.0");
+    }
+
+    #[test]
+    fn test_package_version_representative_is_checksum_deterministic() {
+        assert!(should_replace_package_version("bbbb", 100, "aaaa", 500));
+        assert!(!should_replace_package_version("aaaa", 500, "bbbb", 100));
+    }
+
+    #[test]
+    fn test_package_version_representative_uses_size_tiebreaker() {
+        assert!(should_replace_package_version("aaaa", 500, "aaaa", 100));
+        assert!(!should_replace_package_version("aaaa", 100, "aaaa", 500));
+        assert!(!should_replace_package_version("aaaa", 100, "aaaa", 100));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/upload_service.rs
+++ b/backend/src/services/upload_service.rs
@@ -29,6 +29,7 @@ pub struct UploadSession {
     pub artifact_metadata_properties: Option<serde_json::Value>,
     pub package_description: Option<String>,
     pub package_metadata: Option<serde_json::Value>,
+    pub is_replication: bool,
     pub content_type: String,
     pub total_size: i64,
     pub chunk_size: i32,
@@ -181,6 +182,7 @@ pub struct CreateSessionParams<'a> {
     pub artifact_metadata_properties: Option<&'a serde_json::Value>,
     pub package_description: Option<&'a str>,
     pub package_metadata: Option<&'a serde_json::Value>,
+    pub is_replication: bool,
     pub total_size: i64,
     pub chunk_size: Option<i32>,
     pub checksum_sha256: &'a str,
@@ -241,10 +243,10 @@ impl UploadService {
                 (id, user_id, repository_id, repository_key, artifact_path,
                  artifact_name, artifact_version, artifact_metadata_format,
                  artifact_metadata, artifact_metadata_properties, package_description,
-                 package_metadata, content_type, total_size, chunk_size, total_chunks,
-                 checksum_sha256, temp_file_path)
+                 package_metadata, is_replication, content_type, total_size, chunk_size,
+                 total_chunks, checksum_sha256, temp_file_path)
             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                    $14, $15, $16, $17, $18)
+                    $14, $15, $16, $17, $18, $19)
             RETURNING *
             "#,
         )
@@ -260,6 +262,7 @@ impl UploadService {
         .bind(artifact_metadata_properties)
         .bind(package_description)
         .bind(package_metadata)
+        .bind(p.is_replication)
         .bind(content_type)
         .bind(p.total_size)
         .bind(chunk_size)
@@ -1368,6 +1371,7 @@ mod tests {
             artifact_metadata_properties: None,
             package_description: None,
             package_metadata: None,
+            is_replication: false,
             content_type: "application/octet-stream".into(),
             total_size: 1024,
             chunk_size: DEFAULT_CHUNK_SIZE,
@@ -1402,6 +1406,7 @@ mod tests {
             artifact_metadata_properties: None,
             package_description: None,
             package_metadata: None,
+            is_replication: false,
             content_type: "application/octet-stream".into(),
             total_size: 100,
             chunk_size: DEFAULT_CHUNK_SIZE,


### PR DESCRIPTION
## Summary

Fixes #1864 

Hosted PyPI uploads were persisted locally but never queued for peer
replication because the PyPI upload handler stored blobs and inserted artifact
rows directly instead of using the shared artifact upload path that fans out
`sync_tasks` for push/mirror peer subscriptions.

This PR makes normal hosted PyPI uploads enqueue peer sync tasks while still
suppressing fan-out for incoming replication writes marked with
`x-artifact-keeper-replication`. It also preserves PyPI-specific metadata on the
artifact and package catalog rows so a fresh peer can serve the replicated
package through the Simple API, PEP 658 `.metadata` sidecars, package APIs, and
native `pip` flows.

While validating the PyPI HA flow, two additional replication consistency issues
showed up and are fixed here as part of making PyPI replication production-safe:

- replication-owned resumable upload sessions are now marked and cleaned up
  after peer replication completes, and stale replication sessions for the same
  artifact path are removed before retrying that path
- `package_versions` now keeps a deterministic representative row for package
  formats such as PyPI that can publish multiple distributions for the same
  package/version, avoiding DB row divergence when peers process wheel/sdist
  artifacts in different orders

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

Added/updated coverage includes:

- direct PyPI uploads enqueue sync tasks when a repository has a push/mirror
  peer subscription
- replication-marked PyPI uploads persist metadata but do not requeue back to
  peers
- PyPI upload metadata is stored as `artifact_metadata(format = 'pypi')` and in
  package catalog metadata
- retrying peer replication removes stale replication upload sessions/chunks and
  stale temp files for the same repository/path
- ordinary completed resumable upload sessions remain queryable for client
  status, while replication sessions are cleaned up after completion
- `package_versions` representative selection is deterministic for multiple
  artifacts sharing the same package/version

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation performed for this branch:

```text
git diff --check
git diff --cached --check
```

The local Rust toolchain was not available in the preparation shell, so
`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
and `cargo test --workspace --lib` still need to be run in a Rust-enabled local
or CI environment before merge.

Manual/live HA validation was run against two Artifact Keeper peers using hosted
PyPI repositories:

- checksum-negative PyPI uploads were rejected with HTTP 400 in both directions
- single-package PyPI replication succeeded in both directions, including API,
  Simple API, DB rows, downloads, and Docker `pip install`
- large chunked PyPI package replication was interrupted mid-transfer on the
  target peer after 3 of 4 chunks, then recovered after a 20-minute outage
- the interrupted 172,305,868-byte wheel arrived byte-identical on the target
  peer with the expected SHA-256
- post-recovery direct downloads succeeded on both peers: 239/239 each, 0
  failures
- post-recovery Docker `pip` matrix succeeded on both peers: 12/12 each, 0
  failures
- `artifacts`, `artifact_metadata`, `packages`, and `package_versions` were
  equivalent across peers after replication settled
- no stale upload sessions remained on either peer/repository after recovery
- the PyPI HA protocol reported PASS with 0 HA warnings

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

This adds an internal `upload_sessions.is_replication` flag plus an index used
to distinguish replication-owned resumable upload sessions from ordinary client
upload sessions during retry/cleanup. It does not add new endpoints.