### PR TITLE
feat(storage): add tracing spans around storage backend operations

### DIFF
--- a/backend/src/storage/azure.rs
+++ b/backend/src/storage/azure.rs
@@ -1118,6 +1118,7 @@ impl AzureBackend {
 
 #[async_trait]
 impl StorageBackend for AzureBackend {
+    #[tracing::instrument(skip(self, content), fields(otel.kind = "client", storage.system = "azure", storage.operation = "put"))]
     async fn put(&self, key: &str, content: Bytes) -> Result<()> {
         let url = self.blob_url(key);
         let response = self.authorized_put(&url, key, &content).await?;
@@ -1134,6 +1135,7 @@ impl StorageBackend for AzureBackend {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "get"))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let url = self.read_url(key, Duration::from_secs(300))?;
         let response = self.authorized_get(&url).await?;
@@ -1187,6 +1189,7 @@ impl StorageBackend for AzureBackend {
         Ok(bytes)
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "get_range"))]
     async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
         if length == 0 {
             return Ok(Bytes::new());
@@ -1220,6 +1223,9 @@ impl StorageBackend for AzureBackend {
         )))
     }
 
+    // The span covers GET initiation (time-to-first-byte); the body transfer
+    // happens later as the caller polls the returned stream.
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "get_stream"))]
     async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
         let url = self.read_url(key, Duration::from_secs(300))?;
         let mut response = self.authorized_get(&url).await?;
@@ -1263,6 +1269,7 @@ impl StorageBackend for AzureBackend {
         Ok(Box::pin(stream))
     }
 
