### PR TITLE
feat(conda): redirect hosted package downloads to presigned storage URLs

### DIFF
--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2304,6 +2304,26 @@ async fn build_virtual_channeldata(
     }))
 }
 
+/// Returns a `302` redirect to a presigned object-storage URL for a hosted
+/// download when `PRESIGNED_DOWNLOADS_ENABLED` is set and the storage backend
+/// supports redirects; otherwise `None`, so the caller falls back to streaming
+/// the bytes through the backend. Kept free of state/DB so it is unit-testable
+/// with a mock `StorageBackend`.
+async fn presigned_download_redirect(
+    config: &crate::config::Config,
+    storage: &dyn crate::storage::StorageBackend,
+    storage_key: &str,
+) -> Option<Response> {
+    let expiry = std::time::Duration::from_secs(config.presigned_download_expiry_secs);
+    crate::api::download_response::try_presigned_redirect(
+        storage,
+        storage_key,
+        config.presigned_downloads_enabled,
+        expiry,
+    )
+    .await
+}
+
 // ---------------------------------------------------------------------------
 // GET /conda/{repo_key}/{subdir}/{filename} - Download package
 // ---------------------------------------------------------------------------
@@ -2417,24 +2437,16 @@ async fn download_package(
     // Redirect to a presigned storage URL when enabled, so the client pulls the
     // package directly from object storage instead of streaming through the
     // backend (conda/mamba verify against repodata.json, not response headers).
-    if state.config.presigned_downloads_enabled {
-        let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
-        if let Some(redirect) = crate::api::download_response::try_presigned_redirect(
-            storage.as_ref(),
-            &artifact.storage_key,
-            true,
-            expiry,
+    if let Some(redirect) =
+        presigned_download_redirect(&state.config, storage.as_ref(), &artifact.storage_key).await
+    {
+        let _ = sqlx::query!(
+            "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+            artifact.id
         )
-        .await
-        {
-            let _ = sqlx::query!(
-                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-                artifact.id
-            )
-            .execute(&state.db)
-            .await;
-            return Ok(redirect);
-        }
+        .execute(&state.db)
+        .await;
+        return Ok(redirect);
     }
 
     let stream = storage
@@ -8540,5 +8552,112 @@ mod tests {
             verifying_key.verify(&json_bytes, &signature).is_ok(),
             "Signature should verify against the public key"
         );
+    }
+}
+
+#[cfg(test)]
+mod presign_redirect_tests {
+    use crate::error::Result as StorageResult;
+    use crate::storage::{PresignedUrl, PresignedUrlSource, StorageBackend};
+    use async_trait::async_trait;
+    use axum::http::StatusCode;
+    use bytes::Bytes;
+    use std::time::Duration;
+
+    /// Storage backend that supports presigned URLs (e.g. S3).
+    struct RedirectBackend;
+
+    #[async_trait]
+    impl StorageBackend for RedirectBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> StorageResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> StorageResult<Bytes> {
+            Ok(Bytes::from_static(b"data"))
+        }
+        async fn exists(&self, _key: &str) -> StorageResult<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> StorageResult<()> {
+            Ok(())
+        }
+        fn supports_redirect(&self) -> bool {
+            true
+        }
+        async fn get_presigned_url(
+            &self,
+            key: &str,
+            expires_in: Duration,
+        ) -> StorageResult<Option<PresignedUrl>> {
+            Ok(Some(PresignedUrl {
+                url: format!("https://s3.example.com/{}", key),
+                expires_in,
+                source: PresignedUrlSource::S3,
+            }))
+        }
+    }
+
+    /// Storage backend that does not support presigned URLs (e.g. filesystem).
+    struct NoRedirectBackend;
+
+    #[async_trait]
+    impl StorageBackend for NoRedirectBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> StorageResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> StorageResult<Bytes> {
+            Ok(Bytes::from_static(b"data"))
+        }
+        async fn exists(&self, _key: &str) -> StorageResult<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> StorageResult<()> {
+            Ok(())
+        }
+    }
+
+    fn config(presigned_downloads_enabled: bool) -> crate::config::Config {
+        crate::config::Config {
+            presigned_downloads_enabled,
+            presigned_download_expiry_secs: 300,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn redirects_when_enabled_and_supported() {
+        let resp = super::presigned_download_redirect(
+            &config(true),
+            &RedirectBackend,
+            "channel/linux-64/pkg-1.0.conda",
+        )
+        .await
+        .expect("should redirect when enabled and backend supports it");
+        assert_eq!(resp.status(), StatusCode::FOUND);
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.contains("s3.example.com"));
+        assert!(location.contains("pkg-1.0.conda"));
+    }
+
+    #[tokio::test]
+    async fn streams_when_feature_disabled() {
+        let resp = super::presigned_download_redirect(
+            &config(false),
+            &RedirectBackend,
+            "channel/linux-64/pkg-1.0.conda",
+        )
+        .await;
+        assert!(resp.is_none(), "must stream when feature flag is off");
+    }
+
+    #[tokio::test]
+    async fn streams_when_backend_unsupported() {
+        let resp = super::presigned_download_redirect(
+            &config(true),
+            &NoRedirectBackend,
+            "channel/linux-64/pkg-1.0.conda",
+        )
+        .await;
+        assert!(resp.is_none(), "must stream when backend cannot presign");
     }
 }

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2414,6 +2414,29 @@ async fn download_package(
         .await
         .map_err(|e| e.into_response())?;
 
+    // Redirect to a presigned storage URL when enabled, so the client pulls the
+    // package directly from object storage instead of streaming through the
+    // backend (conda/mamba verify against repodata.json, not response headers).
+    if state.config.presigned_downloads_enabled {
+        let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
+        if let Some(redirect) = crate::api::download_response::try_presigned_redirect(
+            storage.as_ref(),
+            &artifact.storage_key,
+            true,
+            expiry,
+        )
+        .await
+        {
+            let _ = sqlx::query!(
+                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+                artifact.id
+            )
+            .execute(&state.db)
+            .await;
+            return Ok(redirect);
+        }
+    }
+
     let stream = storage
         .get_stream(&artifact.storage_key)
         .await


### PR DESCRIPTION
## Summary

Wire the conda hosted package download (`backend/src/api/handlers/conda.rs`, `download_package`) to attempt a presigned-redirect before streaming. When `PRESIGNED_DOWNLOADS_ENABLED=true` and the storage backend supports redirects, a hosted `.conda` / `.tar.bz2` GET returns a `302` to object storage instead of streaming the body through the backend; it falls back to streaming when unsupported (e.g. filesystem).

**Backend-offload / burst-resilience, not a download speedup.** Measured in-cluster (single-replica backend, 4 vCPU limit, in-region object storage): a 118 MB artifact streams through the backend at ~94 MB/s single-stream and ~425 MB/s aggregate across 8 concurrent streams at only ~18% of the backend's CPU — the backend is not the download-throughput bottleneck. The value is taking the backend out of the byte path (freeing a worker per download, avoiding the re-stream under burst — large conda packages are a prime case) and matching the existing PyPI presign path.

**Scoping (reviewed):** only the package-bytes download is touched. `repodata.json` and all the other index/metadata (`current_repodata.json`, `channeldata.json`, JLAP, CEP-16 shards) are generated in-memory by separate handlers and are never redirected; upload/repodata-regen is a separate write path. conda/mamba follow the 302, and integrity is verified against the `sha256` in `repodata.json` (not response headers), so dropping the streamed `X-Checksum-SHA256` / `Content-Length` on the redirect is safe. The package path does no `Range`/`HEAD` today, so the 302 → object storage (which honours `Range`) is at worst neutral.

Closes #1950.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

The presign decision is extracted into a pure `presigned_download_redirect` helper (no state/DB) and unit-tested with mock `StorageBackend`s for the enabled+supported (302), feature-disabled, and backend-unsupported cases (matching the existing `try_presigned_redirect` tests). `cargo fmt --check` and `cargo clippy -p artifact-keeper-backend --lib --tests -- -D warnings` are clean. Integration/E2E tests are N/A: no new endpoints, and the redirect is gated behind `PRESIGNED_DOWNLOADS_ENABLED` (default false) so the streamed fallback (existing behaviour) is unchanged.

## API Changes
- [x] N/A - no API changes

