### PR TITLE
fix: block API token writes in demo mode

### DIFF
--- a/backend/src/api/middleware/demo.rs
+++ b/backend/src/api/middleware/demo.rs
@@ -13,8 +13,51 @@ use std::sync::Arc;
 
 use crate::api::AppState;
 
+/// Auth-related paths that may accept write methods even while the instance is
+/// in demo mode, because they are part of the login/session lifecycle rather
+/// than state-mutating operations.
+///
+/// This is an explicit allowlist so the guard is deny-by-default: any new write
+/// endpoint added under `/api/v1/auth` (for example API token creation) is
+/// blocked in demo mode unless it is intentionally added here. The previous
+/// implementation exempted the whole `/api/v1/auth` prefix, which let
+/// `POST /api/v1/auth/tokens` (create API token) and
+/// `DELETE /api/v1/auth/tokens/{id}` (revoke) slip through.
+fn is_allowed_auth_write(path: &str) -> bool {
+    const EXACT_ALLOWED: &[&str] = &[
+        "/api/v1/auth/login",
+        "/api/v1/auth/logout",
+        "/api/v1/auth/refresh",
+        // Short-lived download tickets are read-oriented (they authorize a
+        // download), so they stay available in a read-only demo.
+        "/api/v1/auth/ticket",
+    ];
+
+    if EXACT_ALLOWED.contains(&path) {
+        return true;
+    }
+
+    // TOTP 2FA and SSO sub-trees carry their own login/verify/callback steps
+    // that must work for users to authenticate.
+    path.starts_with("/api/v1/auth/totp/") || path.starts_with("/api/v1/auth/sso/")
+}
+
+/// Returns true when a request must be blocked by the demo guard.
+///
+/// Reads (GET/HEAD/OPTIONS) are always allowed. Writes are blocked unless they
+/// target an explicitly allowlisted auth/session endpoint.
+fn should_block(method: &Method, path: &str) -> bool {
+    let is_read_only = matches!(*method, Method::GET | Method::HEAD | Method::OPTIONS);
+    if is_read_only {
+        return false;
+    }
+    !is_allowed_auth_write(path)
+}
+
 /// Middleware that rejects write operations (POST/PUT/DELETE/PATCH) in demo mode.
-/// Auth endpoints are exempted so users can log in.
+///
+/// Login and session endpoints are exempted so users can authenticate, but all
+/// other writes, including API token creation and revocation, are blocked.
 pub async fn demo_guard(
     State(state): State<Arc<AppState>>,
     request: Request<Body>,
@@ -24,23 +67,67 @@ pub async fn demo_guard(
         return next.run(request).await;
     }
 
-    let is_read_only = matches!(
-        *request.method(),
-        Method::GET | Method::HEAD | Method::OPTIONS
-    );
-    let is_auth_endpoint = request.uri().path().starts_with("/api/v1/auth");
-
-    // Allow read operations and auth endpoints (login, refresh, etc.)
-    if is_read_only || is_auth_endpoint {
-        return next.run(request).await;
+    if should_block(request.method(), request.uri().path()) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({
+                "error": "Write operations are disabled in the demo. Deploy your own instance to get full access."
+            })),
+        )
+            .into_response();
     }
 
-    // Block all other write operations
-    (
-        StatusCode::FORBIDDEN,
-        Json(json!({
-            "error": "Write operations are disabled in the demo. Deploy your own instance to get full access."
-        })),
-    )
-        .into_response()
+    next.run(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_are_never_blocked() {
+        for method in [Method::GET, Method::HEAD, Method::OPTIONS] {
+            assert!(!should_block(&method, "/api/v1/repositories"));
+            assert!(!should_block(&method, "/api/v1/auth/tokens"));
+        }
+    }
+
+    #[test]
+    fn token_writes_are_blocked() {
+        assert!(should_block(&Method::POST, "/api/v1/auth/tokens"));
+        assert!(should_block(&Method::DELETE, "/api/v1/auth/tokens/abc-123"));
+        assert!(!is_allowed_auth_write("/api/v1/auth/tokens"));
+        assert!(!is_allowed_auth_write("/api/v1/auth/tokens/abc-123"));
+    }
+
+    #[test]
+    fn login_session_writes_are_allowed() {
+        for path in [
+            "/api/v1/auth/login",
+            "/api/v1/auth/logout",
+            "/api/v1/auth/refresh",
+            "/api/v1/auth/ticket",
+            "/api/v1/auth/totp/verify",
+            "/api/v1/auth/sso/callback",
+        ] {
+            assert!(is_allowed_auth_write(path), "{path} should be allowed");
+            assert!(!should_block(&Method::POST, path), "{path} should not block");
+        }
+    }
+
+    #[test]
+    fn non_auth_writes_are_blocked() {
+        assert!(should_block(&Method::POST, "/api/v1/repositories"));
+        assert!(should_block(&Method::PUT, "/api/v1/admin/settings"));
+        assert!(should_block(&Method::PATCH, "/api/v1/users/123"));
+        assert!(should_block(&Method::DELETE, "/api/v1/repositories/abc"));
+    }
+
+    #[test]
+    fn unrelated_auth_prefix_paths_do_not_leak() {
+        // A path that merely starts with the auth string but is not an
+        // allowlisted login endpoint must still be blocked for writes.
+        assert!(should_block(&Method::POST, "/api/v1/auth/tokens/extra"));
+        assert!(should_block(&Method::POST, "/api/v1/authzzz"));
+    }
 }

--- a/backend/src/api/middleware/demo.rs
+++ b/backend/src/api/middleware/demo.rs
@@ -111,7 +111,10 @@ mod tests {
             "/api/v1/auth/sso/callback",
         ] {
             assert!(is_allowed_auth_write(path), "{path} should be allowed");
-            assert!(!should_block(&Method::POST, path), "{path} should not block");
+            assert!(
+                !should_block(&Method::POST, path),
+                "{path} should not block"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

The demo write guard (`backend/src/api/middleware/demo.rs`) exempted the entire `/api/v1/auth` prefix so login/refresh/logout would work in demo mode. That exemption was too broad: the protected auth router also mounts `POST /api/v1/auth/tokens` (create API token) and `DELETE /api/v1/auth/tokens/{id}` (revoke), so demo visitors (auto-logged-in as admin) could mint real API tokens. Confirmed on the live demo: `POST /api/v1/auth/tokens` returned 200 with a usable token persisted in `api_tokens`.

Impact is limited (every other write stays blocked, so a minted token only grants read access plus minting more tokens), but a read-only demo should not issue credentials.

This change makes the guard deny-by-default. It exempts only an explicit allowlist of login/session endpoints (`/login`, `/logout`, `/refresh`, `/ticket`, and the `/totp/*` and `/sso/*` sub-trees) and blocks all other writes under `/auth`, including token management. Any future write endpoint added under `/auth` is blocked unless added to the allowlist intentionally.

A Caddy edge rule on the demo host already returns 403 for `POST|PUT|PATCH|DELETE /api/v1/auth/tokens*` as an immediate mitigation; this backend fix is the durable fix and can keep the edge rule as defense in depth.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The new `token_writes_are_blocked` test fails on `main` (the old guard allowed any `/api/v1/auth` path) and passes here.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo fmt --check`, `cargo clippy --lib -- -D warnings`, and `cargo test --lib api::middleware::demo` (5/5 pass) all run clean locally.

## API Changes
- [x] N/A - no API changes

Closes #2070