+    #[tracing::instrument(skip(self, stream), fields(otel.kind = "client", storage.system = "azure", storage.operation = "put_stream"))]
     async fn put_stream(
         &self,
         key: &str,
@@ -1337,6 +1344,7 @@ impl StorageBackend for AzureBackend {
         })
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "copy"))]
     async fn copy(&self, source: &str, dest: &str) -> Result<()> {
         let size = match self.size(source).await {
             Ok(size) => size,
@@ -1382,6 +1390,7 @@ impl StorageBackend for AzureBackend {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "exists"))]
     async fn exists(&self, key: &str) -> Result<bool> {
         let url = self.read_url(key, Duration::from_secs(60))?;
         let response = self.authorized_head(&url).await?;
@@ -1411,6 +1420,7 @@ impl StorageBackend for AzureBackend {
         Ok(false)
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "delete"))]
     async fn delete(&self, key: &str) -> Result<()> {
         let url = self.blob_url(key);
         let response = self.authorized_delete(&url, key).await?;
@@ -1433,6 +1443,7 @@ impl StorageBackend for AzureBackend {
     /// revalidation. Returns `Ok(None)` for a missing blob or for a
     /// response without an `ETag` header so the freshness probe can fall
     /// through to the slow path without surfacing a backend error.
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "head_etag"))]
     async fn head_etag(&self, key: &str) -> Result<Option<String>> {
         let url = self.read_url(key, Duration::from_secs(60))?;
         let response = self.authorized_head(&url).await?;
@@ -1459,6 +1470,7 @@ impl StorageBackend for AzureBackend {
         self.config.redirect_downloads && !self.is_rbac()
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "get_presigned_url"))]
     async fn get_presigned_url(
         &self,
         key: &str,
@@ -1494,6 +1506,7 @@ impl StorageBackend for AzureBackend {
     /// PUT BlockBlob request and let `reqwest::Body::wrap_stream` pump the
     /// file chunk-by-chunk over the wire. Peak heap usage is O(chunk_size),
     /// not O(file_size).
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "put_file"))]
     async fn put_file(&self, key: &str, path: &std::path::Path) -> Result<()> {
         use futures::StreamExt;
         use tokio::io::BufReader;
@@ -1569,6 +1582,7 @@ impl StorageBackend for AzureBackend {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "azure", storage.operation = "health_check"))]
     async fn health_check(&self) -> Result<()> {
         // HEAD a sentinel blob path. A 404 is fine (proves the container is
         // reachable and credentials are accepted). Only transport-level or

--- a/backend/src/storage/filesystem.rs
+++ b/backend/src/storage/filesystem.rs
@@ -120,6 +120,7 @@ impl FilesystemStorage {
 
 #[async_trait]
 impl StorageBackend for FilesystemStorage {
+    #[tracing::instrument(skip(self, content), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "put"))]
     async fn put(&self, key: &str, content: Bytes) -> Result<()> {
         let path = self.key_to_path(key);
 
@@ -164,6 +165,7 @@ impl StorageBackend for FilesystemStorage {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "get"))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let path = self.key_to_path(key);
         let content = fs::read(&path).await.map_err(|e| {
@@ -184,11 +186,13 @@ impl StorageBackend for FilesystemStorage {
         Ok(Bytes::from(content))
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "exists"))]
     async fn exists(&self, key: &str) -> Result<bool> {
         let path = self.key_to_path(key);
         Ok(path.exists())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "delete"))]
     async fn delete(&self, key: &str) -> Result<()> {
         let path = self.key_to_path(key);
         fs::remove_file(&path).await.map_err(|e| {
@@ -204,6 +208,7 @@ impl StorageBackend for FilesystemStorage {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "copy"))]
     async fn copy(&self, source: &str, dest: &str) -> Result<()> {
         let source_path = self.key_to_path(source);
         let dest_path = self.key_to_path(dest);
@@ -251,6 +256,7 @@ impl StorageBackend for FilesystemStorage {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "put_file"))]
     async fn put_file(&self, key: &str, path: &std::path::Path) -> Result<()> {
         let dest = self.key_to_path(key);
         if let Some(parent) = dest.parent() {
@@ -262,6 +268,9 @@ impl StorageBackend for FilesystemStorage {
         Ok(())
     }
 
+    // The span covers GET initiation (time-to-first-byte); the body transfer
+    // happens later as the caller polls the returned stream.
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "get_stream"))]
     async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
         let path = self.key_to_path(key);
         let file = fs::File::open(&path).await.map_err(|e| {
@@ -286,6 +295,7 @@ impl StorageBackend for FilesystemStorage {
         Ok(Box::pin(mapped))
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "get_range"))]
     async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
         if length == 0 {
             return Ok(Bytes::new());
@@ -324,6 +334,7 @@ impl StorageBackend for FilesystemStorage {
         Ok(Bytes::from(out))
     }
 
+    #[tracing::instrument(skip(self, stream), fields(otel.kind = "internal", storage.system = "filesystem", storage.operation = "put_stream"))]
     async fn put_stream(
         &self,
         key: &str,

--- a/backend/src/storage/gcs.rs
+++ b/backend/src/storage/gcs.rs
@@ -1481,6 +1481,7 @@ impl GcsBackend {
 
 #[async_trait]
 impl StorageBackend for GcsBackend {
+    #[tracing::instrument(skip(self, content), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "put"))]
     async fn put(&self, key: &str, content: Bytes) -> Result<()> {
         let response = self.authorized_put(key, content).await?;
         require_success(response, "GCS upload failed").await?;
@@ -1512,6 +1513,7 @@ impl StorageBackend for GcsBackend {
     ///
     /// On any error after the session is initiated the session is aborted with
     /// a best-effort DELETE so GCS does not retain an orphaned upload session.
+    #[tracing::instrument(skip(self, stream), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "put_stream"))]
     async fn put_stream(
         &self,
         key: &str,
@@ -1574,6 +1576,7 @@ impl StorageBackend for GcsBackend {
         }
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "get"))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let url = self.object_download_url(key);
         let response = self.authorized_get(&url).await?;
@@ -1599,6 +1602,7 @@ impl StorageBackend for GcsBackend {
         unreachable!()
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "get_range"))]
     async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
         if length == 0 {
             return Ok(Bytes::new());
@@ -1639,6 +1643,9 @@ impl StorageBackend for GcsBackend {
     /// pools and OOM-kill the pod. `bytes_stream()` pulls chunks straight from
     /// the HTTPS connection, keeping the in-flight footprint at reqwest's TCP
     /// read buffer (~64 KiB) instead of object-size.
+    // The span covers GET initiation (time-to-first-byte); the body transfer
+    // happens later as the caller polls the returned stream.
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "get_stream"))]
     async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
         let url = self.object_download_url(key);
         let response = self.authorized_get_stream(&url).await?;
@@ -1664,6 +1671,7 @@ impl StorageBackend for GcsBackend {
         unreachable!()
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "exists"))]
     async fn exists(&self, key: &str) -> Result<bool> {
         let url = self.object_metadata_url(key);
         let response = self.authorized_get(&url).await?;
@@ -1680,6 +1688,7 @@ impl StorageBackend for GcsBackend {
         unreachable!()
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "delete"))]
     async fn delete(&self, key: &str) -> Result<()> {
         let response = self.authorized_delete(key).await?;
 
@@ -1691,6 +1700,7 @@ impl StorageBackend for GcsBackend {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "copy"))]
     async fn copy(&self, source: &str, dest: &str) -> Result<()> {
         GcsBackend::copy(self, source, dest).await
     }
