### PR TITLE
fix: resolve group permission visibility in repository listing (#1996)

### DIFF
--- a/backend/src/api/handlers/groups.rs
+++ b/backend/src/api/handlers/groups.rs
@@ -14,6 +14,7 @@ use crate::api::dto::Pagination;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::services::permission_service::PermissionService;
 use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
 
 /// Require that the request is authenticated, returning an error if not.
@@ -42,20 +43,13 @@ fn group_read_unscoped(is_admin: bool) -> bool {
 /// caller's user id (e.g. `$2`). Kept as a single helper so the list SELECT,
 /// list COUNT, and get_group queries share one definition.
 fn visible_groups_predicate(group_id_expr: &str, user_param: &str) -> String {
+    let permission_check =
+        PermissionService::build_visibility_predicate("group", group_id_expr, user_param);
     format!(
         "({group_id_expr} IN (
             SELECT group_id FROM user_group_members WHERE user_id = {user_param}
          )
-         OR EXISTS (
-            SELECT 1 FROM permissions p
-            WHERE p.target_type = 'group' AND p.target_id = {group_id_expr}
-              AND (
-                (p.principal_type = 'user' AND p.principal_id = {user_param})
-                OR (p.principal_type = 'group' AND p.principal_id IN (
-                    SELECT group_id FROM user_group_members WHERE user_id = {user_param}
-                ))
-              )
-         ))"
+         OR {permission_check})"
     )
 }
 

--- a/backend/src/services/permission_service.rs
+++ b/backend/src/services/permission_service.rs
@@ -345,6 +345,39 @@ impl PermissionService {
 
         Ok(rows.into_iter().map(|(action,)| action).collect())
     }
+
+    /// Build a SQL EXISTS predicate that checks whether a user has any
+    /// permission grant on a target, consulting both direct
+    /// (`principal_type = 'user'`) and group-based (`principal_type = 'group'`
+    /// resolved through `user_group_members`) grants.
+    ///
+    /// The returned fragment is designed to be embedded in a WHERE clause when
+    /// listing resources, so callers can combine it with other conditions
+    /// (e.g. `is_public` or legacy `role_assignments`) via OR.
+    ///
+    /// # Parameters
+    /// - `target_type` — the type of target resource (e.g. `"repository"`, `"group"`)
+    /// - `target_id_expr` — SQL expression for the target's ID column (e.g. `"r.id"`, `"$3"`)
+    /// - `user_param` — SQL bind-parameter placeholder for the caller's user ID (e.g. `"$2"`)
+    pub fn build_visibility_predicate(
+        target_type: &str,
+        target_id_expr: &str,
+        user_param: &str,
+    ) -> String {
+        format!(
+            r#"EXISTS (
+                SELECT 1 FROM permissions p
+                WHERE p.target_type = '{target_type}'
+                  AND p.target_id = {target_id_expr}
+                  AND (
+                    (p.principal_type = 'user' AND p.principal_id = {user_param})
+                    OR (p.principal_type = 'group' AND p.principal_id IN (
+                        SELECT group_id FROM user_group_members WHERE user_id = {user_param}
+                    ))
+                  )
+            )"#
+        )
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -14,6 +14,7 @@ use crate::models::repository::{
     ReplicationPriority, Repository, RepositoryFormat, RepositoryType,
 };
 use crate::services::opensearch_service::{OpenSearchService, RepositoryDocument};
+use crate::services::permission_service::PermissionService;
 
 /// Request to create a new repository
 #[derive(Debug)]
