### PR TITLE
fix(scanner): qualify Trivy image scan target with owning repository key

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -241,7 +241,10 @@ fn classify_grype_spawn_error(err: &std::io::Error) -> AppError {
 ///
 /// The returned value has any scheme (`https://`, `http://`) stripped and
 /// trailing `/` trimmed, because Grype expects `host[:port]`, not a URL.
-fn resolve_registry_host() -> String {
+///
+/// `pub(crate)` so `ImageScanner::extract_image_ref_for_repo` reuses the same
+/// host-resolution logic when qualifying the Trivy scan target.
+pub(crate) fn resolve_registry_host() -> String {
     let raw = std::env::var("AK_GRYPE_REGISTRY_HOST")
         .ok()
         .filter(|s| !s.is_empty())

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -6,7 +6,7 @@ use tracing::{info, warn};
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::services::scanner_service::{
-    cached_trivy_cli_version, ScanOutput, Scanner, VersionCache,
+    cached_trivy_cli_version, ScanOutput, ScanTarget, Scanner, VersionCache,
 };
 
 #[cfg(test)]
@@ -129,6 +129,62 @@ impl ImageScanner {
         Some(crate::services::scanner_service::join_oci_image_ref(
             name, reference,
         ))
+    }
+
+    /// Repository-aware image ref: `<host>/<repo_key>/<name>:<reference>`.
+    ///
+    /// Stored OCI artifact paths omit the routing key
+    /// (`v2/<image>/manifests/<ref>`), so the bare ref from `extract_image_ref`
+    /// resolves against Docker Hub instead of Artifact Keeper's own registry —
+    /// silently scanning the wrong image (public name collision) or returning 0
+    /// packages for internal-only images. Prepending the owning repository key
+    /// (mirroring `GrypeScanner::build_registry_image_ref_for_repo`) makes the
+    /// scan target the stored artifact. Host comes from the shared
+    /// `grype_scanner::resolve_registry_host` (AK_GRYPE_REGISTRY_HOST /
+    /// PEER_PUBLIC_ENDPOINT / `localhost:8080`).
+    fn extract_image_ref_for_repo(artifact: &Artifact, repository_key: &str) -> Option<String> {
+        let (name, reference) =
+            crate::services::scanner_service::parse_oci_manifest_path(&artifact.path)?;
+        let host = crate::services::grype_scanner::resolve_registry_host();
+        let qualified = format!("{}/{}/{}", host, repository_key, name);
+        Some(crate::services::scanner_service::join_oci_image_ref(
+            &qualified, reference,
+        ))
+    }
+
+    /// Health-check Trivy, scan `image_ref`, and convert the report. Shared by
+    /// the legacy `scan` (bare ref) and the repository-aware `scan_target`
+    /// so both paths apply the same health gate and conversion.
+    async fn run_image_scan(&self, image_ref: &str) -> Result<ScanOutput> {
+        // Check if Trivy server is healthy. If it is not reachable we must
+        // surface an error so the scan record is marked FAILED. Returning
+        // Ok(vec![]) here would silently mark the scan COMPLETED with zero
+        // findings even though no scanning ever happened (issue #888).
+        if let Err(e) = self.check_trivy_health().await {
+            return Err(AppError::BadGateway(format!(
+                "Trivy image scan failed for {}: {}",
+                image_ref, e
+            )));
+        }
+
+        info!("Starting Trivy scan for image: {}", image_ref);
+
+        let report = self.scan_with_trivy(image_ref).await?;
+        // Source label is intentionally "trivy" (not "trivy-image") to
+        // preserve back-compat with dashboards / filters that group
+        // findings by `source = 'trivy'`. The pre-#903 ImageScanner used
+        // the same string. Changing it here would silently drop
+        // existing image-scanner rows from any operator filter.
+        let output = ScanOutput::from_trivy_report(&report, "trivy");
+
+        info!(
+            "Trivy scan complete for {}: {} vulnerabilities, {} packages",
+            image_ref,
+            output.findings.len(),
+            output.packages.len()
+        );
+
+        Ok(output)
     }
 
     /// Number of `/healthz` attempts before declaring the Trivy server down.
@@ -337,11 +393,11 @@ impl Scanner for ImageScanner {
             "ImageScanner::scan called on a non-container artifact; the orchestrator must gate on is_applicable first"
         );
 
-        // Image reference extraction can still fail even on an applicable
-        // (content-type-matching) artifact when the path is malformed.
-        // That is a real error, not a "not applicable" case: surface it as
-        // a failed scan so the operator sees error_message rather than a
-        // silent completed-with-zero-findings row (issue #994).
+        // Legacy path retained for the trait contract / direct callers. It
+        // uses the bare ref from the stored path, which omits the repository
+        // key. The orchestrator calls `scan_target` (below), which restores
+        // the key so Trivy pulls AK's own artifact rather than a Docker Hub
+        // image of the same name.
         let image_ref = match Self::extract_image_ref(artifact) {
             Some(r) => r,
             None => {
@@ -351,36 +407,36 @@ impl Scanner for ImageScanner {
                 )));
             }
         };
+        self.run_image_scan(&image_ref).await
+    }
 
