### PR TITLE
docs(lifecycle): clarify tag_pattern_keep is a deletion policy, not protection

### DIFF
--- a/backend/src/services/lifecycle_service.rs
+++ b/backend/src/services/lifecycle_service.rs
@@ -4,7 +4,16 @@
 //! - max_age_days: delete artifacts older than N days
 //! - max_versions: keep only the last N versions per package
 //! - no_downloads_days: delete artifacts not downloaded in N days
-//! - tag_pattern_keep: keep artifacts matching a regex pattern
+//! - tag_pattern_keep: delete artifacts whose name does NOT match a regex
+//!   pattern (the SQL inverse of `tag_pattern_delete`). Despite the "keep"
+//!   name this is a *deletion* policy, NOT a protection rule: it does not
+//!   mark matching artifacts as protected and does not stop other lifecycle
+//!   policies from deleting artifacts it preserved. Each policy emits an
+//!   independent `UPDATE artifacts SET is_deleted = true` with no shared
+//!   notion of "protected", so pairing `tag_pattern_keep` with a
+//!   `tag_pattern_delete` (or any other deletion policy) on the same
+//!   repository can still empty the repository. The wire string stays
+//!   `tag_pattern_keep` for backward compatibility. See issue #1905.
 //! - tag_pattern_delete: delete artifacts matching a regex pattern
 //! - size_quota_bytes: enforce per-repo storage quotas
 
@@ -130,6 +139,11 @@ pub(crate) enum PolicyType {
     MaxAgeDays,
     MaxVersions,
     NoDownloadsDays,
+    /// Deletes artifacts whose name does NOT match the configured regex (the
+    /// inverse of `TagPatternDelete`). The "keep" in the wire name refers to
+    /// which artifacts survive *this* policy's pass; it is NOT a protection
+    /// rule and does not shield matching artifacts from other deletion
+    /// policies. See the module-level docs and issue #1905.
     TagPatternKeep,
     TagPatternDelete,
     SizeQuotaBytes,
@@ -1051,7 +1065,10 @@ impl LifecycleService {
 
         let repo_filter = policy.repository_id;
 
-        // Inverse of tag_pattern_delete: find artifacts that do NOT match the pattern
+        // Inverse of tag_pattern_delete: find artifacts that do NOT match the
+        // pattern and soft-delete them. NOTE: this is a deletion pass, not a
+        // protection mark — artifacts matching the pattern survive only this
+        // policy and remain deletable by other lifecycle policies (#1905).
         let matched = sqlx::query_as::<_, CountBytes>(
             r#"
             SELECT COUNT(*) as count, COALESCE(SUM(a.size_bytes), 0)::BIGINT as bytes


### PR DESCRIPTION
## Summary

`tag_pattern_keep` is named in a way that implies it protects matching artifacts from deletion. In reality it is the SQL inverse of `tag_pattern_delete`: it soft-deletes artifacts whose name does **not** match the configured regex, and provides no protection against other lifecycle policies. Each policy emits an independent `UPDATE artifacts SET is_deleted = true` with no shared notion of "protected", so combining `tag_pattern_keep` with another deletion policy (e.g. `tag_pattern_delete = .*`) can still silently empty a repository — the "keep + delete the rest" migration mental model is a footgun.

This change clarifies the misleading semantics without altering behavior or the wire format:

- Rewrites the module-level doc bullet for `tag_pattern_keep` to state it is a deletion policy, not a protection rule, and that coexisting deletion policies will still delete artifacts it preserved.
- Adds a doc-comment to the `PolicyType::TagPatternKeep` variant explaining the inverted "keep" meaning.
- Strengthens the inline comment in `execute_tag_pattern_keep`.

The wire string `tag_pattern_keep` is **kept unchanged** for backward compatibility (it is the serialized `policy_type` value and config key). This is the documentation/clarity scope of #1905. The actual sole-tag deletion protection is tracked separately in #1682; the broader cross-policy protection set (Option 2/3 in the issue) is a larger behavioral change left out of this minimal fix.

## Regression test (required for `fix/*` PRs)
- [x] N/A — documentation/comment-only change, no behavioral change

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] No regressions in existing tests (`cargo check -p artifact-keeper-backend` passes)

## API Changes
- [x] N/A - no API changes

Fixes #1905