### PR TITLE
fix(openapi): give quarantine reject a unique operationId (unblocks SDK publishing)

### DIFF
--- a/backend/src/api/handlers/quarantine.rs
+++ b/backend/src/api/handlers/quarantine.rs
@@ -166,6 +166,7 @@ pub async fn release_artifact(
     post,
     path = "/{artifact_id}/reject",
     context_path = "/api/v1/quarantine",
+    operation_id = "reject_quarantined_artifact",
     tag = "quarantine",
     params(
         ("artifact_id" = Uuid, Path, description = "Artifact ID"),

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -235,6 +235,56 @@ mod tests {
         );
     }
 
+    /// Regression: every operation must have a globally unique `operationId`.
+    /// utoipa derives it from the handler fn name by default, so two handlers
+    /// that share a name (e.g. `reject_artifact` in both promotion.rs and
+    /// quarantine.rs) silently produce a duplicate `operationId`. That fails the
+    /// artifact-keeper-api spectral gate (`operation-operationId-unique`), which
+    /// skips ALL SDK generation/publishing for the release — the reason the
+    /// published `@artifact-keeper/sdk` stalled at 1.1.6. Catch it here, in
+    /// backend CI, instead of discovering it after a release tag is cut.
+    #[test]
+    fn test_openapi_operation_ids_are_unique() {
+        use std::collections::HashMap;
+
+        let spec = build_openapi();
+        let mut seen: HashMap<String, Vec<String>> = HashMap::new();
+
+        for (path, item) in &spec.paths.paths {
+            for (method, op) in [
+                ("GET", &item.get),
+                ("PUT", &item.put),
+                ("POST", &item.post),
+                ("DELETE", &item.delete),
+                ("PATCH", &item.patch),
+                ("HEAD", &item.head),
+            ] {
+                if let Some(op) = op {
+                    if let Some(id) = &op.operation_id {
+                        seen.entry(id.clone())
+                            .or_default()
+                            .push(format!("{method} {path}"));
+                    }
+                }
+            }
+        }
+
+        let mut dups: Vec<String> = seen
+            .iter()
+            .filter(|(_, locs)| locs.len() > 1)
+            .map(|(id, locs)| format!("  {id}: {}", locs.join(", ")))
+            .collect();
+        dups.sort();
+
+        assert!(
+            dups.is_empty(),
+            "Duplicate operationId(s) found — these fail the api-repo spectral gate \
+             and block SDK generation/publishing. Give one handler an explicit \
+             `operation_id = \"...\"` in its #[utoipa::path]:\n{}",
+            dups.join("\n")
+        );
+    }
+
     #[test]
     fn test_repository_labels_endpoints_in_spec() {
         let spec = build_openapi();


### PR DESCRIPTION
Closes #1938

## Summary

The SDK publish pipeline has been silently broken since **v1.1.9-rc.5** — the last client that actually published was `@artifact-keeper/sdk@1.1.6`. Two handlers are both named `reject_artifact` (`promotion.rs` and `quarantine.rs`), so utoipa derives the same `operationId: reject_artifact` for both endpoints. A duplicate operationId fails the `artifact-keeper-api` spectral gate (`operation-operationId-unique`, `--fail-severity error`), which **skips every SDK generate+publish job** for the release. Backend CI never caught it because the OpenAPI tests check operation *count*, not *uniqueness*.

Fix: add an explicit `operation_id = "reject_quarantined_artifact"` to the quarantine handler (promotion keeps the original `reject_artifact`). Verified against the generated spec — this is the only colliding pair.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_openapi_operation_ids_are_unique` builds the merged OpenAPI doc and asserts every operationId is globally unique. **Fails on `main`** (the `reject_artifact` duplicate), **passes here**. Catches this class of bug in backend CI before a release tag ever reaches the api-repo spectral gate.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo test --lib test_openapi_operation_ids_are_unique` → ok; `cargo check --lib` clean)
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates (operationIds now unique; spectral passes with 0 errors)
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Note: `operationId` is the SDK method name. `reject_quarantined_artifact` is also clearer than the previous collision and disambiguates from the promotion-workflow reject.