### PR TITLE
fix: make Maven hosted repositories production-ready

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -11,7 +11,7 @@
 use axum::body::Body;
 use axum::extract::{Path, State};
 use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Extension;
@@ -19,7 +19,7 @@ use axum::Router;
 use bytes::Bytes;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::api::handlers::error_helpers::{map_db_err, map_storage_err};
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
@@ -1397,20 +1397,14 @@ async fn serve_artifact(
                                 return Ok(result);
                             }
 
-                            // Fallback B: storage-direct for GAV-grouped secondary
-                            // files (.pom, .module, -sources.jar, .sha512, …) whose
-                            // bytes exist in storage at `maven/<path>` but do NOT
-                            // have their own `artifacts` row (the row lives under
-                            // the primary .jar/.aar). The helper enforces three
-                            // gates internally: (1) the path's extension must be a
-                            // known secondary file, (2) a live primary must exist
-                            // in the same GAV directory, (3) the primary must not
-                            // be quarantined or soft-deleted. So unlike the
-                            // hosted-repo storage fallback at `maven.rs` lines
-                            // 1264-1284 (which this PR does NOT touch but which has
-                            // the same quarantine-bypass issue tracked separately),
-                            // the virtual-side fallback honors the primary's policy
-                            // state.
+                            // Legacy storage-direct fallback for old Maven rows
+                            // created by the former GAV grouping model. Fresh
+                            // uploads now create one artifact row per physical
+                            // Maven asset, but older repositories may still only
+                            // have a primary row while companion bytes live at
+                            // `maven/<path>`. The helper gates this on a known
+                            // Maven companion path and an active, non-quarantined
+                            // primary artifact in the same GAV directory.
                             crate::api::handlers::maven_proxy::maven_local_fetch_storage_fallback(
                                 &db,
                                 &state,
@@ -1431,10 +1425,10 @@ async fn serve_artifact(
                 );
             }
 
