### PR TITLE
fix(auth): stop LDAP env bootstrap from duplicating an existing provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -257,9 +257,14 @@ JWT_EXPIRATION_SECS=86400
 
 # --- LDAP (optional) ---
 # When LDAP_URL and LDAP_BASE_DN are set, the backend seeds an enabled LDAP
-# provider into the database on first boot so it appears in the SSO list,
-# the same way OIDC_* is bootstrapped. After first boot the database is the
-# source of truth: edit the provider in the admin UI rather than via env vars.
+# provider into the database so it appears in the SSO list, the same way OIDC_*
+# is bootstrapped. The env-managed provider (named by LDAP_NAME, default
+# "default") is reconciled on every boot, so changing LDAP_* and redeploying
+# takes effect. If a provider with that name does not exist but other LDAP
+# providers do (e.g. one created in the admin UI), bootstrap skips creation and
+# logs a warning instead of adding a duplicate -- set LDAP_NAME to the existing
+# provider's name to let env vars manage it.
+# LDAP_NAME=default
 # LDAP_URL=ldap://ldap.example.com:389
 # LDAP_BASE_DN=dc=example,dc=com
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1130,10 +1130,13 @@ async fn init_peer_identity(db: &sqlx::PgPool, config: &Config) -> Result<uuid::
     Ok(id)
 }
 
-/// Bootstrap an OIDC provider from environment variables when the database
-/// has no OIDC configs yet.  This lets operators configure OIDC entirely via
-/// env vars (OIDC_ISSUER, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, etc.) without
-/// needing admin API access first.
+/// Bootstrap an OIDC provider from environment variables.  This lets operators
+/// configure OIDC entirely via env vars (OIDC_ISSUER, OIDC_CLIENT_ID,
+/// OIDC_CLIENT_SECRET, etc.) without needing admin API access first.
+///
+/// The provider named by OIDC_NAME (default `default`) is reconciled on every
+/// boot. If providers already exist but none carries that name, bootstrap skips
+/// creation and warns rather than duplicating a pre-existing provider.
 async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
     use artifact_keeper_backend::services::auth_config_service::{
         plan_provider_reconcile, AuthConfigService, ReconcileAction,
@@ -1167,6 +1170,17 @@ async fn bootstrap_oidc_from_env(db: &sqlx::PgPool) -> Result<()> {
                 "Reconciled env-managed OIDC provider '{}' (id={}) from environment variables",
                 name,
                 cfg.id
+            );
+        }
+        ReconcileAction::Skip(existing_name) => {
+            tracing::warn!(
+                "OIDC_* env set but an OIDC provider ('{}') already exists and none is named \
+                 '{}'; env bootstrap skipped to avoid creating a duplicate. Set OIDC_NAME to the \
+                 existing provider's name (or rename it to '{}') to let env vars manage it, or \
+                 unset OIDC_*.",
+                existing_name,
+                req.name,
+                req.name
             );
         }
     }
@@ -1255,10 +1269,14 @@ fn build_oidc_request_from_values(
     })
 }
 
-/// Bootstrap an LDAP provider from environment variables when the database
-/// has no LDAP configs yet.  This lets operators configure LDAP entirely via
-/// env vars (LDAP_URL, LDAP_BASE_DN, LDAP_BIND_DN, etc.) without needing admin
-/// API access first.  Mirrors `bootstrap_oidc_from_env` (fixes #1434).
+/// Bootstrap an LDAP provider from environment variables.  This lets operators
+/// configure LDAP entirely via env vars (LDAP_URL, LDAP_BASE_DN, LDAP_BIND_DN,
+/// etc.) without needing admin API access first.  Mirrors
+/// `bootstrap_oidc_from_env` (fixes #1434).
+///
+/// The provider named by LDAP_NAME (default `default`) is reconciled on every
+/// boot. If providers already exist but none carries that name, bootstrap skips
+/// creation and warns rather than duplicating a pre-existing provider (#1887).
 async fn bootstrap_ldap_from_env(db: &sqlx::PgPool) -> Result<()> {
     use artifact_keeper_backend::services::auth_config_service::{
         plan_provider_reconcile, AuthConfigService, ReconcileAction,
@@ -1294,6 +1312,17 @@ async fn bootstrap_ldap_from_env(db: &sqlx::PgPool) -> Result<()> {
                 cfg.id
             );
         }
+        ReconcileAction::Skip(existing_name) => {
+            tracing::warn!(
+                "LDAP_* env set but an LDAP provider ('{}') already exists and none is named \
+                 '{}'; env bootstrap skipped to avoid creating a duplicate. Set LDAP_NAME to the \
+                 existing provider's name (or rename it to '{}') to let env vars manage it, or \
+                 unset LDAP_*.",
+                existing_name,
+                req.name,
+                req.name
+            );
+        }
     }
 
     Ok(())
