### PR TITLE
fix(proxy): index proxy-cached Maven artifacts into the package catalog (#1999)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2706,6 +2706,25 @@ async fn list_artifacts_grouped_by_maven_component(
     // is generous; most Maven repos have far fewer cached artifacts.
     const MAX_FETCH: i64 = 10_000;
 
+    // Remote (proxy) repositories do NOT record cached items in the `artifacts`
+    // table (#1278 / #1280), so `artifact_service.list` returns nothing for them
+    // and component grouping came back empty (#1999, regression in 1.2.1).
+    // Proxy-cached Maven artifacts ARE indexed into the package catalog
+    // (`packages` / `package_versions`, written by
+    // `ProxyService::index_cached_package`), so reconstruct the component list
+    // from there instead. Hosted/local/virtual grouping is unchanged below.
+    if repo.repo_type == RepositoryType::Remote {
+        let components = maven_components_from_catalog(
+            &state.db,
+            repo.id,
+            repo_key,
+            &format!("{:?}", repo.format).to_lowercase(),
+            search_query,
+        )
+        .await?;
+        return Ok(paginate_maven_components(components, page, per_page));
+    }
+
     let (artifacts, _total_files) = if repo.repo_type == RepositoryType::Virtual {
         let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id)
             .await
@@ -2734,6 +2753,18 @@ async fn list_artifacts_grouped_by_maven_component(
         &format!("{:?}", repo.format).to_lowercase(),
     );
 
+    Ok(paginate_maven_components(components, page, per_page))
+}
+
+/// Paginate a fully-built list of Maven components into an
+/// [`ArtifactListResponse`]. Shared by the hosted/local (artifacts-table) and
+/// the remote/proxy (package-catalog) grouping paths so pagination math lives
+/// in exactly one place.
+fn paginate_maven_components(
+    components: Vec<MavenComponentResponse>,
+    page: u32,
+    per_page: u32,
+) -> Json<ArtifactListResponse> {
     let total_components = components.len() as i64;
     let total_pages = ((total_components as f64) / (per_page as f64)).ceil() as u32;
     let offset = ((page - 1) * per_page) as usize;
@@ -2743,7 +2774,7 @@ async fn list_artifacts_grouped_by_maven_component(
         .take(per_page as usize)
         .collect();
 
-    Ok(Json(ArtifactListResponse {
+    Json(ArtifactListResponse {
         items: Vec::new(),
         pagination: Pagination {
             page,
@@ -2753,7 +2784,80 @@ async fn list_artifacts_grouped_by_maven_component(
         },
         components: Some(page_components),
         docker_tags: None,
-    }))
+    })
+}
+
+/// Build the Maven component list for a remote/proxy repository from the
+/// package catalog (#1999).
+///
+/// Proxy-cached Maven artifacts are indexed into `packages` /
+/// `package_versions` with `packages.name = "groupId:artifactId"` (see
+/// [`crate::services::proxy_service::maven_proxy_package_name`]). Each catalog
+/// row maps to one [`MavenComponentResponse`]; rows whose name does not split
+/// into `groupId:artifactId` are skipped defensively. Results are ordered by
+/// name for a stable, paginatable list.
+async fn maven_components_from_catalog(
+    db: &sqlx::PgPool,
+    repository_id: Uuid,
+    repo_key: &str,
+    format: &str,
+    search_query: Option<&str>,
+) -> Result<Vec<MavenComponentResponse>> {
+    use sqlx::Row;
+
+    let search_pattern = search_query.map(|q| format!("%{}%", q));
+
+    let rows = sqlx::query(
+        r#"
+        SELECT p.id, p.name, p.version, p.size_bytes, p.download_count, p.created_at
+        FROM packages p
+        WHERE p.repository_id = $1
+          AND ($2::text IS NULL OR p.name ILIKE $2)
+        ORDER BY p.name ASC, p.version ASC
+        "#,
+    )
+    .bind(repository_id)
+    .bind(&search_pattern)
+    .fetch_all(db)
+    .await
+    .map_err(|e| AppError::Internal(format!("Failed to list proxy package catalog: {e}")))?;
+
+    let mut components = Vec::with_capacity(rows.len());
+    for row in rows {
+        let name: String = row.get("name");
+        let Some((group_id, artifact_id)) = split_maven_catalog_name(&name) else {
+            // Defensive: a catalog row not written by the proxy indexer (no
+            // `groupId:artifactId` shape) cannot be rendered as a component.
+            continue;
+        };
+        components.push(MavenComponentResponse {
+            id: row.get("id"),
+            group_id,
+            artifact_id,
+            version: row.get("version"),
+            repository_key: repo_key.to_string(),
+            format: format.to_string(),
+            size_bytes: row.get("size_bytes"),
+            download_count: row.get("download_count"),
+            created_at: row.get("created_at"),
+            artifact_files: Vec::new(),
+        });
+    }
+
+    Ok(components)
+}
+
+/// Split a proxy package-catalog name (`groupId:artifactId`) back into its
+/// `(groupId, artifactId)` parts (#1999). Returns `None` when the name has no
+/// `:` separator or either side is empty, so a malformed/foreign catalog row is
+/// skipped rather than rendered as a broken component. Maven artifactIds never
+/// contain `:`, and groupIds use `.` separators, so the FIRST `:` is the split.
+fn split_maven_catalog_name(name: &str) -> Option<(String, String)> {
+    let (group_id, artifact_id) = name.split_once(':')?;
+    if group_id.is_empty() || artifact_id.is_empty() {
+        return None;
+    }
+    Some((group_id.to_string(), artifact_id.to_string()))
 }
 
 /// GAV key used to group Maven artifacts.
@@ -5288,6 +5392,93 @@ mod tests {
         // A trailing slash would otherwise yield an empty basename; fall back
         // to the full path rather than emitting an empty filename.
         assert_eq!(download_filename("a/b/"), "a/b/");
+    }
+
+    // -----------------------------------------------------------------------
+    // Proxy package-catalog component grouping (#1999)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn split_maven_catalog_name_splits_group_and_artifact() {
+        assert_eq!(
+            split_maven_catalog_name("org.apache.commons:commons-lang3"),
+            Some((
+                "org.apache.commons".to_string(),
+                "commons-lang3".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn split_maven_catalog_name_rejects_missing_separator() {
+        assert!(split_maven_catalog_name("commons-lang3").is_none());
+    }
+
+    #[test]
+    fn split_maven_catalog_name_rejects_empty_sides() {
+        assert!(split_maven_catalog_name(":commons-lang3").is_none());
+        assert!(split_maven_catalog_name("org.apache:").is_none());
+        assert!(split_maven_catalog_name(":").is_none());
+    }
+
+    #[test]
+    fn split_maven_catalog_name_uses_first_colon() {
+        // groupId uses dot separators and artifactId has no colon, so any
+        // extra colon (defensive) is folded into the artifactId.
+        assert_eq!(
+            split_maven_catalog_name("g:a:b"),
+            Some(("g".to_string(), "a:b".to_string()))
+        );
+    }
+
+    fn maven_component(group: &str, artifact: &str) -> MavenComponentResponse {
+        MavenComponentResponse {
+            id: Uuid::new_v4(),
+            group_id: group.to_string(),
+            artifact_id: artifact.to_string(),
+            version: "1.0.0".to_string(),
+            repository_key: "maven-proxy".to_string(),
+            format: "maven".to_string(),
+            size_bytes: 10,
+            download_count: 0,
+            created_at: chrono::Utc::now(),
+            artifact_files: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn paginate_maven_components_reports_total_and_page() {
+        let comps = vec![
+            maven_component("g", "a"),
+            maven_component("g", "b"),
+            maven_component("g", "c"),
+        ];
+        let resp = paginate_maven_components(comps, 1, 2).0;
+        assert_eq!(resp.pagination.total, 3);
+        assert_eq!(resp.pagination.total_pages, 2);
+        assert_eq!(resp.components.as_ref().unwrap().len(), 2);
+        assert!(resp.items.is_empty());
+        assert!(resp.docker_tags.is_none());
+    }
+
+    #[test]
+    fn paginate_maven_components_second_page_has_remainder() {
+        let comps = vec![
+            maven_component("g", "a"),
+            maven_component("g", "b"),
+            maven_component("g", "c"),
+        ];
+        let resp = paginate_maven_components(comps, 2, 2).0;
+        assert_eq!(resp.components.as_ref().unwrap().len(), 1);
+        assert_eq!(resp.components.as_ref().unwrap()[0].artifact_id, "c");
+    }
+
+    #[test]
+    fn paginate_maven_components_empty_catalog() {
+        let resp = paginate_maven_components(Vec::new(), 1, 20).0;
+        assert_eq!(resp.pagination.total, 0);
+        assert_eq!(resp.pagination.total_pages, 0);
+        assert!(resp.components.as_ref().unwrap().is_empty());
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2179,6 +2179,20 @@ impl ProxyService {
                             // unimplemented setting fails loudly, not silently.
                             self.warn_if_proxy_scan_unsupported(repo.id, cache_path)
                                 .await;
+
+                            // #1999: index the newly-cached Maven artifact into
+                            // the package catalog (packages/package_versions
+                            // only — never the artifacts table, preserving
+                            // #1278). Best-effort: failures are swallowed and
+                            // never fail the client's proxy fetch.
+                            let checksum = StorageService::calculate_hash(&resp.content);
+                            self.index_cached_package(
+                                repo.id,
+                                cache_path,
+                                resp.content.len() as i64,
+                                Some(&checksum),
+                            )
+                            .await;
                         }
 
                         // Package Age Policy (#1770): hold the just-fetched
@@ -2555,6 +2569,20 @@ impl ProxyService {
         // setting is observable in logs rather than silently doing nothing.
         self.warn_if_proxy_scan_unsupported(repo.id, cache_path)
             .await;
+
+        // #1999: index the newly-cached Maven artifact into the package
+        // catalog (packages/package_versions only — never the artifacts
+        // table, preserving #1278). The streaming tee computes the checksum
+        // only after the body is fully written, so it is unknown here; pass
+        // the upstream Content-Length when advertised (0 otherwise) and no
+        // checksum. Best-effort: failures never fail the client's fetch.
+        self.index_cached_package(
+            repo.id,
+            cache_path,
+            upstream.content_length.unwrap_or(0) as i64,
+            None,
+        )
+        .await;
 
         let headers = StreamHeaders {
             content_type: upstream.content_type.clone(),
@@ -3708,6 +3736,90 @@ impl ProxyService {
         }
     }
 
+    /// Index a newly proxy-cached artifact into the `packages` /
+    /// `package_versions` catalog (#1999).
+    ///
+    /// Proxy-cached artifacts are deliberately NOT written to the `artifacts`
+    /// table (#1278 / #1280): doing so reintroduced a doubled-prefix storage
+    /// bug on filesystem backends, and the contract is pinned by the meta-test
+    /// `test_cache_artifact_does_not_insert_into_artifacts_table`. As a result
+    /// the package catalog — populated only by the local-upload handlers via
+    /// [`PackageService::try_create_or_update_from_artifact`] — stayed empty for
+    /// remote/proxy repositories, so `GET /api/v1/packages` and Maven component
+    /// grouping returned nothing for cached artifacts (#1999, regression in
+    /// 1.2.1).
+    ///
+    /// This best-effort helper closes that gap WITHOUT touching the `artifacts`
+    /// table: it writes ONLY `packages` / `package_versions` rows (idempotent
+    /// `ON CONFLICT` upsert), so a second pull of the same GAV (cache hit) does
+    /// not double the catalog and the #1278 meta-test stays green.
+    ///
+    /// Invariants:
+    /// * Called ONLY on the new-cache branch (the same gated spot as
+    ///   [`Self::warn_if_proxy_scan_unsupported`]), so it fires once per new
+    ///   write and never on cache hits.
+    /// * Maven checksum sidecars (`.sha1` / `.md5`) and `maven-metadata.xml`
+    ///   are skipped — they are not packages.
+    /// * A path with no extractable version yields no row.
+    /// * Indexing failure must NOT fail the client's proxy fetch:
+    ///   [`PackageService::try_create_or_update_from_artifact`] swallows + logs.
+    ///
+    /// The repository format is resolved from the DB by `repository_id` rather
+    /// than taken from the caller: the proxy fetch path operates on a synthetic
+    /// `Repository` whose `format` is always `Generic`
+    /// (`proxy_helpers::build_remote_repo`), so trusting it would skip every
+    /// real Maven repo.
+    async fn index_cached_package(
+        &self,
+        repository_id: Uuid,
+        artifact_path: &str,
+        size_bytes: i64,
+        checksum_sha256: Option<&str>,
+    ) {
+        // Resolve the real repository format (the synthetic proxy `Repository`
+        // carries `Generic`, not the configured format). A read failure or
+        // unparseable format degrades to "not indexed" (best-effort).
+        let format_text: Option<String> =
+            sqlx::query_scalar(r#"SELECT format::text FROM repositories WHERE id = $1"#)
+                .bind(repository_id)
+                .fetch_optional(&self.db)
+                .await
+                .ok()
+                .flatten();
+        let Some(repo_format) = catalog_indexable_format(format_text.as_deref()) else {
+            // Only Maven-family proxy repos populate the catalog for now
+            // (#1999). Other formats keep the pre-fix behavior until their
+            // grouping/listing paths are taught to read from the catalog too.
+            return;
+        };
+
+        let Some(name) = maven_proxy_package_name(artifact_path) else {
+            return;
+        };
+        let Some(version) = extract_version_from_path(&repo_format, artifact_path) else {
+            return;
+        };
+
+        // The streaming tee computes the checksum only after the body is fully
+        // written, so it is unknown at this gated spot; fall back to an empty
+        // string. The buffered path passes the real digest. Either way the
+        // catalog row exists; a later buffered pull refreshes the digest.
+        let checksum = checksum_sha256.unwrap_or("");
+
+        let pkg_svc = crate::services::package_service::PackageService::new(self.db.clone());
+        pkg_svc
+            .try_create_or_update_from_artifact(
+                repository_id,
+                &name,
+                &version,
+                size_bytes,
+                checksum,
+                None,
+                None,
+            )
+            .await;
+    }
+
     /// Attempt to retrieve a cached artifact even if it has expired.
     /// Used as a fallback when upstream is unavailable.
     ///
@@ -3738,6 +3850,56 @@ impl ProxyService {
     }
 }
 
+/// Derive the package-catalog name (`groupId:artifactId`) for a Maven-family
+/// proxy-cached artifact path (#1999), or `None` if the path is not a Maven
+/// package asset that should be indexed.
+///
+/// Skip rules (these are not packages):
+/// * Maven checksum sidecars — `*.sha1`, `*.md5`, `*.sha256`, `*.sha512`, `*.asc`.
+/// * `maven-metadata.xml` (and its own checksum sidecars).
+/// * Any path that does not parse as Maven coordinates
+///   (`groupId/artifactId/version/filename`).
+///
+/// Using `groupId:artifactId` (rather than the bare `artifactId` that the
+/// local-upload path stores) keeps proxy package names globally unambiguous and
+/// lets the remote component-grouping branch reconstruct the `groupId` /
+/// `artifactId` split without consulting the storage path.
+pub(crate) fn maven_proxy_package_name(path: &str) -> Option<String> {
+    let path = path.trim_start_matches('/');
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    let lower = filename.to_ascii_lowercase();
+
+    // Checksum / signature sidecars are not packages.
+    const SKIP_SUFFIXES: [&str; 5] = [".sha1", ".md5", ".sha256", ".sha512", ".asc"];
+    if SKIP_SUFFIXES.iter().any(|s| lower.ends_with(s)) {
+        return None;
+    }
+
+    // Maven metadata index files are not packages.
+    if lower == "maven-metadata.xml" || lower.starts_with("maven-metadata.xml.") {
+        return None;
+    }
+
+    let coords = crate::formats::maven::MavenHandler::parse_coordinates(path).ok()?;
+    Some(format!("{}:{}", coords.group_id, coords.artifact_id))
+}
+
+/// Map a repository `format::text` value to the [`RepositoryFormat`] whose
+/// proxy-cached artifacts are indexed into the package catalog (#1999).
+///
+/// Only the Maven family is indexed for now; every other format (including a
+/// missing/unknown value) returns `None`, leaving the pre-fix behavior intact.
+/// Factored out of [`ProxyService::index_cached_package`] so the eligibility
+/// decision is unit-testable without a database round-trip.
+pub(crate) fn catalog_indexable_format(format_text: Option<&str>) -> Option<RepositoryFormat> {
+    match format_text {
+        Some("maven") => Some(RepositoryFormat::Maven),
+        Some("gradle") => Some(RepositoryFormat::Gradle),
+        Some("sbt") => Some(RepositoryFormat::Sbt),
+        _ => None,
+    }
+}
+
 /// Extract version from an artifact path based on the repository format.
 ///
 /// Each package format encodes the version differently in the path. This
@@ -3745,12 +3907,9 @@ impl ProxyService {
 /// for metadata files, index pages, or paths where the version cannot be
 /// determined.
 ///
-/// Currently unused: the previous caller in `cache_artifact` was removed
-/// when proxy-cached items stopped being inserted into the `artifacts`
-/// table (issue #1278). Kept around because the version-extraction logic
-/// is broadly useful and tests still exercise it; if a future cache
-/// listing/UX feature wants per-version metadata it should call this.
-#[allow(dead_code)]
+/// Called by [`ProxyService::index_cached_package`] (#1999) to populate the
+/// package catalog for proxy-cached Maven artifacts, and exercised directly by
+/// the unit tests below.
 pub(crate) fn extract_version_from_path(format: &RepositoryFormat, path: &str) -> Option<String> {
     let path = path.trim_start_matches('/');
 
@@ -5438,6 +5597,119 @@ SHA256:
             extract_version_from_path(&RepositoryFormat::Maven, "org/junit/maven-metadata.xml");
         // parse_coordinates requires 4 segments, so this returns None
         assert!(version.is_none());
+    }
+
+    // =======================================================================
+    // maven_proxy_package_name — package-catalog name derivation + skip logic
+    // for proxy-cached Maven artifacts (#1999)
+    // =======================================================================
+
+    #[test]
+    fn test_maven_proxy_package_name_jar() {
+        assert_eq!(
+            maven_proxy_package_name(
+                "org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar"
+            )
+            .as_deref(),
+            Some("org.apache.commons:commons-lang3")
+        );
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_pom() {
+        assert_eq!(
+            maven_proxy_package_name("org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom").as_deref(),
+            Some("org.junit:junit-bom")
+        );
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_leading_slash() {
+        // The cache_path may arrive with a leading slash; it must be trimmed.
+        assert_eq!(
+            maven_proxy_package_name("/org/junit/junit-bom/5.10.1/junit-bom-5.10.1.jar").as_deref(),
+            Some("org.junit:junit-bom")
+        );
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_skips_sha1() {
+        // Checksum sidecars are not packages and must NOT create a row.
+        assert!(
+            maven_proxy_package_name("org/junit/junit-bom/5.10.1/junit-bom-5.10.1.jar.sha1")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_skips_md5() {
+        assert!(
+            maven_proxy_package_name("org/junit/junit-bom/5.10.1/junit-bom-5.10.1.pom.md5")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_skips_signature_and_other_checksums() {
+        for path in [
+            "org/junit/junit-bom/5.10.1/junit-bom-5.10.1.jar.asc",
+            "org/junit/junit-bom/5.10.1/junit-bom-5.10.1.jar.sha256",
+            "org/junit/junit-bom/5.10.1/junit-bom-5.10.1.jar.sha512",
+        ] {
+            assert!(
+                maven_proxy_package_name(path).is_none(),
+                "expected {path} to be skipped"
+            );
+        }
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_skips_maven_metadata() {
+        // Version-level maven-metadata.xml (and its checksums) are index files.
+        assert!(
+            maven_proxy_package_name("org/junit/junit-bom/5.10.1/maven-metadata.xml").is_none()
+        );
+        assert!(
+            maven_proxy_package_name("org/junit/junit-bom/5.10.1/maven-metadata.xml.sha1")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_maven_proxy_package_name_skips_unparseable_path() {
+        // Too few segments to be a GAV → no package.
+        assert!(maven_proxy_package_name("org/junit/something.jar").is_none());
+    }
+
+    #[test]
+    fn test_catalog_indexable_format_maven_family() {
+        assert_eq!(
+            catalog_indexable_format(Some("maven")),
+            Some(RepositoryFormat::Maven)
+        );
+        assert_eq!(
+            catalog_indexable_format(Some("gradle")),
+            Some(RepositoryFormat::Gradle)
+        );
+        assert_eq!(
+            catalog_indexable_format(Some("sbt")),
+            Some(RepositoryFormat::Sbt)
+        );
+    }
+
+    #[test]
+    fn test_catalog_indexable_format_other_formats_not_indexed() {
+        for f in ["npm", "pypi", "docker", "generic", "cargo", "nuget"] {
+            assert!(
+                catalog_indexable_format(Some(f)).is_none(),
+                "{f} must not be catalog-indexed yet"
+            );
+        }
+    }
+
+    #[test]
+    fn test_catalog_indexable_format_missing_value() {
+        assert!(catalog_indexable_format(None).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #1999.

Proxy-cached Maven artifacts were invisible to the package catalog and to Maven
component grouping. `GET /api/v1/packages?repository_key=<proxy>` returned 0
packages and `GET /api/v1/repositories/<proxy>/artifacts?group_by=maven_component`
returned 0 components for a remote/proxy repository, even after artifacts had been
pulled (and cached) through it.

Root cause: proxy-cached artifacts are deliberately **not** written to the
`artifacts` table (#1278 / #1280 — doing so reintroduced a doubled-prefix storage
bug on filesystem backends, pinned by the meta-test
`test_cache_artifact_does_not_insert_into_artifacts_table`). The `packages` /
`package_versions` catalog, however, is populated only by the local-upload
handlers, and the proxy cache-write path ran no catalog population. So both the
catalog endpoint and the component-grouping endpoint (which read from the
`artifacts` table) came back empty for proxy repos.

This change closes the gap **without** re-inserting into the `artifacts` table:

1. **`ProxyService::index_cached_package`** (best-effort) is invoked on the
   new-cache branch only — the same gated spot as `warn_if_proxy_scan_unsupported`,
   so it fires once per new cache write and never on cache hits — for both the
   buffered and streaming proxy paths. It:
   - skips Maven checksum/signature sidecars (`.sha1`, `.md5`, `.sha256`,
     `.sha512`, `.asc`) and `maven-metadata.xml` (these are not packages);
   - derives the version via the existing `extract_version_from_path` (no version
     ⇒ no row) and the catalog name `groupId:artifactId`;
   - resolves the **real** repository format from the DB by `repository_id` (the
     proxy fetch path operates on a synthetic `Repository` whose `format` is
     always `Generic`, so the caller's format cannot be trusted) and only indexes
     Maven-family formats for now;
   - writes **only** `packages` / `package_versions` via
     `PackageService::try_create_or_update_from_artifact` (idempotent `ON CONFLICT`
     upsert), so a second pull of the same GAV (cache hit) does not double the
     catalog;
   - is best-effort: an indexing failure is swallowed/logged and never fails the
     client's proxy fetch. The helper contains no `INSERT INTO artifacts`, so the
     #1278 meta-test stays green.

2. **`list_artifacts` component grouping** now routes remote/proxy + Maven
   grouping through the package catalog (reconstructing `MavenComponentResponse`
   rows from `packages` for the repo), instead of the `artifacts`-table query that
   is always empty for proxy repos. Hosted / local / virtual grouping is
   unchanged.

No migration. Backfill of artifacts cached **before** this change is **lazy**:
each item is re-indexed on its next pull after TTL expiry. A follow-up reindex
ticket should be filed if operators want immediate backfill of historical cache
entries — a SQL backfill is not possible here because the version lives in the
storage path, not in any table.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New unit tests:
- `maven_proxy_package_name` — `groupId:artifactId` derivation, leading-slash
  trimming, and skip logic for `.sha1` / `.md5` / `.sha256` / `.sha512` / `.asc`
  sidecars, `maven-metadata.xml` (+ its checksum), and unparseable paths.
- `catalog_indexable_format` — Maven-family maps to a format; other/missing
  formats are not indexed.
- `split_maven_catalog_name` / `paginate_maven_components` — catalog → component
  reconstruction and pagination math (shared by hosted and proxy grouping paths).
- Existing `test_cache_artifact_does_not_insert_into_artifacts_table` (#1278
  meta-test) continues to pass.

Manual end-to-end validation against a Maven remote/proxy repo (upstream
maven-central), pulling `org.apache.commons:commons-lang3:3.12.0`:
- before: `GET /api/v1/packages?repository_key=<proxy>` = 0, grouping = 0;
- after pulling pom + jar: packages = 1, components = 1, search matches;
- pulling the `.jar.sha1` sidecar and `maven-metadata.xml` adds **no** package row;
- a second pull of the same jar (cache hit) returns 200 (not 500, preserving
  #1278) and does **not** double the package count;
- local/hosted Maven publish still groups via the `artifacts` table (one
  component with both files), unchanged.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

The existing `MavenComponentResponse` / `PackageResponse` shapes are reused; no
new endpoints, request/response types, or migrations.
