### PR TITLE
fix(migration): map Artifactory FEDERATED repos to Local repository type

### DIFF
--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -74,16 +74,19 @@ impl RepositoryType {
     /// Parse a source-side repository type string.
     ///
     /// Accepts both the Artifactory vocabulary (`local` / `remote` /
-    /// `virtual`) and the Nexus vocabulary (`hosted` / `proxy` / `group`).
-    /// The two sets denote the same three logical kinds — the enum doc
-    /// comments above have always pinned this mapping. Prior to this fix
-    /// the function only matched the Artifactory triple, so every Nexus
+    /// `virtual` / `federated`) and the Nexus vocabulary (`hosted` / `proxy` /
+    /// `group`). These denote the same three logical kinds — the enum doc
+    /// comments above have always pinned this mapping. Artifactory
+    /// `federated` repos store artifacts locally (a local repo that also
+    /// mirrors to peer instances), so they map to `Local`. Prior to these
+    /// fixes the function only matched the Artifactory triple, so every Nexus
     /// repository was rejected by `prepare_repository_migration` with
     /// `Unknown repository type: hosted` and an entire Nexus source was
-    /// effectively un-migratable (issue #1889).
+    /// effectively un-migratable (issue #1889); `federated` sources hit the
+    /// same wall with `Unknown repository type: FEDERATED`.
     pub fn from_artifactory(rclass: &str) -> Option<Self> {
         match rclass.to_lowercase().as_str() {
-            "local" | "hosted" => Some(Self::Local),
+            "local" | "hosted" | "federated" => Some(Self::Local),
             "remote" | "proxy" => Some(Self::Remote),
             "virtual" | "group" => Some(Self::Virtual),
             _ => None,
@@ -1479,6 +1482,10 @@ mod tests {
             RepositoryType::from_artifactory("virtual"),
             Some(RepositoryType::Virtual)
         );
+        assert_eq!(
+            RepositoryType::from_artifactory("federated"),
+            Some(RepositoryType::Local)
+        );
     }
 
     #[test]
@@ -1499,11 +1506,9 @@ mod tests {
 
     #[test]
     fn test_repository_type_from_artifactory_unknown() {
-        // `federated` (Artifactory) and `unknown_kind` are genuinely
-        // unmapped. `hosted` used to live here too — see #1889; it is
-        // Nexus's name for `Local` and is now accepted by
-        // `from_artifactory` via the alias branch below.
-        assert_eq!(RepositoryType::from_artifactory("federated"), None);
+        // `hosted` used to live here too — see #1889; it is Nexus's name
+        // for `Local` and is now accepted via the alias branch. `federated`
+        // maps to `Local` because federated repos store artifacts locally.
         assert_eq!(RepositoryType::from_artifactory(""), None);
         assert_eq!(RepositoryType::from_artifactory("unknown_kind"), None);
     }
@@ -2064,11 +2069,11 @@ mod tests {
         use crate::services::artifactory_client::RepositoryListItem;
 
         let repo = RepositoryListItem {
-            key: "federated-repo".to_string(),
-            repo_type: "federated".to_string(),
+            key: "unknown-repo".to_string(),
+            repo_type: "unknown_kind".to_string(),
             package_type: "maven".to_string(),
             description: None,
-            url: Some("http://artifactory/federated-repo".to_string()),
+            url: Some("http://artifactory/unknown-repo".to_string()),
         };
 
         let result = MigrationService::prepare_repository_migration(&repo, None);


### PR DESCRIPTION
## Summary
<!-- What does this PR do and why? -->

Artifactory `federated` repositories store artifacts locally (a local repo
that also mirrors to peer instances), but `RepositoryType::from_artifactory`
only matched `local`/`remote`/`virtual`. Federated sources were rejected by
`prepare_repository_migration` with `Unknown repository type: FEDERATED`,
making them un-migratable. This maps `federated` → `Local`.

Closes #2027 

## Regression test (required for `fix/*` PRs)
<!--
Hardening Core (https://github.com/orgs/artifact-keeper/projects/2) requires
every bug-fix PR to land with a regression test that fails on `main` and
passes on this PR. Choose one that fits the bug:
  - unit test (closest to the buggy logic)
  - integration test (requires DB/storage/etc.)
  - end-to-end test in artifact-keeper-test (exercises the user flow)

For non-fix PRs (feat/, chore/, docs/, ci/, refactor/) check N/A.
Reviewers should not approve fix/* PRs without a checked box.
-->
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
