### PR TITLE
fix(auth): seed baseline 'user' role assumed by federated role mapping

### DIFF
--- a/backend/migrations/135_seed_user_role.sql
+++ b/backend/migrations/135_seed_user_role.sql
@@ -1,0 +1,24 @@
+-- Seed the baseline `user` role that federated role mapping assumes exists.
+--
+-- Federated role mapping (OIDC/LDAP/SAML) unconditionally appends a `user`
+-- role to every federated user's resolved role set (the federated mapping
+-- builder in `auth_service.rs` pushes `"user"` after applying group->role
+-- mappings). Role assignment in `apply_role_mapping` only persists roles that
+-- exist in the `roles` table, so when `user` is absent it is silently dropped.
+--
+-- The user's persisted roles can then NEVER equal the resolved mapping (the
+-- mapping always carries `user`, the persisted set never can), so the
+-- per-login privilege re-sync computes `privilege_changed = true` on EVERY
+-- login. That bumps `users.privileges_changed_at = NOW()` and calls
+-- `invalidate_user_tokens(user_id)` on every login, which -- combined with the
+-- in-memory watermark race (#1911) -- invalidates the access token the same
+-- login just minted, producing a 401 on `/auth/me` immediately after callback.
+--
+-- The default role seed (002_roles.sql) creates `admin`, `developer`, and
+-- `reader`, but not `user`. This migration adds the missing baseline role so
+-- federated role mapping converges and stops perpetually flagging a privilege
+-- change. Idempotent via ON CONFLICT so it is safe on databases where a `user`
+-- role was created manually.
+INSERT INTO roles (name, description, is_system)
+VALUES ('user', 'Baseline role for all authenticated users', true)
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## What

Seed the baseline `user` role that federated role mapping assumes exists.

## Why

Federated role mapping (OIDC/LDAP/SAML) unconditionally appends a `user` role to every federated user's resolved role set, but `apply_role_mapping` only persists roles that exist in the `roles` table, and the default seed (`002_roles.sql`) creates only `admin`, `developer`, and `reader`. So `user` is silently dropped and a federated user's persisted roles can never equal the resolved mapping. The per-login privilege re-sync therefore reports `privilege_changed = true` on **every** login, bumping `privileges_changed_at = NOW()` and calling `invalidate_user_tokens()` each login. Combined with the watermark race (#1911), this self-invalidates the token the same login just minted, 401-ing `/auth/me` right after the OIDC callback.

Full analysis in #1918.

## Change

Adds migration `135_seed_user_role.sql` inserting the `user` role, idempotent via `ON CONFLICT (name) DO NOTHING` (safe where a `user` role was created manually).

## Notes

- Narrowly scoped to the seed. Does not touch the watermark race (#1911 / #1915) — this addresses why a privilege change is signalled on every login in the first place.
- After the role exists, a federated user's first login still converges (`[...] -> [..., user]`); every login after that is a no-op re-sync.

Fixes #1918
Related: #1911, #1915
