### PR TITLE
fix(scanner): scan local OCI images with Grype without internal registry auth

### DIFF
--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -1763,6 +1763,130 @@ mod tests {
         fx.teardown().await;
     }
 
+    #[tokio::test]
+    async fn test_prepare_local_oci_layout_returns_none_without_db_context() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let mut artifact = make_test_artifact(
+            "alpine:3.20",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "v2/alpine/manifests/3.20",
+        );
+        artifact.repository_id = fx.repo_id;
+        artifact.checksum_sha256 =
+            "d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068".to_string();
+        let scanner = GrypeScanner::new(
+            fx.storage_dir
+                .join("grype-layout-test-no-db")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let target = ScanTarget {
+            artifact: &artifact,
+            repository_key: "docker-local",
+            repository_type: "local",
+            db: None,
+            storage: Some(fx.state.storage.as_ref()),
+        };
+
+        let manifest = Bytes::from_static(
+            br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#,
+        );
+
+        assert!(scanner
+            .prepare_local_oci_layout(&artifact, &target, &manifest)
+            .await
+            .expect("layout preparation should not error")
+            .is_none());
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_prepare_local_oci_layout_returns_none_without_storage_context() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "docker").await else {
+            return;
+        };
+
+        let manifest_hex = "d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068";
+        let config_digest =
+            "sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4";
+        let layer_digest =
+            "sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78";
+        let manifest_digest = format!("sha256:{manifest_hex}");
+        let config_key = format!("oci-blobs/{config_digest}");
+        let layer_key = format!("oci-blobs/{layer_digest}");
+
+        sqlx::query(
+            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(fx.repo_id)
+        .bind(config_digest)
+        .bind(24_i64)
+        .bind(&config_key)
+        .execute(&fx.pool)
+        .await
+        .expect("insert config blob row");
+        sqlx::query(
+            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(fx.repo_id)
+        .bind(layer_digest)
+        .bind(11_i64)
+        .bind(&layer_key)
+        .execute(&fx.pool)
+        .await
+        .expect("insert layer blob row");
+        sqlx::query(
+            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind) VALUES ($1,$2,$3,'config'), ($1,$4,$3,'layer')",
+        )
+        .bind(&manifest_digest)
+        .bind(config_digest)
+        .bind(fx.repo_id)
+        .bind(layer_digest)
+        .execute(&fx.pool)
+        .await
+        .expect("insert manifest blob refs");
+
+        let mut artifact = make_test_artifact(
+            "alpine:3.20",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "v2/alpine/manifests/3.20",
+        );
+        artifact.repository_id = fx.repo_id;
+        artifact.checksum_sha256 = manifest_hex.to_string();
+        let scanner = GrypeScanner::new(
+            fx.storage_dir
+                .join("grype-layout-test-no-storage")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        let target = ScanTarget {
+            artifact: &artifact,
+            repository_key: "docker-local",
+            repository_type: "local",
+            db: Some(&fx.pool),
+            storage: None,
+        };
+        let manifest = Bytes::from_static(
+            br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#,
+        );
+
+        assert!(scanner
+            .prepare_local_oci_layout(&artifact, &target, &manifest)
+            .await
+            .expect("layout preparation should not error")
+            .is_none());
+
+        fx.teardown().await;
+    }
+
     #[test]
     fn test_is_applicable_accepts_npm_tarball() {
         // The happy path: Grype's existing fs scan does work on lockfiles,

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -306,10 +306,7 @@ fn digest_hex(digest: &str) -> Result<&str> {
             digest
         ))
     })?;
