### PR TITLE
chore(docker): harden backend runtime image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,43 +1,47 @@
-# .trivyignore — residual CVEs in the BUNDLED scanner CLI binaries only.
+# .trivyignore — residual CVEs in the BUNDLED grype scanner CLI binary only.
 #
 # Scope and honesty notes (read before adding anything here):
 #
-# * Every entry below is a Go-dependency CVE compiled INTO one of the two
-#   vendored scanner CLIs that the backend ships and invokes for OFFLINE
-#   artifact scanning:
-#     - /usr/local/bin/trivy  (ghcr.io/aquasecurity/trivy:0.71.2)
+# * Every entry below is a Go-dependency CVE compiled INTO the one vendored
+#   scanner CLI that the backend still ships and invokes for OFFLINE artifact
+#   scanning:
 #     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.114.0)
-#   These are short-lived CLI subprocesses the server shells out to. They are
-#   NOT part of the network-reachable service surface (axum HTTP :8080 /
-#   gRPC :9090). The vulnerable code paths (docker/containerd client libs,
-#   golang.org/x/net HTTP/2 server, etc.) are not exercised by how the backend
-#   drives these tools.
+#   This is a short-lived CLI subprocess the server shells out to. It is NOT
+#   part of the network-reachable service surface (axum HTTP :8080 / gRPC
+#   :9090). The vulnerable code paths (docker client libs, golang.org/x/net
+#   HTTP/2 server, etc.) are not exercised by how the backend drives grype.
+#
+# * The trivy CLI is NO LONGER bundled in the runtime image (issue #1544): the
+#   backend drives Trivy in server mode against the trivy sidecar (TRIVY_URL)
+#   with a pure-HTTP Twirp fallback, so the in-image binary was dead weight.
+#   The trivy-binary containerd CVE suppressions that used to live here have
+#   been removed accordingly — there is no longer a trivy binary in the image
+#   for them to apply to.
 #
 # * These are deliberately NOT suppressed in the backend service binary or in
 #   the UBI/Alpine base OS packages. Only vendored-scanner-binary CVEs that have
 #   no fixed *tool release* are listed here.
 #
-# * We are already on the latest upstream releases of both tools:
-#     - trivy 0.71.2 (bumped from 0.71.0 in this change — cleared the
-#       golang.org/x/net + Go stdlib CVEs the 0.71.0 binary carried).
-#     - grype v0.114.0 (latest; no newer build exists yet).
-#   For the CVEs below, either no fixed tool release exists yet, or the upstream
-#   dependency fix has not landed in a tagged release of the tool. They will
-#   drop off automatically when we bump the tool to a release that rebuilds
-#   against the fixed dependency — re-evaluate on every scanner bump.
+# * Grype is pinned to v0.114.0 (latest; no newer build exists yet). For the
+#   CVEs below, either no fixed tool release exists yet, or the upstream
+#   dependency fix has not landed in a tagged release. They will drop off
+#   automatically when grype ships a release rebuilt against the fixed
+#   dependency — re-evaluate on every scanner bump.
 #
 # * CI scans with `ignore-unfixed: true`, so the genuinely no-fix-available
 #   entries below already don't alert; they are listed for completeness and so
 #   future maintainers see the full residual set in one place.
 #
-# Trivy tracker: https://github.com/aquasecurity/trivy/releases
 # Grype tracker: https://github.com/anchore/grype/releases
 
 # ---------------------------------------------------------------------------
-# trivy 0.71.2 binary — github.com/containerd/containerd/v2 @ v2.3.1
-# containerd has fixed releases (2.3.2) but trivy 0.71.2 has not yet rebuilt
-# against them. Code path: trivy's container image inspection client; not used
-# in a way reachable by the backend's offline artifact scans.
+# grype v0.114.0 binary — github.com/containerd/containerd/v2 @ v2.3.1
+# containerd has fixed releases (2.3.2 etc.) but grype v0.114.0 (latest) has not
+# yet rebuilt against them. Code path: containerd's image/snapshotter client
+# pulled in transitively by grype's OCI source handling; the backend invokes
+# grype against on-disk artifacts/SBOMs, not a containerd daemon. (These CVEs
+# previously also appeared in the now-removed trivy CLI binary; they remain only
+# because the same containerd version is vendored into the grype binary.)
 CVE-2026-47262
 CVE-2026-50195
 CVE-2026-53488
@@ -47,10 +51,10 @@ CVE-2026-53492
 # ---------------------------------------------------------------------------
 # grype v0.114.0 binary — github.com/docker/docker @ v28.5.2+incompatible
 # CVE-2026-41567 / -41568 / -42306: NO upstream-fixed docker release exists yet
-# (Trivy/Grype both report FixedVersion=none). CVE-2026-33997 / -34040 are
-# fixed in docker 29.3.1 but grype v0.114.0 (latest) has not rebuilt against
-# it. Code path: grype's Docker engine client for `docker:` image sources; the
-# backend invokes grype against on-disk artifacts/SBOMs, not the Docker daemon.
+# (Grype reports FixedVersion=none). CVE-2026-33997 / -34040 are fixed in
+# docker 29.3.1 but grype v0.114.0 (latest) has not rebuilt against it. Code
+# path: grype's Docker engine client for `docker:` image sources; the backend
+# invokes grype against on-disk artifacts/SBOMs, not the Docker daemon.
 CVE-2026-33997
 CVE-2026-34040
 CVE-2026-41567
@@ -59,10 +63,8 @@ CVE-2026-42306
 
 # ---------------------------------------------------------------------------
 # grype v0.114.0 binary — Go stdlib @ go1.26.3
-# Fixed in Go 1.26.4 / 1.25.11. trivy 0.71.2 already ships a fixed stdlib (so
-# these are gone from the trivy binary); grype v0.114.0 (latest) is still built
-# with the older toolchain. Drops off when grype ships a release rebuilt on
-# Go >= 1.26.4.
+# Fixed in Go 1.26.4 / 1.25.11. grype v0.114.0 (latest) is still built with the
+# older toolchain. Drops off when grype ships a release rebuilt on Go >= 1.26.4.
 CVE-2026-27145
 CVE-2026-42504
 CVE-2026-42507

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,11 @@ edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"
 
+# Strip symbols from the release binary. Reduces the shipped binary size with no
+# behavioral change; complements the runtime-image hardening in issue #1544.
+[profile.release]
+strip = true
+
 [workspace.dependencies]
 # Async runtime
 tokio = { version = "1.50", features = ["full"] }

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -294,7 +294,7 @@ impl ImageScanner {
     /// Scan an image reference using the Trivy CLI with server mode.
     async fn scan_with_trivy(&self, image_ref: &str) -> Result<TrivyReport> {
         // Use tokio::process to call trivy CLI with server mode
-        let output = tokio::process::Command::new("trivy")
+        let spawn_result = tokio::process::Command::new("trivy")
             .args([
                 "image",
                 "--server",
@@ -311,8 +311,27 @@ impl ImageScanner {
                 image_ref,
             ])
             .output()
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to execute Trivy: {}", e)))?;
+            .await;
+
+        // If the trivy CLI is not present in the image at all, spawning it
+        // fails with ErrorKind::NotFound. The runtime image no longer bundles
+        // the trivy binary (#1544) — image scans run through the trivy sidecar
+        // (TRIVY_URL), so degrade gracefully to the HTTP/Twirp endpoint instead
+        // of failing the scan. Other spawn errors (e.g. permission) are real
+        // and still surface.
+        let output = match spawn_result {
+            Ok(output) => output,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                warn!("Trivy CLI not installed, falling back to HTTP API");
+                return self.scan_with_trivy_http(image_ref).await;
+            }
+            Err(e) => {
+                return Err(AppError::Internal(format!(
+                    "Failed to execute Trivy: {}",
+                    e
+                )))
+            }
+        };
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -731,6 +750,53 @@ mod tests {
             "error message should describe the health-check failure, got: {}",
             msg
         );
+    }
+
+    /// #1544: the runtime image no longer bundles the trivy CLI; image scans
+    /// must succeed via the HTTP/Twirp fallback against the trivy sidecar.
+    /// This exercises `scan_with_trivy_http` (the fallback target that
+    /// `scan_with_trivy` routes to when the CLI is absent) end-to-end against a
+    /// mock Twirp server and asserts the report is parsed correctly.
+    #[tokio::test]
+    async fn test_scan_with_trivy_http_fallback_parses_report() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let report = serde_json::json!({
+            "Results": [{
+                "Target": "myapp:latest (alpine 3.19)",
+                "Class": "os-pkgs",
+                "Type": "alpine",
+                "Vulnerabilities": [{
+                    "VulnerabilityID": "CVE-2026-0001",
+                    "PkgName": "openssl",
+                    "InstalledVersion": "3.1.0",
+                    "FixedVersion": "3.1.1",
+                    "Severity": "HIGH",
+                    "Title": "test vuln",
+                    "Description": "desc",
+                    "PrimaryURL": "https://example.test/cve"
+                }]
+            }]
+        });
+        Mock::given(method("POST"))
+            .and(path("/twirp/trivy.scanner.v1.Scanner/Scan"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(report))
+            .mount(&server)
+            .await;
+
+        let scanner = ImageScanner::new(server.uri());
+        let result = scanner.scan_with_trivy_http("myapp:latest").await;
+
+        let report = result.expect("HTTP/Twirp fallback should return a parsed report");
+        assert_eq!(report.results.len(), 1);
+        let vulns = report.results[0]
+            .vulnerabilities
+            .as_ref()
+            .expect("results should carry the mocked vulnerability");
+        assert_eq!(vulns.len(), 1);
+        assert_eq!(vulns[0].vulnerability_id, "CVE-2026-0001");
     }
 
     /// `check_trivy_health` retries before declaring failure so a brief

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -68,7 +68,7 @@ FROM registry.access.redhat.com/ubi9/ubi:9.8 AS rootfs-builder
 # Install only essential runtime libraries into a clean rootfs.
 # --refresh forces fresh repo metadata and the follow-up `upgrade -y` pulls
 # the latest RHEL 9 z-stream security errata for every installed package
-# (curl-minimal/libcurl, jq, glibc*, tar, bzip2-libs, openssl-libs, xz-libs,
+# (curl-minimal/libcurl, glibc*, tar, openssl-libs, xz-libs,
 # zlib, zstd) that the install step alone may miss when the metadata cache is
 # stale. This guarantees the rootfs is rebuilt against current errata on every
 # image build. The reposdir override is required on the upgrade step because
@@ -91,9 +91,7 @@ RUN mkdir -p /mnt/rootfs && \
         openssl-libs \
         zlib \
         xz-libs \
-        bzip2-libs \
         curl-minimal \
-        jq \
         tar \
         gzip \
         zstd \
@@ -155,13 +153,27 @@ RUN if [ -f /mnt/rootfs/etc/dnf/dnf.conf ]; then \
 # Remove any leftover cache/tmp artifacts
 RUN rm -rf /mnt/rootfs/var/cache/* /mnt/rootfs/var/log/* /mnt/rootfs/tmp/*
 
+# Strip residual setuid/setgid bits (shadow-utils chage/gpasswd/newgrp etc. are
+# pulled transitively and are never used by a non-root, no-login container) and
+# drop interpreters/shells the runtime does not need. The CMD (`artifact-keeper`)
+# and the curl healthcheck do not invoke bash/gawk/sed; jq is referenced only in
+# code comments and never spawned. Removing them shrinks attack surface and
+# clears jq's MEDIUM-CVE load. /bin/sh (coreutils-supplied) is intentionally
+# left in place.
+RUN find /mnt/rootfs -xdev -perm /6000 -type f -exec chmod a-s {} + && \
+    rm -f /mnt/rootfs/usr/bin/bash \
+          /mnt/rootfs/usr/bin/gawk \
+          /mnt/rootfs/usr/bin/sed \
+          /mnt/rootfs/usr/bin/bashbug*
+
 # ---------- Stage 5: Copy scanner CLIs from official images ----------
-# Trivy is pinned to the latest release (0.71.2). The bump from 0.71.0 clears
-# the golang.org/x/net (CVE-2026-25680/25681/27136/39821/42502/42506) and Go
-# stdlib (CVE-2026-27145/42504/42507) CVEs that Trivy 0.71.0's binary carried,
-# including the deps behind the code-scanning grpc finding. Residual containerd
-# CVEs that 0.71.2 has not yet rebuilt against are documented in /.trivyignore.
-FROM ghcr.io/aquasecurity/trivy:0.71.2 AS trivy-bin
+# The trivy CLI is intentionally NOT bundled in the runtime image. The backend
+# drives Trivy in server mode against the trivy sidecar (TRIVY_URL) and falls
+# back to the pure-HTTP Twirp endpoint (`scan_with_trivy_http`) when the CLI is
+# absent, so the in-image binary is dead weight. Dropping it removes the trivy
+# binary's HIGH-severity Go-dependency CVEs and ~150 MB of image size with no
+# functional loss. See issue #1544.
+#
 # Grype is pinned to v0.114.0, which is the latest upstream release. There is no
 # newer Grype build that picks up fixed versions of its bundled Go deps
 # (docker, containerd, stdlib), so its residual CVEs are upstream-unfixable for
@@ -187,8 +199,8 @@ FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
 # Copy minimal rootfs (glibc, openssl, ca-certs, curl, user/group, dirs)
 COPY --from=rootfs-builder /mnt/rootfs /
 
-# Copy scanner CLIs from official images
-COPY --from=trivy-bin /usr/local/bin/trivy /usr/local/bin/
+# Copy the grype scanner CLI (local SBOM/vuln scans). The trivy CLI is
+# deliberately omitted; image scans use the trivy sidecar via TRIVY_URL.
 COPY --from=grype-bin /grype /usr/local/bin/
 
 # Pre-seeded Grype vulnerability DB (avoids first-scan network fetch)
@@ -196,6 +208,19 @@ COPY --from=grype-db-seed --chown=1001:0 /grype-db /home/artifact/.cache/grype
 
 # Copy application binary
 COPY --from=builder /app/target/release/artifact-keeper /usr/local/bin/
+
+# Remove the bash shell that the ubi-micro BASE layer ships (the rootfs-builder
+# strip only affects the copied rootfs, not files already present in the base).
+# On ubi-micro `/bin/sh` and `/usr/bin/sh` are symlinks to bash, so dropping
+# bash removes the only interactive shell. Nothing at runtime needs it: the
+# binary spawns its subprocesses (tar/chmod/grype) directly via Command::new
+# (no `sh -c`), CMD is exec-form `["artifact-keeper"]`, and the HEALTHCHECK is
+# exec-form curl. Done with the real coreutils `rm` (exec-form RUN) so it does
+# not depend on the shell being deleted. See issue #1544.
+RUN ["/usr/bin/rm", "-f", \
+     "/usr/bin/bash", "/bin/bash", \
+     "/usr/bin/sh", "/bin/sh", \
+     "/usr/bin/bashbug", "/usr/bin/bashbug-64"]
 
 WORKDIR /app
 USER 1001

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -47,12 +47,13 @@ RUN if [ -n "${APP_VERSION}" ]; then \
     cargo build --release --features "$FEATURES" --bin artifact-keeper
 
 # ---------- Stage 4: Copy scanner CLIs from official images ----------
-# Trivy is pinned to the latest release (0.71.2). The bump from 0.71.0 clears
-# the golang.org/x/net (CVE-2026-25680/25681/27136/39821/42502/42506) and Go
-# stdlib (CVE-2026-27145/42504/42507) CVEs in the Trivy binary, including the
-# deps behind the code-scanning grpc finding. Residual containerd CVEs that
-# 0.71.2 has not yet rebuilt against are documented in /.trivyignore.
-FROM ghcr.io/aquasecurity/trivy:0.71.2 AS trivy-bin
+# The trivy CLI is intentionally NOT bundled in the runtime image. The backend
+# drives Trivy in server mode against the trivy sidecar (TRIVY_URL) and falls
+# back to the pure-HTTP Twirp endpoint (`scan_with_trivy_http`) when the CLI is
+# absent, so the in-image binary is dead weight. Dropping it removes the trivy
+# binary's HIGH-severity Go-dependency CVEs and image size with no functional
+# loss. See issue #1544.
+#
 # Grype is pinned to v0.114.0, the latest upstream release. No newer Grype build
 # picks up fixed versions of its bundled Go deps (docker, containerd, stdlib),
 # so its residual CVEs are upstream-unfixable for now and are documented/
@@ -78,7 +79,7 @@ FROM alpine:3.24
 # current errata on every image build; the targeted `add` keeps the install
 # set explicit.
 RUN apk upgrade --no-cache && \
-    apk add --no-cache --upgrade ca-certificates libgcc libstdc++ zlib xz-libs libbz2 curl jq
+    apk add --no-cache --upgrade ca-certificates libgcc libstdc++ zlib xz-libs curl
 
 # --- CIS hardening (adapted from CIS Alpine Linux Benchmark) ---
 
@@ -113,8 +114,8 @@ RUN rm -rf /var/cache/apk/* /tmp/*
 
 # --- End CIS hardening ---
 
-# Copy scanner CLIs (statically linked Go binaries)
-COPY --from=trivy-bin /usr/local/bin/trivy /usr/local/bin/
+# Copy the grype scanner CLI (statically linked Go binary). The trivy CLI is
+# deliberately omitted; image scans use the trivy sidecar via TRIVY_URL.
 COPY --from=grype-bin /grype /usr/local/bin/
 
 # Pre-seeded Grype vulnerability DB (avoids first-scan network fetch)


### PR DESCRIPTION
## Summary

Hardens the backend runtime container image to shrink imported attack surface
and shipped size, with **no base-image swap** (the binary keeps dynamically
linking UBI's openssl/glibc/zlib) and **no functional loss**. Closes #1544.

Changes (`docker/Dockerfile.backend`, mirrored to `docker/Dockerfile.backend.alpine`):

- **Drop the bundled `trivy` CLI from the runtime image.** The backend drives
  Trivy in *server mode* against the trivy sidecar (`TRIVY_URL`) and falls back
  to the pure-HTTP Twirp endpoint when the CLI is absent, so the in-image binary
  was dead weight. Removing it eliminates the trivy binary's HIGH-severity
  Go-dependency CVEs and a large chunk of image size.
- **Make the CLI-absent path actually reach the HTTP fallback**
  (`backend/src/services/image_scanner.rs`). Previously a missing `trivy`
  executable surfaced as a spawn error (`ErrorKind::NotFound`) and failed the
  scan; it now degrades to `scan_with_trivy_http` so image scanning continues to
  work against the sidecar without the in-image CLI. Covered by a new unit test.
- **Slim the rootfs:** remove `jq` and `bzip2-libs` (neither is needed — the
  binary has no `NEEDED` ref to libbz2 and `jq` is only mentioned in code
  comments, never spawned; `jq` alone carried the bulk of the MEDIUM CVE load).
- **Strip residual privilege/shell surface:** clear all setuid/setgid bits in
  the rootfs and remove unused interpreters/shells (`bash`, `gawk`, `sed`,
  `bashbug`). The ubi-micro base layer also ships `bash` (with `/bin/sh`
  symlinked to it), which is removed in the final stage; nothing at runtime
  needs a shell (subprocesses are spawned directly, CMD/HEALTHCHECK are
  exec-form).
- **Strip the release binary** (`[profile.release] strip = true`).
- **Keep grype + the seeded grype DB + `GRYPE_DB_*`** (real local-scan
  dependency) and trim `/.trivyignore` to the grype-binary residual CVEs only
  (containerd / docker / Go-stdlib that grype upstream has not yet rebuilt
  against); the obsolete trivy-CLI-specific suppressions are removed.

### Attack-surface / CVE / size reduction (trivy 0.71.2, full severity)

| Metric | Before | After |
| --- | --- | --- |
| HIGH | 11 (8 grype + 3 trivy CLI) | 8 (grype-only residual) |
| MEDIUM | 71 | 57 |
| LOW | 32 | 30 |
| Image size | 2.17 GB | 1.99 GB (-184 MB) |

- The **3 trivy-CLI HIGH CVEs are gone** (binary removed). The remaining 8 HIGH
  all live in the grype binary and are upstream-unfixable today; they are
  documented and suppressed in `/.trivyignore`. A CI-equivalent scan
  (`--ignore-unfixed` + ignorefile) reports **0 alerting HIGH/CRITICAL**.
- **MEDIUM drops by 14** (the jq removal).

### Validation (isolated instance, :8081, with trivy sidecar)

- Health `200`; admin login OK; repo create OK; artifact upload→download is
  **byte-identical** (sha256 match).
- Image scan of a pushed OCI image **completes via the trivy sidecar/Twirp
  fallback without the in-image CLI** (logs:
  `Trivy CLI not installed, falling back to HTTP API` → scan `completed`).
- Local **grype** scan still works with the seeded DB
  (`Grype OCI local layout scan complete ... 14 vulnerabilities`).
- In-container hardening: `id` → uid 1001; setuid/setgid scan empty;
  `bash`/`gawk`/`sed`/`jq`/`trivy` and `/bin/sh` all absent; `grype`/`tar`/`curl`
  present; the binary boots healthy (dynamic libs intact).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`backend/src/services/image_scanner.rs::tests::test_scan_with_trivy_http_fallback_parses_report`
exercises the HTTP/Twirp fallback the image-scan path now relies on when the
trivy CLI is not present in the image.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
