### PR TITLE
fix(scanner): resolve OCI image index to a concrete child platform before scanning (#1971)

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -28,8 +28,8 @@ use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::models::security::{RawFinding, RawPackage, Severity};
 use crate::services::scanner_service::{
     cached_cli_version, capture_cli_version, fail_scan, format_grype_version,
-    is_oci_image_artifact, join_oci_image_ref, parse_oci_manifest_path, validate_trivy_purl,
-    ScanOutput, ScanTarget, ScanWorkspace, Scanner, VersionCache,
+    is_oci_image_artifact, join_oci_image_ref, parse_oci_manifest_path, resolve_scan_reference,
+    validate_trivy_purl, ScanOutput, ScanTarget, ScanWorkspace, Scanner, VersionCache,
 };
 
 // ---------------------------------------------------------------------------
@@ -300,11 +300,22 @@ impl GrypeScanner {
     /// `v2/<name>/manifests/<ref>` path; the caller skips Grype rather than
     /// falling through to dir mode (which would resurrect #966's zero-
     /// findings-on-manifest-JSON bug).
-    pub(crate) fn build_registry_image_ref(artifact: &Artifact) -> Option<String> {
+    /// `body` is the in-hand manifest body for the artifact (the orchestrator
+    /// loads it and threads it through `scan`). For a multi-arch image index it
+    /// is used to resolve a concrete scannable child-platform digest before the
+    /// host/name qualification and join (#1971); for single-arch / malformed /
+    /// absent bodies the reference is unchanged (passthrough). Applicability
+    /// gates have no body at gate time and pass `None`, which resolves to
+    /// passthrough — gating stays on the PATH only, never on the index body.
+    pub(crate) fn build_registry_image_ref(
+        artifact: &Artifact,
+        body: Option<&[u8]>,
+    ) -> Option<String> {
         let (name, reference) = parse_oci_manifest_path(&artifact.path)?;
+        let resolved = resolve_scan_reference(body.unwrap_or_default(), reference).into_reference();
         let host = resolve_registry_host();
         let qualified_name = format!("{}/{}", host, name);
-        Some(join_oci_image_ref(&qualified_name, reference))
+        Some(join_oci_image_ref(&qualified_name, &resolved))
     }
 
     /// Build the Grype registry image ref using the owning repository routing
@@ -321,11 +332,13 @@ impl GrypeScanner {
         artifact: &Artifact,
         repository_key: &str,
         _repository_type: &str,
+        body: Option<&[u8]>,
     ) -> Option<String> {
         let (name, reference) = parse_oci_manifest_path(&artifact.path)?;
+        let resolved = resolve_scan_reference(body.unwrap_or_default(), reference).into_reference();
         let host = resolve_registry_host();
         let qualified_name = format!("{}/{}/{}", host, repository_key, name);
-        Some(join_oci_image_ref(&qualified_name, reference))
+        Some(join_oci_image_ref(&qualified_name, &resolved))
     }
 
     /// Single source of truth for the OCI `registry:` image ref used by the
@@ -343,11 +356,19 @@ impl GrypeScanner {
     /// and the registry rejected with `NAME_UNKNOWN` because no repository
     /// named `<image>` exists. Threading the owning repository key restores a
     /// routable `<host>/<repo_key>/<image>:<tag>` ref.
-    fn oci_registry_target(artifact: &Artifact, target: &ScanTarget<'_>) -> Option<String> {
+    ///
+    /// `body` is the in-hand manifest body used for index→child resolution
+    /// (#1971); applicability gating passes `None` so it stays path-only.
+    fn oci_registry_target(
+        artifact: &Artifact,
+        target: &ScanTarget<'_>,
+        body: Option<&[u8]>,
+    ) -> Option<String> {
         Self::build_registry_image_ref_for_repo(
             artifact,
             target.repository_key,
             target.repository_type,
+            body,
         )
     }
 
@@ -724,7 +745,11 @@ impl Scanner for GrypeScanner {
             // registry mode has nothing to pull, and falling through to dir
             // mode would resurrect the #966 "0 findings on manifest JSON"
             // bug. Better to skip Grype for malformed OCI paths.
-            return Self::build_registry_image_ref(artifact).is_some();
+            // Applicability gates on the PATH only: there is no manifest body
+            // at gate time, so pass None (→ passthrough). A malformed index
+            // body must never flip an artifact applicable→not-applicable and
+            // skip the scan (#1971).
+            return Self::build_registry_image_ref(artifact, None).is_some();
         }
         true
     }
@@ -735,7 +760,8 @@ impl Scanner for GrypeScanner {
             // Production OCI applicability is repository-aware: stored
             // artifact paths omit the routing key, so Grype must validate that
             // a ref can be built with the owning repository key restored.
-            return Self::oci_registry_target(artifact, target).is_some();
+            // Path-only applicability: no manifest body at gate time (#1971).
+            return Self::oci_registry_target(artifact, target, None).is_some();
         }
         self.is_applicable(artifact)
     }
@@ -768,13 +794,18 @@ impl Scanner for GrypeScanner {
         // regression). `is_applicable` already filtered out OCI paths Grype
         // cannot build a ref for.
         if is_oci_image_artifact(artifact) {
-            let image_ref = Self::build_registry_image_ref(artifact).ok_or_else(|| {
-                AppError::Internal(
-                    "Grype OCI scan: failed to reconstruct registry image ref \
+            // #1971: pass the in-hand manifest body so a multi-arch image index
+            // is resolved to a concrete scannable child digest before grype
+            // sees it (otherwise grype's default platform pick can catalog zero
+            // packages → empty SBOM).
+            let image_ref =
+                Self::build_registry_image_ref(artifact, Some(content)).ok_or_else(|| {
+                    AppError::Internal(
+                        "Grype OCI scan: failed to reconstruct registry image ref \
                      (is_applicable should have rejected this artifact)"
-                        .to_string(),
-                )
-            })?;
+                            .to_string(),
+                    )
+                })?;
             return self.scan_oci_registry_ref(artifact, image_ref).await;
         }
 
@@ -828,13 +859,15 @@ impl Scanner for GrypeScanner {
     ) -> Result<ScanOutput> {
         let artifact = target.artifact;
         if is_oci_image_artifact(artifact) {
-            let image_ref = Self::oci_registry_target(artifact, target).ok_or_else(|| {
-                AppError::Internal(
-                    "Grype OCI scan: failed to reconstruct repository-qualified registry image ref \
+            // #1971: thread the in-hand manifest body for index→child resolution.
+            let image_ref =
+                Self::oci_registry_target(artifact, target, Some(content)).ok_or_else(|| {
+                    AppError::Internal(
+                        "Grype OCI scan: failed to reconstruct repository-qualified registry image ref \
                      (is_applicable_for_target should have rejected this artifact)"
-                        .to_string(),
-                )
-            })?;
+                            .to_string(),
+                    )
+                })?;
             return self.scan_oci_registry_ref(artifact, image_ref).await;
         }
 
@@ -967,7 +1000,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
             "v2/library/nginx/manifests/latest",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local", None)
             .expect("ref must build");
         assert_eq!(r, "localhost:8080/docker-local/library/nginx:latest");
     }
@@ -980,7 +1013,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
             "v2/library/nginx/manifests/latest",
         );
-        let r = GrypeScanner::build_registry_image_ref(&a).expect("ref must build");
+        let r = GrypeScanner::build_registry_image_ref(&a, None).expect("ref must build");
         assert_eq!(
             r, "localhost:8080/library/nginx:latest",
             "legacy callers without ScanTarget context still get the old path-only ref; production uses build_registry_image_ref_for_repo"
@@ -1001,7 +1034,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
             "v2/org/app/manifests/sha256:cf4501fe4ed427dfc7c81f68be661271ffd164bb2e774caf0e3aa8eac775eb6b",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "oci-prod", "local")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "oci-prod", "local", None)
             .expect("ref must build");
         assert_eq!(
             r,
@@ -1027,7 +1060,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
             "v2/library/redis/manifests/7.2",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local", None)
             .expect("ref must build");
         // Scheme stripped, trailing slashes trimmed.
         assert_eq!(
@@ -1045,8 +1078,9 @@ mod tests {
             "application/vnd.docker.distribution.manifest.v2+json",
             "v2/library/alpine/manifests/3.19",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-mirror", "remote")
-            .expect("ref must build");
+        let r =
+            GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-mirror", "remote", None)
+                .expect("ref must build");
         assert_eq!(
             r,
             "ak.svc.cluster.local:8080/docker-mirror/library/alpine:3.19"
@@ -1069,7 +1103,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
             "v2/library/nginx/manifests/latest",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local", None)
             .expect("ref must build");
         assert!(
             !r.contains("hunter2") && !r.contains("svcuser"),
@@ -1095,7 +1129,7 @@ mod tests {
             "stored OCI artifact paths are repository-internal and intentionally omit the repo key"
         );
 
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local", None)
             .expect("ref must build");
         assert_eq!(r, "localhost:8080/docker-local/library/nginx:latest");
     }
@@ -1108,7 +1142,7 @@ mod tests {
             "application/vnd.docker.distribution.manifest.v2+json",
             "v2/library/alpine/manifests/3.19",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-cache", "remote")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-cache", "remote", None)
             .expect("ref must build");
         assert_eq!(r, "localhost:8080/docker-cache/library/alpine:3.19");
     }
@@ -1121,7 +1155,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
             "v2/library/nginx/manifests/latest",
         );
-        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "library", "local")
+        let r = GrypeScanner::build_registry_image_ref_for_repo(&a, "library", "local", None)
             .expect("ref must build");
         assert_eq!(r, "localhost:8080/library/library/nginx:latest");
     }
@@ -1137,12 +1171,79 @@ mod tests {
         ] {
             let a = make_test_artifact("x", "application/octet-stream", path);
             assert!(
-                GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local")
+                GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local", None)
                     .is_none(),
                 "malformed path '{}' must not produce a registry ref",
                 path
             );
         }
+    }
+
+    /// #1971 builder integration: when an image-index body is threaded into
+    /// the repo-scoped builder, the ref it produces addresses a concrete child
+    /// digest (host/repo/name@sha256:<child>), not the index tag — so grype
+    /// enumerates a real image instead of falling back to an empty default
+    /// platform pick.
+    #[test]
+    fn test_build_registry_image_ref_for_repo_resolves_index_to_child_digest() {
+        let _env = EnvGuard::new();
+        let child = match crate::services::scanner_service::runner_arch() {
+            "arm64" => "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            _ => "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        };
+        let index_body = r#"{"manifests":[
+                 {"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","platform":{"os":"linux","architecture":"amd64"}},
+                 {"digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222","platform":{"os":"linux","architecture":"arm64"}}
+               ]}"#;
+        let a = make_test_artifact(
+            "app",
+            "application/vnd.oci.image.index.v1+json",
+            "v2/org/app/manifests/latest",
+        );
+        let r = GrypeScanner::build_registry_image_ref_for_repo(
+            &a,
+            "oci-prod",
+            "local",
+            Some(index_body.as_bytes()),
+        )
+        .expect("ref must build");
+        assert_eq!(r, format!("localhost:8080/oci-prod/org/app@{}", child));
+        assert!(
+            !r.ends_with(":latest"),
+            "index ref must be resolved to a child digest, not the index tag: {r}"
+        );
+    }
+
+    /// #1971 regression: a single-arch image body threaded into the builder
+    /// leaves the tag ref unchanged (passthrough) — identical to the no-body
+    /// path the existing tests assert.
+    #[test]
+    fn test_build_registry_image_ref_for_repo_single_arch_body_is_unchanged() {
+        let _env = EnvGuard::new();
+        let single_arch = br#"{"schemaVersion":2,"config":{"digest":"sha256:cfg"},"layers":[]}"#;
+        let a = make_test_artifact(
+            "nginx",
+            "application/vnd.oci.image.manifest.v1+json",
+            "v2/library/nginx/manifests/latest",
+        );
+        let with_body = GrypeScanner::build_registry_image_ref_for_repo(
+            &a,
+            "docker-local",
+            "local",
+            Some(single_arch),
+        )
+        .expect("ref must build");
+        let without_body =
+            GrypeScanner::build_registry_image_ref_for_repo(&a, "docker-local", "local", None)
+                .expect("ref must build");
+        assert_eq!(
+            with_body,
+            "localhost:8080/docker-local/library/nginx:latest"
+        );
+        assert_eq!(
+            with_body, without_body,
+            "single-arch body must be byte-for-byte identical to the no-body path"
+        );
     }
 
     /// Regression test for issue #1903 ("Cannot run Grype OCI scan on images
