### PR TITLE
fix(promotion-rules): restrict rule authoring to admins and default auto_promote to false

### DIFF
--- a/backend/src/api/handlers/promotion_rules.rs
+++ b/backend/src/api/handlers/promotion_rules.rs
@@ -4,7 +4,7 @@
 //! to release repositories when all configured policies pass.
 
 use axum::{
-    extract::{Path, Query, State},
+    extract::{Extension, Path, Query, State},
     routing::{get, post},
     Json, Router,
 };
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::Result;
 use crate::models::promotion::PromotionRule;
@@ -61,7 +62,11 @@ pub struct CreateRuleRequest {
     pub min_staging_hours: Option<i32>,
     pub max_artifact_age_days: Option<i32>,
     pub min_health_score: Option<i32>,
-    #[serde(default = "default_true")]
+    // Safe default: a request that omits `auto_promote` parses to `false`. This
+    // rule governs the auto-flow gate from staging to release, so it must never
+    // be silently turned on by an omitted field — auto-promotion is enabled only
+    // when the caller explicitly opts in.
+    #[serde(default)]
     pub auto_promote: bool,
 }
 
@@ -133,6 +138,29 @@ pub struct ArtifactEvalEntry {
 
 fn default_true() -> bool {
     true
+}
+
+// ---------------------------------------------------------------------------
+// Authorization
+// ---------------------------------------------------------------------------
+
+/// Gate for authoring/mutating promotion rules.
+///
+/// Promotion rules govern the auto-flow gate from staging to release, so only
+/// admins may create, update, or delete them. Mirrors the admin gate on direct
+/// promotion (`promotion::ensure_promotion_authorized`) and on the approval
+/// workflow's approve/reject handlers. Non-admins still keep read and dry-run
+/// access (list/get/evaluate).
+///
+/// Split into a pure helper so the decision is shared by all three mutating
+/// handlers and can be unit tested without a DB or storage.
+fn ensure_rule_management_authorized(is_admin: bool) -> Result<()> {
+    if !is_admin {
+        return Err(crate::error::AppError::Authorization(
+            "Only admins can manage promotion rules".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -212,8 +240,10 @@ async fn list_rules(
 )]
 async fn create_rule(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Json(body): Json<CreateRuleRequest>,
 ) -> Result<Json<PromotionRuleResponse>> {
+    ensure_rule_management_authorized(auth.is_admin)?;
     let service = PromotionRuleService::new(state.db.clone());
     let input = CreatePromotionRuleInput {
         name: body.name,
@@ -274,9 +304,11 @@ async fn get_rule(
 )]
 async fn update_rule(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateRuleRequest>,
 ) -> Result<Json<PromotionRuleResponse>> {
+    ensure_rule_management_authorized(auth.is_admin)?;
     let service = PromotionRuleService::new(state.db.clone());
     let input = UpdatePromotionRuleInput {
         name: body.name,
@@ -310,8 +342,10 @@ async fn update_rule(
 )]
 async fn delete_rule(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
+    ensure_rule_management_authorized(auth.is_admin)?;
     let service = PromotionRuleService::new(state.db.clone());
     service.delete(id).await?;
     Ok(Json(serde_json::json!({ "deleted": true })))
@@ -421,7 +455,9 @@ mod tests {
         let req: CreateRuleRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name, "staging-to-prod");
         assert!(req.is_enabled);
-        assert!(req.auto_promote);
+        // Safe default: an omitted `auto_promote` must parse to false so a rule
+        // is never silently created with auto-promotion enabled.
+        assert!(!req.auto_promote);
         // Omitting max_cve_severity leaves it unset so the rule imposes no CVE
         // gate (a staging-hours-only rule must not silently require a scan).
         assert!(req.max_cve_severity.is_none());
@@ -639,5 +675,19 @@ mod tests {
         assert_eq!(resp.rule_name, "eval-test");
         assert!(!resp.passed);
         assert_eq!(resp.violations.len(), 2);
+    }
+
+    #[test]
+    fn test_ensure_rule_management_authorized_admin_ok() {
+        assert!(ensure_rule_management_authorized(true).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_rule_management_authorized_non_admin_denied() {
+        let err = ensure_rule_management_authorized(false).unwrap_err();
+        // Non-admin rule management is an authorization failure (HTTP 403),
+        // matching the direct-promotion and approve/reject admin gates.
+        assert!(matches!(err, crate::error::AppError::Authorization(_)));
+        assert!(err.to_string().contains("admin"));
     }
 }


### PR DESCRIPTION
## Summary

Promotion rules govern the automatic flow gate from staging to release repositories. This PR brings their authoring API in line with the rest of the promotion workflow on two points:

1. **Restrict rule authoring to admins.** The mutating handlers (`create_rule`, `update_rule`, `delete_rule`) previously took no `AuthExtension` and performed no role check — the router layers `auth_middleware` (authentication) but no admin gate. Any authenticated principal, including a non-admin release manager, could create/update/delete promotion rules and enable an `auto_promote=true`, `is_enabled=true`, `require_signature=false` rule. Direct promotion is already admin-gated (`promotion::ensure_promotion_authorized`), and approve/reject in the approval workflow are admin-gated; rule authoring now matches. A shared pure helper `ensure_rule_management_authorized(is_admin)` returns `AppError::Authorization` (HTTP 403) for non-admins. Read and dry-run paths (`list_rules`, `get_rule`, `evaluate_rule`) are intentionally left open so release managers can still inspect and dry-run rules.

2. **Safe default for `auto_promote`.** `CreateRuleRequest::auto_promote` used `#[serde(default = "default_true")]`, so a create body that omitted the field deserialized to `true` — silently creating a rule with auto-promotion on. Changed to `#[serde(default)]` so an omitted value parses to `false`; auto-promotion is now enabled only when the caller explicitly opts in. `is_enabled` keeps its existing `default_true` (a disabled rule does nothing).

No DB migration: this changes request-body parsing defaults only. Stored rows and the column default are untouched; existing rules keep their stored `auto_promote` values.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_ensure_rule_management_authorized_non_admin_denied` asserts the non-admin path returns `AppError::Authorization` whose message contains "admin"; `test_ensure_rule_management_authorized_admin_ok` covers the admin path. `test_create_rule_request_deserialization_minimal` now asserts an omitted `auto_promote` parses to `false` (would fail on `main`).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification against a running instance:
- Non-admin POST/PUT/DELETE `/api/v1/promotion-rules` → 403 `{"code":"FORBIDDEN","message":"Only admins can manage promotion rules"}`.
- Non-admin GET list, GET by id, POST `/{id}/evaluate` → 200 (still allowed).
- Admin POST/PUT/DELETE → 200 (DELETE returns `{"deleted":true}`).
- Admin POST omitting `auto_promote` → created rule has `auto_promote=false`.
- Full workspace lib suite green (`cargo test --workspace --lib`, 11774 passed), `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, jscpd on the changed file 1.44% (< 3%).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (behavior of existing endpoints only: authz gate + a request-body default; no new routes, schemas, or migration)

Fixes #2016