### PR TITLE
fix(maven): include WWW-Authenticate headers in guest_access_guard 401 response

### DIFF
--- a/backend/src/api/middleware/guest_access.rs
+++ b/backend/src/api/middleware/guest_access.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Request, State},
-    http::StatusCode,
+    http::{header, HeaderValue, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
     Json,
@@ -84,15 +84,32 @@ fn is_allowlisted(path: &str) -> bool {
 }
 
 /// 401 response body returned when guest access is disabled.
+/// Includes `WWW-Authenticate` headers (Basic, Bearer, Cargo) so
+/// RFC 7235-compliant clients (Maven, pip, npm, etc.) can determine
+/// the auth scheme and retry with credentials.
 fn unauthorized_response() -> Response {
-    (
+    let mut response = (
         StatusCode::UNAUTHORIZED,
         Json(json!({
             "error": "GUEST_ACCESS_DISABLED",
             "message": "This instance requires authentication. Please log in.",
         })),
     )
-        .into_response()
+        .into_response();
+
+    response.headers_mut().insert(
+        header::WWW_AUTHENTICATE,
+        HeaderValue::from_static("Basic realm=\"artifact-keeper\""),
+    );
+    response.headers_mut().append(
+        header::WWW_AUTHENTICATE,
+        HeaderValue::from_static("Bearer realm=\"artifact-keeper\", charset=\"UTF-8\""),
+    );
+    response
+        .headers_mut()
+        .append(header::WWW_AUTHENTICATE, HeaderValue::from_static("Cargo"));
+
+    response
 }
 
 /// Middleware that blocks unauthenticated requests when guest access is
@@ -204,6 +221,54 @@ mod tests {
             .map(|v| v.to_str().unwrap_or("").to_string())
             .unwrap_or_default();
         assert!(ct.starts_with("application/json"));
+    }
+
+    #[test]
+    fn unauthorized_response_includes_www_authenticate_basic() {
+        let resp = unauthorized_response();
+        let challenges: Vec<&str> = resp
+            .headers()
+            .get_all(header::WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert!(
+            challenges.contains(&"Basic realm=\"artifact-keeper\""),
+            "expected Basic challenge, got: {:?}",
+            challenges
+        );
+    }
+
+    #[test]
+    fn unauthorized_response_includes_www_authenticate_bearer() {
+        let resp = unauthorized_response();
+        let challenges: Vec<&str> = resp
+            .headers()
+            .get_all(header::WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert!(
+            challenges.contains(&"Bearer realm=\"artifact-keeper\", charset=\"UTF-8\""),
+            "expected Bearer challenge, got: {:?}",
+            challenges
+        );
+    }
+
+    #[test]
+    fn unauthorized_response_includes_www_authenticate_cargo() {
+        let resp = unauthorized_response();
+        let challenges: Vec<&str> = resp
+            .headers()
+            .get_all(header::WWW_AUTHENTICATE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .collect();
+        assert!(
+            challenges.contains(&"Cargo"),
+            "expected Cargo challenge, got: {:?}",
+            challenges
+        );
     }
 
     // -- end-to-end behaviour via Axum router (ServiceExt::oneshot) --


### PR DESCRIPTION
## Summary

When `AK_GUEST_ACCESS_ENABLED=false`, the `guest_access_guard` middleware returns 401 with a JSON body but **no `WWW-Authenticate` header**. Maven's Apache HttpClient needs this header to determine the auth scheme (Basic) and retry with credentials from `settings.xml`. Without it, Maven logs "Response contains no authentication challenges" and drops the connection.

Adds the same three `WWW-Authenticate` challenges (`Basic`, `Bearer`, `Cargo`) that the inner `auth` middleware already sends, so the guard response is RFC 7235-compliant.

Fixes #1916

## Regression test

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests — 26/26 pass

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes