### PR TITLE
fix(maven): sbt short-filename parse and storage fallback security gates

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2144,8 +2144,17 @@ async fn upload(
 
     match gav_existing {
         Some((existing_id, existing_path, existing_storage_key, existing_meta)) => {
-            // An artifact record already exists for this GAV.
-            let existing_is_pom = MavenHandler::is_pom(&existing_path);
+            // An artifact record already exists for this GAV. The anchor row is
+            // the first-created file in the directory, which — depending on the
+            // client's upload order — can be a POM or a classifier artifact
+            // (e.g. sbt publishes `-tests-sources.jar` before the main `.jar`).
+            // Determine whether that anchor is itself a primary packaging
+            // artifact so a later-arriving primary can be promoted over it.
+            let existing_coords = MavenHandler::parse_coordinates(&existing_path).ok();
+            let existing_is_primary = existing_coords
+                .as_ref()
+                .map(is_primary_maven_artifact)
+                .unwrap_or(false);
 
             let new_file = make_file_entry(
                 &path,
@@ -2156,15 +2165,18 @@ async fn upload(
                 &checksum_sha256,
             );
 
-            if is_primary && existing_is_pom {
-                // The existing record is a POM-only placeholder. Promote the new
-                // JAR/WAR to primary and demote the POM into the files list.
-                let old_pom_coords = MavenHandler::parse_coordinates(&existing_path).ok();
-                let old_ext = old_pom_coords
+            if is_primary && !existing_is_primary {
+                // The existing record is a non-primary placeholder: either a POM,
+                // or a classifier artifact that happened to be uploaded before the
+                // main artifact (sbt's publish order). Promote the new JAR/WAR to
+                // primary and demote the existing file into the files list, so the
+                // canonical row is always the main artifact regardless of the order
+                // files arrived in.
+                let old_ext = existing_coords
                     .as_ref()
                     .map(|c| c.extension.as_str())
                     .unwrap_or("pom");
-                let old_classifier = old_pom_coords
+                let old_classifier = existing_coords
                     .as_ref()
                     .and_then(|c| c.classifier.as_deref());
 
@@ -2181,7 +2193,7 @@ async fn upload(
                     .unwrap_or("")
                     .to_string();
 
-                let pom_file = make_file_entry(
+                let demoted_file = make_file_entry(
                     &existing_path,
                     old_ext,
                     old_classifier,
@@ -2196,7 +2208,7 @@ async fn upload(
                     .and_then(|f| f.as_array())
                     .cloned()
                     .unwrap_or_default();
-                files.push(pom_file);
+                files.push(demoted_file);
 
                 // Merge POM-parsed fields into the new primary metadata
                 let mut merged = file_metadata.clone();

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -174,17 +174,18 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     // committed between two separate queries can't be observed inconsistently
     // (which would let the quarantine check be skipped).
     if is_primary {
-        let own = sqlx::query_as::<_, (bool, Option<String>, Option<chrono::DateTime<chrono::Utc>>)>(
-            "SELECT is_deleted, quarantine_status, quarantine_until \
+        let own =
+            sqlx::query_as::<_, (bool, Option<String>, Option<chrono::DateTime<chrono::Utc>>)>(
+                "SELECT is_deleted, quarantine_status, quarantine_until \
              FROM artifacts \
              WHERE repository_id = $1 AND path = $2 \
              LIMIT 1",
-        )
-        .bind(repo_id)
-        .bind(artifact_path)
-        .fetch_optional(db)
-        .await
-        .map_err(|e| internal_error("Database", e))?;
+            )
+            .bind(repo_id)
+            .bind(artifact_path)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| internal_error("Database", e))?;
 
         match own {
             // Retracted: refuse even if a live sibling would satisfy Gate 2.

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -83,7 +83,14 @@ fn maven_gav_directory(artifact_path: &str) -> Option<&str> {
 
 /// Primary Maven artifact extensions eligible for the storage fallback when
 /// a live sibling row anchors the GAV and the primary has no soft-deleted own row.
-const MAVEN_PRIMARY_FILE_EXTENSIONS: &[&str] = &[".jar", ".aar", ".war", ".ear", ".zip"];
+///
+/// Must stay in sync with `is_primary_maven_artifact` in `handlers/maven.rs`
+/// (the upload side that decides which file gets the canonical row) and with
+/// the Gate 2 anchor-preference `CASE` below. A type listed here but not there
+/// (or vice versa) means a primary that is parked rowless on upload but 404s on
+/// virtual-repo fetch.
+const MAVEN_PRIMARY_FILE_EXTENSIONS: &[&str] =
+    &[".jar", ".aar", ".war", ".ear", ".zip", ".bundle", ".tar.gz"];
 
 /// Returns `true` when `path` ends with a primary extension.
 ///
@@ -95,18 +102,6 @@ fn is_maven_primary_path_given_not_secondary(path: &str) -> bool {
     MAVEN_PRIMARY_FILE_EXTENSIONS
         .iter()
         .any(|ext| path.ends_with(ext))
-}
-
-/// Escape SQL LIKE metacharacters (`%` and `_`) for use with `LIKE … ESCAPE '\'`.
-///
-/// Without escaping, sbt cross-versioned artifact IDs such as
-/// `sbt-foo_2.12_1.0` contain `_` characters that act as
-/// single-character wildcards and can match sibling rows from adjacent
-/// coordinates.
-fn escape_like(s: &str) -> String {
-    s.replace('\\', "\\\\")
-        .replace('%', "\\%")
-        .replace('_', "\\_")
 }
 
 /// Maven-specific storage-direct fallback for virtual-repo downloads.
@@ -173,9 +168,15 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     // soft-delete and quarantine before reaching Gate 2. Without this, a CLEAN
     // sibling in the same GAV (e.g. the .pom) could anchor past a quarantined
     // or retracted primary's own row.
+    //
+    // Fetch is_deleted alongside the quarantine columns in a single query: one
+    // round-trip on the live-own-row path, and an atomic read so a soft-delete
+    // committed between two separate queries can't be observed inconsistently
+    // (which would let the quarantine check be skipped).
     if is_primary {
-        let own_is_deleted = sqlx::query_scalar::<_, bool>(
-            "SELECT is_deleted FROM artifacts \
+        let own = sqlx::query_as::<_, (bool, Option<String>, Option<chrono::DateTime<chrono::Utc>>)>(
+            "SELECT is_deleted, quarantine_status, quarantine_until \
+             FROM artifacts \
              WHERE repository_id = $1 AND path = $2 \
              LIMIT 1",
         )
@@ -185,27 +186,20 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
         .await
         .map_err(|e| internal_error("Database", e))?;
 
-        match own_is_deleted {
+        match own {
             // Retracted: refuse even if a live sibling would satisfy Gate 2.
-            Some(true) => return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response()),
+            Some((true, _, _)) => {
+                return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response())
+            }
             // Live own row: also check quarantine on the primary's own row so a
             // CLEAN sibling cannot anchor past a quarantined primary.
-            Some(false) => {
-                let own = sqlx::query_as::<_, LocalArtifactRow>(
-                    "SELECT id, storage_key, content_type, size_bytes, \
-                            quarantine_status, quarantine_until \
-                     FROM artifacts \
-                     WHERE repository_id = $1 AND path = $2 AND is_deleted = false \
-                     LIMIT 1",
+            Some((false, quarantine_status, quarantine_until)) => {
+                crate::services::quarantine_service::check_download_allowed(
+                    quarantine_status.as_deref(),
+                    quarantine_until,
+                    chrono::Utc::now(),
                 )
-                .bind(repo_id)
-                .bind(artifact_path)
-                .fetch_optional(db)
-                .await
-                .map_err(|e| internal_error("Database", e))?;
-                if let Some(ref row) = own {
-                    check_quarantine_row(row)?;
-                }
+                .map_err(|e| e.into_response())?;
             }
             // No own row (rowless primary — GAV-grouped). Proceed to Gate 2
             // to anchor on the live sibling.
@@ -214,18 +208,27 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     }
 
     // Gate 2: Verify a live sibling exists in the same GAV directory.
-    // Prefer primary-extension rows as the anchor so quarantine is checked
-    // against the authoritative row, not an arbitrary younger sibling.
+    // Prefer a *true primary* row (primary extension, no classifier) as the
+    // anchor so quarantine is checked against the authoritative artifact, not
+    // an arbitrary younger sibling. Classifier jars (`-sources.jar`,
+    // `-tests.jar`, …) also end in `.jar`, so they must be excluded from the
+    // primary bucket — otherwise a CLEAN classifier jar with its own row (as
+    // produced by row-per-file migration imports) could anchor past a
+    // quarantined primary and leak the GAV's companion files.
     // Escape LIKE metacharacters — sbt artifact IDs contain `_` (SQL wildcard).
     // A miss means there is no primary to anchor the secondary, so a stray
     // storage byte at `maven/<path>` (e.g. orphaned by a botched delete) must
     // not be served.
+    //
+    // The primary/classifier suffix lists below mirror MAVEN_PRIMARY_FILE_EXTENSIONS
+    // and the classifier-jar entries of MAVEN_SECONDARY_FILE_EXTENSIONS; keep them
+    // in sync.
     let gav_dir = match maven_gav_directory(artifact_path) {
         Some(dir) if !dir.is_empty() => dir,
         // Top-level / empty-dir paths can't be valid maven artifact paths.
         _ => return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response()),
     };
-    let sibling_like = format!("{}/", escape_like(gav_dir)) + "%";
+    let sibling_like = format!("{}/", super::escape_like_literal(gav_dir)) + "%";
     let primary = sqlx::query_as::<_, LocalArtifactRow>(
         "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
          FROM artifacts \
@@ -233,9 +236,14 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
            AND path LIKE $2 ESCAPE '\\' \
            AND is_deleted = false \
          ORDER BY \
-           CASE WHEN path LIKE '%.jar' ESCAPE '\\' OR path LIKE '%.aar' ESCAPE '\\' \
-                     OR path LIKE '%.war' ESCAPE '\\' OR path LIKE '%.ear' ESCAPE '\\' \
-                     OR path LIKE '%.zip' ESCAPE '\\' \
+           CASE WHEN (path LIKE '%.jar' ESCAPE '\\' OR path LIKE '%.aar' ESCAPE '\\' \
+                      OR path LIKE '%.war' ESCAPE '\\' OR path LIKE '%.ear' ESCAPE '\\' \
+                      OR path LIKE '%.zip' ESCAPE '\\' OR path LIKE '%.bundle' ESCAPE '\\' \
+                      OR path LIKE '%.tar.gz' ESCAPE '\\') \
+                     AND path NOT LIKE '%-sources.jar' ESCAPE '\\' \
+                     AND path NOT LIKE '%-javadoc.jar' ESCAPE '\\' \
+                     AND path NOT LIKE '%-tests.jar' ESCAPE '\\' \
+                     AND path NOT LIKE '%-test-sources.jar' ESCAPE '\\' \
                 THEN 0 ELSE 1 END ASC, \
            created_at DESC \
          LIMIT 1",
@@ -868,6 +876,76 @@ mod tests {
         // Same downstream refusal-status set as
         // `test_storage_fallback_honors_quarantine_on_primary` — what
         // matters is that the classifier bytes are NOT served.
+        assert!(
+            err.status() == StatusCode::CONFLICT
+                || err.status() == StatusCode::FORBIDDEN
+                || err.status() == StatusCode::UNAVAILABLE_FOR_LEGAL_REASONS
+                || err.status() == StatusCode::NOT_FOUND,
+            "expected a refusal status, got {}",
+            err.status()
+        );
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_storage_fallback_anchors_on_true_primary_not_clean_classifier() {
+        // SECURITY: a row-per-file GAV (as produced by migration imports) can
+        // hold both a quarantined true primary `.jar` AND a CLEAN classifier
+        // `-sources.jar`, each with its own row. Gate 2 must anchor the
+        // quarantine check on the true primary (no classifier), not on the
+        // clean classifier jar — otherwise the quarantined GAV's companions
+        // leak. The classifier jar is inserted AFTER the primary so the old
+        // `created_at DESC` tiebreak would have preferred it.
+        let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
+            return;
+        };
+        let primary_id = insert_primary_jar(
+            &pool,
+            repo_id,
+            user_id,
+            "com/example/qclf/1.0/qclf-1.0.jar",
+            "maven/com/example/qclf/1.0/qclf-1.0.jar",
+        )
+        .await;
+        sqlx::query(
+            "UPDATE artifacts SET quarantine_status = 'quarantined', \
+             quarantine_until = NULL WHERE id = $1",
+        )
+        .bind(primary_id)
+        .execute(&pool)
+        .await
+        .expect("set quarantine");
+        // Clean classifier jar with its own row, created after the primary.
+        insert_primary_jar(
+            &pool,
+            repo_id,
+            user_id,
+            "com/example/qclf/1.0/qclf-1.0-sources.jar",
+            "maven/com/example/qclf/1.0/qclf-1.0-sources.jar",
+        )
+        .await;
+        // Companion that would leak if quarantine were checked against the
+        // clean classifier jar instead of the quarantined primary.
+        put_artifact_bytes(
+            &state,
+            &repo,
+            "maven/com/example/qclf/1.0/qclf-1.0.pom",
+            Bytes::from_static(b"<project>qclf</project>"),
+        )
+        .await
+        .expect("put pom");
+
+        let location = repo.storage_location();
+        let err = maven_local_fetch_storage_fallback(
+            &pool,
+            &state,
+            repo_id,
+            &location,
+            "com/example/qclf/1.0/qclf-1.0.pom",
+        )
+        .await
+        .expect_err("clean classifier jar must not anchor past the quarantined primary");
         assert!(
             err.status() == StatusCode::CONFLICT
                 || err.status() == StatusCode::FORBIDDEN

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -40,12 +40,10 @@ use crate::storage::StorageLocation;
 /// are handled separately by parsing the Maven coordinate below.
 ///
 /// Primary file extensions (`.jar`, `.aar`, `.war`, `.ear`, `.zip`) are
-/// **deliberately excluded** from this list. Primary files always have
-/// their own row in `artifacts` (and therefore go through the
-/// SQL-backed `proxy_helpers::local_fetch_by_path`); allowing the
-/// storage fallback to serve a primary would silently bypass the
-/// quarantine and soft-delete gating on the primary's own row. The
-/// allowlist scopes the fallback to its documented purpose.
+/// **deliberately excluded** from this list; they are handled by a
+/// separate primary-path check in [`maven_local_fetch_storage_fallback`]
+/// Gate 1, which admits a primary only when a live sibling anchors the
+/// GAV *and* the primary has no soft-deleted own row.
 const MAVEN_SECONDARY_FILE_EXTENSIONS: &[&str] = &[
     ".pom",
     ".module",
@@ -83,6 +81,34 @@ fn maven_gav_directory(artifact_path: &str) -> Option<&str> {
     artifact_path.rsplit_once('/').map(|(dir, _)| dir)
 }
 
+/// Primary Maven artifact extensions eligible for the storage fallback when
+/// a live sibling row anchors the GAV and the primary has no soft-deleted own row.
+const MAVEN_PRIMARY_FILE_EXTENSIONS: &[&str] = &[".jar", ".aar", ".war", ".ear", ".zip"];
+
+/// Returns `true` when `path` ends with a primary extension.
+///
+/// The caller must pre-compute `is_secondary` and only call this when
+/// `!is_secondary`; that avoids running `parse_coordinates` twice for
+/// the same path.
+#[inline]
+fn is_maven_primary_path_given_not_secondary(path: &str) -> bool {
+    MAVEN_PRIMARY_FILE_EXTENSIONS
+        .iter()
+        .any(|ext| path.ends_with(ext))
+}
+
+/// Escape SQL LIKE metacharacters (`%` and `_`) for use with `LIKE … ESCAPE '\'`.
+///
+/// Without escaping, sbt cross-versioned artifact IDs such as
+/// `sbt-foo_2.12_1.0` contain `_` characters that act as
+/// single-character wildcards and can match sibling rows from adjacent
+/// coordinates.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// Maven-specific storage-direct fallback for virtual-repo downloads.
 ///
 /// The Maven download handler (`handlers/maven.rs`) groups artifacts by
@@ -106,15 +132,15 @@ fn maven_gav_directory(artifact_path: &str) -> Option<&str> {
 /// files (which have no row of their own), this helper:
 ///
 /// 1. Refuses any path that is neither a known companion-file suffix
-///    ([`MAVEN_SECONDARY_FILE_EXTENSIONS`]) nor a valid Maven coordinate
-///    with a classifier.
-///    Primary `.jar`/`.aar`/`.war`/`.ear` paths fall back to
-///    `NotFound` here so the caller can't accidentally route them
-///    around their own SQL row.
-/// 2. Looks up a "primary" sibling row in the same GAV directory and
-///    verifies it is not soft-deleted and not quarantined before
-///    serving the secondary bytes. A quarantined or deleted primary
-///    means the whole GAV is gated; the secondary travels with it.
+///    ([`MAVEN_SECONDARY_FILE_EXTENSIONS`]) / classifier artifact nor a
+///    bare primary extension ([`MAVEN_PRIMARY_FILE_EXTENSIONS`]).
+///    For primaries: also checks the primary's own row for soft-delete
+///    and quarantine (Gate 1.5) so a CLEAN sibling cannot anchor past
+///    a retracted or quarantined primary.
+/// 2. Looks up a live anchor row in the same GAV directory, preferring
+///    a primary-extension row so quarantine is checked against the
+///    authoritative row rather than an arbitrary younger sibling.
+///    A miss means the GAV is gone; stray storage bytes must not be served.
 /// 3. Only then reads `maven/<path>` from storage.
 ///
 /// ## Composition
@@ -134,36 +160,88 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     location: &StorageLocation,
     artifact_path: &str,
 ) -> Result<StreamingFetchResult, Response> {
-    // Gate 1: Only companion files and classifier artifacts are eligible.
-    // A primary `.jar`/`.aar`/etc. always has its own row and must travel
-    // the SQL path so its quarantine/soft-delete state is honored.
-    if !is_maven_secondary_path(artifact_path) {
+    // Gate 1: Only secondaries and bare primaries are eligible; anything else is 404.
+    // Compute is_secondary once — is_maven_primary_path_given_not_secondary takes the
+    // pre-computed flag so parse_coordinates is only called once per request.
+    let is_secondary = is_maven_secondary_path(artifact_path);
+    let is_primary = !is_secondary && is_maven_primary_path_given_not_secondary(artifact_path);
+    if !is_secondary && !is_primary {
         return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());
     }
 
-    // Gate 2: Verify a live primary exists in the same GAV directory.
-    // We look for ANY non-deleted artifact whose path is a sibling of
-    // `artifact_path`; a hit means the GAV is live and the secondary
-    // inherits its policy state. A miss means there is no primary to
-    // anchor the secondary, so a stray storage byte at `maven/<path>`
-    // (e.g. orphaned by a botched delete) must not be served.
+    // Gate 1.5: For primary artifacts, check the primary's own DB row for both
+    // soft-delete and quarantine before reaching Gate 2. Without this, a CLEAN
+    // sibling in the same GAV (e.g. the .pom) could anchor past a quarantined
+    // or retracted primary's own row.
+    if is_primary {
+        let own_is_deleted = sqlx::query_scalar::<_, bool>(
+            "SELECT is_deleted FROM artifacts \
+             WHERE repository_id = $1 AND path = $2 \
+             LIMIT 1",
+        )
+        .bind(repo_id)
+        .bind(artifact_path)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| internal_error("Database", e))?;
+
+        match own_is_deleted {
+            // Retracted: refuse even if a live sibling would satisfy Gate 2.
+            Some(true) => return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response()),
+            // Live own row: also check quarantine on the primary's own row so a
+            // CLEAN sibling cannot anchor past a quarantined primary.
+            Some(false) => {
+                let own = sqlx::query_as::<_, LocalArtifactRow>(
+                    "SELECT id, storage_key, content_type, size_bytes, \
+                            quarantine_status, quarantine_until \
+                     FROM artifacts \
+                     WHERE repository_id = $1 AND path = $2 AND is_deleted = false \
+                     LIMIT 1",
+                )
+                .bind(repo_id)
+                .bind(artifact_path)
+                .fetch_optional(db)
+                .await
+                .map_err(|e| internal_error("Database", e))?;
+                if let Some(ref row) = own {
+                    check_quarantine_row(row)?;
+                }
+            }
+            // No own row (rowless primary — GAV-grouped). Proceed to Gate 2
+            // to anchor on the live sibling.
+            None => {}
+        }
+    }
+
+    // Gate 2: Verify a live sibling exists in the same GAV directory.
+    // Prefer primary-extension rows as the anchor so quarantine is checked
+    // against the authoritative row, not an arbitrary younger sibling.
+    // Escape LIKE metacharacters — sbt artifact IDs contain `_` (SQL wildcard).
+    // A miss means there is no primary to anchor the secondary, so a stray
+    // storage byte at `maven/<path>` (e.g. orphaned by a botched delete) must
+    // not be served.
     let gav_dir = match maven_gav_directory(artifact_path) {
         Some(dir) if !dir.is_empty() => dir,
         // Top-level / empty-dir paths can't be valid maven artifact paths.
         _ => return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response()),
     };
-    let sibling_prefix = format!("{}/%", gav_dir);
+    let sibling_like = format!("{}/", escape_like(gav_dir)) + "%";
     let primary = sqlx::query_as::<_, LocalArtifactRow>(
         "SELECT id, storage_key, content_type, size_bytes, quarantine_status, quarantine_until \
          FROM artifacts \
          WHERE repository_id = $1 \
-           AND path LIKE $2 \
+           AND path LIKE $2 ESCAPE '\\' \
            AND is_deleted = false \
-         ORDER BY created_at DESC \
+         ORDER BY \
+           CASE WHEN path LIKE '%.jar' ESCAPE '\\' OR path LIKE '%.aar' ESCAPE '\\' \
+                     OR path LIKE '%.war' ESCAPE '\\' OR path LIKE '%.ear' ESCAPE '\\' \
+                     OR path LIKE '%.zip' ESCAPE '\\' \
+                THEN 0 ELSE 1 END ASC, \
+           created_at DESC \
          LIMIT 1",
     )
     .bind(repo_id)
-    .bind(&sibling_prefix)
+    .bind(&sibling_like)
     .fetch_optional(db)
     .await
     .map_err(|e| internal_error("Database", e))?
@@ -527,10 +605,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_storage_fallback_refuses_primary_extensions() {
-        // SECURITY: even if bytes exist at `maven/<path>.jar`, the
-        // storage fallback must refuse — primaries always have their
-        // own row and must travel the SQL path.
+    async fn test_storage_fallback_refuses_primary_without_sibling_anchor() {
+        // SECURITY: primaries with no live sibling row in the same GAV directory
+        // must return 404 — there is nothing to anchor the GAV policy on.
         let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
             return;
         };
@@ -548,10 +625,96 @@ mod tests {
             .expect("put");
             let err = maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, &path)
                 .await
-                .expect_err(&format!("primary {} must be refused", primary_ext));
+                .expect_err(&format!(
+                    "primary {} with no sibling anchor must be refused",
+                    primary_ext
+                ));
             assert_eq!(err.status(), StatusCode::NOT_FOUND);
         }
 
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_storage_fallback_serves_primary_jar_anchored_by_pom_row() {
+        // A rowless primary JAR must be served when a live sibling POM row
+        // anchors the GAV (sbt/Maven GAV-grouping: AK parks the canonical row
+        // on the POM and the JAR has no own row).
+        let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
+            return;
+        };
+        let pom_path = "com/example/anc/1.0/anc-1.0.pom";
+        insert_primary_jar(
+            &pool,
+            repo_id,
+            user_id,
+            pom_path,
+            &format!("maven/{}", pom_path),
+        )
+        .await;
+        let jar_path = "com/example/anc/1.0/anc-1.0.jar";
+        let jar_bytes = Bytes::from_static(b"primary-jar-bytes");
+        put_artifact_bytes(
+            &state,
+            &repo,
+            &format!("maven/{}", jar_path),
+            jar_bytes.clone(),
+        )
+        .await
+        .expect("put jar");
+        let location = repo.storage_location();
+        let result =
+            maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, jar_path)
+                .await
+                .expect("rowless primary anchored by sibling POM must be served");
+        let content = result.collect().await.unwrap();
+        assert_eq!(&content[..], &jar_bytes[..]);
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_storage_fallback_refuses_deleted_primary_jar() {
+        // SECURITY: a primary JAR with `is_deleted = true` must be refused even
+        // though a live sibling POM exists (Gate 1.5). The artifact was retracted.
+        let Some((pool, state, repo_id, repo, user_id)) = maven_fixture().await else {
+            return;
+        };
+        let pom_path = "com/example/del/1.0/del-1.0.pom";
+        insert_primary_jar(
+            &pool,
+            repo_id,
+            user_id,
+            pom_path,
+            &format!("maven/{}", pom_path),
+        )
+        .await;
+        let jar_path = "com/example/del/1.0/del-1.0.jar";
+        let jar_id = insert_primary_jar(
+            &pool,
+            repo_id,
+            user_id,
+            jar_path,
+            &format!("maven/{}", jar_path),
+        )
+        .await;
+        sqlx::query("UPDATE artifacts SET is_deleted = true WHERE id = $1")
+            .bind(jar_id)
+            .execute(&pool)
+            .await
+            .expect("soft-delete jar");
+        put_artifact_bytes(
+            &state,
+            &repo,
+            &format!("maven/{}", jar_path),
+            Bytes::from_static(b"deleted-jar-must-not-leak"),
+        )
+        .await
+        .expect("put jar bytes");
+        let location = repo.storage_location();
+        let err = maven_local_fetch_storage_fallback(&pool, &state, repo_id, &location, jar_path)
+            .await
+            .expect_err("soft-deleted primary must be refused");
+        assert_eq!(err.status(), StatusCode::NOT_FOUND);
         db_helpers::cleanup(&pool, repo_id, user_id).await;
     }
 

--- a/backend/src/formats/maven.rs
+++ b/backend/src/formats/maven.rs
@@ -55,49 +55,87 @@ impl MavenHandler {
     ) -> Result<(Option<String>, String)> {
         let expected_prefix = format!("{}-{}", artifact_id, version);
 
+        // sbt cross-versioned plugins publish under a directory named after the
+        // full cross-versioned artifact ID (e.g. `sbt-foo_2.12_1.0`) but write
+        // filenames using only the short base name without the cross-version
+        // suffix (e.g. `sbt-foo-2.0.4.jar`). Strip up to two trailing
+        // `_segment` components where each segment looks like a version string
+        // (contains `.` or starts with a digit) to derive the short base name.
+        let looks_like_version =
+            |s: &str| s.contains('.') || s.chars().next().is_some_and(|c| c.is_ascii_digit());
+        let short_base: Option<&str> = artifact_id.rfind('_').and_then(|i| {
+            if looks_like_version(&artifact_id[i + 1..]) {
+                let after = &artifact_id[..i];
+                Some(
+                    after
+                        .rfind('_')
+                        .filter(|&j| looks_like_version(&after[j + 1..]))
+                        .map_or(after, |j| &after[..j]),
+                )
+            } else {
+                None
+            }
+        });
+
         // For SNAPSHOT versions, Maven resolves the filename to a timestamp like:
         // artifact-1.0.0-20260211.124623-1.jar instead of artifact-1.0.0-SNAPSHOT.jar
         // Accept either the exact version or the timestamp-resolved form.
-        let snapshot_prefix = version
-            .strip_suffix("-SNAPSHOT")
-            .map(|base_version| format!("{}-{}", artifact_id, base_version));
+        let base_version = version.strip_suffix("-SNAPSHOT");
+        let snapshot_prefix = base_version.map(|bv| format!("{}-{}", artifact_id, bv));
 
-        let mut is_snapshot_timestamp = false;
-        let remainder = if filename.starts_with(&expected_prefix) {
-            &filename[expected_prefix.len()..]
-        } else if let Some(ref snap) = snapshot_prefix {
-            if filename.starts_with(snap) {
-                is_snapshot_timestamp = true;
-                &filename[snap.len()..]
-            } else {
-                // Could be metadata file
-                if filename == "maven-metadata.xml"
-                    || filename.ends_with(".md5")
-                    || filename.ends_with(".sha1")
-                    || filename.ends_with(".sha256")
-                    || filename.ends_with(".sha512")
-                {
-                    return Ok((None, filename.to_string()));
-                }
-                return Err(AppError::Validation(format!(
-                    "Invalid Maven filename: expected to start with {}",
-                    expected_prefix
-                )));
-            }
-        } else {
-            // Could be metadata file
-            if filename == "maven-metadata.xml"
-                || filename.ends_with(".md5")
-                || filename.ends_with(".sha1")
-                || filename.ends_with(".sha256")
-                || filename.ends_with(".sha512")
-            {
-                return Ok((None, filename.to_string()));
-            }
-            return Err(AppError::Validation(format!(
+        // Short-form prefixes for sbt plugins. `short_prefix` includes the full
+        // version (e.g. `sbt-foo-2.0.4-SNAPSHOT`) so it matches exact-SNAPSHOT
+        // filenames before `short_snapshot_prefix` can misparse `-SNAPSHOT` as a
+        // classifier.
+        let short_prefix = short_base.map(|sb| format!("{}-{}", sb, version));
+        let short_snapshot_prefix = short_base
+            .zip(base_version)
+            .map(|(sb, bv)| format!("{}-{}", sb, bv));
+
+        let is_metadata = |f: &str| {
+            f == "maven-metadata.xml"
+                || f.ends_with(".md5")
+                || f.ends_with(".sha1")
+                || f.ends_with(".sha256")
+                || f.ends_with(".sha512")
+        };
+        let validation_err = || {
+            Err(AppError::Validation(format!(
                 "Invalid Maven filename: expected to start with {}",
                 expected_prefix
-            )));
+            )))
+        };
+
+        // Try prefixes in priority order. `short_prefix` comes before
+        // `short_snapshot_prefix` so the exact-SNAPSHOT short form is handled
+        // before the timestamp branch can misparse `-SNAPSHOT` as a classifier.
+        let remainder: &str = 'find: {
+            if filename.starts_with(&expected_prefix) {
+                break 'find &filename[expected_prefix.len()..];
+            }
+            if let Some(ref snap) = snapshot_prefix {
+                if filename.starts_with(snap.as_str()) {
+                    let rem = &filename[snap.len()..];
+                    // Strip the timestamp-build suffix (-YYYYMMDD.HHMMSS-N) so
+                    // classifier parsing works correctly on the remainder.
+                    break 'find Self::strip_snapshot_timestamp(rem);
+                }
+            }
+            if let Some(ref spfx) = short_prefix {
+                if filename.starts_with(spfx.as_str()) {
+                    break 'find &filename[spfx.len()..];
+                }
+            }
+            if let Some(ref ssnap) = short_snapshot_prefix {
+                if filename.starts_with(ssnap.as_str()) {
+                    let rem = &filename[ssnap.len()..];
+                    break 'find Self::strip_snapshot_timestamp(rem);
+                }
+            }
+            if is_metadata(filename) {
+                return Ok((None, filename.to_string()));
+            }
+            return validation_err();
         };
 
         if remainder.is_empty() {
@@ -105,15 +143,6 @@ impl MavenHandler {
                 "Invalid Maven filename: missing extension".to_string(),
             ));
         }
-
-        // For snapshot timestamps, the remainder starts with the
-        // timestamp-build suffix: -YYYYMMDD.HHMMSS-N
-        // Strip it so classifier parsing works correctly.
-        let remainder = if is_snapshot_timestamp {
-            Self::strip_snapshot_timestamp(remainder)
-        } else {
-            remainder
-        };
 
         // Check for classifier: -classifier.ext
         //
@@ -853,6 +882,57 @@ mod tests {
             Some("1.0.0"),
         );
         assert!(merge_plugin_prefix_metadata(&[versions_doc, "<metadata/>".to_string()]).is_none());
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_short_filename() {
+        // sbt plugins publish under `artifact_2.12_1.0/` but write filenames in
+        // the short form without the cross-version suffix (`artifact-2.0.4.jar`).
+        let coords =
+            MavenHandler::parse_coordinates("com/example/sbt-foo_2.12_1.0/2.0.4/sbt-foo-2.0.4.jar")
+                .unwrap();
+        assert_eq!(coords.artifact_id, "sbt-foo_2.12_1.0");
+        assert_eq!(coords.version, "2.0.4");
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_single_underscore() {
+        // Plugins with a single cross-version component (scala version only)
+        // must also be handled by the short-filename path.
+        let coords =
+            MavenHandler::parse_coordinates("com/example/sbt-foo_2.12/2.0.4/sbt-foo-2.0.4.jar")
+                .unwrap();
+        assert_eq!(coords.artifact_id, "sbt-foo_2.12");
+        assert_eq!(coords.version, "2.0.4");
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_snapshot_timestamp() {
+        // sbt SNAPSHOT plugins may publish timestamp-resolved filenames.
+        let coords = MavenHandler::parse_coordinates(
+            "com/example/sbt-foo_2.12_1.0/2.0.4-SNAPSHOT/sbt-foo-2.0.4-20240101.120000-3.jar",
+        )
+        .unwrap();
+        assert_eq!(coords.artifact_id, "sbt-foo_2.12_1.0");
+        assert_eq!(coords.version, "2.0.4-SNAPSHOT");
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
+    }
+
+    #[test]
+    fn test_parse_sbt_plugin_exact_snapshot_not_misclassified() {
+        // Exact-SNAPSHOT filename (`sbt-foo-2.0.4-SNAPSHOT.jar`) must NOT parse
+        // `-SNAPSHOT` as a classifier — it should be a no-classifier `.jar`.
+        let coords = MavenHandler::parse_coordinates(
+            "com/example/sbt-foo_2.12_1.0/2.0.4-SNAPSHOT/sbt-foo-2.0.4-SNAPSHOT.jar",
+        )
+        .unwrap();
+        assert_eq!(coords.classifier, None);
+        assert_eq!(coords.extension, "jar");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1899

## Summary

### `backend/src/formats/maven.rs` — `parse_filename`
- sbt cross-versioned plugins publish under `artifact_2.12_1.0/` but the filename uses the short base name (`artifact-2.0.4.jar`). The parser now strips up to two trailing `_<version-segment>` components, handling single (`name_2.12`) and double (`name_2.12_1.0`) cross-version suffixes, so `parse_coordinates` succeeds for short-form sbt plugin filenames.
- Exact-SNAPSHOT misparse fixed: the full-version short prefix (including `-SNAPSHOT`) is tried before the timestamp-snapshot prefix, so `-SNAPSHOT` is never parsed as a classifier.
- Removed a dead `is_snapshot_timestamp` flag; `strip_snapshot_timestamp` is applied inline.
- Refactored the prefix-priority chain to a labeled block.

### `backend/src/api/handlers/maven.rs` — upload GAV grouping
- Promote an incoming primary artifact to the canonical GAV row whenever the existing anchor is **non-primary** (a POM *or* a classifier artifact), not only when it is a POM. Clients that publish a classifier artifact (e.g. `-tests-sources.jar`) before the main artifact previously left the main artifact rowless and the canonical row anchored on the wrong file.

### `backend/src/api/handlers/maven_proxy.rs` — `maven_local_fetch_storage_fallback`
- **LIKE wildcard injection**: artifact IDs can contain `_` (a SQL single-character wildcard). The sibling-lookup now uses the shared `escape_like_literal` helper with `ESCAPE '\'`.
- **Quarantine anchor**: Gate 2 prefers a **true primary** (primary extension, no classifier) as the anchor. Classifier jars (`-sources.jar`, `-tests.jar`, …) also end in `.jar`; without excluding them, a clean classifier jar with its own row (as produced by row-per-file layouts such as bulk migration imports) could anchor past a quarantined primary and leak the GAV's companion files.
- **Primary serving**: Gate 1 admits bare primary extensions so the fallback can serve a rowless primary when a live sibling anchors the GAV. `MAVEN_PRIMARY_FILE_EXTENSIONS` is aligned with `is_primary_maven_artifact` (adds `.bundle`/`.tar.gz`) so those packaging types are servable rather than 404.
- **Gate 1.5 — retraction/quarantine**: a primary with a soft-deleted or quarantined own row is refused before Gate 2, so a clean sibling cannot anchor past it. Implemented as a single atomic query (one round-trip; no soft-delete race between two reads).

### Tests
- Regression test: a quarantined true primary with a clean classifier-jar sibling in the same GAV must withhold its companions (the clean classifier jar must not anchor the quarantine check).

## Risk / rollback
- No schema changes.
- All changes tighten existing security gates or correct anchor selection; no existing behavior is loosened.
- The LIKE-escape and primary-extension definitions are consolidated to reduce drift between the upload and serving paths.
