### PR TITLE
fix(lifecycle): retain the sole oci_tags row protecting a live image

### DIFF
--- a/backend/src/services/lifecycle_service.rs
+++ b/backend/src/services/lifecycle_service.rs
@@ -50,6 +50,34 @@ use crate::services::scheduler_service::normalize_cron_expression;
 /// extracting a shared constant. The path-based predicate is the primary
 /// join key, the storage_key predicate is a secondary integrity check
 /// that protects against artifact-name/path drift.
+///
+/// **Last-protecting-tag guard (#1682).** A retention sweep is not an
+/// explicit user delete: it must never be the thing that orphans a live
+/// image. The storage GC orphan predicate
+/// (`storage_gc_service.rs` `ORPHAN_PREDICATE_SQL`) treats a manifest as
+/// reachable while *any* `oci_tags` row carries its `manifest_digest`. So
+/// if the cascade deletes the *last* `oci_tags` row protecting a
+/// `(repository_id, manifest_digest)`, the manifest flips into the GC
+/// orphan set and its blobs are reclaimed — silent data loss.
+///
+/// The guard therefore prunes an `oci_tags` row only when a **surviving
+/// sibling** row keeps the same `(repository_id, manifest_digest)`
+/// reachable after this sweep — i.e. another `oci_tags` row for the same
+/// repo+digest, with a different `id`, that is NOT itself being pruned
+/// (its backing manifest artifact is not soft-deleted under the same
+/// join shape). The inner `NOT EXISTS` must be self-aware: the sole-tag
+/// bug is just the `N=1` case of "all protecting tags pruned at once", so
+/// a naive any-other-row check would let two doomed tags for one digest
+/// each treat the other as a protector and delete both, re-orphaning the
+/// image. With the surviving-sibling guard, when every tag for a digest
+/// matches a single sweep none of them satisfy the `EXISTS`, so all are
+/// retained and the image stays reachable.
+///
+/// This is a pure WHERE-tightening: it deletes strictly fewer rows than
+/// before (never anything previously retained), so no migration is
+/// needed. Explicit `DELETE /v2/<image>/manifests/<ref>` is unchanged and
+/// still removes the sole tag intentionally; GC's index-child clause still
+/// governs per-arch children of live indexes.
 const CASCADE_OCI_TAGS_SQL: &str = r#"
 DELETE FROM oci_tags ot
 USING artifacts a
@@ -59,6 +87,27 @@ WHERE a.is_deleted = true
   AND a.path = 'v2/' || ot.name || '/manifests/' || ot.tag
   AND a.version = ot.tag
   AND ($1::UUID IS NULL OR a.repository_id = $1)
+  -- #1682: never delete the sole oci_tags row protecting a live manifest.
+  -- Only prune this tag if SOME OTHER oci_tags row keeps the same
+  -- (repository_id, manifest_digest) reachable after this sweep — i.e. a
+  -- sibling tag that is NOT itself being soft-deleted/pruned. A sibling is
+  -- "surviving" when no soft-deleted manifest artifact joins to it.
+  AND EXISTS (
+      SELECT 1
+      FROM oci_tags keep
+      WHERE keep.repository_id = ot.repository_id
+        AND keep.manifest_digest = ot.manifest_digest
+        AND keep.id <> ot.id
+        AND NOT EXISTS (
+            SELECT 1
+            FROM artifacts ka
+            WHERE ka.is_deleted = true
+              AND ka.repository_id = keep.repository_id
+              AND ka.storage_key = 'oci-manifests/' || keep.manifest_digest
+              AND ka.path = 'v2/' || keep.name || '/manifests/' || keep.tag
+              AND ka.version = keep.tag
+        )
+  )
 "#;
 
 /// Scope of a lifecycle policy execution: either a specific repository or
@@ -662,9 +711,11 @@ impl LifecycleService {
         Ok(removed)
     }
 
