### PR TITLE
fix(pypi): stream remote package downloads instead of buffering in memory

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -937,6 +937,64 @@ pub async fn proxy_fetch_with_cache_key(
     .await
 }
 
+/// Streaming sibling of [`proxy_fetch_with_cache_key`] (#895 OOM relief for
+/// format handlers whose upstream download URL differs from the canonical
+/// artifact path). Fetches `fetch_path` from the upstream but keys the proxy
+/// cache on `cache_path`, returning the body as a [`StreamingFetchResult`]
+/// that the caller tees to the client without buffering.
+pub async fn proxy_fetch_streaming_with_cache_key(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
+    with_proxy_repo(
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        |repo| async move {
+            proxy_service
+                .fetch_artifact_streaming_with_cache_path(&repo, fetch_path, cache_path)
+                .await
+        },
+    )
+    .await
+}
+
+/// Streaming sibling of [`proxy_check_cache`]: probe the proxy cache for
+/// `cache_path` and stream a hit straight from storage instead of buffering
+/// the cached body in memory. Returns `None` on miss or on any probe error
+/// (including a negative-cache hit) — best-effort semantics matching the
+/// buffered probe, so callers fall through to the full fetch, which
+/// re-applies the negative-cache gate itself.
+pub async fn proxy_check_cache_streaming(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    cache_path: &str,
+) -> Option<crate::services::proxy_service::StreamingFetchResult> {
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
+    match proxy_service
+        .streaming_cached_artifact_by_path(&repo, cache_path)
+        .await
+    {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::debug!(
+                "Streaming cache probe failed for {}/{}, treating as miss: {}",
+                repo_key,
+                cache_path,
+                e
+            );
+            None
+        }
+    }
+}
+
 /// Fetch from upstream directly, bypassing the proxy cache.
 ///
 /// Use this instead of [`proxy_fetch`] when the caller needs the raw upstream

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -4741,4 +4741,190 @@ mod tests {
 
         do_cleanup().await;
     }
