### PR TITLE
feat(maven): populate packages table on artifact upload

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -28,6 +28,7 @@ use crate::api::SharedState;
 use crate::error::AppError;
 use crate::formats::maven::{generate_metadata_xml, MavenCoordinates, MavenHandler};
 use crate::models::repository::RepositoryType;
+use crate::services::package_service::PackageService;
 
 // TODO: Remaining format handlers (beyond maven, npm, pypi, cargo) still use
 // plain-text error responses and should be migrated to AppError (#553).
@@ -2323,6 +2324,23 @@ async fn upload(
             .bind(&metadata)
             .execute(&state.db)
             .await;
+
+            // Populate packages / package_versions tables (best-effort)
+            let pkg_description = metadata.get("description").and_then(|v| v.as_str());
+            PackageService::new(state.db.clone())
+                .try_create_or_update_from_artifact(
+                    repo.id,
+                    &name,
+                    &coords.version,
+                    size_bytes,
+                    &checksum_sha256,
+                    pkg_description,
+                    Some(serde_json::json!({
+                        "groupId": coords.group_id,
+                        "artifactId": coords.artifact_id,
+                    })),
+                )
+                .await;
         }
     }
 

--- a/scripts/native-tests/test-maven.sh
+++ b/scripts/native-tests/test-maven.sh
@@ -92,6 +92,24 @@ fi
 
 echo "==> Artifact download returned HTTP $HTTP_CODE"
 
+# Verify packages API shows the uploaded artifact
+echo "==> Verifying package appears in packages API..."
+API_BASE="http://localhost:30080/api/v1"
+PACKAGES_JSON=$(curl -s -u "$REGISTRY_USER:$REGISTRY_PASS" \
+  "$API_BASE/packages?repository_key=test-maven")
+
+if ! echo "$PACKAGES_JSON" | grep -q '"total":1'; then
+  echo "FAIL: Expected 1 package in packages API, got: $PACKAGES_JSON"
+  exit 1
+fi
+
+if ! echo "$PACKAGES_JSON" | grep -q '"name":"test-artifact-native"'; then
+  echo "FAIL: Package 'test-artifact-native' not found in packages API"
+  exit 1
+fi
+
+echo "==> Packages API correctly shows the uploaded artifact"
+
 # Verify maven-metadata.xml
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
   "$REGISTRY_URL/com/test/test-artifact-native/maven-metadata.xml")


### PR DESCRIPTION
## Summary

The Maven upload handler was not calling PackageService after storing
artifacts, so the Packages tab always showed 'No packages in this
repository yet.' even when Maven artifacts existed in the repository.

Added a best-effort call to `PackageService::try_create_or_update_from_artifact`
in the None branch (new GAV artifact) to create/update the packages and
package_versions rows, matching the behavior of all other format handlers
(PyPI, npm, NuGet, etc.).

Also added a verification step in the Maven native test script to assert
the package appears in the packages API after upload.

Fixes #1910

### Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [ ] No regressions in existing tests

### API Changes
- [x] N/A - no API changes