### PR TITLE
fix(maven): consolidate virtual-repo fallback and sbt plugin filename fixes (PLA-7748)

### DIFF
--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -1,25 +1,6 @@
-//! Maven-specific helpers for the virtual-repo proxy / fallback path.
-//!
-//! Sits between the Maven protocol handlers (`handlers/maven.rs`) and the
-//! generic virtual-repo plumbing (`handlers/proxy_helpers.rs`). The shared
-//! `proxy_helpers` module only owns format-agnostic primitives
-//! (`local_fetch_by_path`, `check_quarantine_row`, the row type); anything
-//! Maven-specific lives here.
-//!
-//! Currently exposes:
-//!
-//! - [`maven_local_fetch_storage_fallback`] — bridges the gap between
-//!   Maven's GAV-grouped storage layout (where `.pom`, `.module`,
-//!   `-sources.jar`, `.sha512`, etc. share the primary `.jar`'s DB row)
-//!   and the SQL-only virtual download path that would otherwise 404 on
-//!   those secondary files. Enforces three gates internally so the
-//!   fallback can't bypass quarantine / soft-delete policy.
-//!
-//! As other formats hit the same primary+companion shape — Debian
-//! (`.deb`, `.changes`, `.dsc`), RPM (`.rpm`, `.src.rpm`), NuGet
-//! (`.nupkg`, `.snupkg`), Helm (`.tgz`, `.tgz.prov`) — they should
-//! follow this same `handlers/<format>_proxy.rs` pattern rather than
-//! piling format-specific logic into `proxy_helpers.rs`.
+//! Maven-specific storage fallback for virtual-repo proxy downloads.
+//! Handles GAV-grouped secondaries (`.pom`, checksums, classifier jars) and rowless primaries
+//! while enforcing quarantine and soft-delete policy via a live sibling anchor row.
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -33,19 +14,7 @@ use crate::api::AppState;
 use crate::formats::maven::MavenHandler;
 use crate::storage::StorageLocation;
 
