### PR TITLE
fix(promotion): enforce promotion_only repos reject all direct artifact uploads

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -150,10 +150,12 @@ pub fn reject_write_if_not_hosted(repo_type: &str) -> Result<(), Response> {
 /// (handlers/promotion.rs), which does NOT go through the HTTP upload handlers,
 /// so promotions are unaffected by this check.
 ///
-/// Admins are exempt: they can still publish directly (e.g. for break-glass /
-/// bootstrap), so the gate only constrains non-admin direct uploads.
-pub fn promotion_only_blocks_direct_upload(promotion_only: bool, is_admin: bool) -> bool {
-    promotion_only && !is_admin
+/// ALL direct uploads to a `promotion_only` repository are rejected (including
+/// admin tokens). Artifacts may only enter such a repository via the promotion
+/// workflow (quality gates + approval + provenance); a direct upload would
+/// bypass every one of those controls, so there is no admin exemption.
+pub fn promotion_only_blocks_direct_upload(promotion_only: bool, _is_admin: bool) -> bool {
+    promotion_only
 }
 
 /// 409 plain-text response for a rejected direct upload to a `promotion_only`
@@ -3016,9 +3018,11 @@ mod tests {
     }
 
     #[test]
-    fn test_promotion_only_admin_is_exempt() {
-        // Admins may still publish directly to a promotion_only repo.
-        assert!(!promotion_only_blocks_direct_upload(true, true));
+    fn test_promotion_only_blocks_admin_too() {
+        // Admins are no longer exempt: a direct upload to a promotion_only repo
+        // is blocked regardless of admin status (artifacts must enter via the
+        // promotion workflow).
+        assert!(promotion_only_blocks_direct_upload(true, true));
     }
 
     #[test]
@@ -3036,8 +3040,10 @@ mod tests {
     }
 
     #[test]
-    fn test_reject_direct_upload_if_promotion_only_allows_admin_and_normal() {
-        assert!(reject_direct_upload_if_promotion_only(true, true).is_ok());
+    fn test_reject_direct_upload_if_promotion_only_blocks_admin_allows_normal() {
+        // Admin direct upload to a promotion_only repo is now rejected too.
+        assert!(reject_direct_upload_if_promotion_only(true, true).is_err());
+        // Normal (non-promotion_only) repos are never blocked.
         assert!(reject_direct_upload_if_promotion_only(false, false).is_ok());
     }
 
@@ -4040,87 +4046,65 @@ mod tests {
         assert_eq!(storage.get_calls.load(Ordering::SeqCst), 0);
     }
 
+    // Redirect-capable facade backends used to exercise the `Ok(None)` and
+    // `Err(e)` arms of `try_proxy_cache_redirect`. They share the same trivial
+    // StorageBackend surface and differ only in what `get_presigned_url`
+    // returns, so generate them from one macro to avoid copy-paste mocks.
+    macro_rules! presign_mock {
+        ($name:ident, $presign:expr) => {
+            struct $name;
+
+            #[async_trait::async_trait]
+            impl crate::services::storage_service::StorageBackend for $name {
+                async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
+                    Ok(())
+                }
+                async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+                    Ok(Bytes::from_static(b"body"))
+                }
+                async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+                    Ok(true)
+                }
+                async fn delete(&self, _key: &str) -> crate::error::Result<()> {
+                    Ok(())
+                }
+                async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
+                    Ok(Vec::new())
+                }
+                async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
+                    Ok(())
+                }
+                async fn size(&self, _key: &str) -> crate::error::Result<u64> {
+                    Ok(0)
+                }
+                fn supports_redirect(&self) -> bool {
+                    true
+                }
+                async fn get_presigned_url(
+                    &self,
+                    _key: &str,
+                    _expires_in: std::time::Duration,
+                ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
+                    $presign
+                }
+            }
+        };
+    }
+
     // A redirect-capable facade backend whose presign returns `Ok(None)`
     // (e.g. a presign-disabled S3 handle): the helper must fall through to
     // streaming. Covers the `Ok(None)` arm of `try_proxy_cache_redirect`.
-    struct NonePresignStorage;
-
-    #[async_trait::async_trait]
-    impl crate::services::storage_service::StorageBackend for NonePresignStorage {
-        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
-            Ok(())
-        }
-        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
-            Ok(Bytes::from_static(b"body"))
-        }
-        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
-            Ok(true)
-        }
-        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
-            Ok(())
-        }
-        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
-            Ok(Vec::new())
-        }
-        async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
-            Ok(())
-        }
-        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
-            Ok(0)
-        }
-        fn supports_redirect(&self) -> bool {
-            true
-        }
-        async fn get_presigned_url(
-            &self,
-            _key: &str,
-            _expires_in: std::time::Duration,
-        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
-            Ok(None)
-        }
-    }
+    presign_mock!(NonePresignStorage, Ok(None));
 
     // A redirect-capable facade backend whose presign ERRORS (transient signing
     // failure): the helper must warn + fall through to streaming, never panic.
     // Covers the `Err(e)` warn-and-fall-back arm of `try_proxy_cache_redirect`.
