### PR TITLE
chore(release): bump version to 1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.2"
+version = "1.2.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.2.2",
+        version = "1.2.3",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Bumps the application version to 1.2.3 ahead of the release tag.

- `Cargo.toml` workspace version 1.2.2 -> 1.2.3 (drives /health, SBOM, telemetry)
- `backend/src/api/openapi.rs` Swagger info.version 1.2.2 -> 1.2.3
- `Cargo.lock` workspace-member version synced (no dependency changes)

v1.2.3 milestone is complete (security fixes, regressions, proxy-cache purge, Grype OCI scan, image hardening, wasmtime advisory). No functional changes in this PR.

Closes #2067