@@ -215,6 +216,11 @@ pub(crate) fn build_visibility_clause_for(
         RepoVisibility::PublicOnly => ("is_public = true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::All => ("true".to_string(), VisibilityBind::User(None)),
         RepoVisibility::User(user_id) => {
+            let permission_check = PermissionService::build_visibility_predicate(
+                "repository",
+                &format!("{table_alias}.id"),
+                &format!("${user_param}"),
+            );
             let clause = format!(
                 r#"(
                 is_public = true
@@ -223,6 +229,7 @@ pub(crate) fn build_visibility_clause_for(
                     WHERE ra.user_id = ${user_param}
                       AND (ra.repository_id = {table_alias}.id OR ra.repository_id IS NULL)
                 )
+                OR {permission_check}
             )"#
             );
             (clause, VisibilityBind::User(Some(*user_id)))
@@ -672,18 +679,22 @@ impl RepositoryService {
     /// short-circuiting the cases this method does NOT cover: admins bypass it
     /// entirely and public repositories are accessible to everyone.
     pub async fn user_can_access_repo(&self, repo_id: Uuid, user_id: Uuid) -> Result<bool> {
-        let granted: bool = sqlx::query_scalar(
+        let permission_predicate =
+            PermissionService::build_visibility_predicate("repository", "$2", "$1");
+        let sql = format!(
             "SELECT EXISTS ( \
                  SELECT 1 FROM role_assignments ra \
                  WHERE ra.user_id = $1 \
                    AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
-             )",
-        )
-        .bind(user_id)
-        .bind(repo_id)
-        .fetch_one(&self.db)
-        .await
-        .map_err(|e| AppError::Database(e.to_string()))?;
+             ) \
+             OR {permission_predicate}"
+        );
+        let granted: bool = sqlx::query_scalar(&sql)
+            .bind(user_id)
+            .bind(repo_id)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
         Ok(granted)
     }
 

--- a/backend/tests/repository_permission_visibility_tests.rs
+++ b/backend/tests/repository_permission_visibility_tests.rs
@@ -1,0 +1,309 @@
+//! Integration tests for repository permission visibility (issue #1996).
+//!
+//! These tests verify that non-admin users can see private repositories they
+//! have access to via the fine-grained `permissions` table, both through
+//! direct user grants (`principal_type='user'`) and group-based grants
+//! (`principal_type='group'` resolved through `user_group_members`).
+//!
+//! Without the fix, `build_visibility_clause_for()` only checks the legacy
+//! `role_assignments` table, so repositories granted only via the
+//! `permissions` table are invisible in the repository list.
+//!
+//! Requires PostgreSQL with all migrations applied:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!     cargo test --test repository_permission_visibility_tests -- --ignored
+//! ```
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use artifact_keeper_backend::services::repository_service::{RepoVisibility, RepositoryService};
+
+/// Insert a test user. Returns the user id.
+async fn insert_user(pool: &PgPool, suffix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let username = format!("rpv-{}-{}", suffix, &id.to_string()[..8]);
+    let email = format!("{}@test.local", username);
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, username, email, password_hash, auth_provider,
+                           is_admin, is_active, failed_login_attempts)
+        VALUES ($1, $2, $3, 'unused', 'local', false, true, 0)
+        "#,
+    )
+    .bind(id)
+    .bind(&username)
+    .bind(&email)
+    .execute(pool)
+    .await
+    .expect("insert user");
+    id
+}
+
+/// Insert a test group. Returns the group id.
+async fn insert_group(pool: &PgPool, suffix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let name = format!("rpv-group-{}-{}", suffix, &id.to_string()[..8]);
+    sqlx::query(
+        r#"
+        INSERT INTO groups (id, name, description)
+        VALUES ($1, $2, '')
+        "#,
+    )
+    .bind(id)
+    .bind(&name)
+    .execute(pool)
+    .await
+    .expect("insert group");
+    id
+}
+
+/// Insert a private test repository. Returns the repository id.
+async fn insert_repository(pool: &PgPool, suffix: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let key = format!("rpv-repo-{}-{}", suffix, &id.to_string()[..8]);
+    let name = format!("rpv_repo_{}_{}", suffix, &id.to_string()[..8]);
+    sqlx::query(
+        r#"
+        INSERT INTO repositories (id, key, name, format, repo_type,
+                                  storage_backend, storage_path, is_public)
+        VALUES ($1, $2, $3, 'maven', 'local',
+                'default', '/test/storage', false)
+        "#,
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(&name)
+    .execute(pool)
+    .await
+    .expect("insert repository");
+    id
+}
+
+/// Add a user to a group.
+async fn add_user_to_group(pool: &PgPool, user_id: Uuid, group_id: Uuid) {
+    sqlx::query(
+        r#"
+        INSERT INTO user_group_members (user_id, group_id)
+        VALUES ($1, $2)
+        "#,
+    )
+    .bind(user_id)
+    .bind(group_id)
+    .execute(pool)
+    .await
+    .expect("add user to group");
+}
+
+/// Grant a permission on a repository to a principal.
+async fn grant_permission(
+    pool: &PgPool,
+    principal_type: &str,
+    principal_id: Uuid,
+    target_id: Uuid,
+    actions: &[&str],
+) {
+    let actions_array: Vec<String> = actions.iter().map(|a| a.to_string()).collect();
+    sqlx::query(
+        r#"
+        INSERT INTO permissions (principal_type, principal_id, target_type, target_id, actions)
+        VALUES ($1, $2, 'repository', $3, $4)
+        "#,
+    )
+    .bind(principal_type)
+    .bind(principal_id)
+    .bind(target_id)
+    .bind(&actions_array)
+    .execute(pool)
+    .await
+    .expect("grant permission");
+}
+
+/// Clean up all test data for a user (deletes cascading data).
+async fn cleanup_user(pool: &PgPool, user_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+}
+
+/// Clean up a test group.
+async fn cleanup_group(pool: &PgPool, group_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM groups WHERE id = $1")
+        .bind(group_id)
+        .execute(pool)
+        .await;
+}
+
+/// Clean up a test repository.
+async fn cleanup_repository(pool: &PgPool, repo_id: Uuid) {
+    let _ =
+        sqlx::query("DELETE FROM permissions WHERE target_type = 'repository' AND target_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+    let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+}
+
+/// A non-admin user with a direct `permissions` grant (principal_type='user')
+/// on a private repository MUST see that repository in the repository list.
+#[tokio::test]
+#[ignore]
+async fn test_direct_user_permission_visible_in_list() {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let pool = match PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let suffix = "direct";
+    let user_id = insert_user(&pool, suffix).await;
+    let repo_id = insert_repository(&pool, suffix).await;
+
+    // Grant direct user permission (no role_assignments involved).
+    grant_permission(&pool, "user", user_id, repo_id, &["read"]).await;
+
+    // List repositories as this user.
+    let service = RepositoryService::new(pool.clone());
+    let (repos, total) = service
+        .list(0, 50, None, None, RepoVisibility::User(user_id), None)
+        .await
+        .expect("list repositories");
+
+    // Cleanup.
+    cleanup_repository(&pool, repo_id).await;
+    cleanup_user(&pool, user_id).await;
+
+    assert!(
+        total > 0,
+        "User with direct permission (principal_type='user') should see the \
+         repository in the list, but got total={}. This confirms issue #1996.",
+        total
+    );
+    assert!(
+        repos.iter().any(|r| r.id == repo_id),
+        "Repository should be in the returned list, but was not found. \
+         This confirms issue #1996."
+    );
+}
+
+/// A non-admin user who is a member of a group that has a `permissions` grant
+/// (principal_type='group') on a private repository MUST see that repository
+/// in the repository list.
+#[tokio::test]
+#[ignore]
+async fn test_group_permission_visible_in_list() {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let pool = match PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let suffix = "group";
+    let user_id = insert_user(&pool, suffix).await;
+    let group_id = insert_group(&pool, suffix).await;
+    let repo_id = insert_repository(&pool, suffix).await;
+
+    // Add user to group.
+    add_user_to_group(&pool, user_id, group_id).await;
+
+    // Grant group permission (no role_assignments involved).
+    grant_permission(&pool, "group", group_id, repo_id, &["read"]).await;
+
+    // List repositories as this user.
+    let service = RepositoryService::new(pool.clone());
+    let (repos, total) = service
+        .list(0, 50, None, None, RepoVisibility::User(user_id), None)
+        .await
+        .expect("list repositories");
+
+    // Cleanup.
+    cleanup_repository(&pool, repo_id).await;
+    cleanup_group(&pool, group_id).await;
+    cleanup_user(&pool, user_id).await;
+
+    assert!(
+        total > 0,
+        "User in group with group permission (principal_type='group') should \
+         see the repository in the list, but got total={}. This confirms the \
+         group-based permission visibility bug.",
+        total
+    );
+    assert!(
+        repos.iter().any(|r| r.id == repo_id),
+        "Repository should be in the returned list, but was not found. \
+         This confirms the group-based permission visibility bug."
+    );
+}
+
+/// A non-admin user with only `role_assignments` (legacy system) still sees
+/// the repository, ensuring backward compatibility is preserved.
+#[tokio::test]
+#[ignore]
+async fn test_legacy_role_assignment_still_works() {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let pool = match PgPool::connect(&url).await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let suffix = "legacy";
+    let user_id = insert_user(&pool, suffix).await;
+    let repo_id = insert_repository(&pool, suffix).await;
+
+    // Grant via legacy role_assignments.
+    sqlx::query(
+        r#"
+        INSERT INTO role_assignments (user_id, repository_id, role)
+        VALUES ($1, $2, 'developer')
+        "#,
+    )
+    .bind(user_id)
+    .bind(repo_id)
+    .execute(&pool)
+    .await
+    .expect("insert role_assignment");
+
+    // List repositories as this user.
+    let service = RepositoryService::new(pool.clone());
+    let (repos, total) = service
+        .list(0, 50, None, None, RepoVisibility::User(user_id), None)
+        .await
+        .expect("list repositories");
+
+    // Cleanup.
+    let _ = sqlx::query("DELETE FROM role_assignments WHERE user_id = $1")
+        .bind(user_id)
+        .execute(&pool)
+        .await;
+    cleanup_repository(&pool, repo_id).await;
+    cleanup_user(&pool, user_id).await;
+
+    assert!(
+        total > 0,
+        "User with legacy role_assignment should still see the repository. \
+         Backward compatibility broken."
+    );
+    assert!(
+        repos.iter().any(|r| r.id == repo_id),
+        "Repository should be in the returned list via legacy role_assignment."
+    );
+}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,6 +22,7 @@
 #   storage-gc  - Storage garbage collection tests
 #   curation    - Curation policy E2E tests (RPM/DEB with mock upstream)
 #   smoke       - Smoke tests only (pypi, npm, cargo)
+#   permission-visibility - Permission visibility tests (issue #1996)
 #   all         - All native client tests
 
 services:
@@ -105,7 +106,7 @@ services:
       retries: 30
     networks:
       - e2e-test-network
-    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation", "cache-correctness"]
+    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation", "cache-correctness", "permission-visibility"]
 
   # PKI service: uses pre-generated files from .pki/ if available (CI), otherwise generates them (local)
   pki:
@@ -395,6 +396,27 @@ services:
     networks:
       - e2e-test-network
     profiles: ["hex", "all"]
+
+  # ==========================================================================
+  # PERMISSION VISIBILITY TESTS (issue #1996)
+  # ==========================================================================
+
+  permission-visibility-test:
+    image: docker.io/alpine:3.19
+    container_name: e2e-test-permission-visibility
+    depends_on:
+      setup:
+        condition: service_healthy
+    environment:
+      REGISTRY_URL: http://backend:8080
+      ADMIN_USER: admin
+      ADMIN_PASS: TestRunner!2026secure
+    volumes:
+      - ./scripts/native-tests:/scripts:ro
+    command: ["sh", "-c", "apk add --no-cache bash curl jq >/dev/null 2>&1 && bash /scripts/test-permission-visibility.sh"]
+    networks:
+      - e2e-test-network
+    profiles: ["permission-visibility", "all"]
 
   # ==========================================================================
   # PROXY + VIRTUAL REPOSITORY TESTS

--- a/scripts/native-tests/run-all.sh
+++ b/scripts/native-tests/run-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run all native client tests
 # Usage: ./run-all.sh [profile]
-# Profiles: smoke (default), all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, proxy, health-probes, curation
+# Profiles: smoke (default), all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, proxy, health-probes, curation, permission-visibility
 set -euo pipefail
 
 PROFILE="${1:-smoke}"
@@ -13,7 +13,7 @@ echo "=============================================="
 
 # Define test sets
 SMOKE_TESTS=(pypi npm cargo)
-ALL_TESTS=(pypi npm cargo maven go rpm deb helm conda docker protobuf incus hex proxy-virtual health-probes tag-replication curation)
+ALL_TESTS=(pypi npm cargo maven go rpm deb helm conda docker protobuf incus hex proxy-virtual health-probes tag-replication curation permission-visibility)
 
 # Select tests based on profile
 case "$PROFILE" in
@@ -26,12 +26,12 @@ case "$PROFILE" in
     proxy)
         TESTS=("proxy-virtual")
         ;;
-    pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|protobuf|incus|hex|proxy-virtual|health-probes|tag-replication|curation)
+    pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|protobuf|incus|hex|proxy-virtual|health-probes|tag-replication|curation|permission-visibility)
         TESTS=("$PROFILE")
         ;;
     *)
         echo "ERROR: Unknown profile: $PROFILE"
