### PR TITLE
fix(auth): anchor the must-change-password self-lookup exemption to the exact /auth/me route

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use axum::{
-    extract::{Request, State},
+    extract::{OriginalUri, Request, State},
     http::{
         header::{AUTHORIZATION, COOKIE},
         HeaderMap, HeaderName, Method, StatusCode,
@@ -409,19 +409,22 @@ fn decode_basic_credentials(encoded: &str) -> Option<(String, String)> {
 ///     `POST /api/v1/users/:id/password`) — clears the flag, and
 ///   * logout (`.../auth/logout`) — lets the client end the session.
 ///
-/// Matching is by stripped suffix, NOT the full request path: this middleware
-/// is layered *inside* the `/api/v1` + `/auth` nests, so axum strips those
-/// prefixes before `request.uri().path()` reaches it. The middleware therefore
-/// observes `/me`, `/tokens`, `/users/:id/password`, etc. — never the full
-/// `/api/v1/auth/me`. Suffix matching keeps the allowlist robust to the nest
-/// prefix (and to any future prefix change). The admin reset / force-change
-/// routes (`.../password/reset`, `.../force-password-change`) deliberately do
-/// NOT match — they sit behind `admin_middleware`, not this one, and would not
-/// be self-recoverable. Only read-only / self-recovery endpoints are exempt;
+/// Matching is by suffix of the FULL, un-stripped request path (see
+/// [`auth_middleware`], which reads `OriginalUri`). This middleware is layered
+/// *inside* the `/api/v1` + `/auth` nests, so `request.uri().path()` is the
+/// fully nest-stripped suffix — `GET /api/v1/auth/me` and
+/// `DELETE /api/v1/sbom/me` (id = "me") both arrive as exactly `/me`, which a
+/// stripped-path predicate cannot tell apart. The genuine self-lookup is
+/// therefore anchored to the full route `.../auth/me`, so impostors like
+/// `/api/v1/sbom/me`, `/api/v1/webhooks/me`, and `/api/v1/promotion-rules/me`
+/// stay gated. The admin reset / force-change routes
+/// (`.../password/reset`, `.../force-password-change`) deliberately do NOT
+/// match — they sit behind `admin_middleware`, not this one, and would not be
+/// self-recoverable. Only read-only / self-recovery endpoints are exempt;
 /// every state-changing API surface stays gated until the flag is cleared.
 fn path_exempt_from_password_change(path: &str) -> bool {
     let path = path.strip_suffix('/').unwrap_or(path);
-    path.ends_with("/me") || path.ends_with("/password") || path.ends_with("/auth/logout")
+    path.ends_with("/auth/me") || path.ends_with("/password") || path.ends_with("/auth/logout")
 }
 
 /// 428 Precondition Required: the principal must rotate their password before
@@ -554,7 +557,23 @@ pub async fn auth_middleware(
             // "unauthenticated". The DB read only happens for non-exempt paths,
             // so the common authenticated request pays nothing extra on the
             // password-change / logout recovery routes.
-            if !path_exempt_from_password_change(request.uri().path())
+            //
+            // Use the FULL request path via `OriginalUri` (populated by the
+            // outer router before any nest stripped its prefix), not
+            // `request.uri().path()` which axum has already stripped down to a
+            // bare suffix. The exemption anchors the self-lookup to
+            // `.../auth/me`, and the stripped suffix `/me` is identical for the
+            // genuine `GET /api/v1/auth/me` and impostors like
+            // `DELETE /api/v1/sbom/me`; only the original path can tell them
+            // apart. Fall back to `request.uri().path()` when `OriginalUri` is
+            // absent (e.g. a flat-router unit test with no nest) so the path
+            // still carries the full route.
+            let gate_path = request
+                .extensions()
+                .get::<OriginalUri>()
+                .map(|o| o.0.path().to_string())
+                .unwrap_or_else(|| request.uri().path().to_string());
+            if !path_exempt_from_password_change(&gate_path)
                 && principal_must_change_password(auth_service.db(), ext.user_id).await
             {
                 return must_change_password_response();
@@ -4123,19 +4142,30 @@ mod tests {
     fn test_path_exempt_from_password_change_allowlist() {
         // Recovery / change-screen routes: the current-user self lookup, the
         // self password-change route, and logout (with or without a trailing
-        // slash, with or without the nest prefix). The middleware is layered
-        // inside the `/api/v1` + `/auth` nests, so it actually observes the
-        // STRIPPED suffix form (e.g. `/me`, not `/api/v1/auth/me`); both shapes
-        // are asserted to document that suffix matching covers them.
-        assert!(path_exempt_from_password_change("/me"));
+        // slash). The helper now keys off the FULL request path (the middleware
+        // reads `OriginalUri`, not the nest-stripped suffix), so the self
+        // lookup is anchored to the exact `/auth/me` route.
         assert!(path_exempt_from_password_change("/api/v1/auth/me"));
-        assert!(path_exempt_from_password_change("/me/"));
+        assert!(path_exempt_from_password_change("/api/v1/auth/me/"));
         assert!(path_exempt_from_password_change(
             "/api/v1/users/4040201f-c67a-4719-a292-79ec66a7bd2d/password"
         ));
         assert!(path_exempt_from_password_change("/users/abc/password/"));
         assert!(path_exempt_from_password_change("/api/v1/auth/logout"));
         assert!(path_exempt_from_password_change("/auth/logout/"));
+
+        // The core of this finding: a bare `/me` (the stripped form, and any
+        // `/<resource>/me` whose terminal :id is the literal "me") is NOT the
+        // self lookup and must stay gated. Anchoring to `/auth/me` rejects the
+        // `DELETE /api/v1/sbom/me`, `/api/v1/webhooks/me`, and
+        // `/api/v1/promotion-rules/me` impostors that an `ends_with("/me")`
+        // suffix would have exempted.
+        assert!(!path_exempt_from_password_change("/me"));
+        assert!(!path_exempt_from_password_change("/api/v1/sbom/me"));
+        assert!(!path_exempt_from_password_change("/api/v1/webhooks/me"));
+        assert!(!path_exempt_from_password_change(
+            "/api/v1/promotion-rules/me"
+        ));
 
         // Everything else is gated, including the admin reset / force-change
         // routes (which live behind admin_middleware, not this one), the
@@ -4226,35 +4256,42 @@ mod tests {
             make_test_config_for_middleware(),
         ));
 
-        // The change screen's supporting calls reach this middleware as the
-        // STRIPPED suffix forms (`/me`, `/tokens`, ...), because the live
-        // router layers `auth_middleware` inside the `/api/v1` + `/auth` nests.
-        // Routes are registered in those stripped shapes to mirror that.
+        // Register routes through a real `/api/v1` nest with `auth_middleware`
+        // layered INSIDE each sub-nest, exactly as the live router does. axum
+        // strips the matched prefix before the middleware reads
+        // `request.uri()`, but populates `OriginalUri` with the full path —
+        // which the gate now reads. This is what lets the genuine
+        // `GET /api/v1/auth/me` be exempt while the `DELETE /api/v1/sbom/me`
+        // impostor (terminal :id = "me") stays gated.
         let app = || {
-            Router::new()
-                .route(
-                    "/api/v1/repositories",
-                    any(|| async { (StatusCode::OK, "repos") }),
-                )
-                .route("/me", any(|| async { (StatusCode::OK, "me") }))
-                .route("/tokens", any(|| async { (StatusCode::OK, "tokens") }))
-                .route(
-                    "/api/v1/users/:id/password",
-                    any(|| async { (StatusCode::OK, "pw") }),
-                )
-                .route(
-                    "/api/v1/auth/logout",
-                    any(|| async { (StatusCode::OK, "logout") }),
-                )
-                .layer(middleware::from_fn_with_state(
-                    auth_service.clone(),
-                    auth_middleware,
-                ))
+            let layer = middleware::from_fn_with_state(auth_service.clone(), auth_middleware);
+            Router::new().nest(
+                "/api/v1",
+                Router::new()
+                    .route("/repositories", any(|| async { (StatusCode::OK, "repos") }))
+                    .nest(
+                        "/auth",
+                        Router::new()
+                            .route("/me", any(|| async { (StatusCode::OK, "me") }))
+                            .route("/logout", any(|| async { (StatusCode::OK, "logout") }))
+                            .route("/tokens", any(|| async { (StatusCode::OK, "tokens") })),
+                    )
+                    .nest(
+                        "/sbom",
+                        Router::new().route("/:id", any(|| async { (StatusCode::OK, "sbom") })),
+                    )
+                    .nest(
+                        "/users",
+                        Router::new()
+                            .route("/:id/password", any(|| async { (StatusCode::OK, "pw") })),
+                    )
+                    .layer(layer),
+            )
         };
 
-        let mk_req = |uri: &str, bearer: &str| {
+        let mk_req = |method: Method, uri: &str, bearer: &str| {
             axum::http::Request::builder()
-                .method(Method::GET)
+                .method(method)
                 .uri(uri)
                 .header("Authorization", bearer)
                 .body(axum::body::Body::empty())
@@ -4267,7 +4304,7 @@ mod tests {
 
         // A normal route is refused with 428.
         let resp = app()
-            .oneshot(mk_req("/api/v1/repositories", &flagged_bearer))
+            .oneshot(mk_req(Method::GET, "/api/v1/repositories", &flagged_bearer))
             .await
             .unwrap();
         assert_eq!(
@@ -4279,7 +4316,7 @@ mod tests {
         // Token management is state-changing and stays gated even though the
         // change screen runs while flagged (#1948 must not over-broaden).
         let resp = app()
-            .oneshot(mk_req("/tokens", &flagged_bearer))
+            .oneshot(mk_req(Method::GET, "/api/v1/auth/tokens", &flagged_bearer))
             .await
             .unwrap();
         assert_eq!(
@@ -4288,9 +4325,27 @@ mod tests {
             "flagged principal must still be 428'd on token management"
         );
 
-        // The current-user self lookup (`/me`, stripped form) the mandatory
-        // change screen calls to render IS reachable while flagged (#1948).
-        let resp = app().oneshot(mk_req("/me", &flagged_bearer)).await.unwrap();
+        // Core of this finding: a `/<resource>/me` whose terminal :id is the
+        // literal "me" must NOT be mistaken for the self lookup. With the gate
+        // reading `OriginalUri`, `DELETE /api/v1/sbom/me` is refused with 428
+        // (the handler is NOT reached) — an `ends_with("/me")` suffix on the
+        // stripped path would have let it through.
+        let resp = app()
+            .oneshot(mk_req(Method::DELETE, "/api/v1/sbom/me", &flagged_bearer))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::PRECONDITION_REQUIRED,
+            "flagged principal must be 428'd on /sbom/me (terminal :id impostor)"
+        );
+
+        // The genuine current-user self lookup (`GET /api/v1/auth/me`) the
+        // mandatory change screen calls to render IS reachable while flagged.
+        let resp = app()
+            .oneshot(mk_req(Method::GET, "/api/v1/auth/me", &flagged_bearer))
+            .await
+            .unwrap();
         assert_eq!(
             resp.status(),
             StatusCode::OK,
@@ -4300,6 +4355,7 @@ mod tests {
         // The self password-change recovery route is still reachable.
         let resp = app()
             .oneshot(mk_req(
+                Method::POST,
                 &format!("/api/v1/users/{}/password", flagged_id),
                 &flagged_bearer,
             ))
@@ -4313,7 +4369,7 @@ mod tests {
 
         // Logout is reachable too.
         let resp = app()
-            .oneshot(mk_req("/api/v1/auth/logout", &flagged_bearer))
+            .oneshot(mk_req(Method::POST, "/api/v1/auth/logout", &flagged_bearer))
             .await
             .unwrap();
         assert_eq!(
@@ -4326,7 +4382,11 @@ mod tests {
         let (_unflagged_id, unflagged_bearer) =
             mint_bearer_for_flagged_user(&pool, &auth_service, false).await;
         let resp = app()
-            .oneshot(mk_req("/api/v1/repositories", &unflagged_bearer))
+            .oneshot(mk_req(
+                Method::GET,
+                "/api/v1/repositories",
+                &unflagged_bearer,
+            ))
             .await
             .unwrap();
         assert_eq!(


### PR DESCRIPTION
## Summary

The forced-rotation (`must_change_password`) gate in `auth_middleware`
exempts a narrow recovery allowlist — the current-user self lookup, the self
password-change route, and logout — so a flagged user can still get to the
first-login change screen. The self-lookup exemption was matched with
`path.ends_with("/me")`.

That predicate runs against the request path the middleware actually sees, and
`auth_middleware` is layered *inside* each route nest (and inside `/api/v1`),
so axum has stripped every matched prefix before the URI reaches the gate. As a
result the genuine `GET /api/v1/auth/me` and a `/<resource>/me` request whose
terminal `:id` segment is the literal string `me` (e.g.
`DELETE /api/v1/sbom/me`, `/api/v1/webhooks/me`,
`/api/v1/promotion-rules/me`) both arrive as exactly `/me`. The
`ends_with("/me")` suffix therefore exempted every such route from the gate,
not just the self lookup. (Today those terminal `:id` extractors are
`Path<Uuid>`, so axum 400s on `"me"` before any handler logic runs — but the
exemption itself was wider than intended, and a future `Path<String>` terminal
would let a flagged user do real state-changing work while still flagged.)

A stripped-path-only fix is not possible, because `/auth/me` and `/sbom/me`
collapse to the identical stripped string `/me`; no predicate over the stripped
path can separate them. The only value that distinguishes the genuine
self-lookup is the full, un-stripped request path.

This change reads the full request path from `axum::extract::OriginalUri`
(populated by the outer router before any nest stripped a prefix; the same
extractor already used in `handlers/incus.rs`), falling back to
`request.uri().path()` when `OriginalUri` is absent, and anchors the
self-lookup exemption to `ends_with("/auth/me")`. Only `GET /api/v1/auth/me` is
exempt; `/sbom/me`, `/webhooks/me`, `/promotion-rules/me`, and any future
`/<resource>/me` stay gated with `428 Precondition Required`. The `/password`
and `/auth/logout` recovery suffixes are unchanged; admin reset / force-change
routes (which end in `/reset` / `/force-password-change` and sit behind
`admin_middleware`) and all token routes remain not-exempt.

`path_exempt_from_password_change` stays a pure `fn(&str) -> bool` with no other
callers, so the tightening has no blast radius.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

The pure-predicate unit test
(`test_path_exempt_from_password_change_allowlist`) now asserts the full-path
self-lookup forms (`/api/v1/auth/me`, `.../me/`) and adds the core negatives
`!/me`, `!/api/v1/sbom/me`, `!/api/v1/webhooks/me`,
`!/api/v1/promotion-rules/me`. The DB-backed
`test_must_change_password_gates_normal_routes_but_allows_recovery` now
registers routes through a real `/api/v1` nest (so `OriginalUri` is exercised
exactly as in production) and asserts a flagged user gets `428` on
`DELETE /api/v1/sbom/me` (handler not reached) while `GET /api/v1/auth/me`,
`POST /api/v1/users/<id>/password`, and logout still succeed, and an unflagged
user is unaffected.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Fixes #2017