### PR TITLE
fix(proxy): align proxy-cache write/freshness/presign paths when S3_PREFIX is set

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -6245,6 +6245,123 @@ SHA256:
     }
 
     // -----------------------------------------------------------------------
+    // Proxy-cache write key consistency (S3_PREFIX mismatch fix)
+    //
+    // Regression guard: CachePersister must pass the raw key produced by
+    // CacheKeys::derive to the storage backend without adding any prefix.
+    // S3_PREFIX (if configured) is applied once inside the storage backend.
+    // Since the presigning path (try_proxy_cache_redirect → get_presigned_url)
+    // receives the same raw key and calls the SAME backend instance, the
+    // resulting S3 object key is identical in both directions.
+    // -----------------------------------------------------------------------
+
+    use crate::services::storage_service::{
+        PutStreamResult as ServicePutStreamResult, StorageBackend as ServiceStorageBackend,
+        StorageService as RealStorageService,
+    };
+
+    /// Recording backend that captures every key passed to `put()`.
+    /// Used by key-consistency tests to verify no caller-side prefix is added.
+    struct PutKeyCapture {
+        keys: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl PutKeyCapture {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                keys: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+
+        fn keys_snapshot(&self) -> Vec<String> {
+            self.keys.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceStorageBackend for PutKeyCapture {
+        async fn put(&self, key: &str, _content: Bytes) -> Result<()> {
+            self.keys.lock().unwrap().push(key.to_string());
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            Err(AppError::NotFound(key.to_string()))
+        }
+        async fn exists(&self, _key: &str) -> Result<bool> {
+            Ok(false)
+        }
+        async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _src: &str, _dst: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// `CachePersister::write_buffered` must store content and metadata under
+    /// exactly the raw keys that `CacheKeys::derive` produces — no caller-side
+    /// prefix appended. The storage backend (now the same instance used by
+    /// presigning after the S3_PREFIX fix) is the single point that applies any
+    /// object-key prefix.
+    #[tokio::test]
+    async fn test_cache_persister_write_buffered_uses_raw_cache_keys() {
+        let capture = PutKeyCapture::new();
+        let storage = Arc::new(RealStorageService::new(capture.clone()));
+        let persister = CachePersister::new(storage);
+
+        let keys =
+            CacheKeys::derive("npm-proxy", "lodash/-/lodash-4.17.21.tgz").expect("valid path");
+
+        persister
+            .write_buffered(
+                &keys.content,
+                &keys.metadata,
+                &Bytes::from_static(b"fake-package-bytes"),
+                Some("application/octet-stream".to_string()),
+                None,  // etag
+                None,  // last_modified
+                3600,  // ttl_secs
+                uuid::Uuid::new_v4(),
+                "lodash/-/lodash-4.17.21.tgz",
+                None, // quarantine_until
+            )
+            .await
+            .expect("write_buffered must succeed");
+
+        let written = capture.keys_snapshot();
+        // Exactly two writes: content object first, then metadata sidecar.
+        assert_eq!(written.len(), 2, "expected content write + metadata write, got {:?}", written);
+        assert_eq!(
+            written[0], keys.content,
+            "first write must be the raw content key from CacheKeys::derive"
+        );
+        assert_eq!(
+            written[1], keys.metadata,
+            "second write must be the raw metadata key from CacheKeys::derive"
+        );
+        // Neither key carries a hardcoded prefix; the backend applies S3_PREFIX.
+        assert!(
+            written[0].starts_with("proxy-cache/"),
+            "content key must be a raw proxy-cache key: {}",
+            written[0]
+        );
+        assert!(
+            written[1].starts_with("proxy-cache/"),
+            "metadata key must be a raw proxy-cache key: {}",
+            written[1]
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // tee_upstream_to_cache (#895): proxy slow-path streaming
     //
     // The tee forwards each upstream chunk to BOTH the client stream and a
@@ -6253,10 +6370,6 @@ SHA256:
     // be able to keep up under realistic chunk sizes.
     // -----------------------------------------------------------------------
 
-    use crate::services::storage_service::{
-        PutStreamResult as ServicePutStreamResult, StorageBackend as ServiceStorageBackend,
-        StorageService as RealStorageService,
-    };
     use futures::stream::BoxStream as ServiceBoxStream;
     use sha2::{Digest, Sha256};
 

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -408,6 +408,12 @@ pub struct S3BackendWrapper {
 
 impl S3BackendWrapper {
     pub async fn from_config(config: &Config) -> crate::error::Result<Self> {
+        // Read S3_PREFIX from the environment so this backend applies the same
+        // object-key prefix as the primary S3Backend (built via S3Backend::from_env
+        // in main.rs). Without this, proxy-cache writes land at raw keys while
+        // presigned URLs reference {S3_PREFIX}/{raw_key}, causing every presigned
+        // proxy-cache download to 404 when S3_PREFIX is non-empty.
+        let prefix = std::env::var("S3_PREFIX").ok();
         let s3_config = crate::storage::s3::S3Config::new(
             config.s3_bucket.clone().unwrap_or_default(),
             config
@@ -415,7 +421,7 @@ impl S3BackendWrapper {
                 .clone()
                 .unwrap_or_else(|| "us-east-1".to_string()),
             config.s3_endpoint.clone(),
-            None, // No prefix by default
+            prefix,
         );
         let inner = crate::storage::s3::S3Backend::new(s3_config).await?;
         Ok(Self { inner })


### PR DESCRIPTION
Fixes #2076

## Problem

When `S3_PREFIX` is set, `S3BackendWrapper::from_config` hard-coded `prefix = None`, while the primary backend (`S3Backend::from_env`) correctly reads `S3_PREFIX`. This caused proxy-cache writes to land at the unprefixed key (`proxy-cache/…/__content__`) while freshness checks and presigned URLs targeted the prefixed key (`{S3_PREFIX}/proxy-cache/…/__content__`). Result: `is_cache_fresh` always misses, and any presigned redirect that did fire returned HTTP 404.

## Fix

One-line change in `S3BackendWrapper::from_config`: read `S3_PREFIX` from the environment the same way `S3Config::from_env` already does, so both construction paths apply the prefix identically.

```rust
// before
let s3_config = S3Config::new(config.endpoint.clone(), config.region.clone(), None);

// after
let prefix = std::env::var("S3_PREFIX").ok();
let s3_config = S3Config::new(config.endpoint.clone(), config.region.clone(), prefix);
```

The invariant now holds for any `(repo_key, path)` pair: `CacheKeys::derive` produces a raw key, and all three operations — write, freshness check, presign — prepend `S3_PREFIX` exactly once via the shared `make_full_key` path.

## Scope

`S3BackendWrapper::from_config` is also used by `BackupService`. This fix means backup/restore operations now correctly target the prefixed key namespace on prefixed deployments. This is the intended behaviour (backups should live alongside the artifacts they back up), but is a real behaviour change for existing prefixed deployments that took backups before this fix — those backups lived at unprefixed keys. Operators should account for this on upgrade.

## Regression test

`test_cache_persister_write_buffered_uses_raw_cache_keys` — intercepts at the `StorageBackend` trait boundary via `PutKeyCapture`, confirming `CachePersister::write_buffered` passes the raw `CacheKeys::derive` output (no caller-side prefix injection) to the backend for both the content blob and the sidecar.

## Rollout notes

Existing deployments with `S3_PREFIX` set will have orphaned proxy-cache objects at the unprefixed `proxy-cache/…` root. These were never actually served (freshness probes always missed them) and are safe to prune after upgrading.

## Test results

```
test result: ok. 11575 passed; 1 failed; 4 ignored
```

The single failure (`test_large_object_client_builder_does_not_apply_total_timeout`) is pre-existing and timing-sensitive — confirmed to fail identically on `main` before this change.