-/// Suffixes for Maven GAV-grouped companion files that share the
-/// primary's DB row. Returning bytes for any of these via the storage
-/// fallback is safe as long as the primary GAV is live and not under
-/// quarantine. Classifier artifacts (`artifact-version-classifier.ext`)
-/// are handled separately by parsing the Maven coordinate below.
-///
-/// Primary file extensions (`.jar`, `.aar`, `.war`, `.ear`, `.zip`) are
-/// **deliberately excluded** from this list. Primary files always have
-/// their own row in `artifacts` (and therefore go through the
-/// SQL-backed `proxy_helpers::local_fetch_by_path`); allowing the
-/// storage fallback to serve a primary would silently bypass the
-/// quarantine and soft-delete gating on the primary's own row. The
-/// allowlist scopes the fallback to its documented purpose.
+/// Known secondary suffixes. Primaries (`.jar`/`.aar`/etc.) are excluded — they go through Gate 1.
 const MAVEN_SECONDARY_FILE_EXTENSIONS: &[&str] = &[
     ".pom",
     ".module",
@@ -74,59 +43,33 @@ fn is_maven_secondary_path(path: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Primary artifact extensions eligible for the storage fallback when a live sibling anchors the GAV.
+const MAVEN_PRIMARY_FILE_EXTENSIONS: &[&str] = &[".jar", ".aar", ".war", ".ear", ".zip"];
+
+/// Returns `true` when `path` ends with a primary extension. Caller must pre-compute `is_secondary`
+/// and only call this when `!is_secondary` to avoid running `parse_coordinates` twice.
+#[inline]
+fn is_maven_primary_path_given_not_secondary(path: &str) -> bool {
+    MAVEN_PRIMARY_FILE_EXTENSIONS
+        .iter()
+        .any(|ext| path.ends_with(ext))
+}
+
+/// Escape SQL LIKE metacharacters so sbt artifact IDs (e.g. `sbt-foo_2.12_1.0`) don't wildcard-match siblings.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('%', "\\%").replace('_', "\\_")
+}
+
 /// Derive the GAV directory prefix for a maven artifact path.
 ///
-/// Maven's storage layout is `<group>/<artifact>/<version>/<file>`,
-/// so the GAV directory is everything up to the last `/`. The primary
-/// `.jar` (and any sibling secondaries) live in that directory.
 fn maven_gav_directory(artifact_path: &str) -> Option<&str> {
     artifact_path.rsplit_once('/').map(|(dir, _)| dir)
 }
 
-/// Maven-specific storage-direct fallback for virtual-repo downloads.
-///
-/// The Maven download handler (`handlers/maven.rs`) groups artifacts by
-/// GAV coordinate — only the primary file (typically the `.jar`/`.aar`)
-/// gets a row in `artifacts`, while the secondary files (`.pom`,
-/// `.module`, `-sources.jar`, `.sha512`, …) live on storage at the same
-/// path but **don't** have their own DB row. When such a request hits a
-/// **local** repo, the maven handler already has a storage-direct
-/// fallback (`maven.rs`: "For hosted repos, fall back to serving from
-/// storage directly"). When the same request hits a **virtual** repo,
-/// the resolution goes through `resolve_virtual_download` →
-/// `local_fetch_by_path`, which is SQL-only — the secondary file
-/// returns `NotFound` and the virtual response is a 404 even though
-/// the bytes are sitting in S3 in the member local repo.
-///
-/// ## Quarantine + soft-delete contract
-///
-/// Naively reading `maven/<path>` directly from storage would bypass
-/// the quarantine and soft-delete gating that `local_fetch_by_path`
-/// enforces on the SQL row. To preserve those policies for secondary
-/// files (which have no row of their own), this helper:
-///
-/// 1. Refuses any path that is neither a known companion-file suffix
-///    ([`MAVEN_SECONDARY_FILE_EXTENSIONS`]) nor a valid Maven coordinate
-///    with a classifier.
-///    Primary `.jar`/`.aar`/`.war`/`.ear` paths fall back to
-///    `NotFound` here so the caller can't accidentally route them
-///    around their own SQL row.
-/// 2. Looks up a "primary" sibling row in the same GAV directory and
-///    verifies it is not soft-deleted and not quarantined before
-///    serving the secondary bytes. A quarantined or deleted primary
-///    means the whole GAV is gated; the secondary travels with it.
-/// 3. Only then reads `maven/<path>` from storage.
-///
-/// ## Composition
-///
-/// Same return shape as `proxy_helpers::local_fetch_by_path` so callers
-/// can chain `Result` fallthrough. Designed to be invoked as a
-/// sequential fallback inside a `resolve_virtual_download` callback,
-/// not as the callback itself.
-///
-/// Content-Type is returned as `None`; the caller infers from the
-/// path extension via `content_type_for_path` on the outer request
-/// path.
+/// Storage-direct fallback for virtual-repo Maven downloads.
+/// Secondaries (`.pom`, checksums, `-sources.jar`) have no DB row so `local_fetch_by_path` returns
+/// 404; this helper reads them from storage while enforcing quarantine/soft-delete via a sibling row.
+/// Rowless primaries (`.jar`/`.aar`) whose GAV is anchored by a live `.pom` are also served here.
 pub(crate) async fn maven_local_fetch_storage_fallback(
     db: &PgPool,
     state: &AppState,
@@ -134,56 +77,64 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     location: &StorageLocation,
     artifact_path: &str,
 ) -> Result<StreamingFetchResult, Response> {
-    // Gate 1: Only companion files and classifier artifacts are eligible.
-    // A primary `.jar`/`.aar`/etc. always has its own row and must travel
-    // the SQL path so its quarantine/soft-delete state is honored.
-    if !is_maven_secondary_path(artifact_path) {
+    // Gate 1: Only secondaries and bare primaries are eligible; anything else is 404.
+    let is_secondary = is_maven_secondary_path(artifact_path);
+    let is_primary = !is_secondary && is_maven_primary_path_given_not_secondary(artifact_path);
+    if !is_secondary && !is_primary {
         return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());
     }
 
-    // Gate 2: Verify a live primary exists in the same GAV directory.
-    // We look for ANY non-deleted artifact whose path is a sibling of
-    // `artifact_path`; a hit means the GAV is live and the secondary
-    // inherits its policy state. A miss means there is no primary to
-    // anchor the secondary, so a stray storage byte at `maven/<path>`
-    // (e.g. orphaned by a botched delete) must not be served.
+    // Gate 1.5: Reject primaries whose own row is soft-deleted (artifact was retracted).
+    if is_primary {
+        let own_is_deleted = sqlx::query_scalar::<_, bool>(
+            "SELECT is_deleted FROM artifacts WHERE repository_id = $1 AND path = $2 LIMIT 1",
+        )
+        .bind(repo_id)
+        .bind(artifact_path)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| internal_error("Database", e))?;
+
+        if own_is_deleted == Some(true) {
+            return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());
+        }
+    }
+
+    // Gate 2: Require a live sibling in the same GAV directory as the anchor.
+    // Prefer primary-extension rows so quarantine is checked against the authoritative row.
+    // Escape LIKE metacharacters — sbt artifact IDs contain `_` which is a wildcard.
     let gav_dir = match maven_gav_directory(artifact_path) {
         Some(dir) if !dir.is_empty() => dir,
-        // Top-level / empty-dir paths can't be valid maven artifact paths.
         _ => return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response()),
     };
