### PR TITLE
chore(docker): harden images — bump bundled trivy to 0.71.2, refresh base OS errata, document residual scanner CVEs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -351,6 +351,9 @@ jobs:
           output: 'backend-trivy.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          # Suppress residual CVEs in the bundled trivy/grype CLI binaries that
+          # have no fixed tool release yet (justified per-CVE in .trivyignore).
+          trivyignores: '.trivyignore'
           exit-code: '0'
           skip-setup-trivy: true
 
@@ -363,6 +366,7 @@ jobs:
           output: 'openscap-trivy.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          trivyignores: '.trivyignore'
           exit-code: '0'
           skip-setup-trivy: true
 
@@ -376,6 +380,7 @@ jobs:
           output: 'backend-alpine-trivy.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          trivyignores: '.trivyignore'
           exit-code: '0'
           skip-setup-trivy: true
 

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -49,6 +49,9 @@ jobs:
           output: 'backend-trivy.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          # Suppress residual CVEs in the bundled trivy/grype CLI binaries that
+          # have no fixed tool release yet (justified per-CVE in .trivyignore).
+          trivyignores: '.trivyignore'
           exit-code: '0'
           skip-setup-trivy: true
 
@@ -61,6 +64,7 @@ jobs:
           output: 'openscap-trivy.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          trivyignores: '.trivyignore'
           exit-code: '0'
           skip-setup-trivy: true
 
@@ -73,6 +77,7 @@ jobs:
           output: 'backend-alpine-trivy.sarif'
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
+          trivyignores: '.trivyignore'
           exit-code: '0'
           skip-setup-trivy: true
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,68 @@
+# .trivyignore — residual CVEs in the BUNDLED scanner CLI binaries only.
+#
+# Scope and honesty notes (read before adding anything here):
+#
+# * Every entry below is a Go-dependency CVE compiled INTO one of the two
+#   vendored scanner CLIs that the backend ships and invokes for OFFLINE
+#   artifact scanning:
+#     - /usr/local/bin/trivy  (ghcr.io/aquasecurity/trivy:0.71.2)
+#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.114.0)
+#   These are short-lived CLI subprocesses the server shells out to. They are
+#   NOT part of the network-reachable service surface (axum HTTP :8080 /
+#   gRPC :9090). The vulnerable code paths (docker/containerd client libs,
+#   golang.org/x/net HTTP/2 server, etc.) are not exercised by how the backend
+#   drives these tools.
+#
+# * These are deliberately NOT suppressed in the backend service binary or in
+#   the UBI/Alpine base OS packages. Only vendored-scanner-binary CVEs that have
+#   no fixed *tool release* are listed here.
+#
+# * We are already on the latest upstream releases of both tools:
+#     - trivy 0.71.2 (bumped from 0.71.0 in this change — cleared the
+#       golang.org/x/net + Go stdlib CVEs the 0.71.0 binary carried).
+#     - grype v0.114.0 (latest; no newer build exists yet).
+#   For the CVEs below, either no fixed tool release exists yet, or the upstream
+#   dependency fix has not landed in a tagged release of the tool. They will
+#   drop off automatically when we bump the tool to a release that rebuilds
+#   against the fixed dependency — re-evaluate on every scanner bump.
+#
+# * CI scans with `ignore-unfixed: true`, so the genuinely no-fix-available
+#   entries below already don't alert; they are listed for completeness and so
+#   future maintainers see the full residual set in one place.
+#
+# Trivy tracker: https://github.com/aquasecurity/trivy/releases
+# Grype tracker: https://github.com/anchore/grype/releases
+
+# ---------------------------------------------------------------------------
+# trivy 0.71.2 binary — github.com/containerd/containerd/v2 @ v2.3.1
+# containerd has fixed releases (2.3.2) but trivy 0.71.2 has not yet rebuilt
+# against them. Code path: trivy's container image inspection client; not used
+# in a way reachable by the backend's offline artifact scans.
+CVE-2026-47262
+CVE-2026-50195
+CVE-2026-53488
+CVE-2026-53489
+CVE-2026-53492
+
+# ---------------------------------------------------------------------------
+# grype v0.114.0 binary — github.com/docker/docker @ v28.5.2+incompatible
+# CVE-2026-41567 / -41568 / -42306: NO upstream-fixed docker release exists yet
+# (Trivy/Grype both report FixedVersion=none). CVE-2026-33997 / -34040 are
+# fixed in docker 29.3.1 but grype v0.114.0 (latest) has not rebuilt against
+# it. Code path: grype's Docker engine client for `docker:` image sources; the
+# backend invokes grype against on-disk artifacts/SBOMs, not the Docker daemon.
+CVE-2026-33997
+CVE-2026-34040
+CVE-2026-41567
+CVE-2026-41568
+CVE-2026-42306
+
+# ---------------------------------------------------------------------------
+# grype v0.114.0 binary — Go stdlib @ go1.26.3
+# Fixed in Go 1.26.4 / 1.25.11. trivy 0.71.2 already ships a fixed stdlib (so
+# these are gone from the trivy binary); grype v0.114.0 (latest) is still built
+# with the older toolchain. Drops off when grype ships a release rebuilt on
+# Go >= 1.26.4.
+CVE-2026-27145
+CVE-2026-42504
+CVE-2026-42507

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -66,12 +66,22 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 FROM registry.access.redhat.com/ubi9/ubi:9.8 AS rootfs-builder
 
 # Install only essential runtime libraries into a clean rootfs.
