### PR TITLE
fix(authz): enforce repository tenant ownership on all write paths independent of fine-grained RBAC

### DIFF
--- a/backend/src/api/handlers/approval.rs
+++ b/backend/src/api/handlers/approval.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::api::dto::Pagination;
 use crate::api::handlers::promotion::validate_promotion_repos;
+use crate::api::handlers::repositories::require_visible;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -208,6 +209,15 @@ pub async fn request_approval(
     let source_repo = repo_service.get_by_key(&req.source_repository).await?;
     let target_repo = repo_service.get_by_key(&req.target_repository).await?;
     validate_promotion_repos(&source_repo, &target_repo)?;
+
+    // Close the cross-tenant existence oracle. The /approval surface resolves the
+    // source repository by key with NO caller visibility filter and then probes
+    // it for the artifact below; without this gate a non-member could use that
+    // probe as an existence oracle against another tenant's private repo and
+    // write a promotion_approvals row referencing it. require_visible derives the
+    // gate from is_public + per-repo role-assignment membership (NotFound on a
+    // private repo the caller cannot see), so the denial happens BEFORE the probe.
+    require_visible(&source_repo, &Some(auth.clone()), &repo_service).await?;
 
     // Verify the artifact exists in the source repo
     let artifact_exists: Option<(Uuid,)> = sqlx::query_as(
@@ -873,6 +883,32 @@ pub struct ApprovalApiDoc;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Cross-tenant oracle guard (xtenant-write-authz-systemic). `request_approval`
+    /// resolves the source repository by key and probes it for the artifact; it
+    /// must call `require_visible` on the source repo BEFORE that probe so a
+    /// non-member cannot use the probe as an existence oracle against another
+    /// tenant's private repo. String-grep because the handler needs a real DB.
+    #[test]
+    fn test_request_approval_gates_source_repo_before_probe() {
+        let source = include_str!("approval.rs");
+        let start = source
+            .find("pub async fn request_approval(")
+            .expect("request_approval not found");
+        let rest = &source[start..];
+        let end = rest.find("\npub async fn ").unwrap_or(rest.len());
+        let body = &rest[..end];
+        let gate = body
+            .find("require_visible(")
+            .expect("request_approval must call require_visible on the source repo (xtenant)");
+        let probe = body
+            .find("SELECT id FROM artifacts WHERE id = $1")
+            .expect("artifact existence probe not found");
+        assert!(
+            gate < probe,
+            "require_visible must run BEFORE the artifact existence probe (xtenant oracle)"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (moved into test module)

--- a/backend/src/api/handlers/email_subscriptions.rs
+++ b/backend/src/api/handlers/email_subscriptions.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::repositories::require_repo_write_access;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -186,6 +187,34 @@ fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     Ok(auth)
 }
 
+/// Resolve a repository by key and fully authorize the caller for an
+/// email-subscription operation on it. Combines the three gates the handlers
+/// share: write scope (`require_repo_write`), token repo-scope with
+/// existence-hiding 404 (`can_access_repo`), and the canonical tenant gate
+/// (`require_repo_write_access` = is_public + per-repo role-assignment
+/// membership). Returns the authorized principal and the resolved repository id.
+///
+/// The /repositories nest runs under `optional_auth_middleware` only, NOT
+/// `repo_visibility_middleware`, so this enforcement lives in-handler; factoring
+/// it here keeps the three handlers from re-deriving (or forgetting) the gate.
+async fn authorize_subscription_repo(
+    state: &SharedState,
+    auth: Option<AuthExtension>,
+    key: &str,
+) -> Result<(AuthExtension, Uuid)> {
+    let auth = require_repo_write(auth)?;
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(key).await?;
+    if !auth.can_access_repo(repo.id) {
+        return Err(AppError::NotFound(format!(
+            "Repository '{}' not found",
+            key
+        )));
+    }
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    Ok((auth, repo.id))
+}
+
 /// Validate the supplied event-type tokens against [`VALID_EVENT_TYPES`].
 /// Returns `Err(Validation)` listing unknown tokens; doing this at write
 /// time prevents typos from silently dropping notifications at delivery.
@@ -284,16 +313,7 @@ pub async fn list_subscriptions(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
 ) -> Result<Json<EmailSubscriptionListResponse>> {
-    let auth = require_repo_write(auth)?;
-    let repo = RepositoryService::new(state.db.clone())
-        .get_by_key(&key)
-        .await?;
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (_auth, repo_id) = authorize_subscription_repo(&state, auth, &key).await?;
 
     let rows: Vec<EmailSubscriptionRow> = sqlx::query_as(
         r#"
@@ -304,7 +324,7 @@ pub async fn list_subscriptions(
         ORDER BY created_at DESC
         "#,
     )
-    .bind(repo.id)
+    .bind(repo_id)
     .fetch_all(&state.db)
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
@@ -336,16 +356,7 @@ pub async fn create_subscription(
     Path(key): Path<String>,
     Json(body): Json<CreateEmailSubscriptionRequest>,
 ) -> Result<Json<EmailSubscriptionResponse>> {
-    let auth = require_repo_write(auth)?;
-    let repo = RepositoryService::new(state.db.clone())
-        .get_by_key(&key)
-        .await?;
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (auth, repo_id) = authorize_subscription_repo(&state, auth, &key).await?;
 
     validate_event_types(&body.event_types)?;
     validate_recipients(&body.recipients)?;
@@ -359,7 +370,7 @@ pub async fn create_subscription(
                   created_at, updated_at
         "#,
     )
-    .bind(repo.id)
+    .bind(repo_id)
     .bind(&body.recipients)
     .bind(&body.event_types)
     .bind(body.enabled)
@@ -375,7 +386,7 @@ pub async fn create_subscription(
         &state,
         AuditAction::EmailSubscriptionCreated,
         auth.user_id,
-        repo.id,
+        repo_id,
         row.id,
         serde_json::json!({
             "recipient_count": row.recipients.len(),
@@ -411,21 +422,12 @@ pub async fn delete_subscription(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, subscription_id)): Path<(String, Uuid)>,
 ) -> Result<axum::http::StatusCode> {
-    let auth = require_repo_write(auth)?;
-    let repo = RepositoryService::new(state.db.clone())
-        .get_by_key(&key)
-        .await?;
-    if !auth.can_access_repo(repo.id) {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
-    }
+    let (auth, repo_id) = authorize_subscription_repo(&state, auth, &key).await?;
 
     let result =
         sqlx::query("DELETE FROM email_subscriptions WHERE id = $1 AND repository_id = $2")
             .bind(subscription_id)
-            .bind(repo.id)
+            .bind(repo_id)
             .execute(&state.db)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -443,7 +445,7 @@ pub async fn delete_subscription(
         &state,
         AuditAction::EmailSubscriptionDeleted,
         auth.user_id,
-        repo.id,
+        repo_id,
         subscription_id,
         serde_json::json!({}),
     )
@@ -467,6 +469,44 @@ pub struct EmailSubscriptionsApiDoc;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Cross-tenant authz guard (xtenant-write-authz-systemic). The
+    /// email-subscription endpoints live under the /repositories nest (not gated
+    /// by repo_visibility_middleware) and previously enforced only token-scope
+    /// (`can_access_repo`), which falls open across tenants. Assert each handler
+    /// also calls the tenant gate `require_repo_write_access` (is_public +
+    /// role_assignments membership). String-grep because the handlers need a DB.
+    #[test]
+    fn test_email_subscription_handlers_enforce_tenant_gate() {
+        let source = include_str!("email_subscriptions.rs");
+        for handler in [
+            "list_subscriptions",
+            "create_subscription",
+            "delete_subscription",
+        ] {
+            let marker = format!("pub async fn {}(", handler);
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler `{}` not found", handler));
+            let rest = &source[start + marker.len()..];
+            let end = rest.find("\npub async fn ").unwrap_or(rest.len());
+            assert!(
+                rest[..end].contains("authorize_subscription_repo("),
+                "handler `{}` must authorize through authorize_subscription_repo (xtenant)",
+                handler
+            );
+        }
+        // The shared helper is where the tenant gate actually lives.
+        let helper_start = source
+            .find("async fn authorize_subscription_repo(")
+            .expect("authorize_subscription_repo helper not found");
+        let helper = &source[helper_start..];
+        let helper_end = helper.find("\n}\n").map(|i| i + 2).unwrap_or(helper.len());
+        assert!(
+            helper[..helper_end].contains("require_repo_write_access("),
+            "authorize_subscription_repo must call require_repo_write_access (xtenant)"
+        );
+    }
 
     #[test]
     fn test_validate_event_types_accepts_known_tokens() {

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -93,7 +93,14 @@ fn require_repo_access(auth: &AuthExtension, repo_id: Uuid) -> Result<()> {
 /// repositories, per-repo authorization: admins bypass; every other caller must
 /// hold a role assignment scoped to the repo (direct or global). Public repos
 /// keep their existing behavior (token-scope only).
-async fn require_repo_write_access(
+///
+/// Exposed as `pub(crate)` so the repository sub-resource handlers that live in
+/// sibling modules (labels, security, email subscriptions) and the chunked
+/// upload-session create path can route through the SAME tenant write gate
+/// rather than re-deriving (or forgetting) it. The `/api/v1/repositories` nest
+/// runs under `optional_auth_middleware` only, NOT `repo_visibility_middleware`,
+/// so each sub-handler must enforce this itself.
+pub(crate) async fn require_repo_write_access(
     auth: &AuthExtension,
     repo: &crate::models::repository::Repository,
     repo_service: &RepositoryService,
@@ -123,7 +130,10 @@ async fn require_repo_write_access(
 ///
 /// Denials on private repos return `NotFound` (not `Forbidden`) to avoid
 /// leaking the existence of repositories the caller may not see.
-async fn require_visible(
+///
+/// Exposed as `pub(crate)` so leaky-read sub-resource handlers in sibling
+/// modules (labels list, security read) can reuse the canonical visibility gate.
+pub(crate) async fn require_visible(
     repo: &crate::models::repository::Repository,
     auth: &Option<AuthExtension>,
     repo_service: &RepositoryService,
@@ -718,7 +728,7 @@ pub async fn set_cache_ttl(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &service).await?;
 
     // Reject writes on non-remote repos before any further validation: the
     // value would never be read back by the proxy code path (see #917).
@@ -852,7 +862,7 @@ pub async fn invalidate_cache(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &service).await?;
 
     // Cache invalidation is meaningless on Local / Virtual / Staging repos --
     // only Remote (proxy) repos own a cache. Reject up front before touching
@@ -994,7 +1004,7 @@ pub async fn put_pypi_track(
     auth.require_scope("write")?;
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &service).await?;
     require_pypi_tracks_repo(&repo)?;
 
     let tracks_url = payload.tracks_url.trim().to_string();
@@ -1056,7 +1066,7 @@ pub async fn delete_pypi_track(
     auth.require_scope("write")?;
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &service).await?;
 
     let normalized = crate::api::handlers::pypi::normalize_pep503(&project);
     sqlx::query(
@@ -4752,6 +4762,8 @@ pub async fn set_upstream_auth(
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
     let repo = load_remote_repo(&state, &auth, &key).await?;
+    let repo_service = RepositoryService::new(state.db.clone());
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
 
     if payload.auth_type == "none" {
         crate::services::upstream_auth::remove_upstream_auth(&state.db, repo.id).await?;
@@ -4805,6 +4817,8 @@ pub async fn test_upstream(
     let auth = require_auth(auth)?;
     auth.require_scope("read")?;
     let repo = load_remote_repo(&state, &auth, &key).await?;
+    let repo_service = RepositoryService::new(state.db.clone());
+    require_visible(&repo, &Some(auth.clone()), &repo_service).await?;
 
     let upstream_url = repo.upstream_url.as_deref().ok_or_else(|| {
         AppError::Validation("Repository has no upstream URL configured".to_string())
@@ -4947,7 +4961,7 @@ pub async fn set_routing_rules(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &service).await?;
 
     let value = serde_json::to_string(&payload.rules)
         .map_err(|e| AppError::Internal(format!("Failed to serialize routing rules: {}", e)))?;
@@ -4998,7 +5012,7 @@ pub async fn delete_routing_rules(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_access(&auth, repo.id)?;
+    require_repo_write_access(&auth, &repo, &service).await?;
 
     sqlx::query(
         r#"
@@ -8018,6 +8032,53 @@ mod tests {
             "list_virtual_members must filter the response by \
              can_access_repo(member_repo_id) (issue #913)"
         );
+    }
+
+    /// Cross-tenant write authz (xtenant-write-authz-systemic):
+    ///
+    /// The `/api/v1/repositories` REST nest runs under `optional_auth_middleware`
+    /// only, NOT `repo_visibility_middleware`, so each sub-resource mutation
+    /// handler must enforce the tenant write gate itself. Assert every such
+    /// handler references `require_repo_write_access` (the canonical
+    /// `is_public + role_assignments` gate) so a future handler cannot silently
+    /// fall open to a non-member, non-admin caller on a private repo. String-grep
+    /// because the handlers need a full `SharedState` to run.
+    #[test]
+    fn test_repo_mutation_handlers_call_write_gate() {
+        let source = include_str!("repositories.rs");
+
+        for handler in [
+            "set_cache_ttl",
+            "invalidate_cache",
+            "put_pypi_track",
+            "delete_pypi_track",
+            "set_routing_rules",
+            "delete_routing_rules",
+            "set_upstream_auth",
+            "upload_artifact",
+            "delete_artifact",
+        ] {
+            let marker = format!("pub async fn {}(", handler);
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler `{}` not found in repositories.rs", handler));
+            let rest = &source[start + marker.len()..];
+            let end = rest
+                .find("\npub async fn ")
+                .or_else(|| rest.find("\npub fn "))
+                .unwrap_or(rest.len());
+            let body = &rest[..end];
+
+            assert!(
+                body.contains("require_repo_write_access("),
+                "handler `{}` does not call `require_repo_write_access` \
+                 (xtenant-write-authz-systemic). The /repositories nest is not \
+                 covered by repo_visibility_middleware, so each mutation handler \
+                 must enforce the tenant write gate itself. If you intentionally \
+                 restructured the authz model, update this test to match.",
+                handler
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -7841,6 +7841,152 @@ mod tests {
         assert!(!member_mutation_admin_allowed(false, false));
     }
 
+    // -----------------------------------------------------------------------
+    // xtenant-write-authz-systemic: behavioral coverage for the two shared
+    // tenant gates (`require_repo_write_access` / `require_visible`) that every
+    // repository sub-resource handler now routes through. The no-DB
+    // short-circuits (token scope, public, admin, anonymous) run everywhere;
+    // the per-repo role-assignment branch is exercised by the `*_db` tests,
+    // which seed a real Postgres and skip cleanly when DATABASE_URL is unset
+    // (the same `try_pool()` convention the virtual-member tests use).
+    // -----------------------------------------------------------------------
+    fn no_db_repo_service() -> RepositoryService {
+        RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool())
+    }
+
+    #[tokio::test]
+    async fn test_require_repo_write_access_admin_short_circuits_no_db() {
+        let repo = make_repo_with_id(Uuid::new_v4(), "globex-private");
+        let res = require_repo_write_access(&make_admin_ext(), &repo, &no_db_repo_service()).await;
+        assert!(
+            res.is_ok(),
+            "admin must pass the write gate via is_admin, no DB: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_repo_write_access_public_allowed_no_db() {
+        let repo = make_repo(true); // is_public = true
+        let res =
+            require_repo_write_access(&make_auth_ext(None), &repo, &no_db_repo_service()).await;
+        assert!(
+            res.is_ok(),
+            "a public repo is writable past the gate, no DB: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_repo_write_access_out_of_token_scope_denied_no_db() {
+        // A repo-scoped token whose scope excludes this repo is denied before any
+        // DB lookup (the `require_repo_access` token-scope gate).
+        let repo = make_repo_with_id(Uuid::new_v4(), "globex-private");
+        let auth = make_auth_ext(Some(vec![Uuid::new_v4()]));
+        let res = require_repo_write_access(&auth, &repo, &no_db_repo_service()).await;
+        assert!(
+            matches!(res, Err(AppError::Authorization(_))),
+            "a repo-scoped token must be denied write outside its scope: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_visible_public_is_visible_to_anonymous_no_db() {
+        let repo = make_repo(true);
+        let res = require_visible(&repo, &None, &no_db_repo_service()).await;
+        assert!(
+            res.is_ok(),
+            "public repos are visible to anonymous callers: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_visible_private_hidden_from_anonymous_no_db() {
+        let repo = make_repo_with_id(Uuid::new_v4(), "globex-private");
+        let res = require_visible(&repo, &None, &no_db_repo_service()).await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "private repos must be hidden (NotFound) from anonymous callers: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_visible_out_of_token_scope_not_found_no_db() {
+        let repo = make_repo_with_id(Uuid::new_v4(), "globex-private");
+        let auth = make_auth_ext(Some(vec![Uuid::new_v4()]));
+        let res = require_visible(&repo, &Some(auth), &no_db_repo_service()).await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "a repo-scoped token must not see a repo outside its scope: {res:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_require_visible_admin_sees_private_no_db() {
+        let repo = make_repo_with_id(Uuid::new_v4(), "globex-private");
+        let res = require_visible(&repo, &Some(make_admin_ext()), &no_db_repo_service()).await;
+        assert!(
+            res.is_ok(),
+            "admins see any repo via the is_admin short-circuit: {res:?}"
+        );
+    }
+
+    /// DB-backed: a non-admin, unrestricted-scope session (the password/JWT shape
+    /// the systemic fix targets) is DENIED write to a private repo it holds no
+    /// role on, and granting a role lets it through. Skips with no DATABASE_URL.
+    #[tokio::test]
+    async fn test_require_repo_write_access_nonmember_denied_then_granted_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let repo = make_repo_with_id(repo_id, &key); // is_public = false
+        let ext = tdh::make_auth(user_id, &username);
+        let svc = RepositoryService::new(pool.clone());
+
+        let denied = require_repo_write_access(&ext, &repo, &svc).await;
+        assert!(
+            matches!(denied, Err(AppError::Authorization(_))),
+            "non-member must be denied write on a private repo: {denied:?}"
+        );
+
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let allowed = require_repo_write_access(&ext, &repo, &svc).await;
+        assert!(
+            allowed.is_ok(),
+            "a granted member must pass the write gate: {allowed:?}"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    /// DB-backed sibling for the read/visibility gate: a non-member gets NotFound
+    /// on a private repo; a granted member sees it. Skips with no DATABASE_URL.
+    #[tokio::test]
+    async fn test_require_visible_nonmember_not_found_then_granted_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let repo = make_repo_with_id(repo_id, &key);
+        let ext = tdh::make_auth(user_id, &username);
+        let svc = RepositoryService::new(pool.clone());
+
+        let hidden = require_visible(&repo, &Some(ext.clone()), &svc).await;
+        assert!(
+            matches!(hidden, Err(AppError::NotFound(_))),
+            "non-member must get NotFound on a private repo: {hidden:?}"
+        );
+
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let seen = require_visible(&repo, &Some(ext), &svc).await;
+        assert!(seen.is_ok(), "a granted member must see the repo: {seen:?}");
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
     /// DB-backed: a non-admin without `repository:admin` on the virtual parent
     /// is rejected (Insufficient permissions), and granting the rule lets them
     /// through — mirroring the gate `update_repository` enforces. Skips when no

--- a/backend/src/api/handlers/repository_labels.rs
+++ b/backend/src/api/handlers/repository_labels.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::repositories::{require_repo_write_access, require_visible};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -97,6 +98,21 @@ fn labels_list_response(labels: Vec<RepositoryLabel>) -> LabelsListResponse {
     LabelsListResponse { items, total }
 }
 
+/// Re-evaluate sync policies after a label mutation. A failure here is logged at
+/// `warn!` and swallowed so a sync-policy hiccup never turns a successful label
+/// write into a 5xx. Factored out of the three mutating handlers (they shared an
+/// identical block).
+async fn reevaluate_sync_policies(db: &sqlx::PgPool, repo_id: Uuid) {
+    let sync_svc = SyncPolicyService::new(db.clone());
+    if let Err(e) = sync_svc.evaluate_for_repository(repo_id).await {
+        tracing::warn!(
+            "Sync policy re-evaluation failed for repo {}: {}",
+            repo_id,
+            e
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -122,10 +138,14 @@ async fn list_labels(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
 ) -> Result<Json<LabelsListResponse>> {
-    let _auth = require_auth(auth)?;
+    let auth = require_auth(auth)?;
 
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
+    // The /repositories nest is not gated by repo_visibility_middleware, so the
+    // read must enforce the canonical visibility gate (is_public + per-repo
+    // role-assignment membership) itself to avoid leaking a private repo's labels.
+    require_visible(&repo, &Some(auth), &repo_service).await?;
 
     let label_service = RepositoryLabelService::new(state.db.clone());
     let labels = label_service.get_labels(repo.id).await?;
@@ -156,10 +176,13 @@ async fn set_labels(
     Path(key): Path<String>,
     Json(payload): Json<SetLabelsRequest>,
 ) -> Result<Json<LabelsListResponse>> {
-    let _auth = require_auth(auth)?;
+    let auth = require_auth(auth)?;
 
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
+    // Tenant write gate: the /repositories nest bypasses repo_visibility_middleware,
+    // so enforce is_public + role-assignment membership here (see #xtenant).
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
 
     let entries: Vec<LabelEntry> = payload
         .labels
@@ -173,15 +196,7 @@ async fn set_labels(
     let label_service = RepositoryLabelService::new(state.db.clone());
     let labels = label_service.set_labels(repo.id, &entries).await?;
 
-    // Re-evaluate sync policies after label change
-    let sync_svc = SyncPolicyService::new(state.db.clone());
-    if let Err(e) = sync_svc.evaluate_for_repository(repo.id).await {
-        tracing::warn!(
-            "Sync policy re-evaluation failed for repo {}: {}",
-            repo.id,
-            e
-        );
-    }
+    reevaluate_sync_policies(&state.db, repo.id).await;
 
     Ok(Json(labels_list_response(labels)))
 }
@@ -210,25 +225,20 @@ async fn add_label(
     Path((key, label_key)): Path<(String, String)>,
     Json(payload): Json<AddLabelRequest>,
 ) -> Result<Json<LabelResponse>> {
-    let _auth = require_auth(auth)?;
+    let auth = require_auth(auth)?;
 
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
+    // Tenant write gate: the /repositories nest bypasses repo_visibility_middleware,
+    // so enforce is_public + role-assignment membership here (see #xtenant).
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
 
     let label_service = RepositoryLabelService::new(state.db.clone());
     let label = label_service
         .add_label(repo.id, &label_key, &payload.value)
         .await?;
 
-    // Re-evaluate sync policies after label change
-    let sync_svc = SyncPolicyService::new(state.db.clone());
-    if let Err(e) = sync_svc.evaluate_for_repository(repo.id).await {
-        tracing::warn!(
-            "Sync policy re-evaluation failed for repo {}: {}",
-            repo.id,
-            e
-        );
-    }
+    reevaluate_sync_policies(&state.db, repo.id).await;
 
     Ok(Json(label_to_response(label)))
 }
@@ -255,23 +265,18 @@ async fn delete_label(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, label_key)): Path<(String, String)>,
 ) -> Result<axum::http::StatusCode> {
-    let _auth = require_auth(auth)?;
+    let auth = require_auth(auth)?;
 
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
+    // Tenant write gate: the /repositories nest bypasses repo_visibility_middleware,
+    // so enforce is_public + role-assignment membership here (see #xtenant).
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
 
     let label_service = RepositoryLabelService::new(state.db.clone());
     label_service.remove_label(repo.id, &label_key).await?;
 
-    // Re-evaluate sync policies after label change
-    let sync_svc = SyncPolicyService::new(state.db.clone());
-    if let Err(e) = sync_svc.evaluate_for_repository(repo.id).await {
-        tracing::warn!(
-            "Sync policy re-evaluation failed for repo {}: {}",
-            repo.id,
-            e
-        );
-    }
+    reevaluate_sync_policies(&state.db, repo.id).await;
 
     Ok(axum::http::StatusCode::NO_CONTENT)
 }
@@ -279,6 +284,37 @@ async fn delete_label(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Cross-tenant authz guard (xtenant-write-authz-systemic). The labels
+    /// surface lives under the /repositories nest, which is NOT covered by
+    /// repo_visibility_middleware, so each handler must enforce the tenant gate
+    /// itself. Assert the mutating handlers call `require_repo_write_access` and
+    /// the read handler calls `require_visible`. String-grep because the handlers
+    /// need a full DB-backed `SharedState` to run.
+    #[test]
+    fn test_label_handlers_enforce_tenant_gate() {
+        let source = include_str!("repository_labels.rs");
+        for handler in ["set_labels", "add_label", "delete_label"] {
+            let marker = format!("async fn {}(", handler);
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler `{}` not found", handler));
+            let rest = &source[start + marker.len()..];
+            let end = rest.find("\nasync fn ").unwrap_or(rest.len());
+            assert!(
+                rest[..end].contains("require_repo_write_access("),
+                "handler `{}` must call require_repo_write_access (xtenant)",
+                handler
+            );
+        }
+        let start = source.find("async fn list_labels(").expect("list_labels");
+        let rest = &source[start..];
+        let end = rest.find("\nasync fn ").unwrap_or(rest.len());
+        assert!(
+            rest[..end].contains("require_visible("),
+            "list_labels must call require_visible (xtenant)"
+        );
+    }
 
     #[test]
     fn test_set_labels_request_deserialization() {

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -10,11 +10,13 @@ use sqlx::PgPool;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::repositories::{require_repo_write_access, require_visible};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::security::ScanResult;
 use crate::services::policy_service::PolicyService;
+use crate::services::repository_service::RepositoryService;
 use crate::services::scan_config_service::{ScanConfigService, UpsertScanConfigRequest};
 use crate::services::scan_result_service::ScanResultService;
 
@@ -1018,14 +1020,16 @@ async fn get_repo_security(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
 ) -> Result<Json<RepoSecurityResponse>> {
-    let _auth =
+    let auth =
         auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
-    // Resolve repository by key
-    let repo = sqlx::query_scalar!("SELECT id FROM repositories WHERE key = $1", key,)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound("Repository not found".to_string()))?;
+    // Resolve repository by key. The /repositories nest is NOT gated by
+    // repo_visibility_middleware, so enforce the canonical visibility gate
+    // (is_public + per-repo role-assignment membership) here to avoid leaking a
+    // private repo's security config/score to a non-member.
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+    require_visible(&repo, &Some(auth), &repo_service).await?;
+    let repo = repo.id;
 
     let config_svc = ScanConfigService::new(state.db.clone());
     let result_svc = ScanResultService::new(state.db.clone());
@@ -1060,13 +1064,14 @@ async fn update_repo_security(
     Path(key): Path<String>,
     Json(body): Json<UpsertScanConfigRequest>,
 ) -> Result<Json<ScanConfigResponse>> {
-    let _auth =
+    let auth =
         auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
-    let repo = sqlx::query_scalar!("SELECT id FROM repositories WHERE key = $1", key,)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound("Repository not found".to_string()))?;
+    // Tenant write gate: the /repositories nest bypasses repo_visibility_middleware,
+    // so enforce is_public + per-repo role-assignment membership here.
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    let repo = repo.id;
 
     let svc = ScanConfigService::new(state.db.clone());
     let c = svc.upsert_config(repo, &body).await?;
@@ -1136,13 +1141,15 @@ async fn list_repo_scans(
     Path(key): Path<String>,
     Query(query): Query<ListScansQuery>,
 ) -> Result<Json<ScanListResponse>> {
-    let _auth =
+    let auth =
         auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
-    let repo = sqlx::query_scalar!("SELECT id FROM repositories WHERE key = $1", key,)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?
-        .ok_or_else(|| AppError::NotFound("Repository not found".to_string()))?;
+    // Resolve repository by key. The /repositories nest bypasses
+    // repo_visibility_middleware, so enforce the canonical visibility gate here
+    // to avoid leaking a private repo's scan list to a non-member.
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service.get_by_key(&key).await?;
+    require_visible(&repo, &Some(auth), &repo_service).await?;
+    let repo = repo.id;
 
     let svc = ScanResultService::new(state.db.clone());
     let page = query.page.unwrap_or(1);
@@ -1201,6 +1208,37 @@ pub struct SecurityApiDoc;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Cross-tenant authz guard (xtenant-write-authz-systemic). The repo-scoped
+    /// security endpoints live under the /repositories nest (not gated by
+    /// repo_visibility_middleware), so each must enforce the tenant gate itself.
+    /// Assert the write handler calls `require_repo_write_access` and the read
+    /// handlers call `require_visible`. String-grep because the handlers need a
+    /// full DB-backed `SharedState` to run.
+    #[test]
+    fn test_repo_security_handlers_enforce_tenant_gate() {
+        let source = include_str!("security.rs");
+        let body_of = |handler: &str| -> &str {
+            let marker = format!("async fn {}(", handler);
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler `{}` not found", handler));
+            let rest = &source[start + marker.len()..];
+            let end = rest.find("\nasync fn ").unwrap_or(rest.len());
+            &rest[..end]
+        };
+        assert!(
+            body_of("update_repo_security").contains("require_repo_write_access("),
+            "update_repo_security must call require_repo_write_access (xtenant)"
+        );
+        for reader in ["get_repo_security", "list_repo_scans"] {
+            assert!(
+                body_of(reader).contains("require_visible("),
+                "{} must call require_visible (xtenant)",
+                reader
+            );
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Pure helper functions (testable without DB)

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -21,9 +21,11 @@ use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
 use crate::api::handlers::proxy_helpers;
+use crate::api::handlers::repositories::require_repo_write_access;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::services::package_service::PackageService;
+use crate::services::repository_service::RepositoryService;
 use crate::services::upload_service::{self, UploadError, UploadService};
 
 // ---------------------------------------------------------------------------
@@ -210,6 +212,28 @@ async fn create_session(
     })?;
     let repo_id = repo.0;
     let repo_promotion_only = repo.1;
+
+    // Tenant write gate (xtenant-write-authz-systemic).
+    //
+    // The /uploads router runs under auth_middleware only (no
+    // repo_visibility_middleware), and the target repo is named in the JSON body,
+    // so the tenant-membership gate that protects the URL-addressed artifact PUT
+    // never sees this request. The fine-grained RBAC checks below fall OPEN when
+    // a repo has no permission rules (`has_rules == false`), so derive the tenant
+    // boundary from `is_public` + role_assignments membership
+    // (`require_repo_write_access`): a non-member, non-admin can never open a
+    // session against another tenant's private repo regardless of whether any
+    // permission rule exists. Admins, public-repo writers, same-org members and
+    // write/admin-holding peer-replication identities all pass unchanged. Mirrors
+    // `repositories::upload_artifact`.
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo_record = repo_service
+        .get_by_key(&req.repository_key)
+        .await
+        .map_err(IntoResponse::into_response)?;
+    require_repo_write_access(&auth, &repo_record, &repo_service)
+        .await
+        .map_err(IntoResponse::into_response)?;
 
     // Promotion-only gate (#817 parity with the direct upload path).
     //
@@ -950,6 +974,27 @@ fn replication_session_metadata_from_request<'a>(
 #[allow(clippy::io_other_error, clippy::unnecessary_literal_unwrap)]
 mod tests {
     use super::*;
+
+    /// Cross-tenant authz guard (xtenant-write-authz-systemic). `session_write_authorized`
+    /// (and `upload_write_decision`) fall OPEN when the target repo has no
+    /// fine-grained permission rules (`!has_rules`), so `create_session` must
+    /// ALSO enforce the rule-independent tenant gate `require_repo_write_access`
+    /// (is_public + role_assignments membership). String-grep because the handler
+    /// needs a real DB to run.
+    #[test]
+    fn test_create_session_enforces_tenant_gate() {
+        let source = include_str!("upload.rs");
+        let start = source
+            .find("async fn create_session(")
+            .expect("create_session not found");
+        let rest = &source[start..];
+        let end = rest.find("\nasync fn ").unwrap_or(rest.len());
+        assert!(
+            rest[..end].contains("require_repo_write_access("),
+            "create_session must call require_repo_write_access independent of \
+             fine-grained rule existence (xtenant)"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // session_write_authorized (pure write-authorization decision)


### PR DESCRIPTION
## Summary

Enforce repository tenant ownership on all write paths independent of fine-grained
RBAC rules.

The `/api/v1/repositories` REST nest is layered with `optional_auth_middleware`
only (`backend/src/api/routes.rs`), not `repo_visibility_middleware` — so the
canonical tenant/visibility choke point (`repo_visibility_middleware`, which gates
on `is_public` plus per-repo `role_assignments` membership) never runs on the REST
`/repositories/{key}/*` surface. Every sub-handler must therefore re-derive that
check itself, and several did not:

- **Labels** (`repository_labels.rs`): `set_labels`/`add_label`/`delete_label`
  (and the `list_labels` read) only required authentication, then mutated.
- **Security** (`security.rs`): `update_repo_security` (and the `get_repo_security`
  / `list_repo_scans` reads) resolved the repo by raw SQL with authentication only.
- **Approval** (`approval.rs`): `request_approval` resolved the source repo by key
  and probed an artifact (`SELECT ... WHERE id=$1 AND repository_id=$2`) with no
  caller visibility filter — a cross-tenant existence oracle plus a
  `promotion_approvals` write referencing the private source artifact.
- **Chunked upload** (`upload.rs`): `create_session`'s write authorization fell
  open when the target repo had no fine-grained permission rules (`!has_rules`),
  with no `is_public` / membership tenant check.
- **Lower-severity, same root cause** (`repositories.rs`): the cache-TTL,
  routing-rules, upstream-auth, and pypi-track config handlers, and
  (`email_subscriptions.rs`) the email-subscription handlers, enforced only the
  token repo-scope (`require_repo_access` / `can_access_repo`).

This routes those handlers through the two helpers the artifact upload/delete path
already uses — `require_repo_write_access` (write gate) and `require_visible` (read
gate), both in `repositories.rs`. Both derive the tenant boundary from `is_public`
plus `role_assignments` membership via `RepositoryService::user_can_access_repo`,
so authorization no longer depends on whether any fine-grained rule happens to
exist. The two helpers are exposed `pub(crate)` and imported by the sibling
modules; the upload-session create path performs the same check after resolving
the repo from the request body.

There is no `org_id` column on `repositories` — the tenant boundary *is*
`role_assignments`, and `user_can_access_repo` is the canonical primitive.

Behavior preserved: admins (bypass), same-org members holding a repo-scoped or
global role assignment, public-repo writers, the token repo-scope check (#504),
and peer-replication identities (the `x-artifact-keeper-replication` header is a
loop-prevention hint only and grants nothing; replication principals authenticate
as admin or a write/admin holder and pass unchanged).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added:
- Structural guards (string-grep over handler source) asserting each mutating
  repository sub-resource handler references `require_repo_write_access` and each
  leaky read references `require_visible`
  (`test_repo_mutation_handlers_call_write_gate`,
  `test_label_handlers_enforce_tenant_gate`,
  `test_repo_security_handlers_enforce_tenant_gate`,
  `test_email_subscription_handlers_enforce_tenant_gate`,
  `test_create_session_enforces_tenant_gate`), so a future handler cannot silently
  fall open.
- `test_request_approval_gates_source_repo_before_probe` asserts `require_visible`
  runs on the source repo *before* the artifact existence probe (oracle closed).
- The existing `require_repo_write_access` unit tests
  (public-allow / admin-allow / token-scope-deny) cover the shared gate; the
  private non-member denial is covered by the `user_can_access_repo` service test
  and the integration verification below.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance with the two-tenant seed (corp +
globex private repos):

- Non-member, non-admin denied: `sam.dev` label POST and security PUT on a private
  globex repo → 403; `olivia.sec` security GET → 404; `tess.qa` upload-session
  create into a private globex repo → 403; `ravi.rel` approval/request with a
  cross-tenant source repo → 404 with body `Repository '...' not found` (returned
  *before* the artifact probe). DB confirms no `repository_labels`,
  `promotion_approvals`, or `upload_sessions` rows were written.
- Legitimate use preserved: admin label write → 200; a globex member (repo-scoped
  `role_assignments` row) label write, security PUT, and security GET → 200; any
  authenticated user's label write on a public repo → 200.

Full `cargo test --workspace --lib` passes (11479 passed, 0 failed) against a
throwaway Postgres; `cargo fmt --check` and `cargo clippy --workspace --all-targets
-- -D warnings` are clean; duplication on the changed files is under 3%.

## API Changes
- [x] N/A - no API changes

No new endpoints, no schema changes, no migration. Denials reuse existing error
shapes: private-repo reads return 404 (existence-hiding, matching
`get_repository`); write denials return 403.
