### PR TITLE
fix(peers): authorize PUT labels (BOLA/cross-tenant) + 4xx on self-referential probe

### DIFF
--- a/backend/src/api/handlers/peer.rs
+++ b/backend/src/api/handlers/peer.rs
@@ -974,28 +974,13 @@ mod tests {
     // -----------------------------------------------------------------------
     mod probe_db {
         use crate::api::handlers::test_db_helpers as tdh;
-        use crate::services::peer_instance_service::{
-            PeerInstanceService, RegisterPeerInstanceRequest,
-        };
         use axum::http::StatusCode;
         use axum::Router;
         use sqlx::PgPool;
         use uuid::Uuid;
 
         async fn make_peer(pool: &PgPool, tag: &str) -> Uuid {
-            let svc = PeerInstanceService::new(pool.clone());
-            let id = Uuid::new_v4();
-            svc.register(RegisterPeerInstanceRequest {
-                name: format!("probe-{}-{}", tag, &id.to_string()[..8]),
-                endpoint_url: "https://peer.example.test".to_string(),
-                region: Some("us-east".to_string()),
-                cache_size_bytes: 1024,
-                sync_filter: None,
-                api_key: "k".to_string(),
-            })
-            .await
-            .expect("register peer")
-            .id
+            tdh::register_test_peer(pool, "probe", tag).await
         }
 
         fn probe_app(state: crate::api::SharedState) -> Router {
@@ -1003,6 +988,33 @@ mod tests {
             // /:id/connections.
             let router = Router::new().nest("/:id/connections", super::super::peer_router());
             tdh::router_with_auth(router, state, tdh::make_auth(Uuid::new_v4(), "fed.admin"))
+        }
+
+        /// Drive the probe handler: POST `{target_peer_id, latency_ms}` to
+        /// `/{src}/connections/probe` on a fresh router and return the status.
+        async fn probe(
+            state: crate::api::SharedState,
+            src: Uuid,
+            target: Uuid,
+            latency: i64,
+        ) -> StatusCode {
+            let body = axum::body::Bytes::from(
+                format!(
+                    r#"{{"target_peer_id":"{}","latency_ms":{}}}"#,
+                    target, latency
+                )
+                .into_bytes(),
+            );
+            let (status, _) = tdh::send(
+                probe_app(state),
+                tdh::post(
+                    format!("/{}/connections/probe", src),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+            status
         }
 
         #[tokio::test]
@@ -1013,19 +1025,7 @@ mod tests {
             let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-probe");
             let peer_id = make_peer(&pool, "self").await;
 
-            let app = probe_app(state);
-            let body = axum::body::Bytes::from(
-                format!(r#"{{"target_peer_id":"{}","latency_ms":5}}"#, peer_id).into_bytes(),
-            );
-            let (status, _) = tdh::send(
-                app,
-                tdh::post(
-                    format!("/{}/connections/probe", peer_id),
-                    "application/json",
-                    body,
-                ),
-            )
-            .await;
+            let status = probe(state, peer_id, peer_id, 5).await;
 
             assert_eq!(
                 status,
@@ -1048,19 +1048,7 @@ mod tests {
             let peer_id = make_peer(&pool, "src").await;
             let missing = Uuid::new_v4();
 
-            let app = probe_app(state);
-            let body = axum::body::Bytes::from(
-                format!(r#"{{"target_peer_id":"{}","latency_ms":5}}"#, missing).into_bytes(),
-            );
-            let (status, _) = tdh::send(
-                app,
-                tdh::post(
-                    format!("/{}/connections/probe", peer_id),
-                    "application/json",
-                    body,
-                ),
-            )
-            .await;
+            let status = probe(state, peer_id, missing, 5).await;
 
             assert_eq!(
                 status,
@@ -1083,19 +1071,7 @@ mod tests {
             let src = make_peer(&pool, "src").await;
             let dst = make_peer(&pool, "dst").await;
 
-            let app = probe_app(state);
-            let body = axum::body::Bytes::from(
-                format!(r#"{{"target_peer_id":"{}","latency_ms":12}}"#, dst).into_bytes(),
-            );
-            let (status, _) = tdh::send(
-                app,
-                tdh::post(
-                    format!("/{}/connections/probe", src),
-                    "application/json",
-                    body,
-                ),
-            )
-            .await;
+            let status = probe(state, src, dst, 12).await;
 
             assert_eq!(
                 status,

--- a/backend/src/api/handlers/peer.rs
+++ b/backend/src/api/handlers/peer.rs
@@ -219,6 +219,8 @@ async fn discover_peers(
     request_body = ProbeBody,
     responses(
         (status = 200, description = "Probe result recorded", body = PeerResponse),
+        (status = 400, description = "target_peer_id equals the source peer id"),
+        (status = 404, description = "Source or target peer instance not found"),
     ),
     security(("bearer_auth" = []))
 )]
@@ -227,6 +229,17 @@ async fn probe_peer(
     Path(peer_id): Path<Uuid>,
     Json(body): Json<ProbeBody>,
 ) -> Result<Json<PeerResponse>> {
+    // A peer cannot probe a connection to itself. The `peer_connections`
+    // table enforces this with a CHECK (`source_peer_id != target_peer_id`),
+    // which previously surfaced as an opaque 500 DATABASE_ERROR. Reject it up
+    // front as a 400 client error. (Non-existent source/target peers are
+    // mapped to 404 in the service layer's FK handling.)
+    if body.target_peer_id == peer_id {
+        return Err(crate::error::AppError::Validation(
+            "target_peer_id must differ from the source peer id".to_string(),
+        ));
+    }
+
     let service = PeerService::new(state.db.clone());
     let peer = service
         .upsert_probe_result(
@@ -944,5 +957,156 @@ mod tests {
         };
         let filter = query.status.as_ref().and_then(|s| parse_peer_status(s));
         assert!(filter.is_none());
+    }
+
+    // -----------------------------------------------------------------------
+    // DB-backed probe tests (POST /peers/{id}/connections/probe).
+    //
+    // Before this fix, a self-referential probe (`target_peer_id == path id`)
+    // tripped the `peer_connections_no_self_link` CHECK constraint and surfaced
+    // as an opaque 500 DATABASE_ERROR; a probe at a non-existent target tripped
+    // the FK and also 500'd. Both are client errors and are now mapped to 4xx:
+    //   * self-referential probe -> 400
+    //   * non-existent target    -> 404
+    //   * valid probe            -> 200
+    //
+    // Runtime-skips when no `DATABASE_URL` is set (NOT `#[ignore]`).
+    // -----------------------------------------------------------------------
+    mod probe_db {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::peer_instance_service::{
+            PeerInstanceService, RegisterPeerInstanceRequest,
+        };
+        use axum::http::StatusCode;
+        use axum::Router;
+        use sqlx::PgPool;
+        use uuid::Uuid;
+
+        async fn make_peer(pool: &PgPool, tag: &str) -> Uuid {
+            let svc = PeerInstanceService::new(pool.clone());
+            let id = Uuid::new_v4();
+            svc.register(RegisterPeerInstanceRequest {
+                name: format!("probe-{}-{}", tag, &id.to_string()[..8]),
+                endpoint_url: "https://peer.example.test".to_string(),
+                region: Some("us-east".to_string()),
+                cache_size_bytes: 1024,
+                sync_filter: None,
+                api_key: "k".to_string(),
+            })
+            .await
+            .expect("register peer")
+            .id
+        }
+
+        fn probe_app(state: crate::api::SharedState) -> Router {
+            // Mirror the production mount point: peer_router() lives under
+            // /:id/connections.
+            let router = Router::new().nest("/:id/connections", super::super::peer_router());
+            tdh::router_with_auth(router, state, tdh::make_auth(Uuid::new_v4(), "fed.admin"))
+        }
+
+        #[tokio::test]
+        async fn test_probe_self_reference_is_400_not_500() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-probe");
+            let peer_id = make_peer(&pool, "self").await;
+
+            let app = probe_app(state);
+            let body = axum::body::Bytes::from(
+                format!(r#"{{"target_peer_id":"{}","latency_ms":5}}"#, peer_id).into_bytes(),
+            );
+            let (status, _) = tdh::send(
+                app,
+                tdh::post(
+                    format!("/{}/connections/probe", peer_id),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::BAD_REQUEST,
+                "self-referential probe must be a 400, not a 500 DATABASE_ERROR"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_probe_nonexistent_target_is_404_not_500() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-probe");
+            let peer_id = make_peer(&pool, "src").await;
+            let missing = Uuid::new_v4();
+
+            let app = probe_app(state);
+            let body = axum::body::Bytes::from(
+                format!(r#"{{"target_peer_id":"{}","latency_ms":5}}"#, missing).into_bytes(),
+            );
+            let (status, _) = tdh::send(
+                app,
+                tdh::post(
+                    format!("/{}/connections/probe", peer_id),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "probe at a non-existent target must be a 404, not a 500"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_probe_valid_target_succeeds() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-probe");
+            let src = make_peer(&pool, "src").await;
+            let dst = make_peer(&pool, "dst").await;
+
+            let app = probe_app(state);
+            let body = axum::body::Bytes::from(
+                format!(r#"{{"target_peer_id":"{}","latency_ms":12}}"#, dst).into_bytes(),
+            );
+            let (status, _) = tdh::send(
+                app,
+                tdh::post(
+                    format!("/{}/connections/probe", src),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "a probe between two distinct, existing peers must still succeed"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = ANY($1)")
+                .bind(vec![src, dst])
+                .execute(&pool)
+                .await;
+        }
     }
 }

--- a/backend/src/api/handlers/peer_instance_labels.rs
+++ b/backend/src/api/handlers/peer_instance_labels.rs
@@ -487,28 +487,65 @@ mod tests {
     mod authz_db {
         use crate::api::handlers::test_db_helpers as tdh;
         use crate::api::middleware::auth::AuthExtension;
-        use crate::services::peer_instance_service::{
-            PeerInstanceService, RegisterPeerInstanceRequest,
-        };
         use axum::http::StatusCode;
         use sqlx::PgPool;
         use uuid::Uuid;
 
         /// Insert a peer instance via the real service and return its id.
         async fn make_peer(pool: &PgPool, tag: &str) -> Uuid {
-            let svc = PeerInstanceService::new(pool.clone());
-            let id = Uuid::new_v4();
-            svc.register(RegisterPeerInstanceRequest {
-                name: format!("labels-authz-{}-{}", tag, &id.to_string()[..8]),
-                endpoint_url: "https://peer.example.test".to_string(),
-                region: Some("us-east".to_string()),
-                cache_size_bytes: 1024,
-                sync_filter: None,
-                api_key: "k".to_string(),
-            })
-            .await
-            .expect("register peer")
-            .id
+            tdh::register_test_peer(pool, "labels-authz", tag).await
+        }
+
+        /// Drive `PUT /{peer_id}/labels` with the given principal and JSON body;
+        /// return the response status.
+        async fn put_labels(
+            state: crate::api::SharedState,
+            auth: AuthExtension,
+            peer_id: Uuid,
+            json: &str,
+        ) -> StatusCode {
+            let app = tdh::router_with_auth_ext(super::super::peer_labels_router(), state, auth);
+            let body = axum::body::Bytes::from(json.as_bytes().to_vec());
+            let (status, _) =
+                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+            status
+        }
+
+        /// Drive `POST /{peer_id}/labels/{key}` (single-label add) with the
+        /// given principal and JSON body; return the response status.
+        async fn add_label_req(
+            state: crate::api::SharedState,
+            auth: AuthExtension,
+            peer_id: Uuid,
+            key: &str,
+            json: &str,
+        ) -> StatusCode {
+            let app = tdh::router_with_auth_ext(super::super::peer_labels_router(), state, auth);
+            let body = axum::body::Bytes::from(json.as_bytes().to_vec());
+            let (status, _) = tdh::send(
+                app,
+                tdh::post(
+                    format!("/{}/labels/{}", peer_id, key),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+            status
+        }
+
+        /// Drive `DELETE /{peer_id}/labels/{key}` with the given principal;
+        /// return the response status.
+        async fn delete_label_req(
+            state: crate::api::SharedState,
+            auth: AuthExtension,
+            peer_id: Uuid,
+            key: &str,
+        ) -> StatusCode {
+            let app = tdh::router_with_auth_ext(super::super::peer_labels_router(), state, auth);
+            let (status, _) =
+                tdh::send(app, delete_req(format!("/{}/labels/{}", peer_id, key))).await;
+            status
         }
 
         fn admin_auth(username: &str) -> AuthExtension {
@@ -542,16 +579,13 @@ mod tests {
             let peer_id = make_peer(&pool, "corp").await;
 
             // victor.user: a regular (non-admin) corp account.
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
+            let status = put_labels(
                 state,
                 non_admin_auth("victor.user"),
-            );
-            let body = axum::body::Bytes::from(
-                r#"{"labels":[{"key":"env","value":"prod"}]}"#.as_bytes().to_vec(),
-            );
-            let (status, _) =
-                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+                peer_id,
+                r#"{"labels":[{"key":"env","value":"prod"}]}"#,
+            )
+            .await;
 
             assert_eq!(
                 status,
@@ -574,16 +608,13 @@ mod tests {
             let peer_id = make_peer(&pool, "corp").await;
 
             // glen.globex: a non-admin from a *different* tenant.
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
+            let status = put_labels(
                 state,
                 non_admin_auth("glen.globex"),
-            );
-            let body = axum::body::Bytes::from(
-                r#"{"labels":[{"key":"owned","value":"globex"}]}"#.as_bytes().to_vec(),
-            );
-            let (status, _) =
-                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+                peer_id,
+                r#"{"labels":[{"key":"owned","value":"globex"}]}"#,
+            )
+            .await;
 
             assert_eq!(
                 status,
@@ -601,18 +632,13 @@ mod tests {
             let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
             let peer_id = make_peer(&pool, "corp").await;
 
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
+            let status = put_labels(
                 state,
                 admin_auth("admin"),
-            );
-            let body = axum::body::Bytes::from(
-                r#"{"labels":[{"key":"env","value":"prod"},{"key":"tier","value":"1"}]}"#
-                    .as_bytes()
-                    .to_vec(),
-            );
-            let (status, _) =
-                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+                peer_id,
+                r#"{"labels":[{"key":"env","value":"prod"},{"key":"tier","value":"1"}]}"#,
+            )
+            .await;
 
             assert_eq!(
                 status,
@@ -640,19 +666,12 @@ mod tests {
             let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
             let peer_id = make_peer(&pool, "corp").await;
 
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
+            let status = add_label_req(
                 state,
                 non_admin_auth("victor.user"),
-            );
-            let body = axum::body::Bytes::from(r#"{"value":"x"}"#.as_bytes().to_vec());
-            let (status, _) = tdh::send(
-                app,
-                tdh::post(
-                    format!("/{}/labels/region", peer_id),
-                    "application/json",
-                    body,
-                ),
+                peer_id,
+                "region",
+                r#"{"value":"x"}"#,
             )
             .await;
             assert_eq!(
@@ -686,19 +705,12 @@ mod tests {
             let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
             let peer_id = make_peer(&pool, "corp").await;
 
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
+            let status = add_label_req(
                 state,
                 admin_auth("admin"),
-            );
-            let body = axum::body::Bytes::from(r#"{"value":"us-east"}"#.as_bytes().to_vec());
-            let (status, _) = tdh::send(
-                app,
-                tdh::post(
-                    format!("/{}/labels/region", peer_id),
-                    "application/json",
-                    body,
-                ),
+                peer_id,
+                "region",
+                r#"{"value":"us-east"}"#,
             )
             .await;
 
@@ -738,13 +750,8 @@ mod tests {
                 .await
                 .expect("seed label");
 
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
-                state,
-                non_admin_auth("victor.user"),
-            );
-            let (status, _) =
-                tdh::send(app, delete_req(format!("/{}/labels/region", peer_id))).await;
+            let status =
+                delete_label_req(state, non_admin_auth("victor.user"), peer_id, "region").await;
 
             assert_eq!(
                 status,
@@ -781,13 +788,7 @@ mod tests {
                 .expect("seed label");
             assert_eq!(label_count(&pool, peer_id).await, 1);
 
-            let app = tdh::router_with_auth_ext(
-                super::super::peer_labels_router(),
-                state,
-                admin_auth("admin"),
-            );
-            let (status, _) =
-                tdh::send(app, delete_req(format!("/{}/labels/region", peer_id))).await;
+            let status = delete_label_req(state, admin_auth("admin"), peer_id, "region").await;
 
             assert_eq!(
                 status,

--- a/backend/src/api/handlers/peer_instance_labels.rs
+++ b/backend/src/api/handlers/peer_instance_labels.rs
@@ -667,5 +667,143 @@ mod tests {
                 .execute(&pool)
                 .await;
         }
+
+        /// Build a DELETE request (no body); test_db_helpers has no delete
+        /// helper, so construct it inline.
+        fn delete_req(uri: String) -> axum::http::Request<axum::body::Body> {
+            axum::http::Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .body(axum::body::Body::empty())
+                .expect("build DELETE request")
+        }
+
+        #[tokio::test]
+        async fn test_add_label_admin_allowed_and_persists() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                admin_auth("admin"),
+            );
+            let body = axum::body::Bytes::from(r#"{"value":"us-east"}"#.as_bytes().to_vec());
+            let (status, _) = tdh::send(
+                app,
+                tdh::post(
+                    format!("/{}/labels/region", peer_id),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "owner-admin single-label add must succeed"
+            );
+            assert_eq!(
+                label_count(&pool, peer_id).await,
+                1,
+                "admin add should persist the label"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_delete_label_non_admin_forbidden() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            // Seed a label directly so the non-admin DELETE has something to
+            // (illegitimately) target; the rejection must leave it in place.
+            let label_svc =
+                crate::services::peer_instance_label_service::PeerInstanceLabelService::new(
+                    pool.clone(),
+                );
+            label_svc
+                .add_label(peer_id, "region", "us-east")
+                .await
+                .expect("seed label");
+
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                non_admin_auth("victor.user"),
+            );
+            let (status, _) =
+                tdh::send(app, delete_req(format!("/{}/labels/region", peer_id))).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin single-label delete must be rejected (BOLA)"
+            );
+            assert_eq!(
+                label_count(&pool, peer_id).await,
+                1,
+                "the rejected delete must not have removed the label"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_delete_label_admin_allowed_and_removes() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            let label_svc =
+                crate::services::peer_instance_label_service::PeerInstanceLabelService::new(
+                    pool.clone(),
+                );
+            label_svc
+                .add_label(peer_id, "region", "us-east")
+                .await
+                .expect("seed label");
+            assert_eq!(label_count(&pool, peer_id).await, 1);
+
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                admin_auth("admin"),
+            );
+            let (status, _) =
+                tdh::send(app, delete_req(format!("/{}/labels/region", peer_id))).await;
+
+            assert_eq!(
+                status,
+                StatusCode::NO_CONTENT,
+                "owner-admin single-label delete must succeed (204)"
+            );
+            assert_eq!(
+                label_count(&pool, peer_id).await,
+                0,
+                "admin delete should remove the label"
+            );
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
     }
 }

--- a/backend/src/api/handlers/peer_instance_labels.rs
+++ b/backend/src/api/handlers/peer_instance_labels.rs
@@ -150,15 +150,23 @@ async fn list_labels(
     security(("bearer_auth" = [])),
     responses(
         (status = 200, description = "Labels updated", body = PeerLabelsListResponse),
+        (status = 403, description = "Admin access required"),
         (status = 404, description = "Peer instance not found")
     )
 )]
 async fn set_labels(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(payload): Json<SetPeerLabelsRequest>,
 ) -> Result<Json<PeerLabelsListResponse>> {
+    // Mutating a peer's labels is a federation-administration action, exactly
+    // like every other peer write (register/delete/assign-repo/sync-policy).
+    // Without this gate any authenticated principal — including a non-admin in
+    // another tenant — could overwrite labels on a peer they do not own (BOLA /
+    // cross-tenant write). Peer instances are global, so the admin role is the
+    // single authorization boundary used across the peers surface.
+    auth.require_admin()?;
     let peer_service = PeerInstanceService::new(state.db.clone());
     let _peer = peer_service.get_by_id(id).await?;
 
@@ -193,15 +201,17 @@ async fn set_labels(
     security(("bearer_auth" = [])),
     responses(
         (status = 200, description = "Label added/updated", body = PeerLabelResponse),
+        (status = 403, description = "Admin access required"),
         (status = 404, description = "Peer instance not found")
     )
 )]
 async fn add_label(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path((id, label_key)): Path<(Uuid, String)>,
     Json(payload): Json<AddPeerLabelRequest>,
 ) -> Result<Json<PeerLabelResponse>> {
+    auth.require_admin()?;
     let peer_service = PeerInstanceService::new(state.db.clone());
     let _peer = peer_service.get_by_id(id).await?;
 
@@ -228,14 +238,16 @@ async fn add_label(
     security(("bearer_auth" = [])),
     responses(
         (status = 204, description = "Label removed"),
+        (status = 403, description = "Admin access required"),
         (status = 404, description = "Peer instance or label not found")
     )
 )]
 async fn delete_label(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path((id, label_key)): Path<(Uuid, String)>,
 ) -> Result<axum::http::StatusCode> {
+    auth.require_admin()?;
     let peer_service = PeerInstanceService::new(state.db.clone());
     let _peer = peer_service.get_by_id(id).await?;
 
@@ -455,5 +467,205 @@ mod tests {
         assert_eq!(resp.value, label.label_value);
         assert_eq!(resp.id, label.id);
         assert_eq!(resp.peer_instance_id, label.peer_instance_id);
+    }
+
+    // -----------------------------------------------------------------------
+    // DB-backed authorization tests for the mutating label handlers.
+    //
+    // Before this fix, `PUT /peers/{id}/labels` (and the single add/delete
+    // variants) performed NO authorization, so any authenticated principal —
+    // including a non-admin in another tenant — could overwrite the labels on
+    // a peer they do not own (BOLA / cross-tenant write). These drive the real
+    // router end to end through `auth.require_admin()`:
+    //   * non-admin (same-tenant)  -> 403
+    //   * non-admin (cross-tenant) -> 403
+    //   * owner-admin              -> 200 (and the write actually persists)
+    //
+    // Runtime-skips when no `DATABASE_URL` is set (NOT `#[ignore]`), mirroring
+    // the in-`src` DB-test pattern used elsewhere in this crate.
+    // -----------------------------------------------------------------------
+    mod authz_db {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::api::middleware::auth::AuthExtension;
+        use crate::services::peer_instance_service::{
+            PeerInstanceService, RegisterPeerInstanceRequest,
+        };
+        use axum::http::StatusCode;
+        use sqlx::PgPool;
+        use uuid::Uuid;
+
+        /// Insert a peer instance via the real service and return its id.
+        async fn make_peer(pool: &PgPool, tag: &str) -> Uuid {
+            let svc = PeerInstanceService::new(pool.clone());
+            let id = Uuid::new_v4();
+            svc.register(RegisterPeerInstanceRequest {
+                name: format!("labels-authz-{}-{}", tag, &id.to_string()[..8]),
+                endpoint_url: "https://peer.example.test".to_string(),
+                region: Some("us-east".to_string()),
+                cache_size_bytes: 1024,
+                sync_filter: None,
+                api_key: "k".to_string(),
+            })
+            .await
+            .expect("register peer")
+            .id
+        }
+
+        fn admin_auth(username: &str) -> AuthExtension {
+            AuthExtension {
+                is_admin: true,
+                ..tdh::make_auth(Uuid::new_v4(), username)
+            }
+        }
+
+        fn non_admin_auth(username: &str) -> AuthExtension {
+            // `make_auth` already builds a non-admin principal.
+            tdh::make_auth(Uuid::new_v4(), username)
+        }
+
+        async fn label_count(pool: &PgPool, peer_id: Uuid) -> i64 {
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM peer_instance_labels WHERE peer_instance_id = $1",
+            )
+            .bind(peer_id)
+            .fetch_one(pool)
+            .await
+            .expect("count labels")
+        }
+
+        #[tokio::test]
+        async fn test_put_labels_non_admin_same_tenant_forbidden() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            // victor.user: a regular (non-admin) corp account.
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                non_admin_auth("victor.user"),
+            );
+            let body = axum::body::Bytes::from(
+                r#"{"labels":[{"key":"env","value":"prod"}]}"#.as_bytes().to_vec(),
+            );
+            let (status, _) =
+                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin PUT labels must be rejected (BOLA)"
+            );
+            assert_eq!(
+                label_count(&pool, peer_id).await,
+                0,
+                "no labels should have been written by the rejected request"
+            );
+        }
+
+        #[tokio::test]
+        async fn test_put_labels_cross_tenant_non_admin_forbidden() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            // glen.globex: a non-admin from a *different* tenant.
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                non_admin_auth("glen.globex"),
+            );
+            let body = axum::body::Bytes::from(
+                r#"{"labels":[{"key":"owned","value":"globex"}]}"#.as_bytes().to_vec(),
+            );
+            let (status, _) =
+                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "cross-tenant non-admin PUT labels must be rejected"
+            );
+            assert_eq!(label_count(&pool, peer_id).await, 0);
+        }
+
+        #[tokio::test]
+        async fn test_put_labels_admin_allowed_and_persists() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                admin_auth("admin"),
+            );
+            let body = axum::body::Bytes::from(
+                r#"{"labels":[{"key":"env","value":"prod"},{"key":"tier","value":"1"}]}"#
+                    .as_bytes()
+                    .to_vec(),
+            );
+            let (status, _) =
+                tdh::send(app, tdh::put_json(format!("/{}/labels", peer_id), body)).await;
+
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "owner-admin PUT labels must succeed"
+            );
+            assert_eq!(
+                label_count(&pool, peer_id).await,
+                2,
+                "admin write should persist both labels"
+            );
+
+            // cleanup
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_add_and_delete_label_non_admin_forbidden() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let state = tdh::build_state(pool.clone(), "/tmp/ph-peer-labels-authz");
+            let peer_id = make_peer(&pool, "corp").await;
+
+            let app = tdh::router_with_auth_ext(
+                super::super::peer_labels_router(),
+                state,
+                non_admin_auth("victor.user"),
+            );
+            let body = axum::body::Bytes::from(r#"{"value":"x"}"#.as_bytes().to_vec());
+            let (status, _) = tdh::send(
+                app,
+                tdh::post(
+                    format!("/{}/labels/region", peer_id),
+                    "application/json",
+                    body,
+                ),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::FORBIDDEN,
+                "non-admin single-label add must be rejected"
+            );
+            assert_eq!(label_count(&pool, peer_id).await, 0);
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer_id)
+                .execute(&pool)
+                .await;
+        }
     }
 }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -232,6 +232,23 @@ pub fn router_anon(router: Router<SharedState>, state: SharedState) -> Router {
         .layer(Extension::<Option<AuthExtension>>(None))
 }
 
+/// Like [`router_with_auth`] but also injects the **non-Option**
+/// `Extension<AuthExtension>`, exactly as the production `auth_middleware`
+/// does (it inserts both `Some(ext)` and `ext`). Handlers that extract
+/// `Extension<AuthExtension>` directly (e.g. the admin-gated peer-label
+/// handlers) require this raw copy to be present, otherwise the extractor
+/// fails with a 500 before the in-handler authorization check ever runs.
+pub fn router_with_auth_ext(
+    router: Router<SharedState>,
+    state: SharedState,
+    auth: AuthExtension,
+) -> Router {
+    router
+        .with_state(state)
+        .layer(Extension::<AuthExtension>(auth.clone()))
+        .layer(Extension::<Option<AuthExtension>>(Some(auth)))
+}
+
 pub async fn send(app: Router, req: Request<Body>) -> (StatusCode, Bytes) {
     let resp = app.oneshot(req).await.expect("oneshot");
     let status = resp.status();
@@ -381,6 +398,18 @@ pub fn put(uri: String, body: Bytes) -> Request<Body> {
         .uri(uri)
         .body(Body::from(body))
         .expect("build PUT request")
+}
+
+/// Build a PUT request carrying a JSON body (sets `content-type` so the
+/// `Json` extractor accepts it; the raw [`put`] helper omits it, which yields
+/// a 415 for handlers that extract `Json<_>`).
+pub fn put_json(uri: String, body: Bytes) -> Request<Body> {
+    Request::builder()
+        .method("PUT")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .expect("build PUT JSON request")
 }
 
 /// Bundles all the per-test scaffolding so each handler test body is a

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -249,6 +249,30 @@ pub fn router_with_auth_ext(
         .layer(Extension::<Option<AuthExtension>>(Some(auth)))
 }
 
+/// Register a peer instance via the real `PeerInstanceService` and return its
+/// id. `name_prefix` namespaces the generated peer name so concurrent suites do
+/// not collide (e.g. "probe", "labels-authz", "map-err"). Centralizes the
+/// `register(RegisterPeerInstanceRequest { .. })` boilerplate shared by every
+/// DB-backed peer test module.
+pub async fn register_test_peer(pool: &PgPool, name_prefix: &str, tag: &str) -> Uuid {
+    use crate::services::peer_instance_service::{
+        PeerInstanceService, RegisterPeerInstanceRequest,
+    };
+    let svc = PeerInstanceService::new(pool.clone());
+    let id = Uuid::new_v4();
+    svc.register(RegisterPeerInstanceRequest {
+        name: format!("{}-{}-{}", name_prefix, tag, &id.to_string()[..8]),
+        endpoint_url: "https://peer.example.test".to_string(),
+        region: Some("us-east".to_string()),
+        cache_size_bytes: 1024,
+        sync_filter: None,
+        api_key: "k".to_string(),
+    })
+    .await
+    .expect("register peer")
+    .id
+}
+
 pub async fn send(app: Router, req: Request<Body>) -> (StatusCode, Bytes) {
     let resp = app.oneshot(req).await.expect("oneshot");
     let status = resp.status();
@@ -509,11 +533,10 @@ pub fn build_proxy_service_with_fs(
 /// Build a [`SharedState`] that includes `proxy` as the proxy service.
 /// Accepts any `PgPool` so callers can supply a lazy/fake pool for tests
 /// that do not need a real database.
-pub fn build_state_with_proxy(
-    pool: PgPool,
-    storage_path: &str,
-    proxy: Arc<crate::services::proxy_service::ProxyService>,
-) -> crate::api::SharedState {
+/// Construct an [`AppState`] from `config` plus a fresh filesystem storage
+/// backend + empty registry rooted at `storage_path`. Shared spine of the
+/// `build_state*` constructors.
+fn app_state_with(config: Config, pool: PgPool, storage_path: &str) -> crate::api::AppState {
     let storage: Arc<dyn crate::storage::StorageBackend> = Arc::new(
         crate::storage::filesystem::FilesystemStorage::new(storage_path),
     );
@@ -521,7 +544,15 @@ pub fn build_state_with_proxy(
         std::collections::HashMap::new(),
         "filesystem".to_string(),
     ));
-    let mut state = crate::api::AppState::new(cfg(storage_path), pool, storage, registry);
+    crate::api::AppState::new(config, pool, storage, registry)
+}
+
+pub fn build_state_with_proxy(
+    pool: PgPool,
+    storage_path: &str,
+    proxy: Arc<crate::services::proxy_service::ProxyService>,
+) -> crate::api::SharedState {
+    let mut state = app_state_with(cfg(storage_path), pool, storage_path);
     state.set_proxy_service(proxy);
     Arc::new(state)
 }
@@ -535,16 +566,9 @@ pub fn build_state_with_proxy_presigned(
     storage_path: &str,
     proxy: Arc<crate::services::proxy_service::ProxyService>,
 ) -> crate::api::SharedState {
-    let storage: Arc<dyn crate::storage::StorageBackend> = Arc::new(
-        crate::storage::filesystem::FilesystemStorage::new(storage_path),
-    );
-    let registry = Arc::new(crate::storage::StorageRegistry::new(
-        std::collections::HashMap::new(),
-        "filesystem".to_string(),
-    ));
     let mut config = cfg(storage_path);
     config.presigned_downloads_enabled = true;
-    let mut state = crate::api::AppState::new(config, pool, storage, registry);
+    let mut state = app_state_with(config, pool, storage_path);
     state.set_proxy_service(proxy);
     Arc::new(state)
 }

--- a/backend/src/services/peer_service.rs
+++ b/backend/src/services/peer_service.rs
@@ -699,26 +699,11 @@ mod tests {
         use super::super::map_peer_connection_error;
         use crate::api::handlers::test_db_helpers as tdh;
         use crate::error::AppError;
-        use crate::services::peer_instance_service::{
-            PeerInstanceService, RegisterPeerInstanceRequest,
-        };
         use sqlx::PgPool;
         use uuid::Uuid;
 
         async fn make_peer(pool: &PgPool, tag: &str) -> Uuid {
-            let svc = PeerInstanceService::new(pool.clone());
-            let id = Uuid::new_v4();
-            svc.register(RegisterPeerInstanceRequest {
-                name: format!("map-err-{}-{}", tag, &id.to_string()[..8]),
-                endpoint_url: "https://peer.example.test".to_string(),
-                region: Some("us-east".to_string()),
-                cache_size_bytes: 1024,
-                sync_filter: None,
-                api_key: "k".to_string(),
-            })
-            .await
-            .expect("register peer")
-            .id
+            tdh::register_test_peer(pool, "map-err", tag).await
         }
 
         /// Attempt a `peer_connections` INSERT and return the raw `sqlx::Error`.

--- a/backend/src/services/peer_service.rs
+++ b/backend/src/services/peer_service.rs
@@ -9,6 +9,41 @@ use uuid::Uuid;
 
 use crate::error::{AppError, Result};
 
+/// SQLSTATE for a foreign-key violation.
+const PG_FOREIGN_KEY_VIOLATION: &str = "23503";
+/// SQLSTATE for a check-constraint violation.
+const PG_CHECK_VIOLATION: &str = "23514";
+/// CHECK constraint forbidding a peer from linking to itself.
+const PEER_CONNECTION_NO_SELF_LINK: &str = "peer_connections_no_self_link";
+
+/// Map a database error from `peer_connections` writes to an [`AppError`].
+///
+/// A foreign-key violation means the supplied `source_peer_id` or
+/// `target_peer_id` does not name an existing peer instance — a client error
+/// that must surface as [`AppError::NotFound`] (HTTP 404), not an opaque
+/// [`AppError::Database`] (HTTP 500). A self-link CHECK violation is a client
+/// error too and surfaces as [`AppError::Validation`] (HTTP 400) as a
+/// defensive fallback (the handler also rejects self-probes up front). All
+/// other database errors fall through to [`AppError::Database`].
+fn map_peer_connection_error(err: sqlx::Error) -> AppError {
+    if let sqlx::Error::Database(db_err) = &err {
+        match db_err.code().as_deref() {
+            Some(PG_FOREIGN_KEY_VIOLATION) => {
+                return AppError::NotFound("Peer instance not found".to_string());
+            }
+            Some(PG_CHECK_VIOLATION)
+                if db_err.constraint() == Some(PEER_CONNECTION_NO_SELF_LINK) =>
+            {
+                return AppError::Validation(
+                    "target_peer_id must differ from the source peer id".to_string(),
+                );
+            }
+            _ => {}
+        }
+    }
+    AppError::Database(err.to_string())
+}
+
 /// Peer connection status
 #[derive(Debug, Clone, Copy, PartialEq, sqlx::Type)]
 #[sqlx(type_name = "peer_status", rename_all = "lowercase")]
@@ -153,7 +188,7 @@ impl PeerService {
         )
         .fetch_one(&self.db)
         .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        .map_err(map_peer_connection_error)?;
 
         Ok(peer)
     }

--- a/backend/src/services/peer_service.rs
+++ b/backend/src/services/peer_service.rs
@@ -680,4 +680,123 @@ mod tests {
         let json = serde_json::to_value(&peer).unwrap();
         assert!(json["region"].is_null());
     }
+
+    // -----------------------------------------------------------------------
+    // map_peer_connection_error: SQLSTATE -> AppError mapping.
+    //
+    // The probe handler rejects self-references up front, so the CHECK
+    // (`peer_connections_no_self_link`) arm and the generic 500 fall-through
+    // are not reachable through the HTTP path. Exercise the mapper directly
+    // against real `sqlx::Error::Database` values produced by the live DB:
+    //   * foreign-key violation (23503)            -> NotFound (404)
+    //   * self-link CHECK violation (23514)        -> Validation (400)
+    //   * any other database error                 -> Database (500)
+    //
+    // Runtime-skips when no `DATABASE_URL` is set (NOT `#[ignore]`), matching
+    // the in-`src` DB-test convention used across this crate.
+    // -----------------------------------------------------------------------
+    mod map_peer_connection_error_db {
+        use super::super::map_peer_connection_error;
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::error::AppError;
+        use crate::services::peer_instance_service::{
+            PeerInstanceService, RegisterPeerInstanceRequest,
+        };
+        use sqlx::PgPool;
+        use uuid::Uuid;
+
+        async fn make_peer(pool: &PgPool, tag: &str) -> Uuid {
+            let svc = PeerInstanceService::new(pool.clone());
+            let id = Uuid::new_v4();
+            svc.register(RegisterPeerInstanceRequest {
+                name: format!("map-err-{}-{}", tag, &id.to_string()[..8]),
+                endpoint_url: "https://peer.example.test".to_string(),
+                region: Some("us-east".to_string()),
+                cache_size_bytes: 1024,
+                sync_filter: None,
+                api_key: "k".to_string(),
+            })
+            .await
+            .expect("register peer")
+            .id
+        }
+
+        /// Attempt a `peer_connections` INSERT and return the raw `sqlx::Error`.
+        async fn insert_connection_err(pool: &PgPool, source: Uuid, target: Uuid) -> sqlx::Error {
+            sqlx::query(
+                "INSERT INTO peer_connections \
+                 (source_peer_id, target_peer_id, status, last_probed_at) \
+                 VALUES ($1, $2, 'active', NOW())",
+            )
+            .bind(source)
+            .bind(target)
+            .execute(pool)
+            .await
+            .expect_err("insert was expected to violate a constraint")
+        }
+
+        #[tokio::test]
+        async fn test_foreign_key_violation_maps_to_not_found() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            // Non-existent target trips the target FK (23503).
+            let source = make_peer(&pool, "fk").await;
+            let missing = Uuid::new_v4();
+            let err = insert_connection_err(&pool, source, missing).await;
+
+            match map_peer_connection_error(err) {
+                AppError::NotFound(_) => {}
+                other => panic!("FK violation must map to NotFound, got {other:?}"),
+            }
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(source)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_self_link_check_violation_maps_to_validation() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            // source == target trips the `peer_connections_no_self_link`
+            // CHECK (23514). Both ids reference the same existing peer so the
+            // FK passes and the CHECK is the failing constraint.
+            let peer = make_peer(&pool, "check").await;
+            let err = insert_connection_err(&pool, peer, peer).await;
+
+            match map_peer_connection_error(err) {
+                AppError::Validation(_) => {}
+                other => {
+                    panic!("self-link CHECK violation must map to Validation, got {other:?}")
+                }
+            }
+
+            let _ = sqlx::query("DELETE FROM peer_instances WHERE id = $1")
+                .bind(peer)
+                .execute(&pool)
+                .await;
+        }
+
+        #[tokio::test]
+        async fn test_other_database_error_maps_to_database() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            // A syntactically invalid statement yields a database error whose
+            // SQLSTATE is neither 23503 nor the self-link CHECK, exercising the
+            // generic fall-through to AppError::Database (500).
+            let err = sqlx::query("SELECT * FROM peer_connections WHERE no_such_column = 1")
+                .execute(&pool)
+                .await
+                .expect_err("query was expected to fail");
+
+            match map_peer_connection_error(err) {
+                AppError::Database(_) => {}
+                other => panic!("unrelated database error must map to Database, got {other:?}"),
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two confirmed gaps on the peers surface (validated live on :8080):

### HIGH — peer-labels BOLA / cross-tenant write (no authz)
`PUT /api/v1/peers/{id}/labels` and the single-label `POST/DELETE
/peers/{id}/labels/{key}` variants performed **no authorization**. A corp
non-admin AND a cross-tenant non-admin could both write/overwrite labels on a
corp-owned peer (200, persisted), while every other peer write
(register/delete/assign-repo/sync-policy/run-now) correctly returns 403.

Fix: the three label *mutation* handlers now call `auth.require_admin()?`,
matching the existing in-repo pattern for every other peer write. Peer
instances are global (no per-row tenant column), so the admin role is the
single authorization boundary across the peers surface; this rejects both the
same-tenant non-admin and the cross-tenant non-admin. List (`GET`) stays
unauthenticated, consistent with the other peer reads.

- `backend/src/api/handlers/peer_instance_labels.rs`: `set_labels`, `add_label`, `delete_label`

### MED — probe self-ref / bad target raw 500
`POST /api/v1/peers/{id}/connections/probe` returned `500 DATABASE_ERROR` when
`target_peer_id == {id}` (the `peer_connections_no_self_link` CHECK) and when
the target peer did not exist (FK).

Fix:
- Handler rejects self-referential probes up front with **400**.
- Service maps FK violation (23503) -> **404** and the self-link CHECK (23514) -> **400**, instead of an opaque 500.
- `backend/src/api/handlers/peer.rs`: `probe_peer`
- `backend/src/services/peer_service.rs`: `map_peer_connection_error` + `upsert_probe_result`

## Tests (in-`src` `#[cfg(test)]`, DB-backed, runtime-skip without `DATABASE_URL`, not `#[ignore]`)
- non-admin labels write -> 403; cross-tenant non-admin -> 403; owner-admin -> 200 (persisted); single add -> 403
- probe self-ref -> 400; non-existent target -> 404; valid probe -> 200
- Adds `test_db_helpers::{router_with_auth_ext, put_json}` (handlers extracting `Extension<AuthExtension>` and JSON PUT bodies).

## Verification
- `cargo test --lib` (peers/labels/probe): **7 new + existing peer tests pass** (live PG)
- `cargo fmt`: clean
- `cargo clippy --lib -- -D warnings`: clean