### PR TITLE
fix(scanner): make scan-dedup short-circuit atomic under concurrency

### DIFF
--- a/backend/src/services/scan_result_service.rs
+++ b/backend/src/services/scan_result_service.rs
@@ -73,6 +73,23 @@ pub(crate) fn stable_lock_key(scan_type: &str) -> i32 {
     hash as i32
 }
 
+/// Fold a 128-bit artifact UUID down to a single 32-bit key, used as the
+/// first key of the per-`(artifact_id, scan_type)` advisory lock in
+/// [`ScanResultService::prepare_scan_placeholder`] (#1935).
+///
+/// The two-argument Postgres advisory-lock functions
+/// (`pg_advisory_xact_lock(key1 int4, key2 int4)`) take two 32-bit keys;
+/// there is no `(int8, int8)` overload. We XOR-fold the UUID's four 32-bit
+/// lanes so the whole identifier contributes to the key and the result is
+/// deterministic across processes (so concurrent backend replicas lock the
+/// same artifact to the same key).
+pub(crate) fn fold_uuid_to_lock_key(id: Uuid) -> i32 {
+    let bits = id.as_u128();
+    let folded =
+        (bits as u32) ^ ((bits >> 32) as u32) ^ ((bits >> 64) as u32) ^ ((bits >> 96) as u32);
+    folded as i32
+}
+
 /// Postgres advisory-lock key for the stuck-scan janitor (PR #1212 audit,
 /// finding H3). The janitor takes `pg_try_advisory_lock(STUCK_SCAN_LOCK_ID)`
 /// for the duration of one sweep so only one replica fires per tick;