-    /// Execute all enabled policies (called by scheduled background task).
-    pub async fn execute_all_enabled(&self) -> Result<Vec<PolicyExecutionResult>> {
-        let policies = sqlx::query_as::<_, LifecyclePolicy>(
+    /// Load every enabled policy, highest priority first. Shared by the
+    /// scheduled `execute_all_enabled` and the cron-aware `execute_due_policies`
+    /// entry points so the selection query lives in one place.
+    async fn load_enabled_policies(&self) -> Result<Vec<LifecyclePolicy>> {
+        sqlx::query_as::<_, LifecyclePolicy>(
             r#"
             SELECT id, repository_id, name, description, enabled,
                    policy_type, config, priority, last_run_at,
@@ -676,29 +727,45 @@ impl LifecycleService {
         )
         .fetch_all(&self.db)
         .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        .map_err(|e| AppError::Database(e.to_string()))
+    }
+
+    /// Run one policy and fold the outcome into `results`, converting an error
+    /// into a failed `PolicyExecutionResult` (logged) rather than aborting the
+    /// whole batch. Shared by both scheduled entry points.
+    async fn run_policy_into(
+        &self,
+        policy: LifecyclePolicy,
+        results: &mut Vec<PolicyExecutionResult>,
+    ) {
+        match self.execute_policy(policy.id, false).await {
+            Ok(result) => results.push(result),
+            Err(e) => {
+                tracing::error!(
+                    "Failed to execute lifecycle policy '{}': {}",
+                    policy.name,
+                    e
+                );
+                results.push(PolicyExecutionResult {
+                    policy_id: policy.id,
+                    policy_name: policy.name,
+                    dry_run: false,
+                    artifacts_matched: 0,
+                    artifacts_removed: 0,
+                    bytes_freed: 0,
+                    errors: vec![e.to_string()],
+                });
+            }
+        }
+    }
+
+    /// Execute all enabled policies (called by scheduled background task).
+    pub async fn execute_all_enabled(&self) -> Result<Vec<PolicyExecutionResult>> {
+        let policies = self.load_enabled_policies().await?;
 
         let mut results = Vec::new();
         for policy in policies {
-            match self.execute_policy(policy.id, false).await {
-                Ok(result) => results.push(result),
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to execute lifecycle policy '{}': {}",
-                        policy.name,
-                        e
-                    );
-                    results.push(PolicyExecutionResult {
-                        policy_id: policy.id,
-                        policy_name: policy.name,
-                        dry_run: false,
-                        artifacts_matched: 0,
-                        artifacts_removed: 0,
-                        bytes_freed: 0,
-                        errors: vec![e.to_string()],
-                    });
-                }
-            }
+            self.run_policy_into(policy, &mut results).await;
         }
 
         Ok(results)
@@ -707,19 +774,7 @@ impl LifecycleService {
     /// Execute only those enabled policies that are currently due, based on each
     /// policy's `cron_schedule` (or a default 6-hour cadence when unset).
     pub async fn execute_due_policies(&self) -> Result<Vec<PolicyExecutionResult>> {
-        let policies = sqlx::query_as::<_, LifecyclePolicy>(
-            r#"
-            SELECT id, repository_id, name, description, enabled,
-                   policy_type, config, priority, last_run_at,
-                   last_run_items_removed, cron_schedule, created_at, updated_at
-            FROM lifecycle_policies
-            WHERE enabled = true
-            ORDER BY priority DESC
-            "#,
-        )
-        .fetch_all(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+        let policies = self.load_enabled_policies().await?;
 
         let now = Utc::now();
         let default_cadence = chrono::Duration::hours(6);
@@ -737,25 +792,7 @@ impl LifecycleService {
                 continue;
             }
 
-            match self.execute_policy(policy.id, false).await {
-                Ok(result) => results.push(result),
-                Err(e) => {
-                    tracing::error!(
-                        "Failed to execute lifecycle policy '{}': {}",
-                        policy.name,
-                        e
-                    );
-                    results.push(PolicyExecutionResult {
-                        policy_id: policy.id,
-                        policy_name: policy.name,
-                        dry_run: false,
-                        artifacts_matched: 0,
-                        artifacts_removed: 0,
-                        bytes_freed: 0,
-                        errors: vec![e.to_string()],
-                    });
-                }
-            }
+            self.run_policy_into(policy, &mut results).await;
         }
 
         Ok(results)
@@ -1048,50 +1085,9 @@ impl LifecycleService {
     ) -> Result<PolicyExecutionResult> {
         let pattern =
             parse_pattern_field(&policy.config, PolicyType::TagPatternKeep.as_wire_str())?;
-
-        let repo_filter = policy.repository_id;
-
-        // Inverse of tag_pattern_delete: find artifacts that do NOT match the pattern
-        let matched = sqlx::query_as::<_, CountBytes>(
-            r#"
-            SELECT COUNT(*) as count, COALESCE(SUM(a.size_bytes), 0)::BIGINT as bytes
-            FROM artifacts a
-            WHERE a.is_deleted = false
-              AND ($1::UUID IS NULL OR a.repository_id = $1)
-              AND a.name !~ $2
-            "#,
-        )
-        .bind(repo_filter)
-        .bind(&pattern)
-        .fetch_one(&mut *conn)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
-
-        let mut removed = 0i64;
-        if !dry_run && matched.count > 0 {
-            let result = sqlx::query(
-                r#"
-                UPDATE artifacts SET is_deleted = true
-                WHERE is_deleted = false
-                  AND ($1::UUID IS NULL OR repository_id = $1)
-                  AND name !~ $2
-                "#,
-            )
-            .bind(repo_filter)
-            .bind(&pattern)
-            .execute(&mut *conn)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
-            removed = result.rows_affected() as i64;
-        }
-
-        Ok(Self::build_execution_result(
-            policy,
-            dry_run,
-            matched.count,
-            removed,
-            matched.bytes,
-        ))
+        // Inverse of tag_pattern_delete: soft-delete artifacts that do NOT
+        // match the pattern (operator `!~`).
+        Self::execute_tag_pattern(conn, policy, dry_run, &pattern, "!~").await
     }
 
     async fn execute_tag_pattern_delete(
@@ -1101,36 +1097,51 @@ impl LifecycleService {
     ) -> Result<PolicyExecutionResult> {
         let pattern =
             parse_pattern_field(&policy.config, PolicyType::TagPatternDelete.as_wire_str())?;
+        // Soft-delete artifacts that DO match the pattern (operator `~`).
+        Self::execute_tag_pattern(conn, policy, dry_run, &pattern, "~").await
+    }
 
+    /// Shared body for the two regex-pattern policies. `op` is the Postgres
+    /// regex operator: `~` (tag_pattern_delete: remove matches) or `!~`
+    /// (tag_pattern_keep: remove non-matches). The operator is a fixed literal
+    /// chosen by the caller (never user input), so interpolating it into the
+    /// SQL text is safe; the pattern itself is always a bound parameter.
+    async fn execute_tag_pattern(
+        conn: &mut sqlx::PgConnection,
+        policy: &LifecyclePolicy,
+        dry_run: bool,
+        pattern: &str,
+        op: &str,
+    ) -> Result<PolicyExecutionResult> {
         let repo_filter = policy.repository_id;
 
-        let matched = sqlx::query_as::<_, CountBytes>(
+        let matched = sqlx::query_as::<_, CountBytes>(&format!(
             r#"
             SELECT COUNT(*) as count, COALESCE(SUM(a.size_bytes), 0)::BIGINT as bytes
             FROM artifacts a
             WHERE a.is_deleted = false
               AND ($1::UUID IS NULL OR a.repository_id = $1)
-              AND a.name ~ $2
-            "#,
-        )
+              AND a.name {op} $2
+            "#
+        ))
         .bind(repo_filter)
-        .bind(&pattern)
+        .bind(pattern)
         .fetch_one(&mut *conn)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         let mut removed = 0i64;
         if !dry_run && matched.count > 0 {
-            let result = sqlx::query(
+            let result = sqlx::query(&format!(
                 r#"
                 UPDATE artifacts SET is_deleted = true
                 WHERE is_deleted = false
                   AND ($1::UUID IS NULL OR repository_id = $1)
-                  AND name ~ $2
-                "#,
-            )
+                  AND name {op} $2
+                "#
+            ))
             .bind(repo_filter)
-            .bind(&pattern)
+            .bind(pattern)
             .execute(&mut *conn)
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
@@ -2695,6 +2706,43 @@ mod tests {
         );
         assert!(CASCADE_OCI_TAGS_SQL.contains("a.version = ot.tag"));
         assert!(CASCADE_OCI_TAGS_SQL.contains("$1::UUID IS NULL OR a.repository_id = $1"));
+    }
+
+    #[test]
+    fn test_cascade_sql_has_last_protecting_tag_guard() {
+        // #1682: a tag may only be pruned when a SURVIVING sibling oci_tags
+        // row (same repo+digest, different id, NOT itself being pruned) still
+        // protects the manifest. The guard is an EXISTS over `oci_tags keep`
+        // with a self-aware inner NOT EXISTS on soft-deleted backing
+        // artifacts. Drifting any of these reopens the data-loss bug.
+        assert!(
+            CASCADE_OCI_TAGS_SQL.contains("FROM oci_tags keep"),
+            "missing surviving-sibling EXISTS subquery (#1682 guard)"
+        );
+        assert!(
+            CASCADE_OCI_TAGS_SQL.contains("keep.repository_id = ot.repository_id"),
+            "sibling guard must correlate on repository_id (per-repo scoping)"
+        );
+        assert!(
+            CASCADE_OCI_TAGS_SQL.contains("keep.manifest_digest = ot.manifest_digest"),
+            "sibling guard must correlate on manifest_digest (reachability key)"
+        );
+        assert!(
+            CASCADE_OCI_TAGS_SQL.contains("keep.id <> ot.id"),
+            "sibling guard must exclude the row being pruned"
+        );
+        // The self-aware inner NOT EXISTS (Option A over Option B): a sibling
+        // counts as a protector only if its backing manifest artifact is NOT
+        // itself soft-deleted. Without this, two doomed tags for one digest
+        // each treat the other as a protector and both get deleted.
+        assert!(
+            CASCADE_OCI_TAGS_SQL.contains("FROM artifacts ka"),
+            "sibling guard must verify the sibling's backing artifact is not soft-deleted (#1682 Option A)"
+        );
+        assert!(
+            CASCADE_OCI_TAGS_SQL.contains("ka.is_deleted = true"),
+            "inner NOT EXISTS must key on a soft-deleted backing artifact"
+        );
     }
 
     // The cascade now runs inside the execute_policy transaction (no

--- a/backend/tests/lifecycle_policy_tests.rs
+++ b/backend/tests/lifecycle_policy_tests.rs
@@ -530,6 +530,51 @@ async fn insert_oci_tag(pool: &PgPool, repo_id: Uuid, image: &str, tag: &str, di
     .expect("failed to insert oci_tag");
 }
 
+/// Re-evaluate the storage GC orphan predicate for a single
+/// (storage_key, repository_id) tuple. This mirrors the NOT EXISTS chain in
+/// `backend/src/services/storage_gc_service.rs::ORPHAN_PREDICATE_SQL`. We
+/// deliberately scope to a single (key, repo) tuple so the parallel test
+/// isolation issue fixed in #1499 cannot affect the assertion. Shared by the
+/// #1407 cascade tests and the #1682 retention-must-not-orphan tests so they
+/// assert against the exact same orphan-detection logic.
+async fn is_storage_key_orphan(pool: &PgPool, repo_id: Uuid, storage_key: &str) -> bool {
+    let row: (i64,) = sqlx::query_as(
+        r#"
+        SELECT COUNT(*)
+        FROM artifacts a
+        JOIN repositories r ON r.id = a.repository_id
+        WHERE a.storage_key = $1
+          AND a.repository_id = $2
+          AND a.is_deleted = true
+          AND NOT EXISTS (
+              SELECT 1 FROM artifacts a2
+              WHERE a2.storage_key = a.storage_key
+                AND a2.is_deleted = false
+          )
+          AND NOT EXISTS (
+              SELECT 1
+              FROM oci_tags ot
+              JOIN repositories otr ON otr.id = ot.repository_id
+              WHERE a.storage_key LIKE 'oci-manifests/%'
+                AND ot.manifest_digest = SUBSTRING(
+                  a.storage_key FROM LENGTH('oci-manifests/') + 1
+                )
+                AND otr.storage_backend = r.storage_backend
+                AND (
+                  r.storage_backend <> 'filesystem'
+                  OR otr.storage_path = r.storage_path
+                )
+          )
+        "#,
+    )
+    .bind(storage_key)
+    .bind(repo_id)
+    .fetch_one(pool)
+    .await
+    .expect("orphan predicate query failed");
+    row.0 > 0
+}
+
 /// Return true if an oci_tags row still exists for the given (repo, image, tag).
 async fn oci_tag_exists(pool: &PgPool, repo_id: Uuid, image: &str, tag: &str) -> bool {
     let row: (i64,) = sqlx::query_as(
@@ -544,9 +589,15 @@ async fn oci_tag_exists(pool: &PgPool, repo_id: Uuid, image: &str, tag: &str) ->
     row.0 > 0
 }
 
-/// Soft-deleting an OCI manifest via tag_pattern_delete must also remove the
-/// matching oci_tags row, otherwise storage GC's orphan predicate (#1144)
-/// keeps the manifest object alive in S3 forever.
+/// Soft-deleting an OCI manifest via tag_pattern_delete must remove the
+/// matching oci_tags row *only when a surviving sibling tag still protects
+/// the same manifest digest* (#1407 cascade reclamation, constrained by the
+/// #1682 last-protecting-tag guard). Here the ephemeral manifest digest is
+/// also referenced by a surviving `release-alias` tag, so pruning the
+/// matched `build-snapshot-images` tag does not orphan the manifest and the
+/// cascade legitimately fires. Without the surviving sibling the cascade
+/// would (correctly, post-#1682) retain the row — see
+/// `cascade_retains_sole_protecting_oci_tag`.
 #[tokio::test]
 #[ignore]
 async fn test_tag_pattern_delete_cascades_oci_tags_for_soft_deleted_manifest() {
@@ -582,6 +633,20 @@ async fn test_tag_pattern_delete_cascades_oci_tags_for_soft_deleted_manifest() {
     )
     .await;
     insert_oci_tag(&pool, repo_id, "myimg", "v1.0.0", release_digest).await;
+    // Surviving sibling tag for the SAME ephemeral digest: its backing
+    // manifest artifact is live (not matched by the delete pattern), so the
+    // ephemeral digest stays reachable after the matched tag is pruned. This
+    // is what licenses the cascade to remove `build-snapshot-images`.
+    insert_oci_manifest_artifact(
+        &pool,
+        repo_id,
+        "myimg",
+        "release-alias",
+        ephemeral_digest,
+        100,
+    )
+    .await;
+    insert_oci_tag(&pool, repo_id, "myimg", "release-alias", ephemeral_digest).await;
 
     let policy = svc
         .create_policy(CreatePolicyRequest {
@@ -623,10 +688,18 @@ async fn test_tag_pattern_delete_cascades_oci_tags_for_soft_deleted_manifest() {
         "release artifact must not be touched"
     );
 
-    // Regression assertion (the bug this PR fixes).
+    // Cascade prunes the matched tag because a surviving sibling
+    // (`release-alias`) still protects the same digest (#1407 reclamation,
+    // licensed by the #1682 guard).
     assert!(
         !oci_tag_exists(&pool, repo_id, "myimg", "build-snapshot-images").await,
-        "cascade should remove oci_tags row for soft-deleted manifest"
+        "cascade should remove the oci_tags row for the soft-deleted manifest \
+         when a surviving sibling tag still protects its digest"
+    );
+    // The surviving sibling for the same digest must remain.
+    assert!(
+        oci_tag_exists(&pool, repo_id, "myimg", "release-alias").await,
+        "surviving sibling tag protecting the same digest must remain"
     );
     // Sanity: the release tag is still alive.
     assert!(
@@ -637,7 +710,9 @@ async fn test_tag_pattern_delete_cascades_oci_tags_for_soft_deleted_manifest() {
     cleanup(&pool, repo_id).await;
 }
 
-/// max_age_days policy soft-deletes by age; the cascade must also fire.
+/// max_age_days policy soft-deletes by age; the cascade then prunes the
+/// matched tag *only* because a surviving fresh sibling tag still protects
+/// the same digest (#1407 reclamation, constrained by the #1682 guard).
 #[tokio::test]
 #[ignore]
 async fn test_max_age_days_cascades_oci_tags() {
@@ -652,6 +727,12 @@ async fn test_max_age_days_cascades_oci_tags() {
     let old_id =
         insert_oci_manifest_artifact(&pool, repo_id, "myimg", "old", old_digest, 100).await;
     insert_oci_tag(&pool, repo_id, "myimg", "old", old_digest).await;
+
+    // Surviving fresh sibling tag for the SAME digest: not backdated, so the
+    // age policy leaves it live and it keeps the digest reachable, licensing
+    // the cascade to prune the aged `old` tag.
+    insert_oci_manifest_artifact(&pool, repo_id, "myimg", "fresh-alias", old_digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "myimg", "fresh-alias", old_digest).await;
 
     // Backdate the artifact to look 10 days old.
     sqlx::query("UPDATE artifacts SET created_at = NOW() - INTERVAL '10 days' WHERE id = $1")
@@ -678,7 +759,11 @@ async fn test_max_age_days_cascades_oci_tags() {
     assert!(is_deleted(&pool, old_id).await);
     assert!(
         !oci_tag_exists(&pool, repo_id, "myimg", "old").await,
-        "max_age_days must also cascade oci_tags"
+        "max_age_days must cascade the aged oci_tags row when a surviving sibling protects the digest"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, "myimg", "fresh-alias").await,
+        "the fresh sibling tag protecting the same digest must survive"
     );
 
     cleanup(&pool, repo_id).await;
@@ -707,6 +792,13 @@ async fn test_cascade_respects_repo_scope() {
     insert_oci_tag(&pool, repo_a, "img", "snapshot-images", digest).await;
     insert_oci_tag(&pool, repo_b, "img", "snapshot-images", digest).await;
 
+    // Surviving sibling in repo_a for the same digest (does not match the
+    // `-images$` pattern), so repo_a's matched tag can be pruned without
+    // orphaning the digest. The guard correlates strictly on repository_id,
+    // so repo_b's same-digest tag does NOT count as a protector for repo_a.
+    insert_oci_manifest_artifact(&pool, repo_a, "img", "keep-alias", digest, 100).await;
+    insert_oci_tag(&pool, repo_a, "img", "keep-alias", digest).await;
+
     // Mark repo_b's artifact soft-deleted with no policy involvement.
     sqlx::query("UPDATE artifacts SET is_deleted = true WHERE id = $1")
         .bind(b_id)
@@ -732,7 +824,11 @@ async fn test_cascade_respects_repo_scope() {
     assert!(is_deleted(&pool, a_id).await);
     assert!(
         !oci_tag_exists(&pool, repo_a, "img", "snapshot-images").await,
-        "tag in repo_a must be cascaded"
+        "tag in repo_a must be cascaded (a surviving same-repo sibling protects the digest)"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_a, "img", "keep-alias").await,
+        "surviving sibling tag in repo_a must remain"
     );
     assert!(
         oci_tag_exists(&pool, repo_b, "img", "snapshot-images").await,
@@ -763,6 +859,11 @@ async fn test_cascade_handles_port_in_image_name() {
     let tag = "snapshot-keep-me";
     let id = insert_oci_manifest_artifact(&pool, repo_id, image, tag, digest, 100).await;
     insert_oci_tag(&pool, repo_id, image, tag, digest).await;
+    // Surviving sibling tag for the same digest (does not match the pattern)
+    // so the matched port-in-name tag can be pruned without orphaning the
+    // manifest — this is what lets us assert the path-based join fired.
+    insert_oci_manifest_artifact(&pool, repo_id, image, "alias", digest, 100).await;
+    insert_oci_tag(&pool, repo_id, image, "alias", digest).await;
 
     let policy = svc
         .create_policy(CreatePolicyRequest {
@@ -791,6 +892,10 @@ async fn test_cascade_handles_port_in_image_name() {
     assert!(
         !oci_tag_exists(&pool, repo_id, image, tag).await,
         "cascade must remove the oci_tags row even when the image carries a host:port prefix"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, image, "alias").await,
+        "surviving sibling tag protecting the same digest must remain"
     );
 
     cleanup(&pool, repo_id).await;
@@ -822,6 +927,11 @@ async fn test_cascade_handles_digest_reference() {
     let reference = digest; // pinned-by-digest case
     let id = insert_oci_manifest_artifact(&pool, repo_id, image, reference, digest, 200).await;
     insert_oci_tag(&pool, repo_id, image, reference, digest).await;
+    // Surviving human-tag sibling for the same digest, not backdated, so the
+    // age policy leaves it live and the digest stays reachable — this lets us
+    // assert the path-based join fired on the digest-shaped reference.
+    insert_oci_manifest_artifact(&pool, repo_id, image, "stable", digest, 200).await;
+    insert_oci_tag(&pool, repo_id, image, "stable", digest).await;
 
     // Backdate the row and run a max_age_days policy: this matches by
     // age, not by name, so we exercise the cascade SQL without depending
@@ -851,10 +961,15 @@ async fn test_cascade_handles_digest_reference() {
 
     // This is the regression assertion: the old regex extracted
     // "imgwithdigest:sha256" from "imgwithdigest:sha256:6666..." and the
-    // join failed. With the path-based predicate it succeeds.
+    // join failed. With the path-based predicate it succeeds — and because a
+    // surviving sibling protects the digest, the matched tag is pruned.
     assert!(
         !oci_tag_exists(&pool, repo_id, image, reference).await,
         "cascade must remove oci_tags row when reference is a digest (sha256:...)"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, image, "stable").await,
+        "surviving sibling tag protecting the same digest must remain"
     );
 
     cleanup(&pool, repo_id).await;
@@ -890,6 +1005,11 @@ async fn test_execute_policy_reclaims_orphan_oci_tags() {
         .execute(&pool)
         .await
         .unwrap();
+    // Surviving sibling tag for the SAME digest (live backing artifact) so
+    // the stale orphan tag can be reclaimed without orphaning the manifest
+    // (#1682 guard requires a surviving protector before pruning).
+    insert_oci_manifest_artifact(&pool, repo_id, "img", "stable", digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "img", "stable", digest).await;
 
     // Run a real policy that won't match the stale artifact (it's
     // already deleted). The cascade still runs in its own transaction
@@ -930,10 +1050,16 @@ async fn test_execute_policy_reclaims_orphan_oci_tags() {
     assert_eq!(result.artifacts_removed, 0);
 
     // The cascade tx ran after the (no-op) soft-delete tx committed.
-    // The stale tag must be gone.
+    // The stale tag must be gone (a surviving sibling protects its digest).
     assert!(
         !oci_tag_exists(&pool, repo_id, "img", "stale").await,
-        "cascade must reclaim pre-existing stale tags from prior crashed runs"
+        "cascade must reclaim pre-existing stale tags from prior crashed runs \
+         when a surviving sibling still protects the digest"
+    );
+    // The surviving sibling for the same digest must remain.
+    assert!(
+        oci_tag_exists(&pool, repo_id, "img", "stable").await,
+        "surviving sibling tag protecting the same digest must remain"
     );
     // The live one must survive.
     assert!(
@@ -998,6 +1124,13 @@ async fn test_cascade_picks_up_orphans_from_prior_run() {
             .execute(&pool)
             .await
             .unwrap();
+        // A surviving sibling tag for the same digest (live backing
+        // artifact) so the orphan tag can be reclaimed without orphaning the
+        // manifest (#1682 guard requires a surviving protector before
+        // pruning). The sibling tag itself is not an orphan.
+        let alias = format!("{tag}-alias");
+        insert_oci_manifest_artifact(&pool, repo_id, image, &alias, digest, 100).await;
+        insert_oci_tag(&pool, repo_id, image, &alias, digest).await;
     }
 
     // Sanity: orphans exist before the recovery run.
@@ -1039,11 +1172,19 @@ async fn test_cascade_picks_up_orphans_from_prior_run() {
     );
 
     // Every orphan tag row must be gone — tx2's filter on
-    // `a.is_deleted = true` picked them up.
+    // `a.is_deleted = true` picked them up (each digest has a surviving
+    // sibling that keeps it reachable).
     for (image, tag, _) in &orphans {
         assert!(
             !oci_tag_exists(&pool, repo_id, image, tag).await,
             "orphan {}:{} must be reclaimed by the cascade sweep",
+            image,
+            tag
+        );
+        // The surviving sibling that protected the digest must remain.
+        assert!(
+            oci_tag_exists(&pool, repo_id, image, &format!("{tag}-alias")).await,
+            "surviving sibling {}:{}-alias must remain",
             image,
             tag
         );
@@ -1157,6 +1298,18 @@ async fn test_max_versions_cascades_oci_tags() {
         .await
         .expect("failed to align names for max_versions partition");
 
+    // Surviving sibling tags for the two doomed digests, each in its OWN
+    // single-member max_versions partition (distinct names, keep=1 keeps
+    // each), so the cascade may prune the rolling-1/rolling-2 tags without
+    // orphaning those digests (#1682 guard). Inserted AFTER the
+    // name-alignment UPDATE so they are not pulled into the `img:rolling`
+    // partition. The insert helper already writes a distinct name per row
+    // ("img:alias-old", "img:alias-mid"), so no rename is needed.
+    insert_oci_manifest_artifact(&pool, repo_id, "img", "alias-old", digest_old, 100).await;
+    insert_oci_tag(&pool, repo_id, "img", "alias-old", digest_old).await;
+    insert_oci_manifest_artifact(&pool, repo_id, "img", "alias-mid", digest_mid, 100).await;
+    insert_oci_tag(&pool, repo_id, "img", "alias-mid", digest_mid).await;
+
     // Backdate so created_at ordering is deterministic.
     sqlx::query(
         "UPDATE artifacts SET created_at = NOW() - INTERVAL '3 days' WHERE storage_key = $1",
@@ -1203,6 +1356,15 @@ async fn test_max_versions_cascades_oci_tags() {
         oci_tag_exists(&pool, repo_id, "img", "rolling-3").await,
         "the kept tag must survive the cascade"
     );
+    // The surviving sibling tags protecting digest_old / digest_mid remain.
+    assert!(
+        oci_tag_exists(&pool, repo_id, "img", "alias-old").await,
+        "surviving sibling protecting digest_old must remain"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, "img", "alias-mid").await,
+        "surviving sibling protecting digest_mid must remain"
+    );
 
     cleanup(&pool, repo_id).await;
 }
@@ -1235,6 +1397,12 @@ async fn test_no_downloads_days_cascades_oci_tags() {
         insert_oci_manifest_artifact(&pool, repo_id, "img", "warm", warm_digest, 100).await;
     insert_oci_tag(&pool, repo_id, "img", "cold", cold_digest).await;
     insert_oci_tag(&pool, repo_id, "img", "warm", warm_digest).await;
+    // Surviving sibling tag for the SAME cold digest, recently downloaded so
+    // the no_downloads_days policy leaves it live and the cold digest stays
+    // reachable — this licenses the cascade to prune the `cold` tag (#1682).
+    let cold_alias_id =
+        insert_oci_manifest_artifact(&pool, repo_id, "img", "cold-alias", cold_digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "img", "cold-alias", cold_digest).await;
 
     sqlx::query("UPDATE artifacts SET created_at = NOW() - INTERVAL '30 days' WHERE id = $1")
         .bind(cold_id)
@@ -1246,7 +1414,13 @@ async fn test_no_downloads_days_cascades_oci_tags() {
         .execute(&pool)
         .await
         .unwrap();
+    sqlx::query("UPDATE artifacts SET created_at = NOW() - INTERVAL '30 days' WHERE id = $1")
+        .bind(cold_alias_id)
+        .execute(&pool)
+        .await
+        .unwrap();
     record_download_days_ago(&pool, warm_id, 1).await;
+    record_download_days_ago(&pool, cold_alias_id, 1).await;
 
     let policy = svc
         .create_policy(CreatePolicyRequest {
@@ -1268,7 +1442,12 @@ async fn test_no_downloads_days_cascades_oci_tags() {
 
     assert!(
         !oci_tag_exists(&pool, repo_id, "img", "cold").await,
-        "no_downloads_days cascade must remove oci_tags for the cold manifest"
+        "no_downloads_days cascade must remove oci_tags for the cold manifest \
+         when a surviving sibling protects its digest"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, "img", "cold-alias").await,
+        "the surviving (downloaded) sibling protecting the cold digest must remain"
     );
     assert!(
         oci_tag_exists(&pool, repo_id, "img", "warm").await,
@@ -1302,6 +1481,12 @@ async fn test_tag_pattern_keep_cascades_oci_tags() {
         insert_oci_manifest_artifact(&pool, repo_id, "img", "nightly", snapshot_digest, 100).await;
     insert_oci_tag(&pool, repo_id, "img", "v1.0.0", release_digest).await;
     insert_oci_tag(&pool, repo_id, "img", "nightly", snapshot_digest).await;
+    // Surviving sibling tag for the SAME snapshot digest, with a semver-shaped
+    // name that the keep-pattern (`:v`) matches, so it is retained live and
+    // keeps the snapshot digest reachable — licensing the cascade to prune the
+    // evicted `nightly` tag (#1682).
+    insert_oci_manifest_artifact(&pool, repo_id, "img", "v0.0.0-snap", snapshot_digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "img", "v0.0.0-snap", snapshot_digest).await;
 
     let policy = svc
         .create_policy(CreatePolicyRequest {
@@ -1326,7 +1511,12 @@ async fn test_tag_pattern_keep_cascades_oci_tags() {
 
     assert!(
         !oci_tag_exists(&pool, repo_id, "img", "nightly").await,
-        "tag_pattern_keep cascade must remove oci_tags for the non-matching (evicted) manifest"
+        "tag_pattern_keep cascade must remove oci_tags for the non-matching (evicted) manifest \
+         when a surviving sibling protects its digest"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, "img", "v0.0.0-snap").await,
+        "the surviving semver-named sibling protecting the snapshot digest must remain"
     );
     assert!(
         oci_tag_exists(&pool, repo_id, "img", "v1.0.0").await,
@@ -1351,21 +1541,27 @@ async fn test_size_quota_bytes_cascades_oci_tags() {
     let repo_id = create_test_repo(&pool, &format!("test-cascade-sq-{}", Uuid::new_v4())).await;
     let svc = LifecycleService::new(pool.clone());
 
-    // Two manifests of 100 bytes each, quota of 100 bytes -> evict one. The
-    // never-downloaded one goes first by LRU rules.
+    // Three 100-byte manifests, quota of 200 bytes -> evict the single
+    // never-downloaded one (evict-me) by LRU. evict-alias shares evict-me's
+    // digest but is recently downloaded, so it survives and keeps the digest
+    // reachable, licensing the cascade to prune the evict-me tag (#1682).
     let evict_digest = "sha256:1407dd00000000000000000000000000000000000000000000000000000001";
     let keep_digest = "sha256:1407dd00000000000000000000000000000000000000000000000000000002";
     let evict_id =
         insert_oci_manifest_artifact(&pool, repo_id, "img", "evict-me", evict_digest, 100).await;
     let keep_id =
         insert_oci_manifest_artifact(&pool, repo_id, "img", "keep-me", keep_digest, 100).await;
+    let evict_alias_id =
+        insert_oci_manifest_artifact(&pool, repo_id, "img", "evict-alias", evict_digest, 100).await;
     insert_oci_tag(&pool, repo_id, "img", "evict-me", evict_digest).await;
     insert_oci_tag(&pool, repo_id, "img", "keep-me", keep_digest).await;
+    insert_oci_tag(&pool, repo_id, "img", "evict-alias", evict_digest).await;
 
-    // Mark keep-me as downloaded so it ranks ahead of evict-me in LRU
-    // ordering (NULLS FIRST puts never-downloaded artifacts at the front
-    // of the eviction queue).
+    // Mark keep-me and evict-alias as downloaded so they rank ahead of
+    // evict-me in LRU ordering (NULLS FIRST puts never-downloaded artifacts
+    // at the front of the eviction queue).
     record_download(&pool, keep_id, "2026-05-29T00:00:00Z").await;
+    record_download(&pool, evict_alias_id, "2026-05-29T00:00:00Z").await;
 
     let policy = svc
         .create_policy(CreatePolicyRequest {
@@ -1373,7 +1569,7 @@ async fn test_size_quota_bytes_cascades_oci_tags() {
             name: "Tight quota".to_string(),
             description: None,
             policy_type: "size_quota_bytes".to_string(),
-            config: serde_json::json!({"quota_bytes": 100}),
+            config: serde_json::json!({"quota_bytes": 200}),
             priority: None,
             cron_schedule: None,
         })
@@ -1384,10 +1580,16 @@ async fn test_size_quota_bytes_cascades_oci_tags() {
     assert_eq!(result.artifacts_removed, 1);
     assert!(is_deleted(&pool, evict_id).await);
     assert!(!is_deleted(&pool, keep_id).await);
+    assert!(!is_deleted(&pool, evict_alias_id).await);
 
     assert!(
         !oci_tag_exists(&pool, repo_id, "img", "evict-me").await,
-        "size_quota_bytes cascade must remove oci_tags for the LRU-evicted manifest"
+        "size_quota_bytes cascade must remove oci_tags for the LRU-evicted manifest \
+         when a surviving sibling protects its digest"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, "img", "evict-alias").await,
+        "the surviving (downloaded) sibling protecting the evicted digest must remain"
     );
     assert!(
         oci_tag_exists(&pool, repo_id, "img", "keep-me").await,
@@ -1397,20 +1599,24 @@ async fn test_size_quota_bytes_cascades_oci_tags() {
     cleanup_with_downloads(&pool, repo_id).await;
 }
 
-/// End-to-end check of the chain the issue describes:
-///   lifecycle policy -> soft-delete artifact -> cascade oci_tags ->
-///   storage GC's orphan predicate recognises the storage key as orphan.
+/// End-to-end check that a retention sweep does NOT orphan a live image
+/// when it soft-deletes the manifest artifact whose tag is the *sole*
+/// reference keeping it reachable (#1682). This supersedes the original
+/// #1407 sole-tag expectation (cascade reclaims the lone tag): #1682
+/// establishes that retention must never be the cause of orphaning. The
+/// cascade only prunes a tag when a surviving sibling still protects the
+/// same digest; explicit `DELETE /v2/<image>/manifests/<ref>` remains the
+/// path that intentionally removes the last reference.
 ///
 /// We don't invoke the real `StorageGcService::run_gc` (it requires a
 /// `StorageRegistry` and would touch real storage backends). Instead we
 /// re-execute the exact orphan predicate from
 /// `backend/src/services/storage_gc_service.rs` (the `ORPHAN_PREDICATE_SQL`
-/// constant) against the database state the cascade leaves behind. If the
-/// cascade ever regresses (or someone weakens the join), this assertion
-/// catches it because the predicate counts the manifest as still-referenced
-/// by `oci_tags` and the test fails. Per-key assertions only — no global
-/// counter, so the test stays safe under parallel coverage runs (the
-/// pattern from #1499).
+/// constant) against the database state the cascade leaves behind. With the
+/// last-protecting-tag guard the sole `oci_tags` row survives, so the
+/// predicate must NOT mark the storage_key as orphan. Per-key assertions
+/// only — no global counter, so the test stays safe under parallel coverage
+/// runs (the pattern from #1499).
 #[tokio::test]
 #[ignore]
 async fn test_lifecycle_cascade_unblocks_storage_gc_orphan_detection() {
@@ -1430,44 +1636,9 @@ async fn test_lifecycle_cascade_unblocks_storage_gc_orphan_detection() {
     // (storage_key, repository_id) tuple. This mirrors the NOT EXISTS chain
     // in storage_gc_service.rs::ORPHAN_PREDICATE_SQL. We deliberately scope
     // to a single (key, repo) tuple so the parallel test isolation issue
-    // fixed in #1499 cannot affect this assertion.
-    async fn is_storage_key_orphan(pool: &PgPool, repo_id: Uuid, storage_key: &str) -> bool {
-        let row: (i64,) = sqlx::query_as(
-            r#"
-            SELECT COUNT(*)
-            FROM artifacts a
-            JOIN repositories r ON r.id = a.repository_id
-            WHERE a.storage_key = $1
-              AND a.repository_id = $2
-              AND a.is_deleted = true
-              AND NOT EXISTS (
-                  SELECT 1 FROM artifacts a2
-                  WHERE a2.storage_key = a.storage_key
-                    AND a2.is_deleted = false
-              )
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM oci_tags ot
-                  JOIN repositories otr ON otr.id = ot.repository_id
-                  WHERE a.storage_key LIKE 'oci-manifests/%'
-                    AND ot.manifest_digest = SUBSTRING(
-                      a.storage_key FROM LENGTH('oci-manifests/') + 1
-                    )
-                    AND otr.storage_backend = r.storage_backend
-                    AND (
-                      r.storage_backend <> 'filesystem'
-                      OR otr.storage_path = r.storage_path
-                    )
-              )
-            "#,
-        )
-        .bind(storage_key)
-        .bind(repo_id)
-        .fetch_one(pool)
-        .await
-        .expect("orphan predicate query failed");
-        row.0 > 0
-    }
+    // fixed in #1499 cannot affect this assertion. The predicate lives in
+    // the module-level `is_storage_key_orphan` helper so the #1682 retention
+    // tests can reuse the exact same orphan-detection SQL.
 
     // Backdate so a max_age_days policy will pick it up.
     sqlx::query("UPDATE artifacts SET created_at = NOW() - INTERVAL '30 days' WHERE id = $1")
@@ -1502,16 +1673,210 @@ async fn test_lifecycle_cascade_unblocks_storage_gc_orphan_detection() {
     assert_eq!(result.artifacts_removed, 1);
     assert!(is_deleted(&pool, id).await);
 
-    // The cascade reclaimed the oci_tags row. Now the orphan predicate
-    // should fire — exactly the chain the issue says was broken.
+    // #1682: the cascade must NOT remove the sole oci_tags row — doing so
+    // would orphan the live image. The tag is the last reference keeping
+    // the manifest reachable, so the last-protecting-tag guard retains it.
     assert!(
-        !oci_tag_exists(&pool, repo_id, "img", "drop-me").await,
-        "cascade must have removed the oci_tags row"
+        oci_tag_exists(&pool, repo_id, "img", "drop-me").await,
+        "cascade must RETAIN the sole oci_tags row protecting the manifest (#1682)"
+    );
+    // Because the tag survives, storage GC's orphan predicate must still
+    // consider the manifest reachable — no silent data loss.
+    assert!(
+        !is_storage_key_orphan(&pool, repo_id, &storage_key).await,
+        "post-cascade: the manifest storage_key must NOT be reclaimable while its \
+         sole protecting tag survives (#1682 — retention must not orphan a live image)"
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+// =============================================================================
+// #1682 — retention must not delete the sole oci_tags row protecting a live
+// image. The cascade hard-deletes oci_tags rows for soft-deleted manifest
+// artifacts; without a reachability guard, deleting the LAST tag protecting a
+// (repository_id, manifest_digest) flips the manifest into storage GC's orphan
+// set and reclaims it (silent data loss). The last-protecting-tag guard in
+// CASCADE_OCI_TAGS_SQL prunes a tag only when a SURVIVING sibling tag (same
+// repo+digest, not itself being pruned) still keeps the digest reachable.
+// =============================================================================
+
+/// EXPLOIT BLOCKED (sole-tag, N=1): one tag + its soft-deleted backing
+/// manifest artifact. The cascade must RETAIN the row (it is the sole
+/// protector), and the GC orphan predicate must remain false for the digest.
+#[tokio::test]
+#[ignore]
+async fn cascade_retains_sole_protecting_oci_tag() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .expect("failed to connect to database");
+
+    let repo_id = create_test_repo(&pool, &format!("test-1682-sole-{}", Uuid::new_v4())).await;
+    let svc = LifecycleService::new(pool.clone());
+
+    let digest = "sha256:16820000000000000000000000000000000000000000000000000000000000a1";
+    let storage_key = format!("oci-manifests/{}", digest);
+    let id = insert_oci_manifest_artifact(&pool, repo_id, "app", "prod", digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "app", "prod", digest).await;
+
+    // A retention rule whose regex matches the manifest artifact's name
+    // ("app:prod"): tx1 soft-deletes the manifest row, tx2 runs the cascade.
+    let policy = svc
+        .create_policy(CreatePolicyRequest {
+            repository_id: Some(repo_id),
+            name: "Prune prod".to_string(),
+            description: None,
+            policy_type: "tag_pattern_delete".to_string(),
+            config: serde_json::json!({"pattern": ":prod$"}),
+            priority: None,
+            cron_schedule: None,
+        })
+        .await
+        .unwrap();
+
+    let result = svc.execute_policy(policy.id, false).await.unwrap();
+    assert_eq!(
+        result.artifacts_removed, 1,
+        "the matched manifest is soft-deleted"
+    );
+    assert!(is_deleted(&pool, id).await);
+
+    // The sole protecting tag must survive — otherwise the image is orphaned.
+    assert!(
+        oci_tag_exists(&pool, repo_id, "app", "prod").await,
+        "cascade must RETAIN the sole oci_tags row protecting the manifest (#1682)"
+    );
+    // GC must not consider the manifest reclaimable while its tag survives.
+    assert!(
+        !is_storage_key_orphan(&pool, repo_id, &storage_key).await,
+        "manifest must stay reachable for storage GC while its sole tag survives (#1682)"
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+/// LEGIT STILL WORKS (redundant tag prunes): two tags for one digest, the
+/// doomed tag's backing artifact soft-deleted, the sibling's backing artifact
+/// live. The cascade must remove the doomed tag and keep the live-backed
+/// sibling; the manifest stays reachable.
+#[tokio::test]
+#[ignore]
+async fn cascade_prunes_redundant_tag_when_sibling_survives() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .expect("failed to connect to database");
+
+    let repo_id = create_test_repo(&pool, &format!("test-1682-redundant-{}", Uuid::new_v4())).await;
+    let svc = LifecycleService::new(pool.clone());
+
+    let digest = "sha256:16820000000000000000000000000000000000000000000000000000000000b2";
+    let storage_key = format!("oci-manifests/{}", digest);
+    // Two tags, same digest. `stale` is pruned; `keep` is the live sibling.
+    let stale_id = insert_oci_manifest_artifact(&pool, repo_id, "app", "stale", digest, 100).await;
+    insert_oci_manifest_artifact(&pool, repo_id, "app", "keep", digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "app", "stale", digest).await;
+    insert_oci_tag(&pool, repo_id, "app", "keep", digest).await;
+
+    // A prune rule matching only "stale": tx1 soft-deletes the `stale`
+    // manifest row (the `keep` row stays live), tx2 runs the cascade.
+    let policy = svc
+        .create_policy(CreatePolicyRequest {
+            repository_id: Some(repo_id),
+            name: "Prune stale".to_string(),
+            description: None,
+            policy_type: "tag_pattern_delete".to_string(),
+            config: serde_json::json!({"pattern": ":stale$"}),
+            priority: None,
+            cron_schedule: None,
+        })
+        .await
+        .unwrap();
+
+    let result = svc.execute_policy(policy.id, false).await.unwrap();
+    assert_eq!(
+        result.artifacts_removed, 1,
+        "only the stale manifest is soft-deleted"
+    );
+    assert!(is_deleted(&pool, stale_id).await);
+
+    // The redundant tag is pruned; the live-backed sibling survives.
+    assert!(
+        !oci_tag_exists(&pool, repo_id, "app", "stale").await,
+        "redundant tag must be pruned when a surviving sibling protects the digest (#1682)"
     );
     assert!(
-        is_storage_key_orphan(&pool, repo_id, &storage_key).await,
-        "post-cascade: storage GC's orphan predicate must now recognise the manifest \
-         storage_key as reclaimable (this is the issue #1407 promise)"
+        oci_tag_exists(&pool, repo_id, "app", "keep").await,
+        "the live-backed sibling tag must survive"
+    );
+    // The live sibling artifact keeps the manifest reachable.
+    assert!(
+        !is_storage_key_orphan(&pool, repo_id, &storage_key).await,
+        "manifest must stay reachable while the live sibling tag survives"
+    );
+
+    cleanup(&pool, repo_id).await;
+}
+
+/// MULTI-TAG VARIANT (what Option A buys over the naive Option B): two tags
+/// for one digest, BOTH backing artifacts soft-deleted by the same sweep.
+/// Neither has a surviving protector, so BOTH oci_tags rows must be RETAINED
+/// (the sole-tag bug is the N=1 case of "all protecting tags pruned at once").
+#[tokio::test]
+#[ignore]
+async fn cascade_retains_all_when_every_protecting_tag_pruned() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .expect("failed to connect to database");
+
+    let repo_id = create_test_repo(&pool, &format!("test-1682-allpruned-{}", Uuid::new_v4())).await;
+    let svc = LifecycleService::new(pool.clone());
+
+    let digest = "sha256:16820000000000000000000000000000000000000000000000000000000000c3";
+    let storage_key = format!("oci-manifests/{}", digest);
+    // Two tags for one digest, both matched by the same sweep.
+    let a_id = insert_oci_manifest_artifact(&pool, repo_id, "app", "prod", digest, 100).await;
+    let b_id = insert_oci_manifest_artifact(&pool, repo_id, "app", "prod-old", digest, 100).await;
+    insert_oci_tag(&pool, repo_id, "app", "prod", digest).await;
+    insert_oci_tag(&pool, repo_id, "app", "prod-old", digest).await;
+
+    // A prune rule whose regex matches BOTH tags' artifact names
+    // ("app:prod", "app:prod-old"): tx1 soft-deletes both manifest rows,
+    // tx2 runs the cascade.
+    let policy = svc
+        .create_policy(CreatePolicyRequest {
+            repository_id: Some(repo_id),
+            name: "Prune all prod".to_string(),
+            description: None,
+            policy_type: "tag_pattern_delete".to_string(),
+            config: serde_json::json!({"pattern": ":prod"}),
+            priority: None,
+            cron_schedule: None,
+        })
+        .await
+        .unwrap();
+
+    let result = svc.execute_policy(policy.id, false).await.unwrap();
+    assert_eq!(
+        result.artifacts_removed, 2,
+        "both prod manifests are soft-deleted"
+    );
+    assert!(is_deleted(&pool, a_id).await);
+    assert!(is_deleted(&pool, b_id).await);
+
+    // A naive any-other-row guard (Option B) would delete BOTH (each sees the
+    // other as a protector). Option A's self-aware guard retains BOTH.
+    assert!(
+        oci_tag_exists(&pool, repo_id, "app", "prod").await,
+        "all protecting tags pruned at once must be RETAINED (#1682 multi-tag variant)"
+    );
+    assert!(
+        oci_tag_exists(&pool, repo_id, "app", "prod-old").await,
+        "all protecting tags pruned at once must be RETAINED (#1682 multi-tag variant)"
+    );
+    // The manifest must remain reachable — no orphaning.
+    assert!(
+        !is_storage_key_orphan(&pool, repo_id, &storage_key).await,
+        "manifest must stay reachable when every protecting tag is retained (#1682)"
     );
 
     cleanup(&pool, repo_id).await;


### PR DESCRIPTION
## Summary

The lifecycle retention cascade can silently orphan a live image.

`execute_policy` runs in two transactions. tx1 (a per-type `execute_*` helper)
does `UPDATE artifacts SET is_deleted = true` for rows matching the policy. For a
pushed OCI manifest the manifest *artifact* row is a real candidate
(`put_manifest` writes it with `path='v2/{image}/manifests/{tag}'`,
`version=tag`, `name='{image}:{tag}'`, `storage_key='oci-manifests/{digest}'`),
so e.g. a `tag_pattern_delete` rule whose regex matches the manifest artifact's
name soft-deletes it. tx2 then runs `CASCADE_OCI_TAGS_SQL`, which hard-deletes
every `oci_tags` row whose matching artifact is `is_deleted = true`.

That cascade had no reachability guard. When the deleted `oci_tags` row is the
**last** row protecting its `(repository_id, manifest_digest)`, removing it makes
the manifest unreferenced. The storage GC orphan predicate
(`storage_gc_service.rs`) defines a manifest as orphaned precisely when no
`oci_tags` row carries its `manifest_digest` (and it is not a live index child),
so a subsequent storage-GC pass hard-deletes the manifest + blobs — silent data
loss. A retention rule matching a manifest's sole tag is enough to trigger it.

This change adds a **last-protecting-tag guard** to `CASCADE_OCI_TAGS_SQL`: a tag
is pruned only when a *surviving sibling* `oci_tags` row (same `repository_id` +
`manifest_digest`, different `id`, whose backing manifest artifact is **not
itself** being soft-deleted) still keeps the digest reachable. The inner
`NOT EXISTS` is self-aware so the multi-tag case is handled too: if every tag for
a digest is matched by one sweep (the sole-tag bug is the N=1 instance of this),
none qualify and all are retained, keeping the image reachable. This is a pure
WHERE-tightening — it deletes strictly fewer rows than before, so no migration is
needed and nothing previously retained can be removed.

Behaviour that is unchanged:
- Redundant-tag pruning (the cascade's primary job): a matched tag whose digest
  is still held by a surviving sibling is still removed.
- Explicit `DELETE /v2/<image>/manifests/<ref>` still removes the sole reference
  intentionally (this PR only touches the lifecycle cascade SQL).
- Index children remain governed by the GC index-child clause.
- The guard correlates strictly per `repository_id`, so a same-digest tag in
  another repo never protects a tag here.

The guard lives in the single shared SQL constant, so it applies uniformly to all
six policy types and to the crash-recovery re-sweep.

This PR also collapses two pre-existing local duplications in the same file
(shared enabled-policies loader/runner for the two scheduled entry points; a
single regex-parametrised body behind `execute_tag_pattern_keep` /
`execute_tag_pattern_delete`). No behaviour change; this keeps the touched file
under the duplication gate.

Closes #1682

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New DB-backed regression tests in `backend/tests/lifecycle_policy_tests.rs`:
- `cascade_retains_sole_protecting_oci_tag` — one tag + soft-deleted matching
  artifact ⇒ the `oci_tags` row is retained and the GC orphan predicate stays
  false for that manifest. (Fails on `main`: the row is deleted and the manifest
  is reported orphan.)
- `cascade_prunes_redundant_tag_when_sibling_survives` — two tags, same digest,
  one backing artifact soft-deleted and the other live ⇒ the doomed tag is
  removed, the live-backed sibling survives, manifest stays reachable.
- `cascade_retains_all_when_every_protecting_tag_pruned` — two tags, same digest,
  both backing artifacts soft-deleted ⇒ both `oci_tags` rows retained (multi-tag
  variant).

A unit assertion `test_cascade_sql_has_last_protecting_tag_guard` pins the guard
clause shape. The existing `#1407`/`#1406` cascade tests were updated to reflect
the corrected reachability semantics: each now provides a surviving sibling tag
for the pruned digest (so the cascade still legitimately prunes the redundant
tag), and the GC end-to-end test now asserts a sole-tag manifest is **not**
reclaimable after a retention run.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo test --workspace --lib` (11693 passed), and the DB-backed lifecycle suite
`cargo test --test lifecycle_policy_tests -- --ignored` (22 passed) against a
throwaway PostgreSQL. Duplication on the changed source file measured at 2.19%
(< 3% gate). End-to-end on a local instance: pushing an image with a single tag,
running a `tag_pattern_delete` policy that matches it, then confirming the
`oci_tags` row is retained, the image still pulls, and storage GC does not reclaim
the manifest; and separately that a redundant tag for a shared digest is still
pruned while the surviving tag keeps the image reachable.

## API Changes
- [x] N/A - no API changes
