### PR TITLE
fix(publish): enforce promotion-only gate on all format-native publish paths

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -741,6 +741,7 @@ async fn upload_package_put(
     let user_id = require_auth_basic_scope(auth, "alpine", "write")?.user_id;
     let repo = resolve_alpine_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if !filename.ends_with(".apk") {
         return Err((StatusCode::BAD_REQUEST, "File must have .apk extension").into_response());
@@ -774,6 +775,7 @@ async fn upload_package_post(
     let user_id = require_auth_basic_scope(auth, "alpine", "write")?.user_id;
     let repo = resolve_alpine_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Extract filename from headers
     let filename = headers

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -406,6 +406,7 @@ async fn upload_collection(
     let user_id = require_auth_basic(auth, "ansible")?.user_id;
     let repo = resolve_ansible_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // The `ansible-galaxy collection publish` CLI sends a multipart body with:
     //   * `file`: the tarball, with the canonical filename
@@ -642,6 +643,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: Some("https://example.com".to_string()),
+            promotion_only: false,
         };
         assert_eq!(info.storage_path, "/tmp/test");
         assert_eq!(info.repo_type, "hosted");

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -720,6 +720,20 @@ async fn publish(
     let repo = resolve_cargo_repo(&state.db, &repo_key, &state.repo_cache).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
 
+    // Reject direct uploads to promotion-only repositories. Such repos accept
+    // artifacts only via the promotion path, not direct `cargo publish`. The
+    // cargo handler owns its own repo struct/cache, so query the flag directly
+    // at this commit choke point (stale-proof, no admin exemption).
+    let promotion_only = sqlx::query_scalar!(
+        "SELECT promotion_only FROM repositories WHERE id = $1",
+        repo.id
+    )
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| proxy_helpers::internal_error("Database", e))?
+    .unwrap_or(false);
+    proxy_helpers::reject_direct_upload_if_promotion_only(promotion_only, false)?;
+
     let parsed = parse_publish_payload(&body)?;
     let name_lower = parsed.crate_name.to_lowercase();
 
@@ -1598,6 +1612,58 @@ mod tests {
             "links": null,
             "rust_version": "1.70.0"
         })
+    }
+
+    /// #2022: a direct `cargo publish` (PUT /api/v1/crates/new) to a
+    /// `promotion_only` repository must be rejected with 409 CONFLICT; the same
+    /// publish to a normal repository must still succeed. Cargo owns its own
+    /// repo struct/cache, so the gate is a direct scalar query at the publish
+    /// choke point. Skips when no test database is configured.
+    #[tokio::test]
+    async fn test_publish_blocked_on_promotion_only_repo() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "cargo").await else {
+            return;
+        };
+
+        let crate_data = b"fake-crate-tarball-bytes";
+        let payload = make_publish_payload(&sample_metadata(), crate_data);
+        let uri = format!("/{}/api/v1/crates/new", fx.repo_key);
+
+        // Flag the repo promotion_only -> direct publish is rejected with 409.
+        fx.set_promotion_only(true).await;
+        let app = tdh::router_with_auth(
+            super::router(),
+            fx.state.clone(),
+            tdh::make_auth(fx.user_id, &fx.username),
+        );
+        let req = tdh::put(uri.clone(), payload.clone());
+        let (blocked_status, _) = tdh::send(app, req).await;
+
+        // Clear the flag -> the same publish succeeds.
+        fx.set_promotion_only(false).await;
+        let app = tdh::router_with_auth(
+            super::router(),
+            fx.state.clone(),
+            tdh::make_auth(fx.user_id, &fx.username),
+        );
+        let req = tdh::put(uri, payload);
+        let (allowed_status, allowed_body) = tdh::send(app, req).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            blocked_status,
+            StatusCode::CONFLICT,
+            "promotion_only direct publish must return 409"
+        );
+        assert_eq!(
+            allowed_status,
+            StatusCode::OK,
+            "publish to a normal repo must still succeed; body: {}",
+            String::from_utf8_lossy(&allowed_body)
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -406,6 +406,7 @@ async fn upload_cookbook(
     let user_id = require_auth_basic(auth, "chef")?.user_id;
     let repo = resolve_chef_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let mut tarball: Option<bytes::Bytes> = None;
     let mut cookbook_json: Option<serde_json::Value> = None;
@@ -674,6 +675,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "hosted");
         assert!(repo.upstream_url.is_none());
@@ -688,6 +690,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://supermarket.chef.io".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert_eq!(

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -295,6 +295,7 @@ async fn push_pod(
     let user_id = require_auth_basic(auth, "cocoapods")?.user_id;
     let repo = resolve_cocoapods_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty pod archive").into_response());
@@ -940,6 +941,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.id, id);
         assert_eq!(repo.repo_type, "hosted");
@@ -954,6 +956,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://cdn.cocoapods.org/".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert_eq!(

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -956,6 +956,7 @@ async fn upload(
     let user_id = require_auth_basic_scope(auth, "composer", "write")?.user_id;
     let repo = resolve_composer_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // The body should be a zip archive containing composer.json
     if body.is_empty() {
@@ -1167,6 +1168,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: Some("https://packagist.org".to_string()),
+            promotion_only: false,
         };
         assert_eq!(info.id, id);
         assert_eq!(info.repo_type, "hosted");

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1344,6 +1344,7 @@ async fn recipe_file_upload(
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = require_auth_basic_scope(auth_ext, "conan", "write")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let artifact_path =
         recipe_artifact_path(&name, &version, &user, &channel, &revision, &file_path);
@@ -2115,6 +2116,7 @@ async fn package_file_upload(
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = require_auth_basic_scope(auth_ext, "conan", "write")?.user_id;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let artifact_path = package_artifact_path(
         &name,

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2465,6 +2465,7 @@ async fn upload_package_put(
     let user_id = require_auth_basic_scope(auth, "conda", "write")?.user_id;
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if !is_conda_package(&filename) {
         return Err((
@@ -2492,6 +2493,7 @@ async fn upload_post(
     let user_id = require_auth_basic_scope(auth, "conda", "write")?.user_id;
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Determine subdir and filename from headers
     let subdir = headers
@@ -2534,6 +2536,7 @@ async fn upload_package_put_with_token(
 
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if !is_conda_package(&filename) {
         return Err((
@@ -2564,6 +2567,7 @@ async fn upload_post_with_token(
 
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let subdir = headers
         .get("X-Conda-Subdir")

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -313,6 +313,7 @@ async fn upload_package(
     let user_id = require_auth_basic_scope(auth, "cran", "write")?.user_id;
     let repo = resolve_cran_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty package file").into_response());
@@ -522,6 +523,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.storage_path, "/data/cran-local");
         assert_eq!(repo.repo_type, "hosted");
@@ -537,6 +539,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://cloud.r-project.org".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert_eq!(

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1721,6 +1721,7 @@ async fn pool_upload(
     let user_id = require_auth_basic_scope(auth, "debian", "write")?.user_id;
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let upload = prepare_debian_upload(&component, &path, &body)?;
     persist_debian_upload(
@@ -1763,6 +1764,7 @@ async fn upload_raw(
     let user_id = require_auth_basic_scope(auth, "debian", "write")?.user_id;
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Extract filename from X-Filename or Content-Disposition header
     let filename = headers

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -193,7 +193,7 @@ async fn resolve_lfs_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respo
     use sqlx::Row;
     let repo = sqlx::query(
         "SELECT id, key, storage_backend, storage_path, format::text as format, \
-         repo_type::text as repo_type, upstream_url FROM repositories WHERE key = $1",
+         repo_type::text as repo_type, upstream_url, promotion_only FROM repositories WHERE key = $1",
     )
     .bind(repo_key)
     .fetch_optional(db)
@@ -225,6 +225,7 @@ async fn resolve_lfs_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respo
         storage_backend: repo.try_get("storage_backend").unwrap_or_default(),
         repo_type: repo.try_get("repo_type").unwrap_or_default(),
         upstream_url: repo.try_get("upstream_url").ok(),
+        promotion_only: repo.try_get("promotion_only").unwrap_or(false),
     })
 }
 
@@ -442,6 +443,7 @@ async fn upload_object(
 
     // Reject writes to remote/virtual repos
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     validate_oid(&oid)?;
 
@@ -1431,6 +1433,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(info.repo_type, "hosted");
         assert!(info.upstream_url.is_none());

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -327,6 +327,7 @@ async fn handle_put(
             .await?;
     let repo = resolve_go_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
     let request = parse_path(&path)?;
 
     match request {

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -446,6 +446,7 @@ async fn upload_chart(
 
     // Reject writes to remote/virtual repos
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Extract chart file from multipart form (field name: "chart")
     let mut chart_content: Option<Bytes> = None;
@@ -760,6 +761,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "hosted");
         assert!(repo.upstream_url.is_none());
@@ -774,6 +776,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://charts.helm.sh/stable".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert_eq!(
@@ -1129,6 +1132,7 @@ entries:
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some(upstream_url),
+            promotion_only: false,
         };
 
         let result = download_chart_via_index(&state, &repo, "tc", "2.0.0", "tc-2.0.0.tgz").await;
@@ -1160,6 +1164,7 @@ entries:
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
 
         let result = download_chart_via_index(&state, &repo, "ch", "1.0.0", "ch-1.0.0.tgz").await;
@@ -1183,6 +1188,7 @@ entries:
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
 
         let result = download_chart_via_index(&state, &repo, "ch", "1.0.0", "ch-1.0.0.tgz").await;

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -351,6 +351,7 @@ async fn publish_package(
     let user_id = require_auth_basic_scope(auth, "hex", "write")?.user_id;
     let repo = resolve_hex_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty tarball").into_response());
@@ -1582,6 +1583,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "hosted");
         assert!(repo.upstream_url.is_none());
@@ -1596,6 +1598,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://repo.hex.pm".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.upstream_url.as_deref(), Some("https://repo.hex.pm"));
     }
@@ -1640,6 +1643,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_ne!(repo.repo_type, "remote");
         assert_ne!(repo.repo_type, "virtual");
@@ -1655,6 +1659,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://repo.hex.pm".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert!(repo.upstream_url.is_some());
@@ -1671,6 +1676,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert!(repo.upstream_url.is_none());
@@ -1686,6 +1692,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "virtual".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "virtual");
     }

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -295,6 +295,7 @@ async fn upload_file(
     let user_id = require_auth_basic_scope(auth, "huggingface", "write")?.user_id;
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty file body").into_response());
@@ -591,6 +592,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "hosted");
         assert!(repo.upstream_url.is_none());
@@ -605,6 +607,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://huggingface.co".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.upstream_url.as_deref(), Some("https://huggingface.co"));
     }

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -543,7 +543,7 @@ async fn upsert_artifact(p: UpsertArtifactParams<'_>) -> Result<Uuid, String> {
 async fn resolve_incus_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Response> {
     use sqlx::Row;
     let repo = sqlx::query(
-        r#"SELECT id, key, storage_backend, storage_path, format::text as format, repo_type::text as repo_type, upstream_url
+        r#"SELECT id, key, storage_backend, storage_path, format::text as format, repo_type::text as repo_type, upstream_url, promotion_only
         FROM repositories WHERE key = $1"#,
     )
     .bind(repo_key)
@@ -572,6 +572,7 @@ async fn resolve_incus_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Res
         storage_backend: repo.get("storage_backend"),
         repo_type: repo.get("repo_type"),
         upstream_url: repo.get("upstream_url"),
+        promotion_only: repo.try_get("promotion_only").unwrap_or(false),
     })
 }
 
@@ -831,6 +832,7 @@ async fn upload_image(
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let artifact_path = build_artifact_path(&product, &version, &filename);
     IncusHandler::parse_path(&artifact_path).map_err(|e| {
@@ -956,6 +958,7 @@ async fn delete_image(
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let artifact_path = build_artifact_path(&product, &version, &filename);
 
@@ -1047,6 +1050,7 @@ async fn start_chunked_upload(
     let prefix = mount_prefix_from_uri(&original_uri);
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let artifact_path = build_artifact_path(&product, &version, &filename);
     IncusHandler::parse_path(&artifact_path).map_err(|e| {
@@ -2362,6 +2366,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(info.repo_type, "hosted");
         assert_eq!(info.storage_path, "/data/incus");
@@ -2377,6 +2382,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://images.linuxcontainers.org".to_string()),
+            promotion_only: false,
         };
         assert_eq!(info.repo_type, "remote");
         assert_eq!(
@@ -3649,6 +3655,7 @@ mod streaming_pipeline_regression_tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
 
         finalize_upload(

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -373,6 +373,7 @@ async fn upload_plugin(
     let user_id = require_auth_basic(auth, "jetbrains")?.user_id;
     let repo = resolve_jetbrains_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty upload body").into_response());
@@ -875,6 +876,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(info.repo_type, "hosted");
         assert!(info.upstream_url.is_none());

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2411,6 +2411,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.id, id);
         assert_eq!(repo.repo_type, "hosted");
@@ -2425,6 +2426,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://repo1.maven.org/maven2".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert_eq!(

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -487,6 +487,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         Some((pool, state, repo_id, repo, user_id))
     }

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1841,6 +1841,7 @@ async fn publish_package(
         require_auth_with_bearer_fallback(auth, headers, &state.db, &state.config, "npm").await?;
     let repo = resolve_npm_repo(&state.db, repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let parsed = parse_npm_publish_payload(&body, package_name)?;
 
@@ -1952,6 +1953,7 @@ async fn dist_tags_put(
         require_auth_with_bearer_fallback(auth, &headers, &state.db, &state.config, "npm").await?;
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if tag.is_empty() {
         return Err(
@@ -2024,6 +2026,7 @@ async fn dist_tags_delete(
         require_auth_with_bearer_fallback(auth, &headers, &state.db, &state.config, "npm").await?;
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if tag == "latest" {
         return Err(
@@ -2771,6 +2774,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(info.repo_type, "hosted");
         assert!(info.upstream_url.is_none());
@@ -4543,6 +4547,65 @@ mod tests {
         assert_eq!(
             json["dist-tags"]["latest"], "1.1.0",
             "latest must stay the highest stable, not the published prerelease"
+        );
+    }
+
+    /// #2022: a direct `npm publish` to a `promotion_only` repository must be
+    /// rejected with 409 CONFLICT; the same publish to a normal repository must
+    /// still succeed. Skips when no test database is configured.
+    #[tokio::test]
+    async fn test_publish_blocked_on_promotion_only_repo() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "npm").await else {
+            return;
+        };
+
+        let tarball_b64 = base64::engine::general_purpose::STANDARD.encode(b"tgz");
+        let publish_body = serde_json::json!({
+            "name": "widget",
+            "versions": { "1.0.0": { "name": "widget", "version": "1.0.0" } },
+            "_attachments": { "widget-1.0.0.tgz": { "data": tarball_b64 } },
+        });
+        let body_bytes =
+            Bytes::from(serde_json::to_vec(&publish_body).expect("serialize publish body"));
+
+        // Flag the repo promotion_only -> direct publish is rejected with 409.
+        fx.set_promotion_only(true).await;
+        let blocked = super::publish_package(
+            &fx.state,
+            Some(tdh::make_auth(fx.user_id, &fx.username)),
+            &fx.repo_key,
+            "widget",
+            &HeaderMap::new(),
+            body_bytes.clone(),
+        )
+        .await;
+
+        // Clear the flag -> the same publish succeeds.
+        fx.set_promotion_only(false).await;
+        let allowed = super::publish_package(
+            &fx.state,
+            Some(tdh::make_auth(fx.user_id, &fx.username)),
+            &fx.repo_key,
+            "widget",
+            &HeaderMap::new(),
+            body_bytes,
+        )
+        .await;
+
+        fx.teardown().await;
+
+        let err = blocked.expect_err("publish to promotion_only repo must be rejected");
+        assert_eq!(
+            err.status(),
+            StatusCode::CONFLICT,
+            "promotion_only direct publish must return 409"
+        );
+        assert!(
+            allowed.is_ok(),
+            "publish to a normal repo must still succeed: {:?}",
+            allowed.err().map(|r| r.status())
         );
     }
 

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -905,6 +905,7 @@ async fn push_package(
     };
     let repo = resolve_nuget_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // The body may be multipart/form-data or raw binary .nupkg.
     let nupkg_bytes = extract_nupkg_bytes(&headers, body)?;
@@ -1652,6 +1653,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(info.repo_type, "hosted");
         assert!(info.upstream_url.is_none());

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -4644,6 +4644,26 @@ async fn handle_complete_upload(
         return resp;
     }
 
+    // Defense-in-depth: reject direct blob finalize on promotion-only repos so
+    // such a repo never accumulates orphan blobs from a blocked push. The
+    // manifest PUT is the load-bearing gate; this stops the blob upstream of it.
+    let promotion_only = sqlx::query_scalar!(
+        "SELECT promotion_only FROM repositories WHERE id = $1",
+        repo.id
+    )
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+    if promotion_only {
+        return oci_error(
+            StatusCode::CONFLICT,
+            "DENIED",
+            "Direct uploads are disabled for this repository; publish via promotion",
+        );
+    }
+
     let storage = match state.storage_for_repo(&repo.location) {
         Ok(s) => s,
         Err(e) => {
@@ -6008,6 +6028,25 @@ async fn handle_put_manifest(
             StatusCode::METHOD_NOT_ALLOWED,
             "UNSUPPORTED",
             "pushes are not supported on remote or virtual repositories",
+        );
+    }
+    // Reject direct pushes to promotion-only repositories. The manifest PUT is
+    // the load-bearing commit of `docker push`; such repos accept images only
+    // via the promotion path. No admin exemption (matches the shared helper).
+    let promotion_only = sqlx::query_scalar!(
+        "SELECT promotion_only FROM repositories WHERE id = $1",
+        repo.id
+    )
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+    if promotion_only {
+        return oci_error(
+            StatusCode::CONFLICT,
+            "DENIED",
+            "Direct uploads are disabled for this repository; publish via promotion",
         );
     }
     let repo_id = repo.id;
@@ -12629,6 +12668,67 @@ mod oci_blob_upload_streaming_tests {
         assert_eq!(
             tags, 0,
             "a rejected degenerate manifest must not create a live tag"
+        );
+    }
+
+    /// #2022: a direct manifest PUT (the `docker push` commit) to a
+    /// `promotion_only` repository must be rejected with 409 + OCI code DENIED.
+    /// The same PUT to a normal repository must pass the gate (here it reaches
+    /// manifest validation and is rejected as degenerate with 400, NOT 409 —
+    /// proving the promotion gate is a no-op on ordinary repos).
+    #[tokio::test]
+    async fn put_manifest_blocked_on_promotion_only_repo() {
+        let Some(f) = OciUploadFixture::setup().await else {
+            return;
+        };
+        // A degenerate-but-parseable manifest body. On a promotion_only repo the
+        // gate fires BEFORE classification (409); on a normal repo the body is
+        // classified and rejected as degenerate (400).
+        let body = Bytes::from_static(br#"{"schemaVersion":2,"layers":[]}"#);
+
+        // promotion_only = true -> 409 DENIED.
+        f.inner.set_promotion_only(true).await;
+        let (blocked_status, _h, blocked_body) = send(
+            f.app(),
+            request(
+                Method::PUT,
+                format!("/{}/app/manifests/v1", f.inner.repo_key),
+                &f.authorization,
+                body.clone(),
+            ),
+        )
+        .await;
+
+        // promotion_only = false -> gate is a no-op; the degenerate manifest is
+        // rejected with 400, not 409.
+        f.inner.set_promotion_only(false).await;
+        let (allowed_status, _h2, _b2) = send(
+            f.app(),
+            request(
+                Method::PUT,
+                format!("/{}/app/manifests/v1", f.inner.repo_key),
+                &f.authorization,
+                body,
+            ),
+        )
+        .await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            blocked_status,
+            StatusCode::CONFLICT,
+            "manifest PUT to promotion_only repo must return 409"
+        );
+        assert!(
+            String::from_utf8_lossy(&blocked_body).contains("DENIED"),
+            "409 body must carry the OCI DENIED code; got: {}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_eq!(
+            allowed_status,
+            StatusCode::BAD_REQUEST,
+            "manifest PUT to a normal repo must pass the gate (degenerate -> 400, not 409)"
         );
     }
 

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -395,7 +395,7 @@ fn connect_error(status: StatusCode, code: &str, message: &str) -> Response {
 async fn resolve_protobuf_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Response> {
     use sqlx::Row;
     let row = sqlx::query(
-        r#"SELECT id, key, storage_backend, storage_path, format::text AS format, repo_type::text AS repo_type, upstream_url
+        r#"SELECT id, key, storage_backend, storage_path, format::text AS format, repo_type::text AS repo_type, upstream_url, promotion_only
         FROM repositories WHERE key = $1"#,
     )
     .bind(repo_key)
@@ -435,6 +435,7 @@ async fn resolve_protobuf_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, 
         storage_backend: row.get("storage_backend"),
         repo_type: row.get("repo_type"),
         upstream_url: row.get("upstream_url"),
+        promotion_only: row.try_get("promotion_only").unwrap_or(false),
     })
 }
 
@@ -875,6 +876,7 @@ async fn create_modules(
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // CreateModules is implicitly handled during upload. Return the request
     // echoed back as acknowledgement (modules are created on first push).
@@ -1046,6 +1048,7 @@ async fn upload(
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let mut result_commits = Vec::new();
 
@@ -1501,6 +1504,7 @@ async fn create_or_update_labels(
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
 
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let mut labels = Vec::new();
     let now = chrono::Utc::now().to_rfc3339();

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -40,6 +40,7 @@ pub struct RepoInfo {
     pub storage_backend: String,
     pub repo_type: String,
     pub upstream_url: Option<String>,
+    pub promotion_only: bool,
 }
 
 impl RepoInfo {
@@ -48,6 +49,17 @@ impl RepoInfo {
             backend: self.storage_backend.clone(),
             path: self.storage_path.clone(),
         }
+    }
+
+    /// Reject a direct upload when this repository is flagged `promotion_only`.
+    ///
+    /// Delegates to [`reject_direct_upload_if_promotion_only`] so that every
+    /// format handler enforces the gate identically. There is no admin
+    /// exemption (the `is_admin` argument is accepted for signature parity but
+    /// has no effect — see [`promotion_only_blocks_direct_upload`]).
+    #[allow(clippy::result_large_err)]
+    pub fn reject_if_promotion_only(&self, is_admin: bool) -> Result<(), Response> {
+        reject_direct_upload_if_promotion_only(self.promotion_only, is_admin)
     }
 }
 
@@ -68,7 +80,7 @@ pub async fn resolve_repo_by_key(
     use sqlx::Row;
     let repo = sqlx::query(
         "SELECT id, key, storage_backend, storage_path, format::text as format, \
-         repo_type::text as repo_type, upstream_url \
+         repo_type::text as repo_type, upstream_url, promotion_only \
          FROM repositories WHERE key = $1",
     )
     .bind(repo_key)
@@ -103,6 +115,7 @@ pub async fn resolve_repo_by_key(
         storage_backend: repo.try_get("storage_backend").unwrap_or_default(),
         repo_type: repo.try_get("repo_type").unwrap_or_default(),
         upstream_url: repo.try_get("upstream_url").ok(),
+        promotion_only: repo.try_get("promotion_only").unwrap_or(false),
     })
 }
 
@@ -3047,6 +3060,46 @@ mod tests {
         assert!(reject_direct_upload_if_promotion_only(false, false).is_ok());
     }
 
+    fn promo_repo_info(promotion_only: bool) -> RepoInfo {
+        RepoInfo {
+            id: uuid::Uuid::new_v4(),
+            key: "gate-test".to_string(),
+            storage_path: "/data/gate-test".to_string(),
+            storage_backend: "filesystem".to_string(),
+            repo_type: "hosted".to_string(),
+            upstream_url: None,
+            promotion_only,
+        }
+    }
+
+    #[test]
+    fn test_repoinfo_reject_if_promotion_only_blocks_when_true() {
+        // A promotion_only RepoInfo rejects direct uploads with 409 CONFLICT,
+        // matching the wired maven/generic sites. The shared method is what the
+        // format-native publish handlers now call.
+        let repo = promo_repo_info(true);
+        let err = repo
+            .reject_if_promotion_only(false)
+            .expect_err("promotion_only repo must reject direct upload");
+        assert_eq!(err.status(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn test_repoinfo_reject_if_promotion_only_no_admin_exemption() {
+        // There is no admin break-glass: the is_admin flag does not change the
+        // outcome for a promotion_only repo.
+        let repo = promo_repo_info(true);
+        assert!(repo.reject_if_promotion_only(true).is_err());
+    }
+
+    #[test]
+    fn test_repoinfo_reject_if_promotion_only_allows_normal_repo() {
+        // A normal (promotion_only = false) repo is a no-op for any caller.
+        let repo = promo_repo_info(false);
+        assert!(repo.reject_if_promotion_only(false).is_ok());
+        assert!(repo.reject_if_promotion_only(true).is_ok());
+    }
+
     // ── LocalLookup dispatch tests ──────────────────────────────────
 
     #[test]
@@ -3530,6 +3583,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         let loc = info.storage_location();
         assert_eq!(loc.backend, "filesystem");
@@ -5285,6 +5339,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
 
         let bytes = Bytes::from_static(b"package-data");
@@ -5434,6 +5489,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
 
         let opts = DownloadResponseOpts {
@@ -5468,6 +5524,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://upstream.example.test".to_string()),
+            promotion_only: false,
         };
 
         // state.proxy_service is None: should short-circuit to Ok(None).
@@ -5503,6 +5560,7 @@ mod tests {
             // Force the Remote branch but with upstream_url = None.
             repo_type: "remote".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
 
         let opts = DownloadResponseOpts {
@@ -5539,6 +5597,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "local".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         let bytes = Bytes::from_static(b"abc123");
         put_artifact_bytes(&state, &repo, "pypi/foo/1.0/foo.whl", bytes.clone())

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -415,6 +415,7 @@ async fn upload_package(
     let user_id = require_auth_basic(auth, "pub")?.user_id;
     let repo = resolve_pub_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Extract the tar.gz file from multipart form data
     let mut file_bytes: Option<bytes::Bytes> = None;

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -327,6 +327,7 @@ async fn publish_module(
     let user_id = require_auth_basic(auth, "puppet")?.user_id;
     let repo = resolve_puppet_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let (tarball, module_json) =
         proxy_helpers::parse_multipart_file_with_json(multipart, &["module"]).await?;

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1734,6 +1734,7 @@ async fn upload(
 
     // Reject writes to remote/virtual repos
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Parse multipart form data
     let mut action: Option<String> = None;
@@ -3899,6 +3900,64 @@ mod tests {
             .execute(&fx.pool)
             .await;
         fx.teardown().await;
+    }
+
+    /// #2022: a direct `twine upload` to a `promotion_only` repository must be
+    /// rejected with 409 CONFLICT; the same upload to a normal repository must
+    /// still succeed. Skips when no test database is configured.
+    #[tokio::test]
+    async fn test_upload_blocked_on_promotion_only_repo() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "pypi").await else {
+            return;
+        };
+
+        let project = "ak-pypi-promotion-gate";
+        let version = "0.1.0";
+        let filename = "ak_pypi_promotion_gate-0.1.0-py3-none-any.whl";
+
+        // Flag the repo promotion_only -> direct upload is rejected with 409.
+        fx.set_promotion_only(true).await;
+        let (content_type, body) = pypi_upload_multipart(
+            project,
+            version,
+            filename,
+            b"fake-wheel-bytes",
+            "promotion gate test",
+            ">=3.8",
+        );
+        let app = fx.router_with_auth(super::router());
+        let req = tdh::post(format!("/{}/", fx.repo_key), &content_type, body);
+        let (blocked_status, _) = tdh::send(app, req).await;
+
+        // Clear the flag -> the same upload succeeds.
+        fx.set_promotion_only(false).await;
+        let (content_type, body) = pypi_upload_multipart(
+            project,
+            version,
+            filename,
+            b"fake-wheel-bytes",
+            "promotion gate test",
+            ">=3.8",
+        );
+        let app = fx.router_with_auth(super::router());
+        let req = tdh::post(format!("/{}/", fx.repo_key), &content_type, body);
+        let (allowed_status, allowed_body) = tdh::send(app, req).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            blocked_status,
+            StatusCode::CONFLICT,
+            "promotion_only direct upload must return 409"
+        );
+        assert_eq!(
+            allowed_status,
+            StatusCode::OK,
+            "upload to a normal repo must still succeed; body: {}",
+            String::from_utf8_lossy(&allowed_body)
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -281,6 +281,7 @@ async fn push_gem(
     let user_id = require_auth_basic_scope(auth, "rubygems", "write")?.user_id;
     let repo = resolve_rubygems_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty gem file").into_response());
@@ -810,6 +811,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: Some("https://rubygems.org".to_string()),
+            promotion_only: false,
         };
         assert_eq!(info.id, id);
         assert_eq!(info.repo_type, "hosted");

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -211,6 +211,7 @@ async fn upload_artifact(
 
     // Reject writes to remote/virtual repos
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     let artifact_path = artifact_path.trim_start_matches('/').to_string();
 

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -793,6 +793,7 @@ async fn publish_release(
 
     // Reject writes to remote/virtual repos
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     // Validate path
     let _info = SwiftHandler::parse_path(&format!("{}/{}/{}", scope, name, version))
@@ -1151,6 +1152,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.id, id);
         assert_eq!(repo.storage_path, "/data/swift-repo");
@@ -1167,6 +1169,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "remote".to_string(),
             upstream_url: Some("https://swift-packages.example.com".to_string()),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert_eq!(

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -516,6 +516,7 @@ async fn upload_module(
     let user_id = require_auth_basic_scope(auth, "terraform", "write")?.user_id;
     let repo = resolve_terraform_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
     let module_name = format!("{}/{}/{}", namespace, name, provider);
 
     // Check for duplicate
@@ -929,6 +930,7 @@ async fn upload_provider(
     let user_id = require_auth_basic_scope(auth, "terraform", "write")?.user_id;
     let repo = resolve_terraform_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
     let provider_name = format!("{}/{}", namespace, type_name);
     let platform = format!("{}_{}", os, arch);
 
@@ -1701,6 +1703,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: Some("https://registry.terraform.io".to_string()),
+            promotion_only: false,
         };
         assert_eq!(info.id, id);
         assert_eq!(info.storage_path, "/data/terraform");
@@ -1720,6 +1723,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert!(info.upstream_url.is_none());
     }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -351,6 +351,7 @@ pub fn make_repo_info(
         storage_backend: "filesystem".to_string(),
         repo_type: repo_type.to_string(),
         upstream_url: upstream_url.map(|s| s.to_string()),
+        promotion_only: false,
     }
 }
 
@@ -475,6 +476,18 @@ impl Fixture {
             storage_dir,
             state,
         })
+    }
+
+    /// Flag the fixture repository as `promotion_only` (or clear the flag).
+    /// Used by the format-native publish-gate tests to assert that a direct
+    /// upload to a promotion_only repository is rejected.
+    pub async fn set_promotion_only(&self, value: bool) {
+        sqlx::query("UPDATE repositories SET promotion_only = $1 WHERE id = $2")
+            .bind(value)
+            .bind(self.repo_id)
+            .execute(&self.pool)
+            .await
+            .expect("set promotion_only");
     }
 
     /// Build a `RepoInfo` matching this fixture's repository. Mirrors the

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -290,6 +290,7 @@ async fn publish_extension(
     let user_id = require_auth_basic(auth, "vscode")?.user_id;
     let repo = resolve_vscode_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
+    repo.reject_if_promotion_only(false)?;
 
     if body.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty VSIX file").into_response());
@@ -821,6 +822,7 @@ mod tests {
             storage_backend: "filesystem".to_string(),
             repo_type: "hosted".to_string(),
             upstream_url: None,
+            promotion_only: false,
         };
         assert_eq!(repo.storage_path, "/data/vscode-local");
         assert_eq!(repo.repo_type, "hosted");
@@ -838,6 +840,7 @@ mod tests {
             upstream_url: Some(
                 "https://marketplace.visualstudio.com/_apis/public/gallery".to_string(),
             ),
+            promotion_only: false,
         };
         assert_eq!(repo.repo_type, "remote");
         assert!(repo.upstream_url.is_some());


### PR DESCRIPTION
## Summary

Closes #2022.

The `promotion_only` repository policy rejects direct artifact uploads so that
artifacts can only enter a repository through the promotion workflow (quality
gates + approval + provenance). The gate was wired into only three write paths
(Maven, the chunked upload session, and the generic repositories upload), so
the format-native publish handlers never enforced it: their shared `RepoInfo`
descriptor did not even select the `promotion_only` column, so the policy was
invisible to them and direct publishes succeeded against a `promotion_only`
repository.

This change enforces the policy uniformly across every format-native publish
path.

### What changed
- `proxy_helpers::RepoInfo` now carries `promotion_only`; `resolve_repo_by_key`
  selects it, and a new `RepoInfo::reject_if_promotion_only()` method centralizes
  the rejection so every handler enforces it identically. The three handlers that
  build a `RepoInfo` from their own query (Git LFS, Incus, Protobuf) select the
  column too.
- Each format-native write handler now calls `reject_if_promotion_only()`
  immediately after the existing hosted-only check (npm, PyPI, NuGet, RubyGems,
  Debian, RPM, Helm, Conan, and the long tail — Alpine, Conda, CRAN, Hex,
  Composer, Go, Git LFS, Hugging Face, CocoaPods, Chef, Ansible, JetBrains,
  Incus, Protobuf, Puppet, sbt, Swift, Terraform, VS Code, Pub).
- Cargo (`publish`) and OCI (manifest PUT, plus blob finalize for
  defense-in-depth) own their own repository structs, so they query the flag
  directly at the publish commit choke point. OCI returns the registry error
  envelope with code `DENIED`.

### Behavior
- Direct publish to a `promotion_only` repository → `409 Conflict`
  (OCI: `409` + `DENIED`), matching the existing wired sites.
- Publish to an ordinary (`promotion_only = false`) repository is unchanged.
- The gate covers direct uploads only. Promotion delivery writes through its own
  path (raw SQL insert in `handlers/promotion.rs`), so promoting an artifact
  *into* a `promotion_only` repository still works.
- Consistent with the existing policy, there is no admin exemption: direct
  uploads are rejected for all callers.

No schema change (the `promotion_only` column already exists). No new
`.sqlx` cache entries are required — the added scalar queries reuse a query
string already present in the offline cache.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added tests:
- `proxy_helpers`: `RepoInfo::reject_if_promotion_only` returns `409` when the
  flag is set, `Ok` otherwise, with no admin exemption.
- DB-backed per-format direct-publish-gate tests for npm, PyPI, Cargo, and OCI:
  a direct publish to a `promotion_only` repository is rejected while the same
  publish to a normal repository succeeds.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
