### PR TITLE
feat(repositories): allow custom User-Agent on remote repository outbound requests

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -257,6 +257,8 @@ async fn authorize_virtual_member_mutation(
 }
 
 /// Generic upsert helper for repository_config key-value pairs.
+const CUSTOM_USER_AGENT_KEY: &str = "custom_user_agent";
+
 ///
 /// Inserts a new row or updates an existing one for the given repository and
 /// config key. Used by multiple update paths (index_upstream_url, quarantine
@@ -585,9 +587,10 @@ async fn with_custom_user_agent(
     mut response: RepositoryResponse,
 ) -> RepositoryResponse {
     let result = sqlx::query_scalar::<_, String>(
-        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = 'custom_user_agent'",
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
     )
     .bind(repo_id)
+    .bind(CUSTOM_USER_AGENT_KEY)
     .fetch_optional(db)
     .await;
     if let Ok(Some(ua)) = result {
@@ -1464,7 +1467,7 @@ pub async fn create_repository(
 
     if let Some(ref ua) = payload.custom_user_agent {
         if !ua.is_empty() {
-            upsert_repo_config(&state.db, repo.id, "custom_user_agent", ua).await?;
+            upsert_repo_config(&state.db, repo.id, CUSTOM_USER_AGENT_KEY, ua).await?;
         }
     }
 
@@ -1736,16 +1739,15 @@ pub async fn update_repository(
             ));
         }
         if ua.is_empty() {
-            sqlx::query(
-                "DELETE FROM repository_config WHERE repository_id = $1 AND key = 'custom_user_agent'",
-            )
-            .bind(repo.id)
-            .execute(&state.db)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
+            sqlx::query("DELETE FROM repository_config WHERE repository_id = $1 AND key = $2")
+                .bind(repo.id)
+                .bind(CUSTOM_USER_AGENT_KEY)
+                .execute(&state.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
         } else {
             validate_custom_user_agent(ua)?;
-            upsert_repo_config(&state.db, repo.id, "custom_user_agent", ua).await?;
+            upsert_repo_config(&state.db, repo.id, CUSTOM_USER_AGENT_KEY, ua).await?;
         }
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -417,6 +417,9 @@ pub struct CreateRepositoryRequest {
     pub upstream_username: Option<String>,
     /// Password (basic) or token (bearer). Write-only, never returned in responses.
     pub upstream_password: Option<String>,
+    /// Custom User-Agent sent on outbound HTTP requests to the upstream for
+    /// this repository. Only valid for remote repositories. Max 256 characters.
+    pub custom_user_agent: Option<String>,
 }
 
 impl CreateRepositoryRequest {
@@ -473,6 +476,10 @@ pub struct UpdateRepositoryRequest {
     /// Pass an empty string to remove the link.
     /// Stored in `repository_config` under `release_repository_id`.
     pub release_repository_key: Option<String>,
+    /// Update the custom User-Agent for outbound HTTP requests to the upstream.
+    /// Only valid for remote repositories. Pass an empty string to remove.
+    /// Max 256 characters. Stored in `repository_config` under `custom_user_agent`.
+    pub custom_user_agent: Option<String>,
 }
 
 impl UpdateRepositoryRequest {
@@ -512,6 +519,10 @@ pub struct RepositoryResponse {
     /// `repository_config` (#1770 B). `None` when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quarantine_duration_minutes: Option<i64>,
+    /// Custom User-Agent used for outbound HTTP requests to the upstream,
+    /// read back from `repository_config`. `None` when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_user_agent: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -547,6 +558,7 @@ fn repo_to_response(
         // db-less, mirroring `upstream_auth_*` above (#1770 B).
         quarantine_enabled: None,
         quarantine_duration_minutes: None,
+        custom_user_agent: None,
         created_at: repo.created_at,
         updated_at: repo.updated_at,
     }
@@ -564,6 +576,23 @@ async fn with_quarantine_settings(
     let (enabled, duration) = crate::services::quarantine_service::repo_settings(db, repo_id).await;
     response.quarantine_enabled = enabled;
     response.quarantine_duration_minutes = duration;
+    response
+}
+
+async fn with_custom_user_agent(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    mut response: RepositoryResponse,
+) -> RepositoryResponse {
+    let result = sqlx::query_scalar::<_, String>(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = 'custom_user_agent'",
+    )
+    .bind(repo_id)
+    .fetch_optional(db)
+    .await;
+    if let Ok(Some(ua)) = result {
+        response.custom_user_agent = Some(ua);
+    }
     response
 }
 
@@ -590,6 +619,20 @@ fn validate_repository_key(key: &str) -> Result<()> {
     if key.contains("..") {
         return Err(AppError::Validation(
             "Repository key must not contain consecutive dots".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_custom_user_agent(ua: &str) -> Result<()> {
+    if ua.len() > 256 {
+        return Err(AppError::Validation(
+            "custom_user_agent must be 256 characters or fewer".to_string(),
+        ));
+    }
+    if ua.chars().any(|c| c == '\r' || c == '\n') {
+        return Err(AppError::Validation(
+            "custom_user_agent must not contain newline characters".to_string(),
         ));
     }
     Ok(())
@@ -1335,6 +1378,15 @@ pub async fn create_repository(
     // See `validate_virtual_repo_member_count` for the rationale (#1279, #1444).
     validate_virtual_repo_member_count(&payload.key, &repo_type, payload.member_repos.as_deref())?;
 
+    if let Some(ref ua) = payload.custom_user_agent {
+        if repo_type != RepositoryType::Remote {
+            return Err(AppError::Validation(
+                "custom_user_agent is only valid for remote repositories".to_string(),
+            ));
+        }
+        validate_custom_user_agent(ua)?;
+    }
+
     // Resolve storage backend: use the requested one or fall back to the default.
     let storage_backend = match &payload.storage_backend {
         None => state.config.storage_backend.clone(),
@@ -1406,6 +1458,12 @@ pub async fn create_repository(
         upsert_index_upstream_url(&state.db, repo.id, index_url).await?;
     }
 
+    if let Some(ref ua) = payload.custom_user_agent {
+        if !ua.is_empty() {
+            upsert_repo_config(&state.db, repo.id, "custom_user_agent", ua).await?;
+        }
+    }
+
     // Add virtual repository members. Post-#1444, the validator accepts
     // `member_repos == None` (deferred-population pattern: caller will
     // POST /members later) and only rejects `Some(empty_vec)`. Treat the
@@ -1466,6 +1524,7 @@ pub async fn create_repository(
         response.upstream_auth_type = Some(at.clone());
         response.upstream_auth_configured = true;
     }
+    response.custom_user_agent = payload.custom_user_agent.filter(|ua| !ua.is_empty());
     Ok(Json(response))
 }
 
@@ -1500,6 +1559,7 @@ pub async fn get_repository(
     response.upstream_auth_configured = auth_type.is_some();
     response.upstream_auth_type = auth_type;
     let response = with_quarantine_settings(&state.db, repo_id, response).await;
+    let response = with_custom_user_agent(&state.db, repo_id, response).await;
     Ok(Json(response))
 }
 
@@ -1665,6 +1725,26 @@ pub async fn update_repository(
         }
     }
 
+    if let Some(ref ua) = payload.custom_user_agent {
+        if existing.repo_type != RepositoryType::Remote {
+            return Err(AppError::Validation(
+                "custom_user_agent is only valid for remote repositories".to_string(),
+            ));
+        }
+        if ua.is_empty() {
+            sqlx::query(
+                "DELETE FROM repository_config WHERE repository_id = $1 AND key = 'custom_user_agent'",
+            )
+            .bind(repo.id)
+            .execute(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        } else {
+            validate_custom_user_agent(ua)?;
+            upsert_repo_config(&state.db, repo.id, "custom_user_agent", ua).await?;
+        }
+    }
+
     let storage_used = service.get_storage_usage(repo.id).await?;
 
     state.event_bus.emit_repository_event(
@@ -1675,7 +1755,14 @@ pub async fn update_repository(
 
     let repo_id = repo.id;
     let response = repo_to_response(repo, storage_used);
-    let response = with_quarantine_settings(&state.db, repo_id, response).await;
+    let mut response = with_quarantine_settings(&state.db, repo_id, response).await;
+    if let Some(ref ua) = payload.custom_user_agent {
+        response.custom_user_agent = if ua.is_empty() {
+            None
+        } else {
+            Some(ua.clone())
+        };
+    }
     Ok(Json(response))
 }
 
@@ -6251,6 +6338,66 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // validate_custom_user_agent
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_validate_custom_user_agent_valid() {
+        assert!(validate_custom_user_agent("MyClient/1.0").is_ok());
+        assert!(validate_custom_user_agent("artifact-keeper-proxy/2.0 (internal)").is_ok());
+        assert!(validate_custom_user_agent(&"a".repeat(256)).is_ok());
+    }
+
+    #[test]
+    fn test_validate_custom_user_agent_too_long() {
+        let ua = "a".repeat(257);
+        let err = validate_custom_user_agent(&ua).unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert!(msg.contains("256")),
+            other => panic!("Expected Validation error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_custom_user_agent_rejects_newline() {
+        let err = validate_custom_user_agent("bad\nvalue").unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert!(msg.contains("newline")),
+            other => panic!("Expected Validation error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_custom_user_agent_rejects_carriage_return() {
+        let err = validate_custom_user_agent("bad\rvalue").unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert!(msg.contains("newline")),
+            other => panic!("Expected Validation error, got: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_create_request_deserializes_custom_user_agent() {
+        let json = r#"{"key":"npm-proxy","name":"NPM Proxy","format":"npm","repo_type":"remote","custom_user_agent":"MyClient/2.0"}"#;
+        let req: CreateRepositoryRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.custom_user_agent.as_deref(), Some("MyClient/2.0"));
+    }
+
+    #[test]
+    fn test_update_request_deserializes_custom_user_agent() {
+        let json = r#"{"custom_user_agent":"MyClient/2.0"}"#;
+        let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.custom_user_agent.as_deref(), Some("MyClient/2.0"));
+    }
+
+    #[test]
+    fn test_update_request_empty_custom_user_agent_clears() {
+        let json = r#"{"custom_user_agent":""}"#;
+        let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.custom_user_agent.as_deref(), Some(""));
+    }
+
+    // -----------------------------------------------------------------------
     // parse_format
     // -----------------------------------------------------------------------
 
@@ -6568,6 +6715,7 @@ mod tests {
             upstream_auth_configured: false,
             quarantine_enabled: None,
             quarantine_duration_minutes: None,
+            custom_user_agent: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -7842,6 +7990,7 @@ mod tests {
             upstream_auth_configured: false,
             quarantine_enabled: Some(true),
             quarantine_duration_minutes: Some(525600),
+            custom_user_agent: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -630,9 +630,13 @@ fn validate_custom_user_agent(ua: &str) -> Result<()> {
             "custom_user_agent must be 256 characters or fewer".to_string(),
         ));
     }
-    if ua.chars().any(|c| c == '\r' || c == '\n') {
+    // RFC 7230 §3.2.6: field-value = *( field-vchar / SP / HTAB ) where field-vchar = VCHAR / obs-text.
+    // VCHAR is %x21-7E; SP (0x20) and HTAB (0x09) are the only allowed non-printable bytes.
+    // Everything below SP except HTAB, and DEL (0x7F), is forbidden.
+    if ua.bytes().any(|b| (b < 0x20 && b != b'\t') || b == 0x7F) {
         return Err(AppError::Validation(
-            "custom_user_agent must not contain newline characters".to_string(),
+            "custom_user_agent must not contain control characters (see RFC 7230 §3.2.6)"
+                .to_string(),
         ));
     }
     Ok(())
@@ -6359,21 +6363,24 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_custom_user_agent_rejects_newline() {
-        let err = validate_custom_user_agent("bad\nvalue").unwrap_err();
+    fn test_validate_custom_user_agent_rejects_control_chars() {
+        // LF, CR, NUL, BEL — all forbidden per RFC 7230 §3.2.6 field-value
+        for bad in ["\n", "\r", "\x00", "\x07"] {
+            let ua = format!("bad{bad}value");
+            let err = validate_custom_user_agent(&ua).unwrap_err();
+            match err {
+                AppError::Validation(msg) => assert!(msg.contains("control characters"), "{ua:?}"),
+                other => panic!("Expected Validation error, got: {:?}", other),
+            }
+        }
+        // DEL (0x7F) is also forbidden
+        let err = validate_custom_user_agent("bad\x7Fvalue").unwrap_err();
         match err {
-            AppError::Validation(msg) => assert!(msg.contains("newline")),
+            AppError::Validation(msg) => assert!(msg.contains("control characters")),
             other => panic!("Expected Validation error, got: {:?}", other),
         }
-    }
-
-    #[test]
-    fn test_validate_custom_user_agent_rejects_carriage_return() {
-        let err = validate_custom_user_agent("bad\rvalue").unwrap_err();
-        match err {
-            AppError::Validation(msg) => assert!(msg.contains("newline")),
-            other => panic!("Expected Validation error, got: {:?}", other),
-        }
+        // HT (0x09) is explicitly allowed
+        assert!(validate_custom_user_agent("MyClient/1.0\t(tab ok)").is_ok());
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1328,8 +1328,18 @@ pub(crate) struct UpstreamClient {
     user_agent_cache: RwLock<HashMap<Uuid, (Option<String>, Instant)>>,
 }
 
+const CUSTOM_USER_AGENT_KEY: &str = "custom_user_agent";
+
 /// TTL for cached custom user-agent entries.
 const USER_AGENT_CACHE_TTL_SECS: u64 = 60;
+
+/// Apply a custom User-Agent header to a request builder if one is configured.
+fn apply_custom_ua(req: reqwest::RequestBuilder, ua: Option<&str>) -> reqwest::RequestBuilder {
+    match ua {
+        Some(ua) => req.header(USER_AGENT, ua),
+        None => req,
+    }
+}
 
 impl UpstreamClient {
     /// Construct an `UpstreamClient` over the given HTTP client and db handle.
@@ -1377,9 +1387,7 @@ impl UpstreamClient {
         if let Some(ref auth) = upstream_auth {
             request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
         }
-        if let Some(ref ua) = custom_ua {
-            request = request.header(USER_AGENT, ua.as_str());
-        }
+        request = apply_custom_ua(request, custom_ua.as_deref());
         // BUFFERED path sets `Accept` on the INITIAL request. The streaming
         // path deliberately does NOT — see `exchange_bearer_then` /
         // `fetch_stream` for why this asymmetry is intentional (#1618 S8).
@@ -1403,11 +1411,7 @@ impl UpstreamClient {
             // decision so the buffered/streaming asymmetry is preserved (#1618 S8).
             if let Some(retry_response) = self
                 .exchange_bearer_then(response, url, &upstream_auth, |req| {
-                    let req = if let Some(ref ua) = custom_ua {
-                        req.header(USER_AGENT, ua.as_str())
-                    } else {
-                        req
-                    };
+                    let req = apply_custom_ua(req, custom_ua.as_deref());
                     if let Some(accept_value) = accept {
                         req.header(ACCEPT, accept_value)
                     } else {
@@ -1514,9 +1518,7 @@ impl UpstreamClient {
         if let Some(ref auth) = upstream_auth {
             request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
         }
-        if let Some(ref ua) = custom_ua {
-            request = request.header(USER_AGENT, ua.as_str());
-        }
+        request = apply_custom_ua(request, custom_ua.as_deref());
         // NOTE: the streaming path intentionally sets NO `Accept` header on the
         // initial request, in contrast to the buffered path which sets it on
         // both the initial request and the retry. This asymmetry is deliberate
@@ -1535,11 +1537,7 @@ impl UpstreamClient {
             // buffered path (#1618 S8).
             if let Some(retry_response) = self
                 .exchange_bearer_then(response, url, &upstream_auth, |req| {
-                    if let Some(ref ua) = custom_ua {
-                        req.header(USER_AGENT, ua.as_str())
-                    } else {
-                        req
-                    }
+                    apply_custom_ua(req, custom_ua.as_deref())
                 })
                 .await?
             {
@@ -1779,10 +1777,10 @@ impl UpstreamClient {
             }
         }
         let ua = sqlx::query_scalar::<_, String>(
-            "SELECT value FROM repository_config \
-             WHERE repository_id = $1 AND key = 'custom_user_agent'",
+            "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
         )
         .bind(repo_id)
+        .bind(CUSTOM_USER_AGENT_KEY)
         .fetch_optional(&self.db)
         .await
         .ok()

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -11,7 +11,7 @@ use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::stream::{BoxStream, StreamExt};
 use reqwest::header::{
-    ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH, WWW_AUTHENTICATE,
+    ACCEPT, CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH, USER_AGENT, WWW_AUTHENTICATE,
 };
 use reqwest::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -1323,7 +1323,13 @@ pub(crate) struct UpstreamClient {
     /// In-memory cache for OCI registry bearer tokens.
     /// Key: "{realm}\0{service}\0{scope}", Value: (token, created_at, ttl_secs)
     token_cache: RwLock<HashMap<String, (String, Instant, u64)>>,
+    /// In-memory cache for per-repo custom user-agents. TTL: 60 s.
+    /// Key: repo_id, Value: (custom_ua, cached_at)
+    user_agent_cache: RwLock<HashMap<Uuid, (Option<String>, Instant)>>,
 }
+
+/// TTL for cached custom user-agent entries.
+const USER_AGENT_CACHE_TTL_SECS: u64 = 60;
 
 impl UpstreamClient {
     /// Construct an `UpstreamClient` over the given HTTP client and db handle.
@@ -1334,6 +1340,7 @@ impl UpstreamClient {
             db,
             http_client,
             token_cache: RwLock::new(HashMap::new()),
+            user_agent_cache: RwLock::new(HashMap::new()),
         }
     }
 
@@ -1364,10 +1371,14 @@ impl UpstreamClient {
 
         let upstream_auth =
             crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
+        let custom_ua = self.get_custom_user_agent(repo_id).await;
 
         let mut request = self.http_client.get(url);
         if let Some(ref auth) = upstream_auth {
             request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
+        }
+        if let Some(ref ua) = custom_ua {
+            request = request.header(USER_AGENT, ua.as_str());
         }
         // BUFFERED path sets `Accept` on the INITIAL request. The streaming
         // path deliberately does NOT — see `exchange_bearer_then` /
@@ -1386,12 +1397,17 @@ impl UpstreamClient {
         // Handle 401 with bearer token exchange (required by Docker Hub and
         // other OCI registries, even for anonymous/public pulls).
         if status == StatusCode::UNAUTHORIZED {
-            // The buffered closure RE-ADDS `Accept` on the bearer retry,
-            // mirroring the initial request. The bearer-exchange helper itself
-            // never touches `Accept`; the closure owns that decision so the
-            // buffered/streaming asymmetry is preserved (#1618 S8).
+            // The buffered closure RE-ADDS `Accept` (and the custom UA) on the
+            // bearer retry, mirroring the initial request. The bearer-exchange
+            // helper itself never touches these headers; the closure owns that
+            // decision so the buffered/streaming asymmetry is preserved (#1618 S8).
             if let Some(retry_response) = self
                 .exchange_bearer_then(response, url, &upstream_auth, |req| {
+                    let req = if let Some(ref ua) = custom_ua {
+                        req.header(USER_AGENT, ua.as_str())
+                    } else {
+                        req
+                    };
                     if let Some(accept_value) = accept {
                         req.header(ACCEPT, accept_value)
                     } else {
@@ -1492,10 +1508,14 @@ impl UpstreamClient {
 
         let upstream_auth =
             crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
+        let custom_ua = self.get_custom_user_agent(repo_id).await;
 
         let mut request = self.http_client.get(url);
         if let Some(ref auth) = upstream_auth {
             request = crate::services::upstream_auth::apply_upstream_auth(request, auth);
+        }
+        if let Some(ref ua) = custom_ua {
+            request = request.header(USER_AGENT, ua.as_str());
         }
         // NOTE: the streaming path intentionally sets NO `Accept` header on the
         // initial request, in contrast to the buffered path which sets it on
@@ -1510,11 +1530,17 @@ impl UpstreamClient {
         let status = response.status();
 
         if status == StatusCode::UNAUTHORIZED {
-            // The streaming closure is the IDENTITY transform: it adds NO
-            // `Accept` header on the bearer retry, preserving the asymmetry
-            // with the buffered path (#1618 S8).
+            // The streaming closure re-applies the custom UA on the bearer retry
+            // but adds NO `Accept` header, preserving the asymmetry with the
+            // buffered path (#1618 S8).
             if let Some(retry_response) = self
-                .exchange_bearer_then(response, url, &upstream_auth, |req| req)
+                .exchange_bearer_then(response, url, &upstream_auth, |req| {
+                    if let Some(ref ua) = custom_ua {
+                        req.header(USER_AGENT, ua.as_str())
+                    } else {
+                        req
+                    }
+                })
                 .await?
             {
                 return Self::read_upstream_response_streaming(retry_response, url);
@@ -1739,6 +1765,33 @@ impl UpstreamClient {
         } else {
             None
         }
+    }
+
+    /// Return the custom user-agent for a repo, hitting the in-memory cache
+    /// first (60 s TTL) to avoid a DB round-trip on every upstream request.
+    async fn get_custom_user_agent(&self, repo_id: Uuid) -> Option<String> {
+        {
+            let cache = self.user_agent_cache.read().await;
+            if let Some((ua, cached_at)) = cache.get(&repo_id) {
+                if cached_at.elapsed() < Duration::from_secs(USER_AGENT_CACHE_TTL_SECS) {
+                    return ua.clone();
+                }
+            }
+        }
+        let ua = sqlx::query_scalar::<_, String>(
+            "SELECT value FROM repository_config \
+             WHERE repository_id = $1 AND key = 'custom_user_agent'",
+        )
+        .bind(repo_id)
+        .fetch_optional(&self.db)
+        .await
+        .ok()
+        .flatten();
+        self.user_agent_cache
+            .write()
+            .await
+            .insert(repo_id, (ua.clone(), Instant::now()));
+        ua
     }
 
     /// Parse a `WWW-Authenticate: Bearer realm="...",service="...",scope="..."`


### PR DESCRIPTION
## Summary

Closes #2080.

Remote repositories can now be configured with a custom `User-Agent` string sent on every outbound HTTP request to the upstream registry. This is useful when the upstream is behind a corporate proxy or rate-limit middleware that routes or throttles traffic based on the User-Agent.

## What changed

**`backend/src/api/handlers/repositories.rs`**

1. New optional field `custom_user_agent: Option<String>` on `CreateRepositoryRequest`, `UpdateRepositoryRequest`, and `RepositoryResponse` (all three already derive `ToSchema`; new field picked up automatically).
2. New helper `with_custom_user_agent(db, repo_id, response)` reads from `repository_config` and populates the response field. Called only in the GET handler to avoid an unnecessary DB round-trip in create/update.
3. New `validate_custom_user_agent(ua: &str)` enforces:
   - Maximum 256 characters (no RFC-imposed limit; pragmatic cap).
   - No control characters per [RFC 7230 §3.2.6](https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6) `field-value` rules: any byte below SP (0x20) except HTAB (0x09), and DEL (0x7F), is rejected.
   - Intentionally more permissive than the strict `product *( RWS ( product / comment ) )` grammar from RFC 7231 §5.5.3 to accommodate real-world User-Agent strings.
4. Create handler: validates `repo_type = remote`, validates the UA, upserts to `repository_config`.
5. Update handler: empty string removes the value, non-empty validates and upserts.
6. Get handler: populates `custom_user_agent` via `with_custom_user_agent`.
7. `CUSTOM_USER_AGENT_KEY` constant used in all SQL queries and `upsert_repo_config` calls.

No schema migration needed; `repository_config` (key/value per repo) already exists.

**`backend/src/services/proxy_service.rs`**

1. New field `user_agent_cache: RwLock<HashMap<Uuid, (Option<String>, Instant)>>` on `UpstreamClient` with a 60 s TTL to avoid a DB round-trip on every upstream request (mirrors the existing `token_cache` pattern).
2. New method `get_custom_user_agent(repo_id)` with cache-first lookup and DB fallback, using `CUSTOM_USER_AGENT_KEY`.
3. New `apply_custom_ua(req, ua)` helper replaces four repeated `if let Some(ua) = ... { req.header(...) }` patterns.
4. `fetch_buffered` and `fetch_stream` apply the custom UA on the initial request and inside the `exchange_bearer_then` bearer-token retry closure. The buffered/streaming Accept-header asymmetry from #1618 S8 is preserved.

## Regression test (required for `fix/*` PRs)

- [x] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes

- [x] Request/response types have `#[derive(ToSchema)]` (already present; new field picked up automatically)
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable); no migration, uses existing `repository_config` table