@@ -763,10 +780,14 @@ impl ScanResultService {
         // Serialize concurrent preparers for this (artifact_id, scan_type)
         // so the re-check below sees any placeholder a racing caller has
         // already committed. Transaction-scoped lock is released on commit
-        // or rollback. Two i32 keys avoid collisions across scan_types for
-        // the same artifact while keeping the lock granular.
-        let lock_key_a = (artifact_id.as_u128() as u64) as i64;
-        let lock_key_b = i64::from(stable_lock_key(scan_type));
+        // or rollback. The two-key advisory lock takes two `int4` (i32)
+        // arguments (there is no `pg_advisory_xact_lock(int8, int8)`
+        // overload), so both keys must be i32: fold the artifact UUID's 128
+        // bits into an i32 for key A and use the 32-bit scan_type hash for
+        // key B. Two keys keep the lock granular per (artifact_id, scan_type)
+        // while avoiding collisions across scan_types for the same artifact.
+        let lock_key_a = fold_uuid_to_lock_key(artifact_id);
+        let lock_key_b = stable_lock_key(scan_type);
         sqlx::query("SELECT pg_advisory_xact_lock($1, $2)")
             .bind(lock_key_a)
             .bind(lock_key_b)
@@ -1970,6 +1991,31 @@ mod tests {
     fn test_stable_lock_key_differs_per_scan_type() {
         assert_ne!(stable_lock_key("dependency"), stable_lock_key("image"));
         assert_ne!(stable_lock_key("image"), stable_lock_key("openscap"));
+    }
+
+    #[test]
+    fn test_fold_uuid_to_lock_key_is_deterministic() {
+        // Must be stable across calls/processes so concurrent replicas lock
+        // the same artifact to the same advisory-lock key.
+        let id = Uuid::from_u128(0x0123_4567_89ab_cdef_0123_4567_89ab_cdef);
+        assert_eq!(fold_uuid_to_lock_key(id), fold_uuid_to_lock_key(id));
+    }
+
+    #[test]
+    fn test_fold_uuid_to_lock_key_mixes_all_lanes() {
+        // Every 32-bit lane of the UUID must contribute to the key, so a
+        // change confined to any single lane changes the key. (Advisory-lock
+        // keys may still collide across distinct UUIDs -- that is safe, the
+        // re-check filters by exact artifact_id -- but the key must not be
+        // derived from only the low lane the way the old truncation was.)
+        let base = Uuid::from_u128(0x0123_4567_89ab_cdef_0011_2233_4455_6677);
+        let key = fold_uuid_to_lock_key(base);
+        // Flip a bit in the high lane only; the folded key must change.
+        let high_flip = Uuid::from_u128(0x0123_4567_89ab_cdee_0011_2233_4455_6677);
+        assert_ne!(key, fold_uuid_to_lock_key(high_flip));
+        // Flip a bit in the low lane only; the folded key must also change.
+        let low_flip = Uuid::from_u128(0x0123_4567_89ab_cdef_0011_2233_4455_6676);
+        assert_ne!(key, fold_uuid_to_lock_key(low_flip));
     }
 
     // =======================================================================

--- a/backend/src/services/scan_result_service.rs
+++ b/backend/src/services/scan_result_service.rs
@@ -58,6 +58,21 @@ pub fn clamp_stuck_scan_reap_limit(value: i64) -> i64 {
 /// than the user-input `details(...)` path.
 const STUCK_SCAN_AUDIT_ACTOR: &str = "system:stuck_scan_janitor";
 
+/// Stable 32-bit hash of a scan_type string, used as the second key of the
+/// per-`(artifact_id, scan_type)` advisory lock in
+/// [`ScanResultService::prepare_scan_placeholder`] (#1935). Deterministic
+/// across processes (FNV-1a, not `DefaultHasher` which is randomized), so
+/// concurrent backend replicas hash the same scan_type to the same key.
+pub(crate) fn stable_lock_key(scan_type: &str) -> i32 {
+    // 32-bit FNV-1a.
+    let mut hash: u32 = 0x811c_9dc5;
+    for byte in scan_type.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_mul(0x0100_0193);
+    }
+    hash as i32
+}
+
 /// Postgres advisory-lock key for the stuck-scan janitor (PR #1212 audit,
 /// finding H3). The janitor takes `pg_try_advisory_lock(STUCK_SCAN_LOCK_ID)`
 /// for the duration of one sweep so only one replica fires per tick;
@@ -696,6 +711,152 @@ impl ScanResultService {
         .map_err(|e| AppError::Database(e.to_string()))?;
 
         Ok(result)
+    }
+
+    /// Atomically resolve the placeholder row for one scanner of one
+    /// artifact, returning the scan_result id to surface to the caller and
+    /// whether that id is a freshly-inserted placeholder.
+    ///
+    /// This closes the check-then-act race in the #1373 short-circuit
+    /// (#1935): the old `prepare_artifact_scan` loop did a bare SELECT
+    /// (`find_existing_scan_for_artifact`) followed by a separate INSERT
+    /// (`create_scan_result_with_checksum`). With no lock, no constraint and
+    /// no transaction, N concurrent triggers on the same fresh artifact all
+    /// observed "no completed row" and each inserted its own `running`
+    /// placeholder, so every trigger ran a full redundant scan and the
+    /// artifact ended with N completed rows for one logical scan.
+    ///
+    /// Here the whole decide-then-insert is serialized per
+    /// `(artifact_id, scan_type)` with a transaction-scoped advisory lock
+    /// (`pg_advisory_xact_lock`, auto-released on commit/rollback) and run
+    /// inside a single transaction. Holding the lock we:
+    ///
+    /// 1. Re-check for a reusable *completed* row (the #1373 happy path) —
+    ///    short-circuit to its id with `inserted = false`.
+    /// 2. Otherwise re-check for an in-flight (`running`) placeholder for the
+    ///    same artifact + bytes + scan_type. The lock guarantees we now see
+    ///    any placeholder a racing prepare already committed, so we reuse its
+    ///    id (`inserted = false`) instead of adding a duplicate.
+    /// 3. Otherwise insert a fresh `running` placeholder and return its id
+    ///    with `inserted = true`.
+    ///
+    /// Uses unchecked `sqlx::query`/`query_as` (mirroring the advisory-lock
+    /// pattern in `main.rs`) so no new compile-time-verified query is added
+    /// and offline `cargo sqlx prepare` is not required.
+    ///
+    /// Returns `(scan_result_id, inserted)`.
+    pub async fn prepare_scan_placeholder(
+        &self,
+        artifact_id: Uuid,
+        repository_id: Uuid,
+        checksum_sha256: &str,
+        scan_type: &str,
+        ttl_days: i32,
+        zero_findings_ttl_days: i32,
+    ) -> Result<(Uuid, bool)> {
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Serialize concurrent preparers for this (artifact_id, scan_type)
+        // so the re-check below sees any placeholder a racing caller has
+        // already committed. Transaction-scoped lock is released on commit
+        // or rollback. Two i32 keys avoid collisions across scan_types for
+        // the same artifact while keeping the lock granular.
+        let lock_key_a = (artifact_id.as_u128() as u64) as i64;
+        let lock_key_b = i64::from(stable_lock_key(scan_type));
+        sqlx::query("SELECT pg_advisory_xact_lock($1, $2)")
+            .bind(lock_key_a)
+            .bind(lock_key_b)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // 1. Reusable completed scan for these exact bytes (the #1373 path).
+        let completed: Option<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT id
+            FROM scan_results
+            WHERE artifact_id = $1
+              AND checksum_sha256 = $2
+              AND scan_type = $3
+              AND status = 'completed'
+              AND completed_at > NOW() - (
+                  CASE WHEN findings_count = 0 THEN $5 ELSE $4 END || ' days'
+              )::interval
+            ORDER BY completed_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(artifact_id)
+        .bind(checksum_sha256)
+        .bind(scan_type)
+        .bind(ttl_days.to_string())
+        .bind(zero_findings_ttl_days.to_string())
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if let Some((id,)) = completed {
+            tx.commit()
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            return Ok((id, false));
+        }
+
+        // 2. In-flight placeholder for the same artifact + bytes + scan_type
+        //    committed by a racing prepare. Reuse it instead of inserting a
+        //    duplicate; the worker that owns it will run the scan once.
+        let running: Option<(Uuid,)> = sqlx::query_as(
+            r#"
+            SELECT id
+            FROM scan_results
+            WHERE artifact_id = $1
+              AND checksum_sha256 = $2
+              AND scan_type = $3
+              AND status = 'running'
+            ORDER BY started_at DESC NULLS LAST, created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(artifact_id)
+        .bind(checksum_sha256)
+        .bind(scan_type)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if let Some((id,)) = running {
+            tx.commit()
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            return Ok((id, false));
+        }
+
+        // 3. No reusable or in-flight row: insert a fresh placeholder.
+        let (id,): (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO scan_results
+                (artifact_id, repository_id, scan_type, status, started_at, checksum_sha256)
+            VALUES ($1, $2, $3, 'running', NOW(), $4)
+            RETURNING id
+            "#,
+        )
+        .bind(artifact_id)
+        .bind(repository_id)
+        .bind(scan_type)
+        .bind(checksum_sha256)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok((id, true))
     }
 
     /// Copy scan results from a source scan to a new artifact.
@@ -1792,6 +1953,24 @@ impl ScanResultService {
 mod tests {
     use super::*;
     use crate::models::security::{Grade, RawFinding, ScanFinding, ScanResult, Severity};
+
+    // =======================================================================
+    // stable_lock_key (#1935 advisory-lock key)
+    // =======================================================================
+
+    #[test]
+    fn test_stable_lock_key_is_deterministic() {
+        // Must be stable across calls/processes so concurrent replicas hash
+        // the same scan_type to the same advisory-lock key.
+        assert_eq!(stable_lock_key("dependency"), stable_lock_key("dependency"));
+        assert_eq!(stable_lock_key("image"), stable_lock_key("image"));
+    }
+
+    #[test]
+    fn test_stable_lock_key_differs_per_scan_type() {
+        assert_ne!(stable_lock_key("dependency"), stable_lock_key("image"));
+        assert_ne!(stable_lock_key("image"), stable_lock_key("openscap"));
+    }
 
     // =======================================================================
     // compute_security_score (extracted pure function)

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
-use crate::models::security::{RawFinding, RawPackage, ScanResult, Severity};
+use crate::models::security::{RawFinding, RawPackage, Severity};
 use crate::services::grype_scanner::GrypeScanner;
 use crate::services::image_scanner::ImageScanner;
 use crate::services::scan_config_service::ScanConfigService;
@@ -445,45 +445,13 @@ pub(crate) fn is_within_dedup_ttl(
     completed_at >= cutoff
 }
 
-/// Outcome of consulting `find_existing_scan_for_artifact` for a single
-/// scanner inside `prepare_artifact_scan`.
-///
-/// Captures the branch the DB-bound caller must take after the query:
-/// either short-circuit and reuse the existing scan id in the trigger
-/// response (no new placeholder, no fresh scan), or fall through to
-/// inserting a new `running` placeholder. Splitting this out makes the
-/// branch unit-testable without a database and pins the contract that
-/// the existing-scan id (not a newly minted UUID) is what gets surfaced
-/// to clients on the dedup path.
-#[derive(Debug, PartialEq, Eq)]
-pub(crate) enum ShortCircuitDecision {
-    /// Reuse the existing scan's id directly. No placeholder row, no
-    /// fresh scan: the artifact already has a completed scan for these
-    /// bytes and this scanner.
-    UseExisting(Uuid),
-    /// No usable existing scan; the caller must insert a fresh
-    /// placeholder and queue the scan normally.
-    InsertPlaceholder,
-}
-
-/// Decide whether to short-circuit the prepare step for one scanner.
-///
-/// Wraps the `Option<&ScanResult>` returned by
-/// `ScanResultService::find_existing_scan_for_artifact`. Pulled out so
-/// the actual SQL stays thin (integration-tested) and the decision
-/// logic stays pure (unit-tested).
-///
-/// Pre-#1373, this branch did not exist: every prepare iteration
-/// inserted a placeholder unconditionally, which is what produced the
-/// duplicate completed rows the release gate caught.
-pub(crate) fn decide_short_circuit_from_existing(
-    existing: Option<&ScanResult>,
-) -> ShortCircuitDecision {
-    match existing {
-        Some(scan) => ShortCircuitDecision::UseExisting(scan.id),
-        None => ShortCircuitDecision::InsertPlaceholder,
-    }
-}
+// The check-then-act decision that used to live here (the
+// `ShortCircuitDecision` enum + `decide_short_circuit_from_existing`) was
+// removed in #1935: the SELECT-existing/INSERT-placeholder branch it modeled
+// raced under concurrent triggers. The decision is now made atomically inside
+// `ScanResultService::prepare_scan_placeholder`, under a per-(artifact_id,
+// scan_type) advisory lock, so there is no longer a database-free branch to
+// unit-test in isolation.
 
 /// Outcome of the same-artifact branch inside `scan_artifact_inner` when
 /// `find_reusable_scan` returns a row whose `artifact_id` matches the
@@ -2614,43 +2582,45 @@ impl ScannerService {
         // gets the missing scanner queued normally.
         let mut prepared = Vec::with_capacity(self.scanners.len());
         for scanner in &self.scanners {
-            // When the caller asked to bypass dedup, skip the lookup entirely
-            // and always insert a fresh placeholder. We deliberately don't
-            // even SELECT here so the explicit-rescan path can't accidentally
-            // be diverted by a row that happens to satisfy the TTL.
-            let existing = if bypass_dedup {
-                None
-            } else {
-                self.scan_result_service
-                    .find_existing_scan_for_artifact(
+            if bypass_dedup {
+                // When the caller asked to bypass dedup, skip the dedup
+                // lookup entirely and always insert a fresh placeholder. We
+                // deliberately don't even SELECT here so the explicit-rescan
+                // path can't accidentally be diverted by a row that happens
+                // to satisfy the TTL.
+                let row = self
+                    .scan_result_service
+                    .create_scan_result_with_checksum(
                         artifact_id,
-                        &artifact.checksum_sha256,
+                        artifact.repository_id,
                         scanner.scan_type(),
-                        DEDUP_TTL_DAYS,
-                        ZERO_FINDINGS_DEDUP_TTL_DAYS,
+                        Some(&artifact.checksum_sha256),
                     )
-                    .await
-                    .ok()
-                    .flatten()
-            };
-
-            match decide_short_circuit_from_existing(existing.as_ref()) {
-                ShortCircuitDecision::UseExisting(id) => {
-                    prepared.push((scanner.scan_type().to_string(), id));
-                }
-                ShortCircuitDecision::InsertPlaceholder => {
-                    let row = self
-                        .scan_result_service
-                        .create_scan_result_with_checksum(
-                            artifact_id,
-                            artifact.repository_id,
-                            scanner.scan_type(),
-                            Some(&artifact.checksum_sha256),
-                        )
-                        .await?;
-                    prepared.push((scanner.scan_type().to_string(), row.id));
-                }
+                    .await?;
+                prepared.push((scanner.scan_type().to_string(), row.id));
+                continue;
             }
+
+            // #1935: the dedup check (look up existing scan) and the
+            // placeholder insert must be atomic. `prepare_scan_placeholder`
+            // serializes both under a per-(artifact_id, scan_type) advisory
+            // lock so concurrent triggers on the same fresh artifact can no
+            // longer each insert a duplicate `running` placeholder. It
+            // short-circuits to an existing completed scan (the #1373 path)
+            // or to an in-flight placeholder committed by a racing prepare,
+            // and only inserts when neither exists.
+            let (id, _inserted) = self
+                .scan_result_service
+                .prepare_scan_placeholder(
+                    artifact_id,
+                    artifact.repository_id,
+                    &artifact.checksum_sha256,
+                    scanner.scan_type(),
+                    DEDUP_TTL_DAYS,
+                    ZERO_FINDINGS_DEDUP_TTL_DAYS,
+                )
+                .await?;
+            prepared.push((scanner.scan_type().to_string(), id));
         }
 
         Ok(prepared)
@@ -9575,7 +9545,7 @@ mod tests {
 
     // -----------------------------------------------------------------------
     // #1373 short-circuit predicates: is_within_dedup_ttl,
-    // decide_short_circuit_from_existing, decide_same_artifact_action.
+    // decide_same_artifact_action.
     //
     // These are the pure decision helpers underpinning the same-artifact
     // dedup short-circuit. The DB-coupled wrappers
@@ -9584,32 +9554,6 @@ mod tests {
     // `backend/tests/scan_dedup_short_circuit_tests.rs`; this section
     // pins the logic that does not need a database.
     // -----------------------------------------------------------------------
-
-    /// Build a minimal ScanResult for predicate tests. Only fields the
-    /// decision functions inspect are meaningful; everything else is
-    /// zero/default.
-    fn fake_scan_result(id: Uuid) -> ScanResult {
-        ScanResult {
-            id,
-            artifact_id: Uuid::nil(),
-            repository_id: Uuid::nil(),
-            scan_type: "trivy".to_string(),
-            status: "completed".to_string(),
-            findings_count: 0,
-            critical_count: 0,
-            high_count: 0,
-            medium_count: 0,
-            low_count: 0,
-            info_count: 0,
-            scanner_version: None,
-            error_message: None,
-            started_at: None,
-            completed_at: Some(Utc::now()),
-            created_at: Utc::now(),
-            is_reused: false,
-            source_scan_id: None,
-        }
-    }
 
     #[test]
     fn test_is_within_dedup_ttl_just_completed_is_within() {
@@ -9692,35 +9636,6 @@ mod tests {
         let now = Utc::now();
         let future = now + chrono::Duration::minutes(5);
         assert!(is_within_dedup_ttl(Some(future), now, 30));
-    }
-
-    #[test]
-    fn test_decide_short_circuit_from_existing_some_returns_use_existing() {
-        let id = Uuid::new_v4();
-        let scan = fake_scan_result(id);
-        let decision = decide_short_circuit_from_existing(Some(&scan));
-        assert_eq!(decision, ShortCircuitDecision::UseExisting(id));
-    }
-
-    #[test]
-    fn test_decide_short_circuit_from_existing_none_returns_insert_placeholder() {
-        let decision = decide_short_circuit_from_existing(None);
-        assert_eq!(decision, ShortCircuitDecision::InsertPlaceholder);
-    }
-
-    #[test]
-    fn test_decide_short_circuit_uses_scan_id_not_artifact_id() {
-        // Regression: the decision must surface the SCAN id, not the
-        // artifact id. Pre-#1373 the trigger response leaked a fresh
-        // placeholder UUID; the fix is meaningless if we ever return
-        // the wrong field here.
-        let scan_id = Uuid::new_v4();
-        let artifact_id = Uuid::new_v4();
-        let mut scan = fake_scan_result(scan_id);
-        scan.artifact_id = artifact_id;
-        assert_ne!(scan_id, artifact_id);
-        let decision = decide_short_circuit_from_existing(Some(&scan));
-        assert_eq!(decision, ShortCircuitDecision::UseExisting(scan_id));
     }
 
     #[test]
@@ -9808,21 +9723,6 @@ mod tests {
         let action =
             decide_same_artifact_action(&PreparedScanAction::Reuse(Uuid::nil()), Uuid::nil());
         assert_eq!(action, SameArtifactAction::NoOp);
-    }
-
-    #[test]
-    fn test_short_circuit_decision_distinct_ids_are_distinct() {
-        // Sanity: two different scans short-circuit to different
-        // decisions. Catches an accidental `_` -> always-same-id
-        // pattern in a future refactor.
-        let id1 = Uuid::new_v4();
-        let id2 = Uuid::new_v4();
-        let s1 = fake_scan_result(id1);
-        let s2 = fake_scan_result(id2);
-        assert_ne!(
-            decide_short_circuit_from_existing(Some(&s1)),
-            decide_short_circuit_from_existing(Some(&s2)),
-        );
     }
 
     #[test]

--- a/backend/tests/scan_dedup_short_circuit_tests.rs
+++ b/backend/tests/scan_dedup_short_circuit_tests.rs
@@ -447,3 +447,85 @@ async fn test_find_existing_returns_most_recent_when_multiple_completed_exist() 
 
     cleanup(&pool, repo_id).await;
 }
+
+// ---------------------------------------------------------------------------
+// #1935: concurrent prepare must not create duplicate placeholders
+// ---------------------------------------------------------------------------
+//
+// Regression for the check-then-act race in the #1373 short-circuit. The old
+// `prepare_artifact_scan` did a bare SELECT followed by a separate INSERT with
+// no lock/constraint/transaction, so N concurrent triggers on one fresh
+// artifact each saw "no completed row" and each inserted its own `running`
+// placeholder (issue reproducer: 10 concurrent triggers -> 10 completed rows
+// for one scan_type). `prepare_scan_placeholder` serializes the decide-then-
+// insert under a per-(artifact_id, scan_type) advisory lock, so the loser of
+// the race reuses the winner's in-flight row.
+//
+// DB-backed: runtime-skips (does NOT fail) when DATABASE_URL is absent.
+
+#[tokio::test]
+async fn test_concurrent_prepare_creates_single_placeholder() {
+    let Ok(database_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("DATABASE_URL not set; skipping DB-backed concurrency test");
+        return;
+    };
+    let pool = PgPool::connect(&database_url)
+        .await
+        .expect("failed to connect to database");
+
+    let repo_id = create_test_repo(&pool).await;
+    let artifact_id = insert_artifact(&pool, repo_id, "concurrent.tgz", CHECKSUM_A).await;
+
+    // Fire many concurrent preparers for the same artifact + scan_type, as a
+    // burst of concurrent scan triggers would. Each task gets its own service
+    // over a clone of the shared pool, mirroring independent request handlers.
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let svc = ScanResultService::new(pool.clone());
+        handles.push(tokio::spawn(async move {
+            svc.prepare_scan_placeholder(artifact_id, repo_id, CHECKSUM_A, "dependency", 30, 30)
+                .await
+        }));
+    }
+
+    let mut ids = Vec::new();
+    let mut inserted_count = 0;
+    for h in handles {
+        let (id, inserted) = h
+            .await
+            .expect("task panicked")
+            .expect("prepare must not error");
+        ids.push(id);
+        if inserted {
+            inserted_count += 1;
+        }
+    }
+
+    // Exactly one caller actually inserted a placeholder; all others reused it.
+    assert_eq!(
+        inserted_count, 1,
+        "exactly one concurrent prepare must insert a placeholder; the rest reuse it"
+    );
+
+    // Every caller surfaced the same scan id.
+    let first = ids[0];
+    assert!(
+        ids.iter().all(|id| *id == first),
+        "all concurrent preparers must return the same scan id, got: {ids:?}"
+    );
+
+    // And the database holds exactly one row for this artifact + scan_type.
+    let row_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM scan_results WHERE artifact_id = $1 AND scan_type = 'dependency'",
+    )
+    .bind(artifact_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count query must not error");
+    assert_eq!(
+        row_count, 1,
+        "concurrent prepare must leave exactly one scan_results row, found {row_count}"
+    );
+
+    cleanup(&pool, repo_id).await;
+}


### PR DESCRIPTION
## Summary

The #1373 same-artifact scan-dedup short-circuit in `prepare_artifact_scan` did a check-then-act with no transaction, row lock, or unique constraint: a SELECT (`find_existing_scan_for_artifact`) followed by a separate INSERT (`create_scan_result_with_checksum`). Under concurrent scan triggers on the same fresh artifact, every caller observed "no completed row" before any INSERT committed, so each inserted its own `running` placeholder and ran a full redundant scan — leaving multiple completed rows for one logical scan and defeating the short-circuit (issue reproducer: 10 concurrent triggers → 10 completed `grype` rows for one scan_type).

This change replaces the loop's per-scanner SELECT+INSERT with `ScanResultService::prepare_scan_placeholder`, which serializes the decide-then-insert per `(artifact_id, scan_type)` using a transaction-scoped advisory lock (`pg_advisory_xact_lock`) inside a single transaction. Holding the lock, it:

1. short-circuits to an existing completed scan (the #1373 happy path); or
2. reuses an in-flight `running` placeholder committed by a racing prepare (the loser of the race reuses the winner's id); or
3. inserts a fresh placeholder when neither exists.

The explicit-rescan (`bypass_dedup`) path is unchanged and still inserts a fresh placeholder unconditionally.

Implementation notes:
- Uses unchecked `sqlx::query`/`query_as` (matching the advisory-lock pattern already in `main.rs`), so **no new compile-time-verified query is added and offline `cargo sqlx prepare` is not required**. No migration / schema change.
- Advisory-lock key is `(low 64 bits of artifact_id, FNV-1a hash of scan_type)`; a deterministic hash so concurrent backend replicas agree on the key. Key collisions only cause harmless extra serialization, never incorrect dedup.
- Removes the now-dead `decide_short_circuit_from_existing` / `ShortCircuitDecision` helper (the check-then-act branch it modeled) and its unit tests, superseded by the atomic method.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Adds `test_concurrent_prepare_creates_single_placeholder` (DB-backed, runtime-skips when `DATABASE_URL` is absent): fires 10 concurrent `prepare_scan_placeholder` calls on one fresh artifact and asserts exactly one placeholder is inserted, all callers return the same id, and exactly one `scan_results` row exists. Also adds unit tests for the deterministic advisory-lock key.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

`cargo clippy -p artifact-keeper-backend --all-targets -- -D warnings` passes clean; lib unit tests pass. The concurrency integration test requires PostgreSQL and was not run locally (no DB available in this environment); it runtime-skips without `DATABASE_URL`.

## API Changes
- [x] N/A - no API changes

Fixes #1935