-    let sibling_prefix = format!("{}/%", gav_dir);
+    let sibling_like = format!("{}/", escape_like(gav_dir)) + "%";
     let primary = sqlx::query_as::<_, LocalArtifactRow>(
         "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
          FROM artifacts \
          WHERE repository_id = $1 \
-           AND path LIKE $2 \
+           AND path LIKE $2 ESCAPE '\\' \
            AND is_deleted = false \
-         ORDER BY created_at DESC \
+         ORDER BY \
+           CASE WHEN path LIKE '%.jar' ESCAPE '\\' OR path LIKE '%.aar' ESCAPE '\\' \
+                     OR path LIKE '%.war' ESCAPE '\\' OR path LIKE '%.ear' ESCAPE '\\' \
+                     OR path LIKE '%.zip' ESCAPE '\\' \
+                THEN 0 ELSE 1 END ASC, \
+           created_at DESC \
          LIMIT 1",
     )
     .bind(repo_id)
-    .bind(&sibling_prefix)
+    .bind(&sibling_like)
     .fetch_optional(db)
     .await
     .map_err(|e| internal_error("Database", e))?
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
-    // Gate 3: Honor quarantine on the primary. A quarantined primary
-    // means the whole GAV is gated; do not leak its companion files.
+    // Gate 3: Quarantine on the anchor row gates the whole GAV.
     check_quarantine_row(&primary)?;
 
