### PR TITLE
ci: move buildkit caches from GHA quota to GHCR registry cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -892,8 +892,11 @@ jobs:
           push: false
           load: true
           tags: artifact-keeper-backend:pr-test
-          cache-from: type=gha,scope=backend-linux/amd64
-          cache-to: type=gha,scope=backend-linux/amd64,mode=max
+          # Read-only registry cache, warmed by docker-publish.yml on main.
+          # No cache-to: PR-triggered jobs must not get packages:write (fork
+          # PRs would inherit it — pwn-request risk), and anonymous GHCR
+          # reads work because the packages are public.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-backend:buildcache-amd64
 
       - name: Verify image starts
         run: |
@@ -943,8 +946,8 @@ jobs:
           push: false
           load: true
           tags: artifact-keeper-openscap:pr-test
-          cache-from: type=gha,scope=openscap-linux/amd64
-          cache-to: type=gha,scope=openscap-linux/amd64,mode=max
+          # Read-only registry cache — see backend image build for rationale.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-openscap:buildcache-amd64
 
       - name: Verify image starts
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,8 +52,10 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ak-ci-runners
+            cache-tag: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            cache-tag: arm64
     outputs:
       digest-amd64: ${{ steps.build.outputs.digest }}
       digest-arm64: ${{ steps.build.outputs.digest }}
@@ -97,8 +99,12 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=backend-${{ matrix.platform }}
-          cache-to: type=gha,scope=backend-${{ matrix.platform }},mode=max
+          # Registry cache instead of type=gha: buildkit blobs were consuming
+          # ~7.7GB of the repo's 10GB Actions cache quota, evicting the rust
+          # caches daily. image-manifest+oci-mediatypes are required for GHCR
+          # to accept mode=max cache manifests.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-${{ matrix.cache-tag }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
           sbom: true
           provenance: mode=max
           build-args: |
@@ -131,8 +137,10 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ak-ci-runners
+            cache-tag: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            cache-tag: arm64
     outputs:
       digest-amd64: ${{ steps.build.outputs.digest }}
       digest-arm64: ${{ steps.build.outputs.digest }}
@@ -174,8 +182,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=openscap-${{ matrix.platform }}
-          cache-to: type=gha,scope=openscap-${{ matrix.platform }},mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:buildcache-${{ matrix.cache-tag }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:buildcache-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
           sbom: true
           provenance: mode=max
 
@@ -209,8 +217,10 @@ jobs:
         include:
           - platform: linux/amd64
             runner: ak-ci-runners
+            cache-tag: amd64
           - platform: linux/arm64
             runner: ubuntu-24.04-arm
+            cache-tag: arm64
     outputs:
       digest-amd64: ${{ steps.build.outputs.digest }}
       digest-arm64: ${{ steps.build.outputs.digest }}
@@ -244,8 +254,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=backend-alpine-${{ matrix.platform }}
-          cache-to: type=gha,scope=backend-alpine-${{ matrix.platform }},mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-alpine-${{ matrix.cache-tag }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-alpine-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
           sbom: true
           provenance: mode=max
           build-args: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -121,8 +121,10 @@ jobs:
           file: docker/Dockerfile.backend
           load: true
           tags: artifact-keeper-backend:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Read-only registry cache warmed by docker-publish.yml on main;
+          # this workflow only has contents:read, so it cannot (and should
+          # not) push cache back to GHCR.
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}-backend:buildcache-amd64
 
       - name: Download PKI assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
## Summary

The repo's 10GB Actions cache quota is at **10.49GB with full turnover every ~24h** (135 of 150 caches under a day old at snapshot 2026-06-12): buildkit blobs (7.7GB) and the Swatinem rust caches (2.67GB) continuously evict each other. Measured baseline: ~30 eviction-driven cold rust builds/week at ~12min penalty each — **~22 runner-hours/week (~8.5% of node capacity)** lost to cache churn.

This moves all buildkit layer caches off the GHA quota onto GHCR registry cache tags:

- **docker-publish.yml** — `cache-from`/`cache-to` `type=registry` on `:buildcache-{amd64,arm64}` tags per image (jobs already have `packages: write` + GHCR login). `image-manifest=true,oci-mediatypes=true` is required for GHCR to accept `mode=max` cache manifests.
- **ci.yml PR image builds** — read-only `cache-from` GHCR (anonymous read, packages are public); `cache-to` dropped. PR-triggered jobs must not get `packages: write` (fork pwn-request risk). Main keeps the cache warm via docker-publish.yml.
- **e2e.yml** — same read-only treatment (workflow has `contents: read` only).

Frees ~7.7GB of quota so the rust caches stop evicting. Companion change: artifact-keeper-iac#163 (sccache cache size on the ARC runners).

Validated by a DevOps infra review against the live cluster + a measured CI baseline (per-job duration stats over 29 runs, cache inventory breakdown, cold-build log forensics).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — YAML structure validated; first `docker-publish.yml` run on main after merge seeds the `:buildcache-*` tags (first run is cold by design)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes