### PR TITLE
ci: emit per-job sccache stats in rust compile jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,11 @@ jobs:
           CARGO_INCREMENTAL: "0"
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # Hit-rate data to evaluate dropping the Swatinem rust-cache step once sccache sustains >80% hits.
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
   test-backend-unit:
     name: 🧪 Backend Unit Tests
     runs-on: ak-ci-runners
@@ -195,6 +200,11 @@ jobs:
         # blob-GC readiness gate is a cluster-wide query, so a concurrent
         # cross-module test's transient rows can make gate/GC assertions flaky.
         run: cargo test --workspace --lib --verbose -- --test-threads=1
+
+      # Hit-rate data to evaluate dropping the Swatinem rust-cache step once sccache sustains >80% hits.
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
 
   shell-tests:
     name: 🐚 Shell Tests
@@ -732,6 +742,11 @@ jobs:
             test_chunked_upload_cross_repo_session_rejected \
             -- --ignored --test-threads=1
 
+      # Hit-rate data to evaluate dropping the GHA rust-cache from the unit/clippy jobs (this job has no rust-cache; stats give a no-GHA-cache baseline).
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
   # ════════════════════════════════════════════════════════════════════════════
   # SMOKE E2E (Every Push/PR) — self-contained via Docker-in-Docker on ARC
   # Spins up fresh backend + postgres, runs native client tests, tears down
@@ -1109,3 +1124,8 @@ jobs:
           path: |
             dist/artifact-keeper-windows-amd64.exe
             dist/artifact-keeper-windows-amd64.exe.sha256
+
+      # Hit-rate data to evaluate dropping the GHA rust-cache from the unit/clippy jobs (this job has no rust-cache; stats give a no-GHA-cache baseline).
+      - name: sccache stats
+        if: always()
+        run: sccache --show-stats || true


### PR DESCRIPTION
## Summary
ak-ci-runners pods run with `RUSTC_WRAPPER=sccache` pod-wide against a shared hostPath cache (`SCCACHE_CACHE_SIZE` recently raised to 50G), but CI currently exposes no per-job hit-rate data. This PR adds a trailing `sccache stats` step (`if: always()` + `sccache --show-stats || true`) to every job that compiles Rust with sccache on `ak-ci-runners`:

- 🦀 Check Rust
- 🧪 Backend Unit Tests
- 🔗 Backend Integration Tests
- 🪟 Windows Cross-Build

Each CI job gets a fresh ephemeral pod, so stats are naturally per-job (no `--zero-stats` needed). The goal is ~a week of hit-rate data to evaluate dropping the Swatinem rust-cache steps from the unit/clippy jobs once sccache sustains >80% hits (not done in this PR).

The 📊 Code Coverage job is deliberately excluded: it sets `RUSTC_WRAPPER: ""`, so its stats would be empty/misleading.

The step is inert by construction — `if: always()` plus `|| true` means an sccache outage (like today's) can never fail CI.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [ ] No regressions in existing tests

YAML validated locally with PyYAML (workflow parses; the four jobs end with the new step; coverage job untouched). CI-only change — no runtime tests apply.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes