### PR TITLE
feat(dtrack): opt-in Google OSV mirror for app-dependency CVE coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -369,6 +369,17 @@ JWT_EXPIRATION_SECS=86400
 # DTRACK_HTTP_PROXY_USERNAME=
 # DTRACK_HTTP_PROXY_PASSWORD=
 # DTRACK_NO_PROXY=localhost,127.0.0.1
+#
+# Google OSV vulnerability mirror (opt-in; default off). NVD — always enabled by
+# init-dtrack.sh — matches by CPE, so purl-based application dependencies
+# (Maven/PyPI/npm/Go/NuGet/Cargo/Composer/...) get few or no findings. OSV
+# matches by purl and aggregates GitHub Security Advisories, so enabling it makes
+# app-dependency analysis produce findings. Off by default because OSV is an
+# additional continuous mirror that adds memory/CPU/Postgres load (the same
+# footprint that makes the bundled DT opt-in). Set to true to have
+# init-dtrack.sh enable OSV (for the AK-hosted, OSV-supported ecosystems) on
+# first DT bootstrap:
+# DTRACK_INIT_OSV_ENABLED=false
 
 # -----------------------------------------------------------------------------
 # Corporate proxy (host-level)

--- a/docker/init-dtrack.sh
+++ b/docker/init-dtrack.sh
@@ -298,6 +298,42 @@ else
   echo "[dtrack-init] WARNING: NVD API config returned HTTP $NVD_RESULT (may already be set)"
 fi
 
+# Google OSV vulnerability mirror (opt-in; OFF by default).
+#
+# NVD (enabled above) matches by CPE, so purl-based application dependencies
+# get few or no findings from NVD alone, leaving Dependency-Track largely
+# redundant with the OS-package scanners for application code. OSV matches by
+# purl and aggregates GitHub Security Advisories, PyPA, RustSec, Go and npm
+# advisories, so enabling it makes app-dependency analysis actually produce
+# findings.
+#
+# Gated behind DTRACK_INIT_OSV_ENABLED and OFF by default: OSV is an additional
+# continuous mirror on top of NVD (and DT's default OSS-Index analyzer) and
+# adds memory/CPU/Postgres load — the same resource footprint that made the
+# bundled DT opt-in (#1432). The ecosystem set covers the purl-based package
+# formats Artifact Keeper hosts that OSV supports (Maven incl. sbt, PyPI, npm
+# incl. pnpm, Go, NuGet, RubyGems, Cargo/crates.io, Composer/Packagist);
+# narrow or extend it from the DT UI (Administration -> Vulnerability Sources
+# -> Google OSV) if needed.
+if [ "${DTRACK_INIT_OSV_ENABLED:-false}" = "true" ]; then
+  OSV_ECOSYSTEMS="Maven;PyPI;npm;Go;NuGet;RubyGems;crates.io;Packagist"
+  echo "[dtrack-init] Enabling Google OSV mirroring for: $OSV_ECOSYSTEMS"
+
+  OSV_RESULT=$(curl -sf -o /dev/null -w "%{http_code}" \
+    -X POST "$DT_URL/api/v1/configProperty" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"groupName\":\"vuln-source\",\"propertyName\":\"google.osv.enabled\",\"propertyValue\":\"${OSV_ECOSYSTEMS}\"}" || true)
+
+  if [ "$OSV_RESULT" = "200" ] || [ "$OSV_RESULT" = "201" ] || [ "$OSV_RESULT" = "204" ]; then
+    echo "[dtrack-init] Google OSV mirroring enabled"
+  else
+    echo "[dtrack-init] WARNING: OSV config returned HTTP $OSV_RESULT (may already be set)"
+  fi
+else
+  echo "[dtrack-init] Google OSV mirroring disabled (set DTRACK_INIT_OSV_ENABLED=true for app-dependency CVE coverage)"
+fi
+
 : > "$BOOTSTRAP_MARKER" 2>/dev/null || true
 
 echo "[dtrack-init] Done"

