### PR TITLE
fix(smoke-e2e): expect PEP 691 api-version 1.2 in pypi native test

### DIFF
--- a/scripts/native-tests/test-pypi.sh
+++ b/scripts/native-tests/test-pypi.sh
@@ -87,7 +87,7 @@ JSON_RESP=$(curl -sf -H "Accept: application/vnd.pypi.simple.v1+json" "$PYPI_URL
 echo "$JSON_RESP" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-assert data['meta']['api-version'] == '1.1', 'Wrong API version'
+assert data['meta']['api-version'] == '1.2', 'Wrong API version'
 assert data['name'] == 'test-package-native', 'Wrong name'
 assert len(data['files']) == 2, f'Expected 2 files, got {len(data[\"files\"])}'
 assert '$TEST_VERSION' in data['versions'], 'Version not listed'


### PR DESCRIPTION
## Summary
- Updates `scripts/native-tests/test-pypi.sh` to assert PEP 691 `api-version == '1.2'`, matching what the backend has served since #1794 (PEP 700 versions/upload-time support).
- This is the sole cause of the 🔥 Smoke E2E failures on every main push that built the backend image since June 10 (`AssertionError: Wrong API version` in step [4/6]); runs in between looked green only because CI-only changes skipped the smoke job.

Test-script-only change — the backend behavior is correct (PEP 700 requires advertising 1.2), so no backend regression test applies; the smoke job itself is the verification.

Fixes #1893

🤖 Generated with [Claude Code](https://claude.com/claude-code)