### PR TITLE
chore(release): bump version to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.1-dev"
+version = "1.2.1"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.1-dev"
+version = "1.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -13,7 +13,7 @@ use utoipa::{Modify, OpenApi};
     info(
         title = "Artifact Keeper API",
         description = "Enterprise artifact registry supporting 45+ package formats.",
-        version = "1.0.0-rc.3",
+        version = "1.2.1",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Release version bump for **v1.2.1**.

- Workspace `version`: `1.2.1-dev` → `1.2.1` (drives `/health` → the UI "Server" version, telemetry, SBOM).
- OpenAPI `info.version`: `1.0.0-rc.3` → `1.2.1` — this was hardcoded and stale; it backs the Swagger `/api-docs` document.
- `Cargo.lock` synced.

Part of the v1.2.1 cut. Companion bumps: `artifact-keeper-web` package.json → 1.2.1 (+ `v1.2.1` tag) and `artifact-keeper-iac` Chart `appVersion` → 1.2.1.