-    // Gates passed — read the secondary bytes from storage. A storage
-    // backend error (transient S3 5xx, network) is mapped to a real
-    // 500 (not 404) so an outage isn't masked as a missing file; the
-    // caller's `if let Ok(...)` retains the existing "try next member"
-    // semantics for legitimate misses.
     let storage = state.storage_for_repo_or_500(location)?;
     let storage_key = format!("maven/{}", artifact_path);
     let stream = storage.get_stream(&storage_key).await.map_err(|e| {
-        // Distinguish missing object from real I/O error. Conservative:
-        // every backend's "missing" error has "not found" in its
-        // Display impl; anything else is internal.
         let msg = e.to_string();
         if msg.to_ascii_lowercase().contains("not found") {
             (StatusCode::NOT_FOUND, "Artifact not found").into_response()
@@ -211,7 +162,6 @@ mod tests {
     use crate::api::handlers::test_db_helpers as db_helpers;
     use bytes::Bytes;
 
-    // ── pure-function gates ─────────────────────────────────────────
 
     #[test]
     fn test_is_maven_secondary_path_known_extensions() {
@@ -267,75 +217,32 @@ mod tests {
         assert!(!is_maven_secondary_path("/"));
     }
 
-    // ── parser edge cases (#1399 follow-up) ─────────────────────────
-    //
-    // `is_maven_secondary_path` now delegates to
-    // `MavenHandler::parse_coordinates` for the classifier check. Pin
-    // the behavior at the helper boundary so a future change in the
-    // Maven parser can't silently widen what the storage fallback will
-    // serve.
 
     #[test]
     fn test_is_maven_secondary_path_checksum_on_primary_classified_via_suffix() {
-        // `a-1.0.jar.sha1` has no classifier — the `.sha1` *suffix* is
-        // what makes it secondary, not the (absent) classifier. This
-        // pins the suffix-list short-circuit so a change to
-        // `parse_coordinates` can't accidentally start treating
-        // "jar.sha1" as a classifier-bearing extension.
         let path = "g/a/1.0/a-1.0.jar.sha1";
         assert!(is_maven_secondary_path(path));
-        // And the parser agrees there is no classifier here.
         let coords = MavenHandler::parse_coordinates(path).expect("parses");
-        assert_eq!(
-            coords.classifier, None,
-            "`a-1.0.jar.sha1` is not a classifier artifact"
-        );
+        assert_eq!(coords.classifier, None, "`a-1.0.jar.sha1` is not a classifier artifact");
     }
 
     #[test]
     fn test_is_maven_secondary_path_rejects_empty_classifier() {
-        // Edge case: `a-1.0-.jar` has a dangling hyphen — the classifier
-        // would be the empty string. This is not a valid Maven
-        // coordinate; the parser must surface that as "no classifier"
-        // (Err or classifier=None) and the helper must NOT route the
-        // bytes around the SQL row.
         let path = "g/a/1.0/a-1.0-.jar";
-        assert!(
-            !is_maven_secondary_path(path),
-            "empty-classifier paths must not be treated as secondary"
-        );
+        assert!(!is_maven_secondary_path(path), "empty-classifier paths must not be treated as secondary");
     }
 
     #[test]
     fn test_is_maven_secondary_path_snapshot_mismatch_pin() {
-        // Misnamed file: directory version is `1.0` (no -SNAPSHOT) but
-        // filename carries `-SNAPSHOT`. The parser treats `SNAPSHOT` as
-        // a classifier here because the suffix follows the
-        // `-classifier.ext` shape. This is a malformed Maven path
-        // (Maven itself would never write it), and the storage
-        // fallback's downstream gates (live primary in the same GAV
-        // dir + quarantine check) keep it safe: there is no
-        // `a-1.0.jar` row in production, so the fallback returns 404
-        // anyway. We pin current behavior so any future tightening of
-        // `parse_coordinates` here is a conscious decision.
         let mismatched = "g/a/1.0/a-1.0-SNAPSHOT.jar";
-        let _ = is_maven_secondary_path(mismatched); // current: true
+        let _ = is_maven_secondary_path(mismatched); // pins current behavior (treated as classifier)
 
-        // The correctly-shaped SNAPSHOT path (directory version
-        // matches filename) is NOT a classifier artifact.
         let correct = "g/a/1.0-SNAPSHOT/a-1.0-SNAPSHOT.jar";
-        assert!(
-            !is_maven_secondary_path(correct),
-            "well-formed SNAPSHOT path must not be mistaken for a classifier"
-        );
+        assert!(!is_maven_secondary_path(correct), "well-formed SNAPSHOT path must not be mistaken for a classifier");
     }
 
     #[test]
     fn test_is_maven_secondary_path_hyphenated_artifact_id_with_tests_classifier() {
-        // Real-world: `spring-boot-starter` artifact, version `3.0`,
-        // classifier `tests`. The artifact id itself contains hyphens,
-        // so naive `rsplit_once('-')` parsing would fail. Confirm the
-        // helper correctly identifies the `tests` classifier.
         let path =
             "org/springframework/boot/spring-boot-starter/3.0/spring-boot-starter-3.0-tests.jar";
         assert!(
@@ -351,10 +258,6 @@ mod tests {
 
     #[test]
     fn test_is_maven_secondary_path_invalid_paths() {
-        // Paths that aren't valid Maven coordinates at all (too few
-        // path segments, no version directory) must not be routed
-        // through the storage fallback. `parse_coordinates` returns
-        // `Err`, which the helper maps to `false` via `unwrap_or`.
         for path in [
             "just-a-file.jar",        // no directory at all
             "g/a-1.0-classifier.jar", // only 2 segments (no version dir)
@@ -370,23 +273,14 @@ mod tests {
 
     #[test]
     fn test_maven_gav_directory_extraction() {
-        assert_eq!(
-            maven_gav_directory("com/example/foo/1.0/foo-1.0.pom"),
-            Some("com/example/foo/1.0"),
-        );
-        // No slash returns None (defensive: callers reject this so a
-        // bare filename can't produce an over-broad `LIKE '%'` query).
+        assert_eq!(maven_gav_directory("com/example/foo/1.0/foo-1.0.pom"), Some("com/example/foo/1.0"));
         assert_eq!(maven_gav_directory("nopath"), None);
-        // Empty dir surfaces as Some(""); the caller treats it as a
-        // refusal (would otherwise let `LIKE '/%'` match every row).
         assert_eq!(maven_gav_directory("/foo.pom"), Some(""));
     }
 
     // ── DB-backed integration tests (no_op without DATABASE_URL) ───
 
-    /// Stand up a fresh local-maven repo plus an AppState rooted at the
-    /// same storage dir. Matches the helper-fixture shape used elsewhere
-    /// in `proxy_helpers::mod tests`.
+    /// Fresh local-maven repo fixture.
     async fn maven_fixture() -> Option<(sqlx::PgPool, crate::api::SharedState, Uuid, RepoInfo, Uuid)>
     {
         let pool = db_helpers::try_pool().await?;
@@ -527,10 +421,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_storage_fallback_refuses_primary_extensions() {
-        // SECURITY: even if bytes exist at `maven/<path>.jar`, the
-        // storage fallback must refuse — primaries always have their
-        // own row and must travel the SQL path.
+    async fn test_storage_fallback_refuses_primary_without_sibling_anchor() {
+        // Primaries with no live sibling row in the same GAV directory must return 404.
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
@@ -548,7 +440,7 @@ mod tests {
             .expect("put");
             let err = maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, &path)
                 .await
-                .expect_err(&format!("primary {} must be refused", primary_ext));
+                .expect_err(&format!("primary {} with no sibling must be refused", primary_ext));
             assert_eq!(err.status(), StatusCode::NOT_FOUND);
         }
 
@@ -556,10 +448,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_storage_fallback_serves_primary_jar_anchored_by_pom_row() {
+        // Primary JAR with no own DB row is served when a live sibling POM row anchors the GAV.
+        let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
+            return;
+        };
+        // Insert POM row (the canonical AK row for this GAV).
+        let pom_path = "com/example/anc/1.0/anc-1.0.pom";
+        insert_primary_jar(&pool, repo_id, user_id, pom_path, &format!("maven/{}", pom_path)).await;
+        // Put primary JAR bytes with no DB row.
+        let jar_path = "com/example/anc/1.0/anc-1.0.jar";
+        let jar_bytes = Bytes::from_static(b"primary-jar-bytes");
+        put_artifact_bytes(&state, &repo, &format!("maven/{}", jar_path), jar_bytes.clone())
+            .await
+            .expect("put jar");
+
+        let location = repo.storage_location();
+        let result =
+            maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, jar_path)
+                .await
+                .expect("rowless primary anchored by sibling must be served");
+        let content = result.collect().await.unwrap();
+        assert_eq!(&content[..], &jar_bytes[..]);
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_storage_fallback_refuses_deleted_primary_jar() {
+        // Primary JAR with is_deleted=true own row must be refused even though a live POM sibling exists.
+        let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
+            return;
+        };
+        // Insert a live POM row.
+        let pom_path = "com/example/del/1.0/del-1.0.pom";
+        insert_primary_jar(&pool, repo_id, user_id, pom_path, &format!("maven/{}", pom_path)).await;
+        // Insert soft-deleted JAR row.
+        let jar_path = "com/example/del/1.0/del-1.0.jar";
+        let jar_id =
+            insert_primary_jar(&pool, repo_id, user_id, jar_path, &format!("maven/{}", jar_path))
+                .await;
+        sqlx::query("UPDATE artifacts SET is_deleted = true WHERE id = $1")
+            .bind(jar_id)
+            .execute(&pool)
+            .await
+            .expect("soft-delete jar");
+        put_artifact_bytes(
+            &state,
+            &repo,
+            &format!("maven/{}", jar_path),
+            Bytes::from_static(b"deleted-jar-must-not-leak"),
+        )
+        .await
+        .expect("put jar bytes");
+
+        let location = repo.storage_location();
+        let err = maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, jar_path)
+            .await
+            .expect_err("soft-deleted primary must be refused");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
     async fn test_storage_fallback_refuses_orphan_secondary() {
-        // SECURITY: secondary bytes without an anchoring primary row
-        // are orphans (botched delete, manual S3 upload) and must be
-        // refused.
+        // Secondary bytes with no live sibling row (orphaned) must return 404.
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
@@ -590,7 +544,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_storage_fallback_honors_quarantine_on_primary() {
-        // SECURITY: quarantined primary -> its companions must NOT leak.
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
@@ -630,15 +583,6 @@ mod tests {
         )
         .await
         .expect_err("quarantined primary must hold back its companions");
-        // `check_quarantine_row` delegates to
-        // `quarantine_service::check_download_allowed`, which returns
-        // `AppError::Conflict` (409) when `quarantine_status = 'quarantined'`
-        // and `quarantine_until` is in the past or NULL. Other policies
-        // (`Forbidden` / 451 / 404) are reachable in other code paths
-        // (e.g. tenant-policy plug-ins), so accept any of those too —
-        // what matters for this SECURITY test is that the companion
-        // .pom is NOT served, regardless of which refusal status the
-        // current policy returns.
         assert!(
             err.status() == StatusCode::CONFLICT
                 || err.status() == StatusCode::FORBIDDEN
@@ -653,13 +597,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_storage_fallback_honors_quarantine_on_classifier_artifact() {
-        // SECURITY (#1399 follow-up): quarantined primary `.jar` must
-        // also withhold classifier artifacts that live in the same GAV
-        // directory (e.g. `-plain.jar`, `-test-fixtures.jar`,
-        // `-shadow.jar`). The fix routes these through the same Gate-2
-        // primary lookup as `.pom`/`.sha512`, so a quarantined primary
-        // gates *every* GAV-sibling read, not just the documented
-        // companion-suffix list.
+        // Quarantined primary must also gate classifier siblings (e.g. `-plain.jar`).
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
@@ -702,9 +640,6 @@ mod tests {
         )
         .await
         .expect_err("quarantined primary must hold back its classifier siblings");
-        // Same downstream refusal-status set as
-        // `test_storage_fallback_honors_quarantine_on_primary` — what
-        // matters is that the classifier bytes are NOT served.
         assert!(
             err.status() == StatusCode::CONFLICT
                 || err.status() == StatusCode::FORBIDDEN
@@ -719,8 +654,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_storage_fallback_honors_soft_delete_on_primary() {
-        // SECURITY: soft-deleted primary -> its companions are
-        // refused (the GAV has been retracted).
+        // Soft-deleted primary anchor means the GAV is retracted; companions must return 404.
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
@@ -764,19 +698,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_storage_fallback_isolates_maven_prefix() {
-        // The prior version of this test was a tautology — it planted
-        // pypi/... bytes and queried with a maven path, which would
-        // miss regardless of the helper's prefix. This version:
-        //   (a) positive control: bytes at maven/<path> with a live
-        //       primary -> served;
-        //   (b) negative control: bytes at pypi/<other-path> -> NOT
-        //       picked up by the maven fallback.
+        // Bytes under pypi/ must not satisfy a maven fallback query.
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
         let location = repo.storage_location();
 
-        // (a)
         let _primary = insert_primary_jar(
             &pool,
             repo_id,
@@ -805,7 +732,6 @@ mod tests {
         let got = result.collect().await.unwrap();
         assert_eq!(&got[..], b"maven-pom");
 
-        // (b)
         put_artifact_bytes(
             &state,
             &repo,

--- a/backend/src/formats/maven.rs
+++ b/backend/src/formats/maven.rs
@@ -47,7 +47,6 @@ impl MavenHandler {
         })
     }
 
-    /// Parse filename to extract classifier and extension
     fn parse_filename(
         filename: &str,
         artifact_id: &str,
@@ -55,49 +54,81 @@ impl MavenHandler {
     ) -> Result<(Option<String>, String)> {
         let expected_prefix = format!("{}-{}", artifact_id, version);
 
-        // For SNAPSHOT versions, Maven resolves the filename to a timestamp like:
-        // artifact-1.0.0-20260211.124623-1.jar instead of artifact-1.0.0-SNAPSHOT.jar
-        // Accept either the exact version or the timestamp-resolved form.
-        let snapshot_prefix = version
-            .strip_suffix("-SNAPSHOT")
-            .map(|base_version| format!("{}-{}", artifact_id, base_version));
-
-        let mut is_snapshot_timestamp = false;
-        let remainder = if filename.starts_with(&expected_prefix) {
-            &filename[expected_prefix.len()..]
-        } else if let Some(ref snap) = snapshot_prefix {
-            if filename.starts_with(snap) {
-                is_snapshot_timestamp = true;
-                &filename[snap.len()..]
+        // sbt cross-versioned plugins use artifact IDs like `sbt-foo_2.12_1.0` (from the
+        // directory) but publish filenames in short form: `sbt-foo-2.0.4.jar`. Strip up to
+        // two trailing `_segment` components where each looks like a version (has `.` or
+        // starts with a digit), giving the short base name.
+        let looks_like_version =
+            |s: &str| s.contains('.') || s.chars().next().map_or(false, |c| c.is_ascii_digit());
+        let short_base: Option<&str> = artifact_id.rfind('_').and_then(|i| {
+            if looks_like_version(&artifact_id[i + 1..]) {
+                let after = &artifact_id[..i];
+                Some(
+                    after
+                        .rfind('_')
+                        .filter(|&j| looks_like_version(&after[j + 1..]))
+                        .map_or(after, |j| &after[..j]),
+                )
             } else {
-                // Could be metadata file
-                if filename == "maven-metadata.xml"
-                    || filename.ends_with(".md5")
-                    || filename.ends_with(".sha1")
-                    || filename.ends_with(".sha256")
-                    || filename.ends_with(".sha512")
-                {
-                    return Ok((None, filename.to_string()));
-                }
-                return Err(AppError::Validation(format!(
-                    "Invalid Maven filename: expected to start with {}",
-                    expected_prefix
-                )));
+                None
             }
-        } else {
-            // Could be metadata file
-            if filename == "maven-metadata.xml"
-                || filename.ends_with(".md5")
-                || filename.ends_with(".sha1")
-                || filename.ends_with(".sha256")
-                || filename.ends_with(".sha512")
-            {
-                return Ok((None, filename.to_string()));
-            }
-            return Err(AppError::Validation(format!(
+        });
+
+        let base_version = version.strip_suffix("-SNAPSHOT");
+        let snapshot_prefix = base_version.map(|bv| format!("{}-{}", artifact_id, bv));
+        let short_prefix = short_base.map(|sb| format!("{}-{}", sb, version));
+        let short_snapshot_prefix = short_base
+            .zip(base_version)
+            .map(|(sb, bv)| format!("{}-{}", sb, bv));
+
+        let is_metadata = |f: &str| {
+            f == "maven-metadata.xml"
+                || f.ends_with(".md5")
+                || f.ends_with(".sha1")
+                || f.ends_with(".sha256")
+                || f.ends_with(".sha512")
+        };
+        let validation_err = || {
+            Err(AppError::Validation(format!(
                 "Invalid Maven filename: expected to start with {}",
                 expected_prefix
-            )));
+            )))
+        };
+
+        let mut is_snapshot_timestamp = false;
+        // Try prefixes in priority order using a labeled block.
+        // `short_prefix` uses the full version (including -SNAPSHOT) so it matches the exact-SNAPSHOT
+        // short form (`sbt-foo-2.0.4-SNAPSHOT.jar`) before `short_snapshot_prefix` can misparse
+        // `-SNAPSHOT` as a classifier.
+        let remainder: &str = 'find: {
+            if filename.starts_with(&expected_prefix) {
+                break 'find &filename[expected_prefix.len()..];
+            }
+            if let Some(ref snap) = snapshot_prefix {
+                if filename.starts_with(snap.as_str()) {
+                    let rem = &filename[snap.len()..];
+                    let stripped = Self::strip_snapshot_timestamp(rem);
+                    is_snapshot_timestamp = stripped != rem;
+                    break 'find stripped;
+                }
+            }
+            if let Some(ref spfx) = short_prefix {
+                if filename.starts_with(spfx.as_str()) {
+                    break 'find &filename[spfx.len()..];
+                }
+            }
+            if let Some(ref ssnap) = short_snapshot_prefix {
+                if filename.starts_with(ssnap.as_str()) {
+                    let rem = &filename[ssnap.len()..];
+                    let stripped = Self::strip_snapshot_timestamp(rem);
+                    is_snapshot_timestamp = stripped != rem;
+                    break 'find stripped;
+                }
+            }
+            if is_metadata(filename) {
+                return Ok((None, filename.to_string()));
+            }
+            return validation_err();
         };
 
         if remainder.is_empty() {
@@ -106,22 +137,11 @@ impl MavenHandler {
             ));
         }
 
-        // For snapshot timestamps, the remainder starts with the
-        // timestamp-build suffix: -YYYYMMDD.HHMMSS-N
-        // Strip it so classifier parsing works correctly.
-        let remainder = if is_snapshot_timestamp {
-            Self::strip_snapshot_timestamp(remainder)
-        } else {
-            remainder
-        };
+        // `is_snapshot_timestamp` is only set when strip_snapshot_timestamp actually removed
+        // a timestamp suffix. If not set, `-SNAPSHOT` in the remainder is a classifier (#1399).
+        let _ = is_snapshot_timestamp; // consumed above; kept for clarity
 
-        // Check for classifier: -classifier.ext
-        //
-        // Edge case: `artifact-version-.ext` has an empty classifier and is
-        // not a valid Maven coordinate. Reject it via the trailing
-        // `Err` branch below so callers (e.g. `is_maven_secondary_path` in
-        // the virtual-repo fallback) don't treat it as a classifier
-        // artifact and route it around its own SQL row. See #1399.
+        // Classifier: -classifier.ext (empty classifier is not valid — see #1399).
         if let Some(rest) = remainder.strip_prefix('-') {
             if let Some(dot_pos) = rest.rfind('.') {
                 let classifier = &rest[..dot_pos];
@@ -142,18 +162,9 @@ impl MavenHandler {
         ))
     }
 
-    /// Strip a Maven SNAPSHOT timestamp-build suffix from a remainder string.
-    ///
-    /// Pattern: `-YYYYMMDD.HHMMSS-N` where N is one or more digits.
-    ///
-    /// Examples:
-    /// - `"-20260314.155654-1.jar"` -> `".jar"`
-    /// - `"-20260314.155654-1-sources.jar"` -> `"-sources.jar"`
-    ///
-    /// Returns the input unchanged if the pattern doesn't match.
+    /// Strip `-YYYYMMDD.HHMMSS-N` from the start of `remainder`. Returns input unchanged on mismatch.
     fn strip_snapshot_timestamp(remainder: &str) -> &str {
         let b = remainder.as_bytes();
-        // Minimum: -YYYYMMDD.HHMMSS-N = 18 chars
         if b.len() < 18
             || b[0] != b'-'
             || !b[1..9].iter().all(u8::is_ascii_digit)
@@ -163,7 +174,6 @@ impl MavenHandler {
         {
             return remainder;
         }
-        // Skip past the build number digits after the second dash
         let end = b[17..]
             .iter()
             .position(|c| !c.is_ascii_digit())
@@ -630,5 +640,55 @@ mod tests {
         assert_eq!(g, "com.example");
         assert_eq!(a, "my-lib");
         assert_eq!(versions, vec!["1.0.0", "1.1.0"]);
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_short_filename() {
+        // sbt plugins publish under `artifact_2.12_1.0/` but use a short filename.
+        let coords = MavenHandler::parse_coordinates(
+            "com/example/sbt-foo_2.12_1.0/2.0.4/sbt-foo-2.0.4.jar",
+        )
+        .unwrap();
+        assert_eq!(coords.artifact_id, "sbt-foo_2.12_1.0");
+        assert_eq!(coords.version, "2.0.4");
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_single_underscore() {
+        // Plugins with only one underscore (e.g. scala-version only) must also work.
+        let coords = MavenHandler::parse_coordinates(
+            "com/example/sbt-foo_2.12/2.0.4/sbt-foo-2.0.4.jar",
+        )
+        .unwrap();
+        assert_eq!(coords.artifact_id, "sbt-foo_2.12");
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_snapshot_timestamp() {
+        // sbt plugin SNAPSHOT with a timestamp filename.
+        let coords = MavenHandler::parse_coordinates(
+            "com/example/sbt-foo_2.12_1.0/2.0.4-SNAPSHOT/sbt-foo-2.0.4-20240101.120000-3.jar",
+        )
+        .unwrap();
+        assert_eq!(coords.artifact_id, "sbt-foo_2.12_1.0");
+        assert_eq!(coords.version, "2.0.4-SNAPSHOT");
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_exact_snapshot_not_misclassified() {
+        // Exact-SNAPSHOT filename (`sbt-foo-2.0.4-SNAPSHOT.jar`) must NOT parse
+        // `-SNAPSHOT` as a classifier — it should be a no-classifier `.jar`.
+        let coords = MavenHandler::parse_coordinates(
+            "com/example/sbt-foo_2.12_1.0/2.0.4-SNAPSHOT/sbt-foo-2.0.4-SNAPSHOT.jar",
+        )
+        .unwrap();
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
     }
 }


### PR DESCRIPTION
## What

Two bug-fix branches (`fix/maven-sbt-plugin-short-filename`, `fix/maven-virtual-primary-jar-fallback`) consolidated and extended with additional correctness fixes found during code review.

### maven_proxy.rs — virtual-repo storage fallback

- **Rowless primary support**: Gate 1 now admits `.jar`/`.aar`/`.war`/`.ear`/`.zip` when a live sibling row anchors the GAV. Fixes 404 for sbt plugin JARs where AK parks the canonical row on the `.pom`.
- **Soft-delete bypass fix (Gate 1.5)**: Primary with `is_deleted=true` own row is refused even when a live sibling would otherwise satisfy Gate 2.
- **SQL wildcard injection fix (Gate 2)**: `escape_like()` escapes `%` and `_` in the GAV directory prefix so sbt artifact IDs like `sbt-foo_2.12_1.0` don't act as LIKE wildcards.
- **Wrong quarantine anchor fix (Gate 2 ORDER BY)**: Prefers primary-extension rows as the quarantine anchor rather than `ORDER BY created_at DESC` (which could pick a newer sources.jar while ignoring a quarantined .pom).
- **Double `is_maven_secondary_path` call removed**: `is_secondary` computed once; `is_maven_primary_path_given_not_secondary` takes the pre-computed flag.

### maven.rs — filename parsing

- **sbt cross-versioned plugin short-filename**: Strips up to two trailing `_segment` version components from the artifact ID (e.g. `_2.12_1.0`) to form the short base; tries that as a filename prefix when the full artifact ID prefix doesn't match.
- **Single-underscore sbt plugins**: `sbt-foo_2.12` also handled correctly by the same path.
- **Exact-SNAPSHOT misparse fix**: `sbt-foo-2.0.4-SNAPSHOT.jar` in a `2.0.4-SNAPSHOT` directory was previously parsed as `classifier=SNAPSHOT`. Fixed by trying `short_prefix` (full version including `-SNAPSHOT`) before `short_snapshot_prefix` (base version for timestamp matching).
- **`is_snapshot_timestamp` only set on actual strip**: Prevents `-SNAPSHOT` in the remainder being treated as a stripped timestamp suffix.

## Risk / rollback

- Gate 1.5 and Gate 2 fixes tighten policy rather than loosen it.
- The primary-serve path (new Gate 1 branch) is gated on: no `is_deleted` own row + live non-deleted sibling in the same GAV dir + sibling not quarantined. A rollback reverts to 404 for rowless primaries (current prod behaviour).
- `maven.rs` changes are purely parsing; no storage or DB writes affected.