-# --refresh forces fresh repo metadata and the follow-up upgrade pulls
-# z-stream errata (e.g. jq el9_7 security fixes) that the install step
-# alone may miss when the cache is stale. The reposdir override is
-# required on the upgrade step because once the installroot has a
-# populated /etc, dnf reads repos from inside it (which is empty)
-# instead of falling back to the host's /etc/yum.repos.d.
+# --refresh forces fresh repo metadata and the follow-up `upgrade -y` pulls
+# the latest RHEL 9 z-stream security errata for every installed package
+# (curl-minimal/libcurl, jq, glibc*, tar, bzip2-libs, openssl-libs, xz-libs,
+# zlib, zstd) that the install step alone may miss when the metadata cache is
+# stale. This guarantees the rootfs is rebuilt against current errata on every
+# image build. The reposdir override is required on the upgrade step because
+# once the installroot has a populated /etc, dnf reads repos from inside it
+# (which is empty) instead of falling back to the host's /etc/yum.repos.d.
+#
+# NOTE on residual base-OS CVEs: `upgrade -y` can only pull a *fixed* package
+# once Red Hat ships errata for it. Trivy currently reports MEDIUM CVEs in
+# these UBI 9.8 packages that Red Hat has marked "Affected" or "Will not fix"
+# (no fixed RPM exists yet) — those cannot be cleared here and are reported by
+# CI with `ignore-unfixed: true`, so they do not produce code-scanning alerts.
+# When Red Hat publishes the errata, the next rebuild picks the fixes up
+# automatically with no Dockerfile change. See the linked hardening issue.
 RUN mkdir -p /mnt/rootfs && \
     dnf install --installroot /mnt/rootfs --releasever 9 --refresh \
         --setopt=reposdir=/etc/yum.repos.d/ \
@@ -146,7 +156,16 @@ RUN if [ -f /mnt/rootfs/etc/dnf/dnf.conf ]; then \
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
 # ---------- Stage 5: Copy scanner CLIs from official images ----------
-FROM ghcr.io/aquasecurity/trivy:0.71.0 AS trivy-bin
+# Trivy is pinned to the latest release (0.71.2). The bump from 0.71.0 clears
+# the golang.org/x/net (CVE-2026-25680/25681/27136/39821/42502/42506) and Go
+# stdlib (CVE-2026-27145/42504/42507) CVEs that Trivy 0.71.0's binary carried,
+# including the deps behind the code-scanning grpc finding. Residual containerd
+# CVEs that 0.71.2 has not yet rebuilt against are documented in /.trivyignore.
+FROM ghcr.io/aquasecurity/trivy:0.71.2 AS trivy-bin
+# Grype is pinned to v0.114.0, which is the latest upstream release. There is no
+# newer Grype build that picks up fixed versions of its bundled Go deps
+# (docker, containerd, stdlib), so its residual CVEs are upstream-unfixable for
+# now and are documented/suppressed in /.trivyignore rather than "bumped away".
 FROM ghcr.io/anchore/grype:v0.114.0 AS grype-bin
 
 # ---------- Stage 5b: Pre-seed the Grype vulnerability DB ----------

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -47,7 +47,16 @@ RUN if [ -n "${APP_VERSION}" ]; then \
     cargo build --release --features "$FEATURES" --bin artifact-keeper
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
-FROM ghcr.io/aquasecurity/trivy:0.71.0 AS trivy-bin
+# Trivy is pinned to the latest release (0.71.2). The bump from 0.71.0 clears
+# the golang.org/x/net (CVE-2026-25680/25681/27136/39821/42502/42506) and Go
+# stdlib (CVE-2026-27145/42504/42507) CVEs in the Trivy binary, including the
+# deps behind the code-scanning grpc finding. Residual containerd CVEs that
+# 0.71.2 has not yet rebuilt against are documented in /.trivyignore.
+FROM ghcr.io/aquasecurity/trivy:0.71.2 AS trivy-bin
+# Grype is pinned to v0.114.0, the latest upstream release. No newer Grype build
+# picks up fixed versions of its bundled Go deps (docker, containerd, stdlib),
+# so its residual CVEs are upstream-unfixable for now and are documented/
+# suppressed in /.trivyignore rather than "bumped away".
 FROM ghcr.io/anchore/grype:v0.114.0 AS grype-bin
 
 # ---------- Stage 4b: Pre-seed the Grype vulnerability DB ----------
@@ -63,8 +72,13 @@ RUN mkdir -p /grype-db && grype db update && grype db status
 # ---------- Stage 5: Alpine runtime ----------
 FROM alpine:3.24
 
