### PR TITLE
chore(release): bump version to 1.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.2.1",
+        version = "1.2.2",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Bumps the application version to 1.2.2 ahead of the release tag.

- `Cargo.toml` workspace version 1.2.1 -> 1.2.2 (drives /health, SBOM, telemetry)
- `backend/src/api/openapi.rs` Swagger info.version 1.2.1 -> 1.2.2

Pre-cut verify is green: all round-6 security fixes held, zero regressions. No functional changes.

Closes #2034