--- a/docker/test-init-dtrack.sh
+++ b/docker/test-init-dtrack.sh
@@ -92,6 +92,7 @@ state = {
 }
 KEY_LOG = os.environ["KEY_LOG"]
 PERM_LOG = os.environ["PERM_LOG"]
+CONFIG_LOG = os.environ["CONFIG_LOG"]
 
 class H(BaseHTTPRequestHandler):
     def log_message(self, *a, **k):
@@ -133,6 +134,8 @@ class H(BaseHTTPRequestHandler):
             return self._send(200, b"eyJhbGciOiJIUzI1NiJ9.mockjwt.signature",
                               ctype="text/plain")
         if self.path == "/api/v1/configProperty":
+            with open(CONFIG_LOG, "a") as f:
+                f.write(body.decode("utf-8", "replace") + "\n")
             return self._send(200)
         if (self.path.startswith(f"/api/v1/permission/")
                 and self.path.endswith(f"/team/{TEAM_UUID}")):
@@ -186,6 +189,9 @@ KEY_LOG="$WORK_DIR/keys.log"
 PERM_LOG="$WORK_DIR/perms.log"
 : > "$PERM_LOG"
 
+CONFIG_LOG="$WORK_DIR/config.log"
+: > "$CONFIG_LOG"
+
 # start_mock <var=value>... — (re)launch the mock with the given env overrides.
 # Tests that need to inject foreign keys or fault-injection knobs restart
 # the mock between phases; a fresh server discards the previous state.