-# Runtime dependencies (no libssl needed - OpenSSL is vendored/static)
-RUN apk add --no-cache --upgrade ca-certificates libgcc libstdc++ zlib xz-libs libbz2 curl jq
+# Refresh the whole base first so the alpine:3.24 layer picks up the latest
+# APK security errata, then install the runtime deps (no libssl needed -
+# OpenSSL is vendored/static). `apk upgrade --no-cache` rebuilds against
+# current errata on every image build; the targeted `add` keeps the install
+# set explicit.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache --upgrade ca-certificates libgcc libstdc++ zlib xz-libs libbz2 curl jq
 
 # --- CIS hardening (adapted from CIS Alpine Linux Benchmark) ---
 

--- a/docker/Dockerfile.openscap
+++ b/docker/Dockerfile.openscap
@@ -19,6 +19,12 @@ RUN ARCH=$(uname -m) && \
 # (which is empty) instead of falling back to the host's /etc/yum.repos.d.
 # Mirrors the rootfs-builder upgrade step in Dockerfile.backend. See
 # artifact-keeper#1544 (weekly container scan findings).
+#
+# NOTE on residual base-OS CVEs: `upgrade -y` can only pull a *fixed* package
+# once Red Hat ships errata for it. CVEs that Red Hat has marked "Affected" or
+# "Will not fix" (no fixed RPM exists yet) cannot be cleared here; CI scans
+# with `ignore-unfixed: true`, so those do not produce code-scanning alerts.
+# The next rebuild picks up fixes automatically once errata are published.
 RUN mkdir -p /mnt/rootfs && \
     dnf install --installroot /mnt/rootfs --releasever 9 --refresh \
         --setopt=reposdir=/etc/yum.repos.d/ \


### PR DESCRIPTION
## Summary

Defensive hardening of our own container images against the Trivy code-scanning CVE findings. Verified with the same scanner (Trivy).

**What this PR does**
- Bumps the bundled **Trivy CLI 0.71.0 -> 0.71.2** (latest) in `Dockerfile.backend` and `Dockerfile.backend.alpine`.
- Keeps **Grype v0.114.0** (already the latest release) with a clarifying pinned-latest comment.
- Clarifies the existing build-time base-OS errata refresh (`dnf upgrade` / `apk upgrade`); makes the alpine refresh an explicit full `apk upgrade --no-cache`.
- Adds a repo-root **`.trivyignore`** that suppresses only the residual vendored-**scanner-binary** CVEs (with honest per-CVE justification) and wires `docker-publish.yml` + `scheduled-container-scan.yml` to read it via `trivyignores:`.

### Trivy before -> after (measured locally, scanner = Trivy 0.71.0, `--severity CRITICAL,HIGH,MEDIUM --scanners vuln`)

Baseline on `ghcr.io/artifact-keeper/artifact-keeper-backend:main` = **91** total:

| Target | Before | After | What changes |
|---|---|---|---|
| UBI 9.8 base OS (`redhat 9.8`) | 64 (MED) | 64 (MED) | **Unchanged — all are Red Hat `Affected`/`Will not fix`, no fixed RPM exists yet.** Not fixable by us today; CI's `ignore-unfixed: true` means these never raised code-scanning alerts. |
| `/usr/local/bin/trivy` (gobinary) | 14 (11H/3M) | **5 (3H/2M)** | trivy 0.71.2 clears all golang.org/x/net + Go stdlib CVEs (incl. the grpc-finding deps). 5 containerd CVEs remain (no trivy release rebuilt against containerd 2.3.2 yet) -> `.trivyignore`. |
| `/usr/local/bin/grype` (gobinary) | 13 (8H/5M) | 13 | grype is already latest; no upstream tool release picks up the fixes -> `.trivyignore`. 3 docker CVEs have no upstream fix at all. |

Measured deltas (trivy gobinary 14->5; grype gobinary 13->13) come from scanning the `trivy:0.71.0` vs `trivy:0.71.2` and `grype:v0.114.0` images directly with Trivy 0.71.0. The trivy-bin stage was confirmed to build against 0.71.2.

**Not run locally:** a full UBI backend image rebuild + rescan (RHEL entitlement + long Rust compile + grype-DB-seed network). The authoritative full-image re-scan will run in **CI** — the same Trivy integration in `docker-publish.yml` that produced these alerts.

### `.trivyignore` justification

Every entry is a Go-dependency CVE compiled into one of the two vendored scanner CLIs (`trivy`, `grype`) the backend shells out to for **offline artifact scanning** — short-lived subprocesses, **not** the network-reachable service surface (HTTP :8080 / gRPC :9090). Each CVE is commented with the tool, the package, why no fixed tool release exists yet, and a link to the tool's release tracker. **Nothing in the backend service binary or the base OS packages is suppressed.** CI already runs `ignore-unfixed: true`, so the genuinely no-fix entries are listed for completeness; the "fixed-upstream-but-not-in-a-tool-release" entries are what the file actively clears from code-scanning.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (chore: container/CI hardening, no Rust source touched)

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (baseline + scanner-image scans with Trivy 0.71.0; trivy-bin stage builds against 0.71.2)
- [x] No regressions in existing tests (Docker/CI-only change)

## API Changes
- [x] N/A - no API changes

Fixes #2003