### PR TITLE
fix(peers): enforce SSRF allowlist on peer endpoint_url and require admin for federation writes

### DIFF
--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -10,6 +10,7 @@ use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
 use crate::api::middleware::auth::AuthExtension;
+use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
 use crate::error::Result;
 use crate::services::peer_instance_service::{
@@ -290,9 +291,12 @@ pub async fn list_peers(
 )]
 pub async fn register_peer(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<RegisterPeerRequest>,
 ) -> Result<Json<PeerInstanceResponse>> {
+    auth.require_admin()?;
+    validate_outbound_url(&payload.endpoint_url, "Peer endpoint URL")?;
+
     let service = PeerInstanceService::new(state.db.clone());
 
     let instance = service
@@ -403,9 +407,10 @@ pub async fn get_peer(
 )]
 pub async fn unregister_peer(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = PeerInstanceService::new(state.db.clone());
     service.unregister(id).await?;
     Ok(())
@@ -462,9 +467,10 @@ pub async fn heartbeat(
 )]
 pub async fn trigger_sync(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = PeerInstanceService::new(state.db.clone());
     service.update_sync_status(id, false).await?;
     Ok(())
@@ -558,10 +564,11 @@ pub async fn get_assigned_repos(
 )]
 pub async fn assign_repo(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(payload): Json<AssignRepoRequest>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let replication_mode =
         payload
             .replication_mode
@@ -653,9 +660,10 @@ pub async fn get_subscription(
 )]
 pub async fn run_subscription_now(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path((id, repo_id)): Path<(Uuid, Uuid)>,
 ) -> Result<(axum::http::StatusCode, Json<RunNowResponse>)> {
+    auth.require_admin()?;
     let service = PeerInstanceService::new(state.db.clone());
     let queued = service.run_subscription_now(id, repo_id).await?;
     Ok((
@@ -686,9 +694,10 @@ pub async fn run_subscription_now(
 )]
 pub async fn unassign_repo(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path((id, repo_id)): Path<(Uuid, Uuid)>,
 ) -> Result<()> {
+    auth.require_admin()?;
     let service = PeerInstanceService::new(state.db.clone());
     service.unassign_repository(id, repo_id).await?;
     Ok(())
@@ -713,6 +722,7 @@ async fn announce_peer(
     Json(body): Json<AnnouncePeerRequest>,
 ) -> Result<Json<serde_json::Value>> {
     auth.require_admin()?;
+    validate_outbound_url(&body.endpoint_url, "Peer endpoint URL")?;
 
     let peer_svc = PeerService::new(state.db.clone());
     let instance_svc = PeerInstanceService::new(state.db.clone());
@@ -1515,5 +1525,118 @@ mod tests {
         // verifies at least one route is registered, and the route table
         // construction itself will panic if a path is malformed.
         assert!(router.has_routes());
+    }
+
+    // -----------------------------------------------------------------------
+    // SSRF: peer endpoint_url must go through the shared outbound-URL
+    // allowlist (validate_outbound_url) before it is persisted. The sync
+    // worker later issues outbound requests to the stored endpoint, so a
+    // loopback / RFC1918 / metadata / dotless-decimal endpoint would be an
+    // SSRF primitive without this guard. Mirrors the same allowlist that
+    // every other outbound sink enforces.
+    // -----------------------------------------------------------------------
+
+    /// Assert the peer-endpoint validator rejects an SSRF target URL.
+    fn assert_peer_endpoint_blocked(url: &str) {
+        assert!(
+            validate_outbound_url(url, "Peer endpoint URL").is_err(),
+            "peer endpoint_url '{url}' must be rejected by the SSRF allowlist"
+        );
+    }
+
+    #[test]
+    fn test_peer_endpoint_rejects_loopback() {
+        assert_peer_endpoint_blocked("http://127.0.0.1:19099/peer-reg");
+    }
+
+    #[test]
+    fn test_peer_endpoint_rejects_ipv6_loopback() {
+        assert_peer_endpoint_blocked("http://[::1]/");
+    }
+
+    #[test]
+    fn test_peer_endpoint_rejects_unspecified() {
+        assert_peer_endpoint_blocked("http://0.0.0.0/");
+    }
+
+    #[test]
+    fn test_peer_endpoint_rejects_rfc1918() {
+        // 10.0.0.0/8 is only blocked under default config; an operator can
+        // opt RFC1918 in via UPSTREAM_ALLOW_PRIVATE_IPS / the CIDR
+        // allowlist. Skip the strict assertion if a parallel test in the
+        // same binary has that relaxation active so this does not flake.
+        if crate::api::validation::upstream_allow_private_ips_enabled()
+            || crate::api::validation::private_cidr_allowlist_value().is_some()
+        {
+            return;
+        }
+        assert_peer_endpoint_blocked("http://10.0.0.5/");
+    }
+
+    #[test]
+    fn test_peer_endpoint_rejects_metadata() {
+        assert_peer_endpoint_blocked("http://169.254.169.254/");
+    }
+
+    #[test]
+    fn test_peer_endpoint_rejects_dotless_decimal_loopback() {
+        // 2130706433 == 127.0.0.1; the URL parser canonicalises the
+        // dotless-decimal integer host to the IPv4 literal, which the
+        // allowlist then classifies as loopback.
+        assert_peer_endpoint_blocked("http://2130706433/");
+    }
+
+    #[test]
+    fn test_peer_endpoint_allows_public_https() {
+        assert!(
+            validate_outbound_url("https://peer1.example.com", "Peer endpoint URL").is_ok(),
+            "a legitimate public peer endpoint must still be accepted"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin gate: the mutating peer handlers (register / unregister /
+    // trigger_sync / assign / unassign / run-now) now call
+    // auth.require_admin()? before touching the service, matching the
+    // in-file pattern already used by heartbeat / announce / identity.
+    // -----------------------------------------------------------------------
+
+    /// Build an [`AuthExtension`] for a non-admin caller.
+    fn non_admin_auth() -> AuthExtension {
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "victor.user".to_string(),
+            email: "victor@example.com".to_string(),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: None,
+        }
+    }
+
+    /// Build an [`AuthExtension`] for an admin caller.
+    fn admin_auth() -> AuthExtension {
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "admin".to_string(),
+            email: "admin@example.com".to_string(),
+            is_admin: true,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: None,
+        }
+    }
+
+    #[test]
+    fn test_peer_write_guard_rejects_non_admin() {
+        // The exact guard expression each mutating peer handler now runs.
+        assert!(non_admin_auth().require_admin().is_err());
+    }
+
+    #[test]
+    fn test_peer_write_guard_allows_admin() {
+        assert!(admin_auth().require_admin().is_ok());
     }
 }

--- a/backend/src/api/handlers/sync_policies.rs
+++ b/backend/src/api/handlers/sync_policies.rs
@@ -1,7 +1,7 @@
 //! Sync policy management handlers.
 
 use axum::{
-    extract::{Path, State},
+    extract::{Extension, Path, State},
     routing::{get, post},
     Json, Router,
 };
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::sync_policy_service::{
@@ -427,8 +428,10 @@ async fn list_policies(State(state): State<SharedState>) -> Result<Json<SyncPoli
 )]
 async fn create_policy(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateSyncPolicyPayload>,
 ) -> Result<Json<SyncPolicyResponse>> {
+    auth.require_admin()?;
     let repo_selector: RepoSelector = parse_selector(payload.repo_selector)?;
     let peer_selector: PeerSelector = parse_selector(payload.peer_selector)?;
     let artifact_filter: ArtifactFilter = parse_selector(payload.artifact_filter)?;
@@ -506,9 +509,11 @@ async fn get_policy(
 )]
 async fn update_policy(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(payload): Json<UpdateSyncPolicyPayload>,
 ) -> Result<Json<SyncPolicyResponse>> {
+    auth.require_admin()?;
     let repo_selector: Option<RepoSelector> = payload
         .repo_selector
         .map(|v| parse_selector(Some(v)))
@@ -563,8 +568,10 @@ async fn update_policy(
 )]
 async fn delete_policy(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode> {
+    auth.require_admin()?;
     let service = SyncPolicyService::new(state.db.clone());
     service.delete_policy(id).await?;
 
@@ -594,9 +601,11 @@ async fn delete_policy(
 )]
 async fn toggle_policy(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(payload): Json<TogglePolicyPayload>,
 ) -> Result<Json<SyncPolicyResponse>> {
+    auth.require_admin()?;
     let service = SyncPolicyService::new(state.db.clone());
     let policy = service.toggle_policy(id, payload.enabled).await?;
 
@@ -621,7 +630,9 @@ async fn toggle_policy(
 )]
 async fn evaluate_policies(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<EvaluationResultResponse>> {
+    auth.require_admin()?;
     let service = SyncPolicyService::new(state.db.clone());
     let result = service.evaluate_policies().await?;
     Ok(Json(evaluation_to_response(result)))
@@ -1067,5 +1078,40 @@ mod tests {
         }
         let obj = json.as_object().unwrap();
         assert_eq!(obj.len(), 13, "SyncPolicyResponse should have 13 fields");
+    }
+
+    // -----------------------------------------------------------------------
+    // Admin gate: the mutating sync-policy handlers (create / update /
+    // delete / toggle / evaluate) now call auth.require_admin()? before
+    // touching the service. These tests exercise the exact guard
+    // expression those handlers run.
+    // -----------------------------------------------------------------------
+
+    /// Build an [`AuthExtension`] with the given admin flag.
+    fn policy_auth(is_admin: bool) -> AuthExtension {
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: if is_admin { "admin" } else { "glen.globex" }.to_string(),
+            email: "policy-test@example.com".to_string(),
+            is_admin,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: None,
+        }
+    }
+
+    #[test]
+    fn test_policy_write_guard_rejects_non_admin() {
+        let err = policy_auth(false).require_admin().unwrap_err();
+        assert!(
+            matches!(err, AppError::Authorization(_)),
+            "non-admin must be rejected with an Authorization error, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_policy_write_guard_allows_admin() {
+        assert!(policy_auth(true).require_admin().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Hardens the federation peer-registration surface in two ways, bringing it in
line with the conventions already used by every other sibling endpoint:

1. **Outbound-URL allowlist parity on `endpoint_url`.** `register_peer`
   (`POST /api/v1/peers`) and `announce_peer` (`POST /api/v1/peers/announce`)
   persisted a client-supplied `endpoint_url` without running it through the
   shared `validate_outbound_url` allowlist. The sync worker later issues
   outbound HTTP requests to that stored endpoint
   (`format!("{}/api/v1/peers", peer.endpoint_url)`), so the registration
   surface is an outbound-request sink. Every other outbound sink in the
   codebase (remote instances, migration, repository service, webhooks, SSO,
   wasm plugins) already calls this validator; the peer write surface was the
   only one missing it. Both handlers now call
   `validate_outbound_url(&endpoint_url, "Peer endpoint URL")` (Upstream
   context) before the value is stored, so loopback / RFC1918 / link-local /
   cloud-metadata / dotless-decimal hosts are rejected with a
   `400 VALIDATION_ERROR`. The existing operator escape hatches
   (`UPSTREAM_ALLOW_PRIVATE_IPS`, `AK_SSRF_ALLOW_PRIVATE_CIDRS`) are honored
   for free, so internal-mirror peers remain reachable when an operator opts
   in.

2. **Admin gate on the mutating handlers.** `/peers` and `/sync-policies` are
   nested under `auth_middleware` (authenticated) rather than
   `admin_middleware`, and several mutating handlers never re-checked the
   caller's role. The read handlers legitimately serve any authenticated user,
   so a blanket middleware swap would break them and the merged peer
   sub-routers. Instead, this PR adds the in-file `auth.require_admin()?`
   pattern (already used by `heartbeat`, `announce_peer`, and `get_identity`)
   to each write handler:
   - peers: `register_peer`, `unregister_peer`, `trigger_sync`, `assign_repo`,
     `unassign_repo`, `run_subscription_now`
   - sync policies: `create_policy`, `update_policy`, `delete_policy`,
     `toggle_policy`, `evaluate_policies`

   Read handlers (`list_peers`, `get_peer`, `get_sync_tasks`,
   `get_assigned_repos`, `get_subscription`, `list_policies`, `get_policy`) are
   intentionally left ungated so authenticated non-admin reads keep working.

No migration, no new config, no router/middleware changes. Two files touched:
`backend/src/api/handlers/peers.rs`,
`backend/src/api/handlers/sync_policies.rs`.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added unit tests:
- `peers.rs`: `test_peer_endpoint_rejects_*` (loopback, IPv6 loopback,
  unspecified, RFC1918, cloud metadata, dotless-decimal) and
  `test_peer_endpoint_allows_public_https` exercise the new
  `validate_outbound_url` call; `test_peer_write_guard_{rejects_non_admin,
  allows_admin}` exercise the new admin gate.
- `sync_policies.rs`: `test_policy_write_guard_{rejects_non_admin,
  allows_admin}` exercise the new admin gate.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance: admin `POST /api/v1/peers` with
loopback / link-local / RFC1918 / IPv6-loopback / unspecified / dotless-decimal
endpoints returns `400 VALIDATION_ERROR`; a public `https://` endpoint still
returns `200`. Non-admin and cross-org users receive `403` on peer/sync-policy
writes, anonymous receives `401`, and admin writes still succeed; non-admin
reads of `/peers` and `/sync-policies` continue to return `200`. Full lib test
suite (`cargo test --workspace --lib`) green; `cargo fmt --check` and
`cargo clippy --workspace --all-targets -- -D warnings` clean.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