@@ -1701,6 +1711,7 @@ impl StorageBackend for GcsBackend {
     /// Returns `Ok(None)` for a missing object so the freshness probe can
     /// fall through to the slow path without losing the I/O-error
     /// distinction.
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "head_etag"))]
     async fn head_etag(&self, key: &str) -> Result<Option<String>> {
         let url = self.object_metadata_url(key);
         let response = self.authorized_get(&url).await?;
@@ -1730,6 +1741,7 @@ impl StorageBackend for GcsBackend {
         matches!(self.auth, GcsAuthMode::ServiceAccountKey { .. }) && self.config.redirect_downloads
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "get_presigned_url"))]
     async fn get_presigned_url(
         &self,
         key: &str,
@@ -1758,6 +1770,7 @@ impl StorageBackend for GcsBackend {
         }))
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "gcs", storage.operation = "health_check"))]
     async fn health_check(&self) -> Result<()> {
         // GET the metadata of a sentinel object (`.health-probe`). This exercises
         // the same object-level permission the backend actually uses at runtime

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -1153,6 +1153,7 @@ impl S3Backend {
 
 #[async_trait]
 impl super::StorageBackend for S3Backend {
+    #[tracing::instrument(skip(self, content), fields(otel.kind = "client", storage.system = "s3", storage.operation = "put"))]
     async fn put(&self, key: &str, content: Bytes) -> Result<()> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
@@ -1166,6 +1167,7 @@ impl super::StorageBackend for S3Backend {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "get"))]
     async fn get(&self, key: &str) -> Result<Bytes> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
@@ -1195,6 +1197,7 @@ impl super::StorageBackend for S3Backend {
         }
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "exists"))]
     async fn exists(&self, key: &str) -> Result<bool> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
@@ -1236,6 +1239,7 @@ impl super::StorageBackend for S3Backend {
         Ok(false)
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "delete"))]
     async fn delete(&self, key: &str) -> Result<()> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
@@ -1262,6 +1266,7 @@ impl super::StorageBackend for S3Backend {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "copy"))]
     async fn copy(&self, source: &str, dest: &str) -> Result<()> {
         S3Backend::copy(self, source, dest).await
     }
@@ -1280,6 +1285,7 @@ impl super::StorageBackend for S3Backend {
     /// Returns `Ok(None)` when the object is missing rather than an error,
     /// so the freshness probe can treat "ETag unavailable" as "do not
     /// fast-path" without losing the distinction from a real I/O failure.
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "head_etag"))]
     async fn head_etag(&self, key: &str) -> Result<Option<String>> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
