### PR TITLE
ci: use cargo-nextest baked into runner image instead of per-run install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,11 +287,9 @@ jobs:
           shared-key: coverage
           workspaces: ". -> target/llvm-cov-target"
 
-      - name: Install cargo-nextest
-        if: steps.detect.outputs.rust_changed == 'true'
-        uses: taiki-e/install-action@4bc351f7f2614e48088386e2a0ad917ca3a7e4ba # v2.81.5
-        with:
-          tool: nextest
+      # cargo-nextest is baked into the runner image at a pinned version
+      # (ghcr.io/artifact-keeper/ak-runner-rust, see artifact-keeper-iac
+      # runner-images/rust/Dockerfile) -- no per-run install needed.
 
       - name: Run database migrations
         if: steps.detect.outputs.rust_changed == 'true'


### PR DESCRIPTION
## Summary
Closes #1875

Removes the `Install cargo-nextest` step (taiki-e/install-action, unpinned `tool: nextest` → `cargo-nextest@latest`) from the coverage job. The ak-runner-rust runner image now bakes **cargo-nextest 0.9.137** at `/usr/local/cargo/bin` (artifact-keeper-iac#166 / iac#165) — the exact version the per-run install resolves to today, so coverage behavior is unchanged.

Why:
- The per-run install was **unpinned**: nextest silently changed version whenever upstream released.
- It added a per-run network dependency on GitHub releases.
- It was redundant: cargo-llvm-cov, sqlx-cli, and cargo-audit already come from the image.

Accuracy note: install-action writes to `/home/runner/.install-action/bin` (pod-local filesystem), not the shared `/cache/cargo-home` hostPath, so the suspected cross-pod install race was theoretical. Version drift and the network dependency are the real motivation.

Deliberately minimal diff: only the install step is removed (replaced with a comment pointing at the image). The `RUSTC_WRAPPER: ""` line and rust-cache steps are untouched.

**Merge ordering**: do not merge until artifact-keeper-iac#166 is merged and the new `:latest` runner image is live (it is currently merge-ready, held pending unrelated runner work).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — built the new runner image and verified `cargo nextest --version` (0.9.137) resolves from `/usr/local/cargo/bin` with the runtime `CARGO_HOME=/cache/cargo-home` override in place
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes