### PR TITLE
fix(uploads): bound total_size and enforce repository quota at upload-session creation

### DIFF
--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -345,6 +345,27 @@ async fn create_session(
         cleanup_stale_replication_upload_sessions(&state.db, repo.0, &req.artifact_path).await;
     }
 
+    // Repository storage-quota gate (parity with the direct artifact-write
+    // path, `ArtifactService::store` -> `RepositoryService::check_quota`). The
+    // chunked upload-session API is another direct-write entry point: without
+    // this check an attacker-chosen `total_size` would both bypass the quota
+    // and drive one DB row per chunk. Skipped for peer replication so artifacts
+    // that legitimately predate a quota change can still replicate; the
+    // `max_upload_size` cap inside `create_session` still applies in that case.
+    if !is_replication {
+        let within_quota = state
+            .create_repository_service()
+            .check_quota(repo_id, req.total_size)
+            .await
+            .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        if !within_quota {
+            return Err(map_err(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "Repository storage quota exceeded",
+            ));
+        }
+    }
+
     let session = UploadService::create_session(upload_service::CreateSessionParams {
         db: &state.db,
         storage_path: &state.config.storage_path,
@@ -361,6 +382,7 @@ async fn create_session(
         package_metadata: replication_metadata.package_metadata,
         is_replication,
         total_size: req.total_size,
+        max_upload_size: state.config.max_upload_size_bytes,
         chunk_size: req.chunk_size,
         checksum_sha256: &req.checksum_sha256,
         content_type: req.content_type.as_deref(),
@@ -745,6 +767,7 @@ fn map_upload_err(e: UploadError) -> Response {
         UploadError::Expired => (StatusCode::GONE, e.to_string()),
         UploadError::InvalidChunk(_) => (StatusCode::BAD_REQUEST, e.to_string()),
         UploadError::InvalidChunkSize => (StatusCode::BAD_REQUEST, e.to_string()),
+        UploadError::TooLarge { .. } => (StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
         UploadError::InvalidStatus(_) => (StatusCode::BAD_REQUEST, e.to_string()),
         UploadError::ChecksumMismatch { .. } => (StatusCode::CONFLICT, e.to_string()),
         UploadError::IncompleteChunks { .. } => (StatusCode::BAD_REQUEST, e.to_string()),
@@ -1722,6 +1745,15 @@ mod tests {
     fn test_map_upload_err_repository_not_found() {
         let resp = map_upload_err(UploadError::RepositoryNotFound("gone-repo".into()));
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_map_upload_err_too_large() {
+        let resp = map_upload_err(UploadError::TooLarge {
+            size: 9_999_999_999_999,
+            max: 10_737_418_240,
+        });
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[test]

--- a/backend/src/services/upload_service.rs
+++ b/backend/src/services/upload_service.rs
@@ -98,6 +98,9 @@ pub enum UploadError {
 
     #[error("invalid chunk size: must be between 1 MB and 256 MB")]
     InvalidChunkSize,
+
+    #[error("total_size {size} exceeds maximum allowed upload size {max}")]
+    TooLarge { size: i64, max: u64 },
 }
 
 // ---------------------------------------------------------------------------
@@ -154,6 +157,24 @@ pub fn validate_artifact_path(path: &str) -> Result<(), UploadError> {
     Ok(())
 }
 
+/// Enforce an upper bound on the attacker-controlled `total_size` before any
+/// expensive work (temp-file pre-allocation, per-chunk row inserts) happens.
+///
+/// `max` is the configured `max_upload_size_bytes`; a value of `0` disables the
+/// cap (matching the direct-upload path semantics). Without this bound an
+/// authenticated caller could pick an enormous `total_size` and force the
+/// session-create transaction to insert one `upload_chunks` row per chunk,
+/// amplifying a tiny request into millions of synchronous INSERTs.
+pub fn enforce_max_total_size(total_size: i64, max: u64) -> Result<(), UploadError> {
+    if max != 0 && total_size as u64 > max {
+        return Err(UploadError::TooLarge {
+            size: total_size,
+            max,
+        });
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -184,6 +205,9 @@ pub struct CreateSessionParams<'a> {
     pub package_metadata: Option<&'a serde_json::Value>,
     pub is_replication: bool,
     pub total_size: i64,
+    /// Maximum permitted `total_size` (`config.max_upload_size_bytes`); `0`
+    /// disables the cap. Bounds the eager per-chunk row loop below.
+    pub max_upload_size: u64,
     pub chunk_size: Option<i32>,
     pub checksum_sha256: &'a str,
     pub content_type: Option<&'a str>,
@@ -203,6 +227,13 @@ impl UploadService {
                 "total_size must be a positive integer".into(),
             ));
         }
+
+        // Bound the attacker-controlled total_size before pre-allocating the
+        // temp file or inserting per-chunk rows. Rejecting here keeps the
+        // eager chunk-row loop below provably bounded (<= max / chunk_size
+        // rows) and stops a tiny request from amplifying into millions of
+        // synchronous INSERTs.
+        enforce_max_total_size(p.total_size, p.max_upload_size)?;
 
         let chunk_size = p.chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE);
         if (chunk_size as i64) < MIN_CHUNK_SIZE || (chunk_size as i64) > MAX_CHUNK_SIZE {
@@ -715,6 +746,50 @@ mod tests {
     fn test_normalize_optional_metadata_keeps_non_empty() {
         assert_eq!(normalize_optional_metadata(Some("pkg")), Some("pkg"));
         assert_eq!(normalize_optional_metadata(Some(" ")), Some(" "));
+    }
+
+    // -----------------------------------------------------------------------
+    // enforce_max_total_size
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_enforce_max_total_size_at_limit_ok() {
+        // total_size exactly at the configured max is accepted.
+        let max: u64 = 10_737_418_240; // 10 GiB default
+        assert!(enforce_max_total_size(max as i64, max).is_ok());
+    }
+
+    #[test]
+    fn test_enforce_max_total_size_one_over_rejected() {
+        let max: u64 = 10_737_418_240;
+        let err = enforce_max_total_size(max as i64 + 1, max).unwrap_err();
+        match err {
+            UploadError::TooLarge { size, max: m } => {
+                assert_eq!(size, max as i64 + 1);
+                assert_eq!(m, max);
+            }
+            other => panic!("expected TooLarge, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_enforce_max_total_size_zero_disables_cap() {
+        // max == 0 disables the cap, mirroring the direct-upload path.
+        assert!(enforce_max_total_size(i64::MAX, 0).is_ok());
+        assert!(enforce_max_total_size(9_999_999_999_999, 0).is_ok());
+    }
+
+    #[test]
+    fn test_enforce_max_total_size_bounds_chunk_count() {
+        // With the cap enforced, the eager per-chunk row count is bounded:
+        // at the 10 GiB default and the 8 MiB default chunk size the loop can
+        // create at most 1280 rows, versus ~1.19M for the unbounded exploit.
+        let max: u64 = 10_737_418_240;
+        let chunk_size: i64 = DEFAULT_CHUNK_SIZE as i64;
+        let max_chunks = (max as i64 + chunk_size - 1) / chunk_size;
+        assert_eq!(max_chunks, 1280);
+        // The exploit value is rejected before the loop ever runs.
+        assert!(enforce_max_total_size(9_999_999_999_999, max).is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bound `total_size` and enforce repository quota at upload-session creation.

`POST /api/v1/uploads` (chunked/resumable upload) derived `total_chunks`
directly from the caller-supplied `total_size` with no upper bound, then
inserted one `upload_chunks` placeholder row per chunk inside a single
transaction. The only pre-loop checks were `total_size > 0` and the
`chunk_size` range — there was no maximum `total_size` and no quota check.
The direct (non-chunked) artifact-write path already enforces the repository
quota (`ArtifactService::store` → `RepositoryService::check_quota`), so the
chunked path was the gap: a small authenticated request with a large
`total_size` (e.g. `9999999999999`) forced ~1.19M synchronous INSERTs and tens
of seconds of transaction work.

This PR adds two cheap guards that both run **before** the temp-file
pre-allocation and the per-chunk row loop:

1. **Size cap** — `UploadService::create_session` rejects any `total_size`
   above `config.max_upload_size_bytes` (the same config that already governs
   direct uploads; `0` disables it, default 10 GiB). New
   `UploadError::TooLarge` maps to HTTP 413. At 10 GiB / 8 MiB the eager chunk
   loop is now bounded to ≤1280 rows.
2. **Quota check** — the handler calls
   `RepositoryService::check_quota(repo_id, total_size)` before creating the
   session, returning 413 when over quota. This is **skipped for peer
   replication** so artifacts that legitimately predate a quota change still
   replicate; the size cap still applies to replication and introduces no
   ceiling below the one already enforced on direct uploads.

No migration. The eager chunk-row loop, `upload_chunk`'s atomic claim, and
`complete_session`'s count check are unchanged — they are simply now bounded.
Legitimate large-but-within-quota resumable uploads are unaffected (a 5 GiB
upload to a no-quota repo still succeeds under the default cap).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Unit tests in `upload_service.rs`: `total_size` exactly at the cap is accepted,
one byte over is rejected (`TooLarge`), `max == 0` disables the cap, and the
bounded chunk count is asserted (1280 at 10 GiB/8 MiB). A `map_upload_err` test
in `upload.rs` asserts `TooLarge → 413`. Handler quota behavior verified
end-to-end on a local instance (over-quota create → 413; replication over quota
not blocked by quota).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (only a new 413 rejection on an existing endpoint)
