### PR TITLE
fix(proxy): presign proxy-cache downloads via the no-prefix backend instead of streaming (#1555)

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -686,11 +686,19 @@ pub async fn proxy_fetch_or_redirect(
     // cache is already fresh, redirect to the signed URL without ever
     // pulling the cached body into the backend's memory. The freshness
     // probe is metadata-only (HEAD-equivalent on cloud backends).
-    if presigned_enabled && proxy_service.is_cache_fresh(repo_key, path).await {
-        // #1555: proxy-cache content is stored without the global key prefix,
-        // so it must be signed through the proxy's own (no-prefix) backend, not
-        // the prefixed repo handle, or the signed key 404s in the object store.
-        if let Some(storage) = proxy_service.cache_storage_backend() {
+    //
+    // #1555: resolve the no-prefix presign handle FIRST and skip the
+    // freshness probe entirely if we can't redirect (no handle, or the
+    // backend doesn't support redirects). The probe loads the cache-meta
+    // sidecar; on a backend that can't presign it would be a pure wasted
+    // S3 GET, since the slow path below re-reads the same sidecar anyway.
+    if presigned_enabled {
+        let storage = proxy_service.cache_storage_backend();
+        if storage.supports_redirect() && proxy_service.is_cache_fresh(repo_key, path).await {
+            // proxy-cache content is stored without the global key prefix,
+            // so it must be signed through the proxy's own (no-prefix)
+            // backend, not the prefixed repo handle, or the signed key
+            // 404s in the object store.
             if let Some(redirect) = try_proxy_cache_redirect(
                 storage.as_ref(),
                 &cache_key,
@@ -716,13 +724,18 @@ pub async fn proxy_fetch_or_redirect(
     if presigned_enabled {
         // #1555: sign the just-populated cache entry through the proxy's
         // no-prefix backend (same handle that wrote it), not the prefixed
-        // repo handle.
-        if let Some(storage) = proxy_service.cache_storage_backend() {
-            if let Some(redirect) =
-                try_presigned_redirect(storage.as_ref(), &cache_key, true, expiry).await
-            {
-                return Ok(redirect);
-            }
+        // repo handle. The entry was just written, so treat it as fresh.
+        let storage = proxy_service.cache_storage_backend();
+        if let Some(redirect) = try_proxy_cache_redirect(
+            storage.as_ref(),
+            &cache_key,
+            presigned_enabled,
+            expiry,
+            /* cache_is_fresh = */ true,
+        )
+        .await
+        {
+            return Ok(redirect);
         }
     }
 
@@ -749,17 +762,48 @@ pub async fn proxy_fetch_or_redirect(
 ///
 /// Extracted from `proxy_fetch_or_redirect` so the redirect short-circuit can
 /// be exercised in unit tests with recording mock storage backends.
-pub(crate) async fn try_proxy_cache_redirect<S: crate::storage::StorageBackend + ?Sized>(
+///
+/// Generic over the facade `storage_service::StorageBackend` trait (#1555):
+/// proxy-cache presigns flow through the single no-prefix backend handle, which
+/// carries presign capability type-enforced on the facade trait — not a
+/// side-channel field. The redirect is built inline (mirroring
+/// `try_presigned_redirect`) since that helper is bound to the inner storage
+/// trait.
+pub(crate) async fn try_proxy_cache_redirect<
+    S: crate::services::storage_service::StorageBackend + ?Sized,
+>(
     storage: &S,
     cache_key: &str,
     presigned_enabled: bool,
     expiry: Duration,
     cache_is_fresh: bool,
 ) -> Option<Response> {
-    if !presigned_enabled || !cache_is_fresh {
+    if !presigned_enabled || !cache_is_fresh || !storage.supports_redirect() {
         return None;
     }
-    try_presigned_redirect(storage, cache_key, true, expiry).await
+    match storage.get_presigned_url(cache_key, expiry).await {
+        Ok(Some(presigned)) => {
+            tracing::debug!(
+                key = %cache_key,
+                source = ?presigned.source,
+                expiry_secs = expiry.as_secs(),
+                "Serving proxy-cache artifact via presigned redirect"
+            );
+            Some(
+                crate::api::download_response::DownloadResponse::redirect(presigned)
+                    .into_response(),
+            )
+        }
+        Ok(None) => None,
+        Err(e) => {
+            tracing::warn!(
+                key = %cache_key,
+                error = %e,
+                "Failed to generate proxy-cache presigned URL, falling back"
+            );
+            None
+        }
+    }
 }
 
 /// Check whether an artifact is present in the proxy cache under `path`
@@ -1283,28 +1327,35 @@ where
                     // Mirrors the fast path in `proxy_fetch_or_redirect`.
                     // Falls through to streaming on a cache miss, so the
                     // OOM-avoidance from #1215 still covers uncached bodies.
-                    if state.config.presigned_downloads_enabled
-                        && proxy.is_cache_fresh(&member.key, path).await
-                    {
-                        if let (Ok(cache_key), Some(storage)) = (
-                            ProxyService::cache_storage_key(&member.key, path),
-                            proxy.cache_storage_backend(),
-                        ) {
-                            // #1555: sign through the proxy's no-prefix backend
-                            // (proxy-cache content lives at the storage root,
-                            // not under the global key prefix).
-                            let expiry =
-                                Duration::from_secs(state.config.presigned_download_expiry_secs);
-                            if let Some(redirect) = try_proxy_cache_redirect(
-                                storage.as_ref(),
-                                &cache_key,
-                                /* presigned_enabled = */ true,
-                                expiry,
-                                /* cache_is_fresh = */ true,
-                            )
-                            .await
+                    // #1555: resolve the no-prefix presign handle and check
+                    // redirect support BEFORE the `is_cache_fresh` probe — the
+                    // probe loads the cache-meta sidecar, so skipping it when we
+                    // can't redirect avoids a wasted S3 GET on the (common)
+                    // cache-miss path that then re-reads the sidecar in the
+                    // streaming fallback below.
+                    if state.config.presigned_downloads_enabled {
+                        let storage = proxy.cache_storage_backend();
+                        if let Ok(cache_key) = ProxyService::cache_storage_key(&member.key, path) {
+                            if storage.supports_redirect()
+                                && proxy.is_cache_fresh(&member.key, path).await
                             {
-                                return Ok(redirect);
+                                // sign through the proxy's no-prefix backend
+                                // (proxy-cache content lives at the storage
+                                // root, not under the global key prefix).
+                                let expiry = Duration::from_secs(
+                                    state.config.presigned_download_expiry_secs,
+                                );
+                                if let Some(redirect) = try_proxy_cache_redirect(
+                                    storage.as_ref(),
+                                    &cache_key,
+                                    /* presigned_enabled = */ true,
+                                    expiry,
+                                    /* cache_is_fresh = */ true,
+                                )
+                                .await
+                                {
+                                    return Ok(redirect);
+                                }
                             }
                         }
                     }
@@ -1952,21 +2003,35 @@ pub async fn local_fetch_or_redirect(
         // no-prefix backend. Hosted artifacts are content-addressed under the
         // global prefix and sign correctly via the repo handle — only switch
         // handles for proxy-cache keys.
-        let cache_backend = if ProxyService::is_proxy_cache_key(&artifact.storage_key) {
+        //
+        // The two handles live on different traits (the proxy's no-prefix
+        // backend is the facade `storage_service::StorageBackend`; the repo
+        // handle is the inner `crate::storage::StorageBackend`), so branch on
+        // the key shape rather than coercing both into one trait object.
+        let proxy_cache_backend = if ProxyService::is_proxy_cache_key(&artifact.storage_key) {
             state
                 .proxy_service
                 .as_deref()
-                .and_then(|p| p.cache_storage_backend())
+                .map(|p| p.cache_storage_backend())
         } else {
             None
         };
-        let presign_storage: &dyn crate::storage::StorageBackend = match &cache_backend {
-            Some(b) => b.as_ref(),
-            None => storage.as_ref(),
+        let redirect = match &proxy_cache_backend {
+            Some(b) => {
+                try_proxy_cache_redirect(
+                    b.as_ref(),
+                    &artifact.storage_key,
+                    /* presigned_enabled = */ true,
+                    expiry,
+                    /* cache_is_fresh = */ true,
+                )
+                .await
+            }
+            None => {
+                try_presigned_redirect(storage.as_ref(), &artifact.storage_key, true, expiry).await
+            }
         };
-        if let Some(redirect) =
-            try_presigned_redirect(presign_storage, &artifact.storage_key, true, expiry).await
-        {
+        if let Some(redirect) = redirect {
             return Ok(redirect);
         }
     }
@@ -3940,6 +4005,59 @@ mod tests {
         }
     }
 
+    // Facade-trait impl so `RecordingStorage` can be driven directly through
+    // `try_proxy_cache_redirect` (now generic over the facade trait, #1555)
+    // while still serving as an inner-trait registry backend elsewhere. Both
+    // impls share the same call counters.
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for RecordingStorage {
+        async fn put(&self, key: &str, content: Bytes) -> crate::error::Result<()> {
+            self.put_calls.fetch_add(1, Ordering::SeqCst);
+            *self.last_put.lock().unwrap() = Some((key.to_string(), content));
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
+            self.get_calls.fetch_add(1, Ordering::SeqCst);
+            match self.get_behavior {
+                RecordingGetBehavior::Hit => Ok(Bytes::from_static(b"full-body")),
+                RecordingGetBehavior::Miss => Err(crate::error::AppError::NotFound(format!(
+                    "Storage key not found: {}",
+                    key
+                ))),
+            }
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+            Ok(0)
+        }
+        fn supports_redirect(&self) -> bool {
+            self.supports
+        }
+        async fn get_presigned_url(
+            &self,
+            key: &str,
+            expires_in: std::time::Duration,
+        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+            self.presigned_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(Some(crate::storage::PresignedUrl {
+                url: format!("https://signed.example.com/{}", key),
+                expires_in,
+                source: crate::storage::PresignedUrlSource::S3,
+            }))
+        }
+    }
+
     #[tokio::test]
     async fn test_try_proxy_cache_redirect_skips_get_on_fresh_cache_hit() {
         // Bug #1018: a fresh cache hit with presigned enabled must NOT
@@ -3982,6 +4100,74 @@ mod tests {
             location.contains("signed.example.com"),
             "redirect should point at the signed URL, got {}",
             location
+        );
+    }
+
+    /// #1555 runtime assertion (no DB): drive the proxy-cache presign path
+    /// through the real `StorageService` facade built on a redirect-capable,
+    /// no-prefix backend, and assert the SIGNED key carries NO global prefix.
+    ///
+    /// This replaces the old source-grep guards (which only checked WHICH
+    /// symbol was called, so they passed even while the feature was dead on
+    /// S3). Here the backend echoes the exact key it was asked to sign into the
+    /// URL, so a prefixed key would surface as a real assertion failure.
+    #[tokio::test]
+    async fn test_proxy_cache_presign_signs_no_prefix_key_1555() {
+        // The proxy's own backend: redirect-capable, signs the key verbatim
+        // (a no-prefix S3 handle does exactly this — no `make_full_key` prefix).
+        let proxy_backend = StdArc::new(RecordingStorage::new(/* supports = */ true));
+        let service = StdArc::new(crate::services::storage_service::StorageService::new(
+            proxy_backend.clone(),
+        ));
+
+        // `cache_storage_backend()` returns this single facade handle; capability
+        // is type-enforced on the facade trait (no side-channel field).
+        let storage = service.backend();
+        assert!(
+            storage.supports_redirect(),
+            "no-prefix proxy-cache backend must report redirect support (#1555)"
+        );
+
+        let cache_key = "proxy-cache/pypi-remote/pkg/pkg-1.0.0-py3-none-any.whl/__content__";
+        let resp = super::try_proxy_cache_redirect(
+            storage.as_ref(),
+            cache_key,
+            /* presigned_enabled = */ true,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ true,
+        )
+        .await
+        .expect("fresh cache + redirect-capable backend must yield a redirect");
+
+        assert_eq!(resp.status(), axum::http::StatusCode::FOUND);
+        let location = resp
+            .headers()
+            .get("location")
+            .expect("location header")
+            .to_str()
+            .unwrap();
+
+        // The signed key is the raw proxy-cache key: starts with `proxy-cache/`
+        // and carries no global (`artifact-keeper/`) prefix.
+        assert!(
+            location.ends_with(cache_key),
+            "signed URL must end with the verbatim no-prefix cache key, got {}",
+            location
+        );
+        assert!(
+            !location.contains("artifact-keeper/"),
+            "signed key must NOT carry a global prefix (#1555), got {}",
+            location
+        );
+        assert_eq!(
+            proxy_backend.presigned_calls.load(Ordering::SeqCst),
+            1,
+            "exactly one presign through the no-prefix handle"
+        );
+        assert_eq!(
+            proxy_backend.get_calls.load(Ordering::SeqCst),
+            0,
+            "body must not be downloaded on the presign fast path"
         );
     }
 
@@ -6125,6 +6311,24 @@ mod tests {
         async fn size(&self, _key: &str) -> crate::error::Result<u64> {
             Ok(9)
         }
+        // #1555: this is the proxy's OWN no-prefix backend (`cache_storage_backend`),
+        // so it must report redirect support and sign the key verbatim — no
+        // `artifact-keeper/` prefix is added. The signed URL echoes the key so
+        // tests can assert the no-prefix layout end to end.
+        fn supports_redirect(&self) -> bool {
+            true
+        }
+        async fn get_presigned_url(
+            &self,
+            key: &str,
+            expires_in: std::time::Duration,
+        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+            Ok(Some(crate::storage::PresignedUrl {
+                url: format!("https://signed.example.com/{}", key),
+                expires_in,
+                source: crate::storage::PresignedUrlSource::S3,
+            }))
+        }
     }
 
     /// #1555 runtime coverage: a fresh proxy-cache hit on an S3-backed Remote
@@ -6151,12 +6355,15 @@ mod tests {
         let (member_id, _member_key, _) = db_helpers::create_repo(&pool, "remote", "pypi").await;
         db_helpers::link_member(&pool, virtual_id, member_id, 0).await;
 
-        // Redirect-capable default backend (registry side) + presigned config.
-        let redirect_storage = StdArc::new(RecordingStorage::new(/* supports = */ true));
+        // Registry-side backend is irrelevant here: #1555 signs proxy-cache
+        // keys through the PROXY's own no-prefix backend, not the registry
+        // handle. We assert the registry backend is never touched for presign.
+        let registry_storage = StdArc::new(RecordingStorage::new(/* supports = */ true));
         let state =
-            db_helpers::build_state_presigned(pool.clone(), "s3-test", redirect_storage.clone());
+            db_helpers::build_state_presigned(pool.clone(), "s3-test", registry_storage.clone());
 
-        // ProxyService whose `is_cache_fresh` returns true for any path.
+        // ProxyService whose own (no-prefix) backend reports the cache fresh
+        // AND presigns, echoing the signed key into the URL.
         let proxy = ProxyService::new(
             pool.clone(),
             StdArc::new(crate::services::storage_service::StorageService::new(
@@ -6198,15 +6405,26 @@ mod tests {
             "Location must point at the presigned URL, got {}",
             location
         );
-        assert_eq!(
-            redirect_storage.presigned_calls.load(Ordering::SeqCst),
-            1,
-            "exactly one presigned URL request expected"
+        // #1555 core assertion: the signed key has NO global prefix — it is the
+        // raw proxy-cache key starting with `proxy-cache/`, never wrapped in an
+        // `artifact-keeper/` (or any) prefix. Signing through a prefixed handle
+        // was the original bug; the no-prefix backend fixes it.
+        assert!(
+            location.contains("/proxy-cache/"),
+            "signed key must be the no-prefix proxy-cache key, got {}",
+            location
         );
+        assert!(
+            !location.contains("artifact-keeper/"),
+            "signed key must NOT carry a global prefix (#1555), got {}",
+            location
+        );
+        // The registry-side backend must never be asked to presign: proxy-cache
+        // signing goes exclusively through the proxy's no-prefix handle.
         assert_eq!(
-            redirect_storage.get_calls.load(Ordering::SeqCst),
+            registry_storage.presigned_calls.load(Ordering::SeqCst),
             0,
-            "the full body must NOT be downloaded when redirecting"
+            "registry backend must NOT presign proxy-cache keys (#1555)"
         );
 
         db_helpers::cleanup(&pool, virtual_id, Uuid::nil()).await;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1243,7 +1243,7 @@ fn is_quarantine_block_response(resp: &Response) -> bool {
 /// emits the same outbound headers as the buffered
 /// [`build_download_response`] used to.
 pub async fn resolve_virtual_download_streaming<F, Fut>(
-    db: &PgPool,
+    state: &AppState,
     proxy_service: Option<&ProxyService>,
     virtual_repo_id: Uuid,
     path: &str,
@@ -1255,7 +1255,7 @@ where
     F: Fn(Uuid, StorageLocation) -> Fut,
     Fut: std::future::Future<Output = Result<StreamingFetchResult, Response>>,
 {
-    let members = fetch_virtual_members(db, virtual_repo_id).await?;
+    let members = fetch_virtual_members(&state.db, virtual_repo_id).await?;
 
     if members.is_empty() {
         return Err((StatusCode::NOT_FOUND, "Virtual repository has no members").into_response());
@@ -1273,6 +1273,41 @@ where
                 if let (Some(proxy), Some(upstream_url)) =
                     (proxy_service, member.upstream_url.as_deref())
                 {
+                    // #1555: prefer a presigned S3 redirect for a fresh cache
+                    // hit so large artifacts (e.g. torch wheels, multi-GB) are
+                    // not streamed through the backend. Streaming holds a
+                    // worker thread for the whole transfer; under burst load
+                    // that saturates the dispatcher and cascades into 502s.
+                    // Mirrors the fast path in `proxy_fetch_or_redirect`.
+                    // Falls through to streaming on a cache miss, so the
+                    // OOM-avoidance from #1215 still covers uncached bodies.
+                    if state.config.presigned_downloads_enabled
+                        && proxy.is_cache_fresh(&member.key, path).await
+                    {
+                        if let Ok(cache_key) = ProxyService::cache_storage_key(&member.key, path) {
+                            let storage_location = StorageLocation {
+                                backend: state.config.storage_backend.clone(),
+                                path: state.config.storage_path.clone(),
+                            };
+                            if let Ok(storage) = state.storage_for_repo(&storage_location) {
+                                let expiry = Duration::from_secs(
+                                    state.config.presigned_download_expiry_secs,
+                                );
+                                if let Some(redirect) = try_proxy_cache_redirect(
+                                    storage.as_ref(),
+                                    &cache_key,
+                                    /* presigned_enabled = */ true,
+                                    expiry,
+                                    /* cache_is_fresh = */ true,
+                                )
+                                .await
+                                {
+                                    return Ok(redirect);
+                                }
+                            }
+                        }
+                    }
+
                     match proxy_fetch_streaming_with_disposition(
                         proxy,
                         member.id,
@@ -1828,6 +1863,40 @@ pub async fn local_fetch_by_path_suffix(
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
     local_fetch_by_path(db, state, repo_id, location, &path).await
+}
+
+/// Variant of [`local_fetch_by_path_suffix`] that issues a presigned S3
+/// redirect instead of streaming when `state.config.presigned_downloads_enabled`
+/// is set (#1555). The suffix→path resolution is identical; only the response
+/// shape differs: a 307 redirect for S3-backed artifacts, or streaming when the
+/// storage backend does not support presigning.
+///
+/// Used by the PyPI virtual-download path (`pypi.rs::serve_file`) which has its
+/// own member-iteration loop and could not share the generic
+/// `resolve_virtual_download_streaming` fix.
+pub async fn local_fetch_or_redirect_by_suffix(
+    db: &PgPool,
+    state: &AppState,
+    repo_id: Uuid,
+    location: &StorageLocation,
+    path_suffix: &str,
+) -> Result<Response, Response> {
+    let reversed_pattern = reverse_suffix_for_like(path_suffix);
+    let path: String = sqlx::query_scalar(
+        "SELECT path FROM artifacts \
+         WHERE repository_id = $1 \
+           AND reverse(path) LIKE $2 || '%' ESCAPE '\\' \
+           AND is_deleted = false \
+         LIMIT 1",
+    )
+    .bind(repo_id)
+    .bind(&reversed_pattern)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| internal_error("Database", e))?
+    .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
+
+    local_fetch_or_redirect(db, state, repo_id, location, &path).await
 }
 
 /// Build the reversed-+-escaped LIKE prefix for a path-suffix query
@@ -2413,7 +2482,7 @@ pub async fn try_remote_or_virtual_download(
                 let suffix = suffix.to_string();
                 let state_arc = state.clone();
                 resolve_virtual_download_streaming(
-                    &state.db,
+                    state,
                     proxy_for_virtual,
                     repo.id,
                     opts.upstream_path,
@@ -2435,7 +2504,7 @@ pub async fn try_remote_or_virtual_download(
                 let path = path.to_string();
                 let state_arc = state.clone();
                 resolve_virtual_download_streaming(
-                    &state.db,
+                    state,
                     proxy_for_virtual,
                     repo.id,
                     opts.upstream_path,
@@ -4752,6 +4821,33 @@ mod tests {
             ))
         }
 
+        /// Build an `AppState` whose default storage backend is the named,
+        /// caller-supplied `redirect_backend` and whose config has presigned
+        /// downloads enabled. Used by the #1555 redirect test to drive
+        /// `resolve_virtual_download_streaming` into its presigned-redirect
+        /// fast path: `config.storage_backend` must resolve through the
+        /// registry to a redirect-capable backend.
+        pub fn build_state_presigned(
+            pool: PgPool,
+            backend_name: &str,
+            redirect_backend: Arc<dyn crate::storage::StorageBackend>,
+        ) -> SharedState {
+            let mut config = test_config("/tmp/ph-presigned");
+            config.presigned_downloads_enabled = true;
+            config.storage_backend = backend_name.to_string();
+
+            let mut backends: std::collections::HashMap<
+                String,
+                Arc<dyn crate::storage::StorageBackend>,
+            > = std::collections::HashMap::new();
+            backends.insert(backend_name.to_string(), redirect_backend.clone());
+            let registry = Arc::new(crate::storage::StorageRegistry::new(
+                backends,
+                backend_name.to_string(),
+            ));
+            Arc::new(AppState::new(config, pool, redirect_backend, registry))
+        }
+
         pub async fn create_user(pool: &PgPool) -> Uuid {
             let id = Uuid::new_v4();
             let username = format!("ph-test-u-{}", id);
@@ -4801,6 +4897,26 @@ mod tests {
                 .await
                 .expect("create repo");
             (id, key, storage_dir)
+        }
+
+        /// Insert a `virtual_repo_members` row so `fetch_virtual_members`
+        /// returns `member_repo_id` when resolving `virtual_repo_id`.
+        pub async fn link_member(
+            pool: &PgPool,
+            virtual_repo_id: Uuid,
+            member_repo_id: Uuid,
+            priority: i32,
+        ) {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virtual_repo_id)
+            .bind(member_repo_id)
+            .bind(priority)
+            .execute(pool)
+            .await
+            .expect("link virtual member");
         }
 
         pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
@@ -5861,6 +5977,178 @@ mod tests {
              it would defeat the whole point of having a streaming \
              resolver."
         );
+    }
+
+    #[test]
+    fn test_resolve_virtual_download_streaming_redirects_before_streaming_1555() {
+        // #1555: a fresh proxy-cache hit on an S3-backed member must be
+        // served as a presigned redirect, NOT streamed through the
+        // backend. Streaming holds a worker thread for the whole transfer
+        // and saturates the dispatcher under burst load. The redirect
+        // attempt must sit BEFORE the streaming fallback so cached bodies
+        // never reach `proxy_fetch_streaming_with_disposition`.
+        let src = include_str!("proxy_helpers.rs");
+        let fn_start = src
+            .find("pub async fn resolve_virtual_download_streaming<")
+            .expect("resolve_virtual_download_streaming must exist");
+        let window_end = (fn_start + 4096).min(src.len());
+        let window = &src[fn_start..window_end];
+
+        let redirect_pos = window.find("try_proxy_cache_redirect(").expect(
+            "`resolve_virtual_download_streaming` MUST attempt \
+             `try_proxy_cache_redirect(` for fresh proxy-cache hits (#1555).",
+        );
+        assert!(
+            window.contains("is_cache_fresh("),
+            "redirect fast-path MUST gate on a metadata-only \
+             `is_cache_fresh(` probe (#1555) so it never pulls the body.",
+        );
+        let stream_pos = window
+            .find("proxy_fetch_streaming_with_disposition(")
+            .expect("streaming fallback must still exist (#1215)");
+        assert!(
+            redirect_pos < stream_pos,
+            "the presigned redirect attempt (#1555) MUST come BEFORE the \
+             streaming fallback (#1215); otherwise cached large artifacts \
+             still stream through the backend.",
+        );
+    }
+
+    /// Proxy-cache storage mock (the `StorageService` trait) that reports a
+    /// single fresh, positive cache entry. The metadata sidecar deserializes
+    /// to a non-expired `CacheMetadata` with no pinned ETag, so
+    /// `ProxyService::is_cache_fresh` takes the existence-check branch and the
+    /// `__content__` key reports as present. The body itself is never read on
+    /// the fast path, so `get` of the content key returns NotFound to surface
+    /// any accidental download as a failure.
+    struct FreshProxyCacheStorage;
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for FreshProxyCacheStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
+            if key.ends_with("__cache_meta__.json") {
+                let meta = crate::services::proxy_service::CacheMetadata {
+                    cached_at: Utc::now(),
+                    upstream_etag: None,
+                    storage_etag: None,
+                    last_modified: None,
+                    negative_cached_until: None,
+                    quarantine_until: None,
+                    expires_at: Utc::now() + chrono::Duration::seconds(3600),
+                    content_type: Some("application/octet-stream".to_string()),
+                    size_bytes: 9,
+                    checksum_sha256: "deadbeef".to_string(),
+                };
+                Ok(Bytes::from(serde_json::to_vec(&meta).unwrap()))
+            } else {
+                Err(crate::error::AppError::NotFound(key.to_string()))
+            }
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            // Both the content key and the metadata sidecar report present.
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+            Ok(9)
+        }
+    }
+
+    /// #1555 runtime coverage: a fresh proxy-cache hit on an S3-backed Remote
+    /// member of a Virtual repo must be served as a presigned 302 redirect,
+    /// NOT streamed through the backend.
+    ///
+    /// This drives the real `resolve_virtual_download_streaming` redirect
+    /// branch end to end: a Remote member is resolved from the DB, the proxy
+    /// reports the cache as fresh, the default storage backend supports
+    /// redirects, and the helper returns a 302 with a `Location` header. The
+    /// `local_fetch` closure panics if invoked, proving the redirect fired
+    /// before any streaming / local fallback.
+    ///
+    /// DB-gated like the other `try_pool` tests: skips when `DATABASE_URL` is
+    /// unset (no live Postgres), runs in CI where one is provisioned.
+    #[tokio::test]
+    async fn test_resolve_virtual_download_streaming_returns_presigned_redirect_1555() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+
+        // Virtual repo with one Remote member.
+        let (virtual_id, _, _) = db_helpers::create_repo(&pool, "virtual", "pypi").await;
+        let (member_id, _member_key, _) = db_helpers::create_repo(&pool, "remote", "pypi").await;
+        db_helpers::link_member(&pool, virtual_id, member_id, 0).await;
+
+        // Redirect-capable default backend (registry side) + presigned config.
+        let redirect_storage = StdArc::new(RecordingStorage::new(/* supports = */ true));
+        let state =
+            db_helpers::build_state_presigned(pool.clone(), "s3-test", redirect_storage.clone());
+
+        // ProxyService whose `is_cache_fresh` returns true for any path.
+        let proxy = ProxyService::new(
+            pool.clone(),
+            StdArc::new(crate::services::storage_service::StorageService::new(
+                StdArc::new(FreshProxyCacheStorage),
+            )),
+        );
+
+        let resp = resolve_virtual_download_streaming(
+            &state,
+            Some(&proxy),
+            virtual_id,
+            "pkg/pkg-1.0.0-py3-none-any.whl",
+            "application/octet-stream",
+            None,
+            // Remote member must redirect before reaching any local fetch.
+            |_id, _loc| async {
+                panic!("local_fetch must NOT run: the redirect fast path should win");
+                #[allow(unreachable_code)]
+                Err(StatusCode::INTERNAL_SERVER_ERROR.into_response())
+            },
+        )
+        .await
+        .expect("fresh cache hit must resolve to a redirect, not an error");
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::FOUND,
+            "fresh proxy-cache hit on an S3-backed member must yield a 302 \
+             redirect (#1555), not a streamed 200"
+        );
+        let location = resp
+            .headers()
+            .get("location")
+            .expect("redirect must carry a Location header")
+            .to_str()
+            .unwrap();
+        assert!(
+            location.contains("signed.example.com"),
+            "Location must point at the presigned URL, got {}",
+            location
+        );
+        assert_eq!(
+            redirect_storage.presigned_calls.load(Ordering::SeqCst),
+            1,
+            "exactly one presigned URL request expected"
+        );
+        assert_eq!(
+            redirect_storage.get_calls.load(Ordering::SeqCst),
+            0,
+            "the full body must NOT be downloaded when redirecting"
+        );
+
+        db_helpers::cleanup(&pool, virtual_id, Uuid::nil()).await;
+        db_helpers::cleanup(&pool, member_id, Uuid::nil()).await;
     }
 
     // ── #1804: per-member authorization for virtual repos ───────────────

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -681,17 +681,16 @@ pub async fn proxy_fetch_or_redirect(
         .map_err(|e| map_proxy_error(repo_key, path, e))?;
     let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
     let presigned_enabled = state.config.presigned_downloads_enabled;
-    let storage_location = StorageLocation {
-        backend: state.config.storage_backend.clone(),
-        path: state.config.storage_path.clone(),
-    };
 
     // Fast path (#1018): if presigned downloads are enabled and the proxy
     // cache is already fresh, redirect to the signed URL without ever
     // pulling the cached body into the backend's memory. The freshness
     // probe is metadata-only (HEAD-equivalent on cloud backends).
     if presigned_enabled && proxy_service.is_cache_fresh(repo_key, path).await {
-        if let Ok(storage) = state.storage_for_repo(&storage_location) {
+        // #1555: proxy-cache content is stored without the global key prefix,
+        // so it must be signed through the proxy's own (no-prefix) backend, not
+        // the prefixed repo handle, or the signed key 404s in the object store.
+        if let Some(storage) = proxy_service.cache_storage_backend() {
             if let Some(redirect) = try_proxy_cache_redirect(
                 storage.as_ref(),
                 &cache_key,
@@ -715,7 +714,10 @@ pub async fn proxy_fetch_or_redirect(
     // If presigned is configured, prefer redirecting to the just-populated
     // cache entry over streaming the buffered content back to the client.
     if presigned_enabled {
-        if let Ok(storage) = state.storage_for_repo(&storage_location) {
+        // #1555: sign the just-populated cache entry through the proxy's
+        // no-prefix backend (same handle that wrote it), not the prefixed
+        // repo handle.
+        if let Some(storage) = proxy_service.cache_storage_backend() {
             if let Some(redirect) =
                 try_presigned_redirect(storage.as_ref(), &cache_key, true, expiry).await
             {
@@ -1284,26 +1286,25 @@ where
                     if state.config.presigned_downloads_enabled
                         && proxy.is_cache_fresh(&member.key, path).await
                     {
-                        if let Ok(cache_key) = ProxyService::cache_storage_key(&member.key, path) {
-                            let storage_location = StorageLocation {
-                                backend: state.config.storage_backend.clone(),
-                                path: state.config.storage_path.clone(),
-                            };
-                            if let Ok(storage) = state.storage_for_repo(&storage_location) {
-                                let expiry = Duration::from_secs(
-                                    state.config.presigned_download_expiry_secs,
-                                );
-                                if let Some(redirect) = try_proxy_cache_redirect(
-                                    storage.as_ref(),
-                                    &cache_key,
-                                    /* presigned_enabled = */ true,
-                                    expiry,
-                                    /* cache_is_fresh = */ true,
-                                )
-                                .await
-                                {
-                                    return Ok(redirect);
-                                }
+                        if let (Ok(cache_key), Some(storage)) = (
+                            ProxyService::cache_storage_key(&member.key, path),
+                            proxy.cache_storage_backend(),
+                        ) {
+                            // #1555: sign through the proxy's no-prefix backend
+                            // (proxy-cache content lives at the storage root,
+                            // not under the global key prefix).
+                            let expiry =
+                                Duration::from_secs(state.config.presigned_download_expiry_secs);
+                            if let Some(redirect) = try_proxy_cache_redirect(
+                                storage.as_ref(),
+                                &cache_key,
+                                /* presigned_enabled = */ true,
+                                expiry,
+                                /* cache_is_fresh = */ true,
+                            )
+                            .await
+                            {
+                                return Ok(redirect);
                             }
                         }
                     }
@@ -1946,8 +1947,25 @@ pub async fn local_fetch_or_redirect(
     // Try presigned redirect before reading content into memory
     if state.config.presigned_downloads_enabled {
         let expiry = Duration::from_secs(state.config.presigned_download_expiry_secs);
+        // #1555: proxy-cache content (remote members) lives at the storage root
+        // with no key prefix, so it must be signed through the proxy's own
+        // no-prefix backend. Hosted artifacts are content-addressed under the
+        // global prefix and sign correctly via the repo handle — only switch
+        // handles for proxy-cache keys.
+        let cache_backend = if ProxyService::is_proxy_cache_key(&artifact.storage_key) {
+            state
+                .proxy_service
+                .as_deref()
+                .and_then(|p| p.cache_storage_backend())
+        } else {
+            None
+        };
+        let presign_storage: &dyn crate::storage::StorageBackend = match &cache_backend {
+            Some(b) => b.as_ref(),
+            None => storage.as_ref(),
+        };
         if let Some(redirect) =
-            try_presigned_redirect(storage.as_ref(), &artifact.storage_key, true, expiry).await
+            try_presigned_redirect(presign_storage, &artifact.storage_key, true, expiry).await
         {
             return Ok(redirect);
         }
@@ -6011,6 +6029,50 @@ mod tests {
             "the presigned redirect attempt (#1555) MUST come BEFORE the \
              streaming fallback (#1215); otherwise cached large artifacts \
              still stream through the backend.",
+        );
+    }
+
+    #[test]
+    fn test_proxy_cache_presign_uses_no_prefix_handle_1555() {
+        // #1555: proxy-cache content lives at the storage ROOT (no global key
+        // prefix), so every proxy-cache presign MUST sign through the proxy's
+        // own no-prefix backend (`cache_storage_backend()`), never through the
+        // prefixed `state.storage_for_repo(...)` handle — otherwise the signed
+        // key carries the prefix and 404s in the object store.
+        let src = include_str!("proxy_helpers.rs");
+
+        for fn_name in [
+            "pub async fn proxy_fetch_or_redirect(",
+            "pub async fn resolve_virtual_download_streaming<",
+            "pub async fn local_fetch_or_redirect(",
+        ] {
+            let fn_start = src
+                .find(fn_name)
+                .unwrap_or_else(|| panic!("{fn_name} must exist"));
+            // Window large enough to cover the function body but bounded so a
+            // later function's tokens cannot satisfy the assertion.
+            let window_end = (fn_start + 4096).min(src.len());
+            let window = &src[fn_start..window_end];
+
+            assert!(
+                window.contains("cache_storage_backend("),
+                "`{fn_name}` MUST presign proxy-cache keys via \
+                 `cache_storage_backend()` (the no-prefix handle), not the \
+                 prefixed repo handle (#1555).",
+            );
+        }
+
+        // The prefixed-handle presign for proxy-cache keys was the bug: the
+        // proxy fast path must no longer reach for `storage_for_repo` to sign.
+        let fn_start = src
+            .find("pub async fn proxy_fetch_or_redirect(")
+            .expect("proxy_fetch_or_redirect must exist");
+        let window_end = (fn_start + 4096).min(src.len());
+        let window = &src[fn_start..window_end];
+        assert!(
+            !window.contains("storage_for_repo("),
+            "`proxy_fetch_or_redirect` MUST NOT sign proxy-cache keys through \
+             the prefixed `storage_for_repo(` handle (#1555).",
         );
     }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4322,6 +4322,126 @@ mod tests {
         assert_eq!(storage.get_calls.load(Ordering::SeqCst), 0);
     }
 
+    // A redirect-capable facade backend whose presign returns `Ok(None)`
+    // (e.g. a presign-disabled S3 handle): the helper must fall through to
+    // streaming. Covers the `Ok(None)` arm of `try_proxy_cache_redirect`.
+    struct NonePresignStorage;
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for NonePresignStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            Ok(Bytes::from_static(b"body"))
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+            Ok(0)
+        }
+        fn supports_redirect(&self) -> bool {
+            true
+        }
+        async fn get_presigned_url(
+            &self,
+            _key: &str,
+            _expires_in: std::time::Duration,
+        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+            Ok(None)
+        }
+    }
+
+    // A redirect-capable facade backend whose presign ERRORS (transient signing
+    // failure): the helper must warn + fall through to streaming, never panic.
+    // Covers the `Err(e)` warn-and-fall-back arm of `try_proxy_cache_redirect`.
+    struct ErrPresignStorage;
+
+    #[async_trait::async_trait]
+    impl crate::services::storage_service::StorageBackend for ErrPresignStorage {
+        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            Ok(Bytes::from_static(b"body"))
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+            Ok(0)
+        }
+        fn supports_redirect(&self) -> bool {
+            true
+        }
+        async fn get_presigned_url(
+            &self,
+            _key: &str,
+            _expires_in: std::time::Duration,
+        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+            Err(crate::error::AppError::Storage(
+                "transient presign failure".to_string(),
+            ))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_try_proxy_cache_redirect_returns_none_when_presign_yields_none() {
+        // #1555: a redirect-capable backend that declines to presign this key
+        // (Ok(None)) must fall through to streaming, not error.
+        let storage = NonePresignStorage;
+        let result = super::try_proxy_cache_redirect(
+            &storage,
+            "proxy-cache/repo/pkg/__content__",
+            /* presigned_enabled = */ true,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ true,
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "Ok(None) presign must fall through to streaming"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_try_proxy_cache_redirect_returns_none_when_presign_errors() {
+        // #1555: a presign error must be swallowed (warn + fall back), never
+        // surfaced as a hard failure — the caller still streams the body.
+        let storage = ErrPresignStorage;
+        let result = super::try_proxy_cache_redirect(
+            &storage,
+            "proxy-cache/repo/pkg/__content__",
+            /* presigned_enabled = */ true,
+            std::time::Duration::from_secs(300),
+            /* cache_is_fresh = */ true,
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "presign Err must warn and fall through to streaming"
+        );
+    }
+
     #[tokio::test]
     async fn test_get_cached_or_refetch_refetches_and_writes_back_when_storage_missing() {
         let Some(pool) = db_helpers::try_pool().await else {
@@ -6429,6 +6549,85 @@ mod tests {
 
         db_helpers::cleanup(&pool, virtual_id, Uuid::nil()).await;
         db_helpers::cleanup(&pool, member_id, Uuid::nil()).await;
+    }
+
+    /// #1555 filesystem fallthrough: `local_fetch_or_redirect` on a proxy-cache
+    /// key (`is_proxy_cache_key(...) == true`) must select the proxy's
+    /// no-prefix `cache_storage_backend()` handle, attempt a presigned
+    /// redirect, and — because that handle is filesystem-backed and reports
+    /// `supports_redirect() == false` — fall through to STREAMING a 200 with
+    /// the body. This is the core non-regression guarantee on the rig / any
+    /// non-S3 deployment: the new proxy-cache handle-selection branch must not
+    /// break filesystem serving. DB-gated (runs in CI where Postgres exists).
+    #[tokio::test]
+    async fn test_local_fetch_or_redirect_proxy_cache_key_streams_on_filesystem_1555() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("remote", "pypi").await else {
+            return;
+        };
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        // Presigned ENABLED + a filesystem-backed proxy service whose
+        // cache_storage_backend() reports supports_redirect() == false.
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), &storage_path);
+        let state =
+            tdh::build_state_with_proxy_presigned(fx.pool.clone(), &storage_path, proxy.clone());
+        let repo_info = tdh::make_repo_info(
+            fx.repo_id,
+            &fx.repo_key,
+            &fx.storage_dir,
+            "remote",
+            Some("https://upstream.example.test"),
+        );
+
+        // Seed a proxy-cache artifact: the storage_key starts with
+        // `proxy-cache/`, so is_proxy_cache_key() is true and the no-prefix
+        // handle branch is taken.
+        let body: &[u8] = b"cached-fs";
+        let artifact_path = "simple/foo/foo-1.0-py3-none-any.whl";
+        let storage_key = format!("proxy-cache/{}/{}", fx.repo_key, artifact_path);
+        assert!(crate::services::proxy_service::ProxyService::is_proxy_cache_key(&storage_key));
+
+        super::put_artifact_bytes(&state, &repo_info, &storage_key, Bytes::from_static(body))
+            .await
+            .expect("seed proxy-cache payload on disk");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(fx.repo_id)
+        .bind(artifact_path)
+        .bind("foo")
+        .bind("1.0")
+        .bind(body.len() as i64)
+        .bind("test-foo")
+        .bind("application/zip")
+        .bind(&storage_key)
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed proxy-cache artifact row");
+
+        let location = repo_info.storage_location();
+        let result =
+            super::local_fetch_or_redirect(&fx.pool, &state, fx.repo_id, &location, artifact_path)
+                .await;
+
+        // Clean up before asserting so a panic still leaves the DB clean.
+        fx.teardown().await;
+
+        let resp = result.expect("filesystem proxy-cache fetch must succeed by streaming");
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "filesystem proxy-cache key must stream a 200 (no 302) on non-S3 (#1555)"
+        );
+        assert!(
+            resp.headers().get("location").is_none(),
+            "filesystem backend must NOT emit a redirect Location header (#1555)"
+        );
     }
 
     // ── #1804: per-member authorization for virtual repos ───────────────

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1545,13 +1545,20 @@ async fn pypi_proxy_cache_redirect(
     if !state.config.presigned_downloads_enabled {
         return None;
     }
+    // #1555: resolve the no-prefix presign handle and confirm redirect support
+    // BEFORE the `is_cache_fresh` probe — the probe loads the cache-meta
+    // sidecar, so we avoid a wasted S3 GET when we can't redirect anyway (the
+    // streaming fallback re-reads the same sidecar).
+    let storage = proxy.cache_storage_backend();
+    if !storage.supports_redirect() {
+        return None;
+    }
     if !proxy.is_cache_fresh(repo_key, cache_path).await {
         return None;
     }
     let cache_key =
         crate::services::proxy_service::ProxyService::cache_storage_key(repo_key, cache_path)
             .ok()?;
-    let storage = proxy.cache_storage_backend()?;
     let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
     proxy_helpers::try_proxy_cache_redirect(
         storage.as_ref(),

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1166,8 +1166,9 @@ async fn serve_file(
 
                 for member in &members {
                     // Try local storage first (works for hosted repos and
-                    // cached remote artifacts)
-                    match proxy_helpers::local_fetch_by_path_suffix(
+                    // cached remote artifacts). #1555: redirect to S3 presigned
+                    // URL instead of streaming when enabled.
+                    match proxy_helpers::local_fetch_or_redirect_by_suffix(
                         &state.db,
                         state,
                         member.id,
@@ -1176,19 +1177,8 @@ async fn serve_file(
                     )
                     .await
                     {
-                        Ok(result) => {
-                            let content_type = pypi_content_type(filename);
-                            let mut builder = Response::builder()
-                                .status(StatusCode::OK)
-                                .header(CONTENT_TYPE, content_type)
-                                .header(
-                                    "Content-Disposition",
-                                    format!("attachment; filename=\"{}\"", filename),
-                                );
-                            if let Some(size) = result.content_length {
-                                builder = builder.header(CONTENT_LENGTH, size.to_string());
-                            }
-                            return Ok(builder.body(Body::from_stream(result.body)).unwrap());
+                        Ok(response) => {
+                            return Ok(response);
                         }
                         Err(e) => {
                             debug!(
@@ -1222,8 +1212,14 @@ async fn serve_file(
                             let normalized = PypiHandler::normalize_name(project);
                             let local_cache_path = format!("simple/{}/{}", normalized, filename);
 
-                            if let Some(result) = proxy_helpers::proxy_check_cache_streaming(
+                            // #1555: proxy_fetch_or_redirect handles presigned redirect
+                            // on a cache hit (or streaming if presigning is unavailable)
+                            // in a single freshness check. Falls through to the PyPI-specific
+                            // upstream fetch on a cache miss (proxy_fetch uses the generic
+                            // path which can't resolve PyPI CDN URLs).
+                            if let Ok(resp) = proxy_helpers::proxy_fetch_or_redirect(
                                 proxy,
+                                state,
                                 member.id,
                                 &member.key,
                                 upstream_url,
@@ -1231,7 +1227,7 @@ async fn serve_file(
                             )
                             .await
                             {
-                                return Ok(build_streaming_file_response(filename, result));
+                                return Ok(resp);
                             }
 
                             match fetch_from_pypi_remote_streaming(

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1101,6 +1101,14 @@ async fn serve_file(
                     let normalized = PypiHandler::normalize_name(project);
                     let local_cache_path = format!("simple/{}/{}", normalized, filename);
 
+                    // #1555: redirect to a presigned URL on a fresh cache hit
+                    // before falling back to streaming.
+                    if let Some(redirect) =
+                        pypi_proxy_cache_redirect(state, proxy, repo_key, &local_cache_path).await
+                    {
+                        return Ok(redirect);
+                    }
+
                     if let Some(result) = proxy_helpers::proxy_check_cache_streaming(
                         proxy,
                         repo.id,
@@ -1211,6 +1219,19 @@ async fn serve_file(
                             // cached from a previous request through this member.
                             let normalized = PypiHandler::normalize_name(project);
                             let local_cache_path = format!("simple/{}/{}", normalized, filename);
+
+                            // #1555: redirect to a presigned URL on a fresh
+                            // cache hit before falling back to streaming.
+                            if let Some(redirect) = pypi_proxy_cache_redirect(
+                                state,
+                                proxy,
+                                &member.key,
+                                &local_cache_path,
+                            )
+                            .await
+                            {
+                                return Ok(redirect);
+                            }
 
                             if let Some(result) = proxy_helpers::proxy_check_cache_streaming(
                                 proxy,
@@ -1506,6 +1527,40 @@ async fn fetch_from_pypi_remote(
     .await?;
 
     Ok(content)
+}
+
+/// #1555: presigned-redirect fast path for a fresh proxy-cache hit on a remote
+/// PyPI member. Returns `Some(307 redirect)` only when presigned downloads are
+/// enabled and the cache is fresh, signing the cache key through the proxy's own
+/// no-prefix backend (proxy-cache content lives at the storage root). Returns
+/// `None` on a miss/disabled so the caller falls back to the streaming path,
+/// which resolves the real upstream URL via the simple index — never via a
+/// presumed download URL.
+async fn pypi_proxy_cache_redirect(
+    state: &SharedState,
+    proxy: &crate::services::proxy_service::ProxyService,
+    repo_key: &str,
+    cache_path: &str,
+) -> Option<Response> {
+    if !state.config.presigned_downloads_enabled {
+        return None;
+    }
+    if !proxy.is_cache_fresh(repo_key, cache_path).await {
+        return None;
+    }
+    let cache_key =
+        crate::services::proxy_service::ProxyService::cache_storage_key(repo_key, cache_path)
+            .ok()?;
+    let storage = proxy.cache_storage_backend()?;
+    let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
+    proxy_helpers::try_proxy_cache_redirect(
+        storage.as_ref(),
+        &cache_key,
+        /* presigned_enabled = */ true,
+        expiry,
+        /* cache_is_fresh = */ true,
+    )
+    .await
 }
 
 /// Streaming sibling of [`fetch_from_pypi_remote`] (#895 OOM relief).
@@ -5123,6 +5178,62 @@ mod tests {
         }
         let _ = std::fs::remove_dir_all(&tmp);
         assert_eq!(body_bytes, wheel_body);
+    }
+
+    #[test]
+    fn test_serve_file_presign_redirect_precedes_streaming_1555() {
+        // #1555: on a fresh proxy-cache hit, the PyPI remote download path must
+        // attempt a presigned redirect (via the proxy's no-prefix handle)
+        // BEFORE falling back to `proxy_check_cache_streaming` / streaming, so
+        // large wheels are not streamed through the backend. The streaming
+        // fallback (#1215 OOM relief) must still be present for cache misses.
+        let src = include_str!("pypi.rs");
+        let fn_start = src
+            .find("async fn serve_file(")
+            .expect("serve_file must exist");
+        let next = src[fn_start + 1..]
+            .find("\nasync fn ")
+            .map(|p| fn_start + 1 + p)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..next];
+
+        let redirect_pos = body
+            .find("pypi_proxy_cache_redirect(")
+            .expect("serve_file MUST attempt pypi_proxy_cache_redirect (#1555)");
+        let stream_pos = body
+            .find("proxy_check_cache_streaming(")
+            .expect("serve_file MUST retain the streaming fallback (#1215)");
+        assert!(
+            redirect_pos < stream_pos,
+            "the presigned redirect attempt (#1555) MUST come BEFORE the \
+             streaming cache check (#1215).",
+        );
+        assert!(
+            body.contains("fetch_from_pypi_remote_streaming("),
+            "serve_file MUST resolve the real upstream URL via \
+             fetch_from_pypi_remote_streaming on a miss, never via a presumed \
+             download URL (#1555).",
+        );
+    }
+
+    #[test]
+    fn test_pypi_proxy_cache_redirect_uses_no_prefix_handle_1555() {
+        // The presign helper must sign through the proxy's no-prefix backend.
+        let src = include_str!("pypi.rs");
+        let fn_start = src
+            .find("async fn pypi_proxy_cache_redirect(")
+            .expect("pypi_proxy_cache_redirect must exist");
+        let window_end = (fn_start + 1500).min(src.len());
+        let window = &src[fn_start..window_end];
+        assert!(
+            window.contains("cache_storage_backend("),
+            "pypi_proxy_cache_redirect MUST sign via cache_storage_backend() \
+             (no-prefix handle), not a prefixed repo handle (#1555).",
+        );
+        assert!(
+            window.contains("is_cache_fresh("),
+            "pypi_proxy_cache_redirect MUST gate on is_cache_fresh (#1555).",
+        );
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1212,14 +1212,8 @@ async fn serve_file(
                             let normalized = PypiHandler::normalize_name(project);
                             let local_cache_path = format!("simple/{}/{}", normalized, filename);
 
-                            // #1555: proxy_fetch_or_redirect handles presigned redirect
-                            // on a cache hit (or streaming if presigning is unavailable)
-                            // in a single freshness check. Falls through to the PyPI-specific
-                            // upstream fetch on a cache miss (proxy_fetch uses the generic
-                            // path which can't resolve PyPI CDN URLs).
-                            if let Ok(resp) = proxy_helpers::proxy_fetch_or_redirect(
+                            if let Some(result) = proxy_helpers::proxy_check_cache_streaming(
                                 proxy,
-                                state,
                                 member.id,
                                 &member.key,
                                 upstream_url,
@@ -1227,7 +1221,7 @@ async fn serve_file(
                             )
                             .await
                             {
-                                return Ok(resp);
+                                return Ok(build_streaming_file_response(filename, result));
                             }
 
                             match fetch_from_pypi_remote_streaming(

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -5243,6 +5243,64 @@ mod tests {
         );
     }
 
+    // Behavioral coverage for `pypi_proxy_cache_redirect` (#1555). The two
+    // short-circuit guards both return BEFORE any DB access, so these run
+    // DB-free on a lazy pool: (1) presigned disabled, and (2) a filesystem
+    // proxy backend that does not support redirects — both must yield None so
+    // `serve_file` falls through to the streaming path on the rig / non-S3.
+    #[tokio::test]
+    async fn test_pypi_proxy_cache_redirect_none_when_presigned_disabled() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let pool = tdh::lazy_pool();
+        let storage_path = std::env::temp_dir()
+            .join(format!("pypi-presign-off-{}", uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), &storage_path);
+        // Default config: presigned_downloads_enabled = false.
+        let state = tdh::build_state_with_proxy(pool.clone(), &storage_path, proxy.clone());
+
+        let result = super::pypi_proxy_cache_redirect(
+            &state,
+            proxy.as_ref(),
+            "pypi-remote",
+            "simple/foo/foo-1.0-py3-none-any.whl",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "presigned disabled must short-circuit before any redirect"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pypi_proxy_cache_redirect_none_when_backend_no_redirect_support() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let pool = tdh::lazy_pool();
+        let storage_path = std::env::temp_dir()
+            .join(format!("pypi-presign-fs-{}", uuid::Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), &storage_path);
+        // Presigned ENABLED, but the filesystem proxy backend reports
+        // supports_redirect() == false, so the helper must still return None
+        // without touching the DB (the is_cache_fresh probe is never reached).
+        let state =
+            tdh::build_state_with_proxy_presigned(pool.clone(), &storage_path, proxy.clone());
+
+        let result = super::pypi_proxy_cache_redirect(
+            &state,
+            proxy.as_ref(),
+            "pypi-remote",
+            "simple/foo/foo-1.0-py3-none-any.whl",
+        )
+        .await;
+        assert!(
+            result.is_none(),
+            "filesystem (non-redirect) backend must yield None → stream fallback (#1555)"
+        );
+    }
+
     #[tokio::test]
     async fn test_build_streaming_file_response_headers() {
         use futures::stream;

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -496,3 +496,26 @@ pub fn build_state_with_proxy(
     state.set_proxy_service(proxy);
     Arc::new(state)
 }
+
+/// Like [`build_state_with_proxy`] but with `presigned_downloads_enabled = true`
+/// so tests can drive the presigned-redirect gate (#1555). The filesystem
+/// backend still reports `supports_redirect() == false`, so the redirect path
+/// short-circuits to streaming — exactly the non-S3 fallback we want to cover.
+pub fn build_state_with_proxy_presigned(
+    pool: PgPool,
+    storage_path: &str,
+    proxy: Arc<crate::services::proxy_service::ProxyService>,
+) -> crate::api::SharedState {
+    let storage: Arc<dyn crate::storage::StorageBackend> = Arc::new(
+        crate::storage::filesystem::FilesystemStorage::new(storage_path),
+    );
+    let registry = Arc::new(crate::storage::StorageRegistry::new(
+        std::collections::HashMap::new(),
+        "filesystem".to_string(),
+    ));
+    let mut config = cfg(storage_path);
+    config.presigned_downloads_enabled = true;
+    let mut state = crate::api::AppState::new(config, pool, storage, registry);
+    state.set_proxy_service(proxy);
+    Arc::new(state)
+}

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2022,6 +2022,19 @@ impl ProxyService {
     /// If the HEAD itself errors (transport failure mid-revalidation), we
     /// treat the cache as not-fresh and fall through to the slow path
     /// rather than silently serving a possibly-stale URL.
+    /// Storage backend handle that owns the proxy cache objects.
+    ///
+    /// Proxy-cache content lives at the storage root (`proxy-cache/<repo>/...`)
+    /// with no configured key prefix. Presigning a cache key MUST go through
+    /// this handle — the same one `is_cache_fresh` and the cache reads/writes
+    /// use — so the signed key matches where the object actually lives. Signing
+    /// via a prefixed handle yields a key the object store has no object for.
+    pub fn cache_storage_backend(
+        &self,
+    ) -> Option<std::sync::Arc<dyn crate::storage::StorageBackend>> {
+        self.storage.presign_backend()
+    }
+
     pub async fn is_cache_fresh(&self, repo_key: &str, path: &str) -> bool {
         // A path that fails validation cannot have produced a cache entry
         // we'd want to redirect to anyway: treat it as a miss so the caller
@@ -3139,6 +3152,16 @@ impl ProxyService {
     /// target from drifting out of sync (#1018).
     pub(crate) fn cache_storage_key(repo_key: &str, path: &str) -> Result<String> {
         CacheKeys::derive(repo_key, path).map(|k| k.content)
+    }
+
+    /// Whether `storage_key` addresses proxy-cache content.
+    ///
+    /// Proxy-cache keys are `proxy-cache/<repo_key>/<path>/__content__` and live
+    /// at the storage root (no global key prefix), unlike hosted artifacts. The
+    /// distinction matters when presigning: cache keys must be signed through
+    /// the no-prefix [`Self::cache_storage_backend`] handle (#1555).
+    pub fn is_proxy_cache_key(storage_key: &str) -> bool {
+        storage_key.starts_with("proxy-cache/")
     }
 
     /// Generate storage key for cache metadata

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2029,10 +2029,10 @@ impl ProxyService {
     /// this handle — the same one `is_cache_fresh` and the cache reads/writes
     /// use — so the signed key matches where the object actually lives. Signing
     /// via a prefixed handle yields a key the object store has no object for.
-    pub fn cache_storage_backend(
+    pub(crate) fn cache_storage_backend(
         &self,
-    ) -> Option<std::sync::Arc<dyn crate::storage::StorageBackend>> {
-        self.storage.presign_backend()
+    ) -> std::sync::Arc<dyn crate::services::storage_service::StorageBackend> {
+        self.storage.backend()
     }
 
     pub async fn is_cache_fresh(&self, repo_key: &str, path: &str) -> bool {

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -3872,6 +3872,48 @@ mod tests {
         assert!(parse_http_date("").is_none());
     }
 
+    // -----------------------------------------------------------------------
+    // #1555 proxy-cache key discrimination
+    //
+    // `is_proxy_cache_key` decides whether a storage key must be presigned
+    // through the no-prefix proxy backend (`cache_storage_backend`) instead of
+    // the prefixed repo handle. Hosted/content-addressed artifacts MUST keep
+    // the prefixed handle, so the predicate must match ONLY the
+    // `proxy-cache/` layout — getting this wrong reintroduces the prefix bug
+    // (signing a key the object store has no object for) or, worse, routes
+    // hosted artifacts through the wrong handle.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_is_proxy_cache_key_matches_proxy_cache_layout() {
+        assert!(ProxyService::is_proxy_cache_key(
+            "proxy-cache/pypi-remote/pkg/pkg-1.0.0-py3-none-any.whl/__content__"
+        ));
+        assert!(ProxyService::is_proxy_cache_key(
+            "proxy-cache/repo/p/__content__"
+        ));
+        // Bare prefix (defensive): still classified as proxy-cache.
+        assert!(ProxyService::is_proxy_cache_key("proxy-cache/"));
+    }
+
+    #[test]
+    fn test_is_proxy_cache_key_rejects_hosted_and_prefixed_keys() {
+        // Content-addressed hosted artifact under the global prefix — must NOT
+        // be treated as proxy-cache (keeps the prefixed repo handle).
+        assert!(!ProxyService::is_proxy_cache_key(
+            "artifact-keeper/cas/ab/cdef0123456789"
+        ));
+        // A prefixed key that merely *contains* `proxy-cache/` later in the
+        // path must not match: the cache layout is always at the root.
+        assert!(!ProxyService::is_proxy_cache_key(
+            "artifact-keeper/proxy-cache/repo/pkg/__content__"
+        ));
+        assert!(!ProxyService::is_proxy_cache_key("cas/deadbeef"));
+        assert!(!ProxyService::is_proxy_cache_key(""));
+        // Substring, not a path segment prefix — must not match.
+        assert!(!ProxyService::is_proxy_cache_key("not-proxy-cache/x"));
+    }
+
     #[test]
     fn test_legacy_sidecar_without_quarantine_deserializes_to_none() {
         // A sidecar written before the quarantine field existed (and before

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -54,6 +54,27 @@ pub trait StorageBackend: Send + Sync {
     /// Delete content by key
     async fn delete(&self, key: &str) -> Result<()>;
 
+    /// Whether this backend can issue presigned download URLs. Default `false`
+    /// so filesystem and test backends opt out. The S3/GCS wrappers forward
+    /// to the inner backend, making presign capability type-enforced on the
+    /// single backend handle (#1555) instead of a side-channel field.
+    fn supports_redirect(&self) -> bool {
+        false
+    }
+
+    /// Get a presigned URL for direct download, or `Ok(None)` when the backend
+    /// does not support presigning. Default returns `None`; the S3/GCS wrappers
+    /// forward to the inner backend. Proxy-cache presigns go through this so the
+    /// signed key matches the no-prefix cache layout (#1555).
+    async fn get_presigned_url(
+        &self,
+        key: &str,
+        expires_in: std::time::Duration,
+    ) -> Result<Option<crate::storage::PresignedUrl>> {
+        let _ = (key, expires_in);
+        Ok(None)
+    }
+
     /// List keys with optional prefix
     async fn list(&self, prefix: Option<&str>) -> Result<Vec<String>>;
 
@@ -347,8 +368,10 @@ impl StorageBackend for FilesystemBackend {
 
 /// Generate a StorageBackend wrapper that delegates to an inner backend.
 ///
-/// Both the `crate::storage::StorageBackend` trait (put/get/exists/delete) and
-/// the extended methods (list/copy/size) are forwarded to the inner type.
+/// Forwards the core `crate::storage::StorageBackend` methods
+/// (put/get/exists/delete), the extended methods (list/copy/size), and the
+/// presign capability (supports_redirect/get_presigned_url, #1555) to the
+/// inner type — so the facade handle is presign-capable when the inner is.
 macro_rules! impl_storage_wrapper {
     ($wrapper:ident, $inner_ty:ty) => {
         #[async_trait]
@@ -367,6 +390,23 @@ macro_rules! impl_storage_wrapper {
             }
             async fn delete(&self, key: &str) -> Result<()> {
                 crate::storage::StorageBackend::delete(self.inner.as_ref(), key).await
+            }
+            // Presign capability forwarded from the inner backend (#1555) so a
+            // single facade handle carries it — no parallel side-channel field.
+            fn supports_redirect(&self) -> bool {
+                crate::storage::StorageBackend::supports_redirect(self.inner.as_ref())
+            }
+            async fn get_presigned_url(
+                &self,
+                key: &str,
+                expires_in: std::time::Duration,
+            ) -> Result<Option<crate::storage::PresignedUrl>> {
+                crate::storage::StorageBackend::get_presigned_url(
+                    self.inner.as_ref(),
+                    key,
+                    expires_in,
+                )
+                .await
             }
             async fn list(&self, prefix: Option<&str>) -> Result<Vec<String>> {
                 self.inner.list(prefix).await
@@ -404,9 +444,10 @@ macro_rules! impl_storage_wrapper {
 
 /// S3 storage backend (wrapper for integration with StorageService).
 ///
-/// Holds the inner backend behind an `Arc` so the same no-prefix object can
-/// also be handed out as a presign-capable `crate::storage::StorageBackend`
-/// (see `StorageService::presign_backend`).
+/// Forwards the facade `StorageBackend` trait — including `supports_redirect`
+/// and `get_presigned_url` — to the inner S3 backend, so the single facade
+/// handle carries presign capability (built with `prefix = None` for the
+/// proxy cache; #1555).
 pub struct S3BackendWrapper {
     inner: Arc<crate::storage::s3::S3Backend>,
 }
@@ -426,53 +467,54 @@ impl_storage_wrapper!(GcsBackendWrapper, crate::storage::gcs::GcsBackend);
 
 /// Storage service facade
 pub struct StorageService {
-    backend: Arc<dyn StorageBackend>,
-    /// Presign-capable view of the same underlying object store, when the
-    /// backend supports it (S3/GCS). `None` for filesystem and test backends.
+    /// Single backend handle. Presign capability is type-enforced on this
+    /// facade trait (`supports_redirect` / `get_presigned_url`), forwarded by
+    /// `impl_storage_wrapper!` from the inner S3/GCS backend (#1555). No
+    /// parallel side-channel field, so no call site can silently get a
+    /// non-presigning handle.
     ///
-    /// This is the concrete `crate::storage::StorageBackend` (the trait that
-    /// carries `get_presigned_url`), not the facade trait above. Proxy-cache
-    /// presigns must use THIS handle so the signed key matches the no-prefix
-    /// layout the proxy cache writes (#1555).
-    presign_backend: Option<Arc<dyn crate::storage::StorageBackend>>,
+    /// For S3 the inner backend is built with `prefix = None` so the signed
+    /// key matches the no-prefix layout the proxy cache writes.
+    backend: Arc<dyn StorageBackend>,
 }
 
 impl StorageService {
     /// Create storage service from config
     pub async fn from_config(config: &Config) -> Result<Self> {
-        let (backend, presign_backend): (
-            Arc<dyn StorageBackend>,
-            Option<Arc<dyn crate::storage::StorageBackend>>,
-        ) = match config.storage_backend.as_str() {
+        let backend: Arc<dyn StorageBackend> = match config.storage_backend.as_str() {
             "filesystem" => {
                 let path = PathBuf::from(&config.storage_path);
                 fs::create_dir_all(&path).await?;
-                (Arc::new(FilesystemBackend::new(path)), None)
+                Arc::new(FilesystemBackend::new(path))
             }
             "s3" => {
-                let s3_config = crate::storage::s3::S3Config::new(
-                    config.s3_bucket.clone().unwrap_or_default(),
-                    config
-                        .s3_region
-                        .clone()
-                        .unwrap_or_else(|| "us-east-1".to_string()),
-                    config.s3_endpoint.clone(),
-                    None, // No prefix: proxy-cache content lives at the bucket root.
-                );
+                // Build the proxy-cache S3 backend from the SAME env-derived
+                // config the primary storage uses (redirect_downloads, presign
+                // creds, CloudFront, path_format, TLS, pool tuning), then force
+                // the key prefix to None. Proxy-cache content lives at the
+                // bucket root (`proxy-cache/...`), not under S3_PREFIX, so the
+                // signed key must carry no prefix. Reusing from_env() (instead
+                // of S3Config::new, which hardcodes redirect_downloads=false and
+                // no presign creds) is what makes presigning actually fire on
+                // this handle (#1555).
+                let mut s3_config = crate::storage::s3::S3Config::from_env()?;
+                s3_config.prefix = None;
                 let inner = Arc::new(crate::storage::s3::S3Backend::new(s3_config).await?);
-                let wrapper = Arc::new(S3BackendWrapper {
-                    inner: Arc::clone(&inner),
-                });
-                (wrapper, Some(inner))
+                Arc::new(S3BackendWrapper { inner })
             }
             "gcs" => {
                 let gcs_config = crate::storage::gcs::GcsConfig::from_env()?;
                 let inner = Arc::new(crate::storage::gcs::GcsBackend::new(gcs_config).await?);
-                let wrapper = Arc::new(GcsBackendWrapper {
-                    inner: Arc::clone(&inner),
-                });
-                (wrapper, Some(inner))
+                Arc::new(GcsBackendWrapper { inner })
             }
+            // TODO(#1555): Azure has no arm here. main.rs builds an Azure
+            // primary backend, but this facade has no AzureBackendWrapper
+            // (the `impl_storage_wrapper!` macro forwards inherent
+            // list/copy/size, which AzureBackend does not yet expose). An
+            // Azure deployment therefore errors loudly below rather than
+            // silently losing presign capability. Wire up a wrapper +
+            // no-prefix presign handle (mirroring the s3/gcs arms) before
+            // enabling Azure for the proxy cache.
             other => {
                 return Err(AppError::Config(format!(
                     "Unknown storage backend: {}",
@@ -481,24 +523,12 @@ impl StorageService {
             }
         };
 
-        Ok(Self {
-            backend,
-            presign_backend,
-        })
+        Ok(Self { backend })
     }
 
     /// Create with a specific backend (for testing)
     pub fn new(backend: Arc<dyn StorageBackend>) -> Self {
-        Self {
-            backend,
-            presign_backend: None,
-        }
-    }
-
-    /// Presign-capable handle for the underlying object store, or `None` when
-    /// the backend cannot issue presigned URLs (filesystem / test backends).
-    pub fn presign_backend(&self) -> Option<Arc<dyn crate::storage::StorageBackend>> {
-        self.presign_backend.clone()
+        Self { backend }
     }
 
     /// Calculate SHA-256 hash of content

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -354,19 +354,19 @@ macro_rules! impl_storage_wrapper {
         #[async_trait]
         impl StorageBackend for $wrapper {
             async fn put(&self, key: &str, content: Bytes) -> Result<()> {
-                crate::storage::StorageBackend::put(&self.inner, key, content).await
+                crate::storage::StorageBackend::put(self.inner.as_ref(), key, content).await
             }
             async fn get(&self, key: &str) -> Result<Bytes> {
-                crate::storage::StorageBackend::get(&self.inner, key).await
+                crate::storage::StorageBackend::get(self.inner.as_ref(), key).await
             }
             async fn exists(&self, key: &str) -> Result<bool> {
-                crate::storage::StorageBackend::exists(&self.inner, key).await
+                crate::storage::StorageBackend::exists(self.inner.as_ref(), key).await
             }
             async fn head_etag(&self, key: &str) -> Result<Option<String>> {
-                crate::storage::StorageBackend::head_etag(&self.inner, key).await
+                crate::storage::StorageBackend::head_etag(self.inner.as_ref(), key).await
             }
             async fn delete(&self, key: &str) -> Result<()> {
-                crate::storage::StorageBackend::delete(&self.inner, key).await
+                crate::storage::StorageBackend::delete(self.inner.as_ref(), key).await
             }
             async fn list(&self, prefix: Option<&str>) -> Result<Vec<String>> {
                 self.inner.list(prefix).await
@@ -381,7 +381,7 @@ macro_rules! impl_storage_wrapper {
             // streaming impls so we pick up S3 ranged GETs, GCS chunked
             // reads, etc., without buffering through this wrapper.
             async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
-                crate::storage::StorageBackend::get_stream(&self.inner, key).await
+                crate::storage::StorageBackend::get_stream(self.inner.as_ref(), key).await
             }
             async fn put_stream(
                 &self,
@@ -389,7 +389,8 @@ macro_rules! impl_storage_wrapper {
                 stream: BoxStream<'static, Result<Bytes>>,
             ) -> Result<PutStreamResult> {
                 let inner_result =
-                    crate::storage::StorageBackend::put_stream(&self.inner, key, stream).await?;
+                    crate::storage::StorageBackend::put_stream(self.inner.as_ref(), key, stream)
+                        .await?;
                 // The two PutStreamResult types are structurally identical
                 // (sha256 hex + byte count); translate at the boundary.
                 Ok(PutStreamResult {
@@ -401,25 +402,13 @@ macro_rules! impl_storage_wrapper {
     };
 }
 
-/// S3 storage backend (wrapper for integration with StorageService)
+/// S3 storage backend (wrapper for integration with StorageService).
+///
+/// Holds the inner backend behind an `Arc` so the same no-prefix object can
+/// also be handed out as a presign-capable `crate::storage::StorageBackend`
+/// (see `StorageService::presign_backend`).
 pub struct S3BackendWrapper {
-    inner: crate::storage::s3::S3Backend,
-}
-
-impl S3BackendWrapper {
-    pub async fn from_config(config: &Config) -> crate::error::Result<Self> {
-        let s3_config = crate::storage::s3::S3Config::new(
-            config.s3_bucket.clone().unwrap_or_default(),
-            config
-                .s3_region
-                .clone()
-                .unwrap_or_else(|| "us-east-1".to_string()),
-            config.s3_endpoint.clone(),
-            None, // No prefix by default
-        );
-        let inner = crate::storage::s3::S3Backend::new(s3_config).await?;
-        Ok(Self { inner })
-    }
+    inner: Arc<crate::storage::s3::S3Backend>,
 }
 
 impl_storage_wrapper!(S3BackendWrapper, crate::storage::s3::S3Backend);
@@ -430,15 +419,7 @@ impl_storage_wrapper!(S3BackendWrapper, crate::storage::s3::S3Backend);
 /// `crate::storage` trait and the extra `list`/`copy`/`size` methods to
 /// `GcsBackend`'s inherent methods.
 pub struct GcsBackendWrapper {
-    inner: crate::storage::gcs::GcsBackend,
-}
-
-impl GcsBackendWrapper {
-    pub async fn from_config(_config: &Config) -> crate::error::Result<Self> {
-        let gcs_config = crate::storage::gcs::GcsConfig::from_env()?;
-        let inner = crate::storage::gcs::GcsBackend::new(gcs_config).await?;
-        Ok(Self { inner })
-    }
+    inner: Arc<crate::storage::gcs::GcsBackend>,
 }
 
 impl_storage_wrapper!(GcsBackendWrapper, crate::storage::gcs::GcsBackend);
@@ -446,24 +427,51 @@ impl_storage_wrapper!(GcsBackendWrapper, crate::storage::gcs::GcsBackend);
 /// Storage service facade
 pub struct StorageService {
     backend: Arc<dyn StorageBackend>,
+    /// Presign-capable view of the same underlying object store, when the
+    /// backend supports it (S3/GCS). `None` for filesystem and test backends.
+    ///
+    /// This is the concrete `crate::storage::StorageBackend` (the trait that
+    /// carries `get_presigned_url`), not the facade trait above. Proxy-cache
+    /// presigns must use THIS handle so the signed key matches the no-prefix
+    /// layout the proxy cache writes (#1555).
+    presign_backend: Option<Arc<dyn crate::storage::StorageBackend>>,
 }
 
 impl StorageService {
     /// Create storage service from config
     pub async fn from_config(config: &Config) -> Result<Self> {
-        let backend: Arc<dyn StorageBackend> = match config.storage_backend.as_str() {
+        let (backend, presign_backend): (
+            Arc<dyn StorageBackend>,
+            Option<Arc<dyn crate::storage::StorageBackend>>,
+        ) = match config.storage_backend.as_str() {
             "filesystem" => {
                 let path = PathBuf::from(&config.storage_path);
                 fs::create_dir_all(&path).await?;
-                Arc::new(FilesystemBackend::new(path))
+                (Arc::new(FilesystemBackend::new(path)), None)
             }
             "s3" => {
-                let s3_backend = S3BackendWrapper::from_config(config).await?;
-                Arc::new(s3_backend)
+                let s3_config = crate::storage::s3::S3Config::new(
+                    config.s3_bucket.clone().unwrap_or_default(),
+                    config
+                        .s3_region
+                        .clone()
+                        .unwrap_or_else(|| "us-east-1".to_string()),
+                    config.s3_endpoint.clone(),
+                    None, // No prefix: proxy-cache content lives at the bucket root.
+                );
+                let inner = Arc::new(crate::storage::s3::S3Backend::new(s3_config).await?);
+                let wrapper = Arc::new(S3BackendWrapper {
+                    inner: Arc::clone(&inner),
+                });
+                (wrapper, Some(inner))
             }
             "gcs" => {
-                let wrapper = GcsBackendWrapper::from_config(config).await?;
-                Arc::new(wrapper)
+                let gcs_config = crate::storage::gcs::GcsConfig::from_env()?;
+                let inner = Arc::new(crate::storage::gcs::GcsBackend::new(gcs_config).await?);
+                let wrapper = Arc::new(GcsBackendWrapper {
+                    inner: Arc::clone(&inner),
+                });
+                (wrapper, Some(inner))
             }
             other => {
                 return Err(AppError::Config(format!(
@@ -473,12 +481,24 @@ impl StorageService {
             }
         };
 
-        Ok(Self { backend })
+        Ok(Self {
+            backend,
+            presign_backend,
+        })
     }
 
     /// Create with a specific backend (for testing)
     pub fn new(backend: Arc<dyn StorageBackend>) -> Self {
-        Self { backend }
+        Self {
+            backend,
+            presign_backend: None,
+        }
+    }
+
+    /// Presign-capable handle for the underlying object store, or `None` when
+    /// the backend cannot issue presigned URLs (filesystem / test backends).
+    pub fn presign_backend(&self) -> Option<Arc<dyn crate::storage::StorageBackend>> {
+        self.presign_backend.clone()
     }
 
     /// Calculate SHA-256 hash of content
@@ -1004,15 +1024,21 @@ mod tests {
         std::env::remove_var("GCS_PROJECT_ID");
         std::env::remove_var("GCS_SERVICE_ACCOUNT_EMAIL");
 
-        let config = minimal_config("gcs");
-        let result = GcsBackendWrapper::from_config(&config).await;
+        let gcs_config = crate::storage::gcs::GcsConfig::from_env();
+        let result = match gcs_config {
+            Ok(cfg) => crate::storage::gcs::GcsBackend::new(cfg).await,
+            Err(e) => Err(e),
+        };
         std::env::remove_var("GCS_BUCKET");
 
         assert!(
             result.is_ok(),
-            "GcsBackendWrapper should construct without error in ADC mode"
+            "GcsBackend should construct without error in ADC mode"
         );
-        let wrapper = result.unwrap();
+        let inner = Arc::new(result.unwrap());
+        let wrapper = GcsBackendWrapper {
+            inner: Arc::clone(&inner),
+        };
         assert_eq!(wrapper.inner.bucket(), "wrapper-test-bucket");
     }
 

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -1148,6 +1148,68 @@ mod tests {
         assert!(result.is_none());
     }
 
+    // ── facade-trait presign defaults (#1555) ──────────────────────────────
+    // The redirect fast path is gated on the FACADE trait
+    // (`storage_service::StorageBackend`) methods, not the inner
+    // `crate::storage::StorageBackend`. The facade `FilesystemBackend` does
+    // NOT override `supports_redirect`/`get_presigned_url`, so it inherits the
+    // `false`/`None` defaults — which is exactly what makes a filesystem (or
+    // any non-presigning) deployment fall through to streaming instead of
+    // emitting a 302. These tests pin that default on the facade handle.
+
+    #[test]
+    fn test_facade_filesystem_does_not_support_redirect() {
+        let backend = FilesystemBackend::new(std::path::PathBuf::from("/tmp/test-artifacts"));
+        // Through the FACADE trait specifically (the one the redirect path uses).
+        assert!(
+            !StorageBackend::supports_redirect(&backend),
+            "filesystem facade must report no redirect support so the proxy \
+             cache path falls through to streaming (#1555)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_facade_filesystem_presigned_url_returns_none() {
+        let backend = FilesystemBackend::new(std::path::PathBuf::from("/tmp/test-artifacts"));
+        let result = StorageBackend::get_presigned_url(
+            &backend,
+            "proxy-cache/repo/pkg/__content__",
+            std::time::Duration::from_secs(300),
+        )
+        .await
+        .unwrap();
+        assert!(
+            result.is_none(),
+            "filesystem facade must never presign — forces the streaming fallback (#1555)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_storage_service_backend_handle_is_non_presigning_on_filesystem() {
+        // `cache_storage_backend()` returns `StorageService::backend()`. On a
+        // filesystem-backed service that handle must report no redirect support
+        // and yield no presigned URL, so `try_proxy_cache_redirect` returns
+        // None and the caller streams. This is the core non-regression
+        // guarantee for non-S3 deployments (the rig) (#1555).
+        let (storage, _temp) = create_test_storage();
+        let handle = storage.backend();
+        assert!(
+            !handle.supports_redirect(),
+            "filesystem StorageService backend handle must not support redirect"
+        );
+        let presigned = handle
+            .get_presigned_url(
+                "proxy-cache/repo/pkg/__content__",
+                std::time::Duration::from_secs(300),
+            )
+            .await
+            .unwrap();
+        assert!(
+            presigned.is_none(),
+            "filesystem StorageService backend handle must not presign"
+        );
+    }
+
     #[test]
     fn test_mock_presigned_inner_supports_redirect() {
         let backend = MockPresignedInner;

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -3836,4 +3836,64 @@ mod integration_tests {
             .expect("Failed to delete test file");
         println!("Test complete");
     }
+
+    /// #1555 live: the proxy-cache handle (env-derived config with prefix
+    /// forced to None, as `StorageService::from_config` builds it) must put,
+    /// presign, and serve a `proxy-cache/...` key at the bucket root with NO
+    /// `S3_PREFIX`. Run with:
+    ///   AK_S3_E2E=1 S3_BUCKET=<test> S3_REGION=us-east-1 S3_REDIRECT_DOWNLOADS=true \
+    ///   cargo test -p artifact-keeper-backend test_proxy_cache_presign_no_prefix_live_1555 -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore]
+    async fn test_proxy_cache_presign_no_prefix_live_1555() {
+        if std::env::var("AK_S3_E2E").ok().as_deref() != Some("1") {
+            println!("Skipping: set AK_S3_E2E=1 to run");
+            return;
+        }
+
+        // Mirror from_config's proxy-cache handle: env-derived config, prefix=None.
+        let mut config = S3Config::from_env().expect("S3Config::from_env");
+        config.prefix = None;
+        let backend = S3Backend::new(config).await.expect("S3Backend::new");
+
+        assert!(
+            StorageBackendTrait::supports_redirect(&backend),
+            "S3_REDIRECT_DOWNLOADS must be true for this test"
+        );
+
+        let key = "proxy-cache/pypi-remote/simple/foo/foo-1.0-py3-none-any.whl/__content__";
+        let body = Bytes::from_static(b"hello-presign-1555");
+        StorageBackendTrait::put(&backend, key, body.clone())
+            .await
+            .expect("put no-prefix proxy-cache object");
+
+        let pre = StorageBackendTrait::get_presigned_url(&backend, key, Duration::from_secs(300))
+            .await
+            .expect("get_presigned_url ok")
+            .expect("presigned URL present");
+        println!("presigned url: {}", pre.url);
+
+        assert!(
+            pre.url.contains("/proxy-cache/pypi-remote/simple/foo/"),
+            "URL must carry the verbatim no-prefix key: {}",
+            pre.url
+        );
+        assert!(
+            !pre.url.contains("artifact-keeper"),
+            "URL must NOT carry a global prefix (#1555): {}",
+            pre.url
+        );
+
+        let resp = reqwest::get(&pre.url).await.expect("GET presigned URL");
+        assert_eq!(
+            resp.status().as_u16(),
+            200,
+            "S3 must serve AK's presigned no-prefix URL"
+        );
+        let got = resp.bytes().await.expect("body");
+        assert_eq!(&got[..], &body[..], "served bytes must match");
+
+        let _ = StorageBackendTrait::delete(&backend, key).await;
+        println!("#1555 no-prefix presign live test OK");
+    }
 }


### PR DESCRIPTION
## Problem
Virtual-repo proxy downloads stream the full artifact body through the backend instead of redirecting to object storage. For large artifacts (multi-hundred-MB to multi-GB, e.g. ML wheels), streaming holds a worker for the entire transfer; under concurrent load the dispatcher saturates and downloads start returning 502.

## Issues found and addressed
1. **Streaming large bodies -> 502 under burst** (the original report). Fresh proxy-cache hits should redirect to a presigned object-storage URL instead of streaming.

2. **Presign signed the wrong key when a storage key prefix is configured.** Proxy-cache content is written and read through the proxy's `StorageService`, which `StorageService::from_config` builds with no key prefix, so cached objects live at `proxy-cache/<repo>/<path>/__content__`. The presign path, however, signed via `state.storage_for_repo(...)`, which applies the configured `S3_PREFIX`, producing a signed key of `<prefix>/proxy-cache/...` that does not exist -> the redirect 404s. Streaming masked this because it reads through the no-prefix proxy handle. Deployments without a prefix would not hit it, which is why it was easy to miss.

3. **Capability was tracked by construction path, not the type.** Because the facade `StorageBackend` trait did not expose the presign methods, presign-capability was carried in a side-channel field set only on some construction paths. A handle built another way silently returned "no presign" and fell back to streaming, with no compile error. This is the same failure class as (2).

4. **A naive redirect helper on the PyPI path negative-cached.** Routing PyPI through the generic `proxy_fetch_or_redirect` calls `proxy_fetch` with `upstream/simple/<pkg>/<file>`, but PyPI serves the index at `/simple/<pkg>/` and hosts files on a separate CDN, so that URL 404s and gets negative-cached, wedging the package. The PyPI path must resolve the real file URL via the simple index (as `fetch_from_pypi_remote_streaming` does).

## Fix
- Sign proxy-cache presigns via the proxy's own no-prefix storage handle (the same handle `is_cache_fresh` already probes), not the prefixed per-repo handle. `from_config` builds that handle from the env-derived S3 config (so it carries redirect setting, presign credentials, CloudFront, and path format) with the prefix set to `None`.
- Move `supports_redirect` / `get_presigned_url` onto the facade `StorageBackend` trait, forwarded by the wrapper macro, so capability is type-enforced and no call site can silently fall back to streaming. The side-channel field is removed.
- In mixed handlers, only `proxy-cache/`-prefixed keys switch to the no-prefix handle; hosted artifacts keep the prefixed handle (their presign was already correct).
- The cheap `supports_redirect()` check runs before the freshness probe, avoiding a wasted metadata round-trip when redirect is unavailable.
- The PyPI remote path keeps index-based URL resolution and a streaming fallback; it does not reintroduce the wrong-URL fetch.

## Validation
- Unit and source-guard tests for the request-path wiring and the no-prefix signing.
- A live integration test (ignored, gated on an env var + a bucket) that builds the proxy-cache handle as `from_config` does, puts a `proxy-cache/...` object, presigns via the backend's own signer, and asserts the signed key carries no prefix and that object storage serves it 200.
- Full end-to-end against real object storage and real upstream PyPI: a cold `GET` proxies and caches at `proxy-cache/...` (no prefix); the cache-hit `GET` returns a 302 to a presigned URL with the verbatim no-prefix key; following it returns 200 with the artifact bytes, served by object storage (one redirect), not streamed through the backend.

## History note
The branch contains the original streaming-to-redirect commit, a revert (to restore safe streaming while the presign handling was reworked), and the final no-prefix presign commits. Can squash before merge.

## Related
#1911 / #1915 (negative-cache `now + 1` watermark race) - related but distinct.


Fixes #1555.
