### PR TITLE
fix(auth): millisecond issued-at claim for exact credential-invalidation ordering

### DIFF
--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -251,10 +251,12 @@ pub async fn enable_totp(
     // When the caller didn't use a JWT (no `iat`), fall back to `NOW()` so
     // the original #1146 semantic still holds for any other JWT sessions
     // this user has.
-    let caller_iat = token_iat.as_ref().map(|Extension(TokenIat(iat))| *iat);
-    let verified_ts: DateTime<Utc> = match caller_iat {
-        Some(iat) => DateTime::<Utc>::from_timestamp(iat, 0).ok_or_else(|| {
-            AppError::Internal(format!("Invalid caller iat for totp_verified_at: {iat}"))
+    let caller_iat_ms = token_iat.as_ref().map(|Extension(TokenIat(iat))| *iat);
+    let verified_ts: DateTime<Utc> = match caller_iat_ms {
+        Some(iat_ms) => DateTime::<Utc>::from_timestamp_millis(iat_ms).ok_or_else(|| {
+            AppError::Internal(format!(
+                "Invalid caller iat_ms for totp_verified_at: {iat_ms}"
+            ))
         })?,
         None => Utc::now(),
     };
@@ -277,8 +279,8 @@ pub async fn enable_totp(
     // Refresh tokens are revoked via the DB on every replica below so the
     // OAuth refresh-grant cannot mint a fresh access token from a stale
     // refresh JWT — that's the original #1146 threat.
-    match caller_iat {
-        Some(iat) => invalidate_user_tokens_except_caller(auth.user_id, iat),
+    match caller_iat_ms {
+        Some(iat_ms) => invalidate_user_tokens_except_caller(auth.user_id, iat_ms),
         None => invalidate_user_tokens(auth.user_id),
     }
 
@@ -561,9 +563,9 @@ pub async fn disable_totp(
     // Invalidate prior tokens issued under the stricter (TOTP-required)
     // policy while exempting the calling session so the user is not signed
     // out by their own disable action (#1370).
-    let caller_iat = token_iat.as_ref().map(|Extension(TokenIat(iat))| *iat);
-    match caller_iat {
-        Some(iat) => invalidate_user_tokens_except_caller(auth.user_id, iat),
+    let caller_iat_ms = token_iat.as_ref().map(|Extension(TokenIat(iat))| *iat);
+    match caller_iat_ms {
+        Some(iat_ms) => invalidate_user_tokens_except_caller(auth.user_id, iat_ms),
         None => invalidate_user_tokens(auth.user_id),
     }
 
@@ -967,9 +969,10 @@ mod totp_token_invalidation_regression_tests {
             allowed_repo_ids: None,
         };
 
-        // Token issued one minute before the change — should fail
+        // Token issued one minute before the change (millisecond issued-at,
+        // matching `Claims::effective_iat_ms`) — should fail
         // is_token_invalidated after enable_totp runs.
-        let pre_change_iat = Utc::now().timestamp() - 60;
+        let pre_change_iat = Utc::now().timestamp_millis() - 60_000;
         assert!(
             !is_token_invalidated(user_id, pre_change_iat),
             "fresh user must not be pre-invalidated"
@@ -1047,15 +1050,19 @@ mod totp_token_invalidation_regression_tests {
             allowed_repo_ids: None,
         };
 
-        // The caller's token was issued "now"; tokens issued before now must
-        // be killed; the caller's own token must survive.
-        let caller_iat = Utc::now().timestamp();
-        let pre_caller_iat = caller_iat - 60;
+        // The caller's token was issued "now" (millisecond `iat_ms`, as the
+        // middleware now supplies via `Claims::effective_iat_ms`); tokens
+        // issued before now must be killed; the caller's own token must
+        // survive. An older token from the SAME second (caller - 1 ms) must
+        // also be caught now that the watermark is millisecond-precise.
+        let caller_iat_ms = Utc::now().timestamp_millis();
+        let pre_caller_iat_ms = caller_iat_ms - 60_000;
+        let older_same_second_ms = caller_iat_ms - 1;
 
         let result = enable_totp(
             State(state),
             Extension(auth),
-            Some(Extension(TokenIat(caller_iat))),
+            Some(Extension(TokenIat(caller_iat_ms))),
             Json(TotpCodeRequest { code }),
         )
         .await;
@@ -1072,12 +1079,16 @@ mod totp_token_invalidation_regression_tests {
             result.err()
         );
         assert!(
-            !is_token_invalidated(user_id, caller_iat),
+            !is_token_invalidated(user_id, caller_iat_ms),
             "calling token (iat == watermark anchor) must NOT be invalidated"
         );
         assert!(
-            is_token_invalidated(user_id, pre_caller_iat),
+            is_token_invalidated(user_id, pre_caller_iat_ms),
             "tokens issued strictly before the caller's iat must be invalidated"
+        );
+        assert!(
+            is_token_invalidated(user_id, older_same_second_ms),
+            "an older token from the SAME second must now be invalidated (ms precision)"
         );
     }
 
@@ -1127,7 +1138,7 @@ mod totp_token_invalidation_regression_tests {
             allowed_repo_ids: None,
         };
 
-        let pre_change_iat = Utc::now().timestamp() - 60;
+        let pre_change_iat = Utc::now().timestamp_millis() - 60_000;
         // Note: enable_totp already invalidates by other tests' side effects
         // potentially, but `tdh::create_user` returns a fresh Uuid, so this
         // user_id has never been invalidated before.
@@ -1211,13 +1222,14 @@ mod totp_token_invalidation_regression_tests {
             allowed_repo_ids: None,
         };
 
-        let caller_iat = Utc::now().timestamp();
-        let pre_caller_iat = caller_iat - 60;
+        let caller_iat_ms = Utc::now().timestamp_millis();
+        let pre_caller_iat_ms = caller_iat_ms - 60_000;
+        let older_same_second_ms = caller_iat_ms - 1;
 
         let result = disable_totp(
             State(state),
             Extension(auth),
-            Some(Extension(TokenIat(caller_iat))),
+            Some(Extension(TokenIat(caller_iat_ms))),
             Json(TotpDisableRequest {
                 password: "real-test-password".to_string(),
                 code,
@@ -1251,12 +1263,16 @@ mod totp_token_invalidation_regression_tests {
             "users.totp_enabled must be false after disable (drives /auth/me response)"
         );
         assert!(
-            !is_token_invalidated(user_id, caller_iat),
+            !is_token_invalidated(user_id, caller_iat_ms),
             "calling token must survive its own disable (#1370)"
         );
         assert!(
-            is_token_invalidated(user_id, pre_caller_iat),
+            is_token_invalidated(user_id, pre_caller_iat_ms),
             "older tokens must still be invalidated by disable"
+        );
+        assert!(
+            is_token_invalidated(user_id, older_same_second_ms),
+            "an older token from the SAME second must now be invalidated (ms precision)"
         );
     }
 }

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -70,6 +70,11 @@ pub struct DownloadTicketAuth;
 /// (TOTP enable/disable, password change) to exempt the calling session's
 /// own token from being killed by the same operation it just performed.
 /// Issue #1370.
+///
+/// Carries the calling token's **millisecond** issued-at
+/// (`Claims::effective_iat_ms`) so the exempt-caller watermark can be set with
+/// millisecond precision (`caller_iat_ms - 1`), exempting only the caller and
+/// catching every strictly-older token — including one from the same second.
 #[derive(Debug, Clone, Copy)]
 pub struct TokenIat(pub i64);
 
@@ -475,7 +480,7 @@ pub async fn auth_middleware(
         ExtractedToken::Bearer(token) => {
             match auth_service.validate_access_token_async(token).await {
                 Ok(claims) => {
-                    let iat = TokenIat(claims.iat);
+                    let iat = TokenIat(claims.effective_iat_ms());
                     Ok((AuthExtension::from(claims), Some(iat)))
                 }
                 Err(_) => match validate_api_token_with_scopes(&auth_service, token).await {
@@ -1769,6 +1774,7 @@ mod tests {
             email: "test@example.com".to_string(),
             is_admin: true,
             iat: 1000,
+            iat_ms: None,
             exp: 2000,
             token_type: "access".to_string(),
             jti: None,
@@ -1792,6 +1798,7 @@ mod tests {
             email: "regular@example.com".to_string(),
             is_admin: false,
             iat: 1000,
+            iat_ms: None,
             exp: 2000,
             token_type: "access".to_string(),
             jti: None,

--- a/backend/src/grpc/auth_interceptor.rs
+++ b/backend/src/grpc/auth_interceptor.rs
@@ -81,7 +81,7 @@ impl AuthInterceptor {
                     crate::services::auth_service::is_token_invalidated_replica_safe(
                         db,
                         token_data.claims.sub,
-                        token_data.claims.iat,
+                        token_data.claims.effective_iat_ms(),
                     ),
                 )
             })
@@ -90,7 +90,7 @@ impl AuthInterceptor {
             // No DB pool wired (test mode) — fall back to in-memory only.
             crate::services::auth_service::is_token_invalidated(
                 token_data.claims.sub,
-                token_data.claims.iat,
+                token_data.claims.effective_iat_ms(),
             )
         };
         if invalidated {
@@ -120,6 +120,7 @@ mod tests {
             email: "test@example.com".to_string(),
             is_admin,
             iat: chrono::Utc::now().timestamp(),
+            iat_ms: None,
             exp: chrono::Utc::now().timestamp() + 3600,
             token_type: token_type.to_string(),
             jti: None,
@@ -245,6 +246,7 @@ mod tests {
             email: "test@example.com".to_string(),
             is_admin: true,
             iat,
+            iat_ms: Some(iat.saturating_mul(1000)),
             exp: iat + 3600,
             token_type: "access".to_string(),
             jti: None,

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -80,6 +80,17 @@ pub struct Claims {
     pub is_admin: bool,
     /// Issued at (Unix timestamp)
     pub iat: i64,
+    /// Issued-at in **milliseconds** (sub-second precision). Private,
+    /// non-standard claim added in 1.2.1 to resolve the same-second
+    /// credential-invalidation race (#1915/#1933): the standard RFC-7519
+    /// `iat` is whole seconds, too coarse to order a token against a
+    /// millisecond credential-change watermark that falls in the same second.
+    ///
+    /// `Option` for backward compatibility: tokens minted before this deploy
+    /// have no `iat_ms`. Consumers MUST fall back to `iat * 1000` (the floored,
+    /// conservative value) when absent — see `effective_iat_ms`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iat_ms: Option<i64>,
     /// Expiration time (Unix timestamp)
     pub exp: i64,
     /// Token type: "access" or "refresh"
@@ -92,6 +103,18 @@ pub struct Claims {
     /// family. Set on refresh tokens only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub family_id: Option<Uuid>,
+}
+
+impl Claims {
+    /// Millisecond issued-at used for credential-invalidation ordering.
+    /// Falls back to `iat * 1000` (floored to the second) for legacy tokens
+    /// minted before the `iat_ms` claim existed. The floored fallback is the
+    /// conservative/secure side: a legacy same-second token is treated as
+    /// minted at the *start* of its second, so a same-second credential change
+    /// (full-ms watermark) still rejects it.
+    pub fn effective_iat_ms(&self) -> i64 {
+        self.iat_ms.unwrap_or_else(|| self.iat.saturating_mul(1000))
+    }
 }
 
 /// Token pair response
@@ -157,13 +180,13 @@ struct CachedApiTokenEntry {
 /// (regression caught in PR #1190 review). Process-local; DB is the
 /// source of truth so multi-replica deployments stay consistent (#1173).
 ///
-/// The `i64` watermark is in **milliseconds** (sub-second precision) so a
-/// token whose RFC-7519 whole-second `iat` floors to the same wall-clock
-/// second as a credential change is still ordered correctly: a real
-/// password change happens strictly after the token was minted, so its
-/// `password_changed_at` carries a positive millisecond offset above the
-/// token's floored `iat * 1000` and the token is rejected. JWT `iat` is
-/// NOT widened; consumers compare `iat * 1000` against this value.
+/// The `i64` watermark is in **milliseconds** (sub-second precision) and is
+/// compared against the token's millisecond issued-at
+/// (`Claims::effective_iat_ms`): a real credential change happens strictly
+/// after the token was minted, so its `password_changed_at` carries a positive
+/// millisecond offset above the token's `iat_ms` and the token is rejected even
+/// when both fall in the same wall-clock second. Legacy tokens without `iat_ms`
+/// fall back to the floored `iat * 1000` (conservative side).
 static CREDENTIAL_INVALIDATIONS: OnceLock<RwLock<HashMap<Uuid, (i64, Instant)>>> = OnceLock::new();
 /// Retention window for in-memory watermarks, in **milliseconds** (matches
 /// the millisecond watermark unit).
@@ -189,61 +212,42 @@ fn invalidation_map() -> &'static RwLock<HashMap<Uuid, (i64, Instant)>> {
 /// precision) — the **mint-then-invalidate** variant used by password change,
 /// password reset and deactivation. Because the credential change happens
 /// strictly after any pre-change token was minted, the watermark carries a
-/// positive sub-second offset above the token's floored `iat * 1000`, so even
-/// a token minted in the same wall-clock second (`iat * 1000 == floor_sec*1000
-/// < watermark_ms`) is rejected by the replica-safe strict `<`. For the
-/// **invalidate-then-mint** case (OIDC login / admin reset that mints in the
-/// same request) use [`invalidate_user_tokens_floor_second`] instead, which
-/// floors the watermark to the start of the current second so the freshly
-/// minted token survives.
+/// positive sub-second offset above the token's `iat_ms`, so even a token
+/// minted in the same wall-clock second is rejected by the replica-safe strict
+/// `<`. The **invalidate-then-mint** case (OIDC login / admin reset that mints
+/// in the same request) also uses this full-millisecond variant: the fresh JWT
+/// is minted microseconds AFTER the invalidate, so its `iat_ms` is strictly
+/// greater than this watermark and survives strict `<` — no floor-second
+/// special case is needed now that the token carries millisecond precision.
 pub fn invalidate_user_tokens(user_id: Uuid) {
     let watermark_ms = Utc::now().timestamp_millis();
     invalidate_user_tokens_at(user_id, watermark_ms);
 }
 
-/// Invalidate-then-mint variant of [`invalidate_user_tokens`].
-///
-/// Writes a watermark floored to the **start of the current wall-clock
-/// second** in milliseconds (`Utc::now().timestamp() * 1000`). Used by paths
-/// that invalidate and then immediately mint a fresh JWT in the same request
-/// (OIDC `apply_role_mapping`, admin reset-then-login). The fresh token's
-/// `iat` floors DOWN to the same second, so `iat * 1000 == watermark` and the
-/// replica-safe strict `<` (`iat * 1000 < watermark`) is **false** ⇒ the
-/// fresh token is **accepted**, while any token from a strictly earlier
-/// second (`iat * 1000 <= (sec - 1) * 1000 < watermark`) is rejected.
-///
-/// This is the counterpart to the full-precision [`invalidate_user_tokens`]:
-/// the floored watermark is what distinguishes invalidate-then-mint (same
-/// second must survive, #1911) from mint-then-invalidate (same second must be
-/// rejected, the #931 invariant). See the safety note on
-/// [`is_token_invalidated_replica_safe`].
-pub fn invalidate_user_tokens_floor_second(user_id: Uuid) {
-    let watermark_ms = Utc::now().timestamp().saturating_mul(1000);
-    invalidate_user_tokens_at(user_id, watermark_ms);
-}
-
 /// Variant of [`invalidate_user_tokens`] that exempts the caller's own JWT.
 ///
-/// `caller_iat` is the calling token's issued-at (seconds). The in-memory
-/// watermark is set to `caller_iat * 1000 - 1` (milliseconds, one millisecond
-/// below the start of the caller's `iat` second) so the sync `<=` check still
-/// passes for the calling token (`caller_iat * 1000 <= caller_iat * 1000 - 1`
-/// is false), while every token issued at any second strictly before
-/// `caller_iat` (`iat * 1000 <= (caller_iat - 1) * 1000 < caller_iat * 1000 -
-/// 1`) is invalidated. The sync path is the one consulted by the gRPC
-/// interceptor (`grpc/auth_interceptor.rs`) and the TOTP causation tests, so
-/// the exempt-caller offset here is load-bearing on those code paths.
+/// `caller_iat_ms` is the calling token's millisecond issued-at
+/// ([`Claims::effective_iat_ms`]). The in-memory watermark is set to
+/// `caller_iat_ms - 1` so the sync `<=` check still passes for the calling
+/// token (`caller_iat_ms <= caller_iat_ms - 1` is false) while EVERY strictly-
+/// older token (`iat_ms <= caller_iat_ms - 1`) is invalidated — now precise to
+/// the millisecond, so an older token from the SAME second is also caught. (The
+/// previous seconds-granularity offset `caller_iat * 1000 - 1` exempted every
+/// other token minted earlier in the caller's own second; ms precision closes
+/// that leak.) The sync path is the one consulted by the gRPC interceptor
+/// (`grpc/auth_interceptor.rs`) and the TOTP causation tests, so the
+/// exempt-caller offset here is load-bearing on those code paths.
 ///
 /// Used by TOTP enable/disable so the session that initiated the credential
 /// change is not logged out by the same operation. Other sessions (and any
 /// stolen pre-change tokens) are still killed. The refresh-grant bypass
 /// from #1146 is closed separately by the caller via
 /// [`AuthService::revoke_all_refresh_token_families`].
-pub fn invalidate_user_tokens_except_caller(user_id: Uuid, caller_iat: i64) {
-    // `caller_iat * 1000 - 1` (ms) so the sync `<=` check at the line
-    // `issued_at * 1000 <= changed_at` lets the calling token through. Older
-    // tokens (iat <= caller_iat - 1) are still caught.
-    let watermark_ms = caller_iat.saturating_mul(1000).saturating_sub(1);
+pub fn invalidate_user_tokens_except_caller(user_id: Uuid, caller_iat_ms: i64) {
+    // `caller_iat_ms - 1` (ms) so the sync `<=` check at the line
+    // `issued_at_ms <= changed_at` lets the calling token through while every
+    // strictly-older token (including an older same-second one) is caught.
+    let watermark_ms = caller_iat_ms.saturating_sub(1);
     invalidate_user_tokens_at(user_id, watermark_ms);
 }
 
@@ -273,10 +277,11 @@ fn invalidate_user_tokens_at(user_id: Uuid, watermark_ms: i64) {
 /// In-memory fast-path version of the credential-invalidation check.
 ///
 /// Returns `true` only when this replica has seen an `invalidate_user_tokens`
-/// call whose watermark is `>=` the token's `iat`. Comparison is `<=` so a
-/// token minted in the same wall-clock second as the invalidation is
-/// rejected too (1-second JWT `iat` resolution race; fixes the boundary
-/// bug at the old line 152).
+/// call whose watermark is `>=` the token's millisecond issued-at
+/// (`issued_at_ms`, resolved by the caller via `Claims::effective_iat_ms`).
+/// Comparison is `<=` so a token minted at the exact watermark instant is
+/// rejected too; with millisecond resolution on both sides this no longer
+/// over-rejects a same-second-but-later token.
 ///
 /// Callers
 /// -------
@@ -301,13 +306,14 @@ fn invalidate_user_tokens_at(user_id: Uuid, watermark_ms: i64) {
 /// `refresh_tokens` consults the DB via [`is_user_credentials_changed_db`].
 /// The DB-backed check is the source of truth; this exists only as the
 /// fast-path for the same replica.
-pub(crate) fn is_token_invalidated(user_id: Uuid, issued_at: i64) -> bool {
+pub(crate) fn is_token_invalidated(user_id: Uuid, issued_at_ms: i64) -> bool {
     if let Ok(map) = invalidation_map().read() {
         if let Some(&(changed_at_ms, _)) = map.get(&user_id) {
-            // `issued_at` is RFC-7519 whole seconds; the watermark is in
-            // milliseconds. Sync plane keeps `<=` (see #1248 distinction at
-            // `is_token_invalidated_replica_safe`); only the unit changed.
-            return issued_at.saturating_mul(1000) <= changed_at_ms;
+            // `issued_at_ms` is the token's millisecond issued-at (resolved by
+            // the caller via `Claims::effective_iat_ms`); the watermark is in
+            // milliseconds too. Sync plane keeps `<=` (see #1248 distinction at
+            // `is_token_invalidated_replica_safe`).
+            return issued_at_ms <= changed_at_ms;
         }
     }
     false
@@ -394,21 +400,16 @@ async fn fetch_credential_change_watermark(
     let Some((watermark_ts, is_active)) = row else {
         return Ok(None);
     };
-    // FLOOR the DB-derived watermark to the second (then to ms). Unlike the
-    // in-memory full-millisecond watermark written by `invalidate_user_tokens`
-    // on an *actual* credential change, the DB-read path must not reject a
-    // token whose `iat` falls in the same wall-clock second as a value that was
-    // merely set at user CREATION. `users.password_changed_at DEFAULT NOW()`
-    // (migration 076) carries the sub-second creation offset (e.g. ...787141),
-    // so `.timestamp_millis()` would make a brand-new user's first same-second
-    // login (`iat * 1000` == ...787000) satisfy `iat*1000 < watermark_ms` and
-    // be wrongly rejected (the #1173/rbac/mesh fresh-user "401" regression).
-    // Flooring to the second makes the creation watermark equal a same-second
-    // login `iat*1000`, so strict `<` ACCEPTS the fresh first login. Real
-    // password-change rejection still comes from the full-ms watermark written
-    // synchronously to the in-memory map by `invalidate_user_tokens`, which the
-    // monotonic-max writer keeps above this floored value on a single replica.
-    let watermark = watermark_ts.timestamp().saturating_mul(1000);
+    // Full-millisecond DB-derived watermark. With millisecond `iat_ms` in the
+    // token, a brand-new user's first login ALWAYS happens in wall-clock time
+    // strictly after user creation, so its `iat_ms` exceeds the creation
+    // watermark (`users.password_changed_at DEFAULT NOW()`, migration 076, e.g.
+    // ...787141) even at full precision — the floor-to-second workaround the
+    // #1173/rbac/mesh fresh-user "401" regression once required is no longer
+    // needed. Full precision is also strictly more correct cross-replica: a
+    // password change observed via the DB on a peer replica now rejects
+    // same-second pre-change tokens there too, which the floored value weakened.
+    let watermark = watermark_ts.timestamp_millis();
 
     // Only cache when the user is active. Caching `is_active=false` would
     // require expanding the cache value to a tuple; instead we skip the
@@ -432,40 +433,33 @@ async fn fetch_credential_change_watermark(
 /// Replica-safe credential-invalidation check.
 ///
 /// Returns `true` when the user's credentials have changed strictly after
-/// the token's `iat`. JWT `iat` is whole seconds (RFC 7519); the DB
-/// `password_changed_at` is microsecond-precision and
-/// [`fetch_credential_change_watermark`] now preserves it at **millisecond**
-/// precision via `.timestamp_millis()`. We compare `iat * 1000` against the
+/// the token was minted. The token carries a millisecond issued-at
+/// (`Claims::effective_iat_ms`: the `iat_ms` claim, or `iat * 1000` floored for
+/// legacy tokens); the DB `password_changed_at` is microsecond-precision and
+/// [`fetch_credential_change_watermark`] preserves it at **millisecond**
+/// precision via `.timestamp_millis()`. We compare `issued_at_ms` against the
 /// millisecond watermark with strict `<` (not `<=`).
 ///
-/// Sub-second precision resolves the same-second conflict that floor-second
-/// data could not:
+/// Millisecond precision on BOTH sides resolves the same-second conflict that
+/// neither floor-second nor full-second token data could:
 ///   * **mint-then-invalidate** (password change / reset / deactivation,
-///     full-precision [`invalidate_user_tokens`]): the change happens strictly
-///     after the token was minted, so the watermark carries a positive
-///     sub-second offset and a same-second pre-change token
-///     (`iat * 1000 == floor_sec*1000 < watermark_ms`) is **rejected**. This
-///     restores the #931 invariant the floor-second `<` had regressed.
-///   * **invalidate-then-mint** (OIDC login / admin reset, floored
-///     [`invalidate_user_tokens_floor_second`]): the watermark is floored to
-///     the start of the current second, so the same-request fresh JWT
-///     (`iat * 1000 == watermark`) survives strict `<` while any
-///     strictly-earlier-second token is rejected (#1911).
-///   * **fresh user** (`POST /users` sets `password_changed_at = NOW()`,
-///     first login mints `iat` in a later second): `iat * 1000 >
-///     watermark_ms` ⇒ accepted (#1173 follow-up).
+///     [`invalidate_user_tokens`]): the change happens strictly after the token
+///     was minted, so the watermark carries a positive offset and a same-second
+///     pre-change token (`iat_ms < watermark_ms`) is **rejected** — the #931
+///     invariant.
+///   * **invalidate-then-mint** (OIDC login / admin reset): the fresh JWT is
+///     minted microseconds AFTER the invalidate, so `iat_ms > watermark_ms` and
+///     it survives strict `<`, while any pre-change token is rejected (#1911).
+///   * **fresh user** (`POST /users` sets `password_changed_at = NOW()`, first
+///     login mints later in real time): `iat_ms > watermark_ms` ⇒ accepted
+///     (#1173 follow-up).
 ///
-/// Safety of `<` for the actual-password-change case: a JWT with `iat`
-/// floored to the same second as the post-change watermark would have to
-/// have been minted in the same wall-clock second the password was changed.
-/// The server requires a successful authentication to mint a JWT, so such a
-/// JWT could only have been minted with the OLD password right up until the
-/// password change — which means the attacker already had the old password
-/// and any JWT obtained that way is equivalent to one obtained a moment
-/// earlier through normal use. With millisecond precision such a pre-change
-/// token is now rejected anyway; only the invalidate-then-mint fresh token
-/// (minted by a successful auth in the same request) survives. There is no
-/// exploitable window.
+/// Safety of `<`: the server requires a successful authentication to mint a
+/// JWT, so the only token that can have `iat_ms >= watermark` is one minted by
+/// a successful auth at or after the credential change. A pre-change token has
+/// `iat_ms < watermark` and is rejected to the millisecond. There is no
+/// exploitable window. Legacy tokens with no `iat_ms` fall back to the floored
+/// `iat * 1000`, the conservative side (rejected against a same-second change).
 ///
 /// Resolution order:
 ///   1. DB watermark, served from the in-memory cache when fresh
@@ -489,7 +483,7 @@ async fn fetch_credential_change_watermark(
 pub(crate) async fn is_token_invalidated_replica_safe(
     db: &PgPool,
     user_id: Uuid,
-    issued_at: i64,
+    issued_at_ms: i64,
 ) -> Result<bool> {
     match fetch_credential_change_watermark(db, user_id).await? {
         Some(entry) => {
@@ -500,15 +494,14 @@ pub(crate) async fn is_token_invalidated_replica_safe(
             if !entry.is_active {
                 return Ok(true);
             }
-            // `issued_at` is RFC-7519 whole seconds; `entry.watermark` is in
-            // milliseconds. Strict `<` (#1248 async-plane comparator): a
-            // full-precision password-change watermark carries a positive
-            // sub-second offset, so a same-second pre-change token
-            // (`iat * 1000 == floor_sec*1000 < watermark_ms`) is rejected,
-            // while an invalidate-then-mint floored watermark
-            // (`watermark == floor_sec*1000`) lets the same-second fresh token
-            // survive (`iat * 1000 == watermark`, strict `<` is false).
-            Ok(issued_at.saturating_mul(1000) < entry.watermark)
+            // `issued_at_ms` is the token's millisecond issued-at (resolved by
+            // the caller via `Claims::effective_iat_ms`); `entry.watermark` is
+            // in milliseconds. Strict `<` (#1248 async-plane comparator): a
+            // pre-change token minted strictly before the credential change has
+            // `iat_ms < watermark` and is rejected, while a token minted (even
+            // microseconds) after — including an invalidate-then-mint fresh
+            // token in the same request — has `iat_ms > watermark` and survives.
+            Ok(issued_at_ms < entry.watermark)
         }
         None => Ok(false),
     }
@@ -994,6 +987,9 @@ impl AuthService {
     /// See [`AuthService::generate_tokens`] for the new-login case.
     pub fn generate_tokens_with_family(&self, user: &User, family_id: Uuid) -> Result<TokenPair> {
         let now = Utc::now();
+        // Capture the millisecond instant once so access and refresh tokens
+        // share the exact same `iat_ms` ordering anchor.
+        let now_ms = now.timestamp_millis();
         let access_exp = now + Duration::minutes(self.config.jwt_access_token_expiry_minutes);
         let refresh_exp = now + Duration::days(self.config.jwt_refresh_token_expiry_days);
 
@@ -1003,6 +999,7 @@ impl AuthService {
             email: user.email.clone(),
             is_admin: user.is_admin,
             iat: now.timestamp(),
+            iat_ms: Some(now_ms),
             exp: access_exp.timestamp(),
             token_type: "access".to_string(),
             jti: None,
@@ -1016,6 +1013,7 @@ impl AuthService {
             email: user.email.clone(),
             is_admin: user.is_admin,
             iat: now.timestamp(),
+            iat_ms: Some(now_ms),
             exp: refresh_exp.timestamp(),
             token_type: "refresh".to_string(),
             jti: Some(refresh_jti),
@@ -1114,7 +1112,7 @@ impl AuthService {
             return Err(AppError::Authentication("Invalid token type".to_string()));
         }
 
-        if is_token_invalidated(token_data.claims.sub, token_data.claims.iat) {
+        if is_token_invalidated(token_data.claims.sub, token_data.claims.effective_iat_ms()) {
             return Err(AppError::Authentication(
                 "Token invalidated by credential change".to_string(),
             ));
@@ -1138,8 +1136,12 @@ impl AuthService {
             return Err(AppError::Authentication("Invalid token type".to_string()));
         }
 
-        if is_token_invalidated_replica_safe(&self.db, token_data.claims.sub, token_data.claims.iat)
-            .await?
+        if is_token_invalidated_replica_safe(
+            &self.db,
+            token_data.claims.sub,
+            token_data.claims.effective_iat_ms(),
+        )
+        .await?
         {
             return Err(AppError::Authentication(
                 "Token invalidated by credential change".to_string(),
@@ -1173,8 +1175,12 @@ impl AuthService {
             return Err(AppError::Authentication("Invalid token type".to_string()));
         }
 
-        if is_token_invalidated_replica_safe(&self.db, token_data.claims.sub, token_data.claims.iat)
-            .await?
+        if is_token_invalidated_replica_safe(
+            &self.db,
+            token_data.claims.sub,
+            token_data.claims.effective_iat_ms(),
+        )
+        .await?
         {
             return Err(AppError::Authentication(
                 "Token invalidated by credential change".to_string(),
@@ -2037,12 +2043,14 @@ impl AuthService {
         //
         // This is an **invalidate-then-mint** flow: `authenticate_federated`
         // calls `generate_tokens` immediately after this, in the same request.
-        // Use the floored-second watermark so the freshly-minted JWT (whose
-        // `iat` floors to the current second) survives the strict `<` check,
-        // while every pre-change token from an earlier second is rejected
-        // (#1911 OIDC self-invalidation guard).
+        // With millisecond `iat_ms`, the freshly-minted JWT is stamped a few
+        // microseconds AFTER this invalidation, so its `iat_ms` is strictly
+        // greater than the full-millisecond watermark and survives the strict
+        // `<` check, while every pre-change token (minted earlier in real time)
+        // has `iat_ms < watermark` and is rejected (#1911 OIDC
+        // self-invalidation guard). No floored-second watermark is needed.
         if privilege_changed {
-            invalidate_user_tokens_floor_second(user_id);
+            invalidate_user_tokens(user_id);
         }
 
         Ok(())
@@ -2324,6 +2332,7 @@ impl AuthService {
             email: user.email.clone(),
             is_admin: user.is_admin,
             iat: now.timestamp(),
+            iat_ms: Some(now.timestamp_millis()),
             exp: exp.timestamp(),
             token_type: "totp_pending".to_string(),
             jti: Some(Uuid::new_v4()),
@@ -2824,6 +2833,7 @@ mod tests {
             email: user.email.clone(),
             is_admin: user.is_admin,
             iat: now.timestamp(),
+            iat_ms: None,
             exp: access_exp.timestamp(),
             token_type: "access".to_string(),
             jti: None,
@@ -2836,6 +2846,7 @@ mod tests {
             email: user.email.clone(),
             is_admin: user.is_admin,
             iat: now.timestamp(),
+            iat_ms: None,
             exp: refresh_exp.timestamp(),
             token_type: "refresh".to_string(),
             jti: Some(Uuid::new_v4()),
@@ -2882,6 +2893,7 @@ mod tests {
             email: "user@test.com".to_string(),
             is_admin: false,
             iat: now.timestamp(),
+            iat_ms: None,
             exp: (now + Duration::days(7)).timestamp(),
             token_type: "refresh".to_string(),
             jti: Some(Uuid::new_v4()),
@@ -2911,6 +2923,7 @@ mod tests {
             email: "expired@test.com".to_string(),
             is_admin: false,
             iat: (now - Duration::hours(2)).timestamp(),
+            iat_ms: None,
             exp: (now - Duration::hours(1)).timestamp(), // expired 1 hour ago
             token_type: "access".to_string(),
             jti: None,
@@ -2934,6 +2947,7 @@ mod tests {
             email: "u@t.com".to_string(),
             is_admin: false,
             iat: now.timestamp(),
+            iat_ms: None,
             exp: (now + Duration::hours(1)).timestamp(),
             token_type: "access".to_string(),
             jti: None,
@@ -2958,6 +2972,7 @@ mod tests {
             email: "test@x.com".to_string(),
             is_admin: true,
             iat: 1000,
+            iat_ms: None,
             exp: 2000,
             token_type: "access".to_string(),
             jti: None,
@@ -2984,6 +2999,7 @@ mod tests {
             email: "u@x.com".to_string(),
             is_admin: false,
             iat: 1000,
+            iat_ms: None,
             exp: 2000,
             token_type: "refresh".to_string(),
             jti: Some(jti),
@@ -3631,21 +3647,20 @@ mod tests {
     #[test]
     fn test_invalidate_user_tokens_marks_user() {
         let user_id = Uuid::new_v4();
-        let before = Utc::now().timestamp();
+        // Millisecond issued-at one second before the invalidation.
+        let before_ms = Utc::now().timestamp_millis() - 1000;
         invalidate_user_tokens(user_id);
-        assert!(is_token_invalidated(user_id, before - 1));
+        assert!(is_token_invalidated(user_id, before_ms));
     }
 
     #[test]
     fn test_token_issued_after_invalidation_is_accepted() {
         let user_id = Uuid::new_v4();
         invalidate_user_tokens(user_id);
-        // Watermark is `now` (no offset) so the sync `<=` map rejects
-        // every iat <= now. We bump the test "after" to `now + 1` to
-        // represent a JWT minted at least one whole second after the
-        // invalidation completed.
-        let after = Utc::now().timestamp() + 1;
-        assert!(!is_token_invalidated(user_id, after));
+        // Watermark is `now` (full ms). A token minted one full second later
+        // (in ms) is strictly after the watermark, so it is accepted.
+        let after_ms = Utc::now().timestamp_millis() + 1000;
+        assert!(!is_token_invalidated(user_id, after_ms));
     }
 
     #[test]
@@ -3658,61 +3673,58 @@ mod tests {
     fn test_reinvalidation_updates_timestamp() {
         let user_id = Uuid::new_v4();
         invalidate_user_tokens(user_id);
-        let mid = Utc::now().timestamp();
+        let mid_ms = Utc::now().timestamp_millis();
         // Slight delay so second invalidation gets a newer timestamp
         std::thread::sleep(std::time::Duration::from_millis(10));
         invalidate_user_tokens(user_id);
-        // Watermark is `now` (no offset). Use `+1` to represent a token
-        // minted strictly after the invalidation.
-        let after = Utc::now().timestamp() + 1;
+        // Watermark is `now` (full ms). Use `+1000` to represent a token minted
+        // a full second after the invalidation.
+        let after_ms = Utc::now().timestamp_millis() + 1000;
         // Token issued before second invalidation is still rejected
-        assert!(is_token_invalidated(user_id, mid - 1));
+        assert!(is_token_invalidated(user_id, mid_ms - 1));
         // Token issued after second invalidation is accepted
-        assert!(!is_token_invalidated(user_id, after));
+        assert!(!is_token_invalidated(user_id, after_ms));
     }
 
     #[test]
     fn test_token_issued_at_exact_invalidation_time_is_rejected() {
-        // Boundary fix (#1173): `iat` (whole-second) floored to the same
-        // wall-clock second as a full-precision watermark must be rejected on
-        // the sync plane (`<=`). The watermark is now in milliseconds; the
-        // token `iat` stays in seconds and is scaled by 1000 internally.
+        // Boundary fix (#1173): a token whose millisecond issued-at equals the
+        // watermark must be rejected on the sync plane (`<=`). Both sides are
+        // milliseconds now (the token via `Claims::effective_iat_ms`).
         let user_id = Uuid::new_v4();
-        let pre = Utc::now().timestamp();
         invalidate_user_tokens(user_id);
-        // The in-memory watermark is in milliseconds; the floored second of
-        // the watermark is the "same second" token's `iat`.
         let map = invalidation_map().read().unwrap();
         let &(watermark_ms, _) = map.get(&user_id).unwrap();
         drop(map);
-        let watermark_sec = watermark_ms.div_euclid(1000);
-        // A token issued in the same second as the invalidation
-        // (`iat * 1000 <= watermark_ms`) should be rejected.
+        // A token issued at the exact watermark millisecond (`iat_ms ==
+        // watermark_ms`) is rejected by `<=`.
         assert!(
-            is_token_invalidated(user_id, watermark_sec),
-            "same-second token must be rejected"
+            is_token_invalidated(user_id, watermark_ms),
+            "token at exact watermark ms must be rejected"
         );
-        // Token issued strictly before invalidation is still rejected.
-        assert!(is_token_invalidated(user_id, pre - 1));
-        // Token issued in a strictly later second is still accepted.
-        assert!(!is_token_invalidated(user_id, watermark_sec + 1));
+        // A token issued one millisecond earlier is rejected.
+        assert!(is_token_invalidated(user_id, watermark_ms - 1));
+        // A token issued one millisecond later is accepted (the same-second
+        // re-login case that #1933 wrongly rejected).
+        assert!(!is_token_invalidated(user_id, watermark_ms + 1));
     }
 
     #[test]
     fn test_multiple_users_invalidated_independently() {
         let user_a = Uuid::new_v4();
         let user_b = Uuid::new_v4();
-        let before = Utc::now().timestamp() - 1;
+        // Millisecond issued-at one second before either invalidation.
+        let before_ms = Utc::now().timestamp_millis() - 1000;
 
         invalidate_user_tokens(user_a);
         // user_a is invalidated, user_b is not
-        assert!(is_token_invalidated(user_a, before));
-        assert!(!is_token_invalidated(user_b, before));
+        assert!(is_token_invalidated(user_a, before_ms));
+        assert!(!is_token_invalidated(user_b, before_ms));
 
         invalidate_user_tokens(user_b);
         // now both are invalidated for tokens issued before
-        assert!(is_token_invalidated(user_a, before));
-        assert!(is_token_invalidated(user_b, before));
+        assert!(is_token_invalidated(user_a, before_ms));
+        assert!(is_token_invalidated(user_b, before_ms));
     }
 
     #[test]
@@ -3720,7 +3732,7 @@ mod tests {
         // Calling is_token_invalidated on a never-seen user should not panic
         // and should return false, exercising the OnceLock init path
         let fresh = Uuid::new_v4();
-        assert!(!is_token_invalidated(fresh, Utc::now().timestamp()));
+        assert!(!is_token_invalidated(fresh, Utc::now().timestamp_millis()));
     }
 
     // -----------------------------------------------------------------------
@@ -3754,12 +3766,24 @@ mod tests {
     /// with the service's configured secret — exactly the shape the HTTP
     /// middleware decodes.
     fn mint_access_token_at(cfg: &Config, user: &User, iat: i64) -> String {
+        // Models a token whose `iat_ms` lands on the floored second boundary
+        // (`iat * 1000`) — i.e. the conservative value a legacy token's
+        // `effective_iat_ms` falls back to. Tests that need a specific
+        // sub-second `iat_ms` use `mint_access_token_at_ms`.
+        mint_access_token_at_ms(cfg, user, iat, iat.saturating_mul(1000))
+    }
+
+    /// Mint an access JWT with an explicit whole-second `iat` AND an explicit
+    /// millisecond `iat_ms`, so tests can pin same-second sub-second ordering
+    /// deterministically without relying on wall-clock crossing a second.
+    fn mint_access_token_at_ms(cfg: &Config, user: &User, iat: i64, iat_ms: i64) -> String {
         let claims = Claims {
             sub: user.id,
             username: user.username.clone(),
             email: user.email.clone(),
             is_admin: user.is_admin,
             iat,
+            iat_ms: Some(iat_ms),
             exp: iat + 3600,
             token_type: "access".to_string(),
             jti: None,
@@ -3829,13 +3853,13 @@ mod tests {
 
     /// Regression test for #1911: OIDC login self-invalidation race condition.
     ///
-    /// The `authenticate_federated` flow calls `apply_role_mapping` (which
-    /// calls `invalidate_user_tokens_floor_second` on privilege change)
-    /// immediately before `generate_tokens`. This is the invalidate-then-mint
-    /// case: the freshly-minted JWT (whose `iat` floors to the current second)
-    /// must NOT be rejected by `is_token_invalidated_replica_safe`. The floored
-    /// watermark (`floor_sec * 1000`) equals the fresh token's `iat * 1000`, so
-    /// strict `<` accepts it.
+    /// The `authenticate_federated` flow calls `apply_role_mapping` (which now
+    /// calls plain `invalidate_user_tokens`, full ms) immediately before
+    /// `generate_tokens`. This is the invalidate-then-mint case: the freshly-
+    /// minted JWT carries an `iat_ms` a few microseconds AFTER the invalidate,
+    /// so `iat_ms > watermark` and `is_token_invalidated_replica_safe`'s strict
+    /// `<` accepts it, while a pre-change token (`iat_ms < watermark`) is
+    /// rejected. Numbers are pinned — no reliance on a wall-clock boundary.
     ///
     /// Uses the lazy (never-connected) pool — the in-memory cache populated
     /// by the invalidation serves the watermark without a DB round-trip.
@@ -3844,13 +3868,18 @@ mod tests {
         let (service, cfg) = invalidation_test_service();
         let user = make_test_user();
 
-        // Step 1: simulate apply_role_mapping → invalidate_user_tokens_floor_second
-        // (the invalidate-then-mint variant used by OIDC login).
-        invalidate_user_tokens_floor_second(user.id);
+        // Anchor on the current second so the JWT `exp` is in the future and
+        // the watermark is within the in-memory retention window; the
+        // discriminator is the PINNED sub-second offset, not a clock boundary.
+        let iat_sec = Utc::now().timestamp();
+        let watermark_ms = iat_sec.saturating_mul(1000) + 141;
 
-        // Step 2: simulate generate_tokens immediately after (same wall-clock second)
-        let now = Utc::now().timestamp();
-        let token = mint_access_token_at(&cfg, &user, now);
+        // Step 1: simulate apply_role_mapping → invalidate_user_tokens (full ms).
+        invalidate_user_tokens_at(user.id, watermark_ms);
+
+        // Step 2: simulate generate_tokens immediately after — minted 1 ms later
+        // in the SAME wall-clock second.
+        let token = mint_access_token_at_ms(&cfg, &user, iat_sec, watermark_ms + 1);
 
         // The replica-safe async path (HTTP auth middleware) must accept this token.
         let result = service.validate_access_token_async(&token).await;
@@ -3860,9 +3889,9 @@ mod tests {
             result.err(),
         );
 
-        // Pre-existing tokens (iat before invalidation) must still be rejected.
-        let old_iat = now - 10;
-        let old_token = mint_access_token_at(&cfg, &user, old_iat);
+        // A pre-change token (1 ms before the watermark, same second) must be
+        // rejected.
+        let old_token = mint_access_token_at_ms(&cfg, &user, iat_sec, watermark_ms - 1);
         let old_result = service.validate_access_token_async(&old_token).await;
         assert!(
             old_result.is_err(),
@@ -3871,29 +3900,29 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Sub-second (millisecond) watermark precision (#931 invariant restore;
-    // the #1915 floor-second regression). The watermark is in milliseconds so
-    // a token whose whole-second `iat` floors to the same wall-clock second as
-    // a credential change is ordered correctly.
+    // Sub-second (millisecond) `iat_ms` precision. With both the token's
+    // issued-at and the credential-change watermark in milliseconds, a token
+    // minted in the same wall-clock second as a change is ordered correctly:
+    // pre-change rejected, post-change (even same second) accepted.
     // -----------------------------------------------------------------------
 
-    /// The gate-failure case: a password change (full-precision
+    /// The auth-gate case: a password change (full-precision
     /// `invalidate_user_tokens`) must reject a token minted in the SAME
-    /// wall-clock second, on both the sync and the replica-safe async plane.
+    /// wall-clock second strictly before it, on both the sync and the
+    /// replica-safe async plane. Numbers pinned.
     #[tokio::test]
     async fn test_password_change_rejects_same_second_pre_change_token() {
         let (service, cfg) = invalidation_test_service();
         let user = make_test_user();
 
-        // The token's `iat` is the floored current second (what a real JWT
-        // minted "just before" the change carries).
+        // Anchor on the current second (future `exp`, retained watermark);
+        // PINNED sub-second offsets do the discriminating. Watermark at T.141;
+        // the pre-change token was minted at T.000 — same second, earlier in ms.
         let iat_sec = Utc::now().timestamp();
-        let token = mint_access_token_at(&cfg, &user, iat_sec);
+        let watermark_ms = iat_sec.saturating_mul(1000) + 141;
+        let token = mint_access_token_at_ms(&cfg, &user, iat_sec, iat_sec.saturating_mul(1000));
 
-        // Full-precision (mint-then-invalidate) credential change. Its
-        // millisecond watermark carries a positive sub-second offset above
-        // `iat_sec * 1000`.
-        invalidate_user_tokens(user.id);
+        invalidate_user_tokens_at(user.id, watermark_ms);
 
         // Sync plane (`<=`): same-second pre-change token rejected.
         assert!(
@@ -3902,108 +3931,197 @@ mod tests {
         );
         // Replica-safe async plane (strict `<`, served from the in-memory
         // cache so no DB round-trip): same-second pre-change token rejected.
-        // This is the exact regression the release gate caught.
         assert!(
             service.validate_access_token_async(&token).await.is_err(),
-            "async plane must reject the same-second pre-change token (the regression)"
+            "async plane must reject the same-second pre-change token"
         );
     }
 
-    /// Fresh-user regression (#1173/rbac/mesh): `users.password_changed_at`
-    /// is `DEFAULT NOW()` at user CREATION (migration 076) and carries a
-    /// sub-second offset (e.g. ...787141). The DB-read path floors that
-    /// watermark to the second (`...787000`) so a brand-new user's first login
-    /// in the SAME wall-clock second (`iat * 1000 == ...787000`) is ACCEPTED
-    /// under strict `<` — it must not be wrongly rejected. Meanwhile a REAL
-    /// password change (full-ms `invalidate_user_tokens`) in that same second
-    /// still REJECTS a same-second pre-change token, because the in-memory
-    /// full-ms watermark dominates the floored creation watermark.
+    /// The platform-gate case (the #1933 regression): an invalidate-then-relogin
+    /// in the SAME wall-clock second must ACCEPT the new token while rejecting an
+    /// older same-second token. This is the test that would have caught #1933.
+    #[tokio::test]
+    async fn test_same_second_relogin_after_invalidation_accepted() {
+        let (service, cfg) = invalidation_test_service();
+        let user = make_test_user();
+
+        // Anchor on the current second; PINNED sub-second offsets discriminate.
+        let iat_sec = Utc::now().timestamp();
+        let watermark_ms = iat_sec.saturating_mul(1000) + 141;
+        invalidate_user_tokens_at(user.id, watermark_ms);
+
+        // NEW token minted 5 ms after the change, SAME second → accepted on
+        // both planes.
+        let new_token = mint_access_token_at_ms(&cfg, &user, iat_sec, watermark_ms + 5);
+        assert!(
+            service.validate_access_token(&new_token).is_ok(),
+            "sync plane must accept the same-second post-change re-login"
+        );
+        assert!(
+            service
+                .validate_access_token_async(&new_token)
+                .await
+                .is_ok(),
+            "async plane must accept the same-second post-change re-login (the #1933 regression)"
+        );
+
+        // OLD token minted 5 ms before the change, SAME second → rejected.
+        let old_token = mint_access_token_at_ms(&cfg, &user, iat_sec, watermark_ms - 5);
+        assert!(
+            service.validate_access_token(&old_token).is_err(),
+            "sync plane must still reject the same-second pre-change token"
+        );
+        assert!(
+            service
+                .validate_access_token_async(&old_token)
+                .await
+                .is_err(),
+            "async plane must still reject the same-second pre-change token"
+        );
+    }
+
+    /// 10 rapid same-second re-logins (mirrors
+    /// `test-admin-password-recovery.sh`'s `10/10` requirement): each iteration
+    /// raises the watermark by 1 ms and mints a token 1 ms later; all 10 must
+    /// validate. The seconds-granularity comparator gave `0/10` here under #1933.
+    #[tokio::test]
+    async fn test_ten_rapid_same_second_relogins_all_accepted() {
+        let (service, cfg) = invalidation_test_service();
+        let user = make_test_user();
+
+        // Anchor on the current second; PINNED 1-ms steps discriminate.
+        let iat_sec = Utc::now().timestamp();
+        let base_ms = iat_sec.saturating_mul(1000) + 100;
+        for i in 0..10 {
+            let watermark_ms = base_ms + i;
+            invalidate_user_tokens_at(user.id, watermark_ms);
+            let token = mint_access_token_at_ms(&cfg, &user, iat_sec, watermark_ms + 1);
+            assert!(
+                service.validate_access_token(&token).is_ok(),
+                "sync plane: same-second re-login #{i} must be accepted"
+            );
+            assert!(
+                service.validate_access_token_async(&token).await.is_ok(),
+                "async plane: same-second re-login #{i} must be accepted"
+            );
+        }
+    }
+
+    /// Fresh-user same-second first login (#1173/rbac/mesh): the DB-read
+    /// watermark is now full ms (creation `password_changed_at` e.g. ...787141).
+    /// A real first login mints strictly later in wall-clock time, so its
+    /// `iat_ms` exceeds the creation watermark even at full precision and is
+    /// ACCEPTED — no floor needed. A subsequent real password change still
+    /// REJECTS a same-second pre-change token. Numbers pinned.
     #[tokio::test]
     async fn test_fresh_user_same_second_first_login_accepted() {
         let (service, cfg) = invalidation_test_service();
         let user = make_test_user();
 
-        // Simulate the DB-derived creation watermark: `password_changed_at`
-        // was set at creation with a sub-second offset, but the DB-read path
-        // FLOORS it to the second before recording it in the in-memory map
-        // (exactly what `fetch_credential_change_watermark` now does:
-        // `watermark_ts.timestamp() * 1000`).
-        let now_sec = Utc::now().timestamp();
-        let floored_creation_watermark_ms = now_sec.saturating_mul(1000);
-        invalidate_user_tokens_at(user.id, floored_creation_watermark_ms);
+        // DB-derived creation watermark at full ms (sub-second creation
+        // offset), anchored on the current second so the JWT `exp` is future
+        // and the watermark stays within the retention window.
+        let iat_sec = Utc::now().timestamp();
+        let creation_ms = iat_sec.saturating_mul(1000) + 787;
+        invalidate_user_tokens_at(user.id, creation_ms);
 
-        // The fresh user's first login in the SAME second mints `iat = now_sec`.
-        let fresh_login = mint_access_token_at(&cfg, &user, now_sec);
+        // First login mints 50 ms later (strictly after creation) — SAME second.
+        let fresh_login = mint_access_token_at_ms(&cfg, &user, iat_sec, creation_ms + 50);
         assert!(
             service
                 .validate_access_token_async(&fresh_login)
                 .await
                 .is_ok(),
-            "fresh-user same-second first login must be accepted (floored DB-read watermark)"
+            "fresh-user same-second first login must be accepted (full-ms ordering)"
         );
 
-        // Now a REAL password change writes the full-ms watermark for the same
-        // second; the monotonic-max writer keeps it above the floored creation
-        // value, so a same-second PRE-change token is correctly rejected.
-        invalidate_user_tokens(user.id);
-        let pre_change = mint_access_token_at(&cfg, &user, now_sec);
+        // A real password change at creation_ms + 200; a pre-change token at
+        // creation_ms + 100 (minted before the change) must be rejected.
+        invalidate_user_tokens_at(user.id, creation_ms + 200);
+        let pre_change = mint_access_token_at_ms(&cfg, &user, iat_sec, creation_ms + 100);
         assert!(
             service
                 .validate_access_token_async(&pre_change)
                 .await
                 .is_err(),
-            "a same-second pre-change token must still be rejected after a real password change"
+            "a same-second pre-change token must be rejected after a real password change"
         );
     }
 
-    /// Invalidate-then-mint (OIDC / admin reset): the floored-second variant
-    /// keeps a same-second freshly-minted token valid while rejecting any
-    /// token from a strictly earlier second.
+    /// Legacy token (no `iat_ms`) backward-compat: `effective_iat_ms` falls back
+    /// to the floored `iat * 1000`, the conservative side. Against a same-second
+    /// full-ms watermark such a token is REJECTED on both planes.
     #[tokio::test]
-    async fn test_oidc_floor_second_keeps_fresh_token() {
+    async fn test_legacy_token_without_iat_ms_falls_back_to_floored_seconds() {
         let (service, cfg) = invalidation_test_service();
         let user = make_test_user();
 
-        // Floored-second invalidate (apply_role_mapping path).
-        invalidate_user_tokens_floor_second(user.id);
+        let iat_sec = Utc::now().timestamp();
+        let legacy = Claims {
+            sub: user.id,
+            username: user.username.clone(),
+            email: user.email.clone(),
+            is_admin: user.is_admin,
+            iat: iat_sec,
+            iat_ms: None,
+            exp: iat_sec + 3600,
+            token_type: "access".to_string(),
+            jti: None,
+            family_id: None,
+        };
+        // The fallback is exactly `iat * 1000`.
+        assert_eq!(legacy.effective_iat_ms(), iat_sec.saturating_mul(1000));
 
-        // A token minted in the same second survives (`iat * 1000 ==
-        // floor_sec * 1000 == watermark`, strict `<` is false).
-        let now = Utc::now().timestamp();
-        let fresh = mint_access_token_at(&cfg, &user, now);
+        let token = encode(
+            &Header::default(),
+            &legacy,
+            &EncodingKey::from_secret(cfg.jwt_secret.as_bytes()),
+        )
+        .expect("encode legacy token");
+
+        // Same-second full-ms watermark (T.000 + 1 ms). The legacy token's
+        // effective_iat_ms == T.000 < watermark → rejected on both planes.
+        let watermark_ms = iat_sec.saturating_mul(1000) + 1;
+        invalidate_user_tokens_at(user.id, watermark_ms);
         assert!(
-            service.validate_access_token_async(&fresh).await.is_ok(),
-            "same-second freshly-minted token must be accepted (invalidate-then-mint)"
+            service.validate_access_token(&token).is_err(),
+            "sync plane must reject a legacy same-second pre-change token (floored fallback)"
         );
-
-        // A token from a strictly earlier second is rejected.
-        let prev = mint_access_token_at(&cfg, &user, now - 1);
         assert!(
-            service.validate_access_token_async(&prev).await.is_err(),
-            "a token from a strictly earlier second must be rejected"
+            service.validate_access_token_async(&token).await.is_err(),
+            "async plane must reject a legacy same-second pre-change token (floored fallback)"
         );
     }
 
     /// The exempt-caller variant operates in milliseconds: the calling token
-    /// (`caller_iat`) is exempt, while a token from any earlier second is
-    /// invalidated.
+    /// (`caller_iat_ms`) is exempt, while EVERY strictly-older token — including
+    /// one from the SAME second (`caller_iat_ms - 1`) — is invalidated. This is
+    /// the precision the seconds-granularity version lacked.
     #[test]
     fn test_except_caller_ms() {
         let user_id = Uuid::new_v4();
-        let caller_iat = Utc::now().timestamp();
+        // Anchor on the current second (so the watermark stays within the
+        // in-memory retention window) with a PINNED sub-second part (537 ms) so
+        // the same-second-older case is exercised deterministically.
+        let caller_iat_ms = Utc::now().timestamp().saturating_mul(1000) + 537;
 
-        invalidate_user_tokens_except_caller(user_id, caller_iat);
+        invalidate_user_tokens_except_caller(user_id, caller_iat_ms);
 
-        // The watermark is `caller_iat * 1000 - 1` (ms): the calling token
-        // (`caller_iat * 1000 <= caller_iat * 1000 - 1` is false) survives.
+        // The watermark is `caller_iat_ms - 1`: the calling token
+        // (`caller_iat_ms <= caller_iat_ms - 1` is false) survives.
         assert!(
-            !is_token_invalidated(user_id, caller_iat),
+            !is_token_invalidated(user_id, caller_iat_ms),
             "the calling token must be exempt"
         );
-        // A token from the previous second is invalidated.
+        // An older token from the SAME second (one ms earlier) is invalidated.
         assert!(
-            is_token_invalidated(user_id, caller_iat - 1),
-            "a token from an earlier second must be invalidated"
+            is_token_invalidated(user_id, caller_iat_ms - 1),
+            "an older same-second token must be invalidated (ms precision)"
+        );
+        // A token from several seconds earlier is invalidated.
+        assert!(
+            is_token_invalidated(user_id, caller_iat_ms - 5000),
+            "a strictly older token must be invalidated"
         );
     }
 
@@ -4030,10 +4148,10 @@ mod tests {
             "a later, lower watermark must not lower the stored watermark"
         );
 
-        // A token at the low watermark's second is still rejected (the high
+        // A token at the low watermark (in ms) is still rejected (the high
         // watermark dominates).
         assert!(
-            is_token_invalidated(user_id, low_ms.div_euclid(1000)),
+            is_token_invalidated(user_id, low_ms),
             "the high watermark must keep rejecting pre-change tokens"
         );
     }
@@ -4313,6 +4431,7 @@ mod tests {
             email: "evil@test.com".to_string(),
             is_admin: true,
             iat: Utc::now().timestamp(),
+            iat_ms: None,
             exp: (Utc::now() + Duration::hours(1)).timestamp(),
             token_type: "access".to_string(),
             jti: None,
@@ -4592,20 +4711,21 @@ mod tests {
         // drift between this process and the database server. Same-second
         // (iat == watermark) is intentionally accepted post-#1248, so a test
         // pinning the "issued before" semantic must leave an unambiguous gap.
-        let iat_before = (Utc::now() - Duration::seconds(120)).timestamp();
+        let iat_before = (Utc::now() - Duration::seconds(120)).timestamp_millis();
 
         // Token issued before the user's existing password_changed_at watermark
         // (inserted as NOW - 60s by `insert_test_user`) must be flagged
         // invalidated by the DB-backed check. This exercises the cross-replica
         // path because the in-memory fast-path map is empty for this user_id
-        // on this process.
+        // on this process. Issued-at is in milliseconds (matching
+        // `Claims::effective_iat_ms`).
         let rejected = is_token_invalidated_replica_safe(&pool, user_id, iat_before)
             .await
             .expect("DB check must succeed");
         assert!(rejected, "token issued before watermark must be rejected");
 
         // A token issued well after the watermark should be accepted.
-        let iat_after = (Utc::now() + Duration::seconds(60)).timestamp();
+        let iat_after = (Utc::now() + Duration::seconds(60)).timestamp_millis();
         let rejected = is_token_invalidated_replica_safe(&pool, user_id, iat_after)
             .await
             .expect("DB check must succeed");
@@ -4806,17 +4926,19 @@ mod tests {
         .await
         .expect("insert fresh user");
 
-        // Token iat == the same second the user was inserted. In production
-        // this is what happens when `POST /users` is followed immediately
-        // by `POST /auth/login` (both wall-clock second N).
-        let iat_same_second = Utc::now().timestamp();
-        let rejected = is_token_invalidated_replica_safe(&pool, id, iat_same_second)
+        // Token iat_ms captured AFTER the INSERT, in the same wall-clock second
+        // as user creation. In production this is `POST /users` followed
+        // immediately by `POST /auth/login`. With full-ms watermarks the login
+        // is strictly later than `password_changed_at DEFAULT NOW()`, so its
+        // `iat_ms` exceeds the creation watermark and is accepted.
+        let iat_same_second_ms = Utc::now().timestamp_millis();
+        let rejected = is_token_invalidated_replica_safe(&pool, id, iat_same_second_ms)
             .await
             .expect("DB check must succeed");
         assert!(
             !rejected,
-            "token issued in the same wall-clock second as user creation \
-             must be accepted (otherwise admin_middleware returns 401 \
+            "token issued in the same wall-clock second as (but after) user \
+             creation must be accepted (otherwise admin_middleware returns 401 \
              instead of letting the request reach the is_admin check)"
         );
 
@@ -4869,7 +4991,7 @@ mod tests {
 
         // Token minted while still admin (iat = NOW - 60s, after the backdated
         // creation watermark). Must be ACCEPTED before any demotion.
-        let pre_demotion_iat = (Utc::now() - Duration::seconds(60)).timestamp();
+        let pre_demotion_iat = (Utc::now() - Duration::seconds(60)).timestamp_millis();
         let rejected_before = is_token_invalidated_replica_safe(&pool, user_id, pre_demotion_iat)
             .await
             .expect("DB check must succeed");
@@ -4903,7 +5025,7 @@ mod tests {
 
         // A token minted AFTER the demotion (with the new is_admin=false claim)
         // is still accepted — invalidation is watermark-scoped, not a lockout.
-        let post_demotion_iat = (Utc::now() + Duration::seconds(60)).timestamp();
+        let post_demotion_iat = (Utc::now() + Duration::seconds(60)).timestamp_millis();
         if let Ok(mut map) = invalidation_map().write() {
             map.remove(&user_id);
         }

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -297,6 +297,9 @@ mod credential_change_grpc {
             email: "grpc-user@test.local".to_string(),
             is_admin: true,
             iat,
+            // Legacy whole-second token shape (no ms claim); exercises the
+            // effective_iat_ms() fallback to iat*1000.
+            iat_ms: None,
             exp: iat + 3600,
             token_type: "access".to_string(),
             jti: None,


### PR DESCRIPTION
## Summary

The standard RFC-7519 `iat` claim is whole-second precision, which is too
coarse to order a token against the **millisecond** credential-change watermark
when a credential change and a token mint fall in the same wall-clock second.
This collision could only ever be resolved one direction at a time:

- flooring the watermark to the second let a same-second re-login through but
  also let a same-second *pre-change* token through;
- keeping the full-millisecond watermark rejected the pre-change token but also
  rejected a legitimate same-second re-login (`password reset returned 401`,
  `0/10 rapid logins`).

This PR adds a private, optional `iat_ms: Option<i64>` JWT claim carrying the
mint instant at millisecond resolution, and compares it (via
`Claims::effective_iat_ms()`) against the millisecond watermark on **both**
invalidation planes. With both sides at millisecond resolution the ordering is
exact by construction:

- a token minted **before** a credential change has `iat_ms < watermark` and is
  rejected (to the millisecond);
- a token minted **after** the change — even in the same second, including the
  invalidate-then-mint OIDC self-update flow — has `iat_ms > watermark` and is
  accepted.

Because the resolution mismatch is removed at the source, two floor-based
special cases are no longer needed and are removed, collapsing three watermark
code paths into a single full-millisecond path:

- the floor-second invalidate variant used by OIDC role mapping (the fresh mint
  is now microseconds after the invalidate, so it survives strict `<`
  naturally);
- the floor-to-second amendment on the DB-read watermark (a real first login is
  always later in milliseconds than user creation, so full precision no longer
  regresses fresh users — and is strictly more correct cross-replica).

Backward compatibility: tokens minted before this deploy have no `iat_ms`;
`effective_iat_ms()` falls back to the floored `iat * 1000` (the conservative,
secure side), so a legacy token can never be wrongly accepted relative to a
same-second change. The `#[serde(default, skip_serializing_if = ...)]` keeps the
wire format additive. The #1248 two-plane invariant is preserved verbatim: the
sync plane keeps `<=`, the replica-safe plane keeps strict `<`, and the
replica-safe path still does not call the sync helper.

No DB schema change, no migration, no `.sqlx` regeneration.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New/updated unit tests in `auth_service.rs` (numbers pinned, no clock reliance):
same-second pre-change token rejected on both planes; same-second
invalidate-then-relogin accepted on both planes (the test that would have caught
the regression); 10 rapid same-second re-logins all accepted; OIDC
invalidate-then-mint accepted while pre-change rejected; fresh-user same-second
first login accepted under the full-ms DB watermark; `except_caller` millisecond
precision (caller exempt, older same-second token caught); legacy token
(`iat_ms = None`) falls back to `iat * 1000` and is rejected against a
same-second watermark. TOTP enable/disable `except_caller` tests updated to
millisecond `TokenIat` and assert older same-second sessions are caught.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
