### PR TITLE
docs: document QUARANTINE_ENABLED mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -316,11 +316,33 @@ JWT_EXPIRATION_SECS=86400
 # MAX_INCUS_SCAN_COMPRESSED_BYTES=17179869184
 # MAX_INCUS_SCAN_EXTRACTED_BYTES=68719476736
 
-# --- Quarantine period (optional) ---
-# Hold newly uploaded artifacts in quarantine until scanning completes or the
-# hold period expires. Downloads return 409 while an artifact is quarantined.
-# Per-repo overrides are available via the repository_config table keys
-# "quarantine_enabled" and "quarantine_duration_minutes".
+# --- Quarantine mode (optional) ---
+# When QUARANTINE_ENABLED=true, newly ingested artifacts are held in a
+# "quarantined" state instead of being served immediately. Quarantined
+# artifacts are not downloadable: download requests return 409 Conflict
+# ("Artifact is quarantined and pending security review") until the artifact
+# is released.
+#
+# An artifact leaves quarantine when either of these happens:
+#   * Security scanning completes. A clean scan transitions the artifact to
+#     "released" (downloadable); a scan with findings transitions it to
+#     "rejected" (download returns 403).
+#   * The hold period expires. QUARANTINE_DURATION_MINUTES sets the default
+#     hold window in minutes (minimum 1, default 60). Once the window has
+#     elapsed the artifact becomes downloadable even if no scan has run.
+#
+# For pull-through / proxy repositories the hold window is measured from the
+# package's upstream release date when that date is known, not from the time
+# this instance first fetched it. This implements a minimum-age policy: a
+# package whose upstream release is already older than the window is served
+# immediately, while a freshly published upstream package is held until it has
+# aged past QUARANTINE_DURATION_MINUTES. This reduces exposure to brand-new
+# (potentially compromised) upstream releases.
+#
+# These two variables set the instance-wide default. Individual repositories
+# can override the default via the repository_config table keys
+# "quarantine_enabled" and "quarantine_duration_minutes"; a per-repo value
+# always takes precedence over the env defaults.
 # QUARANTINE_ENABLED=false
 # QUARANTINE_DURATION_MINUTES=60
 


### PR DESCRIPTION
## Summary

The quarantine mode (`QUARANTINE_ENABLED` / `QUARANTINE_DURATION_MINUTES`) was only listed as a pair of commented env vars with a one-line description. This expands the `.env.example` section to fully document the feature so operators can understand and enable it without reading the source.

The new documentation covers:
- **What it does** — newly ingested artifacts are held in a `quarantined` state; downloads return 409 Conflict until released.
- **How to enable** — `QUARANTINE_ENABLED=true`, with `QUARANTINE_DURATION_MINUTES` controlling the hold window (min 1, default 60).
- **Behavior** — release on clean scan, reject (403) on scan findings, or auto-release once the hold window expires.
- **Minimum-age policy** — for pull-through/proxy repositories the hold is measured from the upstream release date, so freshly published upstream packages are held while already-aged ones are served immediately (the supply-chain protection requested in the issue).
- **Per-repo overrides** — via the `repository_config` keys `quarantine_enabled` and `quarantine_duration_minutes`, which take precedence over the env defaults.

Behavior was verified against `backend/src/services/quarantine_service.rs` (status transitions, expiry, release-date age policy, per-repo precedence) and `backend/src/error.rs` (409 for quarantined, 403 for rejected).

## Test Checklist
- [x] Docs-only change; no code paths modified
- [x] No tests required (no behavioral change)

## API Changes
None.

Fixes #1213