-    if hex.is_empty()
-        || hex.len() != 64
-        || !hex.bytes().all(|b| b.is_ascii_hexdigit())
-    {
+    if hex.is_empty() || hex.len() != 64 || !hex.bytes().all(|b| b.is_ascii_hexdigit()) {
         return Err(AppError::Internal(format!(
             "Invalid sha256 digest for Grype OCI local layout: {}",
             digest
@@ -654,13 +651,15 @@ impl GrypeScanner {
         .map_err(|e| AppError::Storage(format!("Failed to write OCI layout marker: {}", e)))?;
 
         let manifest_path = blob_dir.join(digest_hex(&manifest_digest)?);
-        tokio::fs::write(&manifest_path, content).await.map_err(|e| {
-            AppError::Storage(format!(
-                "Failed to write OCI manifest blob {}: {}",
-                manifest_path.display(),
-                e
-            ))
-        })?;
+        tokio::fs::write(&manifest_path, content)
+            .await
+            .map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to write OCI manifest blob {}: {}",
+                    manifest_path.display(),
+                    e
+                ))
+            })?;
 
         for blob in blobs {
             let out_path = blob_dir.join(digest_hex(&blob.digest)?);
@@ -1144,10 +1143,7 @@ impl Scanner for GrypeScanner {
     ) -> Result<ScanOutput> {
         let artifact = target.artifact;
         if is_oci_image_artifact(artifact) {
-            if let Some(output) = self
-                .scan_oci_layout_dir(artifact, target, content)
-                .await?
-            {
+            if let Some(output) = self.scan_oci_layout_dir(artifact, target, content).await? {
                 return Ok(output);
             }
 
@@ -1659,7 +1655,10 @@ mod tests {
 
         fx.state
             .storage
-            .put(&config_key, Bytes::from_static(br#"{"architecture":"arm64"}"#))
+            .put(
+                &config_key,
+                Bytes::from_static(br#"{"architecture":"arm64"}"#),
+            )
             .await
             .expect("write config blob");
         fx.state

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -19,8 +19,10 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use futures::StreamExt;
 use serde::{Deserialize, Deserializer};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use tokio::io::AsyncWriteExt;
 use tracing::info;
 
 use crate::error::{AppError, Result};
@@ -31,6 +33,7 @@ use crate::services::scanner_service::{
     is_oci_image_artifact, join_oci_image_ref, parse_oci_manifest_path, resolve_scan_reference,
     validate_trivy_purl, ScanOutput, ScanTarget, ScanWorkspace, Scanner, VersionCache,
 };
+use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
 // Grype JSON output structures
@@ -282,6 +285,132 @@ pub struct GrypeScanner {
     cached_version: VersionCache,
 }
 
+struct LocalOciBlob {
+    digest: String,
+    storage_key: String,
+}
+
+fn artifact_digest(checksum_sha256: &str) -> String {
+    let trimmed = checksum_sha256.trim();
+    if trimmed.starts_with("sha256:") {
+        trimmed.to_string()
+    } else {
+        format!("sha256:{}", trimmed)
+    }
+}
+
+fn digest_hex(digest: &str) -> Result<&str> {
+    let hex = digest.strip_prefix("sha256:").ok_or_else(|| {
+        AppError::Internal(format!(
+            "Grype OCI local layout only supports sha256 digests, got {}",
+            digest
+        ))
+    })?;
+    if hex.is_empty()
+        || hex.len() != 64
+        || !hex.bytes().all(|b| b.is_ascii_hexdigit())
+    {
+        return Err(AppError::Internal(format!(
+            "Invalid sha256 digest for Grype OCI local layout: {}",
+            digest
+        )));
+    }
+    Ok(hex)
+}
+
+async fn fetch_local_oci_blobs(
+    target: &ScanTarget<'_>,
+    manifest_digest: &str,
+) -> Result<Vec<LocalOciBlob>> {
+    let Some(db) = target.db else {
+        tracing::debug!(
+            artifact_id = %target.artifact.id,
+            "No database context available for Grype OCI local layout; falling back to registry scan"
+        );
+        return Ok(Vec::new());
+    };
+    let rows = sqlx::query(
+        r#"
+        SELECT mbr.blob_digest, ob.storage_key
+        FROM manifest_blob_refs mbr
+        JOIN oci_blobs ob
+          ON ob.repository_id = mbr.repository_id
+         AND ob.digest = mbr.blob_digest
+        WHERE mbr.repository_id = $1
+          AND mbr.manifest_digest = $2
+        ORDER BY
+          CASE mbr.kind WHEN 'config' THEN 0 WHEN 'layer' THEN 1 ELSE 2 END,
+          mbr.blob_digest
+        "#,
+    )
+    .bind(target.artifact.repository_id)
+    .bind(manifest_digest)
+    .fetch_all(db)
+    .await
+    .map_err(|e| {
+        AppError::Database(format!(
+            "Failed to load OCI blob refs for manifest {}: {}",
+            manifest_digest, e
+        ))
+    })?;
+
+    rows.into_iter()
+        .map(|row| {
+            use sqlx::Row;
+            Ok(LocalOciBlob {
+                digest: row.try_get("blob_digest").map_err(|e| {
+                    AppError::Database(format!("Invalid OCI blob digest row: {}", e))
+                })?,
+                storage_key: row.try_get("storage_key").map_err(|e| {
+                    AppError::Database(format!("Invalid OCI blob storage key row: {}", e))
+                })?,
+            })
+        })
+        .collect()
+}
+
+async fn copy_storage_object_to_file(
+    storage: &dyn StorageBackend,
+    storage_key: &str,
+    path: &Path,
+) -> Result<()> {
+    let mut stream = storage.get_stream(storage_key).await.map_err(|e| {
+        AppError::Storage(format!(
+            "Failed to open OCI blob stream for key {}: {}",
+            storage_key, e
+        ))
+    })?;
+    let mut file = tokio::fs::File::create(path).await.map_err(|e| {
+        AppError::Storage(format!(
+            "Failed to create OCI blob file {}: {}",
+            path.display(),
+            e
+        ))
+    })?;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| {
+            AppError::Storage(format!(
+                "Stream error while materializing OCI blob {}: {}",
+                storage_key, e
+            ))
+        })?;
+        file.write_all(&chunk).await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to write OCI blob file {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+    }
+    file.flush().await.map_err(|e| {
+        AppError::Storage(format!(
+            "Failed to flush OCI blob file {}: {}",
+            path.display(),
+            e
+        ))
+    })
+}
+
 impl GrypeScanner {
     pub fn new(scan_workspace: String) -> Self {
         Self {
@@ -411,6 +540,159 @@ impl GrypeScanner {
             packages,
             scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
         })
+    }
+
+    async fn scan_oci_layout_dir(
+        &self,
+        artifact: &Artifact,
+        target: &ScanTarget<'_>,
+        content: &Bytes,
+    ) -> Result<Option<ScanOutput>> {
+        let Some(layout_dir) = self
+            .prepare_local_oci_layout(artifact, target, content)
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        let grype_target = format!("oci-dir:{}", layout_dir.to_string_lossy());
+        info!("Grype OCI local layout scan target: {}", grype_target);
+        let result = match self.run_grype_target(&grype_target).await {
+            Ok(report) => {
+                let findings = Self::convert_findings(&report);
+                let packages = Self::convert_packages(&report);
+                info!(
+                    "Grype OCI local layout scan complete for {}: {} vulnerabilities, {} components",
+                    artifact.name,
+                    findings.len(),
+                    packages.len()
+                );
+                Ok(ScanOutput {
+                    findings,
+                    packages,
+                    scan_completeness: crate::services::scanner_service::ScanCompleteness::Complete,
+                })
+            }
+            Err(e) => Err(fail_scan(
+                "Grype OCI local layout scan",
+                artifact,
+                &e,
+                &self.scan_workspace,
+                None,
+            )
+            .await),
+        };
+
+        if let Err(e) = tokio::fs::remove_dir_all(&layout_dir).await {
+            tracing::warn!(
+                path = %layout_dir.display(),
+                "Failed to clean up Grype OCI layout workspace: {}",
+                e
+            );
+        }
+
+        result.map(Some)
+    }
+
+    async fn prepare_local_oci_layout(
+        &self,
+        artifact: &Artifact,
+        target: &ScanTarget<'_>,
+        content: &Bytes,
+    ) -> Result<Option<PathBuf>> {
+        let (image_name, reference) = parse_oci_manifest_path(&artifact.path).ok_or_else(|| {
+            AppError::Internal(format!(
+                "Grype OCI local layout: invalid OCI manifest path {}",
+                artifact.path
+            ))
+        })?;
+        let manifest_digest = artifact_digest(&artifact.checksum_sha256);
+        let blobs = fetch_local_oci_blobs(target, &manifest_digest).await?;
+        if blobs.is_empty() {
+            tracing::debug!(
+                artifact_id = %artifact.id,
+                manifest_digest = %manifest_digest,
+                "No local OCI blob refs available for Grype; falling back to registry scan"
+            );
+            return Ok(None);
+        }
+        let Some(storage) = target.storage else {
+            tracing::debug!(
+                artifact_id = %artifact.id,
+                "No storage context available for Grype OCI local layout; falling back to registry scan"
+            );
+            return Ok(None);
+        };
+
+        let layout_dir = PathBuf::from(&self.scan_workspace)
+            .join("grype-oci")
+            .join(artifact.id.to_string());
+        if tokio::fs::metadata(&layout_dir).await.is_ok() {
+            tokio::fs::remove_dir_all(&layout_dir).await.map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to reset Grype OCI layout workspace {}: {}",
+                    layout_dir.display(),
+                    e
+                ))
+            })?;
+        }
+
+        let blob_dir = layout_dir.join("blobs").join("sha256");
+        tokio::fs::create_dir_all(&blob_dir).await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to create Grype OCI layout workspace {}: {}",
+                blob_dir.display(),
+                e
+            ))
+        })?;
+
+        tokio::fs::write(
+            layout_dir.join("oci-layout"),
+            br#"{"imageLayoutVersion":"1.0.0"}"#,
+        )
+        .await
+        .map_err(|e| AppError::Storage(format!("Failed to write OCI layout marker: {}", e)))?;
+
+        let manifest_path = blob_dir.join(digest_hex(&manifest_digest)?);
+        tokio::fs::write(&manifest_path, content).await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to write OCI manifest blob {}: {}",
+                manifest_path.display(),
+                e
+            ))
+        })?;
+
+        for blob in blobs {
+            let out_path = blob_dir.join(digest_hex(&blob.digest)?);
+            copy_storage_object_to_file(storage, &blob.storage_key, &out_path).await?;
+        }
+
+        let mut descriptor = serde_json::json!({
+            "mediaType": artifact.content_type,
+            "digest": manifest_digest,
+            "size": content.len(),
+            "annotations": {
+                "org.opencontainers.image.ref.name": reference,
+                "io.artifact-keeper.repository": target.repository_key,
+                "io.artifact-keeper.image": image_name,
+            }
+        });
+        if artifact.content_type.is_empty() {
+            descriptor
+                .as_object_mut()
+                .and_then(|o| o.remove("mediaType"));
+        }
+        let index = serde_json::json!({
+            "schemaVersion": 2,
+            "manifests": [descriptor],
+        });
+        let index_bytes = serde_json::to_vec(&index)
+            .map_err(|e| AppError::Internal(format!("Failed to encode OCI index: {}", e)))?;
+        tokio::fs::write(layout_dir.join("index.json"), index_bytes)
+            .await
+            .map_err(|e| AppError::Storage(format!("Failed to write OCI index: {}", e)))?;
+
+        Ok(Some(layout_dir))
     }
 
     /// Run grype against the workspace directory.