-        // Check if Trivy server is healthy. If it is not reachable we must
-        // surface an error so the scan record is marked FAILED. Returning
-        // Ok(vec![]) here would silently mark the scan COMPLETED with zero
-        // findings even though no scanning ever happened (issue #888).
-        if let Err(e) = self.check_trivy_health().await {
-            return Err(AppError::BadGateway(format!(
-                "Trivy image scan failed for {}: {}",
-                image_ref, e
-            )));
-        }
-
-        info!("Starting Trivy scan for image: {}", image_ref);
-
-        let report = self.scan_with_trivy(&image_ref).await?;
-        // Source label is intentionally "trivy" (not "trivy-image") to
-        // preserve back-compat with dashboards / filters that group
-        // findings by `source = 'trivy'`. The pre-#903 ImageScanner used
-        // the same string. Changing it here would silently drop
-        // existing image-scanner rows from any operator filter.
-        let output = ScanOutput::from_trivy_report(&report, "trivy");
-
-        info!(
-            "Trivy scan complete for {}: {} vulnerabilities, {} packages",
-            image_ref,
-            output.findings.len(),
-            output.packages.len()
+    /// Repository-aware scan hook used by the orchestrator.
+    ///
+    /// The legacy `scan` builds a bare `<name>:<tag>` ref from the stored OCI
+    /// path, which the Trivy client resolves against Docker Hub — NOT Artifact
+    /// Keeper's own registry. For public images sharing the name the result
+    /// looked plausible; for internal/private images Trivy enumerated 0
+    /// packages and the scan completed "clean" (a false negative). This
+    /// override prepends the owning repository key so Trivy pulls the actual
+    /// stored artifact, mirroring `GrypeScanner::scan_target`.
+    async fn scan_target(
+        &self,
+        target: &ScanTarget<'_>,
+        _metadata: Option<&ArtifactMetadata>,
+        _content: &Bytes,
+    ) -> Result<ScanOutput> {
+        debug_assert!(
+            Self::is_container_image(target.artifact),
+            "ImageScanner::scan_target called on a non-container artifact; the orchestrator must gate on is_applicable first"
         );
-
-        Ok(output)
+        let image_ref = Self::extract_image_ref_for_repo(target.artifact, target.repository_key)
+            .ok_or_else(|| {
+                AppError::Internal(format!(
+                    "Could not extract image reference from artifact path: {}",
+                    target.artifact.path
+                ))
+            })?;
+        self.run_image_scan(&image_ref).await
     }
 }
 
@@ -694,5 +750,99 @@ mod tests {
                 v
             );
         }