-            // For hosted repos, fall back to serving from storage directly.
-            // This handles secondary files (POM, sources, javadoc) that were
-            // grouped under a primary artifact record by GAV grouping — their
-            // database `path` was replaced but the file still exists in storage.
+            // Legacy hosted fallback for repositories populated before Maven
+            // uploads started indexing every physical asset as an artifact row.
+            // Direct byte access remains available for those older companion
+            // files while new uploads resolve through the exact `artifacts.path`.
             if repo.repo_type == RepositoryType::Local || repo.repo_type == RepositoryType::Staging
             {
                 let storage = state
@@ -1598,179 +1592,108 @@ fn compute_checksum(data: &[u8], checksum_type: ChecksumType) -> String {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Maven GAV grouping helpers
-// ---------------------------------------------------------------------------
-
-/// Extract the GAV directory prefix from a Maven path.
-/// For example: `com/example/mylib/1.0.0/mylib-1.0.0.jar` -> `com/example/mylib/1.0.0/`
-fn gav_directory(path: &str) -> &str {
-    let trimmed = path.trim_start_matches('/');
-    match trimmed.rfind('/') {
-        Some(pos) => &trimmed[..=pos],
-        None => trimmed,
-    }
+fn maven_package_name(coords: &MavenCoordinates) -> String {
+    format!("{}:{}", coords.group_id, coords.artifact_id)
 }
 
-/// Determine whether a Maven file is a "primary" packaging artifact (JAR, WAR, EAR, etc.)
-/// without a classifier. POM files and classifier-bearing files (sources, javadoc) are
-/// considered secondary.
-fn is_primary_maven_artifact(coords: &MavenCoordinates) -> bool {
-    if coords.classifier.is_some() {
-        return false;
-    }
-    matches!(
-        coords.extension.as_str(),
-        "jar" | "war" | "ear" | "aar" | "bundle" | "zip" | "tar.gz"
-    )
-}
-
-/// Build a JSON object describing a single file within a Maven package.
-fn make_file_entry(
-    path: &str,
-    extension: &str,
-    classifier: Option<&str>,
-    storage_key: &str,
-    size_bytes: i64,
-    sha256: &str,
-) -> serde_json::Value {
-    let mut entry = serde_json::json!({
-        "path": path,
-        "extension": extension,
-        "storageKey": storage_key,
-        "sizeBytes": size_bytes,
-        "sha256": sha256,
-    });
-    if let Some(c) = classifier {
-        entry["classifier"] = serde_json::Value::String(c.to_string());
-    }
-    entry
-}
-
-/// Update an existing artifact record to point to a new file (used when a
-/// primary upload replaces a secondary, or a SNAPSHOT re-upload updates the
-/// primary). Cleans up any soft-deleted artifact at the target path first.
-#[allow(clippy::too_many_arguments)]
-async fn update_artifact_record(
-    db: &sqlx::PgPool,
-    repo_id: uuid::Uuid,
-    artifact_id: uuid::Uuid,
-    path: &str,
-    size_bytes: i64,
-    checksum_sha256: &str,
-    content_type: &str,
-    storage_key: &str,
-) -> Result<(), Response> {
-    super::cleanup_soft_deleted_artifact(db, repo_id, path).await;
-    sqlx::query(
-        r#"
-        UPDATE artifacts
-        SET path = $1, size_bytes = $2, checksum_sha256 = $3,
-            content_type = $4, storage_key = $5, updated_at = NOW()
-        WHERE id = $6
-        "#,
-    )
-    .bind(path)
-    .bind(size_bytes)
-    .bind(checksum_sha256)
-    .bind(content_type)
-    .bind(storage_key)
-    .bind(artifact_id)
-    .execute(db)
-    .await
-    .map_err(map_db_err)?;
-    Ok(())
-}
-
-/// Build the updated `metadata` JSON value for a secondary-file upload.
-///
-/// Pure transformation factored out of
-/// [`append_secondary_file_to_metadata`] so the JSON-merge rules
-/// (dedupe-by-path, POM field merge) can be unit-tested without a
-/// database. Returns the JSON value that should be persisted to
-/// `artifact_metadata.metadata` for `existing_id` (#1092).
-fn build_updated_secondary_metadata(
-    existing_meta: Option<serde_json::Value>,
-    coords: &MavenCoordinates,
-    path: &str,
-    new_file: serde_json::Value,
-    file_metadata: &serde_json::Value,
-) -> serde_json::Value {
-    let mut updated_meta = existing_meta.unwrap_or_else(|| {
-        serde_json::json!({
-            "groupId": coords.group_id,
-            "artifactId": coords.artifact_id,
-            "version": coords.version,
-        })
-    });
-
-    let mut files = updated_meta
-        .get("files")
-        .and_then(|f| f.as_array())
-        .cloned()
-        .unwrap_or_default();
-    // Dedupe by path so a SNAPSHOT classifier re-upload replaces its
-    // previous entry rather than accumulating duplicates over time.
-    let new_path = new_file
-        .get("path")
+fn maven_package_description(metadata: &serde_json::Value) -> Option<String> {
+    metadata
+        .get("description")
         .and_then(|v| v.as_str())
-        .map(String::from);
-    if let Some(ref np) = new_path {
-        files.retain(|f| f.get("path").and_then(|v| v.as_str()) != Some(np.as_str()));
-    }
-    files.push(new_file);
-    updated_meta["files"] = serde_json::Value::Array(files);
+        .map(ToOwned::to_owned)
+}
 
-    if MavenHandler::is_pom(path) {
-        for key in &["name", "description", "url", "dependencies"] {
-            if let Some(val) = file_metadata.get(*key) {
-                if updated_meta.get(*key).is_none() {
-                    updated_meta[*key] = val.clone();
-                }
-            }
+fn build_maven_package_catalog_metadata(
+    coords: &MavenCoordinates,
+    metadata: &serde_json::Value,
+) -> serde_json::Value {
+    let mut catalog = serde_json::json!({
+        "format": "maven",
+        "groupId": coords.group_id,
+        "artifactId": coords.artifact_id,
+    });
+
+    for key in ["name", "description", "url", "dependencies"] {
+        if let Some(value) = metadata.get(key) {
+            catalog[key] = value.clone();
         }
     }
 
-    updated_meta
+    catalog
 }
 
-/// Append a freshly-uploaded secondary file to an existing artifact's
-/// `metadata.files` array and merge POM-parsed fields when the upload is
-/// a POM. Used by both the SNAPSHOT primary re-upload path and the
-/// secondary-file path so the two arms share a single source of truth
-/// for grouped file metadata (#1092).
-///
-/// `existing_meta` is the metadata JSON loaded for `existing_id` before
-/// the upload, or `None` if no metadata row existed yet. On return the
-/// metadata row reflects the appended file and any merged POM fields.
-async fn append_secondary_file_to_metadata(
-    db: &sqlx::PgPool,
-    existing_id: uuid::Uuid,
-    existing_meta: Option<serde_json::Value>,
-    coords: &MavenCoordinates,
-    path: &str,
-    new_file: serde_json::Value,
-    file_metadata: &serde_json::Value,
-) {
-    let updated_meta =
-        build_updated_secondary_metadata(existing_meta, coords, path, new_file, file_metadata);
+fn should_enqueue_maven_sync_tasks(headers: &HeaderMap) -> bool {
+    !super::is_replication_request(headers)
+}
 
-    let _ = sqlx::query(
+async fn queue_maven_sync_tasks(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    artifact_id: uuid::Uuid,
+    artifact_path: &str,
+    artifact_size: i64,
+    artifact_created: chrono::DateTime<chrono::Utc>,
+) {
+    #[derive(sqlx::FromRow)]
+    struct SubWithFilter {
+        peer_instance_id: uuid::Uuid,
+        artifact_filter: Option<serde_json::Value>,
+    }
+
+    let subscriptions = match sqlx::query_as::<_, SubWithFilter>(
         r#"
-        INSERT INTO artifact_metadata (artifact_id, format, metadata)
-        VALUES ($1, 'maven', $2)
-        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2
+        SELECT prs.peer_instance_id, sp.artifact_filter
+        FROM peer_repo_subscriptions prs
+        LEFT JOIN sync_policies sp ON sp.id = prs.policy_id
+        WHERE prs.repository_id = $1
+          AND prs.sync_enabled = true
+          AND prs.replication_mode::text IN ('push', 'mirror')
         "#,
     )
-    .bind(existing_id)
-    .bind(&updated_meta)
-    .execute(db)
-    .await;
+    .bind(repo_id)
+    .fetch_all(&state.db)
+    .await
+    {
+        Ok(subs) => subs,
+        Err(e) => {
+            warn!(
+                "Failed to query Maven peer subscriptions for repo {} artifact {}: {}",
+                repo_id, artifact_id, e
+            );
+            return;
+        }
+    };
 
-    let _ = sqlx::query("UPDATE artifacts SET updated_at = NOW() WHERE id = $1")
-        .bind(existing_id)
-        .execute(db)
-        .await;
+    for sub in subscriptions {
+        let filter: crate::services::sync_policy_service::ArtifactFilter = sub
+            .artifact_filter
+            .as_ref()
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default();
+
+        if !filter.matches(artifact_path, artifact_size, artifact_created) {
+            continue;
+        }
+
+        if let Err(e) = sqlx::query(
+            r#"
+            INSERT INTO sync_tasks (peer_instance_id, artifact_id, priority)
+            VALUES ($1, $2, 0)
+            ON CONFLICT (peer_instance_id, artifact_id, task_type)
+            DO UPDATE SET priority = GREATEST(sync_tasks.priority, 0)
+            "#,
+        )
+        .bind(sub.peer_instance_id)
+        .bind(artifact_id)
+        .execute(&state.db)
+        .await
+        {
+            warn!(
+                "Failed to queue Maven sync task for peer {} artifact {}: {}",
+                sub.peer_instance_id, artifact_id, e
+            );
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1781,6 +1704,7 @@ async fn upload(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, path)): Path<(String, String)>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: read-scoped API tokens were being accepted on
@@ -1837,10 +1761,15 @@ async fn upload(
     let coords = MavenHandler::parse_coordinates(&path)
         .map_err(|e| AppError::Validation(format!("Invalid Maven path: {}", e)).into_response())?;
 
-    // Compute SHA-256
+    // Compute checksums for the canonical artifact row. Maven checksum
+    // sidecars are stored separately, but the artifact ledger should still
+    // carry the common digests so checksum search, replication, and API
+    // responses have the same fidelity as generic uploads.
     let mut hasher = Sha256::new();
     hasher.update(&body);
     let checksum_sha256 = format!("{:x}", hasher.finalize());
+    let checksum_sha1 = compute_checksum(&body, ChecksumType::Sha1);
+    let checksum_md5 = compute_checksum(&body, ChecksumType::Md5);
 
     let size_bytes = body.len() as i64;
     let ct = content_type_for_path(&path);
@@ -1890,9 +1819,9 @@ async fn upload(
         .await
         .map_err(map_storage_err)?;
 
-    // Build metadata JSON for this file
+    // Build metadata JSON for this physical Maven file.
     let handler = MavenHandler::new();
-    let file_metadata = crate::formats::FormatHandler::parse_metadata(&handler, &path, &body)
+    let mut file_metadata = crate::formats::FormatHandler::parse_metadata(&handler, &path, &body)
         .await
         .unwrap_or_else(|_| {
             serde_json::json!({
@@ -1904,243 +1833,89 @@ async fn upload(
         });
 
     let name = coords.artifact_id.clone();
-    let gav_dir = gav_directory(&path);
-    let is_primary = is_primary_maven_artifact(&coords);
+    let package_name = maven_package_name(&coords);
+    let (package_description, package_metadata) = if MavenHandler::is_pom(&path) {
+        (
+            maven_package_description(&file_metadata),
+            Some(build_maven_package_catalog_metadata(
+                &coords,
+                &file_metadata,
+            )),
+        )
+    } else {
+        (None, None)
+    };
 
-    // Look for an existing artifact record for the same GAV directory.
-    // This groups POM, JAR, sources, javadoc, etc. under a single record
-    // so the UI shows one package per GAV instead of separate entries.
-    let gav_existing: Option<(uuid::Uuid, String, String, Option<serde_json::Value>)> = {
-        // gav_dir comes from the user-supplied request path; escape LIKE
-        // metacharacters so the trailing `%` is the only wildcard.
-        let gav_pattern = format!("{}%", escape_like_literal(gav_dir));
-        let row = sqlx::query(
+    file_metadata["groupId"] = serde_json::Value::String(coords.group_id.clone());
+    file_metadata["artifactId"] = serde_json::Value::String(coords.artifact_id.clone());
+    file_metadata["version"] = serde_json::Value::String(coords.version.clone());
+    file_metadata["extension"] = serde_json::Value::String(coords.extension.clone());
+    if let Some(classifier) = &coords.classifier {
+        file_metadata["classifier"] = serde_json::Value::String(classifier.clone());
+    }
+
+    let (artifact_id, artifact_created): (uuid::Uuid, chrono::DateTime<chrono::Utc>) =
+        sqlx::query_as(
             r#"
-            SELECT a.id, a.path, a.storage_key, am.metadata
-            FROM artifacts a
-            LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
-            WHERE a.repository_id = $1
-              AND a.is_deleted = false
-              AND a.path LIKE $2 ESCAPE '\'
-              AND a.name = $3
-              AND a.version = $4
-            ORDER BY a.created_at ASC
-            LIMIT 1
+            INSERT INTO artifacts (
+                repository_id, path, name, version, size_bytes,
+                checksum_sha256, checksum_sha1, checksum_md5,
+                content_type, storage_key, uploaded_by
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            RETURNING id, created_at
             "#,
         )
         .bind(repo.id)
-        .bind(&gav_pattern)
+        .bind(&path)
         .bind(&name)
         .bind(&coords.version)
-        .fetch_optional(&state.db)
+        .bind(size_bytes)
+        .bind(&checksum_sha256)
+        .bind(&checksum_sha1)
+        .bind(&checksum_md5)
+        .bind(ct)
+        .bind(&storage_key)
+        .bind(user_id)
+        .fetch_one(&state.db)
         .await
         .map_err(map_db_err)?;
 
-        use sqlx::Row;
-        row.map(|r| {
-            (
-                r.get::<uuid::Uuid, _>("id"),
-                r.get::<String, _>("path"),
-                r.get::<String, _>("storage_key"),
-                r.get::<Option<serde_json::Value>, _>("metadata"),
-            )
-        })
-    };
+    sqlx::query(
+        r#"
+        INSERT INTO artifact_metadata (artifact_id, format, metadata)
+        VALUES ($1, 'maven', $2)
+        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2
+        "#,
+    )
+    .bind(artifact_id)
+    .bind(&file_metadata)
+    .execute(&state.db)
+    .await
+    .map_err(map_db_err)?;
 
-    match gav_existing {
-        Some((existing_id, existing_path, existing_storage_key, existing_meta)) => {
-            // An artifact record already exists for this GAV. The anchor row is
-            // the first-created file in the directory, which — depending on the
-            // client's upload order — can be a POM or a classifier artifact
-            // (e.g. sbt publishes `-tests-sources.jar` before the main `.jar`).
-            // Determine whether that anchor is itself a primary packaging
-            // artifact so a later-arriving primary can be promoted over it.
-            let existing_coords = MavenHandler::parse_coordinates(&existing_path).ok();
-            let existing_is_primary = existing_coords
-                .as_ref()
-                .map(is_primary_maven_artifact)
-                .unwrap_or(false);
+    crate::services::package_service::PackageService::new(state.db.clone())
+        .try_create_or_update_from_artifact(
+            repo.id,
+            &package_name,
+            &coords.version,
+            size_bytes,
+            &checksum_sha256,
+            package_description.as_deref(),
+            package_metadata,
+        )
+        .await;
 
-            let new_file = make_file_entry(
-                &path,
-                &coords.extension,
-                coords.classifier.as_deref(),
-                &storage_key,
-                size_bytes,
-                &checksum_sha256,
-            );
-
-            if is_primary && !existing_is_primary {
-                // The existing record is a non-primary placeholder: either a POM,
-                // or a classifier artifact that happened to be uploaded before the
-                // main artifact (sbt's publish order). Promote the new JAR/WAR to
-                // primary and demote the existing file into the files list, so the
-                // canonical row is always the main artifact regardless of the order
-                // files arrived in.
-                let old_ext = existing_coords
-                    .as_ref()
-                    .map(|c| c.extension.as_str())
-                    .unwrap_or("pom");
-                let old_classifier = existing_coords
-                    .as_ref()
-                    .and_then(|c| c.classifier.as_deref());
-
-                let old_size: i64 =
-                    if let Ok(old_content) = storage.get(&existing_storage_key).await {
-                        old_content.len() as i64
-                    } else {
-                        0
-                    };
-                let old_sha = existing_meta
-                    .as_ref()
-                    .and_then(|m| m.get("sha256"))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                let demoted_file = make_file_entry(
-                    &existing_path,
-                    old_ext,
-                    old_classifier,
-                    &existing_storage_key,
-                    old_size,
-                    &old_sha,
-                );
-
-                let mut files = existing_meta
-                    .as_ref()
-                    .and_then(|m| m.get("files"))
-                    .and_then(|f| f.as_array())
-                    .cloned()
-                    .unwrap_or_default();
-                files.push(demoted_file);
-
-                // Merge POM-parsed fields into the new primary metadata
-                let mut merged = file_metadata.clone();
-                if let Some(existing) = &existing_meta {
-                    for key in &["name", "description", "url", "dependencies"] {
-                        if let Some(val) = existing.get(*key) {
-                            merged[*key] = val.clone();
-                        }
-                    }
-                }
-                merged["files"] = serde_json::Value::Array(files);
-
-                // Update the artifact record to point to the JAR as primary
-                update_artifact_record(
-                    &state.db,
-                    repo.id,
-                    existing_id,
-                    &path,
-                    size_bytes,
-                    &checksum_sha256,
-                    ct,
-                    &storage_key,
-                )
-                .await?;
-
-                let _ = sqlx::query(
-                    r#"
-                    INSERT INTO artifact_metadata (artifact_id, format, metadata)
-                    VALUES ($1, 'maven', $2)
-                    ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2
-                    "#,
-                )
-                .bind(existing_id)
-                .bind(&merged)
-                .execute(&state.db)
-                .await;
-            } else if is_primary && coords.version.contains("SNAPSHOT") {
-                // SNAPSHOT re-upload: update the artifact record, then fall
-                // through to the shared metadata update below.
-                update_artifact_record(
-                    &state.db,
-                    repo.id,
-                    existing_id,
-                    &path,
-                    size_bytes,
-                    &checksum_sha256,
-                    ct,
-                    &storage_key,
-                )
-                .await?;
-                append_secondary_file_to_metadata(
-                    &state.db,
-                    existing_id,
-                    existing_meta,
-                    &coords,
-                    &path,
-                    new_file,
-                    &file_metadata,
-                )
-                .await;
-            } else {
-                // Secondary file uploaded after the primary already exists
-                // (POM following a JAR, sources/javadoc/test classifiers,
-                // non-SNAPSHOT primary classifier re-uploads, etc.).
-                // Previously this branch was a no-op so secondary files
-                // were saved to object storage but not recorded against
-                // any artifact row, leaving them invisible to repository
-                // listing APIs (#1092). Record them in the existing
-                // artifact's metadata.files so the storage fallback path
-                // can serve them and the listing path can surface them.
-                append_secondary_file_to_metadata(
-                    &state.db,
-                    existing_id,
-                    existing_meta,
-                    &coords,
-                    &path,
-                    new_file,
-                    &file_metadata,
-                )
-                .await;
-            }
-        }
-        None => {
-            // No existing artifact for this GAV. Create a new record.
-            let mut metadata = file_metadata;
-
-            use sqlx::Row;
-            let row = sqlx::query(
-                r#"
-                INSERT INTO artifacts (
-                    repository_id, path, name, version, size_bytes,
-                    checksum_sha256, content_type, storage_key, uploaded_by
-                )
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                RETURNING id
-                "#,
-            )
-            .bind(repo.id)
-            .bind(&path)
-            .bind(&name)
-            .bind(&coords.version)
-            .bind(size_bytes)
-            .bind(&checksum_sha256)
-            .bind(ct)
-            .bind(&storage_key)
-            .bind(user_id)
-            .fetch_one(&state.db)
-            .await
-            .map_err(map_db_err)?;
-            let artifact_id: uuid::Uuid = row.get("id");
-
-            // Initialize empty files array; the primary info lives on the
-            // artifact record itself.
-            metadata["files"] = serde_json::json!([]);
-
-            let _ = sqlx::query(
-                r#"
-                INSERT INTO artifact_metadata (artifact_id, format, metadata)
-                VALUES ($1, 'maven', $2)
-                ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2
-                "#,
-            )
-            .bind(artifact_id)
-            .bind(&metadata)
-            .execute(&state.db)
-            .await;
-        }
+    if should_enqueue_maven_sync_tasks(&headers) {
+        queue_maven_sync_tasks(
+            &state,
+            repo.id,
+            artifact_id,
+            &path,
+            size_bytes,
+            artifact_created,
+        )
+        .await;
     }
 
     // Update repository timestamp
@@ -2165,10 +1940,6 @@ async fn upload(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // -----------------------------------------------------------------------
-    // build_updated_secondary_metadata (#1092)
-    // -----------------------------------------------------------------------
 
     // -----------------------------------------------------------------------
     // checksum_compute_eligible (#1599): which repo types do a DB checksum
@@ -2226,172 +1997,35 @@ mod tests {
         }
     }
 
-    fn make_file_json(path: &str, ext: &str) -> serde_json::Value {
-        serde_json::json!({
-            "path": path,
-            "extension": ext,
-            "storageKey": format!("maven/{}", path),
-            "sizeBytes": 100,
-            "sha256": "abc",
-        })
+    #[test]
+    fn test_maven_package_name_uses_group_and_artifact() {
+        let coords =
+            MavenHandler::parse_coordinates("org/example/ak/maven/ak-core/1.0.0/ak-core-1.0.0.jar")
+                .unwrap();
+
+        assert_eq!(maven_package_name(&coords), "org.example.ak.maven:ak-core");
     }
 
     #[test]
-    fn test_build_updated_secondary_metadata_initial_pom_after_jar() {
-        // Existing metadata: a JAR primary, empty files array.
-        let existing = Some(serde_json::json!({
-            "groupId": "com.example",
-            "artifactId": "demo",
-            "version": "1.0.0",
-            "files": [],
-        }));
+    fn test_maven_package_catalog_metadata_carries_pom_fields() {
         let coords = sample_coords();
-        let new_file = make_file_json("com/example/demo/1.0.0/demo-1.0.0.pom", "pom");
-        let file_meta = serde_json::json!({
-            "name": "Demo Library",
-            "description": "Example POM",
-            "url": "https://example.com",
-            "dependencies": [],
+        let metadata = serde_json::json!({
+            "name": "Demo",
+            "description": "Catalog metadata test",
+            "url": "https://example.test/demo",
+            "dependencies": [
+                {"groupId": "com.example", "artifactId": "dep", "version": "1.0.0"}
+            ],
+            "files": [{"path": "ignored-by-package-catalog"}]
         });
-        let updated = build_updated_secondary_metadata(
-            existing,
-            &coords,
-            "demo-1.0.0.pom",
-            new_file,
-            &file_meta,
-        );
 
-        // POM is appended to files.
-        let files = updated["files"].as_array().unwrap();
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0]["extension"].as_str(), Some("pom"));
-        // POM-parsed fields are merged in.
-        assert_eq!(updated["name"].as_str(), Some("Demo Library"));
-        assert_eq!(updated["description"].as_str(), Some("Example POM"));
-    }
+        let catalog = build_maven_package_catalog_metadata(&coords, &metadata);
 
-    #[test]
-    fn test_build_updated_secondary_metadata_pom_does_not_clobber_existing_fields() {
-        // Existing metadata already has a `name`. POM upload's `name`
-        // must not overwrite it.
-        let existing = Some(serde_json::json!({
-            "groupId": "com.example",
-            "artifactId": "demo",
-            "version": "1.0.0",
-            "name": "Manually Set Name",
-            "files": [],
-        }));
-        let coords = sample_coords();
-        let new_file = make_file_json("com/example/demo/1.0.0/demo-1.0.0.pom", "pom");
-        let file_meta = serde_json::json!({"name": "POM Name"});
-        let updated = build_updated_secondary_metadata(
-            existing,
-            &coords,
-            "demo-1.0.0.pom",
-            new_file,
-            &file_meta,
-        );
-        assert_eq!(updated["name"].as_str(), Some("Manually Set Name"));
-    }
-
-    #[test]
-    fn test_build_updated_secondary_metadata_appends_when_new_file_has_no_path() {
-        // Defensive: a malformed `new_file` value without a `path` field
-        // must not panic. Dedupe is skipped and the entry is appended
-        // verbatim. Covers the "if let Some(ref np)" false branch.
-        let existing = Some(serde_json::json!({
-            "files": [make_file_json("p/demo-1.0.0.jar", "jar")],
-        }));
-        let coords = sample_coords();
-        let new_file = serde_json::json!({
-            // No "path" field at all.
-            "extension": "jar",
-            "storageKey": "maven/p/demo-1.0.0.jar",
-            "sizeBytes": 1,
-            "sha256": "x",
-        });
-        let updated = build_updated_secondary_metadata(
-            existing,
-            &coords,
-            "p/demo-1.0.0.jar",
-            new_file,
-            &serde_json::json!({}),
-        );
-        let files = updated["files"].as_array().unwrap();
-        // Both the original entry and the path-less new entry are kept.
-        assert_eq!(files.len(), 2);
-    }
-
-    #[test]
-    fn test_build_updated_secondary_metadata_dedupes_by_path() {
-        // Re-upload of the same SNAPSHOT classifier replaces its prior
-        // entry rather than accumulating duplicates.
-        let existing = Some(serde_json::json!({
-            "files": [make_file_json("p/sources.jar", "jar")],
-        }));
-        let coords = sample_coords();
-        let new_file = serde_json::json!({
-            "path": "p/sources.jar",
-            "extension": "jar",
-            "storageKey": "maven/p/sources.jar",
-            "sizeBytes": 200,
-            "sha256": "different",
-        });
-        let updated = build_updated_secondary_metadata(
-            existing,
-            &coords,
-            "p/sources.jar",
-            new_file,
-            &serde_json::json!({}),
-        );
-        let files = updated["files"].as_array().unwrap();
-        assert_eq!(files.len(), 1);
-        // The new (larger) entry replaced the old one.
-        assert_eq!(files[0]["sizeBytes"].as_i64(), Some(200));
-        assert_eq!(files[0]["sha256"].as_str(), Some("different"));
-    }
-
-    #[test]
-    fn test_build_updated_secondary_metadata_initializes_when_none() {
-        // No existing metadata row at all: function synthesizes GAV fields.
-        let coords = sample_coords();
-        let new_file = make_file_json("com/example/demo/1.0.0/demo-1.0.0.pom", "pom");
-        let updated = build_updated_secondary_metadata(
-            None,
-            &coords,
-            "demo-1.0.0.pom",
-            new_file,
-            &serde_json::json!({}),
-        );
-        assert_eq!(updated["groupId"].as_str(), Some("com.example"));
-        assert_eq!(updated["artifactId"].as_str(), Some("demo"));
-        assert_eq!(updated["version"].as_str(), Some("1.0.0"));
-        assert_eq!(updated["files"].as_array().unwrap().len(), 1);
-    }
-
-    #[test]
-    fn test_build_updated_secondary_metadata_non_pom_skips_field_merge() {
-        // Uploading a sources JAR (not a POM) must not pull POM fields
-        // from the file metadata into the artifact metadata.
-        let existing = Some(serde_json::json!({"files": []}));
-        let coords = sample_coords();
-        let new_file = serde_json::json!({
-            "path": "p/demo-1.0.0-sources.jar",
-            "extension": "jar",
-            "classifier": "sources",
-            "storageKey": "maven/p/demo-1.0.0-sources.jar",
-            "sizeBytes": 50,
-            "sha256": "abc",
-        });
-        let file_meta = serde_json::json!({"description": "should not appear"});
-        let updated = build_updated_secondary_metadata(
-            existing,
-            &coords,
-            "demo-1.0.0-sources.jar",
-            new_file,
-            &file_meta,
-        );
-        assert!(updated.get("description").is_none());
+        assert_eq!(catalog["format"], "maven");
+        assert_eq!(catalog["groupId"], "com.example");
+        assert_eq!(catalog["artifactId"], "demo");
+        assert_eq!(catalog["description"], "Catalog metadata test");
+        assert!(catalog.get("files").is_none());
     }
 
     // -----------------------------------------------------------------------
@@ -2960,174 +2594,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // gav_directory
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_gav_directory_jar() {
-        assert_eq!(
-            gav_directory("com/example/mylib/1.0.0/mylib-1.0.0.jar"),
-            "com/example/mylib/1.0.0/"
-        );
-    }
-
-    #[test]
-    fn test_gav_directory_pom() {
-        assert_eq!(
-            gav_directory("com/example/mylib/1.0.0/mylib-1.0.0.pom"),
-            "com/example/mylib/1.0.0/"
-        );
-    }
-
-    #[test]
-    fn test_gav_directory_sources() {
-        assert_eq!(
-            gav_directory("com/example/mylib/1.0.0/mylib-1.0.0-sources.jar"),
-            "com/example/mylib/1.0.0/"
-        );
-    }
-
-    #[test]
-    fn test_gav_directory_leading_slash() {
-        assert_eq!(
-            gav_directory("/com/example/mylib/1.0.0/mylib-1.0.0.jar"),
-            "com/example/mylib/1.0.0/"
-        );
-    }
-
-    #[test]
-    fn test_gav_directory_deep_group() {
-        assert_eq!(
-            gav_directory("org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"),
-            "org/apache/commons/commons-lang3/3.12.0/"
-        );
-    }
-
-    // -----------------------------------------------------------------------
-    // is_primary_maven_artifact
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_is_primary_jar() {
-        let coords =
-            MavenHandler::parse_coordinates("com/example/mylib/1.0.0/mylib-1.0.0.jar").unwrap();
-        assert!(is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_primary_war() {
-        let coords =
-            MavenHandler::parse_coordinates("com/example/webapp/1.0.0/webapp-1.0.0.war").unwrap();
-        assert!(is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_not_primary_pom() {
-        let coords =
-            MavenHandler::parse_coordinates("com/example/mylib/1.0.0/mylib-1.0.0.pom").unwrap();
-        assert!(!is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_not_primary_sources() {
-        let coords =
-            MavenHandler::parse_coordinates("com/example/mylib/1.0.0/mylib-1.0.0-sources.jar")
-                .unwrap();
-        assert!(!is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_not_primary_javadoc() {
-        let coords =
-            MavenHandler::parse_coordinates("com/example/mylib/1.0.0/mylib-1.0.0-javadoc.jar")
-                .unwrap();
-        assert!(!is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_primary_maven_artifact_aar() {
-        let coords = MavenCoordinates {
-            group_id: "com.example".into(),
-            artifact_id: "lib".into(),
-            version: "1.0".into(),
-            classifier: None,
-            extension: "aar".into(),
-        };
-        assert!(is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_primary_maven_artifact_pom_only() {
-        let coords = MavenCoordinates {
-            group_id: "com.example".into(),
-            artifact_id: "parent".into(),
-            version: "1.0".into(),
-            classifier: None,
-            extension: "pom".into(),
-        };
-        assert!(!is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_primary_maven_artifact_sources() {
-        let coords = MavenCoordinates {
-            group_id: "com.example".into(),
-            artifact_id: "lib".into(),
-            version: "1.0".into(),
-            classifier: Some("sources".into()),
-            extension: "jar".into(),
-        };
-        assert!(!is_primary_maven_artifact(&coords));
-    }
-
-    #[test]
-    fn test_is_primary_maven_artifact_javadoc() {
-        let coords = MavenCoordinates {
-            group_id: "com.example".into(),
-            artifact_id: "lib".into(),
-            version: "1.0".into(),
-            classifier: Some("javadoc".into()),
-            extension: "jar".into(),
-        };
-        assert!(!is_primary_maven_artifact(&coords));
-    }
-
-    // -----------------------------------------------------------------------
-    // make_file_entry
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_make_file_entry_without_classifier() {
-        let entry = make_file_entry(
-            "com/example/mylib/1.0.0/mylib-1.0.0.pom",
-            "pom",
-            None,
-            "maven/com/example/mylib/1.0.0/mylib-1.0.0.pom",
-            1024,
-            "abc123",
-        );
-        assert_eq!(entry["path"], "com/example/mylib/1.0.0/mylib-1.0.0.pom");
-        assert_eq!(entry["extension"], "pom");
-        assert!(entry.get("classifier").is_none());
-        assert_eq!(entry["sizeBytes"], 1024);
-        assert_eq!(entry["sha256"], "abc123");
-    }
-
-    #[test]
-    fn test_make_file_entry_with_classifier() {
-        let entry = make_file_entry(
-            "com/example/mylib/1.0.0/mylib-1.0.0-sources.jar",
-            "jar",
-            Some("sources"),
-            "maven/com/example/mylib/1.0.0/mylib-1.0.0-sources.jar",
-            2048,
-            "def456",
-        );
-        assert_eq!(entry["classifier"], "sources");
-        assert_eq!(entry["extension"], "jar");
-    }
-
-    // -----------------------------------------------------------------------
     // checksum_suffix (used in virtual repo checksum resolution, #660)
     // -----------------------------------------------------------------------
 
@@ -3480,6 +2946,314 @@ mod tests {
     // These exercise the maven `download` handler end-to-end through the
     // actual axum Router so a future refactor that breaks virtual-repo
     // routing surfaces the failure here, not at release-gate time.
+
+    /// Regression for Maven Package API visibility: Maven uploads bypass the
+    /// generic ArtifactService path, so the handler itself must populate the
+    /// package catalog.
+    #[tokio::test]
+    async fn test_maven_upload_populates_package_catalog() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "local", "maven").await;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let auth = tdh::make_auth(user_id, &username);
+        let router = tdh::router_with_auth(super::router(), state, auth);
+
+        let path = "com/example/catalog/demo-lib/1.2.3/demo-lib-1.2.3.pom";
+        let pom = bytes::Bytes::from_static(
+            br#"<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.catalog</groupId>
+  <artifactId>demo-lib</artifactId>
+  <version>1.2.3</version>
+  <name>Demo Lib</name>
+  <description>Visible Maven package</description>
+</project>"#,
+        );
+        let (status, body) =
+            tdh::send(router, tdh::put(format!("/{}/{}", repo_key, path), pom)).await;
+
+        let row = if status == StatusCode::CREATED {
+            sqlx::query_as::<
+                _,
+                (
+                    String,
+                    String,
+                    Option<String>,
+                    Option<serde_json::Value>,
+                    String,
+                ),
+            >(
+                r#"
+                SELECT p.name, p.version, p.description, p.metadata, pv.version
+                FROM packages p
+                JOIN package_versions pv ON pv.package_id = p.id
+                WHERE p.repository_id = $1
+                  AND p.name = 'com.example.catalog:demo-lib'
+                "#,
+            )
+            .bind(repo_id)
+            .fetch_optional(&pool)
+            .await
+            .expect("query package catalog")
+        } else {
+            None
+        };
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "Maven PUT must succeed before catalog assertion. body={}",
+            String::from_utf8_lossy(&body)
+        );
+        let (name, version, description, metadata, version_row) =
+            row.expect("Maven upload must create a package catalog row");
+        assert_eq!(name, "com.example.catalog:demo-lib");
+        assert_eq!(version, "1.2.3");
+        assert_eq!(version_row, "1.2.3");
+        assert_eq!(description.as_deref(), Some("Visible Maven package"));
+        let metadata = metadata.expect("Maven package metadata");
+        assert_eq!(metadata["format"], "maven");
+        assert_eq!(metadata["groupId"], "com.example.catalog");
+        assert_eq!(metadata["artifactId"], "demo-lib");
+    }
+
+    /// Maven uploads must keep a physical artifact row for every uploaded
+    /// asset path. The package catalog groups them into one package, but the
+    /// `artifacts` table is the canonical ledger used by exact-path APIs,
+    /// checksums, scanning, and replication.
+    #[tokio::test]
+    async fn test_maven_upload_indexes_each_physical_artifact_path() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+        use std::collections::BTreeSet;
+
+        let Some(fx) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        let router = fx.router_with_auth(super::router());
+        let base = "com/example/ledger/demo/1.0.0";
+        let uploads = vec![
+            (
+                format!("{base}/demo-1.0.0-javadoc.jar"),
+                bytes::Bytes::from_static(b"javadocs"),
+            ),
+            (
+                format!("{base}/demo-1.0.0-sources.jar"),
+                bytes::Bytes::from_static(b"sources"),
+            ),
+            (
+                format!("{base}/demo-1.0.0.jar"),
+                bytes::Bytes::from_static(b"jar-bytes"),
+            ),
+            (
+                format!("{base}/demo-1.0.0.module"),
+                bytes::Bytes::from_static(br#"{"formatVersion":"1.1"}"#),
+            ),
+            (
+                format!("{base}/demo-1.0.0.pom"),
+                bytes::Bytes::from_static(
+                    br#"<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.ledger</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+  <description>Physical artifact ledger test</description>
+</project>"#,
+                ),
+            ),
+            (
+                format!("{base}/demo-1.0.0-linux-x86_64.jar"),
+                bytes::Bytes::from_static(b"classifier"),
+            ),
+            (
+                format!("{base}/demo-1.0.0.tgz"),
+                bytes::Bytes::from_static(b"tgz-bytes"),
+            ),
+        ];
+
+        for (path, body) in &uploads {
+            let (status, response_body) = tdh::send(
+                router.clone(),
+                tdh::put(format!("/{}/{}", fx.repo_key, path), body.clone()),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::CREATED,
+                "Maven PUT must create {path}; body={}",
+                String::from_utf8_lossy(&response_body)
+            );
+        }
+
+        let expected_paths: Vec<String> = uploads.iter().map(|(p, _)| p.clone()).collect();
+        let rows: Vec<(String, String, Option<String>, Option<String>)> = sqlx::query_as(
+            r#"
+            SELECT path, storage_key, checksum_sha1, checksum_md5
+            FROM artifacts
+            WHERE repository_id = $1
+              AND path = ANY($2)
+              AND is_deleted = false
+            "#,
+        )
+        .bind(fx.repo_id)
+        .bind(&expected_paths)
+        .fetch_all(&fx.pool)
+        .await
+        .expect("query Maven artifact rows");
+        let actual_paths: BTreeSet<String> = rows.iter().map(|r| r.0.clone()).collect();
+        let expected_set: BTreeSet<String> = expected_paths.iter().cloned().collect();
+        assert_eq!(actual_paths, expected_set);
+        for (path, storage_key, sha1, md5) in &rows {
+            assert_eq!(storage_key, &format!("maven/{path}"));
+            assert!(sha1.as_deref().is_some_and(|v| v.len() == 40));
+            assert!(md5.as_deref().is_some_and(|v| v.len() == 32));
+        }
+
+        let metadata_rows: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM artifact_metadata am
+            JOIN artifacts a ON a.id = am.artifact_id
+            WHERE a.repository_id = $1
+              AND a.path = ANY($2)
+              AND am.format = 'maven'
+            "#,
+        )
+        .bind(fx.repo_id)
+        .bind(&expected_paths)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("count Maven metadata rows");
+        assert_eq!(metadata_rows, expected_paths.len() as i64);
+
+        let (package_count, version_count): (i64, i64) = sqlx::query_as(
+            r#"
+            SELECT
+              COUNT(DISTINCT p.id)::bigint,
+              COUNT(DISTINCT pv.id)::bigint
+            FROM packages p
+            JOIN package_versions pv ON pv.package_id = p.id
+            WHERE p.repository_id = $1
+              AND p.name = 'com.example.ledger:demo'
+              AND pv.version = '1.0.0'
+            "#,
+        )
+        .bind(fx.repo_id)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("count Maven package rows");
+        assert_eq!(package_count, 1);
+        assert_eq!(version_count, 1);
+
+        fx.teardown().await;
+    }
+
+    /// Direct Maven uploads bypass the generic ArtifactService upload path, so
+    /// the Maven handler must explicitly fan out peer sync tasks for each
+    /// physical artifact row it creates.
+    #[tokio::test]
+    async fn test_maven_upload_queues_sync_tasks_per_artifact_path() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::peer_instance_service::{
+            PeerInstanceService, RegisterPeerInstanceRequest, ReplicationMode,
+        };
+        use axum::http::StatusCode;
+
+        let Some(fx) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        let peer_service = PeerInstanceService::new(fx.pool.clone());
+        let peer = peer_service
+            .register(RegisterPeerInstanceRequest {
+                name: format!("maven-repl-peer-{}", fx.repo_id),
+                endpoint_url: "https://peer.example.test".to_string(),
+                region: None,
+                cache_size_bytes: 1024 * 1024,
+                sync_filter: None,
+                api_key: "peer-key".to_string(),
+            })
+            .await
+            .expect("register test peer");
+        peer_service
+            .assign_repository(
+                peer.id,
+                fx.repo_id,
+                true,
+                Some(ReplicationMode::Mirror),
+                None,
+                None,
+            )
+            .await
+            .expect("assign Maven repo to peer");
+
+        let router = fx.router_with_auth(super::router());
+        let paths = vec![
+            "com/example/repl/demo/1.0.0/demo-1.0.0.pom".to_string(),
+            "com/example/repl/demo/1.0.0/demo-1.0.0.jar".to_string(),
+        ];
+        for path in &paths {
+            let body = if path.ends_with(".pom") {
+                bytes::Bytes::from_static(
+                    br#"<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example.repl</groupId>
+  <artifactId>demo</artifactId>
+  <version>1.0.0</version>
+</project>"#,
+                )
+            } else {
+                bytes::Bytes::from_static(b"jar")
+            };
+            let (status, response_body) = tdh::send(
+                router.clone(),
+                tdh::put(format!("/{}/{}", fx.repo_key, path), body),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::CREATED,
+                "Maven PUT must create {path}; body={}",
+                String::from_utf8_lossy(&response_body)
+            );
+        }
+
+        let queued: i64 = sqlx::query_scalar(
+            r#"
+            SELECT COUNT(*)
+            FROM sync_tasks st
+            JOIN artifacts a ON a.id = st.artifact_id
+            WHERE st.peer_instance_id = $1
+              AND a.repository_id = $2
+              AND a.path = ANY($3)
+              AND st.task_type = 'push'
+            "#,
+        )
+        .bind(peer.id)
+        .bind(fx.repo_id)
+        .bind(&paths)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("count Maven sync tasks");
+        assert_eq!(queued, paths.len() as i64);
+
+        let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+            .bind(peer.id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+    }
 
     /// HTTP-level regression test for #1444 / #839 (re-test): GET a Maven
     /// SNAPSHOT jar by its `-SNAPSHOT` alias through a virtual repo returns

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2166,25 +2166,27 @@ pub async fn list_artifacts(
         .get_download_stats_batch(&artifact_ids)
         .await?;
 
-    // For Maven/Gradle, also load the metadata.files arrays so we can
-    // surface POM, sources, javadoc, and other secondary files that the
-    // upload handler groups under one artifact row (#1092). Without this
-    // expansion the listing only sees the primary JAR/WAR and any
-    // secondary files appear "hidden" until a downstream remote proxy
-    // pulls them, at which point the proxy records them as their own
-    // artifact rows.
+    // Legacy Maven/Gradle uploads used to group POM, sources, javadoc, and
+    // other companion files under one artifact row in metadata.files (#1092).
+    // New uploads store each Maven asset as its own `artifacts` row, but keep
+    // this expansion so older repositories remain browsable after upgrade.
     //
-    // Note: `pagination.total` is the number of primary artifact rows,
-    // not the post-expansion item count. The items array therefore
-    // exceeds `per_page` for any page that contains a GAV with grouped
-    // secondary files. Clients that need exact page sizes should call
-    // the grouped-by-component endpoint instead (`group_by=maven_component`).
+    // Note for legacy rows: `pagination.total` is the number of artifact rows,
+    // not the post-expansion item count. The items array can therefore exceed
+    // `per_page` for a page that contains an old GAV-grouped row. Fresh Maven
+    // uploads already have one row per physical asset and do not rely on this
+    // compatibility expansion.
     let maven_files_by_artifact: std::collections::HashMap<Uuid, Vec<serde_json::Value>> =
         if is_maven_format {
             load_maven_secondary_files(&state.db, &artifact_ids).await
         } else {
             std::collections::HashMap::new()
         };
+    let listed_maven_paths: std::collections::HashSet<String> = if is_maven_format {
+        artifacts.iter().map(|a| a.path.clone()).collect()
+    } else {
+        std::collections::HashSet::new()
+    };
 
     // For npm-family repos the artifact is stored under the
     // version-segmented layout `<name>/<version>/<name>-<version>.tgz`
@@ -2209,7 +2211,12 @@ pub async fn list_artifacts(
         items.push(item);
 
         if let Some(secondary) = maven_files_by_artifact.get(&artifact_id) {
-            items.extend(expand_maven_secondary_files(&artifact, &key, secondary));
+            items.extend(expand_maven_secondary_files(
+                &artifact,
+                &key,
+                secondary,
+                &listed_maven_paths,
+            ));
         }
     }
 
@@ -2546,15 +2553,16 @@ fn expand_maven_secondary_files(
     artifact: &crate::models::artifact::Artifact,
     repo_key: &str,
     secondary: &[serde_json::Value],
+    listed_paths: &std::collections::HashSet<String>,
 ) -> Vec<ArtifactResponse> {
     let mut out = Vec::new();
     for f in secondary {
         let Some(fpath) = f.get("path").and_then(|v| v.as_str()) else {
             continue;
         };
-        if fpath == artifact.path {
-            // Skip the primary's own entry if it ever made it into the
-            // files array.
+        if fpath == artifact.path || listed_paths.contains(fpath) {
+            // Skip the primary's own entry, and skip legacy metadata entries
+            // once the same path exists as a real artifact row.
             continue;
         }
         let size = f.get("sizeBytes").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -5649,7 +5657,12 @@ mod tests {
                 "sha256": "src-sha",
             }),
         ];
-        let rows = expand_maven_secondary_files(&primary, "maven-hosted", &secondary);
+        let rows = expand_maven_secondary_files(
+            &primary,
+            "maven-hosted",
+            &secondary,
+            &std::collections::HashSet::new(),
+        );
         assert_eq!(rows.len(), 2);
         assert_eq!(rows[0].path, "com/example/demo/1.0.0/demo-1.0.0.pom");
         assert_eq!(rows[0].content_type, "text/xml");
@@ -5672,7 +5685,28 @@ mod tests {
             "sizeBytes": 500,
             "sha256": "primary-sha",
         })];
-        let rows = expand_maven_secondary_files(&primary, "maven-hosted", &secondary);
+        let rows = expand_maven_secondary_files(
+            &primary,
+            "maven-hosted",
+            &secondary,
+            &std::collections::HashSet::new(),
+        );
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn test_expand_maven_secondary_files_skips_real_artifact_rows() {
+        let primary = make_artifact_for_test("com/example/demo/1.0.0/demo-1.0.0.jar");
+        let real_path = "com/example/demo/1.0.0/demo-1.0.0.pom".to_string();
+        let secondary = vec![serde_json::json!({
+            "path": real_path,
+            "extension": "pom",
+            "sizeBytes": 200,
+            "sha256": "pom-sha",
+        })];
+        let listed_paths = std::collections::HashSet::from([real_path]);
+        let rows =
+            expand_maven_secondary_files(&primary, "maven-hosted", &secondary, &listed_paths);
         assert!(rows.is_empty());
     }
 
@@ -5685,7 +5719,12 @@ mod tests {
             serde_json::json!({"extension": "pom", "sizeBytes": 100}),
             serde_json::json!({"path": "p/demo.pom", "extension": "pom"}),
         ];
-        let rows = expand_maven_secondary_files(&primary, "k", &secondary);
+        let rows = expand_maven_secondary_files(
+            &primary,
+            "k",
+            &secondary,
+            &std::collections::HashSet::new(),
+        );
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].path, "p/demo.pom");
     }
@@ -5694,7 +5733,12 @@ mod tests {
     fn test_expand_maven_secondary_files_handles_missing_size_and_sha() {
         let primary = make_artifact_for_test("p/demo.jar");
         let secondary = vec![serde_json::json!({"path": "p/demo.pom", "extension": "pom"})];
-        let rows = expand_maven_secondary_files(&primary, "k", &secondary);
+        let rows = expand_maven_secondary_files(
+            &primary,
+            "k",
+            &secondary,
+            &std::collections::HashSet::new(),
+        );
         assert_eq!(rows[0].size_bytes, 0);
         assert_eq!(rows[0].checksum_sha256, "");
     }

--- a/backend/src/services/package_service.rs
+++ b/backend/src/services/package_service.rs
@@ -42,7 +42,9 @@ impl PackageService {
         metadata: Option<JsonValue>,
     ) -> anyhow::Result<Uuid> {
         // Keep one package row per repository/name and let that row reflect
-        // the latest known version.
+        // the latest known version. The row's size is synchronized after the
+        // deterministic `package_versions` upsert below so multi-asset package
+        // formats do not depend on upload or replication order.
         let inserted: Option<(Uuid,)> = sqlx::query_as(
             r#"
             INSERT INTO packages (repository_id, name, version, description, size_bytes, metadata)
@@ -60,8 +62,8 @@ impl PackageService {
         .fetch_optional(&self.db)
         .await?;
 
-        let package_id = if let Some((package_id,)) = inserted {
-            package_id
+        let (package_id, should_update_package_row) = if let Some((package_id,)) = inserted {
+            (package_id, true)
         } else {
             let existing: (Uuid, String) = sqlx::query_as(
                 r#"
@@ -75,44 +77,13 @@ impl PackageService {
             .fetch_one(&self.db)
             .await?;
 
-            if version_compare(version, &existing.1) >= 0 {
-                sqlx::query(
-                    r#"
-                    UPDATE packages
-                    SET version = $2,
-                        description = COALESCE($3, description),
-                        size_bytes = $4,
-                        metadata = COALESCE($5, metadata),
-                        updated_at = NOW()
-                    WHERE id = $1
-                    "#,
-                )
-                .bind(existing.0)
-                .bind(version)
-                .bind(description)
-                .bind(size_bytes)
-                .bind(&metadata)
-                .execute(&self.db)
-                .await?;
-            } else {
-                sqlx::query(
-                    r#"
-                    UPDATE packages
-                    SET updated_at = NOW()
-                    WHERE id = $1
-                    "#,
-                )
-                .bind(existing.0)
-                .execute(&self.db)
-                .await?;
-            }
-
-            existing.0
+            (existing.0, version_compare(version, &existing.1) >= 0)
         };
 
-        // Keep `package_versions` deterministic when a package format (PyPI in
-        // particular) publishes multiple distributions for the same version.
-        // Different peers may process wheel/sdist artifacts in different
+        // Keep `package_versions` deterministic when a package format
+        // publishes multiple physical assets for the same version. Different
+        // peers may process Maven JAR/POM/module/classifier files or PyPI
+        // wheel/sdist artifacts in different
         // orders during replication recovery, so "last writer wins" makes
         // otherwise-equivalent repositories diverge at the DB row level.
         sqlx::query(
@@ -132,6 +103,42 @@ impl PackageService {
         .bind(checksum_sha256)
         .execute(&self.db)
         .await?;
+
+        if should_update_package_row {
+            sqlx::query(
+                r#"
+                UPDATE packages
+                SET version = $2,
+                    description = COALESCE($3, description),
+                    size_bytes = (
+                        SELECT pv.size_bytes
+                        FROM package_versions pv
+                        WHERE pv.package_id = packages.id
+                          AND pv.version = $2
+                    ),
+                    metadata = COALESCE($4, metadata),
+                    updated_at = NOW()
+                WHERE id = $1
+                "#,
+            )
+            .bind(package_id)
+            .bind(version)
+            .bind(description)
+            .bind(&metadata)
+            .execute(&self.db)
+            .await?;
+        } else {
+            sqlx::query(
+                r#"
+                UPDATE packages
+                SET updated_at = NOW()
+                WHERE id = $1
+                "#,
+            )
+            .bind(package_id)
+            .execute(&self.db)
+            .await?;
+        }
 
         Ok(package_id)
     }
@@ -239,6 +246,82 @@ mod tests {
         assert!(should_replace_package_version("aaaa", 500, "aaaa", 100));
         assert!(!should_replace_package_version("aaaa", 100, "aaaa", 500));
         assert!(!should_replace_package_version("aaaa", 100, "aaaa", 100));
+    }
+
+    #[tokio::test]
+    async fn test_package_size_tracks_deterministic_version_representative() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let service = PackageService::new(fx.pool.clone());
+        let package = "multi-asset-package";
+        let version = "1.0.0";
+        let checksum_b = "b".repeat(64);
+        let checksum_a = "a".repeat(64);
+        let checksum_c = "c".repeat(64);
+
+        service
+            .create_or_update_from_artifact(
+                fx.repo_id,
+                package,
+                version,
+                900,
+                &checksum_b,
+                None,
+                None,
+            )
+            .await
+            .expect("insert first representative");
+        service
+            .create_or_update_from_artifact(
+                fx.repo_id,
+                package,
+                version,
+                300,
+                &checksum_a,
+                None,
+                None,
+            )
+            .await
+            .expect("replace with lower checksum representative");
+        service
+            .create_or_update_from_artifact(
+                fx.repo_id,
+                package,
+                version,
+                100,
+                &checksum_c,
+                None,
+                None,
+            )
+            .await
+            .expect("ignore later non-representative asset");
+
+        let row: (i64, i64, String) = sqlx::query_as(
+            r#"
+            SELECT p.size_bytes, pv.size_bytes, pv.checksum_sha256
+            FROM packages p
+            JOIN package_versions pv ON pv.package_id = p.id
+            WHERE p.repository_id = $1
+              AND p.name = $2
+              AND pv.version = $3
+            "#,
+        )
+        .bind(fx.repo_id)
+        .bind(package)
+        .bind(version)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("query deterministic package representative");
+
+        fx.teardown().await;
+
+        assert_eq!(row.0, 300);
+        assert_eq!(row.1, 300);
+        assert_eq!(row.2, checksum_a);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1906 

## Summary

Makes hosted Maven repositories behave like production package repositories for uploaded Maven assets.

This PR fixes two related indexing gaps:

- hosted Maven uploads now populate the package catalog, so `/api/v1/packages` and the Web UI can show uploaded Maven packages and versions
- each uploaded non-sidecar Maven asset is persisted as its own active `artifacts` row by exact Maven path, instead of hiding secondary files inside one grouped GAV artifact

The Maven component/package view remains grouped by `groupId:artifactId`, while the physical artifact ledger now preserves the real uploaded files. That matters for exact-path repository APIs, scans, retention, download accounting, and future peer replication/sync behavior.

The implementation also keeps legacy `metadata.files` expansion as compatibility for old Maven rows, while avoiding duplicate listing rows when real artifact rows exist.

Reviewer note: this is intentionally broader than Package API visibility only. The first fix made packages visible, then deeper E2E/DB verification found that many valid Maven files were still missing exact `artifacts.path` rows. This PR fixes both issues together so Maven hosted repositories are ready as a Nexus/JFrog-like backend before HA/S3 work continues.

CI unblock note: this PR also includes a patch-only Wasmtime bump from `36.0.10` to `36.0.11` because GitHub CI started failing `cargo audit` after `RUSTSEC-2026-0182` was published. The dependency bump is not part of the Maven behavior change; it keeps this PR mergeable until `main` receives the same security update.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation run locally:

```bash
cargo fmt --check
cargo test -p artifact-keeper-backend maven_upload --lib -- --nocapture
cargo test -p artifact-keeper-backend expand_maven_secondary_files --lib -- --nocapture
cargo test -p artifact-keeper-backend package_size_tracks --lib -- --nocapture
cargo clippy -p artifact-keeper-backend --lib -- -D warnings
git diff --check upstream/main...HEAD
```

CI unblock validation:

```bash
cargo update -p wasmtime-wasi --precise 36.0.11
cargo audit
cargo metadata --locked --no-deps --format-version 1
SQLX_OFFLINE=true cargo check -p artifact-keeper-backend --lib --locked
```

External Maven acceptance protocol passed against a deployed test build:

- 230 Maven uploads, all HTTP 201
- direct byte/checksum verification: 46/46
- Maven metadata verification: 14/14
- Package API verification: 15/15
- DB verification: 45 expected artifact rows, missing 0
- snapshot artifact rows: 4/4
- open upload sessions: 0
- Maven deploy-file, Maven reactor deploy, Gradle publish, and Maven/Gradle consumer matrix passed
- external fallback observed: false
- negative cases covered duplicate release conflict and invalid layout/path traversal rejection

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes