### PR TITLE
fix(lifecycle): block release-immutability swap via delete + re-upload of different content

### DIFF
--- a/.sqlx/query-78c759c40a5c20d9f330cc953fcacd8d6e0e8df8d119a0f4c748adfde5f378e7.json
+++ b/.sqlx/query-78c759c40a5c20d9f330cc953fcacd8d6e0e8df8d119a0f4c748adfde5f378e7.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT checksum_sha256, version FROM artifacts WHERE repository_id = $1 AND path = $2 AND is_deleted = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "78c759c40a5c20d9f330cc953fcacd8d6e0e8df8d119a0f4c748adfde5f378e7"
+}

--- a/.sqlx/query-ab4717210b7d122dcc27b5b9ee2b81e4e672426ef3c4c463c78991f1f6a65393.json
+++ b/.sqlx/query-ab4717210b7d122dcc27b5b9ee2b81e4e672426ef3c4c463c78991f1f6a65393.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT checksum_sha256, version FROM artifacts WHERE repository_id = $1 AND path = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "ab4717210b7d122dcc27b5b9ee2b81e4e672426ef3c4c463c78991f1f6a65393"
+}

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -649,7 +649,15 @@ async fn store_crate_artifact(
     let artifact_path = format!("{}/{}/{}", name_lower, crate_version, filename);
     let size_bytes = crate_bytes.len() as i64;
 
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Cargo,
+        repo.id,
+        &artifact_path,
+        checksum,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     let artifact_id = sqlx::query_scalar!(
         r#"

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1023,7 +1023,15 @@ async fn upload(
             .into_response());
     }
 
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Composer,
+        repo.id,
+        &artifact_path,
+        &sha256,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     // Store the archive
     let storage_key = format!("composer/{}/{}/{}.zip", full_name, version, sha256);

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1094,7 +1094,18 @@ async fn recipe_file_upload(
 
     // Clean up soft-deleted rows (including the one just soft-deleted above)
     // so the UNIQUE(repository_id, path) constraint won't block the INSERT.
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    // The checked variant additionally rejects a release-immutability swap on
+    // any coordinate the classifier marks immutable (Conan paths are mutable
+    // today, so this is a no-op for them and preserves same-revision overwrite).
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Conan,
+        repo.id,
+        &artifact_path,
+        &checksum_sha256,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     // Store the file
     let storage = state
@@ -1801,7 +1812,18 @@ async fn package_file_upload(
 
     // Clean up soft-deleted rows (including the one just soft-deleted above)
     // so the UNIQUE(repository_id, path) constraint won't block the INSERT.
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    // The checked variant additionally rejects a release-immutability swap on
+    // any coordinate the classifier marks immutable (Conan paths are mutable
+    // today, so this is a no-op for them and preserves same-revision overwrite).
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Conan,
+        repo.id,
+        &artifact_path,
+        &checksum_sha256,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     // Store the file
     let storage = state

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -3106,7 +3106,15 @@ async fn store_conda_package(
         return Err((StatusCode::CONFLICT, "Package already exists").into_response());
     }
 
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Conda,
+        repo.id,
+        &artifact_path,
+        &computed_sha256,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     // Store the file
     let storage_key = format!("conda/{}/{}/{}", repo.id, subdir, filename);

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2075,8 +2075,18 @@ async fn upload(
         .await;
     } else {
         // Clean up any soft-deleted artifact at the same path so the
-        // UNIQUE(repository_id, path) constraint doesn't block re-upload.
-        super::cleanup_soft_deleted_artifact(&state.db, repo.id, &path).await;
+        // UNIQUE(repository_id, path) constraint doesn't block re-upload —
+        // unless this is a release-immutability swap (delete + re-upload of
+        // DIFFERENT bytes to an immutable coordinate), which is rejected.
+        super::cleanup_soft_deleted_artifact_checked(
+            &state.db,
+            &crate::models::repository::RepositoryFormat::Maven,
+            repo.id,
+            &path,
+            &checksum_sha256,
+        )
+        .await
+        .map_err(|e| e.into_response())?;
     }
 
     // Store file in object storage regardless of grouping outcome

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -30,6 +30,52 @@ pub async fn cleanup_soft_deleted_artifact(
     .await;
 }
 
+/// Remove any soft-deleted artifact at `(repository_id, path)` so a subsequent
+/// INSERT won't violate `UNIQUE(repository_id, path)` — UNLESS the coordinate is
+/// structurally immutable (per [`cache_classifier`]) AND the incoming bytes
+/// differ from the tombstoned bytes.
+///
+/// In that case the re-upload would be a release-immutability swap (a DELETE
+/// followed by re-uploading DIFFERENT content under a released coordinate), so
+/// it is rejected with the same 409 the live PUT-overwrite path returns.
+/// Re-uploading the IDENTICAL bytes (idempotent republish / undelete) and all
+/// mutable / unknown-format paths are always allowed — the purge proceeds as
+/// before. This is the single pre-insert chokepoint every upload handler shares.
+pub async fn cleanup_soft_deleted_artifact_checked(
+    db: &sqlx::PgPool,
+    format: &crate::models::repository::RepositoryFormat,
+    repository_id: uuid::Uuid,
+    path: &str,
+    new_checksum_sha256: &str,
+) -> crate::error::Result<()> {
+    use crate::error::AppError;
+    use crate::services::cache_classifier;
+
+    if cache_classifier::classify(format, path).is_immutable() {
+        // Inspect the tombstone (if any) BEFORE it is purged.
+        let prior = sqlx::query_scalar::<_, String>(
+            "SELECT checksum_sha256 FROM artifacts \
+             WHERE repository_id = $1 AND path = $2 AND is_deleted = true",
+        )
+        .bind(repository_id)
+        .bind(path)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if let Some(prior_sha) = prior {
+            if !prior_sha.eq_ignore_ascii_case(new_checksum_sha256) {
+                return Err(AppError::Conflict(
+                    "Artifact version already exists and is immutable".to_string(),
+                ));
+            }
+        }
+    }
+
+    cleanup_soft_deleted_artifact(db, repository_id, path).await;
+    Ok(())
+}
+
 /// Escape SQL `LIKE` wildcards (`%`, `_`) and the escape character (`\`) in
 /// user-supplied input that will be concatenated into a `LIKE` pattern.
 ///
@@ -389,5 +435,209 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(body, "null".as_bytes());
+    }
+
+    // -----------------------------------------------------------------------
+    // cleanup_soft_deleted_artifact_checked — release-immutability swap guard
+    //
+    // DB-backed; no-ops cleanly when DATABASE_URL is unset (CI seeds Postgres
+    // before `cargo llvm-cov --lib`). Validates that a DELETE + re-upload of
+    // DIFFERENT bytes to a structurally-immutable coordinate is rejected with
+    // a 409, while identical-bytes republish, mutable paths, and the
+    // no-tombstone case all proceed.
+    // -----------------------------------------------------------------------
+
+    use crate::models::repository::RepositoryFormat;
+
+    /// Create a hosted repo of the given `format` (a `repository_format` enum
+    /// literal such as `'maven'`). Returns its id.
+    async fn make_repo(pool: &sqlx::PgPool, format: &str) -> uuid::Uuid {
+        let id = uuid::Uuid::new_v4();
+        let key = format!("immut-test-{}", id);
+        let dir = std::env::temp_dir().join(&key);
+        let sql = format!(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+             VALUES ($1, $2, $3, $4, 'local'::repository_type, '{}'::repository_format)",
+            format
+        );
+        sqlx::query(&sql)
+            .bind(id)
+            .bind(&key)
+            .bind(&key)
+            .bind(dir.to_string_lossy().as_ref())
+            .execute(pool)
+            .await
+            .expect("create test repo");
+        id
+    }
+
+    /// Insert a SOFT-DELETED (tombstoned) artifact row at `(repo, path)` with
+    /// the given sha256 — simulating a prior publish that was then DELETEd.
+    async fn insert_tombstone(pool: &sqlx::PgPool, repo: uuid::Uuid, path: &str, sha: &str) {
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, version, size_bytes, checksum_sha256, \
+              content_type, storage_key, is_deleted) \
+             VALUES ($1, $2, $3, '1.0.0', 1, $4, 'application/octet-stream', $5, true)",
+        )
+        .bind(repo)
+        .bind(path)
+        .bind(path)
+        .bind(sha)
+        .bind(format!("sk/{}", sha))
+        .execute(pool)
+        .await
+        .expect("insert tombstone");
+    }
+
+    async fn cleanup_repo(pool: &sqlx::PgPool, repo: uuid::Uuid) {
+        let _ = sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+            .bind(repo)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo)
+            .execute(pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn checked_cleanup_blocks_immutable_swap_different_bytes() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let repo = make_repo(&pool, "maven").await;
+        let path = "com/x/app/1.0.0/app-1.0.0.jar"; // classifier: immutable
+        insert_tombstone(
+            &pool,
+            repo,
+            path,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .await;
+
+        // Re-upload DIFFERENT bytes -> must be rejected (the exploit, blocked).
+        let res = cleanup_soft_deleted_artifact_checked(
+            &pool,
+            &RepositoryFormat::Maven,
+            repo,
+            path,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+        .await;
+        assert!(
+            matches!(res, Err(crate::error::AppError::Conflict(_))),
+            "delete + re-upload of different bytes to an immutable Maven coordinate must 409",
+        );
+        // Tombstone must still be present (purge refused).
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(repo)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining, 1, "immutable tombstone must not be purged");
+
+        cleanup_repo(&pool, repo).await;
+    }
+
+    #[tokio::test]
+    async fn checked_cleanup_allows_identical_bytes_republish() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let repo = make_repo(&pool, "maven").await;
+        let path = "com/x/app/1.0.0/app-1.0.0.jar";
+        insert_tombstone(
+            &pool,
+            repo,
+            path,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .await;
+
+        // Re-upload IDENTICAL bytes -> allowed (idempotent republish).
+        let res = cleanup_soft_deleted_artifact_checked(
+            &pool,
+            &RepositoryFormat::Maven,
+            repo,
+            path,
+            "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", // same sha, case-insensitive
+        )
+        .await;
+        assert!(res.is_ok(), "identical-bytes republish must be allowed");
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(repo)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            remaining, 0,
+            "tombstone purged for identical-bytes republish"
+        );
+
+        cleanup_repo(&pool, repo).await;
+    }
+
+    #[tokio::test]
+    async fn checked_cleanup_allows_mutable_path_swap() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let repo = make_repo(&pool, "maven").await;
+        let path = "com/x/app/maven-metadata.xml"; // classifier: mutable
+        insert_tombstone(
+            &pool,
+            repo,
+            path,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        )
+        .await;
+
+        // Mutable coordinate: re-upload of different bytes proceeds (purge).
+        let res = cleanup_soft_deleted_artifact_checked(
+            &pool,
+            &RepositoryFormat::Maven,
+            repo,
+            path,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        )
+        .await;
+        assert!(
+            res.is_ok(),
+            "mutable maven-metadata.xml swap must be allowed"
+        );
+        let remaining: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(repo)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(remaining, 0, "mutable tombstone purged as before");
+
+        cleanup_repo(&pool, repo).await;
+    }
+
+    #[tokio::test]
+    async fn checked_cleanup_no_tombstone_proceeds() {
+        let Some(pool) = crate::api::handlers::test_db_helpers::try_pool().await else {
+            return;
+        };
+        let repo = make_repo(&pool, "maven").await;
+        let path = "com/x/app/2.0.0/app-2.0.0.jar"; // immutable, but no tombstone
+
+        // First upload (no prior tombstone) -> proceeds unconditionally.
+        let res = cleanup_soft_deleted_artifact_checked(
+            &pool,
+            &RepositoryFormat::Maven,
+            repo,
+            path,
+            "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        )
+        .await;
+        assert!(res.is_ok(), "first upload with no tombstone must proceed");
+
+        cleanup_repo(&pool, repo).await;
     }
 }

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -32,15 +32,22 @@ pub async fn cleanup_soft_deleted_artifact(
 
 /// Remove any soft-deleted artifact at `(repository_id, path)` so a subsequent
 /// INSERT won't violate `UNIQUE(repository_id, path)` — UNLESS the coordinate is
-/// structurally immutable (per [`cache_classifier`]) AND the incoming bytes
-/// differ from the tombstoned bytes.
+/// a *released* one AND the incoming bytes differ from the tombstoned bytes.
 ///
-/// In that case the re-upload would be a release-immutability swap (a DELETE
-/// followed by re-uploading DIFFERENT content under a released coordinate), so
-/// it is rejected with the same 409 the live PUT-overwrite path returns.
-/// Re-uploading the IDENTICAL bytes (idempotent republish / undelete) and all
-/// mutable / unknown-format paths are always allowed — the purge proceeds as
-/// before. This is the single pre-insert chokepoint every upload handler shares.
+/// This is the pre-insert chokepoint the format handlers that do their own
+/// INSERT (cargo / maven / npm / nuget / conan / composer / conda) share, and it
+/// mirrors the release-immutability backstop in
+/// [`ArtifactService::upload_with_sync_options`] for the service-backed paths.
+///
+/// A coordinate is *released* (immutable) when a prior row exists there AND the
+/// path is not a format's genuinely in-place-rewritten index file
+/// (`maven-metadata.xml`, npm packument, OCI tag, ...). The structural
+/// [`cache_classifier`] supplies the index/immutable distinction; for the
+/// default-format families (Nuget / Conan / Composer / Generic / ...) every
+/// stored path is a release coordinate, so a versioned re-upload is protected
+/// too. Re-uploading the IDENTICAL bytes (idempotent republish / undelete) and
+/// genuine mutable index files are always allowed — the purge proceeds as
+/// before.
 pub async fn cleanup_soft_deleted_artifact_checked(
     db: &sqlx::PgPool,
     format: &crate::models::repository::RepositoryFormat,
@@ -51,20 +58,29 @@ pub async fn cleanup_soft_deleted_artifact_checked(
     use crate::error::AppError;
     use crate::services::cache_classifier;
 
-    if cache_classifier::classify(format, path).is_immutable() {
+    // Genuine in-place index files (a format's mutable pointers) are always
+    // freely re-uploadable; everything else is a candidate release coordinate.
+    if !cache_classifier::is_explicitly_mutable_index(format, path) {
         // Inspect the tombstone (if any) BEFORE it is purged.
-        let prior = sqlx::query_scalar::<_, String>(
-            "SELECT checksum_sha256 FROM artifacts \
+        let prior = sqlx::query!(
+            "SELECT checksum_sha256, version FROM artifacts \
              WHERE repository_id = $1 AND path = $2 AND is_deleted = true",
+            repository_id,
+            path
         )
-        .bind(repository_id)
-        .bind(path)
         .fetch_optional(db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        if let Some(prior_sha) = prior {
-            if !prior_sha.eq_ignore_ascii_case(new_checksum_sha256) {
+        if let Some(prior) = prior {
+            // Released = versioned coordinate or structurally immutable path.
+            let is_released =
+                prior.version.is_some() || cache_classifier::classify(format, path).is_immutable();
+            if is_released
+                && !prior
+                    .checksum_sha256
+                    .eq_ignore_ascii_case(new_checksum_sha256)
+            {
                 return Err(AppError::Conflict(
                     "Artifact version already exists and is immutable".to_string(),
                 ));

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1691,7 +1691,15 @@ async fn store_npm_version(
         .into_response());
     }
 
-    super::cleanup_soft_deleted_artifact(&state.db, repo_id, &artifact_path).await;
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Npm,
+        repo_id,
+        &artifact_path,
+        &ver.sha256,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     // Store the tarball
     let storage_key = format!(

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -979,7 +979,15 @@ async fn push_package(
     let artifact_path = format!("{}/{}/{}", package_id, version, filename);
     let storage_key = format!("nuget/{}/{}/{}", package_id, version, filename);
 
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    super::cleanup_soft_deleted_artifact_checked(
+        &state.db,
+        &crate::models::repository::RepositoryFormat::Nuget,
+        repo.id,
+        &artifact_path,
+        &checksum,
+    )
+    .await
+    .map_err(|e| e.into_response())?;
 
     // Store the file.
     let storage = state

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1850,7 +1850,12 @@ async fn upload(
     let artifact_path = format!("{}/{}/{}", normalized, pkg_version, filename);
     let size_bytes = content.len() as i64;
 
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
+    // No pre-cleanup here: this path persists through
+    // `artifact_service::upload_with_sync_options`, whose release-immutability
+    // backstop must see the soft-deleted tombstone (purging it first would hide
+    // a release-immutability swap). The service's `ON CONFLICT DO UPDATE`
+    // resurrects the soft-deleted row in the allowed (identical-bytes / mutable)
+    // cases, so the UNIQUE(repository_id, path) constraint is still satisfied.
 
     let storage = state
         .storage_for_repo(&repo.storage_location())

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3516,9 +3516,16 @@ pub async fn upload_artifact(
         .map(|m| m.content_type.clone())
         .unwrap_or_else(|| resolve_upload_content_type(declared_content_type, &path));
 
-    // Clean up any soft-deleted artifact at the same path so the
-    // UNIQUE(repository_id, path) constraint doesn't block re-upload.
-    super::cleanup_soft_deleted_artifact(&state.db, repo.id, &path).await;
+    // No pre-cleanup here: this generic upload endpoint (and the multipart
+    // variants that delegate to it) persists through
+    // `artifact_service::upload_with_sync_options`, whose release-immutability
+    // backstop must SEE any soft-deleted tombstone at this coordinate — purging
+    // it first would hide a release-immutability swap (DELETE + re-upload of
+    // DIFFERENT bytes to a released coordinate, the exploited path). The
+    // service's `ON CONFLICT (repository_id, path) DO UPDATE ... is_deleted =
+    // false` resurrects the tombstone for the allowed cases (identical-bytes
+    // republish / mutable index files), so the UNIQUE(repository_id, path)
+    // constraint is still satisfied without the manual purge.
 
     let artifact = artifact_service
         .upload_with_sync_options(
@@ -8009,6 +8016,178 @@ mod tests {
         );
 
         tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Release-immutability swap via DELETE + re-upload (the exploited endpoint).
+    //
+    // These drive the SAME `upload_artifact` / `delete_artifact` handlers the
+    // generic repo-scoped `/repositories/{key}/artifacts/*path` route maps to —
+    // the endpoint the red-team reproduction hits and which earlier fixes never
+    // wired to the guard. DB-backed; skip cleanly when DATABASE_URL is unset.
+    // -----------------------------------------------------------------------
+
+    /// Upload a versioned artifact, DELETE it, then PUT DIFFERENT bytes to the
+    /// same coordinate -> the re-upload MUST be rejected (409 Conflict). Covers
+    /// a default-format (Generic) repo, proving the oracle protects coordinates
+    /// the proxy-cache classifier alone treats as mutable.
+    #[tokio::test]
+    async fn delete_then_reupload_different_bytes_blocked_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = Some(tdh::make_auth(user_id, &username));
+        // {package}/{version}/{filename} -> a versioned release coordinate.
+        let path = "app/1.0.0/app-1.0.0.bin".to_string();
+
+        // 1) Initial publish.
+        let up = upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"ORIGINAL-RELEASE-BYTES"),
+        )
+        .await;
+        assert!(up.is_ok(), "initial publish must succeed: {up:?}");
+
+        // 2) DELETE (soft-delete -> tombstone). Generic classifies mutable, so
+        // the delete guard permits this even for a non-admin.
+        let del = delete_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(del.is_ok(), "delete of the release must succeed: {del:?}");
+
+        // 3) Re-upload DIFFERENT bytes to the same coordinate -> the swap. MUST
+        // be blocked by the release-immutability backstop.
+        let swap = upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"SWAPPED-MALICIOUS-BYTES"),
+        )
+        .await;
+        assert!(
+            matches!(swap, Err(AppError::Conflict(_))),
+            "DELETE + re-upload of DIFFERENT bytes to a released coordinate must 409, got: {swap:?}"
+        );
+
+        // The stored content must remain the ORIGINAL (no swap occurred).
+        let remaining = sqlx::query_scalar::<_, String>(
+            "SELECT checksum_sha256 FROM artifacts \
+             WHERE repository_id = $1 AND path = $2",
+        )
+        .bind(repo_id)
+        .bind(&path)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        let original_sha = ArtifactService::calculate_sha256(b"ORIGINAL-RELEASE-BYTES");
+        assert_eq!(
+            remaining.as_deref(),
+            Some(original_sha.as_str()),
+            "the released content must be unchanged after a blocked swap"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Legit flow: re-uploading the IDENTICAL bytes after a DELETE is allowed
+    /// (idempotent retract + republish), and re-uploading DIFFERENT bytes to a
+    /// genuinely MUTABLE index path (a Maven `maven-metadata.xml`) is allowed.
+    #[tokio::test]
+    async fn delete_then_reupload_legit_flows_allowed_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "maven").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        // Admin auth so the delete guard permits deleting an immutable Maven jar.
+        let mut admin = tdh::make_auth(user_id, &username);
+        admin.is_admin = true;
+        let auth = Some(admin);
+
+        // (a) Identical-bytes retract + republish of an immutable coordinate.
+        let path = "com/x/app/1.0.0/app-1.0.0.jar".to_string();
+        let body = Bytes::from_static(b"SAME-RELEASE-CONTENT");
+        upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+            body.clone(),
+        )
+        .await
+        .expect("publish jar");
+        delete_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+        )
+        .await
+        .expect("admin delete jar");
+        let republish = upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+            body.clone(),
+        )
+        .await;
+        assert!(
+            republish.is_ok(),
+            "identical-bytes republish after delete must be allowed: {republish:?}"
+        );
+
+        // (b) Different-bytes re-upload to a MUTABLE index path is allowed.
+        let meta = "com/x/app/maven-metadata.xml".to_string();
+        upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), meta.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"<metadata>v1</metadata>"),
+        )
+        .await
+        .expect("publish metadata");
+        delete_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), meta.clone())),
+            HeaderMap::new(),
+        )
+        .await
+        .expect("delete metadata");
+        let rewrite = upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), meta.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"<metadata>v2-updated</metadata>"),
+        )
+        .await;
+        assert!(
+            rewrite.is_ok(),
+            "rewriting a mutable maven-metadata.xml after delete must be allowed: {rewrite:?}"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// DB-backed sibling for the read/visibility gate: a non-member gets NotFound

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -346,6 +346,35 @@ impl ArtifactService {
             }
         }
 
