### PR TITLE
fix(robustness): 400 on over-length artifact path (+ migration-connection input)

### DIFF
--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -176,6 +176,26 @@ pub struct MigrationReportRow {
 
 // ============ Request/Response DTOs ============
 
+/// Auth-type values accepted by the `source_connections.auth_type` column,
+/// per the `source_connections_auth_type_check` CHECK constraint in migration
+/// `020_migration_tables.sql`.
+const ALLOWED_CONNECTION_AUTH_TYPES: [&str; 2] = ["api_token", "basic_auth"];
+
+/// Reject any `auth_type` the database CHECK constraint would refuse, mapping
+/// it to a clear HTTP 400 (`AppError::Validation`) instead of letting the
+/// constraint violation surface as an opaque 500 DATABASE_ERROR.
+fn validate_connection_auth_type(auth_type: &str) -> Result<()> {
+    if ALLOWED_CONNECTION_AUTH_TYPES.contains(&auth_type) {
+        Ok(())
+    } else {
+        Err(AppError::Validation(format!(
+            "invalid auth_type '{}'; must be one of: {}",
+            auth_type,
+            ALLOWED_CONNECTION_AUTH_TYPES.join(", ")
+        )))
+    }
+}
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateConnectionRequest {
     pub name: String,
@@ -494,6 +514,13 @@ async fn create_connection(
 ) -> Result<(StatusCode, Json<ConnectionResponse>)> {
     // Validate URL to prevent SSRF when migration fetches from this source
     validate_outbound_url(&req.url, "Migration source URL")?;
+
+    // Validate auth_type against the values permitted by the
+    // `source_connections_auth_type_check` CHECK constraint (migration
+    // 020_migration_tables.sql). Without this, any other string reached the
+    // INSERT and surfaced the constraint violation as an opaque HTTP 500
+    // DATABASE_ERROR instead of a clear 400.
+    validate_connection_auth_type(&req.auth_type)?;
 
     // Encrypt credentials before storing
     let credentials_json = serde_json::to_string(&req.credentials)?;
@@ -1784,6 +1811,37 @@ mod tests {
         assert_eq!(response.auth_type, "api_token");
         assert_eq!(response.source_type, "artifactory");
         assert!(response.verified_at.is_some());
+    }
+
+    #[test]
+    fn test_validate_connection_auth_type() {
+        // Table-driven: accepted values must pass; anything the
+        // source_connections_auth_type_check CHECK constraint would refuse
+        // must map to a Validation error (HTTP 400), never reach the INSERT
+        // and surface as an opaque 500 DATABASE_ERROR.
+        let cases: &[(&str, bool)] = &[
+            ("api_token", true),
+            ("basic_auth", true),
+            ("basic", false), // the persona's body shape -> previously 500
+            ("token", false),
+            ("", false),
+            ("API_TOKEN", false), // case-sensitive
+            ("' OR 1=1--", false),
+        ];
+        for &(auth_type, should_pass) in cases {
+            let result = validate_connection_auth_type(auth_type);
+            assert_eq!(
+                result.is_ok(),
+                should_pass,
+                "auth_type {auth_type:?} expected pass={should_pass}, got {result:?}"
+            );
+            if !should_pass {
+                assert!(
+                    matches!(result, Err(AppError::Validation(_))),
+                    "auth_type {auth_type:?} should yield Validation (400), got {result:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -792,6 +792,7 @@ fn map_upload_err(e: UploadError) -> Response {
         UploadError::InvalidChunk(_) => (StatusCode::BAD_REQUEST, e.to_string()),
         UploadError::InvalidChunkSize => (StatusCode::BAD_REQUEST, e.to_string()),
         UploadError::TooLarge { .. } => (StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
+        UploadError::PathTooLong { .. } => (StatusCode::BAD_REQUEST, e.to_string()),
         UploadError::InvalidStatus(_) => (StatusCode::BAD_REQUEST, e.to_string()),
         UploadError::ChecksumMismatch { .. } => (StatusCode::CONFLICT, e.to_string()),
         UploadError::IncompleteChunks { .. } => (StatusCode::BAD_REQUEST, e.to_string()),

--- a/backend/src/services/upload_service.rs
+++ b/backend/src/services/upload_service.rs
@@ -101,11 +101,25 @@ pub enum UploadError {
 
     #[error("total_size {size} exceeds maximum allowed upload size {max}")]
     TooLarge { size: i64, max: u64 },
+
+    #[error("artifact_path is too long: {len} characters (maximum {max})")]
+    PathTooLong { len: usize, max: usize },
 }
 
 // ---------------------------------------------------------------------------
 // Validation
 // ---------------------------------------------------------------------------
+
+/// Maximum permitted artifact-path length, in characters.
+///
+/// The `artifacts.path` column is `VARCHAR(2048)` (see migration
+/// `004_artifacts.sql`). An over-length path used to reach the INSERT and
+/// surface the Postgres length/constraint violation as an opaque HTTP 500
+/// `DATABASE_ERROR`. Rejecting up front in `validate_artifact_path` turns
+/// that into a clear HTTP 400, and protects every upload entry point that
+/// routes through this validator (URL-path variant, multipart-with-path,
+/// chunked sessions, replication).
+pub const MAX_ARTIFACT_PATH_LEN: usize = 2048;
 
 /// Validate that an artifact path is safe (no traversal, not empty).
 pub fn validate_artifact_path(path: &str) -> Result<(), UploadError> {
@@ -113,6 +127,15 @@ pub fn validate_artifact_path(path: &str) -> Result<(), UploadError> {
         return Err(UploadError::InvalidChunk(
             "artifact_path cannot be empty".into(),
         ));
+    }
+
+    // Reject paths longer than the backing column before they reach the
+    // INSERT, where the length violation would surface as an opaque 500.
+    if path.len() > MAX_ARTIFACT_PATH_LEN {
+        return Err(UploadError::PathTooLong {
+            len: path.len(),
+            max: MAX_ARTIFACT_PATH_LEN,
+        });
     }
 
     // Reject null bytes (could bypass C-level path checks)
@@ -1695,6 +1718,39 @@ mod tests {
     fn test_validate_path_valid_dots_in_filename() {
         // Filenames with dots that aren't traversal should be fine
         assert!(validate_artifact_path("my.app.v1.2.3.tar.gz").is_ok());
+    }
+
+    // --- over-length artifact paths (robustness: 400, never 500) ---
+
+    #[test]
+    fn test_validate_path_length_boundaries() {
+        // Table-driven so the length cap maps to a 4xx rejection (a clear
+        // PathTooLong) rather than reaching the INSERT and surfacing the
+        // Postgres VARCHAR(2048) violation as an opaque 500 DATABASE_ERROR.
+        let cases: &[(usize, bool)] = &[
+            (1, true),                          // trivially fine
+            (MAX_ARTIFACT_PATH_LEN - 1, true),  // just under the cap
+            (MAX_ARTIFACT_PATH_LEN, true),      // exactly at the cap
+            (MAX_ARTIFACT_PATH_LEN + 1, false), // one over -> reject
+            (5000, false),                      // the reported red-team payload
+        ];
+        for &(len, should_pass) in cases {
+            let path = "a".repeat(len);
+            let result = validate_artifact_path(&path);
+            assert_eq!(
+                result.is_ok(),
+                should_pass,
+                "path of length {len} expected pass={should_pass}, got {result:?}"
+            );
+            if !should_pass {
+                // Must be the dedicated PathTooLong variant (-> HTTP 400),
+                // not a generic/DB error.
+                assert!(
+                    matches!(result, Err(UploadError::PathTooLong { .. })),
+                    "length {len} should yield PathTooLong, got {result:?}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Two write-path inputs that should produce a **4xx** were instead surfacing the underlying Postgres constraint/length violation as an opaque **HTTP 500 `DATABASE_ERROR`** — the same class as #1954 / #1959.

### Fix 1 — over-length artifact path (MED robustness)
`PUT /api/v1/repositories/{key}/artifacts/{path}` with a ~5000-char path reached the INSERT and 500ed because `artifacts.path` is `VARCHAR(2048)` (migration `004_artifacts.sql`).

- Added `MAX_ARTIFACT_PATH_LEN = 2048` and a `PathTooLong` check at the top of `validate_artifact_path` (`backend/src/services/upload_service.rs`). This is the shared validator already called by `upload_artifact`, so all upload entry points (URL-path, multipart-with-path, chunked sessions, replication) are covered.
- New `UploadError::PathTooLong` maps to **400** in `map_upload_err` (`backend/src/api/handlers/upload.rs`); via `upload_artifact`'s `AppError::Validation` mapping it is **400** there too.

### Fix 2 — invalid migration-connection auth_type
`POST /api/v1/migrations/connections` with a valid body but an `auth_type` outside the `source_connections_auth_type_check` CHECK constraint (anything other than `api_token` / `basic_auth`, per migration `020_migration_tables.sql`) reached the INSERT and 500ed (confirmed live: `auth_type:"basic"` -> 500 `DATABASE_ERROR`, log shows `violates check constraint "source_connections_auth_type_check"`).

- Added `validate_connection_auth_type` (allowlist) called up front in `create_connection` (`backend/src/api/handlers/migration.rs`); invalid value -> **400** with the permitted values.

> Note: the round-3 persona's body used `base_url` (the field is `url`) which is why their probe returned 422 — but a fully-valid body with an out-of-range `auth_type` is a real 500, now fixed.

## Tests
Table-driven in-crate `#[cfg(test)]` unit tests (not `#[ignore]`, not in `backend/tests/`):
- `services::upload_service::tests::test_validate_path_length_boundaries` — under/at/over the cap incl. the 5000-char payload; over-length yields `PathTooLong`.
- `api::handlers::migration::tests::test_validate_connection_auth_type` — accepted values pass; `basic`, empty, wrong-case, injection-y values -> `Validation` (400).

## Verification
- `cargo test -p artifact-keeper-backend --lib` (relevant tests) — 2 passed, 0 failed
- `cargo fmt --check` — clean
- `cargo clippy --lib -- -D warnings` — clean
- No `query!`/`query_as!` macros touched, so no `cargo sqlx prepare` needed.