### PR TITLE
fix(db): evict pooled Postgres connections that fail a liveness probe

### DIFF
--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -5,6 +5,11 @@ use crate::error::Result;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use std::time::Duration;
 
+/// Connections idle longer than this run a full `SELECT 1` probe before being
+/// returned by the pool. Short-idle acquires skip the probe to keep the hot
+/// path free of an extra round trip.
+const IDLE_LIVENESS_THRESHOLD: Duration = Duration::from_secs(30);
+
 /// Create a new database connection pool using the connection pool settings
 /// from [`Config`]. Pool sizing and timeouts are configurable via the
 /// `DATABASE_MAX_CONNECTIONS`, `DATABASE_MIN_CONNECTIONS`,
@@ -18,6 +23,26 @@ pub async fn create_pool(config: &Config) -> Result<PgPool> {
         .acquire_timeout(Duration::from_secs(config.database_acquire_timeout_secs))
         .idle_timeout(Duration::from_secs(config.database_idle_timeout_secs))
         .max_lifetime(Duration::from_secs(config.database_max_lifetime_secs))
+        .before_acquire(|conn, meta| {
+            Box::pin(async move {
+                // sqlx's default `test_before_acquire` only sends a protocol
+                // PING, which can succeed on a TCP socket that has been
+                // silently broken by an upstream event (CNI flow reflow,
+                // NAT rotation, brief Postgres unavailability). When that
+                // happens, the next real query fails with an IO error and
+                // the pool keeps handing back the same dead connection,
+                // turning a transient glitch into a permanent outage that
+                // only a pod restart fixes. Issue #1877.
+                //
+                // For connections that have actually been idle, run a real
+                // query so a stale socket is detected here and the
+                // connection is evicted by sqlx before any caller sees it.
+                if meta.idle_for >= IDLE_LIVENESS_THRESHOLD {
+                    sqlx::query("SELECT 1").execute(&mut *conn).await?;
+                }
+                Ok(true)
+            })
+        })
         .connect(&config.database_url)
         .await?;
 


### PR DESCRIPTION
## Summary

Adds a `before_acquire` liveness probe to the Postgres pool so a broken pooled connection is evicted before the caller sees an `Error::Io`. Without this, a transient network-path failure (CNI flow reflow, NAT rotation, brief Postgres unavailability) is sticky — every subsequent query keeps hitting the same dead connection and only a pod restart recovers the backend.

The default `test_before_acquire` only sends a protocol PING, which can succeed on a TCP socket the kernel has already marked dead. A real `SELECT 1` surfaces the breakage at acquire time so sqlx drops the connection.

To keep the hot path cheap, the probe only runs on connections that have been idle for `IDLE_LIVENESS_THRESHOLD` (30 s). Acquires of recently-used connections skip the extra round trip.

Closes #1877

## Test plan

- [x] `cargo check --package artifact-keeper-backend --lib` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI green
- [ ] Maintainer review on the threshold value (`30s` is a guess — happy to make it configurable via env if you'd prefer)
- [ ] Repro the original failure mode in a follow-up integration test (e.g. kill Postgres mid-query, drop traffic for 30 s, verify pool recovers without restart)

## Notes for review

- I cannot deterministically reproduce the trigger locally (the original repro involved kube-OVN flow reprogramming on a single-node cluster), so this is a targeted defensive change rather than a verified end-to-end fix. If you have an integration-test harness that can fault-inject Postgres traffic, that would be the ideal place to validate.
- Open to making the threshold configurable (e.g. `DATABASE_LIVENESS_PROBE_AFTER_IDLE_SECS`) — left it as a const for the minimal patch.
- Did not touch `test_before_acquire` since it's already `true` by default in sqlx 0.8; the `before_acquire` callback runs after the default test and supersedes it on the idle path.