### PR TITLE
fix(tests): add rate_limit_trusted_proxy_cidrs to integration-test Config literals

### DIFF
--- a/backend/tests/composer_packages_index_tests.rs
+++ b/backend/tests/composer_packages_index_tests.rs
@@ -107,6 +107,7 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,
         rate_limit_trusted_cidrs: Vec::new(),
+        rate_limit_trusted_proxy_cidrs: Vec::new(),
         account_lockout_threshold: 5,
         account_lockout_duration_minutes: 30,
         quarantine_enabled: false,

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -95,6 +95,7 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,
         rate_limit_trusted_cidrs: Vec::new(),
+        rate_limit_trusted_proxy_cidrs: Vec::new(),
         account_lockout_threshold: 5,
         account_lockout_duration_minutes: 30,
         quarantine_enabled: false,


### PR DESCRIPTION
Closes #2060

## Summary

PR #2046 added `rate_limit_trusted_proxy_cidrs` to `Config` and updated in-source test helpers, but two integration-test files that build `Config { ... }` directly were missed. This causes `cargo check --tests` / `cargo clippy --all-targets` to fail on `main` with a "missing field" compile error.

The fix adds `rate_limit_trusted_proxy_cidrs: Vec::new(),` to the `Config` literal in each of the two affected files, matching the pattern used by all other test helpers in the codebase. No other changes.

Files changed:
- `backend/tests/composer_packages_index_tests.rs`
- `backend/tests/incus_upload_tests.rs`

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

The broken test files themselves are the regression test: they previously failed to compile (missing field) and now compile cleanly. `cargo check --tests` passes on this branch and fails on `main`.

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — the affected integration-test files now compile
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo check --tests` and `cargo fmt --check` both pass
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
