### PR TITLE
fix(proxy): reject truncated streamed cache writes (#1912)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1329,36 +1329,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de2be1bdbf929c2a2242cbbe15d6583c56f1cc723c6c8452d0179362de28c9d5"
+checksum = "2ad3e7d446bbdc05f33371b17aae2857e2c5f1dd6750848f555c129c5060725f"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a0336914de11298290783a95a9a7154b894da601659eb5f8f8bc62d1bea98f8"
+checksum = "96ee145f9cbf7474350ee48e5c33ec2312177fa32c07e4eb395727250892a201"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb972cba51a52c1b2a329fec993b911e4d1f9cfab3795811a319b6746c28e014"
+checksum = "7025668e34c499fd0960dfaf68bc1689c961002fb67227f3dd262535c4118e52"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642c920666bfed9aebca39d8c6e7cb76f09314cc7a4074b1db5edcccdde771b9"
+checksum = "4ad0b552e9b906fee4416b68664463e80f9024215da2cebd4065eee99d5d3008"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1366,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1231caaeee3d2363d9b2dba9d6c1f7ff835b8ede6612fba98120af73df44bd"
+checksum = "f87371fa1b0e21dc0a7943f372ce5a308c7d6b26ef8c9982a8a063218fe101ae"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -1393,9 +1393,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb83e89be8b413e4f7a4215a02d5c5f3e6f04b1060f5db293dd1007b2871dcf5"
+checksum = "a24ef297d4dd3af3e571691568958ceea1d3e723bb24eef4e934bbd569c93ef6"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -1406,24 +1406,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d14f8068a98f0a85ffa63dc5fe73cb486a955adbe7311465d13cde54c656d5f"
+checksum = "d65396f589d1f746f52db7370372bc8611aa7a5bc0b0322f77deaa1b62e12287"
 
 [[package]]
 name = "cranelift-control"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c070aee9312b9736028e99b58d45e1099683386082af38529d5e2ce8c76648f3"
+checksum = "a5731530f81a1566057f9475639f34463e723210ef2484fe9f087e03d79e879a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d619bb3d14251e96dc9b6a846d6955d78048a168cc3876eb2b789b855c1c22"
+checksum = "3437f152d3766d07420956f4eabaa6f89fa98543e53d387dd1e395980441c68d"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2350fcff24d78be5e4201e1eeb4b306e474b9f21e452722b21ffc4f773e8d49a"
+checksum = "c9dbb5c65123d9bd76a701523d72f78e1f9b754321caa7767a70ea9304f49be1"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1444,15 +1444,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bdc2b14d7491c53c2989b967b4c07511374733abbc01a895fb01ea31e97bfc8"
+checksum = "a493c7a6e01f9c6e9b5468faa7f13a06d6d882f92942f8042a0fd0a8e3e8bc2c"
 
 [[package]]
 name = "cranelift-native"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e98dbe1326d0001a17b3b0675e3adafcfbd0e7f25f1f845a2f1bb9ce3029f359"
+checksum = "79bd8bd6a0a5bce75e9b24b4e9578114ef6be94795956c4d19aeaa1da607abfd"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1461,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.123.10"
+version = "0.123.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d7af563cd300c8a1e4e64387929b40e32867112143f0a0e1ce90f977ce4a41"
+checksum = "7c33438ba0b8ba75137bd45eb0d36a319efe90cf145f9fd5773b84f0b89f0edc"
 
 [[package]]
 name = "crc"
@@ -2910,7 +2910,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4670,7 +4670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -4690,7 +4690,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4707,9 +4707,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329f575a931601f71fbcb3b31d32d16273da5ba7f532fc10be2e432e710b02de"
+checksum = "fae33db3d81aa92ead4ba06f7f9bbf32b2d8ff4132a00df5fa0913fd03dfa33c"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -4719,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bccae89ed67a40989e780105fab43e6c71a077b9fc8ae4c805ff5f73d2a79c8"
+checksum = "055100cf63f790c7bd02e606339916e1a403485358d4ae890ce912c102a9e80d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4792,7 +4792,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4830,7 +4830,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6266,7 +6266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.52.0",
@@ -7343,9 +7343,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507d213104e83a7519d91af444a8b19c04281f2eef162d448ee7a894ac1c827d"
+checksum = "319b720df5e1c49b5dbc916d28a386aad3f03ed96fa3cebe2c6270eb11b6baf3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -7398,9 +7398,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9784b325c3b85562ac6d7f81c8348c42af1f137d98dd4fc6631860e4e68bb655"
+checksum = "acc2633f356486b8c5917e2aad7aca2b5b54f0f674a8f384a166e34d48101893"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -7425,18 +7425,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-asm-macros"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcaa9336cd5ba934ba734dfdfe35f5245c3c74b4e34f9af9e114fad892d81b3d"
+checksum = "f0e647efa7382e8cc8b668ee871af1da0f097d5f12ba2242ac865107c30996e8"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e297746bc001fd919f8f9bb3d28ed1a01fb1ff10a5ccd9720e649b5807bf2b68"
+checksum = "acd2f0ea194190ae3d89e7d3f7a9bf95ccf7decdcb27ddef8418f7e03f5aeed5"
 dependencies = [
  "anyhow",
  "base64",
@@ -7454,9 +7454,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aba228ec4f646cb9514be55538c842822cb96f2c306f75d664eea6b6f2e9eb"
+checksum = "13915309c8ac371ce8aaadf856aad7a7685e390fdf158df1d35c3b0b7a320c44"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -7469,15 +7469,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f4a2387b0aea544aa2317e295583be54fed852e0d1a31c0070984bfd6a507"
+checksum = "08935e3f35beb765593e42432b6f97fd6df16f1c9aa629a79137a04d30a168f4"
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7d938ae501275f44e7e5532ae4bb720542b429357014d33842e128c46fb9b54"
+checksum = "dd24355be6b01300639f3fd2e83dfbb75efc18a3d3386e955e87415c96fc105d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7502,9 +7502,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1443b0914ff848ee7920e0f232368168e2819b739c54f3c352f0559b6164343"
+checksum = "d322d8644a6057b221215ca579c40e4bdf90146119d4dc5172d2b37b1a0e3bb9"
 dependencies = [
  "anyhow",
  "cc",
@@ -7518,9 +7518,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "861d6f2a1652e95ca10b02552934b3bd460d7416b285fe10d7ca8c0a2b90dc3e"
+checksum = "307cef37d6c5563e0a408e24ab983b06ebe3ec27dd01675c7e7b12133205484c"
 dependencies = [
  "cc",
  "object",
@@ -7530,9 +7530,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1caeb3140c46319fecf09d93dc38a373eb535fd478e401a9fb2ac2da30fe5f6"
+checksum = "1f2e02bd5006f643d8787a33c71e8fb401f029a35df25cd237d25d6d2ddc1c07"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7542,24 +7542,24 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-math"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c631615929951a4076aae64da7d6cad88668d292f19672606392c24ae9c5a00"
+checksum = "a28b0166bd79eb87e2e2e9d6ed7bc6c593428cadfd82cbc94fd113268c29d36a"
 dependencies = [
  "libm",
 ]
 
 [[package]]
 name = "wasmtime-internal-slab"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b28104d57b5bdb5d8facb3a8418463ec6c2cb40bb4adf9833b727ebf6a254eb"
+checksum = "1c3295d1f1de2f3769b749a15e8f64341c38da6faa7fcd737ed485eb3fa40158"
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd89f2db7377869aeaf66b71f56def8df54b9482e4f4e5533ccec2505f5c691"
+checksum = "a34055eb99cdff44ddd277e3b3baec670ef0302c847465c894f1118d4e7b1e3d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7570,9 +7570,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9cdb9c2e3965ee15629d067203cb800e9822664d04335dadc6fe1788d4fc335"
+checksum = "e69f8a29ae6fdf7218ae37f38b1cc9fe539344a17b7fffba203de3ee2194d605"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7581,9 +7581,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f693c8db710f20b927bcee025acd345acf599d055b63f122613d52f5553a5f"
+checksum = "c08a4d8a3501080d3707f845acfcd2fedec9bb91dad3fd9078b7a17e8c8a0884"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -7598,9 +7598,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c97d4e849494d290e05573298bd372e12be86b2074502dc5e02f4ef7628002"
+checksum = "cc86f7cc67cafad52959bc1b91176d73e1ed6dbcc00c7a31b3c0a30ac32e881a"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -7611,9 +7611,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eabc75a6afeac11870ee5402268ec0f61fc394728d6dcbe5091a57dc6eb5a57"
+checksum = "e53a8072429ae61b472280b33b61dc0d21173b2b21b68a18bb9cc2024d18414d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7642,9 +7642,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367b77d382241c7f9b3cde3c8cfc1c0d800f04d665622779a724b71d0a2a2028"
+checksum = "d3bd4ac921831465ff97529a528e93f786095adf748d03736e2bd7fb3b0f5623"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7749,9 +7749,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aed7ef247a05956b0a25e7905fdb709ae89e506547af42897e40301b0658d07"
+checksum = "7406efc093a6a31c9a48fb7346e721088a6c9426056217012f1c31e206d07d4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7764,9 +7764,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d5550c5f49730d0a8babd089771ff7412e598cf8f7bbe3b647b8e2147a11b"
+checksum = "57eb5ff74b0b8b35b22a484a340732dce2f6f2ebb1e54aae0bb2a7f6e72e4285"
 dependencies = [
  "anyhow",
  "heck",
@@ -7778,9 +7778,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602175405f0c04fd47439ad6afc5e151c4864883259254d3676562bfb00a7ce8"
+checksum = "cba7d2d428b0753e045dd2144b02cb96e0ae7e4f17965905025391ea6810fb5e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7821,9 +7821,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "36.0.10"
+version = "36.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4332c8656af179fb8fc3ae5114c738c29399ee97b638d431725201c17f99294e"
+checksum = "e33afb2737056d7162813a167fc53b8d986e725724a4e6c76ca9910952bb94b5"
 dependencies = [
  "anyhow",
  "cranelift-assembler-x64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,8 +95,8 @@ bytes = "1.5"
 clap = { version = "4.5", features = ["derive", "env"] }
 
 # WASM runtime
-wasmtime = { version = "36.0.10", features = ["component-model", "async"] }
-wasmtime-wasi = "36.0.10"
+wasmtime = { version = "36.0.11", features = ["component-model", "async"] }
+wasmtime-wasi = "36.0.11"
 
 # Git operations
 git2 = "0.20"

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -310,6 +310,38 @@ fn extract_streaming_headers(
     (content_type, etag, content_length)
 }
 
+/// Whether a freshly streamed proxy-cache write should be committed or
+/// rejected. A rejected object is deleted (and its metadata sidecar skipped)
+/// so the next request refetches upstream and self-heals.
+#[derive(Debug, PartialEq, Eq)]
+enum StreamWriteOutcome {
+    /// Write is good; persist the metadata sidecar.
+    Commit,
+    /// Zero-byte body — never cache it (#1365).
+    RejectEmpty,
+    /// Bytes written disagree with the upstream `Content-Length`, i.e. the
+    /// stream was truncated/interrupted mid-body. Committing it would poison
+    /// the cache and serve a corrupt archive (#1912).
+    RejectTruncated { expected: u64, actual: u64 },
+}
+
+/// Classify a completed streaming cache write. `expected_len` is the upstream
+/// `Content-Length` when known; truncation is only enforced when it is present
+/// (a chunked/auto-decompressed response strips it, so we cannot validate and
+/// must not falsely reject).
+fn classify_stream_write(bytes_written: u64, expected_len: Option<u64>) -> StreamWriteOutcome {
+    if bytes_written == 0 {
+        return StreamWriteOutcome::RejectEmpty;
+    }
+    match expected_len {
+        Some(expected) if bytes_written != expected => StreamWriteOutcome::RejectTruncated {
+            expected,
+            actual: bytes_written,
+        },
+        _ => StreamWriteOutcome::Commit,
+    }
+}
+
 /// Decide whether to emit a "scan-on-proxy is configured but did not run"
 /// warning for a freshly cached upstream artifact.
 ///
@@ -1076,6 +1108,7 @@ impl CachePersister {
         cache_key: String,
         metadata_key: String,
         template: CacheMetadataTemplate,
+        expected_len: Option<u64>,
     ) -> BoxStream<'static, Result<Bytes>> {
         let storage = Arc::clone(&self.storage);
 
@@ -1101,85 +1134,102 @@ impl CachePersister {
                 .await;
 
             match put_result {
-                Ok(result) if result.bytes_written == 0 => {
-                    // #1618 S9 / #1365: never cache a zero-byte body. A
-                    // Maven client resolving dependencies can drive an
-                    // upstream response with no body (a 204, a 200 with
-                    // `Content-Length: 0`, or a HEAD-style probe that
-                    // reaches the streaming download path), and the upstream
-                    // POM/JAR is non-empty. Writing the metadata sidecar
-                    // here would mark the empty object as a fresh,
-                    // non-expired cache hit; the next GET would then serve
-                    // `Content-Length: 0`, and Gradle fails parsing the POM
-                    // with "Content is not allowed in prolog." Skip the
-                    // sidecar so the entry is treated as a miss, and delete
-                    // the empty object we just wrote so a later GET
-                    // re-fetches the real body from upstream (self-heal).
-                    // The buffered sibling [`Self::write_buffered`] applies
-                    // the same guard before the content write.
-                    tracing::warn!(
-                        cache_key = %cache_key_for_writer,
-                        "proxy upstream returned an empty body; not caching the zero-byte \
-                         object (no metadata sidecar) so the next request refetches upstream"
-                    );
-                    if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
-                        tracing::debug!(
-                            cache_key = %cache_key_for_writer,
-                            error = %e,
-                            "best-effort delete of empty proxy-cache object failed; \
-                             the missing metadata sidecar still forces a refetch"
-                        );
-                    }
-                }
-                Ok(result) => {
-                    let now = Utc::now();
-                    // #1618 S9 / #1051: pin the storage backend's ETag at
-                    // write time so the fast path can re-HEAD on each hit
-                    // and detect tampering / backend-side replacement. See
-                    // [`pin_storage_etag`] for the best-effort semantics on
-                    // backends without an ETag concept or on transport
-                    // error.
-                    let storage_etag =
-                        pin_storage_etag(&storage_clone, &cache_key_for_writer).await;
-                    let metadata = CacheMetadata {
-                        cached_at: now,
-                        upstream_etag: template.etag,
-                        storage_etag,
-                        last_modified: template.last_modified,
-                        negative_cached_until: None,
-                        // The streaming leader refuses to open upstream at all
-                        // while the repo's Package Age Policy is enabled
-                        // (#1770), so a tee'd entry is never under a hold.
-                        quarantine_until: None,
-                        expires_at: now + chrono::Duration::seconds(template.ttl_secs),
-                        content_type: template.content_type,
-                        size_bytes: result.bytes_written as i64,
-                        checksum_sha256: result.checksum_sha256,
-                    };
-                    match serde_json::to_vec(&metadata) {
-                        Ok(json) => {
-                            // #1618 S9: sidecar written second, after the
-                            // streaming content write (put_stream) above.
-                            if let Err(e) =
-                                storage_clone.put(&metadata_key, Bytes::from(json)).await
-                            {
+                Ok(result) => match classify_stream_write(result.bytes_written, expected_len) {
+                    StreamWriteOutcome::Commit => {
+                        let now = Utc::now();
+                        // #1618 S9 / #1051: pin the storage backend's ETag at
+                        // write time so the fast path can re-HEAD on each hit
+                        // and detect tampering / backend-side replacement. See
+                        // [`pin_storage_etag`] for the best-effort semantics on
+                        // backends without an ETag concept or on transport
+                        // error.
+                        let storage_etag =
+                            pin_storage_etag(&storage_clone, &cache_key_for_writer).await;
+                        let metadata = CacheMetadata {
+                            cached_at: now,
+                            upstream_etag: template.etag,
+                            storage_etag,
+                            last_modified: template.last_modified,
+                            negative_cached_until: None,
+                            // The streaming leader refuses to open upstream at all
+                            // while the repo's Package Age Policy is enabled
+                            // (#1770), so a tee'd entry is never under a hold.
+                            quarantine_until: None,
+                            expires_at: now + chrono::Duration::seconds(template.ttl_secs),
+                            content_type: template.content_type,
+                            size_bytes: result.bytes_written as i64,
+                            checksum_sha256: result.checksum_sha256,
+                        };
+                        match serde_json::to_vec(&metadata) {
+                            Ok(json) => {
+                                // #1618 S9: sidecar written second, after the
+                                // streaming content write (put_stream) above.
+                                if let Err(e) =
+                                    storage_clone.put(&metadata_key, Bytes::from(json)).await
+                                {
+                                    tracing::warn!(
+                                        cache_key = %cache_key_for_writer,
+                                        metadata_key = %metadata_key,
+                                        error = %e,
+                                        "proxy cache metadata sidecar write failed; cache will refetch next request"
+                                    );
+                                }
+                            }
+                            Err(e) => {
                                 tracing::warn!(
                                     cache_key = %cache_key_for_writer,
-                                    metadata_key = %metadata_key,
                                     error = %e,
-                                    "proxy cache metadata sidecar write failed; cache will refetch next request"
+                                    "proxy cache metadata JSON serialization failed"
                                 );
                             }
                         }
-                        Err(e) => {
-                            tracing::warn!(
+                    }
+                    rejected => {
+                        // Reject path for both guards (#1365 empty, #1912
+                        // truncated): writing a sidecar would mark a corrupt
+                        // object as a fresh cache hit. An empty body (a 204, a
+                        // 200 with `Content-Length: 0`, or a HEAD-style probe
+                        // reaching the download path) would serve
+                        // `Content-Length: 0` (e.g. Gradle fails parsing the
+                        // POM: "Content is not allowed in prolog."); a truncated
+                        // body (stream cut mid-download below the advertised
+                        // `Content-Length`) would serve a short, SHA-mismatched
+                        // blob and clients hit "unexpected BufError" extracting
+                        // the archive. Skip the sidecar (entry treated as a
+                        // miss) and delete the bad object so a later GET
+                        // refetches upstream (self-heal). The buffered sibling
+                        // [`Self::write_buffered`] applies the empty-body guard
+                        // before the content write.
+                        match rejected {
+                            StreamWriteOutcome::RejectTruncated { expected, actual } => {
+                                tracing::warn!(
+                                    cache_key = %cache_key_for_writer,
+                                    expected_bytes = expected,
+                                    written_bytes = actual,
+                                    "proxy upstream body was truncated (written != Content-Length); \
+                                     not caching the partial object (no metadata sidecar) so the \
+                                     next request refetches upstream"
+                                );
+                            }
+                            _ => {
+                                tracing::warn!(
+                                    cache_key = %cache_key_for_writer,
+                                    "proxy upstream returned an empty body; not caching the \
+                                     zero-byte object (no metadata sidecar) so the next request \
+                                     refetches upstream"
+                                );
+                            }
+                        }
+                        if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                            tracing::debug!(
                                 cache_key = %cache_key_for_writer,
                                 error = %e,
-                                "proxy cache metadata JSON serialization failed"
+                                "best-effort delete of rejected proxy-cache object failed; \
+                                 the missing metadata sidecar still forces a refetch"
                             );
                         }
                     }
-                }
+                },
                 Err(e) => {
                     tracing::warn!(
                         cache_key = %cache_key_for_writer,
@@ -2508,6 +2558,7 @@ impl ProxyService {
                 last_modified: None,
                 ttl_secs: cache_ttl,
             },
+            upstream.content_length,
         );
 
         Ok(StreamHandle { body, headers })
@@ -6312,7 +6363,7 @@ SHA256:
         metadata_key: String,
         template: CacheMetadataTemplate,
     ) -> BoxStream<'static, Result<Bytes>> {
-        CachePersister::new(storage).tee_stream(upstream, cache_key, metadata_key, template)
+        CachePersister::new(storage).tee_stream(upstream, cache_key, metadata_key, template, None)
     }
 
     fn template() -> CacheMetadataTemplate {
@@ -6447,6 +6498,119 @@ SHA256:
             backend.deletes.lock().await.as_slice(),
             ["cache-key".to_string()],
             "the empty cache object must be deleted so the next request refetches"
+        );
+    }
+
+    #[test]
+    fn test_classify_stream_write_rejects_empty() {
+        assert_eq!(
+            classify_stream_write(0, None),
+            StreamWriteOutcome::RejectEmpty
+        );
+        assert_eq!(
+            classify_stream_write(0, Some(10)),
+            StreamWriteOutcome::RejectEmpty
+        );
+    }
+
+    #[test]
+    fn test_classify_stream_write_commits_when_length_unknown_or_matching() {
+        assert_eq!(classify_stream_write(11, None), StreamWriteOutcome::Commit);
+        assert_eq!(
+            classify_stream_write(11, Some(11)),
+            StreamWriteOutcome::Commit
+        );
+    }
+
+    #[test]
+    fn test_classify_stream_write_rejects_size_mismatch() {
+        assert_eq!(
+            classify_stream_write(11, Some(100)),
+            StreamWriteOutcome::RejectTruncated {
+                expected: 100,
+                actual: 11,
+            }
+        );
+        // A body longer than advertised is equally corrupt; reject it too.
+        assert_eq!(
+            classify_stream_write(120, Some(100)),
+            StreamWriteOutcome::RejectTruncated {
+                expected: 100,
+                actual: 120,
+            }
+        );
+    }
+
+    /// #1912 regression: a truncated upstream body (bytes written < the
+    /// advertised `Content-Length`) must NOT be cached. Committing it would
+    /// serve a short, SHA-mismatched archive on the next GET and clients hit
+    /// "unexpected BufError" extracting it. The writer must skip the metadata
+    /// sidecar and delete the partial object so the next request refetches.
+    #[tokio::test]
+    async fn test_tee_truncated_upstream_is_not_cached() {
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        // Upstream advertises 100 bytes but only delivers 11.
+        let upstream = upstream_chunks(vec![&b"first-chunk"[..]]);
+        let mut client = CachePersister::new(storage).tee_stream(
+            upstream,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            template(),
+            Some(100),
+        );
+
+        let mut total: usize = 0;
+        while let Some(chunk) = client.next().await {
+            total += chunk.unwrap().len();
+        }
+        assert_eq!(
+            total, 11,
+            "client still receives the (truncated) body it got"
+        );
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            backend.metadata_writes.lock().await.is_empty(),
+            "truncated upstream body MUST NOT write a metadata sidecar (#1912)"
+        );
+        assert_eq!(
+            backend.deletes.lock().await.as_slice(),
+            ["cache-key".to_string()],
+            "the truncated cache object must be deleted so the next request refetches"
+        );
+    }
+
+    /// A complete streamed body whose byte count matches the advertised
+    /// `Content-Length` is cached normally — the #1912 guard does not fire on
+    /// well-formed responses.
+    #[tokio::test]
+    async fn test_tee_complete_upstream_with_matching_length_is_cached() {
+        let backend = TeeRecordingBackend::ok();
+        let storage = Arc::new(RealStorageService::new(backend.clone()));
+
+        let upstream = upstream_chunks(vec![&b"first-chunk"[..]]);
+        let mut client = CachePersister::new(storage).tee_stream(
+            upstream,
+            "cache-key".to_string(),
+            "meta-key".to_string(),
+            template(),
+            Some(11),
+        );
+        while let Some(chunk) = client.next().await {
+            let _ = chunk.unwrap();
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            backend.metadata_writes.lock().await.len(),
+            1,
+            "a complete body with a matching Content-Length writes its sidecar"
+        );
+        assert!(
+            backend.deletes.lock().await.is_empty(),
+            "a complete body must not be deleted"
         );
     }
 


### PR DESCRIPTION
## Summary
The PyPI (and any) remote-proxy streaming path could poison its own cache with a **truncated** artifact. `CachePersister::tee_stream` wrote whatever bytes `put_stream` received and then committed the metadata sidecar **without comparing the byte count to the upstream `Content-Length`**. When a download was interrupted mid-body (e.g. `plotly-6.8.0-py3-none-any.whl`), the cache was overwritten with a short, SHA-mismatched blob and served to clients, which then failed zip/wheel extraction with `unexpected BufError`.

This adds a pure `classify_stream_write(bytes_written, expected_len)` guard and threads the upstream `Content-Length` into `tee_stream`. On a size mismatch (or a zero-byte body) the writer **skips the metadata sidecar and deletes the partial object**, so the next request refetches upstream and self-heals — exactly like the existing #1365 empty-body guard. Validation only fires when `Content-Length` is known, so chunked / auto-decompressed responses (which strip `Content-Length`) are never falsely rejected.

Fixes the cache-corruption reported in #1912.

Closes #1912

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_tee_truncated_upstream_is_not_cached` fails on `main` (a truncated body was committed) and passes here (no sidecar, object deleted). Plus `test_tee_complete_upstream_with_matching_length_is_cached` and unit tests for `classify_stream_write`.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

> Note: this contributor's local Windows/MSYS toolchain cannot build `aws-lc-sys` (BoringSSL asm), so `cargo clippy`/`test` were not run locally — relying on CI (Linux) for the full gate. `cargo fmt --check` passes.

## API Changes
- [x] N/A - no API changes