@@ -1297,6 +1303,7 @@ impl super::StorageBackend for S3Backend {
         self.redirect_downloads
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "get_presigned_url"))]
     async fn get_presigned_url(
         &self,
         key: &str,
@@ -1352,6 +1359,7 @@ impl super::StorageBackend for S3Backend {
         }))
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "health_check"))]
     async fn health_check(&self) -> Result<()> {
         let path: ObjectPath = ".health-probe".into();
         match self.store.head(&path).await {
@@ -1361,6 +1369,9 @@ impl super::StorageBackend for S3Backend {
         }
     }
 
+    // The span covers GET initiation (time-to-first-byte); the body transfer
+    // happens later as the caller polls the returned stream.
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "get_stream"))]
     async fn get_stream(&self, key: &str) -> Result<BoxStream<'static, Result<Bytes>>> {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
@@ -1380,6 +1391,7 @@ impl super::StorageBackend for S3Backend {
         Ok(Box::pin(stream))
     }
 
+    #[tracing::instrument(skip(self), fields(otel.kind = "client", storage.system = "s3", storage.operation = "get_range"))]
     async fn get_range(&self, key: &str, offset: u64, length: usize) -> Result<Bytes> {
         if length == 0 {
             return Ok(Bytes::new());
@@ -1428,6 +1440,7 @@ impl super::StorageBackend for S3Backend {
     /// `AbortMultipartUpload` on drop, so the upload does not linger until the
     /// bucket's `AbortIncompleteMultipartUpload` lifecycle rule reclaims it. A
     /// successfully completed upload defuses the guard and is never aborted.
+    #[tracing::instrument(skip(self, stream), fields(otel.kind = "client", storage.system = "s3", storage.operation = "put_stream"))]
     async fn put_stream(
         &self,
         key: &str,


### PR DESCRIPTION
## Summary

The storage backend operations are not instrumented with tracing spans. The only request-scoped spans are at the HTTP middleware layer, so an HTTP request span shows its whole duration as time spent awaiting I/O with no child span to attribute the wait to a specific storage operation. When a request is slow, a trace cannot tell you whether the time went to a storage `GET`, a `HEAD` existence probe, a presign call, or something else.

This adds `#[tracing::instrument]` to the object operations of every `StorageBackend` impl, so each storage call appears as a child span under the request span:

- **S3** (`backend/src/storage/s3.rs`) and **GCS** (`gcs.rs`) and **Azure** (`azure.rs`): `put`, `get`, `exists`, `delete`, `copy`, `head_etag`, `get_presigned_url`, `get_stream`, `get_range`, `put_stream` (and `put_file` where overridden), `health_check`.
- **Filesystem** (`filesystem.rs`): `put`, `get`, `exists`, `delete`, `copy`, `put_file`, `get_stream`, `get_range`, `put_stream`.

Fields are generic OpenTelemetry semantic-convention attributes (`otel.kind`, `storage.system`, `storage.operation`) plus the auto-recorded `key`. `otel.kind` is `"client"` for the object stores and `"internal"` for the local filesystem. Bucket/container name, region, endpoint and credentials are deliberately not recorded.

OTLP export is already wired (`telemetry.rs` installs the `tracing_opentelemetry` layer), so these spans flow to APM automatically when `OTEL_EXPORTER_OTLP_ENDPOINT` is set; with no exporter configured they are near-zero cost. No behaviour change, no new dependencies, no signature changes.

`get_stream`'s span covers `GET` initiation (time-to-first-byte); the body transfers as the caller polls the returned stream, noted in a code comment.

Closes #1946

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified locally: `cargo fmt --check`, `cargo clippy -p artifact-keeper-backend --lib -- -D warnings` (clean), and `cargo test -p artifact-keeper-backend --lib storage::` (369 passed, 0 failed across all four backends). This is an attribute-only, behaviour-neutral change, so no new unit tests are added.

## API Changes
- [x] N/A - no API changes