@@ -199,7 +205,7 @@ start_mock() {
   # KEY=val passed by callers are honored as env assignments. The shell
   # only treats inline VAR=val as an env override when it appears literally
   # at the start of a command — not when it arrives via "$@" expansion.
-  env EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" KEY_LOG="$KEY_LOG" PERM_LOG="$PERM_LOG" \
+  env EXPECTED_KEY="$EXPECTED_KEY" MASKED_KEY="$MASKED_KEY" KEY_LOG="$KEY_LOG" PERM_LOG="$PERM_LOG" CONFIG_LOG="$CONFIG_LOG" \
     "$@" \
     python3 "$WORK_DIR/mock_dtrack.py" "$MOCK_PORT" >>"$WORK_DIR/mock.log" 2>&1 &
   MOCK_PID=$!
@@ -235,7 +241,7 @@ PUBLIC_ID_MARKER="$SHARED_DIR/.dtrack-publicid"
 
 fail() {
   echo "FAIL: $1" >&2
-  for f in init init2 init2_force init2_authfail init2_permfail init2_unreachable init3 init4 init5 init6; do
+  for f in init init2 init2_force init2_authfail init2_permfail init2_unreachable init3 init4 init5 init6 init_osv_off init_osv_on; do
     if [ -f "$WORK_DIR/${f}.out" ] || [ -f "$WORK_DIR/${f}.err" ]; then
       echo "--- ${f} stdout ---" >&2; cat "$WORK_DIR/${f}.out" >&2 || true
       echo "--- ${f} stderr ---" >&2; cat "$WORK_DIR/${f}.err" >&2 || true
@@ -445,4 +451,39 @@ INIT_RC6=$(run_init init6)
 [ ! -f "$KEY_FILE.tmp" ] || \
   fail "Phase 6: failed init left a stale $KEY_FILE.tmp on disk"
 
-echo "PASS: init-dtrack.sh — bug #978 + foreign-key safety rail (#1041 follow-up)"
+# ─────────────────────────────────────────────────────────────────────────────
+# Phase 7: Google OSV vuln source is opt-in (DTRACK_INIT_OSV_ENABLED).
+# NVD is always enabled; OSV must be enabled only when the flag is set. Both are
+# configured on the cold mint path, so each case runs cold from a wiped state.
+# ─────────────────────────────────────────────────────────────────────────────
+# Default (flag unset): NVD enabled, OSV NOT enabled.
+rm -f "$KEY_FILE" "$PUBLIC_ID_MARKER" "$SHARED_DIR/.dtrack-bootstrapped"
+start_mock
+: > "$CONFIG_LOG"
+INIT_RC_OSV_OFF=$(run_init init_osv_off)
+[ "$INIT_RC_OSV_OFF" -eq 0 ] || \
+  fail "Phase 7: OSV-off init exited $INIT_RC_OSV_OFF"
+grep -q 'Google OSV mirroring disabled' "$WORK_DIR/init_osv_off.out" || \
+  fail "Phase 7: OSV-off must log 'disabled'"
+grep -q 'nvd.api.enabled' "$CONFIG_LOG" || \
+  fail "Phase 7: NVD must always be enabled (nvd.api.enabled not POSTed)"
+! grep -q 'google.osv.enabled' "$CONFIG_LOG" || \
+  fail "Phase 7: google.osv.enabled must NOT be POSTed when DTRACK_INIT_OSV_ENABLED is unset"
+
+# Opt-in (flag=true): OSV enabled with the AK-hosted ∩ OSV-supported ecosystems.
+rm -f "$KEY_FILE" "$PUBLIC_ID_MARKER" "$SHARED_DIR/.dtrack-bootstrapped"
+start_mock
+: > "$CONFIG_LOG"
+INIT_RC_OSV_ON=$(run_init init_osv_on env DTRACK_INIT_OSV_ENABLED=true)
+[ "$INIT_RC_OSV_ON" -eq 0 ] || \
+  fail "Phase 7: OSV-on init exited $INIT_RC_OSV_ON"
+grep -q 'Google OSV mirroring enabled' "$WORK_DIR/init_osv_on.out" || \
+  fail "Phase 7: OSV-on must log 'enabled'"
+grep -q 'google.osv.enabled' "$CONFIG_LOG" || \
+  fail "Phase 7: google.osv.enabled must be POSTed when DTRACK_INIT_OSV_ENABLED=true"
+grep -q 'Packagist' "$CONFIG_LOG" || \
+  fail "Phase 7: OSV ecosystem list should include Packagist (Composer)"
+
+echo "[test] OSV opt-in: NVD always on; OSV off -> no google.osv.enabled POST, on -> POSTed incl. Packagist"
+
+echo "PASS: init-dtrack.sh — bug #978 + foreign-key safety rail (#1041 follow-up) + OSV opt-in"


### PR DESCRIPTION
## Summary

`docker/init-dtrack.sh` enables NVD on first Dependency-Track bootstrap but not OSV. NVD matches by CPE, so purl-based application dependencies (Maven/PyPI/npm/Go/NuGet/Cargo/Composer/...) get few or no findings — Dependency-Track ends up largely redundant with the OS-package scanners for application code.

This adds a `DTRACK_INIT_OSV_ENABLED` toggle (default **off**) that, when set, enables `google.osv.enabled` for the ecosystems Artifact Keeper hosts that OSV supports (Maven, PyPI, npm, Go, NuGet, RubyGems, crates.io, Packagist), next to the existing NVD enablement. OSV matches by purl and aggregates GitHub Security Advisories / PyPA / RustSec / Go / npm advisories.

It is off by default because OSV is an additional continuous mirror that adds the same memory/CPU/Postgres footprint that made the bundled Dependency-Track opt-in (#1432); operators opt in with `DTRACK_INIT_OSV_ENABLED=true`. The ecosystem names were confirmed accepted by Dependency-Track 4.14.2.

Closes #1972

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (opt-in feature; tests are still included below)

## Test Checklist
- [x] Unit tests added/updated — `docker/test-init-dtrack.sh` Phase 7 asserts: OSV off → no `google.osv.enabled` POST and a "disabled" log; OSV on → `google.osv.enabled` POSTed with the ecosystem list (incl. Packagist); NVD always enabled in both. `shellcheck`-clean.
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — verified against Dependency-Track 4.14.2 (POST `google.osv.enabled` with all 8 ecosystem names accepted, incl. Packagist).
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
