### PR TITLE
refactor(storage): extract shared oci-manifests/ storage key prefix const

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -36,6 +36,7 @@ use crate::api::SharedState;
 use crate::error::AppError;
 use crate::models::repository::RepositoryType;
 use crate::services::auth_service::AuthService;
+use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
 
 // ---------------------------------------------------------------------------
 // OCI error helpers
@@ -482,16 +483,18 @@ fn blob_storage_key(digest: &str) -> String {
     format!("oci-blobs/{}", digest)
 }
 
-/// Storage key prefix for OCI manifest objects.
+/// Storage key for an OCI manifest object: [`OCI_MANIFEST_STORAGE_PREFIX`]
+/// followed by the manifest digest. This is the source of truth on writes.
 ///
-/// WARNING: the `oci-manifests/` prefix is also hard-coded in the
-/// lifecycle cascade SQL (`backend/src/services/lifecycle_service.rs`,
+/// WARNING: the `oci-manifests/` prefix is also embedded as a SQL literal in
+/// the lifecycle cascade (`backend/src/services/lifecycle_service.rs`,
 /// `CASCADE_OCI_TAGS_SQL`) and in the storage GC orphan predicate
-/// (`backend/src/services/storage_gc_service.rs`). Changing this
-/// function alone will silently break both. Tracked in #1413 for
-/// extracting a shared constant.
+/// (`backend/src/services/storage_gc_service.rs`, `ORPHAN_PREDICATE_SQL`).
+/// Postgres cannot read the Rust constant, so those sites pin the literal to
+/// [`OCI_MANIFEST_STORAGE_PREFIX`] with compile-time assertions; changing the
+/// constant forces those assertions (and the SQL) to be updated in lockstep.
 fn manifest_storage_key(digest: &str) -> String {
-    format!("oci-manifests/{}", digest)
+    format!("{}{}", OCI_MANIFEST_STORAGE_PREFIX, digest)
 }
 
 fn upload_storage_key(uuid: &Uuid) -> String {

--- a/backend/src/services/lifecycle_service.rs
+++ b/backend/src/services/lifecycle_service.rs
@@ -17,6 +17,7 @@ use uuid::Uuid;
 
 use crate::error::{AppError, Result};
 use crate::services::scheduler_service::normalize_cron_expression;
+use crate::storage::keys::prefix_matches;
 
 /// Delete `oci_tags` rows whose matching manifest artifact is soft-deleted.
 ///
@@ -44,12 +45,15 @@ use crate::services::scheduler_service::normalize_cron_expression;
 ///
 /// `artifacts.storage_key` is still asserted to equal
 /// `'oci-manifests/' || ot.manifest_digest` as a defence-in-depth
-/// constraint. Note: this couples the cascade to the
-/// `manifest_storage_key()` invariant in `oci_v2.rs:414`. If anyone ever
-/// changes that prefix the cascade silently no-ops; #1413 tracks
-/// extracting a shared constant. The path-based predicate is the primary
-/// join key, the storage_key predicate is a secondary integrity check
-/// that protects against artifact-name/path drift.
+/// constraint. The `'oci-manifests/'` literal below is the SQL embedding of
+/// [`OCI_MANIFEST_STORAGE_PREFIX`](crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX), the same prefix
+/// `manifest_storage_key()` (`oci_v2.rs`) produces on writes and the storage
+/// GC orphan predicate (`storage_gc_service.rs`, `ORPHAN_PREDICATE_SQL`)
+/// matches on. Postgres cannot read the Rust constant, so the literal is
+/// pinned to it by the `const _: () = assert!(...)` below: changing the
+/// constant breaks the build until this SQL is updated to match (#1413). The
+/// path-based predicate is the primary join key; the storage_key predicate is
+/// a secondary integrity check that protects against artifact-name/path drift.
 const CASCADE_OCI_TAGS_SQL: &str = r#"
 DELETE FROM oci_tags ot
 USING artifacts a
@@ -60,6 +64,12 @@ WHERE a.is_deleted = true
   AND a.version = ot.tag
   AND ($1::UUID IS NULL OR a.repository_id = $1)
 "#;
+
+/// Compile-time guard: the `'oci-manifests/'` literal embedded in
+/// [`CASCADE_OCI_TAGS_SQL`] must match [`OCI_MANIFEST_STORAGE_PREFIX`](crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX).
+/// Postgres cannot reference the Rust constant directly, so this keeps the
+/// SQL literal and the write-path constant from drifting (#1413).
+const _: () = assert!(prefix_matches("oci-manifests/"));
 
 /// Scope of a lifecycle policy execution: either a specific repository or
 /// every repository in the cluster (a "global" policy with `repository_id`

--- a/backend/src/services/manifest_blob_refs_backfill.rs
+++ b/backend/src/services/manifest_blob_refs_backfill.rs
@@ -42,6 +42,7 @@ use std::sync::Arc;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
+use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
 use crate::storage::{StorageLocation, StorageRegistry};
 
 /// Result of a backfill pass. Returned for tracing and tests.
@@ -163,7 +164,7 @@ impl BackfillCandidate {
     /// pinned by a unit test rather than only exercised by Tier-2 storage
     /// reads.
     fn storage_key(&self) -> String {
-        format!("oci-manifests/{}", self.manifest_digest)
+        format!("{}{}", OCI_MANIFEST_STORAGE_PREFIX, self.manifest_digest)
     }
 
     /// The [`StorageLocation`] used to resolve this candidate's backend.

--- a/backend/src/services/oci_manifest_refs_backfill.rs
+++ b/backend/src/services/oci_manifest_refs_backfill.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use sqlx::{PgPool, Row};
 use uuid::Uuid;
 
+use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
 use crate::storage::{StorageLocation, StorageRegistry};
 
 /// Result of a backfill pass. Returned for tracing and tests.
@@ -174,7 +175,7 @@ async fn process_candidate(
         .backend_for(&location)
         .map_err(|e| format!("resolve storage backend: {}", e))?;
 
-    let storage_key = format!("oci-manifests/{}", candidate.parent_digest);
+    let storage_key = format!("{}{}", OCI_MANIFEST_STORAGE_PREFIX, candidate.parent_digest);
     let body = storage
         .get(&storage_key)
         .await

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -11,6 +11,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::error::{AppError, Result};
+use crate::storage::keys::prefix_matches;
 use crate::storage::{StorageBackend, StorageLocation, StorageRegistry};
 
 const ABANDONED_OCI_UPLOAD_TTL_SQL: &str = "INTERVAL '24 hours'";
@@ -38,6 +39,13 @@ const OCI_UPLOAD_CLEANUP_KEY_SCAN_LIMIT: i64 = 1000;
 /// two predicates is what makes a TOCTOU window real in the first place
 /// (#1180); keeping them literally identical is the cheap structural
 /// guarantee that they stay aligned.
+///
+/// The `'oci-manifests/'` literals below are the SQL embedding of
+/// [`OCI_MANIFEST_STORAGE_PREFIX`](crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX) — the same prefix `manifest_storage_key()`
+/// (`oci_v2.rs`) produces on writes and the lifecycle cascade
+/// (`lifecycle_service.rs`, `CASCADE_OCI_TAGS_SQL`) matches on. Postgres
+/// cannot read the Rust constant, so the literal is pinned to it by the
+/// `const _: () = assert!(...)` after this constant (#1413).
 const ORPHAN_PREDICATE_SQL: &str = r#"
 a.is_deleted = true
 AND NOT EXISTS (
@@ -90,6 +98,13 @@ AND NOT EXISTS (
       )
 )
 "#;
+
+/// Compile-time guard: the `'oci-manifests/'` literals embedded in
+/// [`ORPHAN_PREDICATE_SQL`] (both the `LIKE` filter and the `SUBSTRING`
+/// offset) must match [`OCI_MANIFEST_STORAGE_PREFIX`](crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX). Postgres cannot
+/// reference the Rust constant directly, so this keeps the SQL literal and
+/// the write-path constant from drifting (#1413).
+const _: () = assert!(prefix_matches("oci-manifests/"));
 
 /// Minimum age (seconds) a blob must reach before [`StorageGcService::run_blob_gc`]
 /// will consider it for deletion (#1408).

--- a/backend/src/storage/keys.rs
+++ b/backend/src/storage/keys.rs
@@ -1,0 +1,64 @@
+//! Shared storage-key prefixes.
+//!
+//! OCI objects are stored under fixed key prefixes that are referenced from
+//! several independent sites: the write path that produces the keys, the
+//! lifecycle cascade SQL, and the storage GC orphan predicate. The Rust
+//! sites build keys with these constants; the SQL sites still have to embed
+//! the literal (Postgres cannot read Rust constants) but pin themselves to
+//! the constant with compile-time assertions so the two can never drift.
+
+/// Storage-key prefix for OCI image manifest objects: `oci-manifests/`.
+///
+/// Single source of truth for the manifest key shape. Consumed by:
+/// - `crate::api::handlers::oci_v2::manifest_storage_key` (the write path)
+/// - `crate::services::lifecycle_service::CASCADE_OCI_TAGS_SQL`
+/// - `crate::services::storage_gc_service::ORPHAN_PREDICATE_SQL`
+///
+/// The SQL sites embed the literal `'oci-manifests/'`; they assert at
+/// compile time (via [`prefix_matches`]) that the literal matches this
+/// constant. If you change this value, those assertions force you to update
+/// the SQL too.
+pub const OCI_MANIFEST_STORAGE_PREFIX: &str = "oci-manifests/";
+
+/// Const-evaluable equality check between [`OCI_MANIFEST_STORAGE_PREFIX`] and
+/// the bare prefix a SQL literal embeds (e.g. `"oci-manifests/"` extracted
+/// from `'oci-manifests/'`).
+///
+/// `&str` equality is not usable in `const` context on the supported
+/// toolchain, so the SQL-pinning `const _: () = assert!(...)` guards call
+/// this instead. It exists purely so those guards stay one-liners.
+pub const fn prefix_matches(literal: &str) -> bool {
+    let a = OCI_MANIFEST_STORAGE_PREFIX.as_bytes();
+    let b = literal.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_matches_is_exact() {
+        assert!(prefix_matches("oci-manifests/"));
+        assert!(!prefix_matches("oci-manifests"));
+        assert!(!prefix_matches("oci-blobs/"));
+        assert!(!prefix_matches("oci-manifests/x"));
+    }
+
+    #[test]
+    fn prefix_constant_is_stable() {
+        // The SQL literals in the lifecycle cascade and storage GC orphan
+        // predicate hard-code this exact value; keep them in sync.
+        assert_eq!(OCI_MANIFEST_STORAGE_PREFIX, "oci-manifests/");
+    }
+}

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -3,6 +3,7 @@
 pub mod azure;
 pub mod filesystem;
 pub mod gcs;
+pub mod keys;
 pub mod path_format;
 pub mod registry;
 pub mod s3;


### PR DESCRIPTION
## Summary

The `oci-manifests/` storage-key prefix was hard-coded in several independent
places: the write path (`manifest_storage_key` in `oci_v2.rs`), the lifecycle
cascade SQL (`CASCADE_OCI_TAGS_SQL`), the storage GC orphan predicate
(`ORPHAN_PREDICATE_SQL`), and two backfill services. Changing it in one place
silently broke the others — lifecycle would soft-delete manifests that storage
GC could never reclaim (the exact coupling flagged in PR #1406 review).

This change introduces a single source of truth:

- New `storage::keys` module with `pub const OCI_MANIFEST_STORAGE_PREFIX: &str = "oci-manifests/"`.
- All Rust call sites that build manifest keys now derive them from the constant.
- The SQL sites must still embed the literal (Postgres cannot read Rust
  constants), so each is pinned to the constant with a
  `const _: () = assert!(prefix_matches("oci-manifests/"))` compile-time guard
  and cross-referencing doc comments. If the constant ever changes, the build
  fails until the SQL literals are updated to match.

Pure mechanical refactor — no behavioral change. The follow-up FK migration
suggested in the issue is intentionally left out of scope.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated (`storage::keys` tests for `prefix_matches` and constant stability)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo check`, `cargo clippy --lib`, `cargo fmt --check`, targeted unit tests)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Fixes #1413