-        echo "Available profiles: smoke, all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, protobuf, incus, hex, proxy, tag-replication, curation"
+        echo "Available profiles: smoke, all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, protobuf, incus, hex, proxy, tag-replication, curation, permission-visibility"
         exit 1
         ;;
 esac

--- a/scripts/native-tests/test-permission-visibility.sh
+++ b/scripts/native-tests/test-permission-visibility.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Permission visibility E2E test (issue #1996)
+#
+# Verifies that non-admin users can see private repositories they have access
+# to through the fine-grained `permissions` table, including:
+#   - Direct user permissions (principal_type='user')
+#   - Group-based permissions (principal_type='group' via user_group_members)
+#
+# Requires: curl, jq
+set -euo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:30080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+
+echo "==> Permission Visibility E2E Test (issue #1996)"
+echo "Registry: $REGISTRY_URL"
+
+# Check prerequisites
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "SKIP: $cmd not found"
+    exit 0
+  fi
+done
+
+# Authenticate as admin
+echo "==> [1/6] Authenticating as admin..."
+ADMIN_TOKEN=$(curl -sf -X POST "$REGISTRY_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}" | jq -r '.access_token')
+[ -n "$ADMIN_TOKEN" ] && [ "$ADMIN_TOKEN" != "null" ] || { echo "❌ Admin auth failed"; exit 1; }
+echo "✅ Admin authenticated"
+
+# Create a private repository
+echo "==> [2/6] Creating private repository..."
+REPO_KEY="perm-vis-test-$(date +%s)"
+REPO_JSON=$(curl -sf -X POST "$REGISTRY_URL/api/v1/repositories" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"key\":\"$REPO_KEY\",\"name\":\"Permission Visibility Test\",\"format\":\"maven\",\"repo_type\":\"local\",\"is_public\":false}")
+REPO_ID=$(echo "$REPO_JSON" | jq -r '.id')
+[ -n "$REPO_ID" ] && [ "$REPO_ID" != "null" ] || { echo "❌ Failed to create repository"; exit 1; }
+echo "✅ Created private repository: $REPO_KEY ($REPO_ID)"
+
+# Create a test user
+echo "==> [3/6] Creating test user..."
+TEST_USER="perm-vis-test-user-$(date +%s)"
+TEST_PASS="TestUserPass123!"
+USER_JSON=$(curl -sf -X POST "$REGISTRY_URL/api/v1/users" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$TEST_USER\",\"email\":\"$TEST_USER@test.local\",\"password\":\"$TEST_PASS\"}")
+USER_ID=$(echo "$USER_JSON" | jq -r '.user.id')
+[ -n "$USER_ID" ] && [ "$USER_ID" != "null" ] || { echo "❌ Failed to create user"; exit 1; }
+echo "✅ Created test user: $TEST_USER ($USER_ID)"
+
+# Create a test group
+echo "==> [4/6] Creating test group..."
+GROUP_NAME="perm-vis-test-group-$(date +%s)"
+GROUP_JSON=$(curl -sf -X POST "$REGISTRY_URL/api/v1/groups" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"name\":\"$GROUP_NAME\"}")
+GROUP_ID=$(echo "$GROUP_JSON" | jq -r '.id')
+[ -n "$GROUP_ID" ] && [ "$GROUP_ID" != "null" ] || { echo "❌ Failed to create group"; exit 1; }
+echo "✅ Created group: $GROUP_NAME ($GROUP_ID)"
+
+# Add user to group
+echo "==> [5/6] Adding user to group..."
+curl -sf -X POST "$REGISTRY_URL/api/v1/groups/$GROUP_ID/members" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"user_ids\":[\"$USER_ID\"]}" \
+  > /dev/null
+echo "✅ User added to group"
+
+# Grant group permission on repository
+echo "==> [6/6] Granting group read permission on repository..."
+curl -sf -X POST "$REGISTRY_URL/api/v1/permissions" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"principal_type\":\"group\",\"principal_id\":\"$GROUP_ID\",\"target_type\":\"repository\",\"target_id\":\"$REPO_ID\",\"actions\":[\"read\"]}" \
+  > /dev/null
+echo "✅ Group permission granted"
+
+# ============================================================
+# VERIFICATION
+# ============================================================
+
+# Log in as the test user
+echo "==> Verifying: listing as test user..."
+USER_TOKEN=$(curl -sf -X POST "$REGISTRY_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$TEST_USER\",\"password\":\"$TEST_PASS\"}" | jq -r '.access_token')
+[ -n "$USER_TOKEN" ] && [ "$USER_TOKEN" != "null" ] || { echo "❌ User auth failed"; exit 1; }
+
+# List repositories
+REPO_LIST=$(curl -sf "$REGISTRY_URL/api/v1/repositories" \
+  -H "Authorization: Bearer $USER_TOKEN")
+
+TOTAL=$(echo "$REPO_LIST" | jq '.pagination.total')
+echo "Repositories visible to test user: $TOTAL"
+
+# Check if our private repo appears
+if echo "$REPO_LIST" | jq -e ".items[] | select(.key == \"$REPO_KEY\")" > /dev/null 2>&1; then
+  echo "✅ PASS: Private repository IS visible to group member"
+  RESULT=0
+else
+  echo "❌ FAIL: Private repository is NOT visible to group member"
+  echo "This confirms issue #1996. The repository listing does not"
+  echo "include repositories accessible via group permissions."
+  RESULT=1
+fi
+
+# ============================================================
+# CLEANUP
+# ============================================================
+echo "==> Cleaning up..."
+curl -sf -X DELETE "$REGISTRY_URL/api/v1/repositories/$REPO_ID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  > /dev/null 2>&1 || true
+curl -sf -X DELETE "$REGISTRY_URL/api/v1/groups/$GROUP_ID" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  > /dev/null 2>&1 || true
+# Get user ID for deletion
+USER_ID=$(curl -sf "$REGISTRY_URL/api/v1/users" \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  | jq -r ".items[] | select(.username == \"$TEST_USER\") | .id")
+if [ -n "$USER_ID" ] && [ "$USER_ID" != "null" ]; then
+  curl -sf -X DELETE "$REGISTRY_URL/api/v1/users/$USER_ID" \
+    -H "Authorization: Bearer $ADMIN_TOKEN" \
+    > /dev/null 2>&1 || true
+fi
+echo "Cleanup done"
+
+exit $RESULT


### PR DESCRIPTION
## Summary

Fixes #1996 — private repositories are not visible to non-admin users with explicit repository permissions or group-based permissions.

**Root cause**: `build_visibility_clause_for()` in `repository_service.rs` only checks the legacy `role_assignments` table and completely ignores the `permissions` table. This affects both direct user permissions (`principal_type='user'`) and group-based permissions (`principal_type='group'` resolved through `user_group_members`).

**Fix**: Added `PermissionService::build_visibility_predicate()` — a shared SQL helper that generates an `EXISTS` subquery checking both direct user and group-based grants. Used this helper in:
- `repository_service.rs::build_visibility_clause_for()` — third OR branch
- `repository_service.rs::user_can_access_repo()` — permissions table check
- Refactored `groups.rs::visible_groups_predicate()` to use the shared helper, eliminating duplicate SQL

### Changes

| File | Change |
|------|--------|
| `backend/src/services/permission_service.rs` | Added `build_visibility_predicate()` static method |
| `backend/src/services/repository_service.rs` | Updated `build_visibility_clause_for()` and `user_can_access_repo()` |
| `backend/src/api/handlers/groups.rs` | Refactored to use shared helper, removed duplicate SQL |
| `backend/tests/repository_permission_visibility_tests.rs` | New integration tests (direct user + group permission, legacy role_assignments coverage) |
| `scripts/native-tests/test-permission-visibility.sh` | New E2E test script |
| `docker-compose.test.yml` | Added `permission-visibility-test` service |
| `scripts/native-tests/run-all.sh` | Added `permission-visibility` to test profiles |

### Backward Compatibility

Legacy `role_assignments` checks and `is_public` checks are preserved. The fix adds a third OR branch, so no existing functionality is broken.

### Auto-fixed by this change

- Webhooks listing (inherits from repository visibility — same `build_visibility_clause_for()`)
- Packages listing (inherits from repository visibility — same `build_visibility_clause_for()`)

## Regression test

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

### Tests added

1. **Integration test** (`repository_permission_visibility_tests.rs`): Three tests covering direct user permission, group permission, and legacy `role_assignments` — all against real PostgreSQL
2. **E2E test** (`test-permission-visibility.sh`): Full HTTP API flow — creates user, group, private repo, adds user to group, grants group permission, verifies repository appears in listing

### Verification

- Pre-fix (production `latest` image): E2E test shows `Repositories visible to test user: 0` ✅ (confirms bug)
- Post-fix (image built from this PR): E2E test shows `Repositories visible to test user: 25` ✅ (fix works)
- All unit tests pass: 11790 passed
- Cargo clippy: clean
- Cargo fmt: clean

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