@@ -862,6 +1144,13 @@ impl Scanner for GrypeScanner {
     ) -> Result<ScanOutput> {
         let artifact = target.artifact;
         if is_oci_image_artifact(artifact) {
+            if let Some(output) = self
+                .scan_oci_layout_dir(artifact, target, content)
+                .await?
+            {
+                return Ok(output);
+            }
+
             // #1971: thread the in-hand manifest body for index→child resolution.
             let image_ref =
                 Self::oci_registry_target(artifact, target, Some(content)).ok_or_else(|| {
@@ -1275,6 +1564,8 @@ mod tests {
             artifact: &artifact,
             repository_key: "docker-repo1",
             repository_type: "local",
+            db: None,
+            storage: None,
         };
 
         // The scan dispatch resolves a routable, repository-scoped ref.
@@ -1318,6 +1609,8 @@ mod tests {
             artifact: &artifact,
             repository_key: "docker-repo1",
             repository_type: "local",
+            db: None,
+            storage: None,
         };
         assert!(
             grype().is_applicable_for_target(&target),
@@ -1334,6 +1627,141 @@ mod tests {
             ),
             "applicability and dispatch must agree on the repo-scoped ref"
         );
+    }
+
+    #[test]
+    fn test_digest_hex_accepts_only_canonical_sha256() {
+        let digest = "sha256:d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068";
+        assert_eq!(
+            digest_hex(digest).expect("valid digest"),
+            "d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068"
+        );
+        assert!(digest_hex("sha512:abc").is_err());
+        assert!(digest_hex("sha256:not-hex").is_err());
+    }
+
+    #[tokio::test]
+    async fn test_prepare_local_oci_layout_materializes_manifest_and_blobs() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "docker").await else {
+            return; // skip cleanly when no DATABASE_URL
+        };
+
+        let manifest_hex = "d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068";
+        let config_digest =
+            "sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4";
+        let layer_digest =
+            "sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78";
+        let manifest_digest = format!("sha256:{manifest_hex}");
+        let config_key = format!("oci-blobs/{config_digest}");
+        let layer_key = format!("oci-blobs/{layer_digest}");
+
+        fx.state
+            .storage
+            .put(&config_key, Bytes::from_static(br#"{"architecture":"arm64"}"#))
+            .await
+            .expect("write config blob");
+        fx.state
+            .storage
+            .put(&layer_key, Bytes::from_static(b"layer bytes"))
+            .await
+            .expect("write layer blob");
+
+        sqlx::query(
+            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(fx.repo_id)
+        .bind(config_digest)
+        .bind(24_i64)
+        .bind(&config_key)
+        .execute(&fx.pool)
+        .await
+        .expect("insert config blob row");
+        sqlx::query(
+            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(fx.repo_id)
+        .bind(layer_digest)
+        .bind(11_i64)
+        .bind(&layer_key)
+        .execute(&fx.pool)
+        .await
+        .expect("insert layer blob row");
+        sqlx::query(
+            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind) VALUES ($1,$2,$3,'config'), ($1,$4,$3,'layer')",
+        )
+        .bind(&manifest_digest)
+        .bind(config_digest)
+        .bind(fx.repo_id)
+        .bind(layer_digest)
+        .execute(&fx.pool)
+        .await
+        .expect("insert manifest blob refs");
+
+        let mut artifact = make_test_artifact(
+            "alpine:3.20",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "v2/alpine/manifests/3.20",
+        );
+        artifact.repository_id = fx.repo_id;
+        artifact.checksum_sha256 = manifest_hex.to_string();
+        let manifest = Bytes::from_static(
+            br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#,
+        );
+        let workspace = fx
+            .storage_dir
+            .join("grype-layout-test")
+            .to_string_lossy()
+            .into_owned();
+        let scanner = GrypeScanner::new(workspace);
+        let target = ScanTarget {
+            artifact: &artifact,
+            repository_key: "docker-local",
+            repository_type: "local",
+            db: Some(&fx.pool),
+            storage: Some(fx.state.storage.as_ref()),
+        };
+
+        let layout = scanner
+            .prepare_local_oci_layout(&artifact, &target, &manifest)
+            .await
+            .expect("layout materialization should succeed")
+            .expect("local blob refs should produce an OCI layout");
+
+        assert!(layout.join("oci-layout").exists());
+        assert!(layout.join("index.json").exists());
+        assert_eq!(
+            tokio::fs::read(layout.join("blobs/sha256").join(manifest_hex))
+                .await
+                .expect("read manifest"),
+            manifest.to_vec()
+        );
+        assert_eq!(
+            tokio::fs::read(
+                layout
+                    .join("blobs/sha256")
+                    .join(config_digest.trim_start_matches("sha256:"))
+            )
+            .await
+            .expect("read config"),
+            br#"{"architecture":"arm64"}"#
+        );
+        assert_eq!(
+            tokio::fs::read(
+                layout
+                    .join("blobs/sha256")
+                    .join(layer_digest.trim_start_matches("sha256:"))
+            )
+            .await
+            .expect("read layer"),
+            b"layer bytes"
+        );
+
+        tokio::fs::remove_dir_all(&layout)
+            .await
+            .expect("cleanup layout");
+        fx.teardown().await;
     }
 
     #[test]

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -31,8 +31,10 @@ use crate::models::security::{RawFinding, RawPackage, Severity};
 use crate::services::scanner_service::{
     cached_cli_version, capture_cli_version, fail_scan, format_grype_version,
     is_oci_image_artifact, join_oci_image_ref, parse_oci_manifest_path, resolve_scan_reference,
-    validate_trivy_purl, ScanOutput, ScanTarget, ScanWorkspace, Scanner, VersionCache,
+    validate_trivy_purl, ScanOutput, ScanReferenceResolution, ScanTarget, ScanWorkspace, Scanner,
+    VersionCache,
 };
+use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
 use crate::storage::StorageBackend;
 
 // ---------------------------------------------------------------------------
@@ -288,6 +290,18 @@ pub struct GrypeScanner {
 struct LocalOciBlob {
     digest: String,
     storage_key: String,
+}
+
+/// The concrete single-platform image manifest a local OCI layout is built
+/// from. For a single-arch artifact this is the artifact's own manifest; for
+/// an image index it is the resolved child-platform manifest (#2053).
+struct LayoutManifest {
+    /// `sha256:...` digest of the manifest the layout's `index.json` points at.
+    digest: String,
+    /// The manifest body written as the layout's referenced manifest blob.
+    body: Bytes,
+    /// `mediaType` for the layout descriptor (empty ⇒ omitted).
+    media_type: String,
 }
 
 fn artifact_digest(checksum_sha256: &str) -> String {
@@ -591,6 +605,93 @@ impl GrypeScanner {
         result.map(Some)
     }
 
+    /// Resolve the concrete single-platform image manifest the local OCI
+    /// layout should be built from.
+    ///
+    /// For a single-arch image manifest the artifact's own manifest digest and
+    /// in-hand body are used directly (`mediaType` from `artifact.content_type`).
+    ///
+    /// For an image **index** / manifest list (#2053 follow-up), the artifact's
+    /// own manifest digest has no `manifest_blob_refs` rows (per migration 120,
+    /// only image manifests record config+layer edges), so the local-layout
+    /// path previously gave up and fell back to the broken `registry:` scan.
+    /// Instead we reuse [`resolve_scan_reference`] to pick a concrete scannable
+    /// child-platform digest, load that child manifest body from its
+    /// `oci-manifests/<digest>` storage key, and build the layout from the
+    /// **child** manifest (whose config+layer edges DO exist). The child
+    /// manifest body itself becomes the layout's single referenced manifest.
+    ///
+    /// Returns `None` when the index cannot be resolved to a local child
+    /// manifest (no storage context, missing child body), so the caller keeps
+    /// the existing `registry:` fallback.
+    async fn resolve_layout_manifest(
+        &self,
+        artifact: &Artifact,
+        target: &ScanTarget<'_>,
+        reference: &str,
+        content: &Bytes,
+    ) -> Result<Option<LayoutManifest>> {
+        let artifact_manifest_digest = artifact_digest(&artifact.checksum_sha256);
+
+        // Single-arch / malformed / non-index bodies pass through unchanged so
+        // the dominant path is byte-for-byte identical to before.
+        let child_digest = match resolve_scan_reference(content, reference) {
+            ScanReferenceResolution::ResolvedIndexChild(digest) => digest,
+            ScanReferenceResolution::Passthrough(_)
+            | ScanReferenceResolution::UnresolvableIndex(_) => {
+                return Ok(Some(LayoutManifest {
+                    digest: artifact_manifest_digest,
+                    body: content.clone(),
+                    media_type: artifact.content_type.clone(),
+                }));
+            }
+        };
+
+        // The body is an image index. The child manifest is stored under its
+        // own `oci-manifests/<digest>` key with its config+layer edges recorded
+        // in `manifest_blob_refs`; load that body and build the layout from it.
+        let Some(storage) = target.storage else {
+            tracing::debug!(
+                artifact_id = %artifact.id,
+                "No storage context available to resolve OCI index child for Grype; falling back to registry scan"
+            );
+            return Ok(None);
+        };
+        // Validate the child digest shape before using it in a storage key.
+        digest_hex(&child_digest)?;
+        let child_key = format!("{}{}", OCI_MANIFEST_STORAGE_PREFIX, child_digest);
+        let child_body = match storage.get(&child_key).await {
+            Ok(body) => body,
+            Err(e) => {
+                tracing::debug!(
+                    artifact_id = %artifact.id,
+                    child_digest = %child_digest,
+                    "OCI index child manifest unavailable from local storage ({}); falling back to registry scan",
+                    e
+                );
+                return Ok(None);
+            }
+        };
+
+        // Prefer the child manifest's own declared mediaType; fall back to the
+        // generic OCI image manifest type so the oci-dir descriptor is valid.
+        let media_type = serde_json::from_slice::<serde_json::Value>(&child_body)
+            .ok()
+            .and_then(|v| {
+                v.get("mediaType")
+                    .and_then(|m| m.as_str())
+                    .map(|s| s.to_string())
+            })
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "application/vnd.oci.image.manifest.v1+json".to_string());
+
+        Ok(Some(LayoutManifest {
+            digest: child_digest,
+            body: child_body,
+            media_type,
+        }))
+    }
+
     async fn prepare_local_oci_layout(
         &self,
         artifact: &Artifact,
@@ -603,7 +704,15 @@ impl GrypeScanner {
                 artifact.path
             ))
         })?;
-        let manifest_digest = artifact_digest(&artifact.checksum_sha256);
+        let Some(layout_manifest) = self
+            .resolve_layout_manifest(artifact, target, reference, content)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let manifest_digest = layout_manifest.digest;
+        let manifest_body = layout_manifest.body;
+        let manifest_media_type = layout_manifest.media_type;
         let blobs = fetch_local_oci_blobs(target, &manifest_digest).await?;
         if blobs.is_empty() {
             tracing::debug!(
@@ -651,7 +760,7 @@ impl GrypeScanner {
         .map_err(|e| AppError::Storage(format!("Failed to write OCI layout marker: {}", e)))?;
 
         let manifest_path = blob_dir.join(digest_hex(&manifest_digest)?);
-        tokio::fs::write(&manifest_path, content)
+        tokio::fs::write(&manifest_path, &manifest_body)
             .await
             .map_err(|e| {
                 AppError::Storage(format!(
@@ -667,16 +776,16 @@ impl GrypeScanner {
         }
 
         let mut descriptor = serde_json::json!({
-            "mediaType": artifact.content_type,
+            "mediaType": manifest_media_type,
             "digest": manifest_digest,
-            "size": content.len(),
+            "size": manifest_body.len(),
             "annotations": {
                 "org.opencontainers.image.ref.name": reference,
                 "io.artifact-keeper.repository": target.repository_key,
                 "io.artifact-keeper.image": image_name,
             }
         });
-        if artifact.content_type.is_empty() {
+        if manifest_media_type.is_empty() {
             descriptor
                 .as_object_mut()
                 .and_then(|o| o.remove("mediaType"));
@@ -1172,6 +1281,76 @@ mod tests {
         make_test_artifact(name, content_type, &format!("test/{}", name))
     }
 
+    /// Canonical config/layer digests reused by the local-OCI-layout tests.
+    const TEST_CONFIG_DIGEST: &str =
+        "sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4";
+    const TEST_LAYER_DIGEST: &str =
+        "sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78";
+    /// A single-arch image manifest body referencing the two digests above.
+    const TEST_IMAGE_MANIFEST: &[u8] = br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#;
+
+    /// Insert the `oci_blobs` rows (config + layer) and the `manifest_blob_refs`
+    /// edges that link them to `manifest_digest`, scoped to `repo_id`. The
+    /// three `#[tokio::test]` layout cases share this setup verbatim; factoring
+    /// it keeps the duplicated SQL out of jscpd's reach.
+    async fn insert_image_manifest_refs(
+        pool: &sqlx::PgPool,
+        repo_id: uuid::Uuid,
+        manifest_digest: &str,
+    ) {
+        let config_key = format!("oci-blobs/{TEST_CONFIG_DIGEST}");
+        let layer_key = format!("oci-blobs/{TEST_LAYER_DIGEST}");
+        sqlx::query(
+            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(repo_id)
+        .bind(TEST_CONFIG_DIGEST)
+        .bind(24_i64)
+        .bind(&config_key)
+        .execute(pool)
+        .await
+        .expect("insert config blob row");
+        sqlx::query(
+            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
+        )
+        .bind(repo_id)
+        .bind(TEST_LAYER_DIGEST)
+        .bind(11_i64)
+        .bind(&layer_key)
+        .execute(pool)
+        .await
+        .expect("insert layer blob row");
+        sqlx::query(
+            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind) VALUES ($1,$2,$3,'config'), ($1,$4,$3,'layer')",
+        )
+        .bind(manifest_digest)
+        .bind(TEST_CONFIG_DIGEST)
+        .bind(repo_id)
+        .bind(TEST_LAYER_DIGEST)
+        .execute(pool)
+        .await
+        .expect("insert manifest blob refs");
+    }
+
+    /// Write the config + layer blob bodies into `storage` under their
+    /// `oci-blobs/<digest>` keys (companion to [`insert_image_manifest_refs`]).
+    async fn put_image_blob_bodies(storage: &dyn StorageBackend) {
+        storage
+            .put(
+                &format!("oci-blobs/{TEST_CONFIG_DIGEST}"),
+                Bytes::from_static(br#"{"architecture":"arm64"}"#),
+            )
+            .await
+            .expect("write config blob");
+        storage
+            .put(
+                &format!("oci-blobs/{TEST_LAYER_DIGEST}"),
+                Bytes::from_static(b"layer bytes"),
+            )
+            .await
+            .expect("write layer blob");
+    }
+
     // -----------------------------------------------------------------------
     // is_applicable: #1160. OCI / Docker image manifests now route through
     // `grype registry:` mode against artifact-keeper's own registry, so
@@ -1645,58 +1824,12 @@ mod tests {
         };
 
         let manifest_hex = "d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068";
-        let config_digest =
-            "sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4";
-        let layer_digest =
-            "sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78";
+        let config_digest = TEST_CONFIG_DIGEST;
+        let layer_digest = TEST_LAYER_DIGEST;
         let manifest_digest = format!("sha256:{manifest_hex}");
-        let config_key = format!("oci-blobs/{config_digest}");
-        let layer_key = format!("oci-blobs/{layer_digest}");
 
-        fx.state
-            .storage
-            .put(
-                &config_key,
-                Bytes::from_static(br#"{"architecture":"arm64"}"#),
-            )
-            .await
-            .expect("write config blob");
-        fx.state
-            .storage
-            .put(&layer_key, Bytes::from_static(b"layer bytes"))
-            .await
-            .expect("write layer blob");
-
-        sqlx::query(
-            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
-        )
-        .bind(fx.repo_id)
-        .bind(config_digest)
-        .bind(24_i64)
-        .bind(&config_key)
-        .execute(&fx.pool)
-        .await
-        .expect("insert config blob row");
-        sqlx::query(
-            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
-        )
-        .bind(fx.repo_id)
-        .bind(layer_digest)
-        .bind(11_i64)
-        .bind(&layer_key)
-        .execute(&fx.pool)
-        .await
-        .expect("insert layer blob row");
-        sqlx::query(
-            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind) VALUES ($1,$2,$3,'config'), ($1,$4,$3,'layer')",
-        )
-        .bind(&manifest_digest)
-        .bind(config_digest)
-        .bind(fx.repo_id)
-        .bind(layer_digest)
-        .execute(&fx.pool)
-        .await
-        .expect("insert manifest blob refs");
+        put_image_blob_bodies(fx.state.storage.as_ref()).await;
+        insert_image_manifest_refs(&fx.pool, fx.repo_id, &manifest_digest).await;
 
         let mut artifact = make_test_artifact(
             "alpine:3.20",
@@ -1705,9 +1838,7 @@ mod tests {
         );
         artifact.repository_id = fx.repo_id;
         artifact.checksum_sha256 = manifest_hex.to_string();
-        let manifest = Bytes::from_static(
-            br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#,
-        );
+        let manifest = Bytes::from_static(TEST_IMAGE_MANIFEST);
         let workspace = fx
             .storage_dir
             .join("grype-layout-test")
@@ -1763,6 +1894,115 @@ mod tests {
         fx.teardown().await;
     }
 
+    /// #2053 follow-up: a multi-arch image **index** artifact has no
+    /// `manifest_blob_refs` rows under its own digest, so the local-layout
+    /// path must resolve the index to its concrete child-platform manifest
+    /// (whose config+layer edges DO exist), materialize the child layout, and
+    /// scan locally instead of falling back to the `registry:` path. Before
+    /// this fix the index case returned `None` and regressed to the broken
+    /// authenticated `registry:` scan (UNAUTHORIZED).
+    #[tokio::test]
+    async fn test_prepare_local_oci_layout_resolves_index_to_child_layout() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "docker").await else {
+            return; // skip cleanly when no DATABASE_URL
+        };
+
+        // The child (per-arch) image manifest the index points at. Its digest
+        // is what `manifest_blob_refs` is keyed on, NOT the index digest.
+        let child_hex = "1111111111111111111111111111111111111111111111111111111111111111";
+        let child_digest = format!("sha256:{child_hex}");
+        let child_body = Bytes::from_static(TEST_IMAGE_MANIFEST);
+        let child_key = format!("oci-manifests/{child_digest}");
+
+        // The index/manifest-list body the artifact itself stores. It carries
+        // no blobs of its own — only child references.
+        let index_hex = "2222222222222222222222222222222222222222222222222222222222222222";
+        let index_body = Bytes::from(format!(
+            r#"{{"schemaVersion":2,"mediaType":"application/vnd.oci.image.index.v1+json","manifests":[{{"mediaType":"application/vnd.oci.image.manifest.v1+json","digest":"{child_digest}","platform":{{"os":"linux","architecture":"{arch}"}}}}]}}"#,
+            arch = crate::services::scanner_service::runner_arch(),
+        ));
+
+        // Child manifest body lives under its oci-manifests/<digest> key; its
+        // config+layer blobs and edges are recorded against the CHILD digest.
+        fx.state
+            .storage
+            .put(&child_key, child_body.clone())
+            .await
+            .expect("write child manifest");
+        put_image_blob_bodies(fx.state.storage.as_ref()).await;
+        insert_image_manifest_refs(&fx.pool, fx.repo_id, &child_digest).await;
+
+        let mut artifact = make_test_artifact(
+            "alpine:3.20",
+            "application/vnd.oci.image.index.v1+json",
+            "v2/alpine/manifests/3.20",
+        );
+        artifact.repository_id = fx.repo_id;
+        artifact.checksum_sha256 = index_hex.to_string();
+
+        let workspace = fx
+            .storage_dir
+            .join("grype-layout-index-test")
+            .to_string_lossy()
+            .into_owned();
+        let scanner = GrypeScanner::new(workspace);
+        let target = ScanTarget {
+            artifact: &artifact,
+            repository_key: "docker-local",
+            repository_type: "local",
+            db: Some(&fx.pool),
+            storage: Some(fx.state.storage.as_ref()),
+        };
+
+        let layout = scanner
+            .prepare_local_oci_layout(&artifact, &target, &index_body)
+            .await
+            .expect("index layout materialization should succeed")
+            .expect("index should resolve to a local child layout, not registry fallback");
+
+        assert!(layout.join("oci-layout").exists());
+        assert!(layout.join("index.json").exists());
+        // The materialized manifest blob is the CHILD manifest (by child digest),
+        // not the index body.
+        assert_eq!(
+            tokio::fs::read(layout.join("blobs/sha256").join(child_hex))
+                .await
+                .expect("read child manifest"),
+            child_body.to_vec()
+        );
+        assert!(
+            tokio::fs::metadata(layout.join("blobs/sha256").join(index_hex))
+                .await
+                .is_err(),
+            "index manifest body must not be written as the scannable manifest"
+        );
+        // index.json points at the child manifest digest, so Grype scans a
+        // valid single-platform oci-dir.
+        let index_json: serde_json::Value =
+            serde_json::from_slice(&tokio::fs::read(layout.join("index.json")).await.unwrap())
+                .expect("parse layout index.json");
+        assert_eq!(
+            index_json["manifests"][0]["digest"].as_str(),
+            Some(child_digest.as_str())
+        );
+        // Child config + layer blobs were materialized from the child's edges.
+        assert!(layout
+            .join("blobs/sha256")
+            .join(TEST_CONFIG_DIGEST.trim_start_matches("sha256:"))
+            .exists());
+        assert!(layout
+            .join("blobs/sha256")
+            .join(TEST_LAYER_DIGEST.trim_start_matches("sha256:"))
+            .exists());
+
+        tokio::fs::remove_dir_all(&layout)
+            .await
+            .expect("cleanup layout");
+        fx.teardown().await;
+    }
+
     #[tokio::test]
     async fn test_prepare_local_oci_layout_returns_none_without_db_context() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -1793,9 +2033,7 @@ mod tests {
             storage: Some(fx.state.storage.as_ref()),
         };
 
-        let manifest = Bytes::from_static(
-            br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#,
-        );
+        let manifest = Bytes::from_static(TEST_IMAGE_MANIFEST);
 
         assert!(scanner
             .prepare_local_oci_layout(&artifact, &target, &manifest)
@@ -1815,44 +2053,9 @@ mod tests {
         };
 
         let manifest_hex = "d10bea758e065a0cbf1f2d524b90b30a2ef986bdb4294fe9dbdb5fa59174b068";
-        let config_digest =
-            "sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4";
-        let layer_digest =
-            "sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78";
         let manifest_digest = format!("sha256:{manifest_hex}");
-        let config_key = format!("oci-blobs/{config_digest}");
-        let layer_key = format!("oci-blobs/{layer_digest}");
 
-        sqlx::query(
-            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
-        )
-        .bind(fx.repo_id)
-        .bind(config_digest)
-        .bind(24_i64)
-        .bind(&config_key)
-        .execute(&fx.pool)
-        .await
-        .expect("insert config blob row");
-        sqlx::query(
-            "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1,$2,$3,$4)",
-        )
-        .bind(fx.repo_id)
-        .bind(layer_digest)
-        .bind(11_i64)
-        .bind(&layer_key)
-        .execute(&fx.pool)
-        .await
-        .expect("insert layer blob row");
-        sqlx::query(
-            "INSERT INTO manifest_blob_refs (manifest_digest, blob_digest, repository_id, kind) VALUES ($1,$2,$3,'config'), ($1,$4,$3,'layer')",
-        )
-        .bind(&manifest_digest)
-        .bind(config_digest)
-        .bind(fx.repo_id)
-        .bind(layer_digest)
-        .execute(&fx.pool)
-        .await
-        .expect("insert manifest blob refs");
+        insert_image_manifest_refs(&fx.pool, fx.repo_id, &manifest_digest).await;
 
         let mut artifact = make_test_artifact(
             "alpine:3.20",
@@ -1874,9 +2077,7 @@ mod tests {
             db: Some(&fx.pool),
             storage: None,
         };
-        let manifest = Bytes::from_static(
-            br#"{"schemaVersion":2,"config":{"digest":"sha256:ab3fe4defd29ba6231229a4d41440ac8bde8218e85870e53876277faa24b35c4"},"layers":[{"digest":"sha256:3f26bc2dec0b515f1c2818f6e13a8f1da1f88179a008445d4e587233386bff78"}]}"#,
-        );
+        let manifest = Bytes::from_static(TEST_IMAGE_MANIFEST);
 
         assert!(scanner
             .prepare_local_oci_layout(&artifact, &target, &manifest)

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -947,6 +947,8 @@ mod tests {
             artifact: &artifact,
             repository_key: "docker-local",
             repository_type: "local",
+            db: None,
+            storage: None,
         };
 
         let result = scanner.scan_target(&target, None, &Bytes::new()).await;

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -1400,10 +1400,15 @@ fn extract_tar_gz_safe(content: &[u8], target: &Path) -> Result<()> {
 /// `Artifact::path` is repository-internal. Scanners that need an externally
 /// routable identity (currently Grype's OCI `registry:` mode) must use the
 /// repository fields from this context instead of guessing from the path.
+/// Scanners may also use the optional database/storage handles to inspect
+/// repository-local artifact state without re-entering the public registry
+/// route.
 pub struct ScanTarget<'a> {
     pub artifact: &'a Artifact,
     pub repository_key: &'a str,
     pub repository_type: &'a str,
+    pub db: Option<&'a PgPool>,
+    pub storage: Option<&'a dyn StorageBackend>,
 }
 
 /// A pluggable vulnerability scanner.
@@ -2902,7 +2907,10 @@ impl ScannerService {
         // Load content from storage (we need the storage key)
         // NOTE: The orchestrator is called with content already available in
         // upload/proxy paths. For on-demand scans, we fetch from DB metadata.
-        let content = self.fetch_artifact_content(&artifact).await?;
+        let storage = self.resolve_repo_storage(artifact.repository_id).await?;
+        let content = self
+            .fetch_artifact_content_from_storage(&artifact, storage.as_ref())
+            .await?;
 
         // Load metadata if available
         let metadata = sqlx::query_as!(
@@ -2925,6 +2933,8 @@ impl ScannerService {
             artifact: &artifact,
             repository_key: &repository_key,
             repository_type: &repository_type,
+            db: Some(&self.db),
+            storage: Some(storage.as_ref()),
         };
 
         for scanner in &self.scanners {
@@ -3670,7 +3680,11 @@ impl ScannerService {
     /// streaming reads for those backends is tracked separately by #1430 and
     /// #1431 (GCS `get_stream`); this fix deliberately does not expand into
     /// that work.
-    async fn fetch_artifact_content(&self, artifact: &Artifact) -> Result<Bytes> {
+    async fn fetch_artifact_content_from_storage(
+        &self,
+        artifact: &Artifact,
+        storage: &dyn StorageBackend,
+    ) -> Result<Bytes> {
         // Early reject using the recorded size before we open the stream. The
         // streaming loop below re-checks against the same ceiling because
         // `size_bytes` can be stale or wrong for proxied/upstream content.
@@ -3681,9 +3695,8 @@ impl ScannerService {
             )));
         }
 
-        let storage = self.resolve_repo_storage(artifact.repository_id).await?;
         Self::stage_from_storage(
-            storage.as_ref(),
+            storage,
             &artifact.storage_key,
             &self.scan_workspace_path,
         )
@@ -11381,6 +11394,8 @@ mod tests {
             artifact: &artifact,
             repository_key: "docker-local",
             repository_type: "local",
+            db: None,
+            storage: None,
         };
 
         assert!(scanner.is_applicable_for_target(&target));
@@ -11402,6 +11417,8 @@ mod tests {
             artifact: &artifact,
             repository_key: "docker-local",
             repository_type: "local",
+            db: None,
+            storage: None,
         };
 
         assert!(scanner.is_applicable_for_target(&target));

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -3695,21 +3695,17 @@ impl ScannerService {
             )));
         }
 
-        Self::stage_from_storage(
-            storage,
-            &artifact.storage_key,
-            &self.scan_workspace_path,
-        )
-        .await
-        .map_err(|e| match e {
-            // Preserve the validation/size-cap variant; only wrap raw
-            // storage/stream-open failures with artifact context.
-            AppError::Storage(msg) => AppError::Storage(format!(
-                "Failed to stage artifact {} (key={}): {}",
-                artifact.id, artifact.storage_key, msg
-            )),
-            other => other,
-        })
+        Self::stage_from_storage(storage, &artifact.storage_key, &self.scan_workspace_path)
+            .await
+            .map_err(|e| match e {
+                // Preserve the validation/size-cap variant; only wrap raw
+                // storage/stream-open failures with artifact context.
+                AppError::Storage(msg) => AppError::Storage(format!(
+                    "Failed to stage artifact {} (key={}): {}",
+                    artifact.id, artifact.storage_key, msg
+                )),
+                other => other,
+            })
     }
 
     /// Open a streaming read from `storage` for `key` and stage it for scanning.


### PR DESCRIPTION
## Summary

Fixes Grype scans for OCI images stored in Artifact Keeper local Docker repositories by materializing a temporary OCI image layout in the scan workspace and scanning that local layout instead of forcing Grype through Artifact Keeper's authenticated `/v2/...` registry endpoint.

Fixes #2053.

## Problem

When Artifact Keeper scanned an OCI image stored in its own local Docker repository, Grype was invoked against an internal registry reference such as:

```text
registry:localhost:8080/docker-local/alpine:3.20
```

That made Grype call Artifact Keeper's registry endpoint directly:

```text
GET /v2/docker-local/alpine/manifests/3.20
```

Because that request did not include Artifact Keeper credentials, the scan failed with:

```text
UNAUTHORIZED: authentication required
```

## Change

- Thread the scanner service's repository storage backend and database pool into `ScanTarget`.
- For Grype OCI scans, first try to materialize a temporary OCI layout under the scan workspace:
  - `oci-layout`
  - `index.json`
  - `blobs/sha256/<manifest-digest>`
  - referenced config/layer blobs from `manifest_blob_refs` joined to `oci_blobs`
- Invoke Grype with `oci-dir:<layout-path>` when the local OCI blob references are available.
- Preserve the existing registry scan behavior as a fallback when local OCI blob metadata/storage context is unavailable.
- Add regression coverage for digest validation and local OCI layout materialization.

## Validation

Pre-fix reproduction on current main:

- Started the local Docker Compose development stack.
- Created a private local Docker repository named `docker-local`.
- Pushed `alpine:3.20` to `localhost:8080/docker-local/alpine:3.20`.
- Triggered a Grype scan for artifact `3131097b-e69d-4527-8f75-a6f3f407d971`.
- Observed Grype fail through the internal registry endpoint:

```text
Grype OCI registry scan target: registry:localhost:8080/docker-local/alpine:3.20
GET /v2/docker-local/alpine/manifests/3.20
UNAUTHORIZED: authentication required
```

Build validation during the patching session:

- Rebuilt the backend in the Docker Compose dev container after the local OCI layout implementation.
- Backend compiled and started successfully at that point.
- Confirmed Grype scanner initialization in backend startup logs.
- After a final robustness/doc cleanup, Docker stopped responding before another rebuild could be captured.

Post-fix scan validation:

- Grype `0.114.0` and its vulnerability DB were copied into the source-built backend container.
- The same artifact was still present:

```text
3131097b-e69d-4527-8f75-a6f3f407d971 | alpine:3.20 | v2/alpine/manifests/3.20
```

- The Grype DB needed to be mirrored to `/app/.cache/grype/db/6` in the source-built backend container so the bundled Grype binary could validate it.
- The post-fix scan completed successfully:

```text
Grype OCI local layout scan target: oci-dir:/scan-workspace/grype-oci/3131097b-e69d-4527-8f75-a6f3f407d971
Grype OCI local layout scan complete for alpine:3.20: 3 vulnerabilities, 3 components
Scan grype completed for artifact 3131097b-e69d-4527-8f75-a6f3f407d971: 3 findings (0 critical, 0 high), scanner_version=Some("grype-0.114.0"), completeness=complete
```

- The scan results table now shows the Grype row as `completed`.
- The backend log no longer shows the internal registry auth failure for this scan.

Commands attempted:

```text
cargo fmt
cargo test grype_scanner --lib
```

Notes:

- Host `cargo` and `rustfmt` were not installed.
- Earlier container test compilation was interrupted by target locking/memory pressure in the source-built dev container.
- The final Docker Compose backend rebuild completed successfully after the patch, and the post-fix scan is now confirmed passing.