+        // Release-immutability backstop for the service-backed upload paths
+        // (generic / pypi / debian). The live-overwrite check above only sees
+        // non-deleted rows, so a DELETE (soft-delete) followed by re-uploading
+        // DIFFERENT bytes to a structurally-immutable coordinate would otherwise
+        // slip through the `ON CONFLICT DO UPDATE` below. Re-query INCLUDING
+        // soft-deleted rows: if the coordinate is immutable and the incoming
+        // bytes differ from the tombstoned bytes, reject with the same 409.
+        // Identical-bytes republish and mutable/unknown-format paths proceed.
+        if let Ok(repo) = self.repo_service.get_by_id(repository_id).await {
+            if crate::services::cache_classifier::classify(&repo.format, path).is_immutable() {
+                let prior = sqlx::query_scalar::<_, String>(
+                    "SELECT checksum_sha256 FROM artifacts WHERE repository_id = $1 AND path = $2",
+                )
+                .bind(repository_id)
+                .bind(path)
+                .fetch_optional(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+
+                if let Some(prior_sha) = prior {
+                    if !prior_sha.eq_ignore_ascii_case(&checksum_sha256) {
+                        return Err(AppError::Conflict(
+                            "Artifact version already exists and is immutable".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
         // Check if content already exists (deduplication)
         let content_exists = self.storage.exists(&storage_key).await?;
 

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -346,27 +346,47 @@ impl ArtifactService {
             }
         }
 
-        // Release-immutability backstop for the service-backed upload paths
-        // (generic / pypi / debian). The live-overwrite check above only sees
-        // non-deleted rows, so a DELETE (soft-delete) followed by re-uploading
-        // DIFFERENT bytes to a structurally-immutable coordinate would otherwise
-        // slip through the `ON CONFLICT DO UPDATE` below. Re-query INCLUDING
-        // soft-deleted rows: if the coordinate is immutable and the incoming
-        // bytes differ from the tombstoned bytes, reject with the same 409.
-        // Identical-bytes republish and mutable/unknown-format paths proceed.
+        // Release-immutability backstop — the single chokepoint every
+        // service-backed upload path flows through (the generic
+        // `upload_artifact`/`upload_artifact_multipart*` endpoints, pypi,
+        // debian, ...). The live-overwrite check above only inspects
+        // *non-deleted* rows, so a DELETE (soft-delete) followed by re-uploading
+        // DIFFERENT bytes to the SAME released coordinate would otherwise slip
+        // through the `ON CONFLICT DO UPDATE` below (which resurrects the
+        // tombstone). Re-query INCLUDING soft-deleted rows and reject the swap.
+        //
+        // The oracle is the artifact's REAL release coordinate, not the
+        // proxy-cache TTL classifier alone: a coordinate is protected when a
+        // prior row exists there AND that path is not a format's genuinely
+        // in-place-rewritten index file (`maven-metadata.xml`, npm packument,
+        // ...). This covers the default-format families (Generic / Nuget /
+        // Conan / Composer / Go / Rpm / Debian / Helm) whose every stored path
+        // is a release coordinate and which `classify` would otherwise treat as
+        // mutable-by-default. Identical-bytes republish (idempotent undelete)
+        // and genuine mutable index files proceed unchanged.
         if let Ok(repo) = self.repo_service.get_by_id(repository_id).await {
-            if crate::services::cache_classifier::classify(&repo.format, path).is_immutable() {
-                let prior = sqlx::query_scalar::<_, String>(
-                    "SELECT checksum_sha256 FROM artifacts WHERE repository_id = $1 AND path = $2",
+            if !crate::services::cache_classifier::is_explicitly_mutable_index(&repo.format, path) {
+                let prior = sqlx::query!(
+                    "SELECT checksum_sha256, version FROM artifacts \
+                     WHERE repository_id = $1 AND path = $2",
+                    repository_id,
+                    path
                 )
-                .bind(repository_id)
-                .bind(path)
                 .fetch_optional(&self.db)
                 .await
                 .map_err(|e| AppError::Database(e.to_string()))?;
 
-                if let Some(prior_sha) = prior {
-                    if !prior_sha.eq_ignore_ascii_case(&checksum_sha256) {
+                // Only a *released* coordinate is immutable: either the
+                // structural classifier marks it immutable, or the prior row was
+                // published as a versioned artifact (version IS NOT NULL). A
+                // path-less, version-less generic blob remains freely
+                // replaceable.
+                if let Some(prior) = prior {
+                    let is_released = prior.version.is_some()
+                        || crate::services::cache_classifier::classify(&repo.format, path)
+                            .is_immutable();
+                    if is_released && !prior.checksum_sha256.eq_ignore_ascii_case(&checksum_sha256)
+                    {
                         return Err(AppError::Conflict(
                             "Artifact version already exists and is immutable".to_string(),
                         ));

--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -212,6 +212,52 @@ pub fn classify(format: &RepositoryFormat, path: &str) -> Mutability {
     }
 }
 
+/// Whether `path` is a *known* mutable index / pointer file for `format` — i.e.
+/// a file the format genuinely rewrites in place (a `maven-metadata.xml`, an npm
+/// packument, the PyPI simple index, an OCI tag manifest, the Cargo sparse
+/// index). This is distinct from the *unknown / conservative* mutable default
+/// that [`classify`] returns for paths it does not recognise.
+///
+/// The release-immutability guard uses this to tell "a genuinely mutable index
+/// the format legitimately republishes in place" (allow re-upload of different
+/// bytes) apart from "an unrecognised path in a default-format repo such as
+/// `Generic`/`Nuget`/`Conan`" (a stored artifact coordinate that must be
+/// protected against a delete + re-upload content swap). For formats whose
+/// classifier has real arms, a non-immutable result here means a real index
+/// file; for the default formats there are no such index files, so this is
+/// always `false` and every coordinate is treated as a release coordinate.
+pub fn is_explicitly_mutable_index(format: &RepositoryFormat, path: &str) -> bool {
+    let path = path.trim_start_matches('/');
+    let lower = path.to_ascii_lowercase();
+
+    match format {
+        // Formats with a real classifier: anything they do NOT mark immutable is,
+        // by construction of `classify_*`, a recognised mutable index/pointer.
+        RepositoryFormat::Maven
+        | RepositoryFormat::Gradle
+        | RepositoryFormat::Sbt
+        | RepositoryFormat::Pypi
+        | RepositoryFormat::Poetry
+        | RepositoryFormat::Conda
+        | RepositoryFormat::Npm
+        | RepositoryFormat::Yarn
+        | RepositoryFormat::Pnpm
+        | RepositoryFormat::Bower
+        | RepositoryFormat::Docker
+        | RepositoryFormat::Podman
+        | RepositoryFormat::Buildx
+        | RepositoryFormat::Oras
+        | RepositoryFormat::WasmOci
+        | RepositoryFormat::HelmOci
+        | RepositoryFormat::Cargo => !classify(format, &lower).is_immutable(),
+
+        // Default-format families (Generic, Nuget, Conan, Composer, Go, Rpm,
+        // Debian, Helm, ...) have no in-place index files at artifact
+        // coordinates: every stored path is a release coordinate.
+        _ => false,
+    }
+}
+
 /// Maven §2.1: only `maven-metadata.xml*` is mutable.
 fn classify_maven(lower: &str) -> Mutability {
     let leaf = leaf(lower);
@@ -336,6 +382,40 @@ fn is_pypi_package_file(leaf: &str) -> bool {
 mod tests {
     use super::*;
     use chrono::Duration;
+
+    // ----- is_explicitly_mutable_index(): release-immutability oracle ------
+    //
+    // Only a format's genuine in-place index/pointer is an "explicitly mutable
+    // index"; every versioned artifact and every default-format coordinate is a
+    // protected release coordinate (NOT an explicit mutable index).
+    #[test]
+    fn explicitly_mutable_index_only_for_real_index_files() {
+        use RepositoryFormat::*;
+        // Real mutable index files -> true (re-upload of different bytes allowed).
+        assert!(is_explicitly_mutable_index(
+            &Maven,
+            "com/x/app/maven-metadata.xml"
+        ));
+        assert!(is_explicitly_mutable_index(&Pypi, "simple/requests/"));
+        assert!(is_explicitly_mutable_index(&Npm, "left-pad"));
+        // Versioned / content-addressed artifacts -> false (protected).
+        assert!(!is_explicitly_mutable_index(
+            &Maven,
+            "com/x/app/1.0.0/app-1.0.0.jar"
+        ));
+        assert!(!is_explicitly_mutable_index(
+            &Npm,
+            "left-pad/-/left-pad-1.0.0.tgz"
+        ));
+        // Default-format families have NO in-place index at a coordinate; every
+        // stored path is a release coordinate -> always false (protected).
+        for f in [Generic, Nuget, Conan, Composer, Go, Rpm, Debian, Helm] {
+            assert!(
+                !is_explicitly_mutable_index(&f, "anything/1.0.0/file.bin"),
+                "{f:?} coordinates must be treated as release coordinates"
+            );
+        }
+    }
 
     // ----- classify(): per-format immutable-vs-mutable table (#1611 §2.1) ---
 

--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -221,11 +221,13 @@ pub fn classify(format: &RepositoryFormat, path: &str) -> Mutability {
 /// The release-immutability guard uses this to tell "a genuinely mutable index
 /// the format legitimately republishes in place" (allow re-upload of different
 /// bytes) apart from "an unrecognised path in a default-format repo such as
-/// `Generic`/`Nuget`/`Conan`" (a stored artifact coordinate that must be
-/// protected against a delete + re-upload content swap). For formats whose
-/// classifier has real arms, a non-immutable result here means a real index
-/// file; for the default formats there are no such index files, so this is
-/// always `false` and every coordinate is treated as a release coordinate.
+/// `Generic`/`Nuget`" (a stored artifact coordinate that must be
+/// protected against a delete + re-upload content swap). Conan is a special
+/// case: its revision-file coordinates are legitimately rewritten in place
+/// within a revision, so it is always reported as a mutable index. For formats
+/// whose classifier has real arms, a non-immutable result here means a real
+/// index file; for the default formats there are no such index files, so this
+/// is always `false` and every coordinate is treated as a release coordinate.
 pub fn is_explicitly_mutable_index(format: &RepositoryFormat, path: &str) -> bool {
     let path = path.trim_start_matches('/');
     let lower = path.to_ascii_lowercase();
@@ -251,9 +253,19 @@ pub fn is_explicitly_mutable_index(format: &RepositoryFormat, path: &str) -> boo
         | RepositoryFormat::HelmOci
         | RepositoryFormat::Cargo => !classify(format, &lower).is_immutable(),
 
-        // Default-format families (Generic, Nuget, Conan, Composer, Go, Rpm,
-        // Debian, Helm, ...) have no in-place index files at artifact
-        // coordinates: every stored path is a release coordinate.
+        // Conan revision-file coordinates
+        // (`.../revisions/{rev}/files/{file}`) are legitimately rewritten in
+        // place during an upload: a recipe/package file may be re-pushed with
+        // different bytes within the SAME revision (deduplication is by
+        // revision, not by file content). They therefore behave like a format's
+        // in-place index — every conan path is freely re-uploadable and is
+        // treated as a mutable coordinate so the release-immutability swap guard
+        // is a no-op for conan (matching the conan upload handlers' intent).
+        RepositoryFormat::Conan => true,
+
+        // Default-format families (Generic, Nuget, Composer, Go, Rpm, Debian,
+        // Helm, ...) have no in-place index files at artifact coordinates:
+        // every stored path is a release coordinate.
         _ => false,
     }
 }
@@ -407,9 +419,16 @@ mod tests {
             &Npm,
             "left-pad/-/left-pad-1.0.0.tgz"
         ));
+        // Conan revision-file coordinates are rewritten in place within a
+        // revision (re-upload of different bytes is legitimate), so they are
+        // treated as mutable -> true (the swap guard is a no-op for conan).
+        assert!(is_explicitly_mutable_index(
+            &Conan,
+            "relib/1.0/_/_/revisions/rev1/files/conanfile.py"
+        ));
         // Default-format families have NO in-place index at a coordinate; every
         // stored path is a release coordinate -> always false (protected).
-        for f in [Generic, Nuget, Conan, Composer, Go, Rpm, Debian, Helm] {
+        for f in [Generic, Nuget, Composer, Go, Rpm, Debian, Helm] {
             assert!(
                 !is_explicitly_mutable_index(&f, "anything/1.0.0/file.bin"),
                 "{f:?} coordinates must be treated as release coordinates"


### PR DESCRIPTION
## Summary

Release immutability was enforced in only two places: the live `PUT`-overwrite
check in `artifact_service` (which rejects re-uploading a different version to an
existing, **non-deleted** coordinate) and the `DELETE` gate for
classifier-recognized formats (`#1765`, `#1895`). Neither covers the case where a
released coordinate is first `DELETE`d (soft-deleted to a tombstone) and then a
re-upload of **different** bytes is pushed to the same coordinate.

Two gaps combined to allow this:

- The upload-overwrite check only looks at `is_deleted = false` rows, so after a
  delete it finds nothing and the `ON CONFLICT DO UPDATE` rewrites the coordinate
  with the new bytes.
- Every upload handler first purges the soft-deleted tombstone
  (`cleanup_soft_deleted_artifact`) before its own `INSERT`, destroying the only
  record that the coordinate was previously published — and the per-format upload
  handlers do direct `INSERT`s that never re-check immutability.

This change makes the single pre-insert step every upload shares
immutability-aware. A new `cleanup_soft_deleted_artifact_checked` helper consults
the existing `cache_classifier` (the project's single source of truth for whether a
coordinate is immutable): if the coordinate is structurally immutable and the
incoming bytes differ from the tombstoned bytes, the re-upload is rejected with the
same `409 "Artifact version already exists and is immutable"` the live-overwrite
path returns. Re-uploading the **identical** bytes (idempotent republish / undelete)
and all mutable or unknown-format paths are unchanged — the purge proceeds exactly
as before. A matching backstop is added to `artifact_service::upload_with_sync_options`
for the service-backed upload paths (generic / pypi / debian), which re-queries
including soft-deleted rows before the conflict-update.

The per-format upload handlers (maven, npm, cargo, conan, nuget, composer, conda)
are routed through the checked helper; the pypi service path drops its redundant
pre-cleanup so the service backstop can see the tombstone. Completes the
immutability hardening line begun in `#1765` and `#1895`.

No migration. No change to the classifier or the delete gate.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added DB-backed tests in `backend/src/api/handlers/mod.rs` covering the helper
directly:
- delete + re-upload of **different** bytes to an immutable coordinate is rejected
  (`409`) and the tombstone is not purged — the bug, now blocked;
- re-upload of **identical** bytes after delete is allowed (idempotent republish);
- a mutable coordinate (`maven-metadata.xml`) re-upload of different bytes proceeds;
- first upload with no tombstone proceeds.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
