### PR TITLE
fix(auth): cast roles.name to text in apply_role_mapping privilege probe

### DIFF
--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -1846,7 +1846,10 @@ impl AuthService {
             WITH prev AS (
                 SELECT is_admin AS was_admin,
                        ARRAY(
-                           SELECT r.name FROM user_roles ur
+                           -- roles.name is VARCHAR(255); without the cast the
+                           -- IS DISTINCT FROM below is varchar[] vs text[],
+                           -- which Postgres has no operator for.
+                           SELECT r.name::text FROM user_roles ur
                            JOIN roles r ON r.id = ur.role_id
                            WHERE ur.user_id = $1
                            ORDER BY r.name
@@ -4245,6 +4248,82 @@ mod tests {
         assert!(!rejected, "token issued after watermark must be accepted");
 
         // Cleanup.
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// `apply_role_mapping` runs on every federated (LDAP/OIDC/SAML) login.
+    /// Its privilege-change probe builds the user's previous role list from
+    /// `roles.name` (VARCHAR) and compares it `IS DISTINCT FROM` a `text[]`
+    /// bind; without the explicit `::text` element cast Postgres rejects the
+    /// statement (`operator does not exist: character varying[] = text[]`)
+    /// and every federated login 500s. This exercises the real statement
+    /// against the real schema, plus both branches of the watermark CASE.
+    #[tokio::test]
+    async fn test_apply_role_mapping_probes_varchar_roles_without_db_error() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return, // No DB: silently skip; covered in CI.
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return, // DB not reachable: skip.
+        };
+        let cfg = make_test_config();
+        let service = AuthService::new(pool.clone(), cfg);
+        let user_id = insert_test_user(&pool, &format!("rolemap-{}", Uuid::new_v4())).await;
+
+        let watermark = |pool: &sqlx::PgPool, id: Uuid| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query_scalar::<_, chrono::DateTime<chrono::Utc>>(
+                    "SELECT privileges_changed_at FROM users WHERE id = $1",
+                )
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .expect("fetch privileges_changed_at")
+            }
+        };
+        let initial = watermark(&pool, user_id).await;
+
+        // No-op mapping: the varchar[]-vs-text[] comparison must execute
+        // without a DB error, and an unchanged privilege set must not bump
+        // the watermark.
+        let noop = RoleMapping {
+            is_admin: None,
+            roles: vec![],
+        };
+        service
+            .apply_role_mapping(user_id, &noop)
+            .await
+            .expect("no-op apply_role_mapping must not hit a DB error");
+        assert_eq!(
+            watermark(&pool, user_id).await,
+            initial,
+            "no-op role sync must not bump privileges_changed_at"
+        );
+
+        // Privilege change (admin grant): same statement, other CASE branch —
+        // the watermark must move forward.
+        let promote = RoleMapping {
+            is_admin: Some(true),
+            roles: vec![],
+        };
+        service
+            .apply_role_mapping(user_id, &promote)
+            .await
+            .expect("promoting apply_role_mapping must not hit a DB error");
+        assert!(
+            watermark(&pool, user_id).await > initial,
+            "admin grant must bump privileges_changed_at"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM user_roles WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
         let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
             .execute(&pool)
             .await;


### PR DESCRIPTION
## Summary

Every federated (LDAP/OIDC/SAML) login on current main fails with HTTP 500
"Database operation failed". The privilege-change probe added in #1827
(`apply_role_mapping`) compares the user's previous role list — built as
`ARRAY(SELECT r.name ...)` from `roles.name VARCHAR(255)` — `IS DISTINCT FROM`
a `text[]` bind. PostgreSQL has no `varchar[] = text[]` operator, so the
statement fails at plan time on every schema produced by the shipped
migrations. Cast the array elements to `text` so both sides are `text[]`.

Fixes #1886

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_apply_role_mapping_probes_varchar_roles_without_db_error` (DB-gated,
same pattern as the surrounding tests): verified to fail on main with
`operator does not exist: character varying[] = text[]` and pass with the fix.
It also pins the watermark semantics: a no-op role sync must not bump
`privileges_changed_at`, an admin grant must.

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace --lib` with DATABASE_URL: 11507 passed / 0 failed.
Changed-lines coverage 96.3% (52/54; the two uncovered lines are the
DB-unavailable skip arms shared by every DB-gated test in the module).

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes