### PR TITLE
fix(promotion): tenant-ownership check on promote target + separation-of-duties on approval

### DIFF
--- a/backend/src/api/handlers/approval.rs
+++ b/backend/src/api/handlers/approval.rs
@@ -153,6 +153,26 @@ impl ApprovalRow {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Separation-of-duties (four-eyes) decision: may `approver` approve a promotion
+/// that was requested by `requester`?
+///
+/// The promotion approval workflow is a control gate: the principal who requests
+/// a promotion must not be the principal who approves it. Without this, a single
+/// admin-capable principal can both `POST /approval/request` and
+/// `POST /approval/{id}/approve` on their own request, collapsing the four-eyes
+/// control into one (the SoD-bypass finding from the 1.2.2 validation campaign).
+///
+/// There is intentionally NO self-approve override: the whole point of the
+/// control is that a second principal signs off, so a break-glass that lets the
+/// requester approve their own request would defeat it. A genuine emergency
+/// promotion path already exists outside the approval workflow (the admin
+/// `skip_policy_check` direct-promote), so this gate stays absolute.
+///
+/// Pure boolean so it is unit-testable without a database.
+fn approval_separation_of_duties_ok(requester: Uuid, approver: Uuid) -> bool {
+    requester != approver
+}
+
 /// Check whether a repository requires approval for promotions.
 pub async fn check_approval_required(db: &sqlx::PgPool, repo_id: Uuid) -> Result<bool> {
     let row: Option<(bool,)> =
@@ -495,11 +515,12 @@ pub async fn approve_promotion(
         artifact_id: Uuid,
         source_repo_id: Uuid,
         target_repo_id: Uuid,
+        requested_by: Uuid,
         status: String,
     }
 
     let approval: SimpleRow = sqlx::query_as(
-        "SELECT id, artifact_id, source_repo_id, target_repo_id, status FROM promotion_approvals WHERE id = $1",
+        "SELECT id, artifact_id, source_repo_id, target_repo_id, requested_by, status FROM promotion_approvals WHERE id = $1",
     )
     .bind(approval_id)
     .fetch_optional(&state.db)
@@ -512,6 +533,19 @@ pub async fn approve_promotion(
             "Approval request has already been {}",
             approval.status
         )));
+    }
+
+    // Separation of duties (four-eyes). The requester of a promotion must not be
+    // the principal who approves it. Without this an admin-capable principal can
+    // request AND approve their own promotion, collapsing the control gate (the
+    // SoD-bypass finding from the 1.2.2 validation campaign). No self-approve
+    // override: the second-pair-of-eyes requirement is the whole point.
+    if !approval_separation_of_duties_ok(approval.requested_by, auth.user_id) {
+        return Err(AppError::Authorization(
+            "Separation of duties: you cannot approve a promotion you requested. \
+             A different reviewer must approve this request."
+                .to_string(),
+        ));
     }
 
     let repo_service = RepositoryService::new(state.db.clone());
@@ -529,6 +563,19 @@ pub async fn approve_promotion(
 
     let source_repo = repo_service.get_by_key(&source_repo_key.0).await?;
     let target_repo = repo_service.get_by_key(&target_repo_key.0).await?;
+
+    // Tenant-ownership gate (campaign-#4 systemic authz). The admin-capability
+    // check above does NOT bind the approver to a tenant; without this an
+    // admin-capable corp principal could approve a promotion whose target is a
+    // globex repository, laundering an artifact across the tenant boundary via
+    // the governance workflow. Reject cross-tenant approval on either repo with 403.
+    crate::api::handlers::promotion::require_promotion_tenant_access(
+        &repo_service,
+        auth.user_id,
+        &source_repo,
+        &target_repo,
+    )
+    .await?;
 
     #[derive(sqlx::FromRow)]
     #[allow(dead_code)]
@@ -948,6 +995,24 @@ mod tests {
             gate < probe,
             "require_visible must run BEFORE the artifact existence probe (xtenant oracle)"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // approval_separation_of_duties_ok (four-eyes SoD decision)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_sod_requester_cannot_self_approve() {
+        let p = Uuid::new_v4();
+        // Same principal as requester and approver -> not allowed.
+        assert!(!approval_separation_of_duties_ok(p, p));
+    }
+
+    #[test]
+    fn test_sod_distinct_approver_allowed() {
+        let requester = Uuid::new_v4();
+        let approver = Uuid::new_v4();
+        assert!(approval_separation_of_duties_ok(requester, approver));
     }
 
     // -----------------------------------------------------------------------
@@ -1764,7 +1829,69 @@ mod tests {
             .execute(pool)
             .await
             .expect("insert user");
+            // Grant a global (NULL-scoped) admin role assignment, mirroring the
+            // genuine super-admin seeded by migration 002, so this approver
+            // satisfies the promotion tenant-ownership gate for every repo.
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id) \
+                 SELECT $1, r.id FROM roles r WHERE r.name = 'admin'",
+            )
+            .bind(id)
+            .execute(pool)
+            .await
+            .expect("grant global admin role");
             id
+        }
+
+        /// A second principal that is the REQUESTER of an approval. Distinct from
+        /// the approver so the separation-of-duties gate is satisfied in the
+        /// rule-gate tests (which predate SoD). Holds no grants; only needs to
+        /// exist as the `requested_by` identity.
+        async fn make_requester(pool: &PgPool, tag: &str) -> Uuid {
+            let id = Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active) \
+                 VALUES ($1, $2, $3, 'x', 'local', false, true)",
+            )
+            .bind(id)
+            .bind(format!("pr1940-req-{}-{}", tag, &id.to_string()[..8]))
+            .bind(format!("pr1940-req-{}-{}@test.local", tag, &id.to_string()[..8]))
+            .execute(pool)
+            .await
+            .expect("insert requester");
+            id
+        }
+
+        /// Admin-capable but tenant-scoped principal: `is_admin` is true but it
+        /// holds NO global NULL-scoped assignment, only the per-repo grants added
+        /// via `grant_repo`. Models a tenant admin (e.g. corp) for the
+        /// cross-tenant approval test.
+        async fn make_tenant_admin(pool: &PgPool, tag: &str) -> Uuid {
+            let id = Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active) \
+                 VALUES ($1, $2, $3, 'x', 'local', true, true)",
+            )
+            .bind(id)
+            .bind(format!("pr1940-tadm-{}-{}", tag, &id.to_string()[..8]))
+            .bind(format!("pr1940-tadm-{}-{}@test.local", tag, &id.to_string()[..8]))
+            .execute(pool)
+            .await
+            .expect("insert tenant admin");
+            id
+        }
+
+        async fn grant_repo(pool: &PgPool, user: Uuid, repo: Uuid) {
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+                 SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+                 ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+            )
+            .bind(user)
+            .bind(repo)
+            .execute(pool)
+            .await
+            .expect("grant per-repo developer role");
         }
 
         fn admin_ext(user_id: Uuid) -> AuthExtension {
@@ -1926,6 +2053,24 @@ mod tests {
                     .execute(pool)
                     .await;
             }
+            let _ = sqlx::query("DELETE FROM role_assignments WHERE user_id = $1")
+                .bind(user)
+                .execute(pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(user)
+                .execute(pool)
+                .await;
+        }
+
+        /// Delete an auxiliary user (e.g. the requester) and any role assignments
+        /// it holds. Used in addition to `cleanup` when a test creates a distinct
+        /// requester or a second tenant principal.
+        async fn cleanup_user(pool: &PgPool, user: Uuid) {
+            let _ = sqlx::query("DELETE FROM role_assignments WHERE user_id = $1")
+                .bind(user)
+                .execute(pool)
+                .await;
             let _ = sqlx::query("DELETE FROM users WHERE id = $1")
                 .bind(user)
                 .execute(pool)
@@ -1951,7 +2096,10 @@ mod tests {
             let storage = storage_for(&state, &pool, src).await;
             let artifact = make_artifact(&pool, src, &storage, "arej").await;
             make_rule(&pool, src, tgt, None, Some(720)).await;
-            let approval = make_pending_approval(&pool, artifact, src, tgt, user).await;
+            // Distinct requester so the SoD gate (requester != approver) passes
+            // and the rule gate is the one under test.
+            let requester = make_requester(&pool, "arej").await;
+            let approval = make_pending_approval(&pool, artifact, src, tgt, requester).await;
 
             let res = approve_promotion(
                 State(state.clone()),
@@ -1984,6 +2132,7 @@ mod tests {
             );
 
             cleanup(&pool, &[src, tgt], user).await;
+            cleanup_user(&pool, requester).await;
         }
 
         /// A rule-MET approval still executes: the artifact lands in the target
@@ -2004,7 +2153,8 @@ mod tests {
             let storage = storage_for(&state, &pool, src).await;
             let artifact = make_artifact(&pool, src, &storage, "aok").await;
             make_rule(&pool, src, tgt, None, Some(0)).await;
-            let approval = make_pending_approval(&pool, artifact, src, tgt, user).await;
+            let requester = make_requester(&pool, "aok").await;
+            let approval = make_pending_approval(&pool, artifact, src, tgt, requester).await;
 
             let res = approve_promotion(
                 State(state.clone()),
@@ -2024,6 +2174,7 @@ mod tests {
             assert_eq!(approval_status(&pool, approval).await, "approved");
 
             cleanup(&pool, &[src, tgt], user).await;
+            cleanup_user(&pool, requester).await;
         }
 
         /// skip_policy_check admin break-glass still works on the approval path:
@@ -2044,7 +2195,8 @@ mod tests {
             let storage = storage_for(&state, &pool, src).await;
             let artifact = make_artifact(&pool, src, &storage, "askip").await;
             make_rule(&pool, src, tgt, None, Some(720)).await;
-            let approval = make_pending_approval(&pool, artifact, src, tgt, user).await;
+            let requester = make_requester(&pool, "askip").await;
+            let approval = make_pending_approval(&pool, artifact, src, tgt, requester).await;
 
             let res = approve_promotion(
                 State(state.clone()),
@@ -2064,6 +2216,167 @@ mod tests {
             assert_eq!(approval_status(&pool, approval).await, "approved");
 
             cleanup(&pool, &[src, tgt], user).await;
+            cleanup_user(&pool, requester).await;
+        }
+
+        // ---- separation of duties (four-eyes) on approve_promotion -----------
+
+        /// SoD: the requester of a promotion must NOT be able to approve it.
+        /// Self-approval -> 403 Authorization, no copy, approval stays pending.
+        #[tokio::test]
+        async fn test_approval_self_approval_blocked() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr-sod-self-s-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr-sod-self-t-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "sod-self-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "sod-self-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let user = make_admin(&pool, "sod-self").await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "sodself").await;
+            // No rule, so only the SoD gate can block. Same principal requests
+            // AND approves.
+            let approval = make_pending_approval(&pool, artifact, src, tgt, user).await;
+
+            let res = approve_promotion(
+                State(state.clone()),
+                Extension(admin_ext(user)),
+                Path(approval),
+                Json(ReviewRequest {
+                    notes: None,
+                    skip_policy_check: false,
+                }),
+            )
+            .await;
+            match res {
+                Err(AppError::Authorization(msg)) => assert!(
+                    msg.contains("Separation of duties"),
+                    "self-approval must be denied with an SoD message; got: {msg}"
+                ),
+                other => panic!(
+                    "expected SoD Authorization (403) block, got ok={:?}",
+                    other.is_ok()
+                ),
+            }
+            assert!(
+                !target_has_artifact(&pool, tgt, "sodself").await,
+                "a self-approved promotion must NOT copy the artifact"
+            );
+            assert_eq!(
+                approval_status(&pool, approval).await,
+                "pending",
+                "a self-approval-blocked request must remain pending"
+            );
+
+            cleanup(&pool, &[src, tgt], user).await;
+        }
+
+        /// SoD: a DISTINCT approver (different principal from the requester) may
+        /// approve, and the promotion executes.
+        #[tokio::test]
+        async fn test_approval_distinct_approver_allowed() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr-sod-ok-s-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr-sod-ok-t-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "sod-ok-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "sod-ok-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let approver = make_admin(&pool, "sod-ok").await;
+            let requester = make_requester(&pool, "sod-ok").await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "sodok").await;
+            let approval = make_pending_approval(&pool, artifact, src, tgt, requester).await;
+
+            let res = approve_promotion(
+                State(state.clone()),
+                Extension(admin_ext(approver)),
+                Path(approval),
+                Json(ReviewRequest {
+                    notes: Some("second pair of eyes".to_string()),
+                    skip_policy_check: false,
+                }),
+            )
+            .await;
+            assert!(
+                res.is_ok(),
+                "a distinct approver must be able to approve the promotion"
+            );
+            assert!(
+                target_has_artifact(&pool, tgt, "sodok").await,
+                "a distinct-approver promotion must copy the artifact"
+            );
+            assert_eq!(approval_status(&pool, approval).await, "approved");
+
+            cleanup(&pool, &[src, tgt], approver).await;
+            cleanup_user(&pool, requester).await;
+        }
+
+        // ---- tenant-ownership gate on approve_promotion (xtenant) ------------
+
+        /// Cross-tenant approval: an admin-capable principal authorized only for
+        /// the corp source repo approves a promotion whose target is a globex
+        /// repo it does not own -> 403, no copy, approval stays pending.
+        #[tokio::test]
+        async fn test_approval_cross_tenant_target_blocked() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr-xta-s-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr-xta-t-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "xta-corp-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "xta-globex-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            // Tenant admin owns only the corp source, not the globex target.
+            let corp_admin = make_tenant_admin(&pool, "xta-corp").await;
+            grant_repo(&pool, corp_admin, src).await;
+            // Distinct requester so SoD is not what trips first; the tenant gate is.
+            let requester = make_requester(&pool, "xta").await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "xta").await;
+            let approval = make_pending_approval(&pool, artifact, src, tgt, requester).await;
+
+            let res = approve_promotion(
+                State(state.clone()),
+                Extension(admin_ext(corp_admin)),
+                Path(approval),
+                Json(ReviewRequest {
+                    notes: None,
+                    skip_policy_check: false,
+                }),
+            )
+            .await;
+            match res {
+                Err(AppError::Authorization(msg)) => assert!(
+                    msg.contains("tenant"),
+                    "cross-tenant approval must be denied with a tenant message; got: {msg}"
+                ),
+                other => panic!(
+                    "expected tenant Authorization (403) block, got ok={:?}",
+                    other.is_ok()
+                ),
+            }
+            assert!(
+                !target_has_artifact(&pool, tgt, "xta").await,
+                "a cross-tenant approval must NOT copy the artifact"
+            );
+            assert_eq!(
+                approval_status(&pool, approval).await,
+                "pending",
+                "a tenant-blocked approval must remain pending"
+            );
+
+            cleanup(&pool, &[src, tgt], corp_admin).await;
+            cleanup_user(&pool, requester).await;
         }
     }
 }

--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -436,6 +436,65 @@ fn ensure_promotion_authorized(is_admin: bool) -> Result<()> {
     Ok(())
 }
 
+/// Pure tenant-ownership decision for one repository in a promotion.
+///
+/// A promotion crosses a tenant boundary when the caller is authorized for one
+/// tenant's repositories but names another tenant's repository as the source or
+/// target. The codebase models tenancy as per-repository role-assignment
+/// membership (see [`RepositoryService::user_can_access_repo`] and the
+/// `require_repo_write_access` write gate): a caller "owns" a private repo only
+/// if they hold a role assignment scoped to it (direct) or a global,
+/// NULL-scoped assignment (the genuine super-admin seeded in migration 002).
+///
+/// Unlike `require_repo_write_access`, this check does NOT blanket-bypass on the
+/// global `is_admin` flag. The `is_admin` boolean is a capability flag, not a
+/// tenant identity: in a multi-tenant deployment each tenant has admin-capable
+/// principals, and the cross-tenant promote-injection finding (campaign-#4
+/// systemic authz pattern) was reproduced by exactly such a principal promoting
+/// a corp artifact into a globex repository. Defense-in-depth therefore demands
+/// the tenant-ownership check be enforced independent of the admin flag: a
+/// genuine super-admin still passes via their NULL-scoped grant, while a
+/// tenant-scoped admin is rejected for a repository in a tenant they do not own.
+///
+/// Public repositories carry no tenant boundary, so they always pass — mirroring
+/// the public-repo short-circuit in `require_repo_write_access` / `require_visible`.
+///
+/// Split out as a pure boolean so the allow/deny decision is unit-testable
+/// without a database; the DB lookup lives in [`require_promotion_tenant_access`].
+fn promotion_tenant_access_allowed(repo_is_public: bool, has_repo_grant: bool) -> bool {
+    repo_is_public || has_repo_grant
+}
+
+/// Enforce tenant ownership on BOTH the source and target repositories of a
+/// promotion before any copy/insert happens.
+///
+/// Rejects cross-tenant promotion (e.g. a corp-tenant artifact promoted into a
+/// globex-tenant repository) with HTTP 403. Applied to every promote path —
+/// single, bulk, and the approval-execute path — so the governance workflow
+/// cannot be used to launder an artifact across the tenant boundary.
+///
+/// The denial is an `Authorization` error (403) rather than `NotFound` because
+/// the caller, being admin-capable, already proved knowledge of the repository
+/// keys via the source/target lookups; the 403 names which repository is out of
+/// the caller's tenant so legitimate operators get an actionable message.
+pub(crate) async fn require_promotion_tenant_access(
+    repo_service: &RepositoryService,
+    user_id: Uuid,
+    source: &crate::models::repository::Repository,
+    target: &crate::models::repository::Repository,
+) -> Result<()> {
+    for repo in [source, target] {
+        let has_grant = repo_service.user_can_access_repo(repo.id, user_id).await?;
+        if !promotion_tenant_access_allowed(repo.is_public, has_grant) {
+            return Err(AppError::Authorization(format!(
+                "You are not authorized to promote into the '{}' repository's tenant",
+                repo.key
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn failed_response(source: String, target: String, message: String) -> PromotionResponse {
     PromotionResponse {
         promoted: false,
@@ -505,6 +564,13 @@ pub async fn promote_artifact(
     enforce_release_target_link(&state.db, source_repo.id, &target_key).await?;
 
     let target_repo = repo_service.get_by_key(&target_key).await?;
+
+    // Tenant-ownership gate (campaign-#4 systemic authz). The admin-capability
+    // check above does NOT bind the caller to a tenant; without this, an
+    // admin-capable corp principal could promote into a globex repository. Reject
+    // cross-tenant promotion on either the source or target repo with 403.
+    require_promotion_tenant_access(&repo_service, auth.user_id, &source_repo, &target_repo)
+        .await?;
 
     // Look up the artifact first. The artifact lookup is keyed by the source
     // repository id, not by repository type, so it works even when the source
@@ -783,6 +849,12 @@ pub async fn promote_artifacts_bulk(
 
     let target_repo = repo_service.get_by_key(&target_key).await?;
     validate_promotion_repos(&source_repo, &target_repo)?;
+
+    // Tenant-ownership gate (campaign-#4 systemic authz). Enforced once for the
+    // whole batch since source/target are fixed across all items; rejects a
+    // cross-tenant bulk promotion (corp artifacts -> globex repo) with 403.
+    require_promotion_tenant_access(&repo_service, auth.user_id, &source_repo, &target_repo)
+        .await?;
 
     let mut results = Vec::new();
     let mut promoted = 0;
@@ -1510,6 +1582,35 @@ mod tests {
         // the approval workflow's approve/reject endpoints.
         assert!(matches!(err, AppError::Authorization(_)));
         assert!(err.to_string().contains("admin"));
+    }
+
+    // -----------------------------------------------------------------------
+    // promotion_tenant_access_allowed (cross-tenant promote-target gate)
+    //
+    // Pure decision behind require_promotion_tenant_access. A repo passes the
+    // tenant-ownership gate when it is public OR the caller holds a grant on it
+    // (per-repo or global NULL-scoped). The is_admin capability flag is NOT a
+    // tenant identity, so it is intentionally absent here.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_tenant_access_public_repo_always_allowed() {
+        // Public repos carry no tenant boundary, so they pass even without a grant.
+        assert!(promotion_tenant_access_allowed(true, false));
+        assert!(promotion_tenant_access_allowed(true, true));
+    }
+
+    #[test]
+    fn test_tenant_access_private_with_grant_allowed() {
+        // A genuine super-admin (NULL-scoped grant) or a same-tenant operator
+        // holds a grant on the private repo -> allowed.
+        assert!(promotion_tenant_access_allowed(false, true));
+    }
+
+    #[test]
+    fn test_tenant_access_private_without_grant_denied() {
+        // The cross-tenant case: private repo in another tenant, no grant -> deny.
+        assert!(!promotion_tenant_access_allowed(false, false));
     }
 
     // -----------------------------------------------------------------------
@@ -2915,7 +3016,56 @@ mod tests {
             .execute(pool)
             .await
             .expect("insert user");
+            // Grant a global (NULL-scoped) admin role assignment, mirroring the
+            // genuine super-admin seeded by migration 002. The promotion
+            // tenant-ownership gate requires a grant on the source/target repos;
+            // a NULL-scoped assignment satisfies it for every repository, which is
+            // exactly what a real cross-tenant super-admin holds.
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id) \
+                 SELECT $1, r.id FROM roles r WHERE r.name = 'admin'",
+            )
+            .bind(id)
+            .execute(pool)
+            .await
+            .expect("grant global admin role");
             id
+        }
+
+        /// Create a non-super-admin user that is admin-capable (the `is_admin`
+        /// capability flag is true) but tenant-scoped: it holds NO global,
+        /// NULL-scoped role assignment, only the per-repo grants explicitly added
+        /// via `grant_repo`. This models a tenant admin (e.g. a corp admin) in a
+        /// multi-tenant deployment for the cross-tenant promotion tests.
+        async fn make_tenant_admin(pool: &PgPool, tag: &str) -> Uuid {
+            let id = Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active) \
+                 VALUES ($1, $2, $3, 'x', 'local', true, true)",
+            )
+            .bind(id)
+            .bind(format!("pr1940-{}-{}", tag, &id.to_string()[..8]))
+            .bind(format!("pr1940-{}-{}@test.local", tag, &id.to_string()[..8]))
+            .execute(pool)
+            .await
+            .expect("insert tenant admin");
+            id
+        }
+
+        /// Grant `user` the `developer` role scoped to a single repository,
+        /// mirroring the owner auto-grant in `RepositoryService::create`. Used to
+        /// place a tenant admin inside one tenant's repositories only.
+        async fn grant_repo(pool: &PgPool, user: Uuid, repo: Uuid) {
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+                 SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+                 ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+            )
+            .bind(user)
+            .bind(repo)
+            .execute(pool)
+            .await
+            .expect("grant per-repo developer role");
         }
 
         fn admin_ext(user_id: Uuid) -> AuthExtension {
@@ -3046,10 +3196,150 @@ mod tests {
                     .execute(pool)
                     .await;
             }
+            let _ = sqlx::query("DELETE FROM role_assignments WHERE user_id = $1")
+                .bind(user)
+                .execute(pool)
+                .await;
             let _ = sqlx::query("DELETE FROM users WHERE id = $1")
                 .bind(user)
                 .execute(pool)
                 .await;
+        }
+
+        // ---- tenant-ownership gate on promote target (xtenant) ---------------
+        //
+        // A promotion crosses a tenant boundary when an admin-capable principal
+        // authorized for one tenant's repos names another tenant's repo as the
+        // target. `require_promotion_tenant_access` rejects this with 403 on
+        // every promote path. These tests drive a tenant-scoped admin (per-repo
+        // grants only, NO global NULL-scoped assignment) across the single, bulk,
+        // and approval-execute paths.
+
+        /// Cross-tenant SINGLE promote: tenant admin owns the SOURCE (corp) but
+        /// not the TARGET (globex) -> 403, no copy.
+        #[tokio::test]
+        async fn test_single_promote_cross_tenant_target_blocked() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr-xt-ss-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr-xt-st-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "xt-corp-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "xt-globex-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let corp_admin = make_tenant_admin(&pool, "xt-corp").await;
+            // corp admin owns only the source (corp) repo, NOT the globex target.
+            grant_repo(&pool, corp_admin, src).await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "xt").await;
+
+            let err = promote_artifact(
+                State(state.clone()),
+                Extension(admin_ext(corp_admin)),
+                Path((src_key.clone(), artifact)),
+                Json(PromoteArtifactRequest {
+                    target_repository: Some(tgt_key.clone()),
+                    skip_policy_check: false,
+                    notes: None,
+                }),
+            )
+            .await
+            .expect_err("cross-tenant single promote must be rejected");
+            assert!(
+                matches!(err, AppError::Authorization(_)),
+                "cross-tenant promote must be a 403 Authorization error; got {:?}",
+                err
+            );
+            assert!(
+                !target_has_artifact(&pool, tgt, "xt").await,
+                "a cross-tenant single promote must NOT copy the artifact"
+            );
+
+            cleanup(&pool, &[src, tgt], corp_admin).await;
+        }
+
+        /// Same-tenant SINGLE promote: tenant admin owns BOTH repos -> succeeds.
+        #[tokio::test]
+        async fn test_single_promote_same_tenant_allowed() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr-st-ss-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr-st-st-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "st-corp-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "st-corp-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let corp_admin = make_tenant_admin(&pool, "st-corp").await;
+            // corp admin owns BOTH the corp source and corp target.
+            grant_repo(&pool, corp_admin, src).await;
+            grant_repo(&pool, corp_admin, tgt).await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "st").await;
+
+            let res = promote_artifact(
+                State(state.clone()),
+                Extension(admin_ext(corp_admin)),
+                Path((src_key.clone(), artifact)),
+                Json(PromoteArtifactRequest {
+                    target_repository: Some(tgt_key.clone()),
+                    skip_policy_check: false,
+                    notes: None,
+                }),
+            )
+            .await
+            .expect("same-tenant single promote must succeed");
+            assert!(res.0.promoted, "same-tenant single promote must promote");
+            assert!(target_has_artifact(&pool, tgt, "st").await);
+
+            cleanup(&pool, &[src, tgt], corp_admin).await;
+        }
+
+        /// Cross-tenant BULK promote: tenant admin lacks the target tenant -> 403.
+        #[tokio::test]
+        async fn test_bulk_promote_cross_tenant_target_blocked() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr-xtb-ss-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr-xtb-st-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "xtb-corp-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "xtb-globex-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let corp_admin = make_tenant_admin(&pool, "xtb-corp").await;
+            grant_repo(&pool, corp_admin, src).await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "xtb").await;
+
+            let err = promote_artifacts_bulk(
+                State(state.clone()),
+                Extension(admin_ext(corp_admin)),
+                Path(src_key.clone()),
+                Json(BulkPromoteRequest {
+                    target_repository: Some(tgt_key.clone()),
+                    artifact_ids: vec![artifact],
+                    skip_policy_check: false,
+                    notes: None,
+                }),
+            )
+            .await
+            .expect_err("cross-tenant bulk promote must be rejected");
+            assert!(
+                matches!(err, AppError::Authorization(_)),
+                "cross-tenant bulk promote must be a 403; got {:?}",
+                err
+            );
+            assert!(
+                !target_has_artifact(&pool, tgt, "xtb").await,
+                "a cross-tenant bulk promote must NOT copy the artifact"
+            );
+
+            cleanup(&pool, &[src, tgt], corp_admin).await;
         }
 
         // ---- single-promote handler: rule-MET promotes -----------------------


### PR DESCRIPTION
## Summary

Closes two adjacent promotion authorization gaps confirmed live by the 1.2.2 validation campaign. Both are independent of (and not covered by) the merged promotion_rules gate (#1940).

### 1. Cross-tenant promote-target injection (HIGH)
The single, bulk, and approval-execute promote paths gated only on the global `is_admin` capability flag and never checked that the caller owns the **target** (or source) repository's tenant. An admin-capable principal scoped to one tenant (e.g. corp) could promote an artifact into another tenant's repository (e.g. globex).

Fix: new `require_promotion_tenant_access` (promotion.rs) enforces per-repo role-assignment ownership — the codebase's actual tenancy model (`RepositoryService::user_can_access_repo`) — on **both** source and target, **independent of the `is_admin` flag**. A genuine super-admin passes via their global NULL-scoped grant (seeded in migration 002); a tenant-scoped admin is rejected with 403 for a repo outside its tenant. Public repos pass (no tenant boundary), mirroring `require_repo_write_access` / `require_visible`. Wired into `promote_artifact`, `promote_artifacts_bulk`, and `approve_promotion`.

This follows the campaign-#4 systemic-authz prescription: enforce tenant ownership on repository write paths independent of RBAC rule config.

### 2. Promotion four-eyes / separation-of-duties bypass (HIGH)
`approve_promotion` never compared the approver against the requester, so a single principal could both request and approve their own promotion.

Fix: `approve_promotion` now selects `requested_by` and rejects self-approval with 403 via the pure `approval_separation_of_duties_ok` decision. There is no self-approve override (the admin `skip_policy_check` direct-promote remains the documented emergency path). `promotion_approvals.requested_by` already exists (migration 054) — **no migration needed**.

## Tests (in-`src` `#[cfg(test)]`, run under `--lib`)
- Pure: `promotion_tenant_access_allowed` (public / grant / no-grant); `approval_separation_of_duties_ok` (self vs distinct).
- DB-backed: cross-tenant single + bulk promote blocked (403, no copy); same-tenant single promote allowed; cross-tenant approval blocked (403, stays pending); self-approval blocked (403, stays pending); distinct-approver allowed (executes). Existing #1940 rule-gate approval tests updated to use a distinct requester so SoD passes and the rule gate stays the unit under test.

## Verification
- `cargo test -p artifact-keeper-backend --lib 'promotion' -- --test-threads=1` → 242 passed
- `cargo test -p artifact-keeper-backend --lib 'approval' -- --test-threads=1` → 61 passed
- `cargo fmt --check` clean; `cargo clippy --lib -- -D warnings` clean
- No new query macros added (runtime `query`/`query_as` only) → no `cargo sqlx prepare` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)