### PR TITLE
fix(migration): unblock Nexus migrations — empty include_repos + repo-type aliases

### DIFF
--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -71,12 +71,21 @@ pub enum RepositoryType {
 }
 
 impl RepositoryType {
-    /// Parse from Artifactory repository type string
+    /// Parse a source-side repository type string.
+    ///
+    /// Accepts both the Artifactory vocabulary (`local` / `remote` /
+    /// `virtual`) and the Nexus vocabulary (`hosted` / `proxy` / `group`).
+    /// The two sets denote the same three logical kinds — the enum doc
+    /// comments above have always pinned this mapping. Prior to this fix
+    /// the function only matched the Artifactory triple, so every Nexus
+    /// repository was rejected by `prepare_repository_migration` with
+    /// `Unknown repository type: hosted` and an entire Nexus source was
+    /// effectively un-migratable (issue #1889).
     pub fn from_artifactory(rclass: &str) -> Option<Self> {
         match rclass.to_lowercase().as_str() {
-            "local" => Some(Self::Local),
-            "remote" => Some(Self::Remote),
-            "virtual" => Some(Self::Virtual),
+            "local" | "hosted" => Some(Self::Local),
+            "remote" | "proxy" => Some(Self::Remote),
+            "virtual" | "group" => Some(Self::Virtual),
             _ => None,
         }
     }
@@ -1317,9 +1326,14 @@ mod tests {
         // Regression test for issue #857: when Nexus reports `maven2`, the
         // prepared config should carry the canonical `maven` name so the
         // created repository uses the correct AK format.
+        //
+        // `repo_type` here is the real Nexus vocabulary (`hosted`) — not the
+        // Artifactory `local`. Prior fixtures used `local` and so masked
+        // issue #1889, where `RepositoryType::from_artifactory` rejected
+        // every Nexus repo on a live source.
         let repo = RepositoryListItem {
             key: "releases".to_string(),
-            repo_type: "local".to_string(),
+            repo_type: "hosted".to_string(),
             package_type: "maven2".to_string(),
             url: None,
             description: None,
@@ -1333,7 +1347,7 @@ mod tests {
     fn test_prepare_repository_migration_normalizes_nexus_yum() {
         let repo = RepositoryListItem {
             key: "yum".to_string(),
-            repo_type: "local".to_string(),
+            repo_type: "hosted".to_string(),
             package_type: "yum".to_string(),
             url: None,
             description: None,
@@ -1347,7 +1361,7 @@ mod tests {
     fn test_prepare_repository_migration_normalizes_nexus_raw() {
         let repo = RepositoryListItem {
             key: "resources".to_string(),
-            repo_type: "local".to_string(),
+            repo_type: "hosted".to_string(),
             package_type: "raw".to_string(),
             url: None,
             description: None,
@@ -1355,6 +1369,38 @@ mod tests {
         let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
         assert_eq!(config.package_type, "generic");
         assert_eq!(config.format_compatibility, FormatCompatibility::Full);
+    }
+
+    #[test]
+    fn test_prepare_repository_migration_accepts_nexus_proxy() {
+        // Nexus `proxy` ≡ Artifactory `remote`; both must map to
+        // `RepositoryType::Remote` (issue #1889 regression).
+        let repo = RepositoryListItem {
+            key: "maven-central".to_string(),
+            repo_type: "proxy".to_string(),
+            package_type: "maven2".to_string(),
+            url: Some("https://repo1.maven.org/maven2/".to_string()),
+            description: None,
+        };
+        let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
+        assert_eq!(config.repo_type, RepositoryType::Remote);
+        assert_eq!(config.package_type, "maven");
+    }
+
+    #[test]
+    fn test_prepare_repository_migration_accepts_nexus_group() {
+        // Nexus `group` ≡ Artifactory `virtual`; both must map to
+        // `RepositoryType::Virtual` (issue #1889 regression).
+        let repo = RepositoryListItem {
+            key: "maven-public".to_string(),
+            repo_type: "group".to_string(),
+            package_type: "maven2".to_string(),
+            url: None,
+            description: None,
+        };
+        let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
+        assert_eq!(config.repo_type, RepositoryType::Virtual);
+        assert_eq!(config.package_type, "maven");
     }
 
     #[test]
@@ -1453,9 +1499,46 @@ mod tests {
 
     #[test]
     fn test_repository_type_from_artifactory_unknown() {
+        // `federated` (Artifactory) and `unknown_kind` are genuinely
+        // unmapped. `hosted` used to live here too — see #1889; it is
+        // Nexus's name for `Local` and is now accepted by
+        // `from_artifactory` via the alias branch below.
         assert_eq!(RepositoryType::from_artifactory("federated"), None);
         assert_eq!(RepositoryType::from_artifactory(""), None);
-        assert_eq!(RepositoryType::from_artifactory("hosted"), None);
+        assert_eq!(RepositoryType::from_artifactory("unknown_kind"), None);
+    }
+
+    #[test]
+    fn test_repository_type_from_artifactory_accepts_nexus_aliases() {
+        // Nexus reports `hosted` / `proxy` / `group`; these are the same
+        // three kinds as Artifactory's `local` / `remote` / `virtual` and
+        // must map to the same `RepositoryType` variants. Regression
+        // coverage for issue #1889.
+        assert_eq!(
+            RepositoryType::from_artifactory("hosted"),
+            Some(RepositoryType::Local)
+        );
+        assert_eq!(
+            RepositoryType::from_artifactory("proxy"),
+            Some(RepositoryType::Remote)
+        );
+        assert_eq!(
+            RepositoryType::from_artifactory("group"),
+            Some(RepositoryType::Virtual)
+        );
+        // Case-insensitive across the Nexus vocabulary as well.
+        assert_eq!(
+            RepositoryType::from_artifactory("HOSTED"),
+            Some(RepositoryType::Local)
+        );
+        assert_eq!(
+            RepositoryType::from_artifactory("Proxy"),
+            Some(RepositoryType::Remote)
+        );
+        assert_eq!(
+            RepositoryType::from_artifactory("GROUP"),
+            Some(RepositoryType::Virtual)
+        );
     }
 
     #[test]

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -375,6 +375,22 @@ impl MigrationWorker {
             repos_to_process.push((migration_config.target_key, migration_config.package_type));
         }
 
+        // Surface the no-op case explicitly. Without this, a job that ended
+        // up with zero processable repos would walk straight to
+        // `determine_final_status(0, 0) = Completed` and the operator would
+        // see a "Completed 0/0" run with no log line explaining why — the
+        // exact UX gap reported in issue #1901 before the `include_repos: []`
+        // semantics were fixed. We still let the job finish normally so the
+        // existing UI/state-machine contracts hold.
+        if repos_to_process.is_empty() {
+            tracing::warn!(
+                job_id = %job_id,
+                requested = repos.len(),
+                source_repos = source_repos.len(),
+                "No repositories available to migrate; the source listed none, every requested key was missing/unsupported, or every resolved candidate conflicted with an incompatible destination. Job will complete as a no-op."
+            );
+        }
+
         // Process each repository
         for (repo_key, package_type) in &repos_to_process {
             // Check for pause/cancel
@@ -1810,6 +1826,14 @@ pub(crate) struct ResolveRepoPlan {
 /// Match each requested repository key against the source-side repository
 /// list and prepare a `RepositoryMigrationConfig` for it.
 ///
+/// An empty `requested` slice is treated as "every repository the source
+/// reports" — matching the convention used by include/exclude filter pairs
+/// in apt, yum, Bazel, Helm, etc. The previous "empty == migrate nothing"
+/// behavior caused jobs submitted with the default `include_repos: []`
+/// (which is what the UI sends when no specific repo is picked) to silently
+/// complete in ~200ms with `0/0/0`, never enumerating the source and never
+/// writing `migration_items` or `migration_reports` rows (issue #1901).
+///
 /// Pure (no DB, no I/O) so it can be unit-tested end-to-end. The DB-touching
 /// `check_repository_conflict` / `create_repository` follow-up runs in
 /// `MigrationWorker::process_job` over the `resolved` slice.
@@ -1818,6 +1842,20 @@ pub(crate) fn resolve_repos_for_provisioning(
     source_repos: &[crate::services::artifactory_client::RepositoryListItem],
 ) -> ResolveRepoPlan {
     let mut plan = ResolveRepoPlan::default();
+
+    if requested.is_empty() {
+        for source_repo in source_repos {
+            match MigrationService::prepare_repository_migration(source_repo, None) {
+                Ok(c) => plan.resolved.push(c),
+                Err(e) => plan.unsupported.push(UnsupportedRepo {
+                    repo_key: source_repo.key.clone(),
+                    reason: e.to_string(),
+                }),
+            }
+        }
+        return plan;
+    }
+
     for repo_key in requested {
         let source_repo = match source_repos.iter().find(|r| &r.key == repo_key) {
             Some(r) => r,
@@ -3736,9 +3774,51 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_repos_empty_request_yields_empty_plan() {
-        let source = vec![mk_source_repo("maven-releases", "LOCAL", "Maven")];
+    fn test_resolve_repos_empty_request_resolves_all_source_repos() {
+        // Empty `include_repos` means "every repository the source reports"
+        // — matching the apt/yum/Bazel/Helm include-list convention. The
+        // previous "empty == migrate nothing" behavior caused jobs created
+        // with the default empty list to silently no-op (issue #1901).
+        let source = vec![
+            mk_source_repo("maven-releases", "LOCAL", "Maven"),
+            mk_source_repo("npm-releases", "LOCAL", "Npm"),
+        ];
         let plan = resolve_repos_for_provisioning(&[], &source);
+        assert_eq!(plan.resolved.len(), 2);
+        assert!(plan.missing.is_empty());
+        assert!(plan.unsupported.is_empty());
+        let resolved_keys: Vec<&str> = plan
+            .resolved
+            .iter()
+            .map(|c| c.target_key.as_str())
+            .collect();
+        assert!(resolved_keys.contains(&"maven-releases"));
+        assert!(resolved_keys.contains(&"npm-releases"));
+    }
+
+    #[test]
+    fn test_resolve_repos_empty_request_routes_unsupported_source_repos_to_unsupported_bucket() {
+        // Even in the "empty == all" path, an unmappable source repo type
+        // must land in `unsupported` rather than poison the rest of the
+        // plan or short-circuit the whole job.
+        let source = vec![
+            mk_source_repo("maven-releases", "LOCAL", "Maven"),
+            mk_source_repo("weird-repo", "BOGUS_TYPE", "Maven"),
+        ];
+        let plan = resolve_repos_for_provisioning(&[], &source);
+        assert_eq!(plan.resolved.len(), 1);
+        assert_eq!(plan.resolved[0].target_key, "maven-releases");
+        assert!(plan.missing.is_empty());
+        assert_eq!(plan.unsupported.len(), 1);
+        assert_eq!(plan.unsupported[0].repo_key, "weird-repo");
+    }
+
+    #[test]
+    fn test_resolve_repos_empty_request_with_empty_source_yields_empty_plan() {
+        // When both sides are empty there really is nothing to migrate;
+        // verify we return a fully empty plan (caller turns that into a
+        // "no repositories to migrate" warning).
+        let plan = resolve_repos_for_provisioning(&[], &[]);
         assert!(plan.resolved.is_empty());
         assert!(plan.missing.is_empty());
         assert!(plan.unsupported.is_empty());


### PR DESCRIPTION
Closes #1901 and #1889.

This PR bundles two small, independent fixes that both surface as
"submit a Nexus migration job; nothing happens." They live in the same
module and trip the same end-to-end flow, so they ship together.

## #1901 — empty include_repos treated as "migrate nothing"

`migration_worker::resolve_repos_for_provisioning(&[], ...)` walked
its for-loop over the empty `requested` slice, returned an empty
`ResolveRepoPlan`, and `process_job` walked straight to
`determine_final_status(0, 0) = Completed` — silent success in
~200 ms, no `migration_items`, no `migration_reports`. The UI
submits `include_repos: []` by default.

Fix: treat an empty `include_repos` as "every repository the source
reports" (apt / yum / Bazel / Helm convention). Unmappable source
repos still land in `unsupported` so they surface as errors. Also
emits a WARN when `repos_to_process` is empty after provisioning,
so future regressions of this class are observable.

## #1889 — Nexus repo type vocabulary rejected

`RepositoryType::from_artifactory` only matched the Artifactory
triple `local` / `remote` / `virtual`. Nexus reports
`hosted` / `proxy` / `group`, so every Nexus repo failed
`prepare_repository_migration` with `Unknown repository type: hosted`
(or `proxy` / `group`).

Fix: accept the Nexus aliases in `from_artifactory`. The enum doc
comments above the function had always paired the two vocabularies
("Local repository (hosted)" etc.), so the mapping was known to the
original author and just never wired up.

## Why each bug was sticky

Both bugs were pinned into CI by tests that froze the wrong behavior:

- `test_resolve_repos_empty_request_yields_empty_plan` asserted that
  an empty include list yields an empty plan.
- `test_repository_type_from_artifactory_unknown` asserted
  `from_artifactory("hosted") == None`.
- The three `normalizes_nexus_*` tests built fixtures with
  `repo_type: "local"` (Artifactory naming) rather than the `hosted`
  string a real Nexus client returns, so they never exercised the
  problem.

This PR updates the wrong-shaped tests and adds positive coverage:

- `test_resolve_repos_empty_request_resolves_all_source_repos`
- `test_resolve_repos_empty_request_routes_unsupported_source_repos_to_unsupported_bucket`
- `test_resolve_repos_empty_request_with_empty_source_yields_empty_plan`
- `test_repository_type_from_artifactory_accepts_nexus_aliases`
- `test_prepare_repository_migration_accepts_nexus_proxy`
- `test_prepare_repository_migration_accepts_nexus_group`

All 30 `repository_type | prepare_repository_migration | resolve_repos`
unit tests pass.

## Behavior change & risk

`include_repos: []` now means "migrate all source repos" rather than
"migrate nothing" — this matches what the UI's create-job flow already
sends. No internal caller intentionally relies on the empty-list
no-op.

The Nexus alias change is additive — Artifactory inputs keep working.

## Manual verification on a live cluster

Patched backend image rolled into the affected daily cluster:

- **Before fix**: `migration_jobs` row `completed`, 0/0/0, no logs.
- **After #1901 only**: `migration_jobs` row `failed`, 40+ ERROR
  lines from `prepare_repository_migration` rejecting every Nexus
  repo's `hosted` / `proxy` / `group` type — exactly #1889.
- **After both fixes**: worker enumerates every source repository,
  provisions destination repos, and per-artifact rows land in
  `migration_items` for the first time.

Bundled into a single PR because either fix in isolation still leaves
Nexus migration broken end-to-end, and the second fix exists in the
same module immediately downstream of the first.