-    struct ErrPresignStorage;
-
-    #[async_trait::async_trait]
-    impl crate::services::storage_service::StorageBackend for ErrPresignStorage {
-        async fn put(&self, _key: &str, _content: Bytes) -> crate::error::Result<()> {
-            Ok(())
-        }
-        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
-            Ok(Bytes::from_static(b"body"))
-        }
-        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
-            Ok(true)
-        }
-        async fn delete(&self, _key: &str) -> crate::error::Result<()> {
-            Ok(())
-        }
-        async fn list(&self, _prefix: Option<&str>) -> crate::error::Result<Vec<String>> {
-            Ok(Vec::new())
-        }
-        async fn copy(&self, _source: &str, _dest: &str) -> crate::error::Result<()> {
-            Ok(())
-        }
-        async fn size(&self, _key: &str) -> crate::error::Result<u64> {
-            Ok(0)
-        }
-        fn supports_redirect(&self) -> bool {
-            true
-        }
-        async fn get_presigned_url(
-            &self,
-            _key: &str,
-            _expires_in: std::time::Duration,
-        ) -> crate::error::Result<Option<crate::storage::PresignedUrl>> {
-            Err(crate::error::AppError::Storage(
-                "transient presign failure".to_string(),
-            ))
-        }
-    }
+    presign_mock!(
+        ErrPresignStorage,
+        Err(crate::error::AppError::Storage(
+            "transient presign failure".to_string(),
+        ))
+    );
 
     #[tokio::test]
     async fn test_try_proxy_cache_redirect_returns_none_when_presign_yields_none() {

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3453,15 +3453,15 @@ pub async fn upload_artifact(
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
 
-    // Reject direct uploads to promotion-only repositories (non-admins). Such
-    // repos accept artifacts only via the promotion path (staging -> promotion
-    // -> approval); the promotion service writes through its own path and is
-    // unaffected.
+    // Reject direct uploads to promotion-only repositories. Such repos accept
+    // artifacts only via the promotion path (staging -> promotion -> approval);
+    // the promotion service writes through its own path and is unaffected. This
+    // applies to all callers including admins.
     if crate::api::handlers::proxy_helpers::promotion_only_blocks_direct_upload(
         repo.promotion_only,
         auth.is_admin,
     ) {
-        return Err(AppError::Conflict(
+        return Err(AppError::Authorization(
             "Direct uploads are disabled for this repository; publish via promotion".to_string(),
         ));
     }
@@ -11393,6 +11393,67 @@ mod tests {
             matches!(err, AppError::Validation(_)),
             "traversal path must surface as Validation (400), got {err:?}",
         );
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_upload_artifact_admin_blocked_on_promotion_only_repo_403() {
+        // Regression for the promotion_only direct-upload bypass: an admin
+        // direct PUT to a promotion_only repository must be rejected with 403
+        // (AppError::Authorization). Artifacts may only enter such a repo via
+        // the promotion workflow. A normal (non-promotion_only) repo continues
+        // to accept the same admin upload (201). Skips gracefully when no
+        // DATABASE_URL is configured.
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        // Flip the fixture repo to promotion_only.
+        sqlx::query("UPDATE repositories SET promotion_only = true WHERE id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("set promotion_only");
+
+        // Build an ADMIN auth for the fixture user (the realistic actor that
+        // previously bypassed the gate via the `&& !is_admin` exemption).
+        let mut auth = tdh::make_auth(fx.user_id, &fx.username);
+        auth.is_admin = true;
+
+        let blocked = upload_artifact(
+            State(fx.state.clone()),
+            Extension(Some(auth.clone())),
+            Path((fx.repo_key.clone(), "foo/bar.txt".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"directwrite"),
+        )
+        .await;
+
+        let err = blocked.expect_err("admin direct upload to promotion_only repo must be blocked");
+        // AppError::Authorization maps to 403 Forbidden (see error.rs).
+        assert!(
+            matches!(err, AppError::Authorization(_)),
+            "admin direct upload to promotion_only repo must surface as Authorization (403), got {err:?}",
+        );
+
+        // Legit path: revert to a normal repo and the same admin upload succeeds.
+        sqlx::query("UPDATE repositories SET promotion_only = false WHERE id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("clear promotion_only");
+
+        let (status, _) = upload_artifact(
+            State(fx.state.clone()),
+            Extension(Some(auth)),
+            Path((fx.repo_key.clone(), "foo/bar.txt".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"directwrite"),
+        )
+        .await
+        .expect("admin upload to a normal repo must succeed");
+        assert_eq!(status, StatusCode::CREATED);
 
         fx.teardown().await;
     }

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -246,10 +246,10 @@ async fn create_session(
     //
     // This is enforced INDEPENDENTLY of the RBAC permission-rule check below: a
     // promotion_only repo with no explicit permission rules must still be blocked
-    // for non-admin direct uploads. The promotion service writes through its own
-    // RAW SQL INSERT path (handlers/promotion.rs), which does not pass through
-    // these HTTP handlers, so promotions remain unaffected. Admins are exempt
-    // (break-glass / bootstrap), matching the direct path.
+    // for direct uploads. The promotion service writes through its own RAW SQL
+    // INSERT path (handlers/promotion.rs), which does not pass through these HTTP
+    // handlers, so promotions remain unaffected. All direct uploads (including
+    // admins) are blocked, matching the direct path.
     if let Some(rejection) = reject_session_if_promotion_only(repo_promotion_only, auth.is_admin) {
         return Err(rejection);
     }
@@ -850,9 +850,9 @@ fn upload_write_decision(
 /// `promotion_only` repository, or `None` if the upload is permitted.
 ///
 /// Mirrors the direct artifact-write path (`repositories::upload_artifact`):
-/// non-admin direct uploads to a promotion-only repo are blocked (`403`) so the
-/// chunked upload-session API cannot be used to sidestep promotion/approval.
-/// Admins are exempt (break-glass / bootstrap), and normal (non-promotion_only)
+/// direct uploads to a promotion-only repo are blocked (`403`) so the chunked
+/// upload-session API cannot be used to sidestep promotion/approval. All direct
+/// uploads (including admin tokens) are blocked; normal (non-promotion_only)
 /// repositories are never blocked here. The promotion service writes through its
 /// own raw-SQL path and does not pass through this handler, so promotions are
 /// unaffected.
@@ -1210,9 +1210,12 @@ mod tests {
     }
 
     #[test]
-    fn test_promotion_only_session_admin_allowed() {
-        // Admins are exempt (break-glass / bootstrap): no rejection.
-        assert!(reject_session_if_promotion_only(true, true).is_none());
+    fn test_promotion_only_session_blocks_admin_too() {
+        // Admins are no longer exempt: an upload-session create against a
+        // promotion_only repo is rejected (403) regardless of admin status.
+        let rejection = reject_session_if_promotion_only(true, true)
+            .expect("admin direct upload session to promotion_only repo must be rejected");
+        assert_eq!(rejection.status(), StatusCode::FORBIDDEN);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`promotion_only` repositories are meant to accept artifacts **only** through the
promotion workflow (staging → promotion → approval / quality gates), so that
every artifact entering a release repo carries the associated provenance and
approval record. The direct upload gate that enforces this exempted admin
tokens: the shared predicate
`promotion_only_blocks_direct_upload(promotion_only, is_admin)` returned
`promotion_only && !is_admin`. Because the realistic operator typically holds an
admin token, that exemption let an admin direct-`PUT`
(`/api/v1/repositories/{key}/artifacts/{path}`) write straight into a
`promotion_only` repo, bypassing the staging → promotion → approval controls the
flag exists to enforce.

This change removes the admin exemption from the single shared predicate, so all
three enforcement callers tighten consistently:

- generic upload (`repositories::upload_artifact`)
- chunked upload session (`upload::reject_session_if_promotion_only`)
- Maven publish (`proxy_helpers::reject_direct_upload_if_promotion_only`)

It also aligns the generic upload path's rejection to **403 Forbidden**
(`AppError::Authorization`) to match the chunked-session path (both paths now
return 403 for a blocked direct upload).

The promotion workflow itself is unaffected: `promotion::promote_artifact` is
independently admin-gated and writes via its own raw-SQL `INSERT INTO artifacts`
path — it does not go through these upload handlers, so legitimate promotion into
a `promotion_only` repo continues to work. Normal (`promotion_only = false`)
repositories are unchanged for all callers.

Behavior change: an admin can no longer direct-upload into a `promotion_only`
repository and must use the promote endpoint — which is the intended contract of
the flag.

A small test-only cleanup is included in `proxy_helpers.rs`: the two near-identical
presign mock backends (`NonePresignStorage` / `ErrPresignStorage`) are generated
from a single `presign_mock!` macro to remove copy-paste duplication in the test
module (keeps the changed-file duplication gate under threshold).

### Manual verification (isolated stack)

1. Create `promotion_only:true` repo → 201; `GET` confirms `promotion_only:true`.
2. Admin direct `PUT` to that repo → **403** (was 201).
3. Admin `PUT` to a normal (`promotion_only:false`) repo → **201** (unchanged).
4. Promote an artifact from a normal repo into the `promotion_only` repo →
   succeeds, and the artifact appears in the target.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Tests:
- `proxy_helpers::tests::test_promotion_only_blocks_admin_too` — predicate now
  blocks admins for `promotion_only` repos.
- `proxy_helpers::tests::test_reject_direct_upload_if_promotion_only_blocks_admin_allows_normal`
  — Maven-style wrapper now rejects admins, still allows normal repos.
- `upload::tests::test_promotion_only_session_blocks_admin_too` — chunked-session
  gate now blocks admins (403).
- `repositories::tests::test_upload_artifact_admin_blocked_on_promotion_only_repo_403`
  — handler-level: admin direct upload to a `promotion_only` repo → 403; same
  admin upload to a normal repo → 201.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

<!-- Note: the generic upload-rejection status changes from 409 to 403 to match
     the existing chunked-session path; no schema/endpoint changes. -->

Fixes #2009