+
+    // -----------------------------------------------------------------------
+    // resolve_pypi_remote_fetch_target / fetch_from_pypi_remote_streaming
+    // -----------------------------------------------------------------------
+    //
+    // DB-free helpers (MissingSvcStorage / build_proxy_service_no_db) are used
+    // for tests that only probe the cache layer (e.g. cache-miss probes).
+    // Tests that exercise the upstream fetch path require a real PgPool so that
+    // load_upstream_auth succeeds; they use tdh::try_pool() and skip when
+    // DATABASE_URL is unset.
+
+    /// Storage backend that implements `storage_service::StorageBackend` (the
+    /// richer trait used by `StorageService` / `ProxyService`). Reports every
+    /// `get` as a miss (NotFound) so tests hit the upstream fetch path.
+    struct MissingSvcStorage;
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for MissingSvcStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
+            Err(AppError::NotFound(key.to_string()))
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(false)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _src: &str, _dst: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+            Ok(0)
+        }
+    }
+
+    fn build_proxy_service_no_db() -> crate::services::proxy_service::ProxyService {
+        use crate::services::storage_service::StorageService;
+        let storage = std::sync::Arc::new(MissingSvcStorage);
+        let storage_svc = std::sync::Arc::new(StorageService::new(storage));
+        let pool = sqlx::PgPool::connect_lazy("postgres://fake:fake@localhost/fake")
+            .expect("connect_lazy");
+        crate::services::proxy_service::ProxyService::new(pool, storage_svc)
+    }
+
+    /// End-to-end test for the streaming download path via the fallback route.
+    ///
+    /// The simple index page has no matching href, so `resolve_pypi_remote_fetch_target`
+    /// falls through to the stable `simple/{project}/{filename}` fallback path.
+    /// This avoids the SSRF check (which hard-blocks loopback) while still
+    /// exercising `fetch_from_pypi_remote_streaming` and `proxy_fetch_streaming_with_cache_key`.
+    ///
+    /// Skipped when `DATABASE_URL` is unset (CI always sets it).
+    #[tokio::test]
+    async fn test_fetch_from_pypi_remote_streaming_fallback_path() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let server = MockServer::start().await;
+        let wheel_body = b"fake-wheel-bytes";
+
+        // Empty simple-index page → find_upstream_url_for_file returns None →
+        // resolve_pypi_remote_fetch_target falls back to simple/{project}/{filename}.
+        Mock::given(method("GET"))
+            .and(path("/simple/numpy/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_string("<!DOCTYPE html><html><body></body></html>"),
+            )
+            .mount(&server)
+            .await;
+
+        // The fallback fetch path is simple/{normalized}/{filename}.
+        Mock::given(method("GET"))
+            .and(path("/simple/numpy/numpy-2.0.0-py3-none-any.whl"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/zip")
+                    .set_body_bytes(wheel_body.as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir()
+            .join(format!("pypi-stream-e2e-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp dir");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo_id = uuid::Uuid::new_v4();
+
+        let result = fetch_from_pypi_remote_streaming(
+            &proxy,
+            repo_id,
+            "pypi-remote",
+            &server.uri(),
+            "numpy",
+            "numpy-2.0.0-py3-none-any.whl",
+        )
+        .await
+        .expect("streaming fetch via fallback path must succeed");
+
+        let mut body_bytes = Vec::new();
+        let mut body = result.body;
+        while let Some(chunk) = body.next().await {
+            body_bytes.extend_from_slice(&chunk.expect("stream chunk must be Ok"));
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(body_bytes, wheel_body);
+    }
+
+    #[tokio::test]
+    async fn test_build_streaming_file_response_headers() {
+        use futures::stream;
+
+        let wheel_data = Bytes::from_static(b"wheel-content");
+        let data_len = wheel_data.len() as u64;
+        let stream = stream::once(async move {
+            Ok::<Bytes, crate::error::AppError>(wheel_data)
+        });
+        let result = crate::services::proxy_service::StreamingFetchResult {
+            body: Box::pin(stream),
+            content_type: Some("application/zip".to_string()),
+            content_length: Some(data_len),
+        };
+
+        let response = build_streaming_file_response("numpy-1.0-py3-none-any.whl", result);
+
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+        let ct = response
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            ct.contains("application/zip"),
+            "content-type must be application/zip, got: {ct}"
+        );
+        let cd = response
+            .headers()
+            .get("content-disposition")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+        assert!(
+            cd.contains("numpy-1.0-py3-none-any.whl"),
+            "content-disposition must contain filename, got: {cd}"
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(CONTENT_LENGTH)
+                .and_then(|v| v.to_str().ok()),
+            Some(data_len.to_string().as_str()),
+            "content-length must match"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_proxy_check_cache_streaming_returns_none_on_miss() {
+        // Empty MissingStorage → streaming probe returns None without errors.
+        let proxy = build_proxy_service_no_db();
+        let repo_id = uuid::Uuid::new_v4();
+
+        let result = super::proxy_helpers::proxy_check_cache_streaming(
+            &proxy,
+            repo_id,
+            "pypi-remote",
+            "https://pypi.org/simple",
+            "simple/numpy/numpy-2.0.0-py3-none-any.whl",
+        )
+        .await;
+
+        assert!(
+            result.is_none(),
+            "cache miss must yield None, not Some(result)"
+        );
+    }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1095,18 +1095,27 @@ async fn serve_file(
                     // Try the proxy cache first using a predictable local
                     // path. This avoids fetching the simple index from upstream
                     // just to rediscover the download URL when the file is
-                    // already cached from a previous request.
+                    // already cached from a previous request. Streamed straight
+                    // from storage (#895): buffering cached multi-hundred-MiB
+                    // wheels per request OOM-killed memory-constrained pods.
                     let normalized = PypiHandler::normalize_name(project);
                     let local_cache_path = format!("simple/{}/{}", normalized, filename);
 
-                    if let Some((content, _ct)) =
-                        proxy_helpers::proxy_check_cache(proxy, repo_key, &local_cache_path).await
+                    if let Some(result) = proxy_helpers::proxy_check_cache_streaming(
+                        proxy,
+                        repo.id,
+                        repo_key,
+                        upstream_url,
+                        &local_cache_path,
+                    )
+                    .await
                     {
-                        return Ok(build_file_response(filename, content));
+                        return Ok(build_streaming_file_response(filename, result));
                     }
 
-                    // Cache miss: use PyPI-specific fetch logic.
-                    let content = fetch_from_pypi_remote(
+                    // Cache miss: use PyPI-specific fetch logic, streaming the
+                    // package file from upstream while teeing it into the cache.
+                    let result = fetch_from_pypi_remote_streaming(
                         proxy,
                         repo.id,
                         repo_key,
@@ -1116,7 +1125,7 @@ async fn serve_file(
                     )
                     .await?;
 
-                    return Ok(build_file_response(filename, content));
+                    return Ok(build_streaming_file_response(filename, result));
                 }
             }
             // Virtual repo: try each member in priority order.
@@ -1213,17 +1222,19 @@ async fn serve_file(
                             let normalized = PypiHandler::normalize_name(project);
                             let local_cache_path = format!("simple/{}/{}", normalized, filename);
 
-                            if let Some((content, _ct)) = proxy_helpers::proxy_check_cache(
+                            if let Some(result) = proxy_helpers::proxy_check_cache_streaming(
                                 proxy,
+                                member.id,
                                 &member.key,
+                                upstream_url,
                                 &local_cache_path,
                             )
                             .await
                             {
-                                return Ok(build_file_response(filename, content));
+                                return Ok(build_streaming_file_response(filename, result));
                             }
 
-                            match fetch_from_pypi_remote(
+                            match fetch_from_pypi_remote_streaming(
                                 proxy,
                                 member.id,
                                 &member.key,
@@ -1233,8 +1244,8 @@ async fn serve_file(
                             )
                             .await
                             {
-                                Ok(content) => {
-                                    return Ok(build_file_response(filename, content));
+                                Ok(result) => {
+                                    return Ok(build_streaming_file_response(filename, result));
                                 }
                                 Err(e) => {
                                     debug!(
@@ -1304,8 +1315,9 @@ async fn serve_file(
     };
 
     // Record download statistics for locally-stored artifacts only.
-    // Proxied and virtual-repo fetches go through build_file_response()
-    // which intentionally skips stats since the artifact is not ours.
+    // Proxied and virtual-repo fetches go through
+    // build_streaming_file_response() which intentionally skips stats since
+    // the artifact is not ours.
     let _ = sqlx::query!(
         "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
         artifact.id
@@ -1370,20 +1382,38 @@ where
     }
 }
 
-/// Fetch a file from a remote PyPI upstream using the format-specific URL
-/// resolution logic. External PyPI registries (e.g. pypi.org) host files on a
+/// Resolved upstream download target for a PyPI remote file, produced by
+/// [`resolve_pypi_remote_fetch_target`] and consumed by both the buffered
+/// and the streaming fetch variants.
+struct PypiRemoteFetchTarget {
+    /// Upstream base URL for the file download (may be a different host
+    /// than the simple index, e.g. files.pythonhosted.org).
+    fetch_base: String,
+    /// Path relative to `fetch_base`.
+    fetch_path: String,
+    /// Stable proxy-cache key (`simple/{project}/{filename}`), independent
+    /// of the actual upstream URL layout.
+    cache_path: String,
+}
+
+/// Resolve the real download URL for a file hosted by a remote PyPI
+/// upstream. External PyPI registries (e.g. pypi.org) host files on a
 /// different domain (files.pythonhosted.org), so we cannot just append the
 /// filename to the upstream URL. Instead, we fetch the simple index page,
-/// parse it to discover the real download URL for the file, and then download
-/// from that URL.
-async fn fetch_from_pypi_remote(
+/// parse it to discover the real download URL for the file, and validate it
+/// against SSRF before returning.
+///
+/// The index fetch stays buffered by design: simple-index pages are small
+/// HTML documents that must be parsed in-process. Only the package file
+/// itself (potentially hundreds of MiB) needs the streaming path.
+async fn resolve_pypi_remote_fetch_target(
     proxy: &crate::services::proxy_service::ProxyService,
     repo_id: uuid::Uuid,
     repo_key: &str,
     upstream_url: &str,
     project: &str,
     filename: &str,
-) -> Result<Bytes, Response> {
+) -> Result<PypiRemoteFetchTarget, Response> {
     let normalized = PypiHandler::normalize_name(project);
 
     // Strip a trailing `/simple` from the configured upstream URL so we do
@@ -1441,43 +1471,116 @@ async fn fetch_from_pypi_remote(
     // packages/requests/2.31.0/requests-2.31.0.tar.gz which differ from the
     // simple/ convention. A stable cache key ensures the cache-check
     // optimization in serve_file works for all upstream registry types.
-    let local_cache_path = format!("simple/{}/{}", normalized, filename);
+    let cache_path = format!("simple/{}/{}", normalized, filename);
 
     let (fetch_base, fetch_path) = match file_url.as_deref().and_then(split_url_base_and_path) {
         Some(pair) => pair,
         None => fallback(),
     };
 
+    Ok(PypiRemoteFetchTarget {
+        fetch_base,
+        fetch_path,
+        cache_path,
+    })
+}
+
+/// Fetch a file from a remote PyPI upstream using the format-specific URL
+/// resolution logic, buffering the whole body in memory.
+///
+/// **Prefer [`fetch_from_pypi_remote_streaming`] on download paths.** This
+/// buffered variant exists only for callers that genuinely need the full
+/// `Bytes` in-process — currently the cache-recovery closure in
+/// [`get_remote_cached_or_refetch_stream`], which must write the refetched
+/// payload back to storage.
+async fn fetch_from_pypi_remote(
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    project: &str,
+    filename: &str,
+) -> Result<Bytes, Response> {
+    let target =
+        resolve_pypi_remote_fetch_target(proxy, repo_id, repo_key, upstream_url, project, filename)
+            .await?;
+
     let (content, _content_type) = proxy_helpers::proxy_fetch_with_cache_key(
         proxy,
         repo_id,
         repo_key,
-        &fetch_base,
-        &fetch_path,
-        &local_cache_path,
+        &target.fetch_base,
+        &target.fetch_path,
+        &target.cache_path,
     )
     .await?;
 
     Ok(content)
 }
 
-/// Build the HTTP response for serving a PyPI file download.
+/// Streaming sibling of [`fetch_from_pypi_remote`] (#895 OOM relief).
 ///
-/// Used for proxied and virtual-repo fetches. Download statistics are not
-/// recorded here because the artifact is not stored locally; stats are only
-/// tracked for artifacts served from our own storage (see `serve_file`).
-fn build_file_response(filename: &str, content: Bytes) -> Response {
+/// Resolves the real download URL via the simple index exactly like the
+/// buffered variant, then streams the package file from upstream — teed
+/// into the proxy cache — instead of buffering it in memory. Large wheels
+/// (CUDA / ML packages routinely exceed 400 MiB) previously OOM-killed
+/// memory-constrained pods when several `pip install` runs downloaded
+/// concurrently through the buffered path.
+async fn fetch_from_pypi_remote_streaming(
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    project: &str,
+    filename: &str,
+) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
+    let target =
+        resolve_pypi_remote_fetch_target(proxy, repo_id, repo_key, upstream_url, project, filename)
+            .await?;
+
+    proxy_helpers::proxy_fetch_streaming_with_cache_key(
+        proxy,
+        repo_id,
+        repo_key,
+        &target.fetch_base,
+        &target.fetch_path,
+        &target.cache_path,
+    )
+    .await
+}
+
+/// Build the HTTP response for serving a PyPI file download from a
+/// [`StreamingFetchResult`] (proxied and virtual-repo fetches, #895).
+///
+/// Sets the format-specific `Content-Type` and an attachment
+/// `Content-Disposition`; the body is driven from the stream without
+/// buffering. `Content-Length` is set only when the result advertises one;
+/// otherwise the response uses chunked transfer encoding. Download
+/// statistics are not recorded here because the artifact is not stored
+/// locally; stats are only tracked for artifacts served from our own
+/// storage (see `serve_file`).
+fn build_streaming_file_response(
+    filename: &str,
+    result: crate::services::proxy_service::StreamingFetchResult,
+) -> Response {
     let content_type = pypi_content_type(filename);
 
-    Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type)
         .header(
             "Content-Disposition",
             format!("attachment; filename=\"{}\"", filename),
-        )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
+        );
+    if let Some(len) = result.content_length {
+        builder = builder.header(CONTENT_LENGTH, len.to_string());
+    }
+    builder
+        .body(Body::from_stream(
+            result
+                .body
+                .map(|r| r.map_err(|e| std::io::Error::other(e.to_string()))),
+        ))
         .unwrap()
 }
 
@@ -2894,22 +2997,43 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // build_file_response
+    // build_streaming_file_response
     // -----------------------------------------------------------------------
 
-    #[test]
-    fn test_build_file_response_wheel_content_type() {
-        let content = Bytes::from_static(b"fake wheel data");
-        let resp =
-            build_file_response("numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.whl", content);
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "application/zip");
+    /// Wrap static bytes in a one-shot [`StreamingFetchResult`] for header
+    /// tests, with `content_length` advertised only when `len` is `Some`.
+    fn streaming_result_with(
+        content: &'static [u8],
+        len: Option<u64>,
+    ) -> crate::services::proxy_service::StreamingFetchResult {
+        crate::services::proxy_service::StreamingFetchResult {
+            body: futures::stream::once(async move { Ok(Bytes::from_static(content)) }).boxed(),
+            content_type: None,
+            content_length: len,
+        }
     }
 
     #[test]
-    fn test_build_file_response_sdist_content_type() {
-        let content = Bytes::from_static(b"fake sdist data");
-        let resp = build_file_response("six-1.16.0.tar.gz", content);
+    fn test_build_streaming_file_response_wheel_content_type() {
+        let resp = build_streaming_file_response(
+            "numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.whl",
+            streaming_result_with(b"fake wheel data", Some(15)),
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "application/zip");
+        assert_eq!(resp.headers().get(CONTENT_LENGTH).unwrap(), "15");
+        assert_eq!(
+            resp.headers().get("Content-Disposition").unwrap(),
+            "attachment; filename=\"numpy-2.0.0-cp312-cp312-manylinux_2_17_x86_64.whl\""
+        );
+    }
+
+    #[test]
+    fn test_build_streaming_file_response_sdist_content_type() {
+        let resp = build_streaming_file_response(
+            "six-1.16.0.tar.gz",
+            streaming_result_with(b"fake sdist data", Some(15)),
+        );
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
             resp.headers().get(CONTENT_TYPE).unwrap(),
@@ -2918,16 +3042,20 @@ mod tests {
     }
 
     #[test]
-    fn test_build_file_response_zip_extension() {
-        let content = Bytes::from_static(b"some data");
-        let resp = build_file_response("package-1.0.zip", content);
+    fn test_build_streaming_file_response_zip_extension() {
+        let resp = build_streaming_file_response(
+            "package-1.0.zip",
+            streaming_result_with(b"some data", Some(9)),
+        );
         assert_eq!(resp.headers().get(CONTENT_TYPE).unwrap(), "application/zip");
     }
 
     #[test]
-    fn test_build_file_response_unknown_extension() {
-        let content = Bytes::from_static(b"some data");
-        let resp = build_file_response("package-1.0.egg", content);
+    fn test_build_streaming_file_response_unknown_extension() {
+        let resp = build_streaming_file_response(
+            "package-1.0.egg",
+            streaming_result_with(b"some data", Some(9)),
+        );
         assert_eq!(
             resp.headers().get(CONTENT_TYPE).unwrap(),
             "application/octet-stream"
@@ -2935,9 +3063,22 @@ mod tests {
     }
 
     #[test]
-    fn test_build_file_response_content_disposition() {
-        let content = Bytes::from_static(b"data");
-        let resp = build_file_response("requests-2.31.0.tar.gz", content);
+    fn test_build_streaming_file_response_unknown_length_omits_content_length() {
+        // No advertised length -> no Content-Length header; axum falls back
+        // to chunked transfer encoding for the streamed body.
+        let resp = build_streaming_file_response(
+            "package-1.0.whl",
+            streaming_result_with(b"some data", None),
+        );
+        assert!(resp.headers().get(CONTENT_LENGTH).is_none());
+    }
+
+    #[test]
+    fn test_build_streaming_file_response_content_disposition() {
+        let resp = build_streaming_file_response(
+            "requests-2.31.0.tar.gz",
+            streaming_result_with(b"data", Some(4)),
+        );
         assert_eq!(
             resp.headers().get("Content-Disposition").unwrap(),
             "attachment; filename=\"requests-2.31.0.tar.gz\""
@@ -2945,10 +3086,12 @@ mod tests {
     }
 
     #[test]
-    fn test_build_file_response_content_length() {
+    fn test_build_streaming_file_response_content_length() {
         let data = b"hello world data here";
-        let content = Bytes::from_static(data);
-        let resp = build_file_response("pkg-1.0.tar.gz", content);
+        let resp = build_streaming_file_response(
+            "pkg-1.0.tar.gz",
+            streaming_result_with(data, Some(data.len() as u64)),
+        );
         assert_eq!(
             resp.headers().get(CONTENT_LENGTH).unwrap(),
             &data.len().to_string()

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -4835,8 +4835,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let tmp = std::env::temp_dir()
-            .join(format!("pypi-stream-e2e-{}", uuid::Uuid::new_v4()));
+        let tmp = std::env::temp_dir().join(format!("pypi-stream-e2e-{}", uuid::Uuid::new_v4()));
         std::fs::create_dir_all(&tmp).expect("tmp dir");
         let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
         let repo_id = uuid::Uuid::new_v4();
@@ -4867,9 +4866,7 @@ mod tests {
 
         let wheel_data = Bytes::from_static(b"wheel-content");
         let data_len = wheel_data.len() as u64;
-        let stream = stream::once(async move {
-            Ok::<Bytes, crate::error::AppError>(wheel_data)
-        });
+        let stream = stream::once(async move { Ok::<Bytes, crate::error::AppError>(wheel_data) });
         let result = crate::services::proxy_service::StreamingFetchResult {
             body: Box::pin(stream),
             content_type: Some("application/zip".to_string()),

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2191,6 +2191,28 @@ impl ProxyService {
         repo: &Repository,
         path: &str,
     ) -> Result<StreamingFetchResult> {
+        self.fetch_artifact_streaming_with_cache_path(repo, path, path)
+            .await
+    }
+
+    /// Streaming sibling of [`Self::fetch_artifact_with_cache_path`]: fetch
+    /// from upstream using `fetch_path` for the URL but key the proxy cache
+    /// on `cache_path`. This lets format handlers whose upstream download
+    /// URL differs from the canonical artifact path (e.g. PyPI, where wheels
+    /// live on files.pythonhosted.org while the cache key is
+    /// `simple/{project}/{filename}`) use the streaming path instead of
+    /// buffering whole package files in memory.
+    ///
+    /// `cache_path` drives every cache-semantics decision (storage keys,
+    /// TTL classification, negative caching, scan-on-proxy warning);
+    /// `fetch_path` is only ever combined with the repo's upstream URL to
+    /// build the outbound request.
+    pub async fn fetch_artifact_streaming_with_cache_path(
+        &self,
+        repo: &Repository,
+        fetch_path: &str,
+        cache_path: &str,
+    ) -> Result<StreamingFetchResult> {
         // #1631 layer 2 (#1694): single-flight the cold-cache streaming path so
         // N concurrent requests for the same uncached object open upstream ONCE.
         // The streaming coordinator's followers subscribe to the leader's
@@ -2202,13 +2224,41 @@ impl ProxyService {
         // warm cache or wins the election outright.
         const STREAM_REENTER_BUDGET: usize = 8;
         for _ in 0..STREAM_REENTER_BUDGET {
-            if let Some(result) = self.try_fetch_artifact_streaming_once(repo, path).await? {
+            if let Some(result) = self
+                .try_fetch_artifact_streaming_once(repo, fetch_path, cache_path)
+                .await?
+            {
                 return Ok(result);
             }
         }
         // Exhausted re-enters (pathological contention): do one final
         // uncoordinated attempt so the request never spuriously fails.
-        self.fetch_artifact_streaming_uncoordinated(repo, path)
+        self.fetch_artifact_streaming_uncoordinated(repo, fetch_path, cache_path)
+            .await
+    }
+
+    /// Streaming cache probe: serve `cache_path` straight from the proxy
+    /// cache as a stream, without contacting upstream on a miss.
+    ///
+    /// Returns `Ok(None)` on a cache miss (including a stale entry that
+    /// failed revalidation) and `Err(NotFound)` when the path is
+    /// negative-cached. Callers that treat the probe as best-effort (the
+    /// PyPI download pre-check) map both to "miss" and fall through to the
+    /// full fetch, which re-applies the negative-cache gate itself.
+    ///
+    /// Revalidation of a stale mutable entry uses `cache_path` as the
+    /// upstream path — the same behavior the buffered
+    /// [`Self::get_cached_artifact_by_path`] probe had implicitly, since
+    /// package files classify as immutable and never revalidate in
+    /// practice.
+    pub async fn streaming_cached_artifact_by_path(
+        &self,
+        repo: &Repository,
+        cache_path: &str,
+    ) -> Result<Option<StreamingFetchResult>> {
+        let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
+        let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
+        self.try_streaming_cache_hit(repo, cache_path, cache_path, &cache_key, &metadata_key)
             .await
     }
 
@@ -2220,10 +2270,11 @@ impl ProxyService {
     async fn try_fetch_artifact_streaming_once(
         &self,
         repo: &Repository,
-        path: &str,
+        fetch_path: &str,
+        cache_path: &str,
     ) -> Result<Option<StreamingFetchResult>> {
-        let cache_key = Self::cache_storage_key(&repo.key, path)?;
-        let metadata_key = Self::cache_metadata_key(&repo.key, path)?;
+        let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
+        let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
 
         // Cache hit fast path: load metadata sidecar, stream content
         // straight from storage. The slow-path SHA verification done by
@@ -2233,7 +2284,7 @@ impl ProxyService {
         // they do for presigned redirects (#1018 R-tradeoff already
         // accepted upstream).
         if let Some(result) = self
-            .try_streaming_cache_hit(repo, path, &cache_key, &metadata_key)
+            .try_streaming_cache_hit(repo, fetch_path, cache_path, &cache_key, &metadata_key)
             .await?
         {
             return Ok(Some(result));
@@ -2246,7 +2297,13 @@ impl ProxyService {
         let handle = self
             .coordinator
             .coordinate_stream(&stream_lease_key, || {
-                self.open_streaming_leader(repo, path, cache_key.clone(), metadata_key.clone())
+                self.open_streaming_leader(
+                    repo,
+                    fetch_path,
+                    cache_path,
+                    cache_key.clone(),
+                    metadata_key.clone(),
+                )
             })
             .await?;
 
@@ -2260,18 +2317,25 @@ impl ProxyService {
     async fn try_streaming_cache_hit(
         &self,
         repo: &Repository,
-        path: &str,
+        fetch_path: &str,
+        cache_path: &str,
         cache_key: &str,
         metadata_key: &str,
     ) -> Result<Option<StreamingFetchResult>> {
         match self
-            .read_cached_with_revalidation_streaming(repo, path, path, cache_key, metadata_key)
+            .read_cached_with_revalidation_streaming(
+                repo,
+                fetch_path,
+                cache_path,
+                cache_key,
+                metadata_key,
+            )
             .await?
         {
             StreamingCacheReadOutcome::Hit(result) => Ok(Some(result)),
             StreamingCacheReadOutcome::NegativeHit => Err(AppError::NotFound(format!(
                 "Upstream returned 404 (negative-cached) for {}",
-                path
+                cache_path
             ))),
             StreamingCacheReadOutcome::Miss => Ok(None),
         }
@@ -2381,7 +2445,8 @@ impl ProxyService {
     async fn open_streaming_leader(
         &self,
         repo: &Repository,
-        path: &str,
+        fetch_path: &str,
+        cache_path: &str,
         cache_key: String,
         metadata_key: String,
     ) -> Result<StreamHandle> {
@@ -2399,26 +2464,34 @@ impl ProxyService {
         }
 
         let upstream_url = Self::remote_target(repo)?;
-        let full_url = Self::build_upstream_url(upstream_url, path);
+        let full_url = Self::build_upstream_url(upstream_url, fetch_path);
         let upstream = match self.fetch_from_upstream_streaming(&full_url, repo.id).await {
             Ok(upstream) => upstream,
             Err(err) => {
                 return self
-                    .handle_streaming_leader_upstream_error(path, &cache_key, &metadata_key, err)
+                    .handle_streaming_leader_upstream_error(
+                        cache_path,
+                        &cache_key,
+                        &metadata_key,
+                        err,
+                    )
                     .await;
             }
         };
 
         // #1611: classify the path. Immutable paths (versioned artifacts, OCI
         // blobs) cache effectively forever; mutable indexes get the short
-        // conservative TTL (or the repo-configured override).
-        let cache_ttl = self.cache_ttl_for_path(repo, path).await;
+        // conservative TTL (or the repo-configured override). Classification
+        // keys off `cache_path` — the canonical artifact identity — not the
+        // upstream-specific download URL.
+        let cache_ttl = self.cache_ttl_for_path(repo, cache_path).await;
 
         // Cache miss + successful upstream fetch: a new artifact is being
         // cached. Surface the scan-on-proxy gap (#1274) before teeing to
         // the background cache writer so an enabled-but-unimplemented
         // setting is observable in logs rather than silently doing nothing.
-        self.warn_if_proxy_scan_unsupported(repo.id, path).await;
+        self.warn_if_proxy_scan_unsupported(repo.id, cache_path)
+            .await;
 
         let headers = StreamHeaders {
             content_type: upstream.content_type.clone(),
@@ -2491,20 +2564,21 @@ impl ProxyService {
     async fn fetch_artifact_streaming_uncoordinated(
         &self,
         repo: &Repository,
-        path: &str,
+        fetch_path: &str,
+        cache_path: &str,
     ) -> Result<StreamingFetchResult> {
-        let cache_key = Self::cache_storage_key(&repo.key, path)?;
-        let metadata_key = Self::cache_metadata_key(&repo.key, path)?;
+        let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
+        let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
 
         if let Some(result) = self
-            .try_streaming_cache_hit(repo, path, &cache_key, &metadata_key)
+            .try_streaming_cache_hit(repo, fetch_path, cache_path, &cache_key, &metadata_key)
             .await?
         {
             return Ok(result);
         }
 
         let handle = self
-            .open_streaming_leader(repo, path, cache_key, metadata_key)
+            .open_streaming_leader(repo, fetch_path, cache_path, cache_key, metadata_key)
             .await?;
         Ok(StreamingFetchResult::from(handle))
     }
@@ -8699,6 +8773,120 @@ SHA256:
         build_proxy_service_with_storage(Arc::new(GetCachedMock { metadata, body }))
     }
 
+    // --- fetch_artifact_streaming_with_cache_path: key derivation -----------
+
+    /// Map-backed storage that records every key requested via `get`, so
+    /// tests can assert which cache keys the streaming path derives.
+    struct RecordingMapStorage {
+        entries: std::collections::HashMap<String, Bytes>,
+        requested: std::sync::Mutex<Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for RecordingMapStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            self.requested.lock().unwrap().push(key.to_string());
+            self.entries
+                .get(key)
+                .cloned()
+                .ok_or_else(|| AppError::NotFound(key.to_string()))
+        }
+        async fn exists(&self, key: &str) -> Result<bool> {
+            Ok(self.entries.contains_key(key))
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _src: &str, _dst: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, key: &str) -> Result<u64> {
+            Ok(self.entries.get(key).map(|b| b.len() as u64).unwrap_or(0))
+        }
+    }
+
+    /// PyPI-shaped remote repo for the cache-path threading tests: wheels
+    /// classify as immutable under [`cache_classifier`], so a cached entry
+    /// streams without contacting upstream or the database.
+    fn pypi_remote_repo(key: &str) -> Repository {
+        let mut repo = remote_repo_for(key, "https://pypi.org/simple", "/tmp/x");
+        repo.format = RepositoryFormat::Pypi;
+        repo
+    }
+
+    async fn collect_streaming_body(
+        mut body: futures::stream::BoxStream<'static, Result<Bytes>>,
+    ) -> Bytes {
+        let mut buf = Vec::new();
+        while let Some(chunk) = body.next().await {
+            buf.extend_from_slice(&chunk.unwrap());
+        }
+        Bytes::from(buf)
+    }
+
+    #[tokio::test]
+    async fn test_streaming_with_cache_path_keys_cache_on_cache_path() {
+        // The PyPI handler fetches wheels from files.pythonhosted.org-style
+        // URLs but caches them under the stable simple/{project}/{file} key.
+        // A cache hit must be found under `cache_path` even though
+        // `fetch_path` points somewhere else entirely — and the fetch path
+        // must never be used to derive a storage key.
+        let cache_path = "simple/numpy/numpy-2.0.0-py3-none-any.whl";
+        let fetch_path = "packages/ab/cd/numpy-2.0.0-py3-none-any.whl";
+        let wheel_body = Bytes::from_static(b"fake wheel bytes");
+
+        let keys = CacheKeys::derive("pypi-remote", cache_path).unwrap();
+        let mut entries = std::collections::HashMap::new();
+        entries.insert(keys.metadata.clone(), fresh_metadata_bytes());
+        entries.insert(keys.content.clone(), wheel_body.clone());
+
+        let storage = Arc::new(RecordingMapStorage {
+            entries,
+            requested: std::sync::Mutex::new(Vec::new()),
+        });
+        let svc = build_proxy_service_with_storage(storage.clone());
+        let repo = pypi_remote_repo("pypi-remote");
+
+        let result = svc
+            .fetch_artifact_streaming_with_cache_path(&repo, fetch_path, cache_path)
+            .await
+            .expect("cached entry under cache_path must stream as a hit");
+
+        let body = collect_streaming_body(result.body).await;
+        assert_eq!(body, wheel_body);
+
+        let requested = storage.requested.lock().unwrap();
+        assert!(
+            requested.iter().all(|k| !k.contains("packages/")),
+            "no storage key may be derived from fetch_path; requested: {:?}",
+            *requested
+        );
+    }
+
+    #[tokio::test]
+    async fn test_streaming_cached_artifact_by_path_returns_none_on_miss() {
+        // Empty storage: the streaming probe must report a miss without
+        // erroring (callers fall through to the full upstream fetch).
+        let storage = Arc::new(RecordingMapStorage {
+            entries: std::collections::HashMap::new(),
+            requested: std::sync::Mutex::new(Vec::new()),
+        });
+        let svc = build_proxy_service_with_storage(storage);
+        let repo = pypi_remote_repo("pypi-remote");
+
+        let probe = svc
+            .streaming_cached_artifact_by_path(&repo, "simple/numpy/numpy-2.0.0-py3-none-any.whl")
+            .await
+            .expect("a cache miss must not be an error");
+        assert!(probe.is_none(), "missing sidecar must probe as a miss");
+    }
+
     // --- Divergence #1: expiry gate -----------------------------------------
 
     #[tokio::test]
@@ -9351,6 +9539,76 @@ SHA256:
             .expect_err("a 5xx upstream must fail the streaming fetch");
         let _ = std::fs::remove_dir_all(&tmp);
         assert!(matches!(err, AppError::ServiceUnavailable(_)), "{err:?}");
+    }
+
+    /// PyPI-shaped split (#895 follow-up): the upstream download URL
+    /// (files.pythonhosted.org-style `packages/...` path) differs from the
+    /// stable cache key (`simple/{project}/{file}`). The streaming leader
+    /// must fetch `fetch_path` from upstream but tee the body into the
+    /// cache under `cache_path`-derived keys only.
+    #[tokio::test]
+    async fn test_fetch_artifact_streaming_with_cache_path_tees_under_cache_path() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/packages/ab/cd/demo-1.0-py3-none-any.whl"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/zip")
+                    .set_body_bytes(b"wheel-body".as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-cachepath-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("pypi-split", &server.uri(), tmp.to_str().unwrap());
+
+        let fetch_path = "packages/ab/cd/demo-1.0-py3-none-any.whl";
+        let cache_path = "simple/demo/demo-1.0-py3-none-any.whl";
+        let result = proxy
+            .fetch_artifact_streaming_with_cache_path(&repo, fetch_path, cache_path)
+            .await
+            .expect("streaming fetch with split fetch/cache paths must succeed");
+
+        let mut collected = Vec::new();
+        let mut body = result.body;
+        while let Some(chunk) = body.next().await {
+            collected.extend_from_slice(&chunk.expect("stream chunk must be Ok"));
+        }
+        assert_eq!(collected, b"wheel-body");
+
+        // The tee writes the cache in a background task after the client
+        // stream drains; poll briefly for the content object to land.
+        let content_rel = CacheKeys::derive("pypi-split", cache_path)
+            .expect("derive")
+            .content;
+        let content_file = tmp.join(&content_rel);
+        let mut cached = Vec::new();
+        for _ in 0..50 {
+            if let Ok(bytes) = std::fs::read(&content_file) {
+                cached = bytes;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert_eq!(
+            cached, b"wheel-body",
+            "cache body must land under the cache_path-derived key"
+        );
+        // Nothing may be cached under a fetch_path-derived location.
+        assert!(
+            !tmp.join("proxy-cache/pypi-split/packages").exists(),
+            "no cache entry may be derived from fetch_path"
+        );
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     /// #1631 layer 2 (#1694): N concurrent cold-cache streaming requests for


### PR DESCRIPTION
Closes #1863
Advances #1608 (Core Invariant ①: no full-body buffering on artifact paths).

## Problem

Remote/proxy PyPI package downloads buffered the entire wheel/sdist body in memory before serving it. On multi-hundred-MiB files this stalled the client with zero bytes until the upstream transfer finished, and OOM-killed memory-constrained pods (#895 built the tee primitive; PyPI never adopted it).

## Change

Route package-file downloads through the streaming proxy path, teeing the upstream body into the cache while serving it to the client — no full-body buffering.

PyPI keys its cache on `simple/{project}/{filename}` while the files themselves live on a different upstream host (e.g. `files.pythonhosted.org`). To make the existing streaming path usable here, this adds cache-path-aware helpers that decouple the fetch URL from the cache key:

- `ProxyService::fetch_artifact_streaming_with_cache_path(repo, fetch_path, cache_path)` — streaming sibling of `fetch_artifact_with_cache_path`; fetches from `fetch_path` but keys cache/TTL/negative-cache/scan decisions on `cache_path`.
- `ProxyService::streaming_cached_artifact_by_path(repo, cache_path)` — streaming cache probe; serves a hit straight from storage, returns `None`/`NotFound` on miss/negative-cache.
- `proxy_helpers::proxy_fetch_streaming_with_cache_key` / `proxy_check_cache_streaming` — handler-layer wrappers with best-effort probe semantics.

Simple-index pages stay buffered by design (small).

## Testing

- `cargo clippy --all-targets` — clean, 0 warnings
- `cargo test --lib pypi` — 234 passed, 0 failed