+    }
+
+    /// The repository-aware ref must prepend the owning repository
+    /// key so the Trivy client pulls Artifact Keeper's own stored image rather
+    /// than a same-named image from Docker Hub. Mirrors
+    /// `GrypeScanner::build_registry_image_ref_for_repo`. Asserts on the
+    /// host-independent suffix so the test does not depend on the registry-host
+    /// env (host resolution is covered by the grype_scanner tests).
+    #[test]
+    fn test_extract_image_ref_for_repo_prepends_repository_key() {
+        let artifact = make_test_artifact(
+            "v2/library/nginx/manifests/latest",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
+        let r = ImageScanner::extract_image_ref_for_repo(&artifact, "docker-local")
+            .expect("ref must build for a valid OCI manifest path");
+        assert!(
+            r.ends_with("/docker-local/library/nginx:latest"),
+            "scan target must be qualified with the repository key: {r}"
+        );
+    }
+
+    /// Regression (mirrors grype #1483): digest-pinned manifests —
+    /// written by every `docker buildx push` — must join the digest with `@`,
+    /// never `:`, or the Trivy CLI rejects the reference.
+    #[test]
+    fn test_extract_image_ref_for_repo_digest_uses_at_separator() {
+        let artifact = make_test_artifact(
+            "v2/org/app/manifests/sha256:cf4501fe4ed427dfc7c81f68be661271ffd164bb2e774caf0e3aa8eac775eb6b",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
+        let r = ImageScanner::extract_image_ref_for_repo(&artifact, "oci-prod")
+            .expect("ref must build for a digest-pinned manifest");
+        assert!(
+            r.ends_with(
+                "/oci-prod/org/app@sha256:cf4501fe4ed427dfc7c81f68be661271ffd164bb2e774caf0e3aa8eac775eb6b"
+            ),
+            "digest ref must keep the repository key and `@` separator: {r}"
+        );
+        assert!(
+            !r.contains("org/app:sha256:"),
+            "digest ref must not use ':' between name and digest: {r}"
+        );
+    }
+
+    /// The legacy `extract_image_ref` (kept for the trait `scan`
+    /// fallback and direct callers) stays repository-key-free and host-free — a
+    /// bare `<name>:<tag>` that resolves against Docker Hub. Only the new
+    /// `scan_target` path is repository-qualified; this guards that contrast so
+    /// the legacy ref is never silently qualified.
+    #[test]
+    fn test_legacy_extract_image_ref_stays_unqualified() {
+        let artifact = make_test_artifact(
+            "v2/library/nginx/manifests/latest",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
+        let r = ImageScanner::extract_image_ref(&artifact).expect("legacy ref must build");
+        assert_eq!(
+            r, "library/nginx:latest",
+            "legacy ref must remain a bare name:tag without host or repository key"
+        );
+    }
+
+    /// `scan_target` builds the repository-qualified target and routes it
+    /// through the shared health gate. With Trivy unreachable the scan must
+    /// fail (never a silent zero-finding completion, cf. #888), and the
+    /// surfaced error must carry the repository-qualified ref — proving the
+    /// owning repository key reached the scan target rather than the bare
+    /// Docker Hub ref the legacy path produces.
+    #[tokio::test]
+    async fn test_scan_target_uses_repo_qualified_ref_when_trivy_unreachable() {
+        let scanner = ImageScanner::new("http://127.0.0.1:1".to_string());
+        let artifact = make_test_artifact(
+            "v2/myapp/manifests/latest",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
+        let target = ScanTarget {
+            artifact: &artifact,
+            repository_key: "docker-local",
+            repository_type: "local",
+        };
+
+        let result = scanner.scan_target(&target, None, &Bytes::new()).await;
+
+        assert!(
+            result.is_err(),
+            "scan_target() must return Err when Trivy is unreachable, not a silent Ok"
+        );
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("docker-local/myapp:latest"),
+            "error must carry the repository-qualified scan target, got: {}",
+            err_msg
+        );
     }
 }


### PR DESCRIPTION
## Summary

`ImageScanner` used the trait-default `scan_target`, producing a bare `<name>:<tag>` ref that the Trivy client resolved against Docker Hub instead of Artifact Keeper's own registry — internal images (OCI and Docker v2 Schema 2) scanned "clean" (0 findings, no error) and public-name collisions scanned the wrong image.

This adds a repository-aware `scan_target` override that prepends the owning repository key (`<host>/<repo_key>/<name>:<ref>`), mirroring `GrypeScanner` — the Trivy counterpart of #1952, which did the Grype side. `run_image_scan` is extracted so the legacy `scan` (bare ref, kept for the trait contract / direct callers) and the new `scan_target` share the same Trivy health gate and report conversion. `grype_scanner::resolve_registry_host` is made `pub(crate)` for reuse.

Manually verified on a local stand: an internal-only image (both OCI and Docker Schema 2 manifests) returns 0 Trivy findings on `main` and the real CVE set with this change; non-image artifacts (e.g. Maven) are unaffected — `ImageScanner` stays `not_applicable` for them.

Closes #1964

It also partially addresses #1971, where the image scan "completes with zero packages": that report's own diagnosis is the unqualified `<name>:<tag>` scan target this PR fixes — with the repository-qualified target, Trivy pulls the stored Artifact Keeper image, so the scan no longer silently succeeds with an empty inventory. It does **not** cover the OCI image-index → platform-manifest resolution or the SBOM falling back to OpenSCAP findings also described in #1971.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Tests added (fail on `main`, pass here):
- `test_extract_image_ref_for_repo_prepends_repository_key` — tag ref is repository-qualified
- `test_extract_image_ref_for_repo_digest_uses_at_separator` — digest ref keeps the `@` separator (cf. #1483)
- `test_legacy_extract_image_ref_stays_unqualified` — the legacy bare ref is unchanged
- `test_scan_target_uses_repo_qualified_ref_when_trivy_unreachable` — integration: `scan_target` routes the repository-qualified target through the shared health gate

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