@@ -1175,7 +1276,7 @@ mod tests {
 
         // The scan dispatch resolves a routable, repository-scoped ref.
         let dispatched =
-            GrypeScanner::oci_registry_target(&artifact, &target).expect("ref must build");
+            GrypeScanner::oci_registry_target(&artifact, &target, None).expect("ref must build");
         assert_eq!(
             dispatched, "localhost:8080/docker-repo1/sa-backend:release-1.4.0",
             "scan dispatch must thread the owning repository key into the OCI ref"
@@ -1187,7 +1288,7 @@ mod tests {
             dispatched.contains("/docker-repo1/sa-backend:"),
             "dispatched ref must be repo-scoped (<repo>/<image>): {dispatched}"
         );
-        let path_only = GrypeScanner::build_registry_image_ref(&artifact)
+        let path_only = GrypeScanner::build_registry_image_ref(&artifact, None)
             .expect("legacy builder also resolves the path");
         assert_eq!(
             path_only, "localhost:8080/sa-backend:release-1.4.0",
@@ -1221,8 +1322,13 @@ mod tests {
         );
         // And the ref applicability validated is the repo-scoped one.
         assert_eq!(
-            GrypeScanner::oci_registry_target(&artifact, &target),
-            GrypeScanner::build_registry_image_ref_for_repo(&artifact, "docker-repo1", "local"),
+            GrypeScanner::oci_registry_target(&artifact, &target, None),
+            GrypeScanner::build_registry_image_ref_for_repo(
+                &artifact,
+                "docker-repo1",
+                "local",
+                None
+            ),
             "applicability and dispatch must agree on the repo-scoped ref"
         );
     }

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -123,11 +123,23 @@ impl ImageScanner {
     /// `:` for tags per the OCI distribution spec (#1483). Using `:` for
     /// digest refs produces a string the Trivy CLI rejects with
     /// "could not parse reference".
-    fn extract_image_ref(artifact: &Artifact) -> Option<String> {
+    /// `body` is the in-hand manifest body the orchestrator already loaded.
+    /// For a multi-arch image index it is used to resolve a concrete scannable
+    /// child-platform digest before the join (#1971); for single-arch /
+    /// malformed / absent bodies the reference is unchanged (passthrough).
+    /// Applicability gating has no body and passes `None`, so it stays
+    /// path-only. The resolved digest flows through both `scan_with_trivy` and
+    /// the HTTP-Twirp fallback `scan_with_trivy_http` unchanged.
+    fn extract_image_ref(artifact: &Artifact, body: Option<&[u8]>) -> Option<String> {
         let (name, reference) =
             crate::services::scanner_service::parse_oci_manifest_path(&artifact.path)?;
+        let resolved = crate::services::scanner_service::resolve_scan_reference(
+            body.unwrap_or_default(),
+            reference,
+        )
+        .into_reference();
         Some(crate::services::scanner_service::join_oci_image_ref(
-            name, reference,
+            name, &resolved,
         ))
     }
 
@@ -330,7 +342,7 @@ impl Scanner for ImageScanner {
         &self,
         artifact: &Artifact,
         _metadata: Option<&ArtifactMetadata>,
-        _content: &Bytes,
+        content: &Bytes,
     ) -> Result<ScanOutput> {
         debug_assert!(
             Self::is_container_image(artifact),
@@ -342,7 +354,10 @@ impl Scanner for ImageScanner {
         // That is a real error, not a "not applicable" case: surface it as
         // a failed scan so the operator sees error_message rather than a
         // silent completed-with-zero-findings row (issue #994).
-        let image_ref = match Self::extract_image_ref(artifact) {
+        // #1971: pass the in-hand manifest body so a multi-arch image index is
+        // resolved to a concrete scannable child digest before trivy (CLI or
+        // the HTTP-Twirp fallback) sees it.
+        let image_ref = match Self::extract_image_ref(artifact, Some(content)) {
             Some(r) => r,
             None => {
                 return Err(AppError::Internal(format!(
@@ -434,7 +449,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
         );
         assert_eq!(
-            ImageScanner::extract_image_ref(&artifact),
+            ImageScanner::extract_image_ref(&artifact, None),
             Some("myapp:v1.0.0".to_string())
         );
     }
@@ -446,7 +461,7 @@ mod tests {
             "application/vnd.docker.distribution.manifest.v2+json",
         );
         assert_eq!(
-            ImageScanner::extract_image_ref(&artifact),
+            ImageScanner::extract_image_ref(&artifact, None),
             Some("org/myapp:v1.0.0".to_string())
         );
     }
@@ -465,7 +480,7 @@ mod tests {
             "application/vnd.oci.image.manifest.v1+json",
         );
         assert_eq!(
-            ImageScanner::extract_image_ref(&artifact),
+            ImageScanner::extract_image_ref(&artifact, None),
             Some(
                 "org/myapp@sha256:cf4501fe4ed427dfc7c81f68be661271ffd164bb2e774caf0e3aa8eac775eb6b"
                     .to_string()
@@ -476,7 +491,50 @@ mod tests {
     #[test]
     fn test_extract_image_ref_invalid_path() {
         let artifact = make_test_artifact("some/random/path", "application/json");
-        assert_eq!(ImageScanner::extract_image_ref(&artifact), None);
+        assert_eq!(ImageScanner::extract_image_ref(&artifact, None), None);
+    }
+
+    /// #1971: an image-index body threaded into extract_image_ref resolves the
+    /// tag ref to a concrete child digest (name@sha256:<child>), so Trivy (CLI
+    /// or the HTTP-Twirp fallback) scans a real image rather than relying on a
+    /// default platform pick that can produce an empty SBOM.
+    #[test]
+    fn test_extract_image_ref_resolves_index_to_child_digest() {
+        let child = match crate::services::scanner_service::runner_arch() {
+            "arm64" => "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+            _ => "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+        };
+        let index_body = r#"{"manifests":[
+             {"digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111","platform":{"os":"linux","architecture":"amd64"}},
+             {"digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222","platform":{"os":"linux","architecture":"arm64"}}
+           ]}"#;
+        let artifact = make_test_artifact(
+            "v2/org/myapp/manifests/latest",
+            "application/vnd.oci.image.index.v1+json",
+        );
+        assert_eq!(
+            ImageScanner::extract_image_ref(&artifact, Some(index_body.as_bytes())),
+            Some(format!("org/myapp@{}", child))
+        );
+    }
+
+    /// #1971 regression: a single-arch image body leaves the tag ref unchanged
+    /// (passthrough) — identical to the no-body path.
+    #[test]
+    fn test_extract_image_ref_single_arch_body_is_unchanged() {
+        let single_arch = br#"{"schemaVersion":2,"config":{"digest":"sha256:cfg"},"layers":[]}"#;
+        let artifact = make_test_artifact(
+            "v2/org/myapp/manifests/v1.0.0",
+            "application/vnd.oci.image.manifest.v1+json",
+        );
+        assert_eq!(
+            ImageScanner::extract_image_ref(&artifact, Some(single_arch)),
+            ImageScanner::extract_image_ref(&artifact, None),
+        );
+        assert_eq!(
+            ImageScanner::extract_image_ref(&artifact, Some(single_arch)),
+            Some("org/myapp:v1.0.0".to_string())
+        );
     }
 
     #[test]

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -208,6 +208,177 @@ pub fn is_oci_digest_reference(reference: &str) -> bool {
     }
 }
 
+/// Normalize the host CPU architecture to the OCI `platform.architecture`
+/// token used in image-index child descriptors (`amd64`, `arm64`, ...).
+///
+/// `std::env::consts::ARCH` reports the Rust target triple's arch (`x86_64`,
+/// `aarch64`), which does not match the OCI/Go `GOARCH` vocabulary an image
+/// index uses. We only map the two architectures Artifact Keeper actually
+/// runs on; anything else passes through unchanged so an exotic runner still
+/// gets a deterministic (if non-matching) token and falls back to the first
+/// linux child during resolution rather than panicking. Pure + host-stable so
+/// it can anchor the resolution unit tests (#1971).
+pub fn runner_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    }
+}
+
+/// Outcome of resolving a scan reference against an in-hand manifest body.
+///
+/// Distinct variants make the three behaviors testable without inspecting the
+/// returned string: a single-arch / unparseable body is a no-op
+/// (`Passthrough`), an image index that yields a concrete scannable child
+/// rewrites the reference to that child digest (`ResolvedIndexChild`), and an
+/// index whose only children are attestation/unknown/empty manifests cannot be
+/// scanned at all (`UnresolvableIndex`, reference left unchanged so the caller
+/// still attempts the index ref rather than skipping the scan). See #1971.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ScanReferenceResolution {
+    /// Body is not an image index (single-arch image, malformed, or empty):
+    /// the reference is returned unchanged. The dominant single-arch path
+    /// (and digest-pinned #1483 refs) must hit this branch byte-for-byte.
+    Passthrough(String),
+    /// Body is an image index and a concrete scannable child platform manifest
+    /// was selected; the reference now addresses that child by digest.
+    ResolvedIndexChild(String),
+    /// Body is an image index but every child is attestation/unknown/empty, so
+    /// no scannable child digest exists. The reference is returned unchanged.
+    UnresolvableIndex(String),
+}
+
+impl ScanReferenceResolution {
+    /// The (possibly rewritten) reference to hand to the builders.
+    pub fn into_reference(self) -> String {
+        match self {
+            ScanReferenceResolution::Passthrough(r)
+            | ScanReferenceResolution::ResolvedIndexChild(r)
+            | ScanReferenceResolution::UnresolvableIndex(r) => r,
+        }
+    }
+}
+
+/// Whether an image-index child descriptor is an attestation / non-runnable
+/// manifest that must never be selected as a scan target. Selecting one
+/// re-introduces the empty-inventory bug (#1971), because attestation
+/// manifests carry no installed packages.
+///
+/// A child is excluded when ANY of the following hold:
+///   * `platform.os` or `platform.architecture` is `unknown` (the conventional
+///     marker `docker buildx` stamps onto attestation children),
+///   * `annotations["vnd.docker.reference.type"]` is `attestation-manifest`,
+///   * `artifactType` contains `in-toto` (SLSA/provenance attestations).
+fn is_excluded_index_child(child: &serde_json::Value) -> bool {
+    let platform = child.get("platform");
+    let os = platform
+        .and_then(|p| p.get("os"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let arch = platform
+        .and_then(|p| p.get("architecture"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if os.eq_ignore_ascii_case("unknown") || arch.eq_ignore_ascii_case("unknown") {
+        return true;
+    }
+    if child
+        .get("annotations")
+        .and_then(|a| a.get("vnd.docker.reference.type"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t.eq_ignore_ascii_case("attestation-manifest"))
+    {
+        return true;
+    }
+    if child
+        .get("artifactType")
+        .and_then(|v| v.as_str())
+        .is_some_and(|t| t.to_ascii_lowercase().contains("in-toto"))
+    {
+        return true;
+    }
+    false
+}
+
+/// Resolve a scan `reference` against the manifest `body` the orchestrator
+/// already loaded for this artifact (#1971).
+///
+/// When `body` is an OCI / Docker image **index** (manifest list), grype and
+/// trivy would otherwise rely on their own default platform pick; if no child
+/// matches the runner platform — or the only match is an attestation/empty
+/// manifest — the scan catalogs zero packages and the SBOM is empty. To avoid
+/// that, we select a concrete scannable child-platform manifest digest from
+/// the body and rewrite the reference to address it directly, so the scanner
+/// enumerates a real image. Selection order:
+///
+/// 1. the child whose `platform.architecture` matches [`runner_arch`] (and
+///    `platform.os == "linux"`),
+/// 2. else the first `linux` child,
+/// 3. else the first remaining candidate.
+///
+/// Attestation/unknown children are excluded up front (see
+/// [`is_excluded_index_child`]).
+///
+/// For any body that is not an image index (single-arch image, malformed,
+/// empty, or missing the `manifests` array) the reference is returned
+/// unchanged ([`ScanReferenceResolution::Passthrough`]) so the dominant
+/// single-arch and digest-pinned (#1483) paths are byte-for-byte untouched.
+/// This is a pure parse + string rewrite: no network, fully unit-testable.
+pub fn resolve_scan_reference(body: &[u8], reference: &str) -> ScanReferenceResolution {
+    let Ok(json) = serde_json::from_slice::<serde_json::Value>(body) else {
+        return ScanReferenceResolution::Passthrough(reference.to_string());
+    };
+    let Some(manifests) = json.get("manifests").and_then(|m| m.as_array()) else {
+        // Not an image index (single-arch image manifest or other): no-op.
+        return ScanReferenceResolution::Passthrough(reference.to_string());
+    };
+
+    // Candidate = scannable child with a digest, excluding attestation/unknown.
+    let candidates: Vec<&serde_json::Value> = manifests
+        .iter()
+        .filter(|child| {
+            child
+                .get("digest")
+                .and_then(|d| d.as_str())
+                .is_some_and(|d| !d.is_empty())
+                && !is_excluded_index_child(child)
+        })
+        .collect();
+
+    let child_os = |c: &serde_json::Value| -> String {
+        c.get("platform")
+            .and_then(|p| p.get("os"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    let child_arch = |c: &serde_json::Value| -> String {
+        c.get("platform")
+            .and_then(|p| p.get("architecture"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    let selected = candidates
+        .iter()
+        .find(|c| child_os(c) == "linux" && child_arch(c) == runner_arch())
+        .or_else(|| candidates.iter().find(|c| child_os(c) == "linux"))
+        .or_else(|| candidates.first());
+
+    match selected {
+        Some(child) => {
+            let digest = child
+                .get("digest")
+                .and_then(|d| d.as_str())
+                .unwrap_or_default();
+            ScanReferenceResolution::ResolvedIndexChild(digest.to_string())
+        }
+        None => ScanReferenceResolution::UnresolvableIndex(reference.to_string()),
+    }
+}
+
 /// SQL CTE that pins each `(artifact_id, scan_type)` pair to its single most-
 /// recently-completed scan_result row. Bind `$1 = artifact_id` and follow
 /// with `SELECT ... FROM <table> WHERE <table>.scan_result_id IN
@@ -11068,6 +11239,170 @@ mod tests {
             "digest ref must not use ':' between name and digest: {}",
             joined
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // #1971: resolve_scan_reference — OCI image-index → concrete child digest.
+    // Pure JSON parse + reference rewrite; no DB, no network, host-stable via
+    // runner_arch().
+    // -----------------------------------------------------------------------
+
+    const SHA_AMD64: &str =
+        "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+    const SHA_ARM64: &str =
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+    const SHA_ATTEST: &str =
+        "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+
+    fn index_two_arch() -> String {
+        format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json",
+                "manifests":[
+                  {{"digest":"{SHA_AMD64}","platform":{{"os":"linux","architecture":"amd64"}}}},
+                  {{"digest":"{SHA_ARM64}","platform":{{"os":"linux","architecture":"arm64"}}}}
+                ]}}"#
+        )
+    }
+
+    /// (1) An index with both runner-relevant arches resolves to the
+    /// runner-arch child digest (host-stable via runner_arch()).
+    #[test]
+    fn test_resolve_scan_reference_index_picks_runner_arch() {
+        let body = index_two_arch();
+        let res = resolve_scan_reference(body.as_bytes(), "latest");
+        let expected = match runner_arch() {
+            "amd64" => SHA_AMD64,
+            "arm64" => SHA_ARM64,
+            // On an exotic runner neither linux child matches the arch, so the
+            // first linux child wins; assert it is one of the two real digests.
+            _ => SHA_AMD64,
+        };
+        assert_eq!(
+            res,
+            ScanReferenceResolution::ResolvedIndexChild(expected.to_string())
+        );
+        // The joined builder form is name@sha256:... — assert via join.
+        assert_eq!(
+            join_oci_image_ref("host/repo/app", &res.into_reference()),
+            format!("host/repo/app@{}", expected)
+        );
+    }
+
+    /// (2) An index missing the runner arch falls back to the first linux
+    /// child (never empty / never UnresolvableIndex).
+    #[test]
+    fn test_resolve_scan_reference_index_falls_back_to_first_linux_child() {
+        // Single child whose arch is deliberately not the runner arch.
+        let other_arch = if runner_arch() == "amd64" {
+            "arm64"
+        } else {
+            "amd64"
+        };
+        let body = format!(
+            r#"{{"manifests":[
+                 {{"digest":"{SHA_AMD64}","platform":{{"os":"linux","architecture":"{other_arch}"}}}}
+               ]}}"#
+        );
+        let res = resolve_scan_reference(body.as_bytes(), "latest");
+        assert_eq!(
+            res,
+            ScanReferenceResolution::ResolvedIndexChild(SHA_AMD64.to_string())
+        );
+    }
+
+    /// (3) An index with an attestation child plus one real child selects the
+    /// real child, never the attestation digest.
+    #[test]
+    fn test_resolve_scan_reference_excludes_attestation_child() {
+        let body = format!(
+            r#"{{"manifests":[
+                 {{"digest":"{SHA_ATTEST}","platform":{{"os":"unknown","architecture":"unknown"}},
+                   "annotations":{{"vnd.docker.reference.type":"attestation-manifest"}}}},
+                 {{"digest":"{SHA_AMD64}","platform":{{"os":"linux","architecture":"{arch}"}}}}
+               ]}}"#,
+            arch = runner_arch()
+        );
+        let res = resolve_scan_reference(body.as_bytes(), "latest");
+        assert_eq!(
+            res,
+            ScanReferenceResolution::ResolvedIndexChild(SHA_AMD64.to_string()),
+            "must never select the attestation child"
+        );
+        assert_ne!(res.into_reference(), SHA_ATTEST);
+    }
+
+    /// (3b) artifactType in-toto and os=unknown are independently excluding.
+    #[test]
+    fn test_resolve_scan_reference_excludes_in_toto_artifact_type() {
+        let body = format!(
+            r#"{{"manifests":[
+                 {{"digest":"{SHA_ATTEST}","artifactType":"application/vnd.in-toto+json"}},
+                 {{"digest":"{SHA_AMD64}","platform":{{"os":"linux","architecture":"{arch}"}}}}
+               ]}}"#,
+            arch = runner_arch()
+        );
+        assert_eq!(
+            resolve_scan_reference(body.as_bytes(), "latest"),
+            ScanReferenceResolution::ResolvedIndexChild(SHA_AMD64.to_string())
+        );
+    }
+
+    /// (4) An index whose only children are attestation/empty → Unresolvable;
+    /// reference is returned unchanged.
+    #[test]
+    fn test_resolve_scan_reference_attestation_only_index_is_unresolvable() {
+        let body = format!(
+            r#"{{"manifests":[
+                 {{"digest":"{SHA_ATTEST}","platform":{{"os":"unknown","architecture":"unknown"}}}},
+                 {{"platform":{{"os":"linux","architecture":"amd64"}}}}
+               ]}}"#
+        );
+        let res = resolve_scan_reference(body.as_bytes(), "latest");
+        assert_eq!(
+            res,
+            ScanReferenceResolution::UnresolvableIndex("latest".to_string())
+        );
+        assert_eq!(res.into_reference(), "latest");
+    }
+
+    /// (5) REGRESSION: a normal single-arch image manifest body (config, no
+    /// manifests[]) is passthrough — reference byte-for-byte unchanged.
+    #[test]
+    fn test_resolve_scan_reference_single_arch_is_passthrough() {
+        let body = br#"{"schemaVersion":2,"config":{"digest":"sha256:cfg"},"layers":[]}"#;
+        assert_eq!(
+            resolve_scan_reference(body, "v1.0.0"),
+            ScanReferenceResolution::Passthrough("v1.0.0".to_string())
+        );
+        // Digest-pinned single manifest (#1483) also passes through unchanged.
+        assert_eq!(
+            resolve_scan_reference(body, SHA_AMD64),
+            ScanReferenceResolution::Passthrough(SHA_AMD64.to_string())
+        );
+    }
+
+    /// (5b) REGRESSION: malformed / empty bodies are passthrough.
+    #[test]
+    fn test_resolve_scan_reference_malformed_body_is_passthrough() {
+        for body in [&b""[..], &b"not json"[..], &br#"{"schemaVersion":2}"#[..]] {
+            assert_eq!(
+                resolve_scan_reference(body, "latest"),
+                ScanReferenceResolution::Passthrough("latest".to_string())
+            );
+        }
+    }
+
+    /// (6) runner_arch() maps the two architectures Artifact Keeper runs on.
+    #[test]
+    fn test_runner_arch_maps_known_architectures() {
+        // Pure, deterministic on the current host.
+        match std::env::consts::ARCH {
+            "x86_64" => assert_eq!(runner_arch(), "amd64"),
+            "aarch64" => assert_eq!(runner_arch(), "arm64"),
+            other => assert_eq!(runner_arch(), other),
+        }
+        // The returned token must be a non-empty OCI arch token.
+        assert!(!runner_arch().is_empty());
     }
 
     struct ContextOnlyScanner;


### PR DESCRIPTION
## Summary

Multi-arch OCI image-index (manifest list) references were handed straight to
grype/trivy by all three scan entrypoints, which then relied on the scanner's
own default platform pick. When no child matched the runner platform — or the
only matching child was an attestation/empty manifest — the scan cataloged zero
packages, producing zero `scan_packages` rows and an empty-component SBOM
(#1971).

This PR resolves an image index to a concrete scannable child-platform manifest
**digest** before scanning, using the manifest body the orchestrator already
loads and passes through to the scanners — no new registry call. The fix is a
pure parse + reference rewrite, so it lands identically for the grype scan,
grype scan_target, the trivy CLI path, and the trivy HTTP-Twirp fallback.

What changed:
- New shared helper `resolve_scan_reference(body, reference)` in
  `scanner_service.rs`. For an image-index body it selects the best scannable
  child (runner-arch linux child first, else first linux child, else first
  remaining candidate) and returns its digest; attestation/unknown children
  (`platform.os`/`architecture == unknown`,
  `annotations["vnd.docker.reference.type"] == attestation-manifest`, or
  `artifactType` containing `in-toto`) are excluded so the empty-inventory bug
  cannot recur. For any non-index/malformed/empty body the reference is
  returned unchanged (passthrough).
- Companion pure helper `runner_arch()` mapping the host arch
  (`x86_64`→`amd64`, `aarch64`→`arm64`) to the OCI platform vocabulary.
- The in-hand manifest body is threaded into the three ref builders
  (`build_registry_image_ref`, `build_registry_image_ref_for_repo`,
  `extract_image_ref`) so they resolve the reference before host-qualifying and
  joining. Applicability gates have no body at gate time and pass `None`
  (passthrough), so applicability stays path-only and a malformed index body can
  never flip an artifact applicable→not-applicable.

Behavior preserved:
- Single-arch image scans (the dominant path) and digest-pinned (#1483) refs are
  byte-for-byte unchanged (passthrough).
- `join_oci_image_ref`'s `@`-vs-`:` separator behaviour is untouched; resolution
  happens on the reference before the join.
- The malformed-path rejection in the builders is unchanged
  (`parse_oci_manifest_path` still gates first).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The new unit tests fail on `main` (where an index ref is passed through to the
scanner verbatim) and pass here: an image-index body now resolves to the child
digest ref instead of the index tag.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New tests (`cargo test --workspace --lib scanner`, all offline — no DB, no
network, no grype/trivy binary):
- `resolve_scan_reference`: index→runner-arch child digest; arch-miss→first
  linux child; attestation/in-toto child excluded; attestation-only index→
  unresolvable (ref unchanged); single-arch body→passthrough; malformed/empty
  body→passthrough.
- `runner_arch` arch mapping.
- builder integration: index body→`host/repo/name@sha256:<child>`; single-arch
  body→original tag ref (identical to the no-body path).

Full lib suite: 11704 passed, 0 failed. fmt clean, clippy clean
(`-D warnings`), duplication on the changed files 2.75% (< 3%).

Note on e2e: the resolution is proven via the unit tests on the resolution
logic. An end-to-end scan is not reproducible on this environment (host is
aarch64 while the pushed index child is amd64, and `TRIVY_URL` is unset), so the
proof is at the resolution/builder layer where the index ref is rewritten to the
concrete child digest.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #1971
