### PR TITLE
feat(storage): presign hosted downloads in the shared serve_local_artifact helper

### DIFF
--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -269,13 +269,17 @@ async fn download_file(
         }
     };
 
-    proxy_helpers::serve_local_artifact(
+    // Opt out of the presigned redirect: huggingface_hub reads X-Linked-Etag /
+    // X-Linked-Size off the /resolve/ response, which a bare 302 to object
+    // storage cannot carry, so keep streaming for this format.
+    proxy_helpers::serve_local_artifact_redirectable(
         &state,
         &repo,
         artifact.id,
         &artifact.storage_key,
         "application/octet-stream",
         Some(filename),
+        false,
     )
     .await
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -2852,6 +2852,32 @@ pub async fn record_artifact_metadata(
 
 /// Serve an artifact from local storage with quarantine + statistics.
 ///
+/// Returns a `302` redirect to a presigned object-storage URL for a hosted
+/// download when `allow_redirect` is set, `PRESIGNED_DOWNLOADS_ENABLED` is on,
+/// and the storage backend supports redirects; otherwise `None`, so the caller
+/// streams the bytes through the backend. HuggingFace passes `allow_redirect =
+/// false` because its client reads `X-Linked-Etag` / `X-Linked-Size` off the
+/// `/resolve/` response, which a bare 302 cannot carry. Kept free of state/DB
+/// so it is unit-testable with a mock `StorageBackend`.
+async fn presigned_download_redirect(
+    allow_redirect: bool,
+    config: &crate::config::Config,
+    storage: &dyn crate::storage::StorageBackend,
+    storage_key: &str,
+) -> Option<Response> {
+    if !allow_redirect {
+        return None;
+    }
+    let expiry = std::time::Duration::from_secs(config.presigned_download_expiry_secs);
+    try_presigned_redirect(
+        storage,
+        storage_key,
+        config.presigned_downloads_enabled,
+        expiry,
+    )
+    .await
+}
+
 /// Performs the standard hit-path tail used by every format download handler:
 /// quarantine check, storage load, download-statistics insert, and a 200
 /// response with the supplied content type and optional `Content-Disposition`.
@@ -2903,19 +2929,17 @@ pub async fn serve_local_artifact_redirectable(
     // backend. Falls back to streaming when redirects are unsupported (e.g.
     // filesystem) or the caller opted out. Used by rubygems, hex, cran, helm,
     // puppet, ansible; huggingface opts out (allow_redirect = false).
-    if allow_redirect && state.config.presigned_downloads_enabled {
-        let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
-        if let Some(redirect) =
-            try_presigned_redirect(storage.as_ref(), storage_key, true, expiry).await
-        {
-            let _ = sqlx::query(
-                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-            )
-            .bind(artifact_id)
-            .execute(&state.db)
-            .await;
-            return Ok(redirect);
-        }
+    if let Some(redirect) =
+        presigned_download_redirect(allow_redirect, &state.config, storage.as_ref(), storage_key)
+            .await
+    {
+        let _ = sqlx::query(
+            "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+        )
+        .bind(artifact_id)
+        .execute(&state.db)
+        .await;
+        return Ok(redirect);
     }
 
     let content = storage
@@ -6570,5 +6594,129 @@ mod tests {
             .execute(&pool)
             .await;
         let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+}
+
+#[cfg(test)]
+mod presign_redirect_tests {
+    use crate::error::Result as StorageResult;
+    use crate::storage::{PresignedUrl, PresignedUrlSource, StorageBackend};
+    use async_trait::async_trait;
+    use axum::http::StatusCode;
+    use bytes::Bytes;
+    use std::time::Duration;
+
+    /// Storage backend that supports presigned URLs (e.g. S3).
+    struct RedirectBackend;
+
+    #[async_trait]
+    impl StorageBackend for RedirectBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> StorageResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> StorageResult<Bytes> {
+            Ok(Bytes::from_static(b"data"))
+        }
+        async fn exists(&self, _key: &str) -> StorageResult<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> StorageResult<()> {
+            Ok(())
+        }
+        fn supports_redirect(&self) -> bool {
+            true
+        }
+        async fn get_presigned_url(
+            &self,
+            key: &str,
+            expires_in: Duration,
+        ) -> StorageResult<Option<PresignedUrl>> {
+            Ok(Some(PresignedUrl {
+                url: format!("https://s3.example.com/{}", key),
+                expires_in,
+                source: PresignedUrlSource::S3,
+            }))
+        }
+    }
+
+    /// Storage backend that does not support presigned URLs (e.g. filesystem).
+    struct NoRedirectBackend;
+
+    #[async_trait]
+    impl StorageBackend for NoRedirectBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> StorageResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> StorageResult<Bytes> {
+            Ok(Bytes::from_static(b"data"))
+        }
+        async fn exists(&self, _key: &str) -> StorageResult<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> StorageResult<()> {
+            Ok(())
+        }
+    }
+
+    fn config(presigned_downloads_enabled: bool) -> crate::config::Config {
+        crate::config::Config {
+            presigned_downloads_enabled,
+            presigned_download_expiry_secs: 300,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn redirects_when_allowed_enabled_and_supported() {
+        let resp = super::presigned_download_redirect(
+            true,
+            &config(true),
+            &RedirectBackend,
+            "gems/rack-3.0.0.gem",
+        )
+        .await
+        .expect("should redirect when allowed, enabled and backend supports it");
+        assert_eq!(resp.status(), StatusCode::FOUND);
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.contains("s3.example.com"));
+        assert!(location.contains("rack-3.0.0.gem"));
+    }
+
+    #[tokio::test]
+    async fn streams_when_caller_opts_out() {
+        // HuggingFace opt-out: allow_redirect = false must always stream,
+        // even when the feature is enabled and the backend can presign.
+        let resp = super::presigned_download_redirect(
+            false,
+            &config(true),
+            &RedirectBackend,
+            "models/m/resolve/main/model.safetensors",
+        )
+        .await;
+        assert!(resp.is_none(), "allow_redirect = false must never redirect");
+    }
+
+    #[tokio::test]
+    async fn streams_when_feature_disabled() {
+        let resp = super::presigned_download_redirect(
+            true,
+            &config(false),
+            &RedirectBackend,
+            "gems/rack-3.0.0.gem",
+        )
+        .await;
+        assert!(resp.is_none(), "must stream when feature flag is off");
+    }
+
+    #[tokio::test]
+    async fn streams_when_backend_unsupported() {
+        let resp = super::presigned_download_redirect(
+            true,
+            &config(true),
+            &NoRedirectBackend,
+            "gems/rack-3.0.0.gem",
+        )
+        .await;
+        assert!(resp.is_none(), "must stream when backend cannot presign");
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -2865,6 +2865,31 @@ pub async fn serve_local_artifact(
     content_type: &str,
     content_disposition_filename: Option<&str>,
 ) -> Result<Response, Response> {
+    serve_local_artifact_redirectable(
+        state,
+        repo,
+        artifact_id,
+        storage_key,
+        content_type,
+        content_disposition_filename,
+        true,
+    )
+    .await
+}
+
+/// Like `serve_local_artifact`, but `allow_redirect` lets a format opt out of
+/// the presigned-download redirect and keep streaming. HuggingFace opts out:
+/// its client reads `X-Linked-Etag` / `X-Linked-Size` off the `/resolve/`
+/// response, which a bare 302 to object storage cannot carry.
+pub async fn serve_local_artifact_redirectable(
+    state: &crate::api::SharedState,
+    repo: &RepoInfo,
+    artifact_id: Uuid,
+    storage_key: &str,
+    content_type: &str,
+    content_disposition_filename: Option<&str>,
+    allow_redirect: bool,
+) -> Result<Response, Response> {
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
@@ -2872,6 +2897,26 @@ pub async fn serve_local_artifact(
     crate::services::quarantine_service::check_artifact_download(&state.db, artifact_id)
         .await
         .map_err(|e| e.into_response())?;
+
+    // Redirect to a presigned storage URL when enabled, so clients pull the
+    // artifact directly from object storage instead of streaming through the
+    // backend. Falls back to streaming when redirects are unsupported (e.g.
+    // filesystem) or the caller opted out. Used by rubygems, hex, cran, helm,
+    // puppet, ansible; huggingface opts out (allow_redirect = false).
+    if allow_redirect && state.config.presigned_downloads_enabled {
+        let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
+        if let Some(redirect) =
+            try_presigned_redirect(storage.as_ref(), storage_key, true, expiry).await
+        {
+            let _ = sqlx::query(
+                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+            )
+            .bind(artifact_id)
+            .execute(&state.db)
+            .await;
+            return Ok(redirect);
+        }
+    }
 
     let content = storage
         .get(storage_key)


### PR DESCRIPTION
## Summary

Add a gated presigned-redirect (302 to object storage) before the streamed 200 in the shared `serve_local_artifact` helper (`backend/src/api/handlers/proxy_helpers.rs`), so the hosted-download path for **rubygems, hex, cran, helm, puppet and ansible** sends clients straight to object storage instead of buffering the object (`storage.get()`) and re-streaming a 200. Gated on `PRESIGNED_DOWNLOADS_ENABLED` + `StorageBackend::supports_redirect`; falls back to streaming when unsupported (e.g. filesystem) or when the caller opts out. Download stats + quarantine still run before the redirect.

**HuggingFace deliberately opts out** (via the new `serve_local_artifact_redirectable(.., allow_redirect=false)`): `huggingface_hub` reads `X-Linked-Etag` / `X-Linked-Size` off the `/resolve/` response, which a bare 302 cannot carry, so it keeps streaming. Presigning hf would need those headers emitted on the redirect — a possible follow-up.

**This is a backend-offload / burst-resilience change, not a download speedup.** Measured in-cluster (single-replica backend, 4 vCPU limit, in-region object storage): a 118 MB artifact streams through the backend at ~94 MB/s single-stream and ~425 MB/s aggregate across 8 concurrent streams at only ~18% of the backend's CPU — so the backend is not the download-throughput bottleneck. The value is taking the backend out of the byte path (freeing a worker per download and avoiding the re-stream under burst — the 502-on-large-artifacts-under-concurrency class) and matching the existing PyPI presign path.

**Scoping (reviewed per format):** this only touches the artifact-bytes download. Each format's resolve-time index/metadata (rubygems specs, hex registry, CRAN `PACKAGES`, helm `index.yaml`, puppet/ansible JSON) is a separate handler and is never redirected; uploads are a separate write path. The native clients follow the cross-host 302, and integrity is verified from the index checksum over the downloaded bytes (not response headers), so dropping `Content-Type`/`Content-Disposition` on the redirect is safe. The download path does no `Range`/`HEAD` today, so the 302 → object storage (which honours `Range`) is at worst neutral.

Closes #1950.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

The presign decision is extracted into a pure `presigned_download_redirect` helper (no state/DB) and unit-tested with mock `StorageBackend`s for four cases: redirect when allowed+enabled+supported (302), and stream fallback when the caller opts out (`allow_redirect = false`, the HuggingFace path), when the feature flag is off, and when the backend cannot presign. `cargo fmt --check` and `cargo clippy -p artifact-keeper-backend --lib --tests -- -D warnings` are clean. Integration/E2E tests are N/A: no new endpoints, and the redirect is gated behind `PRESIGNED_DOWNLOADS_ENABLED` (default false) so the streamed fallback is unchanged. The streamed-vs-presigned mechanism + the backend-offload measurement above were validated on a live instance.

## API Changes
- [x] N/A - no API changes

