### PR TITLE
fix(auth): make login rate limiter per-identifier so junk floods cannot lock out all accounts

### DIFF
--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -66,10 +66,22 @@ fn login_response(
     response
 }
 
-/// Create public auth routes (no auth required)
+/// Create the login route (no auth required).
+///
+/// Split out from [`public_router`] so the login path can carry the
+/// per-`(username, IP)` `login_rate_limit_middleware` while `/logout` and
+/// `/refresh` — which carry no `username` field — keep the unchanged IP-keyed
+/// `rate_limit_middleware`.
+pub fn login_router() -> Router<SharedState> {
+    Router::new().route("/login", post(login))
+}
+
+/// Create public auth routes (no auth required).
+///
+/// `/login` is intentionally NOT included here; it is wired separately via
+/// [`login_router`] so only it gets the username-peeking login limiter.
 pub fn public_router() -> Router<SharedState> {
     Router::new()
-        .route("/login", post(login))
         .route("/logout", post(logout))
         .route("/refresh", post(refresh_token))
 }

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -2677,6 +2677,8 @@ mod tests {
                 rate_limit_api_per_window: 5000,
                 rate_limit_search_per_window: 300,
                 rate_limit_presign_per_window: 30,
+
+                rate_limit_login_global_per_window: 8192,
                 rate_limit_password_change_per_window: 5,
                 rate_limit_password_change_window_secs: 900,
                 rate_limit_window_secs: 60,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4815,6 +4815,8 @@ mod tests {
                 rate_limit_api_per_window: 5000,
                 rate_limit_search_per_window: 300,
                 rate_limit_presign_per_window: 30,
+
+                rate_limit_login_global_per_window: 8192,
                 rate_limit_password_change_per_window: 5,
                 rate_limit_password_change_window_secs: 900,
                 rate_limit_window_secs: 60,

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -112,6 +112,8 @@ fn cfg(storage_path: &str) -> Config {
         rate_limit_api_per_window: 5000,
         rate_limit_search_per_window: 300,
         rate_limit_presign_per_window: 30,
+
+        rate_limit_login_global_per_window: 8192,
         rate_limit_password_change_per_window: 5,
         rate_limit_password_change_window_secs: 900,
         rate_limit_window_secs: 60,

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -8,6 +8,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use axum::{
+    body::Body,
     extract::{Request, State},
     http::{header::HeaderValue, StatusCode},
     middleware::Next,
@@ -15,6 +16,12 @@ use axum::{
 };
 
 use super::auth::AuthExtension;
+
+/// Maximum login request body we will buffer to peek the `username` for
+/// per-account rate-limit keying. Login payloads are tiny (`{"username":...,
+/// "password":...}`); anything larger is not a legitimate login and is keyed
+/// by IP alone (it still passes through to the handler, which rejects it).
+const LOGIN_BODY_PEEK_LIMIT: usize = 64 * 1024;
 
 /// A parsed CIDR range used for IP-based rate-limit exemption (#969).
 ///
@@ -159,6 +166,70 @@ pub fn rate_limiting_active(enabled: bool) -> bool {
     enabled
 }
 
+/// Pull an `AuthExtension` out of request extensions, whether it was inserted
+/// directly (required-auth middleware) or as an `Option` (optional-auth
+/// middleware). Shared by every rate-limit middleware.
+fn auth_from_request(request: &Request) -> Option<AuthExtension> {
+    request
+        .extensions()
+        .get::<AuthExtension>()
+        .cloned()
+        .or_else(|| {
+            request
+                .extensions()
+                .get::<Option<AuthExtension>>()
+                .and_then(|opt| opt.clone())
+        })
+}
+
+/// Run the username/service-account and trusted-CIDR exemption checks shared by
+/// every rate-limit middleware (#969). Returns `Some(tag)` with the
+/// `X-RateLimit-Exempt` header value when the request is exempt (the caller then
+/// runs `next` and tags the response), or `None` so the caller proceeds to keyed
+/// limiting.
+fn check_rate_limit_exemptions(
+    exemptions: &RateLimitExemptions,
+    auth: Option<&AuthExtension>,
+    request: &Request,
+) -> Option<&'static str> {
+    // User/service-account exemption.
+    if let Some(auth) = auth {
+        if exemptions.is_exempt(auth) {
+            return Some("true");
+        }
+    }
+    // Trusted-CIDR exemption (#969): applies to authed and unauthed alike.
+    if !exemptions.trusted_cidrs.is_empty() {
+        if let Some(ip) = extract_client_ip_addr(request) {
+            if exemptions.is_trusted_cidr(ip) {
+                return Some("trusted-cidr");
+            }
+        }
+    }
+    None
+}
+
+/// Tag a response as rate-limit-exempt and return it.
+fn tag_exempt(mut response: Response, tag: &str) -> Response {
+    if let Ok(value) = HeaderValue::from_str(tag) {
+        response.headers_mut().insert("X-RateLimit-Exempt", value);
+    }
+    response
+}
+
+/// Attach the `X-RateLimit-Limit` / `X-RateLimit-Remaining` headers to an
+/// allowed response.
+fn tag_allowed(mut response: Response, max_requests: u32, remaining: u32) -> Response {
+    let headers = response.headers_mut();
+    if let Ok(value) = HeaderValue::from_str(&max_requests.to_string()) {
+        headers.insert("X-RateLimit-Limit", value);
+    }
+    if let Ok(value) = HeaderValue::from_str(&remaining.to_string()) {
+        headers.insert("X-RateLimit-Remaining", value);
+    }
+    response
+}
+
 /// Per-instance, in-memory rate limiter that tracks requests per key (IP or user ID).
 ///
 /// This limiter is **not shared across replicas**. Each application instance
@@ -254,42 +325,11 @@ pub async fn rate_limit_middleware(
     }
 
     // Extract auth from extensions (required or optional middleware)
-    let auth = request
-        .extensions()
-        .get::<AuthExtension>()
-        .cloned()
-        .or_else(|| {
-            request
-                .extensions()
-                .get::<Option<AuthExtension>>()
-                .and_then(|opt| opt.clone())
-        });
+    let auth = auth_from_request(&request);
 
-    // User/service-account exemptions
-    if let Some(ref auth) = auth {
-        if state.exemptions.is_exempt(auth) {
-            let mut response = next.run(request).await;
-            if let Ok(value) = HeaderValue::from_str("true") {
-                response.headers_mut().insert("X-RateLimit-Exempt", value);
-            }
-            return response;
-        }
-    }
-
-    // Trusted-CIDR exemption (#969). Applies to authed and unauthed
-    // requests alike: a sidecar probe or in-cluster CI runner calling
-    // /api/v1/auth/login from a known internal range bypasses the
-    // limiter so concurrent test pods don't exhaust the auth bucket.
-    if !state.exemptions.trusted_cidrs.is_empty() {
-        if let Some(ip) = extract_client_ip_addr(&request) {
-            if state.exemptions.is_trusted_cidr(ip) {
-                let mut response = next.run(request).await;
-                if let Ok(value) = HeaderValue::from_str("trusted-cidr") {
-                    response.headers_mut().insert("X-RateLimit-Exempt", value);
-                }
-                return response;
-            }
-        }
+    // Username/service-account + trusted-CIDR exemptions (#969).
+    if let Some(tag) = check_rate_limit_exemptions(&state.exemptions, auth.as_ref(), &request) {
+        return tag_exempt(next.run(request).await, tag);
     }
 
     // Determine the rate limit key
@@ -302,46 +342,14 @@ pub async fn rate_limit_middleware(
 
     // Check rate limit
     match state.limiter.check_rate_limit(&key).await {
-        Ok(remaining) => {
-            let mut response = next.run(request).await;
-
-            // Add rate limit headers to successful responses
-            let headers = response.headers_mut();
-            if let Ok(value) = HeaderValue::from_str(&state.limiter.max_requests.to_string()) {
-                headers.insert("X-RateLimit-Limit", value);
-            }
-            if let Ok(value) = HeaderValue::from_str(&remaining.to_string()) {
-                headers.insert("X-RateLimit-Remaining", value);
-            }
-
-            response
-        }
+        Ok(remaining) => tag_allowed(
+            next.run(request).await,
+            state.limiter.max_requests,
+            remaining,
+        ),
         Err(retry_after) => {
-            tracing::debug!(
-                key = %key,
-                retry_after = retry_after,
-                "rate limit exceeded"
-            );
-
-            let mut response = (
-                StatusCode::TOO_MANY_REQUESTS,
-                "Rate limit exceeded. Please try again later.",
-            )
-                .into_response();
-
-            // Add Retry-After header
-            let headers = response.headers_mut();
-            if let Ok(value) = HeaderValue::from_str(&retry_after.to_string()) {
-                headers.insert("Retry-After", value);
-            }
-            if let Ok(value) = HeaderValue::from_str(&state.limiter.max_requests.to_string()) {
-                headers.insert("X-RateLimit-Limit", value);
-            }
-            if let Ok(value) = HeaderValue::from_str("0") {
-                headers.insert("X-RateLimit-Remaining", value);
-            }
-
-            response
+            tracing::debug!(key = %key, retry_after, "rate limit exceeded");
+            too_many_requests(retry_after, state.limiter.max_requests)
         }
     }
 }
@@ -368,42 +376,12 @@ pub async fn rate_limit_by_ip_middleware(
         return next.run(request).await;
     }
 
-    // Username / service-account exemption: legitimate batch downloads
-    // by admin / CI bots should not be throttled even when they
-    // originate from a single egress IP.
-    let auth = request
-        .extensions()
-        .get::<AuthExtension>()
-        .cloned()
-        .or_else(|| {
-            request
-                .extensions()
-                .get::<Option<AuthExtension>>()
-                .and_then(|opt| opt.clone())
-        });
-    if let Some(ref auth) = auth {
-        if state.exemptions.is_exempt(auth) {
-            let mut response = next.run(request).await;
-            if let Ok(value) = HeaderValue::from_str("true") {
-                response.headers_mut().insert("X-RateLimit-Exempt", value);
-            }
-            return response;
-        }
-    }
-
-    // Trusted-CIDR exemption (#969): sidecar probes / in-cluster CI
-    // runners / service-mesh nodes that originate from a known
-    // internal range bypass the limiter regardless of auth.
-    if !state.exemptions.trusted_cidrs.is_empty() {
-        if let Some(ip) = extract_client_ip_addr(&request) {
-            if state.exemptions.is_trusted_cidr(ip) {
-                let mut response = next.run(request).await;
-                if let Ok(value) = HeaderValue::from_str("trusted-cidr") {
-                    response.headers_mut().insert("X-RateLimit-Exempt", value);
-                }
-                return response;
-            }
-        }
+    // Username/service-account + trusted-CIDR exemptions (#969). Legitimate
+    // batch downloads by admin / CI bots (or trusted internal ranges) should
+    // not be throttled even when they share a single egress IP.
+    let auth = auth_from_request(&request);
+    if let Some(tag) = check_rate_limit_exemptions(&state.exemptions, auth.as_ref(), &request) {
+        return tag_exempt(next.run(request).await, tag);
     }
 
     // The whole point of this variant: key by IP, not user_id. An
@@ -412,41 +390,168 @@ pub async fn rate_limit_by_ip_middleware(
     let key = extract_client_ip(&request);
 
     match state.limiter.check_rate_limit(&key).await {
-        Ok(remaining) => {
-            let mut response = next.run(request).await;
-            let headers = response.headers_mut();
-            if let Ok(value) = HeaderValue::from_str(&state.limiter.max_requests.to_string()) {
-                headers.insert("X-RateLimit-Limit", value);
-            }
-            if let Ok(value) = HeaderValue::from_str(&remaining.to_string()) {
-                headers.insert("X-RateLimit-Remaining", value);
-            }
-            response
-        }
+        Ok(remaining) => tag_allowed(
+            next.run(request).await,
+            state.limiter.max_requests,
+            remaining,
+        ),
         Err(retry_after) => {
-            tracing::debug!(
-                key = %key,
-                retry_after = retry_after,
-                "presign-mint rate limit exceeded"
-            );
-            let mut response = (
-                StatusCode::TOO_MANY_REQUESTS,
-                "Rate limit exceeded. Please try again later.",
-            )
-                .into_response();
-            let headers = response.headers_mut();
-            if let Ok(value) = HeaderValue::from_str(&retry_after.to_string()) {
-                headers.insert("Retry-After", value);
-            }
-            if let Ok(value) = HeaderValue::from_str(&state.limiter.max_requests.to_string()) {
-                headers.insert("X-RateLimit-Limit", value);
-            }
-            if let Ok(value) = HeaderValue::from_str("0") {
-                headers.insert("X-RateLimit-Remaining", value);
-            }
-            response
+            tracing::debug!(key = %key, retry_after, "presign-mint rate limit exceeded");
+            too_many_requests(retry_after, state.limiter.max_requests)
         }
     }
+}
+
+/// State for the login-only rate-limit middleware.
+///
+/// Wraps the standard [`RateLimitState`] (the shared auth limiter, exemptions,
+/// and master switch — used here so the login path honors exactly the same
+/// username/service-account exemptions, trusted-CIDR exemptions (#969), and
+/// master off-switch (#1602) as [`rate_limit_middleware`]) and adds a global
+/// backstop limiter. The auth limiter is keyed per-`(username, source-IP)` so a
+/// junk flood against one identity/origin cannot exhaust the budget for other
+/// accounts; the backstop bounds the total login volume (and the size of the
+/// per-key map) so a username-cycling attacker cannot drive unbounded distinct
+/// keys.
+#[derive(Debug, Clone)]
+pub struct LoginRateLimitState {
+    /// Per-`(username, ip)` auth limiter + exemptions + master switch.
+    pub inner: RateLimitState,
+    /// Global shedding backstop, keyed on a single constant bucket. Capacity is
+    /// sized far above any legitimate concurrent-login volume.
+    pub backstop: Arc<RateLimiter>,
+}
+
+/// Build the login rate-limit key from a username and the request's client IP.
+///
+/// Extracted as a pure function so the keyspace contract (one bucket per
+/// `(username, ip)` pair) is unit-testable without constructing middleware.
+/// Login is case-sensitive at the auth layer (the `WHERE username = $1` lookup
+/// uses no `LOWER`/`ILIKE`), so the username is used verbatim to match the auth
+/// identity 1:1.
+pub fn login_rate_limit_key(username: &str, client_ip: &str) -> String {
+    format!("login:{}|{}", username, client_ip)
+}
+
+/// Login-only rate-limit middleware.
+///
+/// Variant of [`rate_limit_middleware`] for the unauthenticated `POST
+/// /auth/login` route. It buffers the (tiny) login JSON, extracts `username`,
+/// and keys the auth limiter per-`(username, source-IP)` instead of per-IP, so
+/// a junk flood against one identity/origin exhausts only its own bucket and
+/// correct logins by other users — or the same user from another IP — are
+/// unaffected, while per-account brute-force caps still hold.
+///
+/// A global backstop limiter (keyed on one constant bucket) sheds once total
+/// login volume per window exceeds its high ceiling, bounding the per-key map
+/// against a username-cycling attacker.
+///
+/// Username/service-account exemptions, trusted-CIDR exemptions (#969), and the
+/// master off-switch (#1602) are honored identically to [`rate_limit_middleware`].
+pub async fn login_rate_limit_middleware(
+    State(state): State<LoginRateLimitState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    let inner = &state.inner;
+
+    // Master off switch (#1602): bypass the limiter entirely.
+    if !rate_limiting_active(inner.enabled) {
+        return next.run(request).await;
+    }
+
+    // Username/service-account + trusted-CIDR exemptions (#969). /login is
+    // unauthenticated, but optional-auth middleware could populate an
+    // AuthExtension upstream; honor the same exemption contract as
+    // rate_limit_middleware for parity.
+    let auth = auth_from_request(&request);
+    if let Some(tag) = check_rate_limit_exemptions(&inner.exemptions, auth.as_ref(), &request) {
+        return tag_exempt(next.run(request).await, tag);
+    }
+
+    // Resolve the client IP before consuming the body.
+    let client_ip = extract_client_ip(&request);
+
+    // Buffer the (small) login body so we can peek `username`, then re-attach
+    // it unchanged for the handler's custom Json extractor.
+    let (parts, body) = request.into_parts();
+    let bytes = match axum::body::to_bytes(body, LOGIN_BODY_PEEK_LIMIT).await {
+        Ok(b) => b,
+        Err(_) => {
+            // Body too large or unreadable: not a legitimate login. Reconstruct
+            // an empty-bodied request keyed by IP and let the handler reject it.
+            let request = Request::from_parts(parts, Body::empty());
+            return run_login_with_key(&state, &client_ip, request, next).await;
+        }
+    };
+
+    // Best-effort username extraction; on any parse failure fall back to an
+    // IP-only key (the body is still forwarded unchanged for the handler).
+    let username = serde_json::from_slice::<serde_json::Value>(&bytes)
+        .ok()
+        .and_then(|v| {
+            v.get("username")
+                .and_then(|u| u.as_str())
+                .map(|s| s.to_string())
+        });
+
+    let key = match username {
+        Some(name) => login_rate_limit_key(&name, &client_ip),
+        None => client_ip.clone(),
+    };
+
+    // Reattach the buffered body unchanged (Content-Type/headers in `parts`
+    // are preserved) so the login handler's extractor sees the original body.
+    let request = Request::from_parts(parts, Body::from(bytes));
+    run_login_with_key(&state, &key, request, next).await
+}
+
+/// Apply the global backstop, then the per-key login limiter, then run the
+/// request. Shared tail of [`login_rate_limit_middleware`] so both the
+/// normal and the oversized-body paths key and shed identically.
+async fn run_login_with_key(
+    state: &LoginRateLimitState,
+    key: &str,
+    request: Request,
+    next: Next,
+) -> Response {
+    // Global backstop first: sheds (rather than starves) once total login
+    // volume per window exceeds its high ceiling.
+    if let Err(retry_after) = state.backstop.check_rate_limit("login:global").await {
+        return too_many_requests(retry_after, state.backstop.max_requests);
+    }
+
+    match state.inner.limiter.check_rate_limit(key).await {
+        Ok(remaining) => tag_allowed(
+            next.run(request).await,
+            state.inner.limiter.max_requests,
+            remaining,
+        ),
+        Err(retry_after) => {
+            tracing::debug!(key = %key, retry_after, "login rate limit exceeded");
+            too_many_requests(retry_after, state.inner.limiter.max_requests)
+        }
+    }
+}
+
+/// Build a 429 response with `Retry-After` and `X-RateLimit-*` headers.
+fn too_many_requests(retry_after: u64, max_requests: u32) -> Response {
+    let mut response = (
+        StatusCode::TOO_MANY_REQUESTS,
+        "Rate limit exceeded. Please try again later.",
+    )
+        .into_response();
+    let headers = response.headers_mut();
+    if let Ok(value) = HeaderValue::from_str(&retry_after.to_string()) {
+        headers.insert("Retry-After", value);
+    }
+    if let Ok(value) = HeaderValue::from_str(&max_requests.to_string()) {
+        headers.insert("X-RateLimit-Limit", value);
+    }
+    if let Ok(value) = HeaderValue::from_str("0") {
+        headers.insert("X-RateLimit-Remaining", value);
+    }
+    response
 }
 
 /// Extract the client IP address from the request.
@@ -1224,5 +1329,248 @@ mod tests {
              limiter keys the request; otherwise search is keyed by IP and \
              collapses all callers into one bucket"
         );
+    }
+
+    // ── Login per-(username, IP) limiter (login-ratelimit-global-dos) ─────────
+
+    #[test]
+    fn test_login_rate_limit_key_partitions_by_user_and_ip() {
+        // The key must combine username and IP: same user different IP, and
+        // same IP different user, must all be distinct buckets.
+        let a = login_rate_limit_key("alice", "ip:10.0.0.1");
+        let b = login_rate_limit_key("bob", "ip:10.0.0.1"); // same IP, diff user
+        let c = login_rate_limit_key("alice", "ip:10.0.0.2"); // same user, diff IP
+        assert_ne!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(b, c);
+        // Stable for the same (user, ip).
+        assert_eq!(a, login_rate_limit_key("alice", "ip:10.0.0.1"));
+    }
+
+    #[test]
+    fn test_login_rate_limit_key_is_case_sensitive() {
+        // Login is case-sensitive at the auth layer, so the key must be too.
+        assert_ne!(
+            login_rate_limit_key("Admin", "ip:10.0.0.1"),
+            login_rate_limit_key("admin", "ip:10.0.0.1")
+        );
+    }
+
+    /// Build a login middleware app with the given per-key and backstop caps.
+    fn login_app(per_key: u32, backstop: u32) -> axum::Router {
+        use axum::routing::post;
+        let state = LoginRateLimitState {
+            inner: RateLimitState {
+                limiter: Arc::new(RateLimiter::new(per_key, 60)),
+                exemptions: Arc::new(RateLimitExemptions::new(Vec::new(), false)),
+                enabled: true,
+            },
+            backstop: Arc::new(RateLimiter::new(backstop, 60)),
+        };
+        axum::Router::new()
+            .route("/login", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                login_rate_limit_middleware,
+            ))
+    }
+
+    /// Drive one login request for `username` from source IP `xff`.
+    async fn login_once(app: &axum::Router, username: &str, xff: &str) -> StatusCode {
+        use tower::ServiceExt;
+        let body = format!(r#"{{"username":"{username}","password":"x"}}"#);
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/login")
+                    .header("X-Forwarded-For", xff)
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn test_login_flood_on_one_identity_does_not_lock_out_others() {
+        // The finding's exact claim: a flood on (user=x, ip=A) 429s, while
+        // (user=y, ip=B) and (user=y, ip=A) stay non-429.
+        let app = login_app(3, 10_000);
+
+        // Exhaust (x, A): first 3 OK, then 429.
+        assert_eq!(login_once(&app, "x", "10.0.0.1").await, StatusCode::OK);
+        assert_eq!(login_once(&app, "x", "10.0.0.1").await, StatusCode::OK);
+        assert_eq!(login_once(&app, "x", "10.0.0.1").await, StatusCode::OK);
+        assert_eq!(
+            login_once(&app, "x", "10.0.0.1").await,
+            StatusCode::TOO_MANY_REQUESTS,
+            "(x, A) must exhaust its own bucket"
+        );
+
+        // (y, B) and (y, A) must be unaffected by the (x, A) flood.
+        assert_eq!(
+            login_once(&app, "y", "10.0.0.2").await,
+            StatusCode::OK,
+            "different user on a different IP must have an independent bucket"
+        );
+        assert_eq!(
+            login_once(&app, "y", "10.0.0.1").await,
+            StatusCode::OK,
+            "different user on the SAME IP must have an independent bucket"
+        );
+        // The same victim user x from another IP is also fine.
+        assert_eq!(
+            login_once(&app, "x", "10.0.0.9").await,
+            StatusCode::OK,
+            "the same user from another IP must have an independent bucket"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_login_global_backstop_sheds_with_retry_after() {
+        // Backstop capacity 2, huge per-key cap: distinct (user, ip) keys never
+        // hit their own bucket but the global backstop trips after 2 attempts.
+        let app = login_app(10_000, 2);
+        assert_eq!(login_once(&app, "u1", "10.0.0.1").await, StatusCode::OK);
+        assert_eq!(login_once(&app, "u2", "10.0.0.2").await, StatusCode::OK);
+
+        use tower::ServiceExt;
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/login")
+                    .header("X-Forwarded-For", "10.0.0.3")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"username":"u3","password":"x"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            resp.headers().contains_key("Retry-After"),
+            "backstop 429 must carry Retry-After"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_login_middleware_preserves_body_for_handler() {
+        // A valid login through the middleware must reach the handler with its
+        // body intact (the handler here echoes the parsed username back).
+        use axum::routing::post;
+        use tower::ServiceExt;
+        let state = LoginRateLimitState {
+            inner: RateLimitState {
+                limiter: Arc::new(RateLimiter::new(100, 60)),
+                exemptions: Arc::new(RateLimitExemptions::new(Vec::new(), false)),
+                enabled: true,
+            },
+            backstop: Arc::new(RateLimiter::new(10_000, 60)),
+        };
+        let app = axum::Router::new()
+            .route(
+                "/login",
+                post(|body: axum::body::Bytes| async move {
+                    let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+                    v.get("username").unwrap().as_str().unwrap().to_string()
+                }),
+            )
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                login_rate_limit_middleware,
+            ));
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/login")
+                    .header("X-Forwarded-For", "10.0.0.1")
+                    .header("content-type", "application/json")
+                    .body(axum::body::Body::from(
+                        r#"{"username":"carol","password":"secret"}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(
+            &bytes[..],
+            b"carol",
+            "handler must receive the original body"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_login_middleware_master_switch_bypasses() {
+        // With the master switch off (#1602), the login middleware must never
+        // 429 even past the per-key capacity.
+        use axum::routing::post;
+        let state = LoginRateLimitState {
+            inner: RateLimitState {
+                limiter: Arc::new(RateLimiter::new(1, 60)),
+                exemptions: Arc::new(RateLimitExemptions::new(Vec::new(), false)),
+                enabled: false,
+            },
+            backstop: Arc::new(RateLimiter::new(1, 60)),
+        };
+        let app = axum::Router::new()
+            .route("/login", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                login_rate_limit_middleware,
+            ));
+        for _ in 0..5 {
+            assert_eq!(login_once(&app, "x", "10.0.0.1").await, StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_login_middleware_username_exemption_bypasses() {
+        // A username on the exemption list bypasses the login limiter even
+        // when an AuthExtension was populated upstream.
+        use axum::routing::post;
+        let state = LoginRateLimitState {
+            inner: RateLimitState {
+                limiter: Arc::new(RateLimiter::new(1, 60)),
+                exemptions: Arc::new(RateLimitExemptions::new(vec!["ci-bot".into()], false)),
+                enabled: true,
+            },
+            backstop: Arc::new(RateLimiter::new(10_000, 60)),
+        };
+        let app = axum::Router::new()
+            .route("/login", post(|| async { "ok" }))
+            .layer(axum::middleware::from_fn_with_state(
+                state,
+                login_rate_limit_middleware,
+            ))
+            // Outer: inject an exempt principal (models optional auth resolving).
+            .layer(axum::middleware::from_fn(
+                |mut request: Request, next: Next| async move {
+                    request.extensions_mut().insert(AuthExtension {
+                        user_id: uuid::Uuid::new_v4(),
+                        username: "ci-bot".to_string(),
+                        email: "ci-bot@test".to_string(),
+                        is_admin: false,
+                        is_api_token: false,
+                        is_service_account: false,
+                        scopes: None,
+                        allowed_repo_ids: None,
+                    });
+                    next.run(request).await
+                },
+            ));
+        for _ in 0..5 {
+            assert_eq!(login_once(&app, "ci-bot", "10.0.0.1").await, StatusCode::OK);
+        }
     }
 }

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -22,8 +22,8 @@ use super::middleware::auth::{
 use super::middleware::demo::demo_guard;
 use super::middleware::guest_access::{guest_access_guard, GuestAccessState};
 use super::middleware::rate_limit::{
-    rate_limit_by_ip_middleware, rate_limit_middleware, RateLimitExemptions, RateLimitState,
-    RateLimiter,
+    login_rate_limit_middleware, rate_limit_by_ip_middleware, rate_limit_middleware,
+    LoginRateLimitState, RateLimitExemptions, RateLimitState, RateLimiter,
 };
 use super::middleware::setup::setup_guard;
 use super::middleware::tracing::correlation_id_middleware;
@@ -301,6 +301,16 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         state.config.rate_limit_presign_per_window,
         state.config.rate_limit_window_secs,
     ));
+    // Global shedding backstop for the login path. The login limiter keys
+    // per-(username, IP); this single-bucket backstop bounds the total login
+    // volume per window (and therefore the size of the per-key map) so a
+    // username-cycling attacker cannot exhaust memory via unbounded distinct
+    // keys. Sized far above any legitimate concurrent-login volume so real
+    // users never reach it; it sheds rather than starves.
+    let login_global_rate_limiter = Arc::new(RateLimiter::new(
+        state.config.rate_limit_login_global_per_window,
+        state.config.rate_limit_window_secs,
+    ));
     // Stricter per-user bucket for self-password-change attempts. The
     // handler bcrypt-verifies the current password, so an attacker who
     // already holds the victim's JWT can otherwise drive ~`api/min`
@@ -324,6 +334,17 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         limiter: Arc::clone(&auth_rate_limiter),
         exemptions: Arc::clone(&exemptions),
         enabled: rate_limit_enabled,
+    };
+    // Login-only state: keys the shared auth limiter per-(username, IP) and
+    // gates it behind the global shedding backstop. Applied only to /login so
+    // /logout and /refresh keep the plain IP-keyed limiter.
+    let login_rate_limit_state = LoginRateLimitState {
+        inner: RateLimitState {
+            limiter: Arc::clone(&auth_rate_limiter),
+            exemptions: Arc::clone(&exemptions),
+            enabled: rate_limit_enabled,
+        },
+        backstop: Arc::clone(&login_global_rate_limiter),
     };
     // Separate state for the unauthenticated TOTP second-factor endpoint
     // (`/auth/totp/verify`). Shares the `auth_rate_limiter` window so the
@@ -361,6 +382,7 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         let api_cleanup = Arc::clone(&api_rate_limiter);
         let search_cleanup = Arc::clone(&search_rate_limiter);
         let presign_cleanup = Arc::clone(&presign_rate_limiter);
+        let login_global_cleanup = Arc::clone(&login_global_rate_limiter);
         let password_change_cleanup = Arc::clone(&password_change_rate_limiter);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
@@ -370,6 +392,7 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 api_cleanup.cleanup_expired().await;
                 search_cleanup.cleanup_expired().await;
                 presign_cleanup.cleanup_expired().await;
+                login_global_cleanup.cleanup_expired().await;
                 password_change_cleanup.cleanup_expired().await;
             }
         });
@@ -393,7 +416,17 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         )
         // Setup status (public, no auth)
         .nest("/setup", handlers::auth::setup_router())
-        // Auth routes - split into public and protected (rate limited)
+        // Auth routes - split into login / public / protected (rate limited).
+        // /login carries the per-(username, IP) login limiter so a junk flood
+        // against one identity/origin cannot lock out other accounts; /logout
+        // and /refresh (no `username` field) keep the plain IP-keyed limiter.
+        .nest(
+            "/auth",
+            handlers::auth::login_router().layer(middleware::from_fn_with_state(
+                login_rate_limit_state,
+                login_rate_limit_middleware,
+            )),
+        )
         .nest(
             "/auth",
             handlers::auth::public_router().layer(middleware::from_fn_with_state(

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -380,6 +380,17 @@ pub struct Config {
     /// the storage backend the attacker can drive in parallel. See
     /// #1053. Env var: `RATE_LIMIT_PRESIGN_PER_MIN`. Default: 30.
     pub rate_limit_presign_per_window: u32,
+    /// Global backstop cap on unauthenticated login attempts per
+    /// `rate_limit_window_secs`, shared across ALL `(username, source-IP)`
+    /// keys. The login limiter partitions its budget per-`(username, ip)` so
+    /// a junk flood against one identity/origin cannot lock out other
+    /// accounts; this backstop bounds the total login volume (and therefore
+    /// the size of the per-key map) so a username-cycling attacker cannot
+    /// exhaust memory via unbounded distinct keys. Sized far above any
+    /// legitimate concurrent-login volume so real users never reach it; it
+    /// sheds rather than starves. Env var:
+    /// `RATE_LIMIT_LOGIN_GLOBAL_PER_WINDOW`. Default: 8192.
+    pub rate_limit_login_global_per_window: u32,
     /// Maximum self-password-change attempts per user per
     /// `rate_limit_password_change_window_secs`. Tighter than the global API
     /// bucket because `POST /users/:id/password` verifies the current
@@ -554,6 +565,7 @@ redacted_debug!(Config {
     show rate_limit_auth_per_window,
     show rate_limit_api_per_window,
     show rate_limit_search_per_window,
+    show rate_limit_login_global_per_window,
     show rate_limit_password_change_per_window,
     show rate_limit_password_change_window_secs,
     show rate_limit_window_secs,
@@ -646,6 +658,7 @@ impl Default for Config {
             rate_limit_api_per_window: 10000,
             rate_limit_search_per_window: 300,
             rate_limit_presign_per_window: 30,
+            rate_limit_login_global_per_window: 8192,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,
@@ -831,6 +844,10 @@ impl Config {
             rate_limit_api_per_window: env_parse("RATE_LIMIT_API_PER_MIN", 10000),
             rate_limit_search_per_window: env_parse("RATE_LIMIT_SEARCH_PER_MIN", 300),
             rate_limit_presign_per_window: env_parse("RATE_LIMIT_PRESIGN_PER_MIN", 30),
+            rate_limit_login_global_per_window: env_parse(
+                "RATE_LIMIT_LOGIN_GLOBAL_PER_WINDOW",
+                8192,
+            ),
             rate_limit_password_change_per_window: env_parse(
                 "RATE_LIMIT_PASSWORD_CHANGE_PER_WINDOW",
                 5,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -947,9 +947,18 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
 
     let http_shutdown_token = shutdown_token.clone();
     let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move { http_shutdown_token.cancelled().await })
-        .await?;
+    // Install `ConnectInfo<SocketAddr>` so the TCP peer address is available
+    // in request extensions. Without it, `extract_client_ip_addr` never sees
+    // a peer and the per-IP rate-limit key degenerates to the constant
+    // `ip:unknown` bucket for every unauthenticated request (direct-to-backend
+    // topology with no X-Forwarded-For), collapsing the login limiter into a
+    // single global counter that 429s every account at once.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move { http_shutdown_token.cancelled().await })
+    .await?;
 
     tracing::info!("HTTP server shut down");
 

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -2801,6 +2801,8 @@ mod tests {
             rate_limit_api_per_window: 5000,
             rate_limit_search_per_window: 300,
             rate_limit_presign_per_window: 30,
+
+            rate_limit_login_global_per_window: 8192,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -791,6 +791,8 @@ mod tests {
             rate_limit_api_per_window: 5000,
             rate_limit_search_per_window: 300,
             rate_limit_presign_per_window: 30,
+
+            rate_limit_login_global_per_window: 8192,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -798,6 +798,8 @@ mod tests {
             rate_limit_api_per_window: 5000,
             rate_limit_search_per_window: 300,
             rate_limit_presign_per_window: 30,
+
+            rate_limit_login_global_per_window: 8192,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,
@@ -897,6 +899,8 @@ mod tests {
             rate_limit_api_per_window: 5000,
             rate_limit_search_per_window: 300,
             rate_limit_presign_per_window: 30,
+
+            rate_limit_login_global_per_window: 8192,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,

--- a/backend/tests/composer_packages_index_tests.rs
+++ b/backend/tests/composer_packages_index_tests.rs
@@ -102,6 +102,7 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_presign_per_window: 30,
         rate_limit_password_change_per_window: 5,
         rate_limit_password_change_window_secs: 900,
+        rate_limit_login_global_per_window: 8192,
         rate_limit_window_secs: 60,
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -90,6 +90,7 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_presign_per_window: 30,
         rate_limit_password_change_per_window: 5,
         rate_limit_password_change_window_secs: 900,
+        rate_limit_login_global_per_window: 8192,
         rate_limit_window_secs: 60,
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,


### PR DESCRIPTION
## Summary

Make the login rate limiter per-identifier so a junk login flood cannot lock out every account at once.

Two coupled defects made the login limiter a single global counter:

1. The HTTP server was started with `axum::serve(listener, app)` and never called
   `.into_make_service_with_connect_info::<SocketAddr>()`, so `ConnectInfo<SocketAddr>`
   was never inserted into request extensions. With no `ConnectInfo` and no
   `X-Forwarded-For` (direct-to-backend topology), `extract_client_ip` falls back to the
   constant string `"ip:unknown"`. Every unauthenticated `POST /api/v1/auth/login`
   therefore keyed on one shared bucket, so once the auth window filled, the limiter
   returned `429` to *everyone* — including correct credentials.

2. Even with a real IP, the login path keyed only by IP, never by username, so a flood
   from one origin exhausted the budget for all users behind it and there was no
   per-account partitioning.

### What this PR changes

- **Wire `ConnectInfo` into the serve call** so the per-IP rate-limit key resolves the
  actual TCP peer instead of degenerating to `ip:unknown`. This makes all existing
  per-IP limiters (login, presign #1053, API) key on the real peer address — strictly
  more correct.
- **Add a login-only middleware** (`login_rate_limit_middleware`) that buffers the small
  login JSON, extracts `username`, and keys the existing auth limiter per-`(username,
  source-IP)`. A junk flood against one identity/origin now exhausts only its own bucket;
  correct logins by other users — or the same user from another IP — are unaffected,
  while per-account brute-force caps still hold.
- **Split the public auth router** so only `/login` gets the new middleware. `/logout`
  and `/refresh` (which carry no `username` field) keep the unchanged IP-keyed
  `rate_limit_middleware`. The `/auth/totp/verify` router is untouched.
- **Global shedding backstop** (`rate_limit_login_global_per_window`, default `8192`,
  env `RATE_LIMIT_LOGIN_GLOBAL_PER_WINDOW`): a single-bucket cap, sized far above any
  legitimate concurrent-login volume, that bounds total login volume (and the size of the
  per-key map) so a username-cycling attacker cannot exhaust memory via unbounded
  distinct keys. It sheds rather than starves. Registered in the existing
  `cleanup_expired` reaper so its map stays bounded.
- Username/service-account exemptions, trusted-CIDR exemptions (#969), and the master
  off-switch (#1602) apply on the login path exactly as before. The shared exemption /
  response-header logic was factored into small helpers reused by all three rate-limit
  middlewares (no behavior change to the existing two).

The login key uses the username verbatim (login is case-sensitive at the auth layer:
`WHERE username = $1`, no `LOWER`/`ILIKE`), so the rate-limit key matches the auth
identity 1:1. No data migration. The login handler still receives the full unmodified
request body (buffered and re-attached with headers preserved).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New tests in `backend/src/api/middleware/rate_limit.rs`:
- `test_login_flood_on_one_identity_does_not_lock_out_others` — proves the finding's exact
  claim: a flood on `(user=x, ip=A)` 429s, while `(user=y, ip=B)`, `(user=y, ip=A)`, and
  `(user=x, ip=B)` stay non-429.
- `test_login_global_backstop_sheds_with_retry_after` — the backstop trips after its cap
  and returns `429` + `Retry-After`.
- `test_login_middleware_preserves_body_for_handler` — a valid login through the middleware
  reaches the handler with its body intact.
- `test_login_middleware_master_switch_bypasses` / `test_login_middleware_username_exemption_bypasses`
  — exemptions and the master off-switch bypass the login middleware identically to the
  IP-keyed middleware.
- `test_login_rate_limit_key_partitions_by_user_and_ip` / `_is_case_sensitive` — the pure
  key-builder partitions correctly and is case-sensitive.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance: a 130-request junk flood for username `x`
trips only `x`'s bucket while `admin` / `victor.user` / `sam.dev` correct credentials all
return `200`; a 6-worker 15s username-cycling flood with a concurrent correct login by an
untouched user returns `200` throughout (20/20); flooding `admin` with wrong passwords
429s `admin` (per-account brute-force cap holds) while a different user on the same origin
stays `200`; a single normal login returns `200` with `X-RateLimit-*` headers; `/logout`,
`/refresh`, and `/health` are unchanged. Full `cargo test --workspace --lib` passes
(11699 tests); `cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Fixes #1994