### PR TITLE
chore(deps): bump quinn-proto to patched version (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2180,7 +2180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4838,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4869,7 +4869,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5385,7 +5385,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5453,7 +5453,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6306,7 +6306,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

RUSTSEC-2026-0185 (quinn-proto: remote memory exhaustion via unbounded out-of-order stream reassembly) is failing the Security Audit (cargo audit) gate on every open PR. `quinn-proto 0.11.14` is in `Cargo.lock` transitively (via reqwest/quinn).

This bumps the locked version to the patched **0.11.15** (advisory: patched `>= 0.11.15`).

## Scope

- **Lock-only change** (`Cargo.lock` only). `quinn 0.11.9` accepts `quinn-proto 0.11.15` with no parent bump and no `Cargo.toml` change.
- The only version change is `quinn-proto 0.11.14 -> 0.11.15`. The `windows-sys` edge re-points in the diff are platform-gated (Windows-only) and do not affect the Linux/CI build.

## Verification

- `cargo build -p artifact-keeper-backend` — succeeds
- `cargo audit` — clean of RUSTSEC-2026-0185 (the remaining fxhash/paste/git2/memmap2/crypto-bigint entries are pre-existing unmaintained/unsound/yanked *warnings*, not the blocker)
- `cargo clippy -p artifact-keeper-backend --lib -- -D warnings` — clean

Unblocks the audit gate for 1.2.2.