### PR TITLE
feat(debian): redirect hosted .deb downloads to presigned storage URLs

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1342,6 +1342,26 @@ fn xz_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
     encoder.finish()
 }
 
+/// Returns a `302` redirect to a presigned object-storage URL for a hosted
+/// download when `PRESIGNED_DOWNLOADS_ENABLED` is set and the storage backend
+/// supports redirects; otherwise `None`, so the caller falls back to streaming
+/// the bytes through the backend. Kept free of state/DB so it is unit-testable
+/// with a mock `StorageBackend`.
+async fn presigned_download_redirect(
+    config: &crate::config::Config,
+    storage: &dyn crate::storage::StorageBackend,
+    storage_key: &str,
+) -> Option<Response> {
+    let expiry = std::time::Duration::from_secs(config.presigned_download_expiry_secs);
+    crate::api::download_response::try_presigned_redirect(
+        storage,
+        storage_key,
+        config.presigned_downloads_enabled,
+        expiry,
+    )
+    .await
+}
+
 // ---------------------------------------------------------------------------
 // GET /debian/{repo_key}/pool/{component}/*path -- Download .deb
 // ---------------------------------------------------------------------------
@@ -1449,24 +1469,16 @@ async fn pool_download(
     // Redirect to a presigned storage URL when enabled, so apt pulls the .deb
     // directly from object storage instead of streaming through the backend
     // (apt verifies via the Packages index hashes, not response headers).
-    if state.config.presigned_downloads_enabled {
-        let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
-        if let Some(redirect) = crate::api::download_response::try_presigned_redirect(
-            storage.as_ref(),
-            &artifact.storage_key,
-            true,
-            expiry,
+    if let Some(redirect) =
+        presigned_download_redirect(&state.config, storage.as_ref(), &artifact.storage_key).await
+    {
+        let _ = sqlx::query!(
+            "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+            artifact.id
         )
-        .await
-        {
-            let _ = sqlx::query!(
-                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-                artifact.id
-            )
-            .execute(&state.db)
-            .await;
-            return Ok(redirect);
-        }
+        .execute(&state.db)
+        .await;
+        return Ok(redirect);
     }
 
     let stream = storage
@@ -3113,5 +3125,112 @@ mod upload_db_tests {
         assert!(release.contains("main/binary-amd64/Packages.xz\n"));
 
         f.teardown().await;
+    }
+}
+
+#[cfg(test)]
+mod presign_redirect_tests {
+    use crate::error::Result as StorageResult;
+    use crate::storage::{PresignedUrl, PresignedUrlSource, StorageBackend};
+    use async_trait::async_trait;
+    use axum::http::StatusCode;
+    use bytes::Bytes;
+    use std::time::Duration;
+
+    /// Storage backend that supports presigned URLs (e.g. S3).
+    struct RedirectBackend;
+
+    #[async_trait]
+    impl StorageBackend for RedirectBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> StorageResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> StorageResult<Bytes> {
+            Ok(Bytes::from_static(b"data"))
+        }
+        async fn exists(&self, _key: &str) -> StorageResult<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> StorageResult<()> {
+            Ok(())
+        }
+        fn supports_redirect(&self) -> bool {
+            true
+        }
+        async fn get_presigned_url(
+            &self,
+            key: &str,
+            expires_in: Duration,
+        ) -> StorageResult<Option<PresignedUrl>> {
+            Ok(Some(PresignedUrl {
+                url: format!("https://s3.example.com/{}", key),
+                expires_in,
+                source: PresignedUrlSource::S3,
+            }))
+        }
+    }
+
+    /// Storage backend that does not support presigned URLs (e.g. filesystem).
+    struct NoRedirectBackend;
+
+    #[async_trait]
+    impl StorageBackend for NoRedirectBackend {
+        async fn put(&self, _key: &str, _content: Bytes) -> StorageResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> StorageResult<Bytes> {
+            Ok(Bytes::from_static(b"data"))
+        }
+        async fn exists(&self, _key: &str) -> StorageResult<bool> {
+            Ok(true)
+        }
+        async fn delete(&self, _key: &str) -> StorageResult<()> {
+            Ok(())
+        }
+    }
+
+    fn config(presigned_downloads_enabled: bool) -> crate::config::Config {
+        crate::config::Config {
+            presigned_downloads_enabled,
+            presigned_download_expiry_secs: 300,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn redirects_when_enabled_and_supported() {
+        let resp = super::presigned_download_redirect(
+            &config(true),
+            &RedirectBackend,
+            "pool/main/h/hello/hello_2.10-3_amd64.deb",
+        )
+        .await
+        .expect("should redirect when enabled and backend supports it");
+        assert_eq!(resp.status(), StatusCode::FOUND);
+        let location = resp.headers().get("location").unwrap().to_str().unwrap();
+        assert!(location.contains("s3.example.com"));
+        assert!(location.contains("hello_2.10-3_amd64.deb"));
+    }
+
+    #[tokio::test]
+    async fn streams_when_feature_disabled() {
+        let resp = super::presigned_download_redirect(
+            &config(false),
+            &RedirectBackend,
+            "pool/main/h/hello/hello_2.10-3_amd64.deb",
+        )
+        .await;
+        assert!(resp.is_none(), "must stream when feature flag is off");
+    }
+
+    #[tokio::test]
+    async fn streams_when_backend_unsupported() {
+        let resp = super::presigned_download_redirect(
+            &config(true),
+            &NoRedirectBackend,
+            "pool/main/h/hello/hello_2.10-3_amd64.deb",
+        )
+        .await;
+        assert!(resp.is_none(), "must stream when backend cannot presign");
     }
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1446,6 +1446,29 @@ async fn pool_download(
         .await
         .map_err(|e| e.into_response())?;
 
+    // Redirect to a presigned storage URL when enabled, so apt pulls the .deb
+    // directly from object storage instead of streaming through the backend
+    // (apt verifies via the Packages index hashes, not response headers).
+    if state.config.presigned_downloads_enabled {
+        let expiry = std::time::Duration::from_secs(state.config.presigned_download_expiry_secs);
+        if let Some(redirect) = crate::api::download_response::try_presigned_redirect(
+            storage.as_ref(),
+            &artifact.storage_key,
+            true,
+            expiry,
+        )
+        .await
+        {
+            let _ = sqlx::query!(
+                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+                artifact.id
+            )
+            .execute(&state.db)
+            .await;
+            return Ok(redirect);
+        }
+    }
+
     let stream = storage
         .get_stream(&artifact.storage_key)
         .await


### PR DESCRIPTION
## Summary

Wire the debian hosted pool download (`backend/src/api/handlers/debian.rs`, `pool_download`) to attempt a presigned-redirect before streaming. When `PRESIGNED_DOWNLOADS_ENABLED=true` and the storage backend supports redirects, a hosted `pool/{component}/…` GET returns a `302` to object storage instead of streaming the `.deb` through the backend; it falls back to streaming when unsupported (e.g. filesystem).

**Backend-offload / burst-resilience, not a download speedup.** Measured in-cluster (single-replica backend, 4 vCPU limit, in-region object storage): a 118 MB artifact streams through the backend at ~94 MB/s single-stream and ~425 MB/s aggregate across 8 concurrent streams at only ~18% of the backend's CPU — the backend is not the download-throughput bottleneck. The value is taking the backend out of the byte path (freeing a worker per download, avoiding the re-stream under burst — `.deb` packages are genuinely large) and matching the existing PyPI presign path.

**Scoping (reviewed):** only the pool artifact-bytes download is touched. `apt update`'s indexes (`Release`, `InRelease`, `Release.gpg`, `Packages[.gz/.xz]`) are generated/PGP-signed inline by separate handlers under `dists/` and are never redirected (they have no stored object to presign). Uploads are a separate write path. `apt`/`apt-get` follow the 302, and integrity is verified against the `Packages` index hashes (not response headers), so dropping `Content-Type`/`Content-Disposition`/`X-Checksum-SHA256` on the redirect is safe. `pool_download` does no `Range` today, so the 302 → object storage (which honours `Range`) actually improves resumable/partial fetches. Note the redirect applies to all stored pool objects (`.deb`/`.udeb`/source), not just `.deb` — all are verified by apt against index hashes.

Closes #1950.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

The presign decision is extracted into a pure `presigned_download_redirect` helper (no state/DB) and unit-tested with mock `StorageBackend`s for the enabled+supported (302), feature-disabled, and backend-unsupported cases (matching the existing `try_presigned_redirect` tests). `cargo fmt --check` and `cargo clippy -p artifact-keeper-backend --lib --tests -- -D warnings` are clean. Integration/E2E tests are N/A: no new endpoints, and the redirect is gated behind `PRESIGNED_DOWNLOADS_ENABLED` (default false) so the streamed fallback (existing behaviour) is unchanged.

## API Changes
- [x] N/A - no API changes

