### PR TITLE
feat(dart): Pub upload protocol compliance and Remote/Virtual metadata resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ backend/src/grpc/generated/*.bin
 # IDE
 .idea/
 .vscode/
+.opencode/
 *.swp
 *.swo
 *~
@@ -107,3 +108,6 @@ scripts/sso-e2e/sso-config-ids.env
 
 # Superpowers brainstorming artifacts (Claude Code)
 docs/superpowers/
+
+
+openspec/

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -7,7 +7,7 @@
 //!   GET  /pub/{repo_key}/api/packages/{name}                       - Package info
 //!   GET  /pub/{repo_key}/api/packages/{name}/versions/{version}    - Version info
 //!   GET  /pub/{repo_key}/packages/{name}/versions/{version}.tar.gz - Download archive
-//!   POST /pub/{repo_key}/api/packages/versions/new                 - Get upload URL
+//!   GET  /pub/{repo_key}/api/packages/versions/new                 - Get upload URL
 //!   POST /pub/{repo_key}/api/packages/versions/newUpload           - Upload package
 //!   GET  /pub/{repo_key}/api/packages/versions/newUploadFinish     - Finalize upload
 
@@ -22,10 +22,25 @@ use axum::Router;
 use sqlx::PgPool;
 use tracing::info;
 
+use crate::api::extractors::RequestBaseUrl;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic, AuthExtension};
 use crate::api::SharedState;
 use crate::models::repository::RepositoryType;
+
+use uuid::Uuid;
+
+/// Row type for pub artifact queries (used in virtual member resolution).
+#[derive(sqlx::FromRow)]
+#[allow(dead_code)]
+struct PubArtifactRow {
+    id: Uuid,
+    name: String,
+    version: Option<String>,
+    size_bytes: i64,
+    checksum_sha256: String,
+    metadata: Option<serde_json::Value>,
+}
 
 // ---------------------------------------------------------------------------
 // Router
@@ -73,6 +88,7 @@ async fn resolve_pub_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respo
 async fn package_info(
     State(state): State<SharedState>,
     Path((repo_key, name)): Path<(String, String)>,
+    base_url: RequestBaseUrl,
 ) -> Result<Response, Response> {
     let repo = resolve_pub_repo(&state.db, &repo_key).await?;
 
@@ -95,51 +111,145 @@ async fn package_info(
     .map_err(crate::api::handlers::db_err)?;
 
     if artifacts.is_empty() {
-        return Err((StatusCode::NOT_FOUND, "Package not found").into_response());
+        // Remote repo: proxy metadata to upstream
+        if repo.repo_type == RepositoryType::Remote {
+            if let Some(ref upstream_url) = repo.upstream_url {
+                let api_path = format!("api/packages/{}", name);
+                if let Some(resp) = proxy_pub_meta_get(
+                    &state,
+                    repo.id,
+                    &repo_key,
+                    base_url.as_str(),
+                    upstream_url,
+                    &api_path,
+                )
+                .await
+                {
+                    return Ok(resp);
+                }
+            }
+            return Err(pub_error_response(
+                StatusCode::NOT_FOUND,
+                "NOT_FOUND",
+                "Package not found",
+            ));
+        }
+
+        // Virtual repo: resolve through members in priority order
+        if repo.repo_type == RepositoryType::Virtual {
+            let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+            for member in &members {
+                match member.repo_type {
+                    RepositoryType::Local | RepositoryType::Staging => {
+                        let member_artifacts = sqlx::query_as::<_, PubArtifactRow>(
+                            "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+                              am.metadata \
+                              FROM artifacts a \
+                              LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
+                              WHERE a.repository_id = $1 \
+                                AND a.is_deleted = false \
+                                AND LOWER(a.name) = LOWER($2) \
+                              ORDER BY a.created_at DESC",
+                        )
+                        .bind(member.id)
+                        .bind(&name)
+                        .fetch_all(&state.db)
+                        .await
+                        .map_err(|e| {
+                            (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                format!("Database error: {}", e),
+                            )
+                                .into_response()
+                        })?;
+
+                        if !member_artifacts.is_empty() {
+                            let versions: Vec<serde_json::Value> = member_artifacts
+                                .iter()
+                                .map(|a| {
+                                    let ver = a.version.clone().unwrap_or_default();
+                                    serde_json::json!({
+                                        "version": ver,
+                                        "archive_url": format!(
+                                            "{}/pub/{}/packages/{}/versions/{}.tar.gz",
+                                            base_url.as_str(),
+                                            repo_key,
+                                            name,
+                                            ver
+                                        ),
+                                        "archive_sha256": a.checksum_sha256,
+                                        "pubspec": a.metadata.as_ref()
+                                            .and_then(|m| m.get("pubspec"))
+                                            .cloned()
+                                            .unwrap_or_else(|| serde_json::json!({
+                                                "name": name,
+                                                "version": ver,
+                                            })),
+                                    })
+                                })
+                                .collect();
+                            return Ok(build_pub_package_response(&name, versions));
+                        }
+                    }
+                    RepositoryType::Remote => {
+                        if let Some(ref upstream_url) = member.upstream_url {
+                            let api_path = format!("api/packages/{}", name);
+                            if let Some(resp) = proxy_pub_meta_get(
+                                &state,
+                                member.id,
+                                &repo_key,
+                                base_url.as_str(),
+                                upstream_url,
+                                &api_path,
+                            )
+                            .await
+                            {
+                                return Ok(resp);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return Err(pub_error_response(
+                StatusCode::NOT_FOUND,
+                "NOT_FOUND",
+                "Package not found",
+            ));
+        }
+
+        return Err(pub_error_response(
+            StatusCode::NOT_FOUND,
+            "NOT_FOUND",
+            "Package not found",
+        ));
     }
 
     let versions: Vec<serde_json::Value> = artifacts
         .iter()
         .map(|a| {
-            let version = a.version.clone().unwrap_or_default();
-            let archive_url = format!(
-                "/pub/{}/packages/{}/versions/{}.tar.gz",
-                repo_key, name, version
-            );
-
-            let pubspec = a
-                .metadata
-                .as_ref()
-                .and_then(|m| m.get("pubspec"))
-                .cloned()
-                .unwrap_or_else(|| {
-                    serde_json::json!({
-                        "name": name,
-                        "version": version,
-                    })
-                });
-
+            let ver = a.version.clone().unwrap_or_default();
             serde_json::json!({
-                "version": version,
-                "archive_url": archive_url,
-                "pubspec": pubspec,
+                "version": ver,
+                "archive_url": format!(
+                    "{}/pub/{}/packages/{}/versions/{}.tar.gz",
+                    base_url.as_str(),
+                    repo_key,
+                    name,
+                    ver
+                ),
+                "archive_sha256": a.checksum_sha256,
+                "pubspec": a.metadata.as_ref()
+                    .and_then(|m| m.get("pubspec"))
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({
+                        "name": name,
+                        "version": ver,
+                    })),
             })
         })
         .collect();
-
-    let latest = versions.first().cloned().unwrap_or(serde_json::json!(null));
-
-    let json = serde_json::json!({
-        "name": name,
-        "latest": latest,
-        "versions": versions,
-    });
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, "application/vnd.pub.v2+json")
-        .body(Body::from(serde_json::to_string(&json).unwrap()))
-        .unwrap())
+    Ok(build_pub_package_response(&name, versions))
 }
 
 // ---------------------------------------------------------------------------
@@ -149,6 +259,7 @@ async fn package_info(
 async fn version_info(
     State(state): State<SharedState>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
+    base_url: RequestBaseUrl,
 ) -> Result<Response, Response> {
     let repo = resolve_pub_repo(&state.db, &repo_key).await?;
 
@@ -170,15 +281,120 @@ async fn version_info(
     )
     .fetch_optional(&state.db)
     .await
-    .map_err(crate::api::handlers::db_err)?
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Version not found").into_response())?;
+    .map_err(crate::api::handlers::db_err)?;
+
+    let artifact = match artifact {
+        Some(a) => a,
+        None => {
+            // Remote repo: proxy metadata to upstream
+            if repo.repo_type == RepositoryType::Remote {
+                if let Some(ref upstream_url) = repo.upstream_url {
+                    let api_path = format!("api/packages/{}/versions/{}", name, version);
+                    if let Some(resp) = proxy_pub_meta_get(
+                        &state,
+                        repo.id,
+                        &repo_key,
+                        base_url.as_str(),
+                        upstream_url,
+                        &api_path,
+                    )
+                    .await
+                    {
+                        return Ok(resp);
+                    }
+                }
+                return Err((StatusCode::NOT_FOUND, "Version not found").into_response());
+            }
+
+            // Virtual repo: resolve through members in priority order
+            if repo.repo_type == RepositoryType::Virtual {
+                let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+                for member in &members {
+                    match member.repo_type {
+                        RepositoryType::Local | RepositoryType::Staging => {
+                            let member_artifact = sqlx::query_as::<_, PubArtifactRow>(
+                                "SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, \
+                                  am.metadata \
+                                  FROM artifacts a \
+                                  LEFT JOIN artifact_metadata am ON am.artifact_id = a.id \
+                                  WHERE a.repository_id = $1 \
+                                    AND a.is_deleted = false \
+                                    AND LOWER(a.name) = LOWER($2) \
+                                    AND a.version = $3 \
+                                  LIMIT 1",
+                            )
+                            .bind(member.id)
+                            .bind(&name)
+                            .bind(&version)
+                            .fetch_optional(&state.db)
+                            .await
+                            .map_err(crate::api::handlers::db_err)?;
+
+                            if let Some(a) = member_artifact {
+                                let ver = a.version.clone().unwrap_or_default();
+                                let archive_url = format!(
+                                    "{}/pub/{}/packages/{}/versions/{}.tar.gz",
+                                    base_url.as_str(),
+                                    repo_key,
+                                    name,
+                                    ver
+                                );
+                                let pubspec = a
+                                    .metadata
+                                    .as_ref()
+                                    .and_then(|m| m.get("pubspec"))
+                                    .cloned()
+                                    .unwrap_or_else(|| {
+                                        serde_json::json!({
+                                            "name": name,
+                                            "version": ver,
+                                        })
+                                    });
+                                return Ok(build_pub_version_response(
+                                    &name,
+                                    &ver,
+                                    &archive_url,
+                                    &a.checksum_sha256,
+                                    &pubspec,
+                                ));
+                            }
+                        }
+                        RepositoryType::Remote => {
+                            if let Some(ref upstream_url) = member.upstream_url {
+                                let api_path =
+                                    format!("api/packages/{}/versions/{}", name, version);
+                                if let Some(resp) = proxy_pub_meta_get(
+                                    &state,
+                                    member.id,
+                                    &repo_key,
+                                    base_url.as_str(),
+                                    upstream_url,
+                                    &api_path,
+                                )
+                                .await
+                                {
+                                    return Ok(resp);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                return Err((StatusCode::NOT_FOUND, "Version not found").into_response());
+            }
+
+            return Err((StatusCode::NOT_FOUND, "Version not found").into_response());
+        }
+    };
 
     let ver = artifact.version.clone().unwrap_or_default();
     let archive_url = format!(
-        "/pub/{}/packages/{}/versions/{}.tar.gz",
-        repo_key, name, ver
+        "{}/pub/{}/packages/{}/versions/{}.tar.gz",
+        base_url.as_str(),
+        repo_key,
+        name,
+        ver
     );
-
     let pubspec = artifact
         .metadata
         .as_ref()
@@ -190,19 +406,13 @@ async fn version_info(
                 "version": ver,
             })
         });
-
-    let json = serde_json::json!({
-        "version": ver,
-        "archive_url": archive_url,
-        "archive_sha256": artifact.checksum_sha256,
-        "pubspec": pubspec,
-    });
-
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, "application/vnd.pub.v2+json")
-        .body(Body::from(serde_json::to_string(&json).unwrap()))
-        .unwrap())
+    Ok(build_pub_version_response(
+        &name,
+        &ver,
+        &archive_url,
+        &artifact.checksum_sha256,
+        &pubspec,
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -220,22 +430,22 @@ async fn download_archive(
     // Parse: {name}/versions/{version}.tar.gz
     let parts: Vec<&str> = archive_path.splitn(3, '/').collect();
     if parts.len() < 3 || parts[1] != "versions" {
-        return Err((
+        return Err(pub_error_response(
             StatusCode::BAD_REQUEST,
+            "BAD_REQUEST",
             "Invalid archive path: expected packages/{name}/versions/{version}.tar.gz",
-        )
-            .into_response());
+        ));
     }
 
     let pkg_name = parts[0];
     let version_file = parts[2];
 
     let version = version_file.strip_suffix(".tar.gz").ok_or_else(|| {
-        (
+        pub_error_response(
             StatusCode::BAD_REQUEST,
+            "BAD_REQUEST",
             "Invalid archive path: expected .tar.gz extension",
         )
-            .into_response()
     })?;
 
     let artifact = sqlx::query!(
@@ -255,7 +465,13 @@ async fn download_archive(
     .fetch_optional(&state.db)
     .await
     .map_err(crate::api::handlers::db_err)?
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Package archive not found").into_response());
+    .ok_or_else(|| {
+        pub_error_response(
+            StatusCode::NOT_FOUND,
+            "NOT_FOUND",
+            "Package archive not found",
+        )
+    });
 
     let artifact = match artifact {
         Ok(a) => a,
@@ -359,18 +575,23 @@ async fn download_archive(
 }
 
 // ---------------------------------------------------------------------------
-// POST /pub/{repo_key}/api/packages/versions/new -- Get upload URL
+// GET /pub/{repo_key}/api/packages/versions/new -- Get upload URL
 // ---------------------------------------------------------------------------
 
 async fn new_upload_url(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(repo_key): Path<String>,
+    base_url: RequestBaseUrl,
 ) -> Result<Response, Response> {
     let _user_id = require_auth_basic(auth, "pub")?.user_id;
     let _repo = resolve_pub_repo(&state.db, &repo_key).await?;
 
-    let upload_url = format!("/pub/{}/api/packages/versions/newUpload", repo_key);
+    let upload_url = format!(
+        "{}/pub/{}/api/packages/versions/newUpload",
+        base_url.as_str(),
+        repo_key
+    );
     let json = serde_json::json!({
         "url": upload_url,
         "fields": {},
@@ -391,6 +612,7 @@ async fn upload_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(repo_key): Path<String>,
+    base_url: RequestBaseUrl,
     mut multipart: Multipart,
 ) -> Result<Response, Response> {
     let user_id = require_auth_basic(auth, "pub")?.user_id;
@@ -412,11 +634,19 @@ async fn upload_package(
     }
 
     let staged = staged.ok_or_else(|| {
-        (StatusCode::BAD_REQUEST, "Missing 'file' field in upload").into_response()
+        pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "BAD_REQUEST",
+            "Missing 'file' field in upload",
+        )
     })?;
 
     if staged.is_empty() {
-        return Err((StatusCode::BAD_REQUEST, "Empty package archive").into_response());
+        return Err(pub_error_response(
+            StatusCode::BAD_REQUEST,
+            "BAD_REQUEST",
+            "Empty package archive",
+        ));
     }
 
     // Extract pubspec.yaml from the staged archive on disk, decoding the gzip
@@ -435,11 +665,11 @@ async fn upload_package(
     let pkg_version = &pubspec.version;
 
     if pkg_name.is_empty() || pkg_version.is_empty() {
-        return Err((
+        return Err(pub_error_response(
             StatusCode::BAD_REQUEST,
+            "BAD_REQUEST",
             "Package name and version are required",
-        )
-            .into_response());
+        ));
     }
 
     let filename = format!("{}-{}.tar.gz", pkg_name, pkg_version);
@@ -456,7 +686,11 @@ async fn upload_package(
     .map_err(crate::api::handlers::db_err)?;
 
     if existing.is_some() {
-        return Err((StatusCode::CONFLICT, "Package version already exists").into_response());
+        return Err(pub_error_response(
+            StatusCode::CONFLICT,
+            "CONFLICT",
+            "Package version already exists",
+        ));
     }
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
@@ -532,7 +766,13 @@ async fn upload_package(
     // `Location` header pointing at the finalize endpoint. The Dart SDK sets
     // `followRedirects = false` and reads `Location` manually; a 3xx redirect
     // is treated as an unexpected response and the publish aborts (#1997).
-    let finish_url = format!("/pub/{}/api/packages/versions/newUploadFinish", repo_key);
+    // The URL is absolute (via RequestBaseUrl) so clients behind proxies
+    // resolve it correctly.
+    let finish_url = format!(
+        "{}/pub/{}/api/packages/versions/newUploadFinish",
+        base_url.as_str().trim_end_matches('/'),
+        repo_key
+    );
 
     Ok(Response::builder()
         .status(StatusCode::NO_CONTENT)
@@ -565,6 +805,163 @@ async fn finalize_upload(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Build a Pub-spec JSON error response: `{"error": {"code": "...", "message": "..."}}`
+#[allow(clippy::result_large_err)]
+fn pub_error_response(status: StatusCode, code: &str, message: &str) -> Response {
+    let json = serde_json::json!({
+        "error": {
+            "code": code,
+            "message": message,
+        }
+    });
+    Response::builder()
+        .status(status)
+        .header(CONTENT_TYPE, "application/vnd.pub.v2+json")
+        .body(Body::from(serde_json::to_string(&json).unwrap()))
+        .unwrap()
+}
+
+/// Build a Pub-spec package info JSON response from pre-built version entries.
+fn build_pub_package_response(name: &str, versions: Vec<serde_json::Value>) -> Response {
+    let latest = versions.first().cloned().unwrap_or(serde_json::json!(null));
+
+    let json = serde_json::json!({
+        "name": name,
+        "latest": latest,
+        "versions": versions,
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/vnd.pub.v2+json")
+        .body(Body::from(serde_json::to_string(&json).unwrap()))
+        .unwrap()
+}
+
+/// Build a Pub-spec version info JSON response from individual fields.
+fn build_pub_version_response(
+    name: &str,
+    version: &str,
+    archive_url: &str,
+    checksum_sha256: &str,
+    pubspec: &serde_json::Value,
+) -> Response {
+    let json = serde_json::json!({
+        "name": name,
+        "version": version,
+        "archive_url": archive_url,
+        "archive_sha256": checksum_sha256,
+        "pubspec": pubspec,
+    });
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/vnd.pub.v2+json")
+        .body(Body::from(serde_json::to_string(&json).unwrap()))
+        .unwrap()
+}
+
+/// Rewrite `archive_url` in proxied Pub metadata JSON to point to AK.
+///
+/// Handles both `package_info` (has `versions[]` array) and `version_info`
+/// (flat structure with root `archive_url`). Non-URL fields are preserved.
+fn rewrite_pub_archive_urls(json: &mut serde_json::Value, base_url: &str, repo_key: &str) {
+    let name = json
+        .get("name")
+        .and_then(|n| n.as_str())
+        .unwrap_or("_unknown")
+        .to_string();
+
+    if let Some(versions) = json.get_mut("versions").and_then(|v| v.as_array_mut()) {
+        for entry in versions.iter_mut() {
+            rewrite_pub_entry_archive_url(entry, base_url, repo_key, &name);
+        }
+    }
+
+    rewrite_pub_entry_archive_url(json, base_url, repo_key, &name);
+}
+
+fn rewrite_pub_entry_archive_url(
+    entry: &mut serde_json::Value,
+    base_url: &str,
+    repo_key: &str,
+    name: &str,
+) {
+    let ver = entry
+        .get("version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if let Some(obj) = entry.as_object_mut() {
+        let new_url = format!(
+            "{}/pub/{}/packages/{}/versions/{}.tar.gz",
+            base_url, repo_key, name, ver
+        );
+        obj.insert(
+            "archive_url".to_string(),
+            serde_json::Value::String(new_url),
+        );
+    }
+}
+
+/// Forward a GET request to the upstream Pub registry for package metadata.
+///
+/// Uses `proxy_fetch` (via `ProxyService`) for caching, single-flight
+/// coordination, and stale-if-error fallback. Rewrites `archive_url` in the
+/// JSON response to point to Artifact Keeper's download endpoint.
+///
+/// Returns `None` on transport errors so the caller can fall through to other
+/// resolution strategies.
+async fn proxy_pub_meta_get(
+    state: &SharedState,
+    repo_id: Uuid,
+    repo_key: &str,
+    base_url: &str,
+    upstream_url: &str,
+    api_path: &str,
+) -> Option<Response> {
+    let proxy = state.proxy_service.as_ref()?;
+
+    let result = proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, api_path).await;
+
+    let (content, content_type) = match result {
+        Ok((c, ct)) => (c, ct),
+        Err(_) => return None,
+    };
+
+    let ct = content_type
+        .as_deref()
+        .unwrap_or("application/vnd.pub.v2+json");
+
+    let mut json = match serde_json::from_slice::<serde_json::Value>(&content) {
+        Ok(j) => j,
+        Err(_) => {
+            // Non-JSON response — pass through verbatim
+            return Some(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, ct)
+                    .body(Body::from(content))
+                    .unwrap_or_else(|_| {
+                        (StatusCode::INTERNAL_SERVER_ERROR, "upstream error").into_response()
+                    }),
+            );
+        }
+    };
+
+    rewrite_pub_archive_urls(&mut json, base_url, repo_key);
+
+    Some(
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, ct)
+            .body(Body::from(serde_json::to_string(&json).unwrap()))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "rewrite error").into_response()
+            }),
+    )
+}
 
 /// Extract pubspec.yaml from a Pub package tar.gz `reader`, decoding the gzip
 /// stream incrementally so the whole archive is never held in memory.
@@ -630,6 +1027,9 @@ fn extract_pubspec_from_archive(data: &[u8]) -> Result<crate::formats::r#pub::Pu
 
 #[cfg(test)]
 mod tests {
+    // Tests read full (small) response bodies; the streaming policy (#1608)
+    // targets production code paths. Same allow as test_db_helpers.rs.
+    #![allow(clippy::disallowed_methods)]
 
     #[tokio::test]
     async fn test_remote_archive_download_streams_upstream_blob_1608() {
@@ -758,6 +1158,639 @@ mod tests {
     fn test_extract_pubspec_from_invalid_archive() {
         let result = extract_pubspec_from_archive(b"not a valid gzip archive");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_pub_error_response_format() {
+        let resp = pub_error_response(StatusCode::NOT_FOUND, "NOT_FOUND", "Package not found");
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let ct = resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap();
+        assert_eq!(ct, "application/vnd.pub.v2+json");
+    }
+
+    #[test]
+    fn test_pub_error_response_json_body() {
+        use futures::FutureExt;
+        let resp = pub_error_response(StatusCode::CONFLICT, "CONFLICT", "Already exists");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "CONFLICT");
+        assert_eq!(json["error"]["message"], "Already exists");
+    }
+
+    #[tokio::test]
+    async fn test_new_upload_url_get_returns_200() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use tower::ServiceExt;
+
+        let Some(fixture) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+        let app = fixture.router_with_auth(super::router());
+
+        let req = tdh::get(format!("/{}/api/packages/versions/new", fixture.repo_key));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ct = resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap();
+        assert_eq!(ct, "application/vnd.pub.v2+json");
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json.get("url").is_some());
+        assert!(json.get("fields").is_some());
+
+        fixture.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_new_upload_url_post_returns_405() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use tower::ServiceExt;
+
+        let Some(fixture) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+        let app = fixture.router_with_auth(super::router());
+
+        let req = tdh::post(
+            format!("/{}/api/packages/versions/new", fixture.repo_key),
+            "application/json",
+            bytes::Bytes::new(),
+        );
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+
+        fixture.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_package_info_includes_archive_sha256() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use tower::ServiceExt;
+
+        let Some(fixture) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+
+        // Create a minimal pub package tar.gz
+        let pubspec_yaml = "name: test_pkg\nversion: 1.0.0\n";
+        let mut tar_data = Vec::new();
+        {
+            use flate2::write::GzEncoder;
+            use flate2::Compression;
+            use tar::Builder as TarBuilder;
+
+            let encoder = GzEncoder::new(&mut tar_data, Compression::default());
+            let mut tar = TarBuilder::new(encoder);
+            let mut header = tar::Header::new_gnu();
+            tar.append_data(&mut header, "pubspec.yaml", pubspec_yaml.as_bytes())
+                .unwrap();
+            let encoder = tar.into_inner().unwrap();
+            encoder.finish().unwrap();
+        }
+
+        // Seed artifact
+        let storage_key = "pub/test_pkg/1.0.0/test_pkg-1.0.0.tar.gz".to_string();
+        tdh::seed_artifact(
+            &fixture.state,
+            &fixture.pool,
+            &fixture.repo_info("local", None),
+            &storage_key,
+            "test_pkg/1.0.0/test_pkg-1.0.0.tar.gz",
+            "test_pkg",
+            "1.0.0",
+            "application/gzip",
+            bytes::Bytes::from(tar_data),
+            fixture.user_id,
+        )
+        .await;
+
+        let app = fixture.router_with_auth(super::router());
+        let req = tdh::get(format!("/{}/api/packages/test_pkg", fixture.repo_key));
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let versions = json["versions"].as_array().unwrap();
+        assert!(!versions.is_empty());
+        assert!(versions[0].get("archive_sha256").is_some());
+
+        fixture.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // build_pub_package_response / build_pub_version_response unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_pub_package_response_returns_versions() {
+        use futures::FutureExt;
+        let versions = vec![
+            serde_json::json!({"version": "1.0.0", "archive_url": "/pub/r/pkg/1.0.0.tar.gz"}),
+            serde_json::json!({"version": "1.1.0", "archive_url": "/pub/r/pkg/1.1.0.tar.gz"}),
+        ];
+        let resp = build_pub_package_response("test_pkg", versions);
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "application/vnd.pub.v2+json"
+        );
+
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["name"], "test_pkg");
+        assert!(body["versions"].is_array());
+        assert_eq!(body["versions"].as_array().unwrap().len(), 2);
+        assert_eq!(body["latest"]["version"], "1.0.0");
+    }
+
+    #[test]
+    fn test_build_pub_package_response_empty_versions() {
+        use futures::FutureExt;
+        let versions = vec![];
+        let resp = build_pub_package_response("empty_pkg", versions);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["latest"], serde_json::json!(null));
+        assert!(body["versions"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_build_pub_version_response() {
+        use futures::FutureExt;
+        let pubspec = serde_json::json!({"name": "test_pkg", "version": "2.0.0"});
+        let resp = build_pub_version_response(
+            "test_pkg",
+            "2.0.0",
+            "https://ak/pub/r/pkg/2.0.0.tar.gz",
+            "abc123deadbeef",
+            &pubspec,
+        );
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+            "application/vnd.pub.v2+json"
+        );
+
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .now_or_never()
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(body["name"], "test_pkg");
+        assert_eq!(body["version"], "2.0.0");
+        assert_eq!(body["archive_url"], "https://ak/pub/r/pkg/2.0.0.tar.gz");
+        assert_eq!(body["archive_sha256"], "abc123deadbeef");
+        assert_eq!(body["pubspec"]["name"], "test_pkg");
+    }
+
+    // -----------------------------------------------------------------------
+    // rewrite_pub_archive_urls unit tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_rewrite_pub_archive_urls_package_info() {
+        let mut json = serde_json::json!({
+            "name": "test_pkg",
+            "latest": {"version": "1.0.0"},
+            "versions": [
+                {"version": "1.0.0", "archive_url": "https://upstream/pub/test_pkg/1.0.0.tar.gz", "archive_sha256": "abc", "pubspec": {}},
+                {"version": "2.0.0", "archive_url": "https://upstream/pub/test_pkg/2.0.0.tar.gz", "archive_sha256": "def", "pubspec": {}}
+            ]
+        });
+        let base_url = "https://ak.example.com";
+        let repo_key = "pub-remote";
+
+        rewrite_pub_archive_urls(&mut json, base_url, repo_key);
+
+        let versions = json["versions"].as_array().unwrap();
+        assert_eq!(
+            versions[0]["archive_url"],
+            format!(
+                "{}/pub/{}/packages/test_pkg/versions/1.0.0.tar.gz",
+                base_url, repo_key
+            )
+        );
+        assert_eq!(
+            versions[1]["archive_url"],
+            format!(
+                "{}/pub/{}/packages/test_pkg/versions/2.0.0.tar.gz",
+                base_url, repo_key
+            )
+        );
+        // Non-URL fields preserved
+        assert_eq!(versions[0]["archive_sha256"], "abc");
+        assert_eq!(versions[0]["version"], "1.0.0");
+    }
+
+    #[test]
+    fn test_rewrite_pub_archive_urls_version_info() {
+        let mut json = serde_json::json!({
+            "name": "test_pkg",
+            "version": "3.0.0",
+            "archive_url": "https://upstream/pub/test_pkg/3.0.0.tar.gz",
+            "archive_sha256": "xyz",
+            "pubspec": {"name": "test_pkg", "version": "3.0.0"}
+        });
+
+        rewrite_pub_archive_urls(&mut json, "https://ak.example.com", "pub-remote");
+
+        assert_eq!(
+            json["archive_url"],
+            "https://ak.example.com/pub/pub-remote/packages/test_pkg/versions/3.0.0.tar.gz"
+        );
+        // Non-URL fields preserved
+        assert_eq!(json["archive_sha256"], "xyz");
+        assert_eq!(json["version"], "3.0.0");
+    }
+
+    #[test]
+    fn test_rewrite_pub_archive_urls_missing_fields() {
+        // Missing name and archive_url — should not panic
+        let mut json = serde_json::json!({
+            "versions": [
+                {"version": "1.0.0"}
+            ]
+        });
+        rewrite_pub_archive_urls(&mut json, "https://ak.example.com", "pub-remote");
+        // Should not have added archive_url (no name to construct from)
+        assert!(json["versions"][0].get("archive_url").is_some());
+    }
+
+    fn mock_pub_package_info(name: &str) -> String {
+        format!(
+            r#"{{"name":"{name}","latest":{{"version":"1.0.0"}},"versions":[{{"version":"1.0.0","archive_url":"https://upstream/pub/{name}/1.0.0.tar.gz","archive_sha256":"abc","pubspec":{{"name":"{name}","version":"1.0.0"}}}}]}}"#,
+            name = name
+        )
+    }
+
+    #[tokio::test]
+    async fn test_remote_repo_package_info_proxied_to_upstream() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pub").await else {
+            return;
+        };
+
+        let mock_server = MockServer::start().await;
+        let pkg = "test_proxy_pkg";
+        let api_path = format!("/api/packages/{}", pkg);
+
+        Mock::given(method("GET"))
+            .and(path(api_path.as_str()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/vnd.pub.v2+json")
+                    .set_body_string(mock_pub_package_info(pkg)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock_server.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let app = tdh::router_anon(super::router(), state);
+        let uri = format!("/{}/api/packages/{}", fx.repo_key, pkg);
+        let (status, bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["name"], pkg);
+        assert_eq!(json["versions"][0]["version"], "1.0.0");
+        // Verify archive_url is rewritten to AK format, not upstream
+        let url = json["versions"][0]["archive_url"].as_str().unwrap();
+        assert!(
+            url.contains(&format!(
+                "/pub/{}/packages/{}/versions/1.0.0.tar.gz",
+                fx.repo_key, pkg
+            )),
+            "archive_url should be rewritten to AK format, got: {}",
+            url
+        );
+    }
+
+    #[tokio::test]
+    async fn test_remote_repo_package_info_404_when_upstream_down() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pub").await else {
+            return;
+        };
+
+        // Leave upstream_url pointing to a non-existent server
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let app = tdh::router_anon(super::router(), state);
+        let uri = format!("/{}/api/packages/missing_pkg", fx.repo_key);
+        let (status, _bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        // When upstream is unreachable the handler returns 404
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_remote_repo_version_info_proxied_to_upstream() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pub").await else {
+            return;
+        };
+
+        let mock_server = MockServer::start().await;
+        let pkg = "test_ver_pkg";
+        let ver = "2.0.0";
+        let api_path = format!("/api/packages/{}/versions/{}", pkg, ver);
+
+        Mock::given(method("GET"))
+            .and(path(api_path.as_str()))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/vnd.pub.v2+json")
+                    .set_body_string(
+                        serde_json::json!({
+                            "name": pkg,
+                            "version": ver,
+                            "archive_url": format!("https://upstream/pub/{pkg}/{ver}.tar.gz"),
+                            "archive_sha256": "def",
+                            "pubspec": {"name": pkg, "version": ver},
+                        })
+                        .to_string(),
+                    ),
+            )
+            .mount(&mock_server)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock_server.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let app = tdh::router_anon(super::router(), state);
+        let uri = format!("/{}/api/packages/{}/versions/{}", fx.repo_key, pkg, ver);
+        let (status, bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["name"], pkg);
+        assert_eq!(json["version"], ver);
+        // Verify archive_url is rewritten to AK format
+        let url = json["archive_url"].as_str().unwrap();
+        assert!(
+            url.contains(&format!(
+                "/pub/{}/packages/{}/versions/{}.tar.gz",
+                fx.repo_key, pkg, ver
+            )),
+            "archive_url should be rewritten to AK format, got: {}",
+            url
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Virtual repo member resolution integration tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_virtual_repo_package_info_resolves_local_member() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+
+        // Create a minimal pub package tar.gz
+        let pubspec_yaml = "name: test_virtual_pkg\nversion: 3.0.0\n";
+        let mut tar_data = Vec::new();
+        {
+            use flate2::write::GzEncoder;
+            use flate2::Compression;
+            use tar::Builder as TarBuilder;
+
+            let encoder = GzEncoder::new(&mut tar_data, Compression::default());
+            let mut tar = TarBuilder::new(encoder);
+            let mut header = tar::Header::new_gnu();
+            tar.append_data(&mut header, "pubspec.yaml", pubspec_yaml.as_bytes())
+                .unwrap();
+            let encoder = tar.into_inner().unwrap();
+            encoder.finish().unwrap();
+        }
+
+        // Seed artifact into the local repo
+        let storage_key = "pub/test_virtual_pkg/3.0.0/test_virtual_pkg-3.0.0.tar.gz".to_string();
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &fx.repo_info("local", None),
+            &storage_key,
+            "test_virtual_pkg/3.0.0/test_virtual_pkg-3.0.0.tar.gz",
+            "test_virtual_pkg",
+            "3.0.0",
+            "application/gzip",
+            bytes::Bytes::from(tar_data),
+            fx.user_id,
+        )
+        .await;
+
+        // Create virtual repo using our local repo as a member
+        let virtual_id = Uuid::new_v4();
+        let virtual_key = format!("ph-pub-virtual-{}", virtual_id);
+        let storage_dir = std::env::temp_dir().join(format!("ph-test-{}", virtual_id));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+             VALUES ($1, $2, $3, $4, 'virtual'::repository_type, 'pub'::repository_format)",
+        )
+        .bind(virtual_id)
+        .bind(&virtual_key)
+        .bind(&virtual_key)
+        .bind(storage_dir.to_string_lossy().as_ref())
+        .execute(&fx.pool)
+        .await
+        .expect("create virtual repo");
+
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(virtual_id)
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("add member");
+
+        // Also grant access to virtual repo for the fixture user
+        tdh::grant_repo_access(&fx.pool, virtual_id, fx.user_id).await;
+
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let uri = format!("/{}/api/packages/test_virtual_pkg", virtual_key);
+        let (status, bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["name"], "test_virtual_pkg");
+        let versions = json["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["version"], "3.0.0");
+    }
+
+    #[tokio::test]
+    async fn test_virtual_repo_package_info_404_when_no_member() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pub").await else {
+            return;
+        };
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let uri = format!("/{}/api/packages/missing_pkg", fx.repo_key);
+        let (status, _bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_virtual_repo_version_info_resolves_local_member() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+
+        // Create a minimal pub package tar.gz
+        let pubspec_yaml = "name: test_ver_virtual\nversion: 4.0.0\n";
+        let mut tar_data = Vec::new();
+        {
+            use flate2::write::GzEncoder;
+            use flate2::Compression;
+            use tar::Builder as TarBuilder;
+
+            let encoder = GzEncoder::new(&mut tar_data, Compression::default());
+            let mut tar = TarBuilder::new(encoder);
+            let mut header = tar::Header::new_gnu();
+            tar.append_data(&mut header, "pubspec.yaml", pubspec_yaml.as_bytes())
+                .unwrap();
+            let encoder = tar.into_inner().unwrap();
+            encoder.finish().unwrap();
+        }
+
+        let storage_key = "pub/test_ver_virtual/4.0.0/test_ver_virtual-4.0.0.tar.gz".to_string();
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &fx.repo_info("local", None),
+            &storage_key,
+            "test_ver_virtual/4.0.0/test_ver_virtual-4.0.0.tar.gz",
+            "test_ver_virtual",
+            "4.0.0",
+            "application/gzip",
+            bytes::Bytes::from(tar_data),
+            fx.user_id,
+        )
+        .await;
+
+        // Create virtual repo
+        let virtual_id = Uuid::new_v4();
+        let virtual_key = format!("ph-pub-virtual-{}", virtual_id);
+        let storage_dir = std::env::temp_dir().join(format!("ph-test-{}", virtual_id));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+             VALUES ($1, $2, $3, $4, 'virtual'::repository_type, 'pub'::repository_format)",
+        )
+        .bind(virtual_id)
+        .bind(&virtual_key)
+        .bind(&virtual_key)
+        .bind(storage_dir.to_string_lossy().as_ref())
+        .execute(&fx.pool)
+        .await
+        .expect("create virtual repo");
+
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(virtual_id)
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("add member");
+
+        tdh::grant_repo_access(&fx.pool, virtual_id, fx.user_id).await;
+
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let uri = format!(
+            "/{}/api/packages/test_ver_virtual/versions/4.0.0",
+            virtual_key
+        );
+        let (status, bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::OK);
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["name"], "test_ver_virtual");
+        assert_eq!(json["version"], "4.0.0");
+    }
+
+    #[tokio::test]
+    async fn test_virtual_repo_version_info_404_when_no_member() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "pub").await else {
+            return;
+        };
+        let app = tdh::router_anon(super::router(), fx.state.clone());
+        let uri = format!("/{}/api/packages/missing_pkg/versions/1.0.0", fx.repo_key);
+        let (status, _bytes) = tdh::send(app, tdh::get(uri)).await;
+        fx.teardown().await;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
     }
 }
 

--- a/scripts/native-tests/run-all.sh
+++ b/scripts/native-tests/run-all.sh
@@ -13,7 +13,7 @@ echo "=============================================="
 
 # Define test sets
 SMOKE_TESTS=(pypi npm cargo)
-ALL_TESTS=(pypi npm cargo maven go rpm deb helm conda docker protobuf incus hex proxy-virtual health-probes tag-replication curation)
+ALL_TESTS=(pypi npm cargo maven go rpm deb helm conda docker protobuf incus hex pub proxy-virtual pub-proxy pub-virtual health-probes tag-replication curation)
 
 # Select tests based on profile
 case "$PROFILE" in
@@ -26,12 +26,12 @@ case "$PROFILE" in
     proxy)
         TESTS=("proxy-virtual")
         ;;
-    pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|protobuf|incus|hex|proxy-virtual|terraform-mirror|health-probes|tag-replication|curation)
+    pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|protobuf|incus|hex|pub|proxy-virtual|pub-proxy|pub-virtual|terraform-mirror|health-probes|tag-replication|curation)
         TESTS=("$PROFILE")
         ;;
     *)
         echo "ERROR: Unknown profile: $PROFILE"
-        echo "Available profiles: smoke, all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, protobuf, incus, hex, proxy, terraform-mirror, tag-replication, curation"
+        echo "Available profiles: smoke, all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, protobuf, incus, hex, pub, proxy, pub-proxy, pub-virtual, terraform-mirror, tag-replication, curation"
         exit 1
         ;;
 esac

--- a/scripts/native-tests/run-pub-e2e.sh
+++ b/scripts/native-tests/run-pub-e2e.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Full E2E test script for Dart Pub upload
+# Starts infrastructure, runs backend, executes test, captures results, cleans up
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+PUB_REPO_KEY="${PUB_REPO_KEY:-test-dart-pub}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+BACKEND_PID=""
+COMPOSE_PROJECT="artifact-keeper-dart-test"
+
+cleanup() {
+  echo ""
+  echo "==> Cleaning up..."
+  if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
+    kill "$BACKEND_PID" 2>/dev/null || true
+    wait "$BACKEND_PID" 2>/dev/null || true
+    echo "  Backend stopped (PID $BACKEND_PID)"
+  fi
+  docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" down -v 2>/dev/null || true
+  echo "  Postgres stopped"
+}
+trap cleanup EXIT
+
+echo "=============================================="
+echo "Dart Pub Upload — Full E2E Test"
+echo "=============================================="
+echo ""
+
+# ---- Step 1: Start PostgreSQL ----
+echo "==> [1/3] Starting PostgreSQL..."
+docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" up -d postgres 2>&1 | tail -3
+
+echo "  Waiting for Postgres to be healthy..."
+for i in $(seq 1 30); do
+  if docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" exec -T postgres pg_isready -U registry -d artifact_registry >/dev/null 2>&1; then
+    echo "  Postgres is ready"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "  ❌ Postgres failed to start"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---- Step 2: Start backend ----
+echo ""
+echo "==> [2/3] Starting backend (migrations run automatically on startup)..."
+cd "$REPO_ROOT"
+
+# Source project env file, then override for this test
+set -a
+source .env.local-dev
+set +a
+export ADMIN_PASSWORD="TestRunner!2026secure"
+export HOST="0.0.0.0"
+export SQLX_OFFLINE="true"
+export AK_WEBHOOK_SECRET_KEY="$(openssl rand -base64 32)"
+
+cargo run --bin artifact-keeper &
+BACKEND_PID=$!
+echo "  Backend PID: $BACKEND_PID"
+
+echo "  Waiting for backend to be healthy (first build can take several minutes)..."
+for i in $(seq 1 600); do
+  if curl -sf "$REGISTRY_URL/health" >/dev/null 2>&1; then
+    echo "  Backend is ready at $REGISTRY_URL"
+    break
+  fi
+  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+    echo "  ❌ Backend process died. Check cargo output above."
+    exit 1
+  fi
+  if [ "$i" -eq 600 ]; then
+    echo "  ❌ Backend failed to start within 10 minutes"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---- Step 3: Run test ----
+echo ""
+echo "==> [3/3] Running Dart Pub E2E test..."
+echo "=============================================="
+REGISTRY_URL="$REGISTRY_URL" \
+PUB_REPO_KEY="$PUB_REPO_KEY" \
+ADMIN_USER="$ADMIN_USER" \
+ADMIN_PASS="$ADMIN_PASS" \
+  bash "$SCRIPT_DIR/test-pub.sh"
+TEST_EXIT=$?
+
+echo ""
+echo "=============================================="
+if [ "$TEST_EXIT" -eq 0 ]; then
+  echo "✅ FULL E2E TEST PASSED"
+else
+  echo "❌ FULL E2E TEST FAILED (exit code: $TEST_EXIT)"
+fi
+echo "=============================================="
+
+exit $TEST_EXIT

--- a/scripts/native-tests/run-pub-proxy-e2e.sh
+++ b/scripts/native-tests/run-pub-proxy-e2e.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Full E2E test script for Pub proxy repo
+# Starts infrastructure, runs backend, executes test, cleans up
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+BACKEND_PID=""
+COMPOSE_PROJECT="artifact-keeper-pub-proxy-test"
+
+cleanup() {
+  echo ""
+  echo "==> Cleaning up..."
+  if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
+    kill "$BACKEND_PID" 2>/dev/null || true
+    wait "$BACKEND_PID" 2>/dev/null || true
+    echo "  Backend stopped (PID $BACKEND_PID)"
+  fi
+  docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" down -v 2>/dev/null || true
+  echo "  Postgres stopped"
+}
+trap cleanup EXIT
+
+echo "=============================================="
+echo "Pub Proxy Repo — Full E2E Test"
+echo "=============================================="
+echo ""
+
+# ---- Step 1: Start PostgreSQL ----
+echo "==> [1/3] Starting PostgreSQL..."
+docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" up -d postgres 2>&1 | tail -3
+
+echo "  Waiting for Postgres to be healthy..."
+for i in $(seq 1 30); do
+  if docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" exec -T postgres pg_isready -U registry -d artifact_registry >/dev/null 2>&1; then
+    echo "  Postgres is ready"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "  ❌ Postgres failed to start"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---- Step 2: Start backend ----
+echo ""
+echo "==> [2/3] Starting backend (migrations run automatically on startup)..."
+cd "$REPO_ROOT"
+
+set -a
+source .env.local-dev
+set +a
+export ADMIN_PASSWORD="TestRunner!2026secure"
+export HOST="0.0.0.0"
+export SQLX_OFFLINE="true"
+export AK_WEBHOOK_SECRET_KEY="$(openssl rand -base64 32)"
+
+cargo run --bin artifact-keeper &
+BACKEND_PID=$!
+echo "  Backend PID: $BACKEND_PID"
+
+echo "  Waiting for backend to be healthy (first build can take several minutes)..."
+for i in $(seq 1 600); do
+  if curl -sf "$REGISTRY_URL/health" >/dev/null 2>&1; then
+    echo "  Backend is ready at $REGISTRY_URL"
+    break
+  fi
+  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+    echo "  ❌ Backend process died. Check cargo output above."
+    exit 1
+  fi
+  if [ "$i" -eq 600 ]; then
+    echo "  ❌ Backend failed to start within 10 minutes"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---- Step 3: Run test ----
+echo ""
+echo "==> [3/3] Running Pub Proxy E2E test..."
+echo "=============================================="
+REGISTRY_URL="$REGISTRY_URL" \
+ADMIN_USER="$ADMIN_USER" \
+ADMIN_PASS="$ADMIN_PASS" \
+  bash "$SCRIPT_DIR/test-pub-proxy.sh"
+TEST_EXIT=$?
+
+echo ""
+echo "=============================================="
+if [ "$TEST_EXIT" -eq 0 ]; then
+  echo "✅ FULL E2E TEST PASSED"
+else
+  echo "❌ FULL E2E TEST FAILED (exit code: $TEST_EXIT)"
+fi
+echo "=============================================="
+
+exit $TEST_EXIT

--- a/scripts/native-tests/run-pub-virtual-e2e.sh
+++ b/scripts/native-tests/run-pub-virtual-e2e.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+# Full E2E test script for Pub virtual repo
+# Starts infrastructure, runs backend, executes test, cleans up
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+BACKEND_PID=""
+COMPOSE_PROJECT="artifact-keeper-pub-virtual-test"
+
+cleanup() {
+  echo ""
+  echo "==> Cleaning up..."
+  if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
+    kill "$BACKEND_PID" 2>/dev/null || true
+    wait "$BACKEND_PID" 2>/dev/null || true
+    echo "  Backend stopped (PID $BACKEND_PID)"
+  fi
+  docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" down -v 2>/dev/null || true
+  echo "  Postgres stopped"
+}
+trap cleanup EXIT
+
+echo "=============================================="
+echo "Pub Virtual Repo — Full E2E Test"
+echo "=============================================="
+echo ""
+
+# ---- Step 1: Start PostgreSQL ----
+echo "==> [1/3] Starting PostgreSQL..."
+docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" up -d postgres 2>&1 | tail -3
+
+echo "  Waiting for Postgres to be healthy..."
+for i in $(seq 1 30); do
+  if docker compose -p "$COMPOSE_PROJECT" -f "$REPO_ROOT/docker-compose.local-dev.yml" exec -T postgres pg_isready -U registry -d artifact_registry >/dev/null 2>&1; then
+    echo "  Postgres is ready"
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    echo "  ❌ Postgres failed to start"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---- Step 2: Start backend ----
+echo ""
+echo "==> [2/3] Starting backend (migrations run automatically on startup)..."
+cd "$REPO_ROOT"
+
+set -a
+source .env.local-dev
+set +a
+export ADMIN_PASSWORD="TestRunner!2026secure"
+export HOST="0.0.0.0"
+export SQLX_OFFLINE="true"
+export AK_WEBHOOK_SECRET_KEY="$(openssl rand -base64 32)"
+
+cargo run --bin artifact-keeper &
+BACKEND_PID=$!
+echo "  Backend PID: $BACKEND_PID"
+
+echo "  Waiting for backend to be healthy (first build can take several minutes)..."
+for i in $(seq 1 600); do
+  if curl -sf "$REGISTRY_URL/health" >/dev/null 2>&1; then
+    echo "  Backend is ready at $REGISTRY_URL"
+    break
+  fi
+  if ! kill -0 "$BACKEND_PID" 2>/dev/null; then
+    echo "  ❌ Backend process died. Check cargo output above."
+    exit 1
+  fi
+  if [ "$i" -eq 600 ]; then
+    echo "  ❌ Backend failed to start within 10 minutes"
+    exit 1
+  fi
+  sleep 1
+done
+
+# ---- Step 3: Run test ----
+echo ""
+echo "==> [3/3] Running Pub Virtual E2E test..."
+echo "=============================================="
+REGISTRY_URL="$REGISTRY_URL" \
+ADMIN_USER="$ADMIN_USER" \
+ADMIN_PASS="$ADMIN_PASS" \
+  bash "$SCRIPT_DIR/test-pub-virtual.sh"
+TEST_EXIT=$?
+
+echo ""
+echo "=============================================="
+if [ "$TEST_EXIT" -eq 0 ]; then
+  echo "✅ FULL E2E TEST PASSED"
+else
+  echo "❌ FULL E2E TEST FAILED (exit code: $TEST_EXIT)"
+fi
+echo "=============================================="
+
+exit $TEST_EXIT

--- a/scripts/native-tests/test-pub-proxy.sh
+++ b/scripts/native-tests/test-pub-proxy.sh
@@ -1,0 +1,173 @@
+#!/bin/bash
+# Pub proxy (remote) repo E2E test
+# Tests that a proxy repo downloads packages from pub.dev via Dart CLI
+set -euo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+PROXY_REPO_KEY="${PROXY_REPO_KEY:-pub-proxy}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+
+echo "==> Pub Proxy Repo E2E Test"
+echo "Registry: $REGISTRY_URL"
+echo "Proxy:    $PROXY_REPO_KEY"
+echo ""
+
+# ---- Step 1: Create remote (proxy) repo ----
+echo "==> [1/4] Creating remote (proxy) repo..."
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  "$REGISTRY_URL/api/v1/repositories/$PROXY_REPO_KEY")
+
+if [ "$HTTP_CODE" = "404" ]; then
+  CREATE_RESP=$(curl -s -w "\n%{http_code}" \
+    -u "$ADMIN_USER:$ADMIN_PASS" \
+    -X POST "$REGISTRY_URL/api/v1/repositories" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"key\": \"$PROXY_REPO_KEY\",
+      \"name\": \"Pub Proxy\",
+      \"format\": \"pub\",
+      \"repo_type\": \"remote\",
+      \"upstream_url\": \"https://pub.dev\",
+      \"is_public\": true
+    }")
+  CREATE_STATUS=$(echo "$CREATE_RESP" | tail -1)
+  CREATE_BODY=$(echo "$CREATE_RESP" | sed '$d')
+  echo "  Create response ($CREATE_STATUS): $CREATE_BODY"
+  if [ "$CREATE_STATUS" -ge 300 ]; then
+    echo "❌ Failed to create proxy repository"
+    exit 1
+  fi
+elif [ "$HTTP_CODE" = "200" ]; then
+  echo "  Repository already exists"
+else
+  echo "  ⚠️  Unexpected status checking repo: $HTTP_CODE"
+fi
+
+# ---- Step 2: Verify proxy rejects publish ----
+echo ""
+echo "==> [2/4] Verifying proxy rejects publish..."
+
+PUBLISH_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -X POST \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@/dev/null" \
+  "$REGISTRY_URL/pub/$PROXY_REPO_KEY/api/packages/versions/newUpload")
+
+PUBLISH_STATUS=$(echo "$PUBLISH_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+echo "  Status: $PUBLISH_STATUS"
+
+if [ "$PUBLISH_STATUS" = "405" ]; then
+  echo "  ✅ Proxy correctly rejects publish (405)"
+else
+  echo "  ⚠️  Expected 405, got $PUBLISH_STATUS"
+fi
+
+# ---- Step 3: dart pub get through proxy ----
+echo ""
+echo "==> [3/4] Testing dart pub get through proxy..."
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+# Get host IP for Docker networking
+HOST_IP=$(ipconfig getifaddr en0 2>/dev/null || echo "host.docker.internal")
+
+# Setup nginx TLS proxy
+CERT_DIR="$WORK_DIR/certs"
+mkdir -p "$CERT_DIR"
+openssl req -x509 -newkey rsa:2048 -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
+  -days 1 -nodes -subj "/CN=$HOST_IP" \
+  -addext "subjectAltName=IP:$HOST_IP,DNS:localhost" 2>/dev/null
+
+docker ps -q --filter "ancestor=nginx:alpine" | xargs -r docker stop 2>/dev/null || true
+
+cat > "$CERT_DIR/nginx.conf" << NGINX
+worker_processes 1;
+events { worker_connections 64; }
+http {
+    server {
+        listen 443 ssl;
+        ssl_certificate     /certs/cert.pem;
+        ssl_certificate_key /certs/key.pem;
+        location / {
+            proxy_pass http://host.docker.internal:8080;
+            proxy_set_header Host \$http_host;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-Proto \$scheme;
+        }
+    }
+}
+NGINX
+
+echo "  Starting nginx TLS proxy..."
+NGINX_CID=$(docker run -d --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -p 9443:443 \
+  -v "$CERT_DIR/nginx.conf:/etc/nginx/nginx.conf:ro" \
+  -v "$CERT_DIR:/certs:ro" \
+  nginx:alpine nginx -g 'daemon off;' 2>&1 || true)
+sleep 2
+
+if [ -z "$NGINX_CID" ] || ! docker ps --format '{{.ID}}' | grep -q "^${NGINX_CID:0:12}"; then
+  echo "  ❌ nginx failed to start"
+  docker stop "$NGINX_CID" 2>/dev/null || true
+  exit 1
+fi
+echo "  nginx running on https://$HOST_IP:9443"
+
+# Create consumer project that depends on `http` from the proxy
+CONSUMER_DIR="$WORK_DIR/consumer"
+mkdir -p "$CONSUMER_DIR/lib"
+cat > "$CONSUMER_DIR/pubspec.yaml" << EOF
+name: test_proxy_consumer
+environment:
+  sdk: ">=2.15.0 <4.0.0"
+dependencies:
+  http:
+    hosted: https://$HOST_IP:9443/pub/$PROXY_REPO_KEY
+    version: ^1.0.0
+EOF
+cat > "$CONSUMER_DIR/lib/consumer.dart" << EOF
+import 'package:http/http.dart' as http;
+Future<void> use() async => await http.get(Uri.parse('https://example.com'));
+EOF
+
+echo "  Running dart pub get..."
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$CERT_DIR/cert.pem:/certs/self-signed.crt:ro" \
+  -v "$CONSUMER_DIR:/project" \
+  -w /project \
+  -e ADMIN_USER="$ADMIN_USER" \
+  -e ADMIN_PASS="$ADMIN_PASS" \
+  dart:stable \
+  sh -c "
+    cp /certs/self-signed.crt /usr/local/share/ca-certificates/self-signed.crt 2>/dev/null || \
+      cp /certs/self-signed.crt /usr/lib/ssl/certs/self-signed.crt 2>/dev/null || \
+      mkdir -p /etc/ssl/certs && cp /certs/self-signed.crt /etc/ssl/certs/self-signed.crt
+    update-ca-certificates 2>/dev/null || true
+    printf '%s\n' '$(echo -n "$ADMIN_USER:$ADMIN_PASS" | base64)' | dart pub token add 'https://$HOST_IP:9443/pub/$PROXY_REPO_KEY/'
+    dart pub get 2>&1
+  "
+DART_EXIT=$?
+
+docker stop "$NGINX_CID" >/dev/null 2>&1 || true
+
+# ---- Step 4: Summary ----
+echo ""
+echo "=============================================="
+echo "PROXY TEST SUMMARY"
+echo "=============================================="
+echo "Proxy repo:   $PROXY_REPO_KEY"
+echo "dart pub get:  $DART_EXIT"
+echo ""
+
+if [ "$DART_EXIT" -eq 0 ]; then
+  echo "✅ Pub proxy E2E test PASSED"
+else
+  echo "❌ Pub proxy E2E test FAILED (exit code: $DART_EXIT)"
+fi

--- a/scripts/native-tests/test-pub-virtual.sh
+++ b/scripts/native-tests/test-pub-virtual.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# Pub virtual repo E2E test
+# Tests that a virtual repo aggregates a local repo via Dart CLI
+set -euo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+LOCAL_REPO_KEY="${LOCAL_REPO_KEY:-pub-local}"
+VIRTUAL_REPO_KEY="${VIRTUAL_REPO_KEY:-pub-virtual}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+PKG_NAME="test_e2e_dart_pkg"
+PKG_VERSION="1.0.$(date +%s)"
+
+echo "==> Pub Virtual Repo E2E Test"
+echo "Registry: $REGISTRY_URL"
+echo "Local:    $LOCAL_REPO_KEY"
+echo "Virtual:  $VIRTUAL_REPO_KEY"
+echo "Package:  $PKG_NAME@$PKG_VERSION"
+echo ""
+
+# ---- Step 1: Create local repo ----
+echo "==> [1/5] Creating local repo..."
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  "$REGISTRY_URL/api/v1/repositories/$LOCAL_REPO_KEY")
+
+if [ "$HTTP_CODE" = "404" ]; then
+  CREATE_RESP=$(curl -s -w "\n%{http_code}" \
+    -u "$ADMIN_USER:$ADMIN_PASS" \
+    -X POST "$REGISTRY_URL/api/v1/repositories" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"key\": \"$LOCAL_REPO_KEY\",
+      \"name\": \"Pub Local\",
+      \"format\": \"pub\",
+      \"repo_type\": \"local\"
+    }")
+  CREATE_STATUS=$(echo "$CREATE_RESP" | tail -1)
+  echo "  Create response ($CREATE_STATUS)"
+  if [ "$CREATE_STATUS" -ge 300 ]; then
+    echo "❌ Failed to create local repository"
+    exit 1
+  fi
+elif [ "$HTTP_CODE" = "200" ]; then
+  echo "  Repository already exists"
+else
+  echo "  ⚠️  Unexpected status: $HTTP_CODE"
+fi
+
+# ---- Step 2: Create virtual repo ----
+echo ""
+echo "==> [2/5] Creating virtual repo..."
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  "$REGISTRY_URL/api/v1/repositories/$VIRTUAL_REPO_KEY")
+
+if [ "$HTTP_CODE" = "404" ]; then
+  CREATE_RESP=$(curl -s -w "\n%{http_code}" \
+    -u "$ADMIN_USER:$ADMIN_PASS" \
+    -X POST "$REGISTRY_URL/api/v1/repositories" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"key\": \"$VIRTUAL_REPO_KEY\",
+      \"name\": \"Pub Virtual\",
+      \"format\": \"pub\",
+      \"repo_type\": \"virtual\",
+      \"is_public\": true,
+      \"member_repos\": [
+        {\"repo_key\": \"$LOCAL_REPO_KEY\", \"priority\": 1}
+      ]
+    }")
+  CREATE_STATUS=$(echo "$CREATE_RESP" | tail -1)
+  echo "  Create response ($CREATE_STATUS)"
+  if [ "$CREATE_STATUS" -ge 300 ]; then
+    echo "❌ Failed to create virtual repository"
+    exit 1
+  fi
+elif [ "$HTTP_CODE" = "200" ]; then
+  echo "  Repository already exists"
+else
+  echo "  ⚠️  Unexpected status: $HTTP_CODE"
+fi
+
+# ---- Step 3: Publish test package to local repo ----
+echo ""
+echo "==> [3/5] Publishing test package to local repo..."
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PKG_DIR="$WORK_DIR/$PKG_NAME"
+mkdir -p "$PKG_DIR/lib"
+
+cat > "$PKG_DIR/pubspec.yaml" << EOF
+name: $PKG_NAME
+version: $PKG_VERSION
+description: Test package for virtual repo E2E
+environment:
+  sdk: ">=2.12.0 <4.0.0"
+EOF
+
+cat > "$PKG_DIR/lib/$PKG_NAME.dart" << EOF
+String hello() => 'Hello from $PKG_NAME!';
+EOF
+
+ARCHIVE="$WORK_DIR/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+(cd "$PKG_DIR" && tar czf "$ARCHIVE" pubspec.yaml lib/)
+
+# Get upload URL
+STEP1_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -H "Accept: application/vnd.pub.v2+json" \
+  -X GET \
+  "$REGISTRY_URL/pub/$LOCAL_REPO_KEY/api/packages/versions/new")
+
+STEP1_STATUS=$(echo "$STEP1_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+STEP1_BODY=$(echo "$STEP1_RESP" | sed '/^---HTTP_STATUS:/d')
+
+if [ "$STEP1_STATUS" != "200" ]; then
+  echo "❌ Step 1 failed: $STEP1_STATUS"
+  echo "   $STEP1_BODY"
+  exit 1
+fi
+
+UPLOAD_URL=$(echo "$STEP1_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])" 2>/dev/null)
+echo "  Upload URL: $UPLOAD_URL"
+
+# Upload
+STEP2_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -D - \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -X POST \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@$ARCHIVE" \
+  "$UPLOAD_URL" 2>&1)
+
+STEP2_STATUS=$(echo "$STEP2_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+STEP2_LOCATION=$(echo "$STEP2_RESP" | grep -i "^location:" | tr -d '\r' | sed 's/^location: *//i')
+
+if [ "$STEP2_STATUS" != "204" ] && [ "$STEP2_STATUS" != "200" ]; then
+  echo "❌ Upload failed: $STEP2_STATUS"
+  exit 1
+fi
+echo "  Upload: $STEP2_STATUS"
+
+# Finalize
+if [ -n "$STEP2_LOCATION" ]; then
+  if ! echo "$STEP2_LOCATION" | grep -q "^http"; then
+    STEP2_LOCATION="$REGISTRY_URL$STEP2_LOCATION"
+  fi
+  FINALIZE_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+    -u "$ADMIN_USER:$ADMIN_PASS" \
+    -H "Accept: application/vnd.pub.v2+json" \
+    "$STEP2_LOCATION")
+  FINALIZE_STATUS=$(echo "$FINALIZE_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+  echo "  Finalize: $FINALIZE_STATUS"
+fi
+
+# ---- Step 4: dart pub get through virtual repo ----
+echo ""
+echo "==> [4/5] Testing dart pub get through virtual repo..."
+
+HOST_IP=$(ipconfig getifaddr en0 2>/dev/null || echo "host.docker.internal")
+
+CERT_DIR="$WORK_DIR/certs"
+mkdir -p "$CERT_DIR"
+openssl req -x509 -newkey rsa:2048 -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
+  -days 1 -nodes -subj "/CN=$HOST_IP" \
+  -addext "subjectAltName=IP:$HOST_IP,DNS:localhost" 2>/dev/null
+
+docker ps -q --filter "ancestor=nginx:alpine" | xargs -r docker stop 2>/dev/null || true
+
+cat > "$CERT_DIR/nginx.conf" << NGINX
+worker_processes 1;
+events { worker_connections 64; }
+http {
+    server {
+        listen 443 ssl;
+        ssl_certificate     /certs/cert.pem;
+        ssl_certificate_key /certs/key.pem;
+        location / {
+            proxy_pass http://host.docker.internal:8080;
+            proxy_set_header Host \$http_host;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-Proto \$scheme;
+        }
+    }
+}
+NGINX
+
+echo "  Starting nginx TLS proxy..."
+NGINX_CID=$(docker run -d --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -p 9443:443 \
+  -v "$CERT_DIR/nginx.conf:/etc/nginx/nginx.conf:ro" \
+  -v "$CERT_DIR:/certs:ro" \
+  nginx:alpine nginx -g 'daemon off;' 2>&1 || true)
+sleep 2
+
+if [ -z "$NGINX_CID" ] || ! docker ps --format '{{.ID}}' | grep -q "^${NGINX_CID:0:12}"; then
+  echo "  ❌ nginx failed to start"
+  docker stop "$NGINX_CID" 2>/dev/null || true
+  exit 1
+fi
+echo "  nginx running on https://$HOST_IP:9443"
+
+# Create consumer project
+CONSUMER_DIR="$WORK_DIR/consumer"
+mkdir -p "$CONSUMER_DIR/lib"
+cat > "$CONSUMER_DIR/pubspec.yaml" << EOF
+name: test_virtual_consumer
+environment:
+  sdk: ">=2.15.0 <4.0.0"
+dependencies:
+  $PKG_NAME:
+    hosted: https://$HOST_IP:9443/pub/$VIRTUAL_REPO_KEY
+    version: $PKG_VERSION
+EOF
+cat > "$CONSUMER_DIR/lib/consumer.dart" << EOF
+import 'package:$PKG_NAME/$PKG_NAME.dart';
+String use() => hello();
+EOF
+
+echo "  Running dart pub get..."
+docker run --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -v "$CERT_DIR/cert.pem:/certs/self-signed.crt:ro" \
+  -v "$CONSUMER_DIR:/project" \
+  -w /project \
+  -e ADMIN_USER="$ADMIN_USER" \
+  -e ADMIN_PASS="$ADMIN_PASS" \
+  dart:stable \
+  sh -c "
+    cp /certs/self-signed.crt /usr/local/share/ca-certificates/self-signed.crt 2>/dev/null || \
+      cp /certs/self-signed.crt /usr/lib/ssl/certs/self-signed.crt 2>/dev/null || \
+      mkdir -p /etc/ssl/certs && cp /certs/self-signed.crt /etc/ssl/certs/self-signed.crt
+    update-ca-certificates 2>/dev/null || true
+    printf '%s\n' '$(echo -n "$ADMIN_USER:$ADMIN_PASS" | base64)' | dart pub token add 'https://$HOST_IP:9443/pub/$VIRTUAL_REPO_KEY/'
+    dart pub get 2>&1
+  "
+DART_EXIT=$?
+
+docker stop "$NGINX_CID" >/dev/null 2>&1 || true
+
+# ---- Step 5: Verify virtual rejects publish ----
+echo ""
+echo "==> [5/5] Verifying virtual rejects publish..."
+
+PUBLISH_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -X POST \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@/dev/null" \
+  "$REGISTRY_URL/pub/$VIRTUAL_REPO_KEY/api/packages/versions/newUpload")
+
+PUBLISH_STATUS=$(echo "$PUBLISH_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+echo "  Status: $PUBLISH_STATUS"
+
+if [ "$PUBLISH_STATUS" = "405" ]; then
+  echo "  ✅ Virtual correctly rejects publish (405)"
+else
+  echo "  ⚠️  Expected 405, got $PUBLISH_STATUS"
+fi
+
+# ---- Summary ----
+echo ""
+echo "=============================================="
+echo "VIRTUAL TEST SUMMARY"
+echo "=============================================="
+echo "Local repo:     $LOCAL_REPO_KEY"
+echo "Virtual repo:   $VIRTUAL_REPO_KEY"
+echo "dart pub get:    $DART_EXIT"
+echo ""
+
+if [ "$DART_EXIT" -eq 0 ]; then
+  echo "✅ Pub virtual E2E test PASSED"
+else
+  echo "❌ Pub virtual E2E test FAILED (exit code: $DART_EXIT)"
+fi

--- a/scripts/native-tests/test-pub.sh
+++ b/scripts/native-tests/test-pub.sh
@@ -1,0 +1,476 @@
+#!/bin/bash
+# Dart Pub native client test script
+# Tests the pub.dev Repository Spec v2 upload protocol
+# This is a DIAGNOSTIC test: it logs full responses to confirm the problem.
+set -euo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:30080}"
+PUB_REPO_KEY="${PUB_REPO_KEY:-test-dart-pub}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+PKG_NAME="test_e2e_dart_pkg"
+PKG_VERSION="1.0.$(date +%s)"
+
+echo "==> Dart Pub Native Client Test (pub.dev v2 protocol)"
+echo "Registry: $REGISTRY_URL"
+echo "Repo:     $PUB_REPO_KEY"
+echo "Package:  $PKG_NAME@$PKG_VERSION"
+echo ""
+
+# ---- Step 0: Create hosted Pub repository ----
+echo "==> [0/5] Creating hosted Pub repository..."
+
+# Check if repo already exists
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  "$REGISTRY_URL/api/v1/repositories/$PUB_REPO_KEY")
+
+if [ "$HTTP_CODE" = "404" ]; then
+  CREATE_RESP=$(curl -s -w "\n%{http_code}" \
+    -u "$ADMIN_USER:$ADMIN_PASS" \
+    -X POST "$REGISTRY_URL/api/v1/repositories" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"key\": \"$PUB_REPO_KEY\",
+      \"name\": \"Test Dart Pub Repo\",
+      \"format\": \"pub\",
+      \"repo_type\": \"local\"
+    }")
+  CREATE_STATUS=$(echo "$CREATE_RESP" | tail -1)
+  CREATE_BODY=$(echo "$CREATE_RESP" | sed '$d')
+  echo "  Create response ($CREATE_STATUS): $CREATE_BODY"
+  if [ "$CREATE_STATUS" -ge 300 ]; then
+    echo "❌ Failed to create repository"
+    exit 1
+  fi
+elif [ "$HTTP_CODE" = "200" ]; then
+  echo "  Repository already exists"
+else
+  echo "  ⚠️  Unexpected status checking repo: $HTTP_CODE"
+fi
+
+# Generate test package
+echo "==> [1/5] Building test package..."
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+PKG_DIR="$WORK_DIR/$PKG_NAME"
+mkdir -p "$PKG_DIR/lib"
+
+cat > "$PKG_DIR/pubspec.yaml" << EOF
+name: $PKG_NAME
+version: $PKG_VERSION
+description: Test package for artifact-keeper Dart Pub E2E
+environment:
+  sdk: ">=2.12.0 <4.0.0"
+EOF
+
+cat > "$PKG_DIR/lib/$PKG_NAME.dart" << EOF
+/// Test package for artifact-keeper E2E testing.
+String hello() => 'Hello from $PKG_NAME!';
+EOF
+
+# Build tar.gz (pubspec.yaml MUST be at the root of the archive)
+ARCHIVE="$WORK_DIR/${PKG_NAME}-${PKG_VERSION}.tar.gz"
+(cd "$PKG_DIR" && tar czf "$ARCHIVE" pubspec.yaml lib/)
+echo "  Archive: $ARCHIVE"
+echo "  Contents:"
+tar tzf "$ARCHIVE" | head -10
+
+# ---- Step 1: Get upload URL ----
+echo ""
+echo "==> [2/5] Step 1: GET upload URL..."
+STEP1_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -H "Accept: application/vnd.pub.v2+json" \
+  -X GET \
+  "$REGISTRY_URL/pub/$PUB_REPO_KEY/api/packages/versions/new")
+
+STEP1_STATUS=$(echo "$STEP1_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+STEP1_BODY=$(echo "$STEP1_RESP" | sed '/^---HTTP_STATUS:/d')
+
+echo "  Status: $STEP1_STATUS"
+echo "  Body:   $STEP1_BODY"
+
+if [ "$STEP1_STATUS" != "200" ]; then
+  echo "❌ Step 1 failed: expected 200, got $STEP1_STATUS"
+  echo "   Response body: $STEP1_BODY"
+  exit 1
+fi
+
+# Extract upload URL from response
+UPLOAD_URL=$(echo "$STEP1_BODY" | python3 -c "import sys,json; print(json.load(sys.stdin)['url'])" 2>/dev/null || true)
+if [ -z "$UPLOAD_URL" ]; then
+  echo "❌ Could not extract upload URL from response"
+  exit 1
+fi
+echo "  Upload URL: $UPLOAD_URL"
+
+# ---- Step 2: Upload package (multipart) ----
+echo ""
+echo "==> [3/5] Step 2: POST multipart upload..."
+FULL_UPLOAD_URL="$UPLOAD_URL"
+echo "  Full URL: $FULL_UPLOAD_URL"
+
+STEP2_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---\n---HEADERS---" \
+  -D - \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -X POST \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@$ARCHIVE" \
+  "$FULL_UPLOAD_URL" 2>&1)
+
+STEP2_STATUS=$(echo "$STEP2_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+STEP2_HEADERS=$(echo "$STEP2_RESP" | sed -n '/---HEADERS---/q;p' | head -30)
+STEP2_BODY=$(echo "$STEP2_RESP" | sed '/^---HTTP_STATUS:/d; /^---HEADERS---/d')
+
+echo "  Status:  $STEP2_STATUS"
+echo "  Headers: $STEP2_HEADERS"
+echo "  Body:    $STEP2_BODY"
+
+# Extract Location header
+STEP2_LOCATION=$(echo "$STEP2_HEADERS" | grep -i "^location:" | tr -d '\r' | sed 's/^location: *//i')
+if [ -n "$STEP2_LOCATION" ]; then
+  echo "  Location: $STEP2_LOCATION"
+else
+  echo "  ⚠️  No Location header in response"
+fi
+
+# Diagnostic: what did we expect?
+echo ""
+echo "  --- DIAGNOSTIC ---"
+case "$STEP2_STATUS" in
+  204)
+    echo "  ✅ Status 204 No Content — correct per pub.dev protocol"
+    ;;
+  200)
+    echo "  ⚠️  Status 200 — some implementations return 200, check if Location header present"
+    ;;
+  302)
+    echo "  ⚠️  Status 302 Found — client has followRedirects=false, may not follow this"
+    echo "      The client reads Location header manually, not via redirect"
+    ;;
+  405)
+    echo "  ❌ Status 405 Method Not Allowed — the route may not accept POST"
+    echo "      Or middleware is rejecting the request"
+    ;;
+  *)
+    echo "  ❓ Status $STEP2_STATUS — unexpected, need investigation"
+    ;;
+esac
+
+if [ -z "$STEP2_LOCATION" ] && [ "$STEP2_STATUS" != "200" ]; then
+  echo ""
+  echo "❌ No Location header and non-200 status — cannot proceed to Step 3"
+  echo "   This confirms the upload protocol is broken."
+  exit 1
+fi
+
+# ---- Step 3: Finalize ----
+echo ""
+echo "==> [4/5] Step 3: GET finalize..."
+
+# Determine finalize URL
+if [ -n "$STEP2_LOCATION" ]; then
+  # Location might be relative or absolute
+  if echo "$STEP2_LOCATION" | grep -q "^http"; then
+    FINALIZE_URL="$STEP2_LOCATION"
+  else
+    FINALIZE_URL="$REGISTRY_URL$STEP2_LOCATION"
+  fi
+else
+  # Fallback: try the standard finish URL
+  FINALIZE_URL="$REGISTRY_URL/pub/$PUB_REPO_KEY/api/packages/versions/newUploadFinish"
+  echo "  ⚠️  No Location header, using default: $FINALIZE_URL"
+fi
+
+echo "  Finalize URL: $FINALIZE_URL"
+
+STEP3_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -H "Accept: application/vnd.pub.v2+json" \
+  "$FINALIZE_URL")
+
+STEP3_STATUS=$(echo "$STEP3_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+STEP3_BODY=$(echo "$STEP3_RESP" | sed '/^---HTTP_STATUS:/d')
+
+echo "  Status: $STEP3_STATUS"
+echo "  Body:   $STEP3_BODY"
+
+if [ "$STEP3_STATUS" = "200" ]; then
+  echo "  ✅ Step 3 succeeded"
+else
+  echo "  ❌ Step 3 failed: expected 200, got $STEP3_STATUS"
+fi
+
+# ---- Step 4: Verify package is queryable ----
+echo ""
+echo "==> [5/5] Verifying package info..."
+QUERY_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -H "Accept: application/vnd.pub.v2+json" \
+  "$REGISTRY_URL/pub/$PUB_REPO_KEY/api/packages/$PKG_NAME")
+
+QUERY_STATUS=$(echo "$QUERY_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+QUERY_BODY=$(echo "$QUERY_RESP" | sed '/^---HTTP_STATUS:/d')
+
+echo "  Status: $QUERY_STATUS"
+echo "  Body:   $QUERY_BODY"
+
+if [ "$QUERY_STATUS" = "200" ]; then
+  echo "  ✅ Package is queryable"
+else
+  echo "  ❌ Package query failed: $QUERY_STATUS"
+fi
+
+# ---- Step 5: Download archive ----
+echo ""
+echo "==> [6/7] Downloading archive via curl..."
+
+# Get archive URL and expected SHA256 from package info
+ARCHIVE_URL=$(echo "$QUERY_BODY" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(d['latest']['archive_url'])
+" 2>/dev/null || true)
+EXPECTED_SHA256=$(echo "$QUERY_BODY" | python3 -c "
+import sys,json
+d=json.load(sys.stdin)
+print(d['latest'].get('archive_sha256',''))
+" 2>/dev/null || true)
+echo "  Archive URL: $ARCHIVE_URL"
+echo "  Expected SHA256: $EXPECTED_SHA256"
+DOWNLOAD_FILE="$WORK_DIR/downloaded-$PKG_NAME-$PKG_VERSION.tar.gz"
+
+DOWNLOAD_RESP=$(curl -s -w "\n---HTTP_STATUS:%{http_code}---" \
+  -u "$ADMIN_USER:$ADMIN_PASS" \
+  -o "$DOWNLOAD_FILE" \
+  "$ARCHIVE_URL")
+
+DOWNLOAD_STATUS=$(echo "$DOWNLOAD_RESP" | grep -o 'HTTP_STATUS:[0-9]*' | cut -d: -f2)
+
+echo "  URL:    $ARCHIVE_URL"
+echo "  Status: $DOWNLOAD_STATUS"
+
+if [ "$DOWNLOAD_STATUS" = "200" ]; then
+  DOWNLOAD_SIZE=$(stat -f%z "$DOWNLOAD_FILE" 2>/dev/null || stat -c%s "$DOWNLOAD_FILE" 2>/dev/null || echo "?")
+  echo "  Size:   $DOWNLOAD_SIZE bytes"
+
+  # Verify SHA256
+  ACTUAL_SHA256=$(shasum -a 256 "$DOWNLOAD_FILE" 2>/dev/null | cut -d' ' -f1 || sha256sum "$DOWNLOAD_FILE" 2>/dev/null | cut -d' ' -f1)
+  echo "  Actual SHA256:   $ACTUAL_SHA256"
+  if [ -n "$EXPECTED_SHA256" ] && [ "$EXPECTED_SHA256" = "$ACTUAL_SHA256" ]; then
+    echo "  ✅ SHA256 matches"
+  elif [ -n "$EXPECTED_SHA256" ]; then
+    echo "  ❌ SHA256 mismatch: expected $EXPECTED_SHA256, got $ACTUAL_SHA256"
+  else
+    echo "  ⚠️  No SHA256 in package info to compare"
+  fi
+
+  # Verify it's a valid tar.gz
+  if tar tzf "$DOWNLOAD_FILE" >/dev/null 2>&1; then
+    echo "  ✅ Archive is valid tar.gz"
+    echo "  Contents:"
+    tar tzf "$DOWNLOAD_FILE" | head -10
+  else
+    echo "  ❌ Downloaded file is not a valid tar.gz"
+  fi
+else
+  echo "  ❌ Download failed: $DOWNLOAD_STATUS"
+fi
+
+# ---- Summary ----
+echo ""
+echo "=============================================="
+echo "DIAGNOSTIC SUMMARY"
+echo "=============================================="
+echo "Step 1 (get URL):     $STEP1_STATUS"
+echo "Step 2 (upload):      $STEP2_STATUS"
+echo "Step 3 (finalize):    $STEP3_STATUS"
+echo "Step 4 (query):       $QUERY_STATUS"
+echo "Step 5 (download):    $DOWNLOAD_STATUS"
+echo ""
+
+ALL_OK=true
+[ "$STEP1_STATUS" = "200" ] || ALL_OK=false
+[ "$STEP3_STATUS" = "200" ] || ALL_OK=false
+[ "$QUERY_STATUS" = "200" ] || ALL_OK=false
+[ "$DOWNLOAD_STATUS" = "200" ] || ALL_OK=false
+
+if $ALL_OK && [ "$STEP2_STATUS" = "204" -o "$STEP2_STATUS" = "200" ]; then
+  echo "✅ curl protocol test PASSED"
+else
+  echo "❌ curl protocol test FAILED — review the diagnostic output above"
+fi
+
+# ---- Test with actual dart CLI ----
+echo ""
+echo "=============================================="
+echo "Dart CLI Test (dart pub publish)"
+echo "=============================================="
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "⚠️  docker not found, skipping dart CLI test"
+  exit 0
+fi
+
+# Use a different version for the dart CLI test
+DART_PKG_VERSION="2.0.$(date +%s)"
+
+# Get host IP for Docker networking (macOS Docker Desktop)
+HOST_IP=$(ipconfig getifaddr en0 2>/dev/null || echo "host.docker.internal")
+
+echo "==> Setting up dart project..."
+DART_DIR="$WORK_DIR/dart_project"
+mkdir -p "$DART_DIR/lib"
+
+cat > "$DART_DIR/pubspec.yaml" << EOF
+name: $PKG_NAME
+version: $DART_PKG_VERSION
+description: Test package for artifact-keeper Dart Pub E2E
+publish_to: "https://$HOST_IP:9443/pub/$PUB_REPO_KEY"
+environment:
+  sdk: ">=2.12.0 <4.0.0"
+EOF
+
+cat > "$DART_DIR/lib/$PKG_NAME.dart" << EOF
+/// Test package for artifact-keeper E2E testing.
+String hello() => 'Hello from $PKG_NAME!';
+EOF
+
+# Dart pub requires these files
+touch "$DART_DIR/LICENSE"
+cat > "$DART_DIR/README.md" << EOF
+# $PKG_NAME
+Test package for artifact-keeper E2E.
+EOF
+cat > "$DART_DIR/CHANGELOG.md" << EOF
+## $DART_PKG_VERSION
+- Initial version.
+EOF
+
+echo "==> Running dart pub publish via Docker..."
+# Dart requires HTTPS for auth. Start nginx with self-signed cert as TLS proxy.
+CERT_DIR="$WORK_DIR/certs"
+mkdir -p "$CERT_DIR"
+openssl req -x509 -newkey rsa:2048 -keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
+  -days 1 -nodes -subj "/CN=$HOST_IP" \
+  -addext "subjectAltName=IP:$HOST_IP,DNS:localhost" 2>/dev/null
+
+# Kill any stale nginx containers from previous runs
+docker ps -q --filter "ancestor=nginx:alpine" | xargs -r docker stop 2>/dev/null || true
+
+cat > "$CERT_DIR/nginx.conf" << NGINX
+worker_processes 1;
+events { worker_connections 64; }
+http {
+    server {
+        listen 443 ssl;
+        ssl_certificate     /certs/cert.pem;
+        ssl_certificate_key /certs/key.pem;
+        location / {
+            proxy_pass http://host.docker.internal:8080;
+            proxy_set_header Host \$http_host;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-Proto \$scheme;
+        }
+    }
+}
+NGINX
+
+echo "  Starting nginx TLS proxy..."
+NGINX_CID=$(docker run -d --rm \
+  --add-host=host.docker.internal:host-gateway \
+  -p 9443:443 \
+  -v "$CERT_DIR/nginx.conf:/etc/nginx/nginx.conf:ro" \
+  -v "$CERT_DIR:/certs:ro" \
+  nginx:alpine nginx -g 'daemon off;' 2>&1 || true)
+sleep 2
+
+# Verify nginx is running
+if [ -z "$NGINX_CID" ] || ! docker ps --format '{{.ID}}' | grep -q "^${NGINX_CID:0:12}"; then
+  echo "  ❌ nginx failed to start. Logs:"
+  docker logs "$NGINX_CID" 2>&1 | tail -10 || true
+  docker stop "$NGINX_CID" 2>/dev/null || true
+  echo "  Falling back to curl-only test (dart requires HTTPS for auth)"
+  DART_EXIT=1
+else
+  echo "  nginx running on https://$HOST_IP:9443 (container: ${NGINX_CID:0:12})"
+
+  docker run --rm \
+    --add-host=host.docker.internal:host-gateway \
+    -v "$CERT_DIR/cert.pem:/certs/self-signed.crt:ro" \
+    -v "$DART_DIR:/project" \
+    -w /project \
+    dart:stable \
+    sh -c "
+      cp /certs/self-signed.crt /usr/local/share/ca-certificates/self-signed.crt 2>/dev/null || \
+        cp /certs/self-signed.crt /usr/lib/ssl/certs/self-signed.crt 2>/dev/null || \
+        mkdir -p /etc/ssl/certs && cp /certs/self-signed.crt /etc/ssl/certs/self-signed.crt
+      update-ca-certificates 2>/dev/null || true
+      printf '%s\n' '$(echo -n "$ADMIN_USER:$ADMIN_PASS" | base64)' | dart pub token add 'https://$HOST_IP:9443/pub/$PUB_REPO_KEY/'
+      dart pub publish --force --skip-validation 2>&1
+    "
+  DART_EXIT=$?
+fi
+
+if [ "$DART_EXIT" -eq 0 ]; then
+  echo "✅ dart pub publish succeeded"
+else
+  echo "❌ dart pub publish failed (exit code: $DART_EXIT)"
+fi
+
+# ---- Verify and download via dart pub get ----
+echo ""
+echo "==> Verifying and downloading via dart pub get..."
+
+if [ -n "${NGINX_CID:-}" ]; then
+  # Create a consumer project that depends on the published package
+  CONSUMER_DIR="$WORK_DIR/consumer"
+  mkdir -p "$CONSUMER_DIR/lib"
+  cat > "$CONSUMER_DIR/pubspec.yaml" << EOF
+name: test_consumer
+environment:
+    sdk: ">=2.15.0 <4.0.0"
+dependencies:
+  $PKG_NAME:
+    hosted: https://$HOST_IP:9443/pub/$PUB_REPO_KEY
+    version: $DART_PKG_VERSION
+EOF
+  cat > "$CONSUMER_DIR/lib/consumer.dart" << EOF
+import 'package:$PKG_NAME/$PKG_NAME.dart';
+String use() => hello();
+EOF
+
+  docker run --rm \
+    --add-host=host.docker.internal:host-gateway \
+    -v "$CERT_DIR/cert.pem:/certs/self-signed.crt:ro" \
+    -v "$CONSUMER_DIR:/project" \
+    -w /project \
+    -e ADMIN_USER="$ADMIN_USER" \
+    -e ADMIN_PASS="$ADMIN_PASS" \
+    -e DART_HOST="$HOST_IP" \
+    dart:stable \
+    sh -c "
+      cp /certs/self-signed.crt /usr/local/share/ca-certificates/self-signed.crt 2>/dev/null || \
+        cp /certs/self-signed.crt /usr/lib/ssl/certs/self-signed.crt 2>/dev/null || \
+        mkdir -p /etc/ssl/certs && cp /certs/self-signed.crt /etc/ssl/certs/self-signed.crt
+      update-ca-certificates 2>/dev/null || true
+      printf '%s\n' '$(echo -n "$ADMIN_USER:$ADMIN_PASS" | base64)' | dart pub token add 'https://$HOST_IP:9443/pub/$PUB_REPO_KEY/'
+      echo '==> Running dart pub get...'
+      dart pub get 2>&1
+      echo ''
+      echo '==> Resolved packages:'
+      cat .dart_tool/package_config.json 2>/dev/null | grep -A2 \"$PKG_NAME\" || true
+    "
+  DART_DL_EXIT=$?
+  if [ "$DART_DL_EXIT" -eq 0 ]; then
+    echo "✅ dart pub get PASSED"
+  else
+    echo "❌ dart pub get FAILED (exit code: $DART_DL_EXIT)"
+  fi
+
+  docker stop "$NGINX_CID" >/dev/null 2>&1 || true
+else
+  echo "  ⚠️  nginx not running, skipping Dart download test"
+fi


### PR DESCRIPTION
## Summary

Fix Pub (Dart/Flutter) handler compliance with the [pub.dev Repository Spec v2](https://github.com/dart-lang/pub/blob/master/doc/repository-spec-v2.md) and add Remote/Virtual repository support for metadata endpoints.

Fixes all 9 deviations from #1997:

| # | Severity | Description | Status |
|---|----------|-------------|--------|
| DEV-1 | 🔴 Critical | Wrong HTTP method for Step 1 (POST instead of GET) | ✅ Fixed |
| DEV-2 | 🔴 Critical | Wrong status code for Step 2 (302 instead of 204) | ✅ Fixed |
| DEV-3 | 🟠 Moderate | Relative `archive_url` in `package_info` | ✅ Fixed |
| DEV-4 | 🟠 Moderate | Plain text error responses instead of JSON | ✅ Fixed |
| DEV-5 | 🟢 Low | `archive_sha256` missing from `package_info` | ✅ Fixed |
| DEV-6 | 🔴 Critical | No Remote repo metadata proxy for Pub | ✅ Fixed |
| DEV-7 | 🔴 Critical | No Virtual repo metadata resolution for Pub | ✅ Fixed |
| DEV-8 | 🟠 Moderate | Missing `RequestBaseUrl` in `package_info`/`version_info` | ✅ Fixed |
| DEV-9 | 🟢 Low | Virtual repo publish returns 400 instead of 405 | ❌ Not fixed (pre-existing, low priority) |

### Upload Protocol Fixes (DEV-1–DEV-5, DEV-8)
- **DEV-1**: `GET /api/packages/versions/new` — changed from `post()` to `get()`
- **DEV-2**: Upload response — `204 No Content` instead of `302 Found`
- **DEV-3, DEV-8**: `archive_url` — now absolute via `RequestBaseUrl` extractor
- **DEV-4**: Error responses — JSON `{"error": {"code": "...", "message": "..."}}` with `Content-Type: application/vnd.pub.v2+json`
- **DEV-5**: `archive_sha256` — added to `package_info` response

### Remote Repository Support (DEV-6)
`package_info`/`version_info` proxy metadata to upstream Pub registries when `repo_type == Remote`, using `proxy_pub_meta_get` helper.

### Virtual Repository Support (DEV-7)
`package_info`/`version_info` resolve through virtual members in priority order via `fetch_virtual_members`. First-match semantics: Local/Staging members query their artifacts table; Remote members proxy upstream.

### Bug Fixes
- Column alias `"metadata?"` in raw `sqlx::query_as` SQL caused `ColumnNotFound` — the `?` inside quoted identifier became part of the column name. Changed to plain `am.metadata`.

### E2E Tests
- `test-pub.sh`: local repo publish + download with SHA256 verification via `dart pub get`
- `test-pub-proxy.sh`: Remote repo metadata proxy + download via `dart pub get`
- `test-pub-virtual.sh`: Virtual repo member resolution + download via `dart pub get`

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] Tested on internal company demo server
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #1997