### PR TITLE
security: escape apostrophe in pypi html_escape helper

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,26 @@ cargo test --workspace --lib
 - Add tests for new functionality
 - Update documentation if your change affects user-facing behavior
 
+### Offloading CPU-bound work with `spawn_blocking`
+
+Request handlers run on the shared Tokio runtime workers. A long
+synchronous computation on a worker stalls every other task scheduled on
+that thread, so CPU-bound work over caller-controlled input must be moved
+off the async path with `tokio::task::spawn_blocking`.
+
+Wrap a parse/compute step in `spawn_blocking` when **both** are true:
+
+- it is synchronous and CPU-bound (regex scans, XML/JSON deserialization,
+  archive extraction, hashing, key generation), and
+- the input size is attacker- or client-controlled and can exceed ~1 MiB
+  (proxied upstream index/metadata bodies, uploaded manifests, SBOMs).
+
+Pair the offload with an explicit size cap and reject oversized bodies
+before parsing, as the PEP 503 simple-index proxy does
+(`api/handlers/pypi.rs`: `MAX_SIMPLE_ROOT_BODY_BYTES` + `spawn_blocking`).
+Small, bounded inputs (a single coordinate string, a short header) do not
+need offloading.
+
 ## Regression-test contract for bug fixes
 
 Every PR that fixes a bug must land with a regression test that fails on

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2010,6 +2010,9 @@ fn html_escape(s: &str) -> String {
         .replace('<', "&lt;")
         .replace('>', "&gt;")
         .replace('"', "&quot;")
+        // Escape the apostrophe so the helper is safe in single-quoted
+        // attribute contexts too, matching html_escape_pep503 in formats/pypi.rs.
+        .replace('\'', "&#39;")
 }
 
 // ---------------------------------------------------------------------------
@@ -2397,6 +2400,15 @@ mod tests {
     #[test]
     fn test_html_escape_quotes() {
         assert_eq!(html_escape("a \"b\" c"), "a &quot;b&quot; c");
+    }
+
+    #[test]
+    fn test_html_escape_apostrophe() {
+        assert_eq!(html_escape("O'Reilly"), "O&#39;Reilly");
+        assert_eq!(
+            html_escape("' onload='alert(1)"),
+            "&#39; onload=&#39;alert(1)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Round 2 follow-up to #1391.

The PyPI simple-index `html_escape` helper in `backend/src/api/handlers/pypi.rs`
escaped `&`, `<`, `>`, and `"` but not the apostrophe (`'`). The helper is
named generically and used to escape values rendered into HTML attributes.
In a single-quoted attribute context an unescaped `'` permits attribute
breakout, so the helper was not safe for that use even though current call
sites are protected upstream (normalize_pep503 strips it) and by CSP. This
adds `&#39;`, bringing it in line with `html_escape_pep503` in
`formats/pypi.rs`, which already escapes the apostrophe.

I also audited the handler-thread parse paths called out in the issue (SBOM
CycloneDX/SPDX, Maven `maven-metadata.xml`, RPM `repomd`). The PEP 503
simple-index proxy already caps the body (`MAX_SIMPLE_ROOT_BODY_BYTES`) and
runs its regex pass under `spawn_blocking` (#1377/#1391); the RPM repomd path
generates XML or streams proxied bytes rather than parsing inline. Rather than
speculatively wrap many parse sites without measured evidence, I documented the
rule in CONTRIBUTING so future parse paths over size-capped, client-controlled
input consistently offload to `spawn_blocking`.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_html_escape_apostrophe` asserts `'` becomes `&#39;`; it fails on `main`
and passes here.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Fixes #1418