@@ -1302,6 +1331,7 @@ async fn bootstrap_ldap_from_env(db: &sqlx::PgPool) -> Result<()> {
 /// Raw LDAP environment variable values for bootstrap.
 #[derive(Default)]
 struct LdapEnvVars {
+    name: Option<String>,
     url: Option<String>,
     base_dn: Option<String>,
     bind_dn: Option<String>,
@@ -1322,6 +1352,7 @@ struct LdapEnvVars {
 fn build_ldap_bootstrap_request(
 ) -> Option<artifact_keeper_backend::services::auth_config_service::CreateLdapConfigRequest> {
     build_ldap_request_from_values(LdapEnvVars {
+        name: std::env::var("LDAP_NAME").ok(),
         url: std::env::var("LDAP_URL").ok(),
         base_dn: std::env::var("LDAP_BASE_DN").ok(),
         bind_dn: std::env::var("LDAP_BIND_DN").ok(),
@@ -1349,13 +1380,18 @@ fn build_ldap_request_from_values(
     let server_url = env.url.filter(|v| !v.is_empty())?;
     let user_base_dn = env.base_dn.filter(|v| !v.is_empty())?;
 
+    let name = env
+        .name
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| "default".to_string());
+
     let use_starttls = env
         .use_starttls
         .map(|v| v == "true" || v == "1")
         .unwrap_or(false);
 
     Some(CreateLdapConfigRequest {
-        name: "default".to_string(),
+        name,
         server_url,
         bind_dn: env.bind_dn.filter(|v| !v.is_empty()),
         bind_password: env.bind_password.filter(|v| !v.is_empty()),
@@ -2259,6 +2295,32 @@ mod tests {
     }
 
     #[test]
+    fn test_ldap_bootstrap_request_name_override() {
+        // LDAP_NAME lets operators point the env-managed provider at an
+        // existing one, mirroring OIDC_NAME (#1887).
+        let req = build_ldap_request_from_values(LdapEnvVars {
+            name: Some("Corporate AD".to_string()),
+            url: Some("ldap://dc.local:389".to_string()),
+            base_dn: Some("DC=domain,DC=local".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(req.name, "Corporate AD");
+    }
+
+    #[test]
+    fn test_ldap_bootstrap_request_empty_name_defaults() {
+        let req = build_ldap_request_from_values(LdapEnvVars {
+            name: Some("".to_string()),
+            url: Some("ldap://dc.local:389".to_string()),
+            base_dn: Some("DC=domain,DC=local".to_string()),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(req.name, "default");
+    }
+
+    #[test]
     fn test_ldap_bootstrap_request_missing_url() {
         let req = build_ldap_request_from_values(ldap_env(None, Some("DC=domain,DC=local")));
         assert!(req.is_none());
@@ -2286,6 +2348,7 @@ mod tests {
     fn test_ldap_bootstrap_request_full_active_directory_config() {
         // Mirrors the Active Directory example from issue #1434.
         let req = build_ldap_request_from_values(LdapEnvVars {
+            name: None,
             url: Some("ldap://dc.local:389".to_string()),
             base_dn: Some("DC=domain,DC=local".to_string()),
             bind_dn: Some("user@domain".to_string()),

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -1605,15 +1605,31 @@ impl AuthConfigService {
 /// Outcome of reconciling an env-managed provider against the DB on boot.
 #[derive(Debug, PartialEq, Eq)]
 pub enum ReconcileAction {
+    /// No providers exist yet: seed the env-managed provider.
     Create,
+    /// A provider with the env-managed name exists: reconcile it in place.
     Update(Uuid),
+    /// Providers exist but none matches the env-managed name: do nothing and
+    /// warn, so a pre-existing (e.g. UI-created) provider is not duplicated.
+    /// Carries the name of an existing provider for the warning message.
+    Skip(String),
 }
 
-/// Select the env-managed provider by name; UI-created providers with other
-/// names are ignored.
+/// Decide how to reconcile the env-managed provider against existing providers.
+///
+/// - If a provider with `desired_name` exists, update it (env stays in control
+///   of that provider). UI-created providers with other names are untouched.
+/// - If no providers exist at all, create the env-managed provider.
+/// - If other providers exist but none is named `desired_name`, skip creation
+///   to avoid duplicating a provider an operator already configured (e.g. via
+///   the admin UI). Restores the "seed only when empty" guarantee from #1486
+///   while keeping #1656's reconcile-on-update for the env-managed provider.
 pub fn plan_provider_reconcile(desired_name: &str, existing: &[(Uuid, String)]) -> ReconcileAction {
-    match existing.iter().find(|(_, name)| name == desired_name) {
-        Some((id, _)) => ReconcileAction::Update(*id),
+    if let Some((id, _)) = existing.iter().find(|(_, name)| name == desired_name) {
+        return ReconcileAction::Update(*id);
+    }
+    match existing.first() {
+        Some((_, name)) => ReconcileAction::Skip(name.clone()),
         None => ReconcileAction::Create,
     }
 }
@@ -2444,12 +2460,30 @@ mod tests {
     }
 
     #[test]
-    fn test_plan_reconcile_create_ignores_other_named_providers() {
+    fn test_plan_reconcile_skip_when_only_other_named_providers() {
+        // A provider exists (e.g. created via the admin UI) but none is named
+        // `default`: bootstrap must skip rather than create a duplicate (#1887).
         let other = Uuid::new_v4();
         let existing = vec![(other, "Corporate SSO".to_string())];
         assert_eq!(
             plan_provider_reconcile("default", &existing),
-            ReconcileAction::Create
+            ReconcileAction::Skip("Corporate SSO".to_string())
+        );
+    }
+
+    #[test]
+    fn test_plan_reconcile_update_when_name_matches_among_others() {
+        // The env-managed provider is still reconciled even when other
+        // providers coexist.
+        let other = Uuid::new_v4();
+        let target = Uuid::new_v4();
+        let existing = vec![
+            (other, "Corporate SSO".to_string()),
+            (target, "default".to_string()),
+        ];
+        assert_eq!(
+            plan_provider_reconcile("default", &existing),
+            ReconcileAction::Update(target)
         );
     }
 


### PR DESCRIPTION
## Summary

Env-var LDAP bootstrap was matching the env-managed provider **by name only** and creating a new `default` provider whenever none existed. A deployment that has `LDAP_*` env vars set **and** an LDAP provider created earlier via the admin UI therefore got a second `default` provider, recreated on every boot (the login page shows two buttons for the same directory).

This restores the "seed only when the table is empty" guarantee that #1486 promised and #1661 inadvertently dropped, while keeping #1656's reconcile-on-update behavior:

- `plan_provider_reconcile` gains a `Skip(existing_name)` outcome. It now:
  - **Update** the provider whose name matches the env-managed name (unchanged).
  - **Create** only when no providers exist at all.
  - **Skip** (and warn) when providers exist but none matches the env-managed name, so a pre-existing UI-created provider is never duplicated.
- Both `bootstrap_ldap_from_env` and `bootstrap_oidc_from_env` handle the new `Skip` arm with an actionable warning (rename the provider / set `*_NAME` / unset env).
- Add `LDAP_NAME` for parity with `OIDC_NAME` (#1397) so operators can point the env-managed provider at an existing one.
- Refresh the stale doc comments in `main.rs` and the `.env.example` LDAP section, which still described first-boot-only seeding.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The previous `test_plan_reconcile_create_ignores_other_named_providers` asserted the buggy behavior (Create when only other-named providers exist). It is replaced by `test_plan_reconcile_skip_when_only_other_named_providers` (asserts Skip) plus `test_plan_reconcile_update_when_name_matches_among_others`, and `LDAP_NAME` is covered by `test_ldap_bootstrap_request_name_override` / `_empty_name_defaults`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (cargo check + targeted unit tests pass)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Fixes #1887