### PR TITLE
fix(proxy): align proxy-cache write/freshness/presign paths when S3_PREFIX is set

### DIFF
--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -6877,7 +6877,12 @@ SHA256:
             .expect("write_buffered must succeed");
 
         let written = capture.keys_snapshot();
-        assert_eq!(written.len(), 2, "expected content write + metadata write, got {:?}", written);
+        assert_eq!(
+            written.len(),
+            2,
+            "expected content write + metadata write, got {:?}",
+            written
+        );
         assert_eq!(
             written[0], keys.content,
             "first write must be the raw content key from CacheKeys::derive"

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -6788,6 +6788,117 @@ SHA256:
     }
 
     // -----------------------------------------------------------------------
+    // CachePersister key-consistency: write path must pass raw CacheKeys keys
+    // to the backend without adding a caller-side prefix. The backend (shared
+    // with the presign path after the S3_PREFIX fix) is the single point that
+    // applies the object-key prefix, so the resulting S3 key is identical in
+    // both directions.
+    // -----------------------------------------------------------------------
+
+    use crate::services::storage_service::{
+        PutStreamResult as ServicePutStreamResult, StorageBackend as ServiceStorageBackend,
+        StorageService as RealStorageService,
+    };
+
+    /// Recording backend that captures every key passed to `put()`.
+    struct PutKeyCapture {
+        keys: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl PutKeyCapture {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                keys: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+
+        fn keys_snapshot(&self) -> Vec<String> {
+            self.keys.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ServiceStorageBackend for PutKeyCapture {
+        async fn put(&self, key: &str, _content: Bytes) -> Result<()> {
+            self.keys.lock().unwrap().push(key.to_string());
+            Ok(())
+        }
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            Err(AppError::NotFound(key.to_string()))
+        }
+        async fn exists(&self, _key: &str) -> Result<bool> {
+            Ok(false)
+        }
+        async fn head_etag(&self, _key: &str) -> Result<Option<String>> {
+            Ok(None)
+        }
+        async fn delete(&self, _key: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn list(&self, _prefix: Option<&str>) -> Result<Vec<String>> {
+            Ok(vec![])
+        }
+        async fn copy(&self, _src: &str, _dst: &str) -> Result<()> {
+            Ok(())
+        }
+        async fn size(&self, _key: &str) -> Result<u64> {
+            Ok(0)
+        }
+    }
+
+    /// `CachePersister::write_buffered` must pass the raw keys from
+    /// `CacheKeys::derive` to the storage backend without adding a prefix.
+    /// The backend is the single point that applies `S3_PREFIX`, so writes
+    /// and presigned URLs (which go through the same backend) resolve to the
+    /// same S3 key.
+    #[tokio::test]
+    async fn test_cache_persister_write_buffered_uses_raw_cache_keys() {
+        let capture = PutKeyCapture::new();
+        let storage = Arc::new(RealStorageService::new(capture.clone()));
+        let persister = CachePersister::new(storage);
+
+        let keys =
+            CacheKeys::derive("npm-proxy", "lodash/-/lodash-4.17.21.tgz").expect("valid path");
+
+        persister
+            .write_buffered(
+                &keys.content,
+                &keys.metadata,
+                &Bytes::from_static(b"fake-package-bytes"),
+                Some("application/octet-stream".to_string()),
+                None,
+                None,
+                3600,
+                uuid::Uuid::new_v4(),
+                "lodash/-/lodash-4.17.21.tgz",
+                None,
+            )
+            .await
+            .expect("write_buffered must succeed");
+
+        let written = capture.keys_snapshot();
+        assert_eq!(written.len(), 2, "expected content write + metadata write, got {:?}", written);
+        assert_eq!(
+            written[0], keys.content,
+            "first write must be the raw content key from CacheKeys::derive"
+        );
+        assert_eq!(
+            written[1], keys.metadata,
+            "second write must be the raw metadata key from CacheKeys::derive"
+        );
+        assert!(
+            written[0].starts_with("proxy-cache/"),
+            "content key must be a raw proxy-cache key: {}",
+            written[0]
+        );
+        assert!(
+            written[1].starts_with("proxy-cache/"),
+            "metadata key must be a raw proxy-cache key: {}",
+            written[1]
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // tee_upstream_to_cache (#895): proxy slow-path streaming
     //
     // The tee forwards each upstream chunk to BOTH the client stream and a
@@ -6796,10 +6907,6 @@ SHA256:
     // be able to keep up under realistic chunk sizes.
     // -----------------------------------------------------------------------
 
-    use crate::services::storage_service::{
-        PutStreamResult as ServicePutStreamResult, StorageBackend as ServiceStorageBackend,
-        StorageService as RealStorageService,
-    };
     use futures::stream::BoxStream as ServiceBoxStream;
     use sha2::{Digest, Sha256};
 

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -490,15 +490,15 @@ impl StorageService {
             "s3" => {
                 // Build the proxy-cache S3 backend from the SAME env-derived
                 // config the primary storage uses (redirect_downloads, presign
-                // creds, CloudFront, path_format, TLS, pool tuning), then force
-                // the key prefix to None. Proxy-cache content lives at the
-                // bucket root (`proxy-cache/...`), not under S3_PREFIX, so the
-                // signed key must carry no prefix. Reusing from_env() (instead
-                // of S3Config::new, which hardcodes redirect_downloads=false and
-                // no presign creds) is what makes presigning actually fire on
-                // this handle (#1555).
-                let mut s3_config = crate::storage::s3::S3Config::from_env()?;
-                s3_config.prefix = None;
+                // creds, CloudFront, path_format, TLS, pool tuning, and
+                // S3_PREFIX). Proxy-cache writes go through this same handle, so
+                // the key prefix here must match the prefix applied at write
+                // time — otherwise presigned URLs resolve to a different S3 key
+                // than where the content was written, causing 404s. Reusing
+                // from_env() (instead of S3Config::new, which hardcodes
+                // redirect_downloads=false and no presign creds) is what makes
+                // presigning actually fire on this handle (#1555).
+                let s3_config = crate::storage::s3::S3Config::from_env()?;
                 let inner = Arc::new(crate::storage::s3::S3Backend::new(s3_config).await?);
                 Arc::new(S3BackendWrapper { inner })
             }


### PR DESCRIPTION
Fixes #2076

## Problem

When `S3_PREFIX` is set, `StorageService::from_config` forced `s3_config.prefix = None` for the proxy-cache storage backend, while the primary S3 backend (used for freshness checks and presigned URLs) applied `S3_PREFIX` via `S3Config::from_env()`. This made proxy-cache writes land at the unprefixed key while presigned URLs referenced the prefixed key — causing every presigned proxy-cache download to 404 when `S3_PREFIX` is non-empty.

## Fix

Remove the `s3_config.prefix = None` override in the `"s3"` arm of `StorageService::from_config`, so the proxy-cache backend uses the same `S3_PREFIX` as the primary backend. Writes, freshness checks, and presigned URLs now all resolve to the same S3 key.

```rust
// before
let mut s3_config = crate::storage::s3::S3Config::from_env()?;
s3_config.prefix = None;   // ← forced key mismatch when S3_PREFIX is set

// after
let s3_config = crate::storage::s3::S3Config::from_env()?;
```

The updated comment also corrects the prior incorrect description of the intended key layout.

## Side effect

`BackupService` uses the same `StorageService` backend. With this fix, backup/restore operations on prefixed deployments will now correctly target the prefixed key namespace rather than the unprefixed root. This is the intended behaviour, but operators upgrading existing prefixed deployments with prior backups should be aware the backup key path changes.

## Regression test

`test_cache_persister_write_buffered_uses_raw_cache_keys` — intercepts at the `StorageBackend` trait boundary via `PutKeyCapture`, confirming `CachePersister::write_buffered` passes the raw `CacheKeys::derive` output to the backend for both the content blob and the sidecar, with no caller-side prefix injected.

## Rollout note

Existing deployments with `S3_PREFIX` set will have orphaned proxy-cache objects at the unprefixed `proxy-cache/…` root (written before this fix, never actually served since freshness probes targeted the prefixed key). These are safe to prune after upgrading.