### PR TITLE
feat(scanner-adapter): in-house multi-arch Trivy Harbor scanner adapter (#2091)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -36,8 +36,10 @@ env:
   REGISTRY: ghcr.io
   BACKEND_IMAGE: ${{ github.repository }}-backend
   OPENSCAP_IMAGE: ${{ github.repository }}-openscap
+  SCANNER_ADAPTER_IMAGE: ${{ github.repository }}-scanner-adapter
   DOCKERHUB_BACKEND: artifactkeeper/backend
   DOCKERHUB_OPENSCAP: artifactkeeper/openscap
+  DOCKERHUB_SCANNER_ADAPTER: artifactkeeper/scanner-adapter
 
 jobs:
   build-backend:
@@ -201,6 +203,82 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+  build-scanner-adapter:
+    name: Scanner Adapter (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ak-ci-runners
+            cache-tag: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            cache-tag: arm64
+    outputs:
+      digest-amd64: ${{ steps.build.outputs.digest }}
+      digest-arm64: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Authenticate to Docker Hub for transitive base-image pulls; see
+      # the matching step in build-backend for rationale.
+      - name: Log in to Docker Hub (for transitive base-image pulls)
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
+        with:
+          context: .
+          file: ./docker/Dockerfile.scanner-adapter
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:buildcache-${{ matrix.cache-tag }}
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:buildcache-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          sbom: true
+          provenance: mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: scanner-adapter-digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   build-backend-alpine:
     name: Backend Alpine (${{ matrix.platform }})
     # Alpine builds suspended. UBI is the default backend image and the
@@ -282,7 +360,7 @@ jobs:
     # `build-backend-alpine` removed from `needs` while alpine builds are
     # suspended. Re-add it (and re-enable the alpine-gated steps below)
     # when the alpine variant comes back online.
-    needs: [build-backend, build-openscap]
+    needs: [build-backend, build-openscap, build-scanner-adapter]
     permissions:
       contents: read
       packages: read
@@ -311,6 +389,12 @@ jobs:
           name: openscap-digests-amd64
           path: /tmp/openscap-digests
 
+      - name: Download scanner-adapter amd64 digest
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: scanner-adapter-digests-amd64
+          path: /tmp/scanner-adapter-digests
+
       # Alpine digest download skipped while alpine builds are suspended.
       # - name: Download backend alpine amd64 digest
       #   uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
@@ -323,8 +407,10 @@ jobs:
         run: |
           BACKEND_DIGEST=$(ls /tmp/backend-digests/)
           OPENSCAP_DIGEST=$(ls /tmp/openscap-digests/)
+          SCANNER_ADAPTER_DIGEST=$(ls /tmp/scanner-adapter-digests/)
           echo "backend=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}@sha256:${BACKEND_DIGEST}" >> $GITHUB_OUTPUT
           echo "openscap=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}@sha256:${OPENSCAP_DIGEST}" >> $GITHUB_OUTPUT
+          echo "scanner-adapter=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@sha256:${SCANNER_ADAPTER_DIGEST}" >> $GITHUB_OUTPUT
           # backend-alpine digest output skipped while alpine builds are suspended.
 
       # --- Trivy CVE scanning ---
@@ -370,6 +456,19 @@ jobs:
           exit-code: '0'
           skip-setup-trivy: true
 
+      - name: Trivy scan - Scanner Adapter
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        if: always()
+        with:
+          image-ref: ${{ steps.refs.outputs.scanner-adapter }}
+          format: 'sarif'
+          output: 'scanner-adapter-trivy.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
+          exit-code: '0'
+          skip-setup-trivy: true
+
       # Alpine scan skipped while alpine builds are suspended.
       - name: Trivy scan - Backend Alpine
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -398,6 +497,13 @@ jobs:
           sarif_file: 'openscap-trivy.sarif'
           category: 'trivy-openscap'
 
+      - name: Upload Scanner Adapter Trivy SARIF
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        if: always()
+        with:
+          sarif_file: 'scanner-adapter-trivy.sarif'
+          category: 'trivy-scanner-adapter'
+
       # Alpine SARIF upload skipped while alpine builds are suspended.
       - name: Upload Backend Alpine Trivy SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -414,6 +520,7 @@ jobs:
           path: |
             backend-trivy.sarif
             openscap-trivy.sarif
+            scanner-adapter-trivy.sarif
             backend-alpine-trivy.sarif
           retention-days: 90
 
@@ -485,6 +592,7 @@ jobs:
           echo "- **Policy**: Fail on CRITICAL or HIGH severity CVEs" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
+          echo "- **Scanner Adapter**: $([ -f scanner-adapter-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend Alpine**: $([ -f backend-alpine-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### OpenSCAP STIG Compliance" >> $GITHUB_STEP_SUMMARY
@@ -720,6 +828,110 @@ jobs:
           push-to-registry: true
         continue-on-error: true
 
+  merge-scanner-adapter:
+    name: Scanner Adapter Multi-Arch Manifest
+    runs-on: ubuntu-latest
+    needs: [build-scanner-adapter]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          path: /tmp/digests
+          pattern: scanner-adapter-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (ghcr.io)
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Extract metadata (Docker Hub)
+        id: meta-dockerhub
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
+        with:
+          images: docker.io/${{ env.DOCKERHUB_SCANNER_ADAPTER }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=1.1-dev,enable=${{ github.ref == format('refs/heads/{0}', 'release/1.1.x') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Create manifest list and push (ghcr.io)
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@sha256:%s ' *)
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+
+      - name: Inspect image
+        id: inspect
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:${{ steps.meta.outputs.version }}
+          DIGEST=$(docker buildx imagetools inspect --format '{{json .Manifest}}' \
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:${{ steps.meta.outputs.version }} | jq -r '.digest')
+          echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+
+      - name: Copy to Docker Hub
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< '${{ steps.meta-dockerhub.outputs.json }}') \
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}
+
+      - name: Sign image with cosign (keyless)
+        run: |
+          cosign sign --yes \
+            ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}@${{ steps.inspect.outputs.digest }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true
+        continue-on-error: true
+
   merge-backend-alpine:
     name: Backend Alpine Multi-Arch Manifest
     # Alpine builds suspended; the multi-arch manifest job follows them.
@@ -871,7 +1083,7 @@ jobs:
       packages: read
     # `merge-backend-alpine` removed from `needs` while alpine builds are
     # suspended (it is `if: false` and would never report success).
-    needs: [merge-backend, merge-openscap]
+    needs: [merge-backend, merge-openscap, merge-scanner-adapter]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Probe ghcr.io manifests for expected semver tags
@@ -879,6 +1091,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BACKEND_IMAGE: ${{ env.BACKEND_IMAGE }}
           OPENSCAP_IMAGE: ${{ env.OPENSCAP_IMAGE }}
+          SCANNER_ADAPTER_IMAGE: ${{ env.SCANNER_ADAPTER_IMAGE }}
         run: |
           set -u
           VERSION="${GITHUB_REF#refs/tags/v}"
@@ -908,6 +1121,7 @@ jobs:
           EXPECTED=(
             "${BACKEND_IMAGE}:${VERSION}"
             "${OPENSCAP_IMAGE}:${VERSION}"
+            "${SCANNER_ADAPTER_IMAGE}:${VERSION}"
           )
 
           missing=()
@@ -933,7 +1147,7 @@ jobs:
     name: Publish Summary
     runs-on: ubuntu-latest
     permissions: {}
-    needs: [merge-backend, merge-openscap]
+    needs: [merge-backend, merge-openscap, merge-scanner-adapter]
     if: always()
     steps:
       - name: Summary
@@ -947,6 +1161,10 @@ jobs:
           echo "### OpenSCAP" >> $GITHUB_STEP_SUMMARY
           echo "- \`${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "- \`docker.io/${{ env.DOCKERHUB_OPENSCAP }}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Scanner Adapter" >> $GITHUB_STEP_SUMMARY
+          echo "- \`${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:latest\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`docker.io/${{ env.DOCKERHUB_SCANNER_ADAPTER }}:latest\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Supply Chain Security" >> $GITHUB_STEP_SUMMARY
           echo "- All images signed with [cosign](https://docs.sigstore.dev/cosign/overview/) keyless signing (GitHub OIDC)" >> $GITHUB_STEP_SUMMARY

--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -1,0 +1,63 @@
+# =============================================================================
+# Artifact Keeper — in-house Trivy scanner adapter (multi-arch)
+# =============================================================================
+# A small AK-owned Go service implementing the Harbor Pluggable Scanner API v1
+# (issue #2091). The backend (TRIVY_ADAPTER_URL) posts a scan request; the
+# adapter execs the bundled trivy CLI against the requested image in the AK
+# registry and serves the resulting vulnerability report in the Harbor format
+# the backend consumes. Trivy is NOT in the backend image (#2059) — it lives
+# here.
+#
+# Build (buildx resolves $TARGETPLATFORM per requested arch):
+#   docker buildx build --platform linux/amd64,linux/arm64 \
+#     -f docker/Dockerfile.scanner-adapter -t artifact-keeper-scanner-adapter:dev .
+# Context is the repo root; the Go module lives at docker/scanner-adapter.
+
+# ---------- Stage 1: cross-compile the Go adapter ----------
+# Pinned to the BUILDPLATFORM so the toolchain runs natively and cross-compiles
+# to the requested TARGET arch (fast, no emulation for the compile step).
+FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS build
+
+ARG TARGETOS
+ARG TARGETARCH
+
+WORKDIR /src
+
+# stdlib-only module: copying go.mod is enough for the build cache; there are no
+# third-party dependencies to download.
+COPY docker/scanner-adapter/go.mod ./
+COPY docker/scanner-adapter/*.go ./
+
+# CGO disabled for a fully static binary; -trimpath + -s -w for a small,
+# reproducible artifact.
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -trimpath -ldflags="-s -w" -o /out/scanner-adapter .
+
+# ---------- Stage 2: pull the matching trivy binary ----------
+# buildx selects this image's TARGETPLATFORM variant automatically, so the
+# arm64 build gets the arm64 trivy and the amd64 build gets amd64. Pinned to
+# 0.71.2 (rig-standard; #2090's backend tests assert trivy-0.71.2). Aqua
+# publishes both linux/amd64 and linux/arm64 for this tag.
+FROM ghcr.io/aquasecurity/trivy:0.71.2 AS trivy
+
+# ---------- Stage 3: minimal runtime ----------
+FROM alpine:3.20
+
+# ca-certificates: TLS to the trivy vuln-DB registry / HTTPS registries.
+# git + rpm: trivy uses them for certain package/source scanners.
+RUN apk add --no-cache ca-certificates git rpm \
+    && adduser -D -u 1001 scanner \
+    && mkdir -p /home/scanner/.cache/trivy \
+    && chown -R scanner:scanner /home/scanner
+
+COPY --from=trivy /usr/local/bin/trivy /usr/local/bin/trivy
+COPY --from=build /out/scanner-adapter /usr/local/bin/scanner-adapter
+
+ENV SCANNER_ADAPTER_ADDR=:8080 \
+    SCANNER_TRIVY_PATH=/usr/local/bin/trivy \
+    SCANNER_TRIVY_CACHE_DIR=/home/scanner/.cache/trivy
+
+USER 1001
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/scanner-adapter"]

--- a/docker/scanner-adapter/config.go
+++ b/docker/scanner-adapter/config.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Config holds the adapter's runtime configuration, populated from the
+// environment. All values have sane defaults so the adapter runs with an empty
+// environment (the container sets only what it needs to override).
+type Config struct {
+	// Addr is the listen address, e.g. ":8080" or ":8090".
+	Addr string
+	// TrivyPath is the trivy binary to exec (absolute path or $PATH name).
+	TrivyPath string
+	// CacheDir is trivy's --cache-dir (vuln DB + fanal cache).
+	CacheDir string
+	// Insecure passes --insecure to trivy so it pulls manifests/blobs from the
+	// AK registry over plain HTTP on the rig/cluster network.
+	Insecure bool
+	// SkipDBUpdate passes --skip-db-update so an air-gapped / pre-seeded cache
+	// is used verbatim instead of contacting the trivy DB registry.
+	SkipDBUpdate bool
+	// Severity is the trivy --severity filter (comma-separated UPPERCASE).
+	Severity string
+	// ScanTimeout bounds a single trivy invocation.
+	ScanTimeout time.Duration
+	// JobTTL is how long a finished job (report or error) is retained before the
+	// sweeper evicts it.
+	JobTTL time.Duration
+	// LogLevel is "debug" | "info" (anything != debug is treated as info).
+	LogLevel string
+	// ScannerVersion is the trivy version reported in the Harbor report's
+	// `scanner.version`. Empty at construction; filled by ProbeVersion at
+	// startup (or overridden via SCANNER_SCANNER_VERSION).
+	ScannerVersion string
+}
+
+// LoadConfig reads the SCANNER_* environment variables, applying defaults.
+func LoadConfig() *Config {
+	return &Config{
+		Addr:           getenv("SCANNER_ADAPTER_ADDR", ":8080"),
+		TrivyPath:      getenv("SCANNER_TRIVY_PATH", "trivy"),
+		CacheDir:       getenv("SCANNER_TRIVY_CACHE_DIR", "/home/scanner/.cache/trivy"),
+		Insecure:       getenvBool("SCANNER_TRIVY_INSECURE", true),
+		SkipDBUpdate:   getenvBool("SCANNER_TRIVY_SKIP_DB_UPDATE", false),
+		Severity:       getenv("SCANNER_TRIVY_SEVERITY", "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"),
+		ScanTimeout:    getenvDuration("SCANNER_TRIVY_TIMEOUT", 5*time.Minute),
+		JobTTL:         getenvDuration("SCANNER_JOB_TTL", 30*time.Minute),
+		LogLevel:       getenv("SCANNER_LOG_LEVEL", "info"),
+		ScannerVersion: os.Getenv("SCANNER_SCANNER_VERSION"),
+	}
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func getenvBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(strings.TrimSpace(v))
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func getenvDuration(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	d, err := time.ParseDuration(strings.TrimSpace(v))
+	if err != nil {
+		return def
+	}
+	return d
+}

--- a/docker/scanner-adapter/go.mod
+++ b/docker/scanner-adapter/go.mod
@@ -1,0 +1,3 @@
+module artifact-keeper/scanner-adapter
+
+go 1.23

--- a/docker/scanner-adapter/harbor.go
+++ b/docker/scanner-adapter/harbor.go
@@ -1,0 +1,145 @@
+package main
+
+// Harbor Pluggable Scanner API v1 request/response types and the trivy->Harbor
+// mapping. See https://github.com/goharbor/pluggable-scanner-spec. The JSON
+// shapes here are the FROZEN contract PR #2090's `image_scanner.rs` deserializes
+// (HarborScanResponse / HarborScanReport), so field names and casing must not
+// drift.
+
+// The media type the report endpoint produces / the backend requests via
+// `Accept`.
+const reportMimeType = "application/vnd.security.vulnerability.report; version=1.1"
+
+// Manifest media types the adapter advertises as consumable in /api/v1/metadata.
+const (
+	ociManifestMimeType    = "application/vnd.oci.image.manifest.v1+json"
+	dockerManifestMimeType = "application/vnd.docker.distribution.manifest.v2+json"
+)
+
+// ScanRequest is the body of POST /api/v1/scan sent by the backend.
+type ScanRequest struct {
+	Registry RegistryRef `json:"registry"`
+	Artifact ArtifactRef `json:"artifact"`
+}
+
+// RegistryRef identifies the registry the adapter should pull from.
+type RegistryRef struct {
+	URL string `json:"url"`
+	// Authorization is "Bearer <jwt>" for private pulls, omitted for anonymous.
+	Authorization string `json:"authorization,omitempty"`
+}
+
+// ArtifactRef identifies the image to scan: repository plus exactly one of
+// tag / digest.
+type ArtifactRef struct {
+	Repository string `json:"repository"`
+	MimeType   string `json:"mime_type"`
+	Tag        string `json:"tag,omitempty"`
+	Digest     string `json:"digest,omitempty"`
+}
+
+// ScanResponse is the body of a successful POST /api/v1/scan: the opaque id used
+// to fetch the report.
+type ScanResponse struct {
+	ID string `json:"id"`
+}
+
+// HarborScanReport is the successful GET /api/v1/scan/{id}/report body.
+type HarborScanReport struct {
+	Scanner         HarborScanner         `json:"scanner"`
+	Vulnerabilities []HarborVulnerability `json:"vulnerabilities"`
+}
+
+// HarborScanner identifies the scanner that produced the report.
+type HarborScanner struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+// HarborVulnerability is one Harbor-shaped CVE row.
+type HarborVulnerability struct {
+	ID          string   `json:"id"`
+	Package     string   `json:"package"`
+	Version     string   `json:"version"`
+	FixVersion  string   `json:"fix_version,omitempty"`
+	Severity    string   `json:"severity"`
+	Description string   `json:"description,omitempty"`
+	Links       []string `json:"links,omitempty"`
+}
+
+// ScannerMetadata is the GET /api/v1/metadata body (Harbor conformance / #237).
+type ScannerMetadata struct {
+	Scanner      HarborScannerInfo   `json:"scanner"`
+	Capabilities []ScannerCapability `json:"capabilities"`
+}
+
+// HarborScannerInfo describes the scanner in metadata.
+type HarborScannerInfo struct {
+	Name    string `json:"name"`
+	Vendor  string `json:"vendor"`
+	Version string `json:"version"`
+}
+
+// ScannerCapability advertises the consumed/produced media types.
+type ScannerCapability struct {
+	ConsumesMimeTypes []string `json:"consumes_mime_types"`
+	ProducesMimeTypes []string `json:"produces_mime_types"`
+}
+
+// mapSeverity translates a trivy UPPERCASE severity token into the Harbor
+// Title-case vocabulary the backend expects. Single source of truth for the
+// severity mapping (referenced by scan + tests).
+func mapSeverity(trivySeverity string) string {
+	switch trivySeverity {
+	case "CRITICAL":
+		return "Critical"
+	case "HIGH":
+		return "High"
+	case "MEDIUM":
+		return "Medium"
+	case "LOW":
+		return "Low"
+	case "UNKNOWN":
+		return "Unknown"
+	default:
+		// Empty or unrecognized -> Unknown (backend maps Unknown -> Info).
+		return "Unknown"
+	}
+}
+
+// firstLink returns the best single reference URL for a trivy vuln: PrimaryURL
+// when present, otherwise the first entry in References. Single source of truth
+// for the link/reference selection (referenced by the mapping + tests).
+func firstLink(v TrivyVulnerability) []string {
+	if v.PrimaryURL != "" {
+		return []string{v.PrimaryURL}
+	}
+	if len(v.References) > 0 {
+		return []string{v.References[0]}
+	}
+	return nil
+}
+
+// mapTrivyToHarbor flattens every result's vulnerabilities into the Harbor
+// report shape. The vulnerabilities slice is always non-nil (empty array, never
+// null) so the JSON body serializes as `[]` for a clean image.
+func mapTrivyToHarbor(report *TrivyReport, scanner HarborScanner) *HarborScanReport {
+	vulns := make([]HarborVulnerability, 0)
+	for _, result := range report.Results {
+		for _, v := range result.Vulnerabilities {
+			vulns = append(vulns, HarborVulnerability{
+				ID:          v.VulnerabilityID,
+				Package:     v.PkgName,
+				Version:     v.InstalledVersion,
+				FixVersion:  v.FixedVersion,
+				Severity:    mapSeverity(v.Severity),
+				Description: v.Description,
+				Links:       firstLink(v),
+			})
+		}
+	}
+	return &HarborScanReport{
+		Scanner:         scanner,
+		Vulnerabilities: vulns,
+	}
+}

--- a/docker/scanner-adapter/harbor_test.go
+++ b/docker/scanner-adapter/harbor_test.go
@@ -1,0 +1,99 @@
+package main
+
+import "testing"
+
+func TestMapSeverity(t *testing.T) {
+	cases := map[string]string{
+		"CRITICAL": "Critical",
+		"HIGH":     "High",
+		"MEDIUM":   "Medium",
+		"LOW":      "Low",
+		"UNKNOWN":  "Unknown",
+		"":         "Unknown",
+		"garbage":  "Unknown",
+	}
+	for in, want := range cases {
+		if got := mapSeverity(in); got != want {
+			t.Errorf("mapSeverity(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFirstLink(t *testing.T) {
+	if got := firstLink(TrivyVulnerability{PrimaryURL: "https://p"}); len(got) != 1 || got[0] != "https://p" {
+		t.Errorf("PrimaryURL should win: %v", got)
+	}
+	got := firstLink(TrivyVulnerability{References: []string{"https://r1", "https://r2"}})
+	if len(got) != 1 || got[0] != "https://r1" {
+		t.Errorf("first reference should be used: %v", got)
+	}
+	if got := firstLink(TrivyVulnerability{}); got != nil {
+		t.Errorf("no links should be nil, got %v", got)
+	}
+}
+
+func TestMapTrivyToHarborEmptyIsArrayNotNull(t *testing.T) {
+	report := mapTrivyToHarbor(&TrivyReport{}, HarborScanner{Name: "Trivy", Version: "0.71.2"})
+	if report.Vulnerabilities == nil {
+		t.Fatal("Vulnerabilities must be an empty slice, not nil")
+	}
+	if len(report.Vulnerabilities) != 0 {
+		t.Fatalf("expected 0 vulns, got %d", len(report.Vulnerabilities))
+	}
+	if report.Scanner.Name != "Trivy" || report.Scanner.Version != "0.71.2" {
+		t.Errorf("scanner metadata not carried through: %+v", report.Scanner)
+	}
+}
+
+func TestMapTrivyToHarborMapsFields(t *testing.T) {
+	trivy := &TrivyReport{
+		Results: []TrivyResult{
+			{
+				Target: "alpine:3.14",
+				Class:  "os-pkgs",
+				Vulnerabilities: []TrivyVulnerability{
+					{
+						VulnerabilityID:  "CVE-2021-1234",
+						PkgName:          "openssl",
+						InstalledVersion: "3.1.0",
+						FixedVersion:     "3.1.1",
+						Severity:         "HIGH",
+						Description:      "buffer overflow",
+						PrimaryURL:       "https://avd.aquasec.com/CVE-2021-1234",
+					},
+					{
+						VulnerabilityID:  "CVE-2022-9999",
+						PkgName:          "musl",
+						InstalledVersion: "1.2.2",
+						Severity:         "CRITICAL",
+						References:       []string{"https://ref/one", "https://ref/two"},
+					},
+				},
+			},
+		},
+	}
+	report := mapTrivyToHarbor(trivy, HarborScanner{Name: "Trivy", Version: "0.71.2"})
+	if len(report.Vulnerabilities) != 2 {
+		t.Fatalf("expected 2 vulns, got %d", len(report.Vulnerabilities))
+	}
+
+	v0 := report.Vulnerabilities[0]
+	if v0.ID != "CVE-2021-1234" || v0.Package != "openssl" || v0.Version != "3.1.0" ||
+		v0.FixVersion != "3.1.1" || v0.Severity != "High" || v0.Description != "buffer overflow" {
+		t.Errorf("v0 mapped incorrectly: %+v", v0)
+	}
+	if len(v0.Links) != 1 || v0.Links[0] != "https://avd.aquasec.com/CVE-2021-1234" {
+		t.Errorf("v0 links: %v", v0.Links)
+	}
+
+	v1 := report.Vulnerabilities[1]
+	if v1.Severity != "Critical" {
+		t.Errorf("v1 severity = %q, want Critical", v1.Severity)
+	}
+	if len(v1.Links) != 1 || v1.Links[0] != "https://ref/one" {
+		t.Errorf("v1 should fall back to first reference: %v", v1.Links)
+	}
+	if v1.FixVersion != "" {
+		t.Errorf("v1 fix_version should be empty, got %q", v1.FixVersion)
+	}
+}

--- a/docker/scanner-adapter/jobs.go
+++ b/docker/scanner-adapter/jobs.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"sync"
+	"time"
+)
+
+// JobStatus is the lifecycle state of a scan job.
+type JobStatus string
+
+const (
+	// StatusPending: accepted, not yet started.
+	StatusPending JobStatus = "Pending"
+	// StatusRunning: trivy is executing.
+	StatusRunning JobStatus = "Running"
+	// StatusSucceeded: a report is available.
+	StatusSucceeded JobStatus = "Succeeded"
+	// StatusFailed: the scan errored; the report endpoint must 500 (fail-closed).
+	StatusFailed JobStatus = "Failed"
+)
+
+// Job is a single scan request's state.
+type Job struct {
+	ID      string
+	Status  JobStatus
+	Report  *HarborScanReport
+	Err     string
+	Created time.Time
+}
+
+// JobStore is a concurrency-safe in-memory job map with TTL eviction.
+type JobStore struct {
+	mu   sync.RWMutex
+	jobs map[string]*Job
+	ttl  time.Duration
+}
+
+// NewJobStore creates a store whose finished jobs live for ttl.
+func NewJobStore(ttl time.Duration) *JobStore {
+	return &JobStore{
+		jobs: make(map[string]*Job),
+		ttl:  ttl,
+	}
+}
+
+// newID returns an opaque hex id from crypto/rand.
+func newID() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Create registers a new Pending job and returns it.
+func (s *JobStore) Create() (*Job, error) {
+	id, err := newID()
+	if err != nil {
+		return nil, err
+	}
+	job := &Job{ID: id, Status: StatusPending, Created: time.Now()}
+	s.mu.Lock()
+	s.jobs[id] = job
+	s.mu.Unlock()
+	return job, nil
+}
+
+// Get returns the job for id and whether it exists.
+func (s *JobStore) Get(id string) (*Job, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	job, ok := s.jobs[id]
+	return job, ok
+}
+
+// setStatus transitions a job's status (no-op if the id is gone).
+func (s *JobStore) setStatus(id string, status JobStatus) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.Status = status
+	}
+}
+
+// Running marks a job as executing.
+func (s *JobStore) Running(id string) { s.setStatus(id, StatusRunning) }
+
+// Succeed attaches a report and marks the job Succeeded.
+func (s *JobStore) Succeed(id string, report *HarborScanReport) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.Report = report
+		job.Status = StatusSucceeded
+	}
+}
+
+// Fail records an error and marks the job Failed (fail-closed; never Succeeded
+// with an empty report on error).
+func (s *JobStore) Fail(id, errMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if job, ok := s.jobs[id]; ok {
+		job.Err = errMsg
+		job.Status = StatusFailed
+	}
+}
+
+// sweep evicts finished jobs older than the TTL. Returns the number evicted.
+func (s *JobStore) sweep(now time.Time) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for id, job := range s.jobs {
+		terminal := job.Status == StatusSucceeded || job.Status == StatusFailed
+		if terminal && now.Sub(job.Created) > s.ttl {
+			delete(s.jobs, id)
+			n++
+		}
+	}
+	return n
+}
+
+// RunSweeper periodically evicts expired jobs until ctx-like stop channel closes.
+func (s *JobStore) RunSweeper(stop <-chan struct{}) {
+	interval := s.ttl / 2
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case now := <-ticker.C:
+			s.sweep(now)
+		}
+	}
+}

--- a/docker/scanner-adapter/main.go
+++ b/docker/scanner-adapter/main.go
@@ -1,0 +1,54 @@
+// Command scanner-adapter is an Artifact-Keeper-owned Harbor Pluggable Scanner
+// API v1 adapter. It accepts scan requests from the AK backend, runs the trivy
+// CLI against the requested image in the AK registry, and serves the resulting
+// vulnerability report in the Harbor format the backend consumes.
+//
+// It is deliberately fail-closed: any trivy error surfaces as a 500 on the
+// report endpoint so the backend marks the scan failed rather than silently
+// completing with zero findings.
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"time"
+)
+
+func main() {
+	cfg := LoadConfig()
+	srv := NewServer(cfg)
+
+	// Probe the trivy version at startup (unless pinned via env). Readiness is
+	// gated on a successful probe so the backend does not dispatch scans to an
+	// adapter whose trivy binary is missing/broken.
+	if cfg.ScannerVersion == "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		version, err := ProbeVersion(ctx, cfg)
+		cancel()
+		if err != nil {
+			log.Printf("trivy version probe failed (staying not-ready): %v", err)
+		} else {
+			cfg.ScannerVersion = version
+			log.Printf("trivy version probed: %s", version)
+			srv.MarkReady()
+		}
+	} else {
+		log.Printf("trivy version pinned via env: %s", cfg.ScannerVersion)
+		srv.MarkReady()
+	}
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go srv.jobs.RunSweeper(stop)
+
+	server := &http.Server{
+		Addr:              cfg.Addr,
+		Handler:           srv.Handler(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Printf("scanner-adapter listening on %s (trivy=%s)", cfg.Addr, cfg.TrivyPath)
+	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/docker/scanner-adapter/scan.go
+++ b/docker/scanner-adapter/scan.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Scanner runs trivy against an image reference and maps the result into the
+// Harbor report shape.
+type Scanner struct {
+	cfg *Config
+}
+
+// NewScanner constructs a Scanner bound to cfg.
+func NewScanner(cfg *Config) *Scanner {
+	return &Scanner{cfg: cfg}
+}
+
+// trimRegistryHost strips any scheme and trailing slash from a registry URL so
+// it can be used as the host prefix of a trivy image reference. Single source
+// of truth for host normalization (referenced by buildRef + tests).
+func trimRegistryHost(registryURL string) string {
+	host := registryURL
+	host = strings.TrimPrefix(host, "http://")
+	host = strings.TrimPrefix(host, "https://")
+	host = strings.TrimRight(host, "/")
+	return host
+}
+
+// buildRef assembles a fully-qualified trivy image reference from the Harbor
+// request fields. It enforces the #1483 rule: a digest reference is joined with
+// `@`, a tag with `:`, and exactly one of the two must be present.
+func buildRef(registryURL, repository, tag, digest string) (string, error) {
+	host := trimRegistryHost(registryURL)
+	if repository == "" {
+		return "", fmt.Errorf("repository is required")
+	}
+	ref := repository
+	if host != "" {
+		ref = host + "/" + repository
+	}
+	switch {
+	case digest != "":
+		return ref + "@" + digest, nil
+	case tag != "":
+		return ref + ":" + tag, nil
+	default:
+		return "", fmt.Errorf("artifact must carry a tag or a digest")
+	}
+}
+
+// buildArgs returns the trivy CLI arguments for scanning imageRef.
+func (s *Scanner) buildArgs(imageRef string) []string {
+	args := []string{
+		"image",
+		"--format", "json",
+		"--scanners", "vuln",
+		"--severity", s.cfg.Severity,
+		"--timeout", s.cfg.ScanTimeout.String(),
+		"--cache-dir", s.cfg.CacheDir,
+		"--quiet",
+	}
+	if s.cfg.Insecure {
+		args = append(args, "--insecure")
+	}
+	if s.cfg.SkipDBUpdate {
+		args = append(args, "--skip-db-update")
+	}
+	args = append(args, imageRef)
+	return args
+}
+
+// registryToken extracts the bare token from a "Bearer <token>" authorization
+// value, or "" for anonymous. Never log the return value.
+func registryToken(authorization string) string {
+	const prefix = "Bearer "
+	if strings.HasPrefix(authorization, prefix) {
+		return strings.TrimSpace(strings.TrimPrefix(authorization, prefix))
+	}
+	return ""
+}
+
+// Scan runs trivy for the given request and returns the Harbor report. Any
+// non-zero exit or parse failure is an error (the caller marks the job Failed
+// and the report endpoint 500s — fail-closed, never a silent empty report).
+func (s *Scanner) Scan(ctx context.Context, req *ScanRequest) (*HarborScanReport, error) {
+	imageRef, err := buildRef(req.Registry.URL, req.Artifact.Repository, req.Artifact.Tag, req.Artifact.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, s.cfg.ScanTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, s.cfg.TrivyPath, s.buildArgs(imageRef)...)
+	// Inherit the adapter's environment; add a per-scan registry token for
+	// private pulls. TRIVY_REGISTRY_TOKEN is consumed by trivy's registry
+	// client. The token is NEVER logged.
+	cmd.Env = cmd.Environ()
+	if token := registryToken(req.Registry.Authorization); token != "" {
+		cmd.Env = append(cmd.Env, "TRIVY_REGISTRY_TOKEN="+token)
+	}
+
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("trivy scan failed for %s: %v: %s", imageRef, err, strings.TrimSpace(stderr.String()))
+	}
+
+	var trivyReport TrivyReport
+	if err := json.Unmarshal([]byte(stdout.String()), &trivyReport); err != nil {
+		return nil, fmt.Errorf("failed to parse trivy output for %s: %w", imageRef, err)
+	}
+
+	scanner := HarborScanner{Name: "Trivy", Version: s.cfg.ScannerVersion}
+	return mapTrivyToHarbor(&trivyReport, scanner), nil
+}
+
+// ProbeVersion runs `trivy --version` and extracts the semantic version string
+// (e.g. "0.71.2"). Used at startup to populate scanner.version and gate
+// readiness.
+func ProbeVersion(ctx context.Context, cfg *Config) (string, error) {
+	cmd := exec.CommandContext(ctx, cfg.TrivyPath, "--version")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("trivy --version failed: %w", err)
+	}
+	v := parseTrivyVersion(string(out))
+	if v == "" {
+		return "", fmt.Errorf("could not parse trivy version from output")
+	}
+	return v, nil
+}
+
+// parseTrivyVersion extracts the version token from `trivy --version` output.
+// The first line is `Version: 0.71.2`.
+func parseTrivyVersion(out string) string {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Version:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "Version:"))
+		}
+	}
+	return ""
+}

--- a/docker/scanner-adapter/scan_test.go
+++ b/docker/scanner-adapter/scan_test.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTrimRegistryHost(t *testing.T) {
+	cases := map[string]string{
+		"http://backend:8080":   "backend:8080",
+		"https://backend:8080/": "backend:8080",
+		"backend:8080":          "backend:8080",
+		"http://host/":          "host",
+	}
+	for in, want := range cases {
+		if got := trimRegistryHost(in); got != want {
+			t.Errorf("trimRegistryHost(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBuildRefTag(t *testing.T) {
+	ref, err := buildRef("http://backend:8080", "docker-local/library/nginx", "1.20", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ref != "backend:8080/docker-local/library/nginx:1.20" {
+		t.Errorf("got %q", ref)
+	}
+}
+
+func TestBuildRefDigestUsesAtSeparator(t *testing.T) {
+	digest := "sha256:cf4501fe4ed427dfc7c81f68be661271ffd164bb2e774caf0e3aa8eac775eb6b"
+	ref, err := buildRef("http://backend:8080", "oci-prod/org/app", "", digest)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "backend:8080/oci-prod/org/app@" + digest
+	if ref != want {
+		t.Errorf("got %q, want %q", ref, want)
+	}
+}
+
+func TestBuildRefErrors(t *testing.T) {
+	if _, err := buildRef("http://backend:8080", "", "1.20", ""); err == nil {
+		t.Error("expected error for empty repository")
+	}
+	if _, err := buildRef("http://backend:8080", "repo", "", ""); err == nil {
+		t.Error("expected error when neither tag nor digest present")
+	}
+}
+
+func TestRegistryToken(t *testing.T) {
+	if got := registryToken("Bearer abc.def.ghi"); got != "abc.def.ghi" {
+		t.Errorf("got %q", got)
+	}
+	if got := registryToken(""); got != "" {
+		t.Errorf("anonymous should be empty, got %q", got)
+	}
+	if got := registryToken("Basic xyz"); got != "" {
+		t.Errorf("non-bearer should be empty, got %q", got)
+	}
+}
+
+func TestParseTrivyVersion(t *testing.T) {
+	out := "Version: 0.71.2\nVulnerability DB:\n  Version: 2\n"
+	if got := parseTrivyVersion(out); got != "0.71.2" {
+		t.Errorf("got %q", got)
+	}
+	if got := parseTrivyVersion("no version here"); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+func TestBuildArgs(t *testing.T) {
+	cfg := &Config{
+		Severity:     "HIGH,CRITICAL",
+		ScanTimeout:  5 * time.Minute,
+		CacheDir:     "/cache",
+		Insecure:     true,
+		SkipDBUpdate: true,
+	}
+	args := strings.Join(NewScanner(cfg).buildArgs("backend:8080/repo:tag"), " ")
+	for _, want := range []string{
+		"image", "--format json", "--scanners vuln", "--severity HIGH,CRITICAL",
+		"--timeout 5m0s", "--cache-dir /cache", "--quiet", "--insecure",
+		"--skip-db-update", "backend:8080/repo:tag",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("args missing %q; got: %s", want, args)
+		}
+	}
+}
+
+func TestBuildArgsOmitsOptionalFlags(t *testing.T) {
+	cfg := &Config{Severity: "LOW", ScanTimeout: time.Minute, CacheDir: "/c"}
+	args := strings.Join(NewScanner(cfg).buildArgs("ref"), " ")
+	if strings.Contains(args, "--insecure") {
+		t.Error("--insecure should be absent when Insecure=false")
+	}
+	if strings.Contains(args, "--skip-db-update") {
+		t.Error("--skip-db-update should be absent when SkipDBUpdate=false")
+	}
+}
+
+func TestLoadConfigDefaults(t *testing.T) {
+	// A clean environment yields the documented defaults.
+	for _, k := range []string{
+		"SCANNER_ADAPTER_ADDR", "SCANNER_TRIVY_PATH", "SCANNER_TRIVY_CACHE_DIR",
+		"SCANNER_TRIVY_INSECURE", "SCANNER_TRIVY_SKIP_DB_UPDATE", "SCANNER_TRIVY_SEVERITY",
+		"SCANNER_TRIVY_TIMEOUT", "SCANNER_JOB_TTL", "SCANNER_LOG_LEVEL", "SCANNER_SCANNER_VERSION",
+	} {
+		t.Setenv(k, "")
+	}
+	cfg := LoadConfig()
+	if cfg.Addr != ":8080" || cfg.TrivyPath != "trivy" || !cfg.Insecure || cfg.SkipDBUpdate {
+		t.Errorf("unexpected defaults: %+v", cfg)
+	}
+	if cfg.ScanTimeout != 5*time.Minute || cfg.JobTTL != 30*time.Minute {
+		t.Errorf("unexpected duration defaults: %+v", cfg)
+	}
+}
+
+func TestLoadConfigOverrides(t *testing.T) {
+	t.Setenv("SCANNER_ADAPTER_ADDR", ":8090")
+	t.Setenv("SCANNER_TRIVY_INSECURE", "false")
+	t.Setenv("SCANNER_TRIVY_SKIP_DB_UPDATE", "true")
+	t.Setenv("SCANNER_TRIVY_TIMEOUT", "90s")
+	t.Setenv("SCANNER_SCANNER_VERSION", "0.71.2")
+	cfg := LoadConfig()
+	if cfg.Addr != ":8090" || cfg.Insecure || !cfg.SkipDBUpdate {
+		t.Errorf("overrides not applied: %+v", cfg)
+	}
+	if cfg.ScanTimeout != 90*time.Second {
+		t.Errorf("timeout override not applied: %v", cfg.ScanTimeout)
+	}
+	if cfg.ScannerVersion != "0.71.2" {
+		t.Errorf("version override not applied: %q", cfg.ScannerVersion)
+	}
+}
+
+func TestGetenvBadValuesFallBackToDefault(t *testing.T) {
+	t.Setenv("SCANNER_TRIVY_INSECURE", "not-a-bool")
+	t.Setenv("SCANNER_TRIVY_TIMEOUT", "not-a-duration")
+	cfg := LoadConfig()
+	if !cfg.Insecure {
+		t.Error("bad bool should fall back to default true")
+	}
+	if cfg.ScanTimeout != 5*time.Minute {
+		t.Error("bad duration should fall back to default 5m")
+	}
+}
+
+func TestJobStoreLifecycle(t *testing.T) {
+	store := NewJobStore(time.Hour)
+	job, err := store.Create()
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if job.Status != StatusPending {
+		t.Errorf("new job should be Pending, got %s", job.Status)
+	}
+	if _, ok := store.Get("nope"); ok {
+		t.Error("unknown id should not be found")
+	}
+
+	store.Running(job.ID)
+	if got, _ := store.Get(job.ID); got.Status != StatusRunning {
+		t.Errorf("expected Running, got %s", got.Status)
+	}
+
+	report := &HarborScanReport{Vulnerabilities: []HarborVulnerability{}}
+	store.Succeed(job.ID, report)
+	if got, _ := store.Get(job.ID); got.Status != StatusSucceeded || got.Report != report {
+		t.Errorf("succeed not recorded: %+v", got)
+	}
+
+	job2, _ := store.Create()
+	store.Fail(job2.ID, "boom")
+	if got, _ := store.Get(job2.ID); got.Status != StatusFailed || got.Err != "boom" {
+		t.Errorf("fail not recorded: %+v", got)
+	}
+}
+
+func TestJobStoreSweep(t *testing.T) {
+	store := NewJobStore(time.Hour)
+	done, _ := store.Create()
+	store.Succeed(done.ID, &HarborScanReport{})
+	pending, _ := store.Create()
+
+	// Not expired yet.
+	if n := store.sweep(time.Now()); n != 0 {
+		t.Errorf("nothing should be swept yet, got %d", n)
+	}
+	// Far in the future: the terminal job is evicted, the pending one retained.
+	if n := store.sweep(time.Now().Add(2 * time.Hour)); n != 1 {
+		t.Errorf("expected 1 swept, got %d", n)
+	}
+	if _, ok := store.Get(done.ID); ok {
+		t.Error("terminal job should have been swept")
+	}
+	if _, ok := store.Get(pending.ID); !ok {
+		t.Error("pending job should NOT be swept")
+	}
+}
+
+func TestNewIDUnique(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		id, err := newID()
+		if err != nil {
+			t.Fatalf("newID: %v", err)
+		}
+		if len(id) != 32 {
+			t.Errorf("expected 32 hex chars, got %d (%q)", len(id), id)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate id %q", id)
+		}
+		seen[id] = true
+	}
+}

--- a/docker/scanner-adapter/server.go
+++ b/docker/scanner-adapter/server.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync/atomic"
+)
+
+// Server holds the adapter's HTTP state.
+type Server struct {
+	cfg     *Config
+	jobs    *JobStore
+	scanner *Scanner
+	// ready is false until the startup trivy-version probe succeeds; /probe/ready
+	// returns 503 until then so the backend fails scans closed rather than
+	// dispatching to a half-initialized adapter.
+	ready atomic.Bool
+}
+
+// NewServer constructs a Server. It is NOT ready until MarkReady is called.
+func NewServer(cfg *Config) *Server {
+	return &Server{
+		cfg:     cfg,
+		jobs:    NewJobStore(cfg.JobTTL),
+		scanner: NewScanner(cfg),
+	}
+}
+
+// MarkReady flips the readiness gate on (called after a successful version probe).
+func (s *Server) MarkReady() { s.ready.Store(true) }
+
+// Handler returns the adapter's HTTP router.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /probe/ready", s.handleReady)
+	mux.HandleFunc("GET /probe/healthy", s.handleHealthy)
+	mux.HandleFunc("GET /api/v1/metadata", s.handleMetadata)
+	mux.HandleFunc("POST /api/v1/scan", s.handleScan)
+	mux.HandleFunc("GET /api/v1/scan/{id}/report", s.handleReport)
+	return mux
+}
+
+func (s *Server) debugf(format string, args ...any) {
+	if s.cfg.LogLevel == "debug" {
+		log.Printf(format, args...)
+	}
+}
+
+// handleReady is the readiness probe called before every scan.
+func (s *Server) handleReady(w http.ResponseWriter, _ *http.Request) {
+	if !s.ready.Load() {
+		http.Error(w, "scanner starting", http.StatusServiceUnavailable)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleHealthy is the liveness probe (always OK once the process is serving).
+func (s *Server) handleHealthy(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleMetadata serves the Harbor scanner metadata document.
+func (s *Server) handleMetadata(w http.ResponseWriter, _ *http.Request) {
+	meta := ScannerMetadata{
+		Scanner: HarborScannerInfo{
+			Name:    "Trivy",
+			Vendor:  "Aqua Security",
+			Version: s.cfg.ScannerVersion,
+		},
+		Capabilities: []ScannerCapability{{
+			ConsumesMimeTypes: []string{ociManifestMimeType, dockerManifestMimeType},
+			ProducesMimeTypes: []string{reportMimeType},
+		}},
+	}
+	writeJSON(w, http.StatusOK, meta)
+}
+
+// handleScan accepts a scan request, starts it asynchronously, and returns the
+// job id.
+func (s *Server) handleScan(w http.ResponseWriter, r *http.Request) {
+	var req ScanRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Artifact.Repository == "" {
+		http.Error(w, "artifact.repository is required", http.StatusBadRequest)
+		return
+	}
+	hasTag := req.Artifact.Tag != ""
+	hasDigest := req.Artifact.Digest != ""
+	if hasTag == hasDigest {
+		http.Error(w, "artifact must carry exactly one of tag or digest", http.StatusBadRequest)
+		return
+	}
+
+	job, err := s.jobs.Create()
+	if err != nil {
+		http.Error(w, "failed to create scan job", http.StatusInternalServerError)
+		return
+	}
+
+	go s.runJob(job.ID, req)
+
+	writeJSON(w, http.StatusAccepted, ScanResponse{ID: job.ID})
+}
+
+// runJob executes the scan and records the outcome. Detached from the request
+// context so a client disconnect does not cancel the scan.
+func (s *Server) runJob(id string, req ScanRequest) {
+	s.jobs.Running(id)
+	report, err := s.scanner.Scan(context.Background(), &req)
+	if err != nil {
+		// Do not include the request authorization; Scan's error messages only
+		// carry the image ref + trivy stderr.
+		log.Printf("scan %s failed: %v", id, err)
+		s.jobs.Fail(id, err.Error())
+		return
+	}
+	s.debugf("scan %s succeeded: %d vulnerabilities", id, len(report.Vulnerabilities))
+	s.jobs.Succeed(id, report)
+}
+
+// handleReport serves the scan report per the Harbor polling contract.
+func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	job, ok := s.jobs.Get(id)
+	if !ok {
+		// Unknown id: treated as pending by the backend (times out -> fail
+		// closed). Never 404 a known-failed job.
+		http.Error(w, "unknown scan id", http.StatusNotFound)
+		return
+	}
+
+	switch job.Status {
+	case StatusSucceeded:
+		w.Header().Set("Content-Type", reportMimeType)
+		writeJSON(w, http.StatusOK, job.Report)
+	case StatusFailed:
+		// Fail-closed: a trivy error is a 500, NEVER a 200 with empty findings.
+		http.Error(w, "scan failed: "+job.Err, http.StatusInternalServerError)
+	default:
+		// Pending / Running: signal "not ready" with an integer Refresh-After.
+		w.Header().Set("Refresh-After", "5")
+		w.WriteHeader(http.StatusFound)
+	}
+}
+
+// writeJSON writes v as a JSON response with the given status.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	if w.Header().Get("Content-Type") == "" {
+		w.Header().Set("Content-Type", "application/json")
+	}
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/docker/scanner-adapter/server_test.go
+++ b/docker/scanner-adapter/server_test.go
@@ -1,0 +1,349 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeStub writes an executable fake `trivy` at a temp path whose body is the
+// given shell script, and returns its path. The script must handle both
+// `--version` (startup probe) and `image ...` (scan) invocations so every path
+// is deterministic without a network or a real trivy.
+func writeStub(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trivy")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+const stubVersion = `if [ "$1" = "--version" ]; then echo "Version: 0.71.2"; exit 0; fi`
+
+// succeedStub emits a canned trivy JSON report with one HIGH finding.
+func succeedStub(t *testing.T) string {
+	return writeStub(t, "#!/bin/sh\n"+stubVersion+`
+cat <<'JSON'
+{"Results":[{"Target":"alpine:3.14","Class":"os-pkgs","Type":"alpine","Vulnerabilities":[
+  {"VulnerabilityID":"CVE-2021-3711","PkgName":"openssl","InstalledVersion":"1.1.1k","FixedVersion":"1.1.1l","Severity":"CRITICAL","Description":"SM2 overflow","PrimaryURL":"https://avd.aquasec.com/CVE-2021-3711"}
+]}]}
+JSON
+`)
+}
+
+// failStub exits non-zero (simulating a failed pull / trivy error).
+func failStub(t *testing.T) string {
+	return writeStub(t, "#!/bin/sh\n"+stubVersion+`
+echo "FATAL: failed to pull image" 1>&2
+exit 1
+`)
+}
+
+// slowStub sleeps before emitting a report so the report can be polled while
+// still Pending/Running.
+func slowStub(t *testing.T) string {
+	return writeStub(t, "#!/bin/sh\n"+stubVersion+`
+sleep 1
+echo '{"Results":[]}'
+`)
+}
+
+// newTestServer builds a ready Server whose scanner execs the given stub trivy.
+func newTestServer(t *testing.T, trivyPath string) *httptest.Server {
+	t.Helper()
+	cfg := LoadConfig()
+	cfg.TrivyPath = trivyPath
+	cfg.CacheDir = t.TempDir()
+	cfg.ScanTimeout = 10 * time.Second
+	// Exercise the real probe against the stub.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	version, err := ProbeVersion(ctx, cfg)
+	if err != nil {
+		t.Fatalf("probe version: %v", err)
+	}
+	if version != "0.71.2" {
+		t.Fatalf("stub version = %q, want 0.71.2", version)
+	}
+	cfg.ScannerVersion = version
+	srv := NewServer(cfg)
+	srv.MarkReady()
+	return httptest.NewServer(srv.Handler())
+}
+
+// noRedirectClient returns an http client that surfaces 302s instead of
+// following them (the backend polls with redirects disabled).
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// submitScan POSTs a scan and returns the assigned id.
+func submitScan(t *testing.T, base string, req ScanRequest) string {
+	t.Helper()
+	body, _ := json.Marshal(req)
+	resp, err := http.Post(base+"/api/v1/scan", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("post scan: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("scan submit status = %d, want 202", resp.StatusCode)
+	}
+	var sr ScanResponse
+	if err := json.NewDecoder(resp.Body).Decode(&sr); err != nil {
+		t.Fatalf("decode scan response: %v", err)
+	}
+	if sr.ID == "" {
+		t.Fatal("empty scan id")
+	}
+	return sr.ID
+}
+
+// pollReport polls the report endpoint until it is no longer Pending (302) or
+// the deadline passes, returning the final response status and body.
+func pollReport(t *testing.T, base, id string) (int, []byte) {
+	t.Helper()
+	client := noRedirectClient()
+	deadline := time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		req, _ := http.NewRequest(http.MethodGet, base+"/api/v1/scan/"+id+"/report", nil)
+		req.Header.Set("Accept", reportMimeType)
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("get report: %v", err)
+		}
+		if resp.StatusCode == http.StatusFound {
+			if ra := resp.Header.Get("Refresh-After"); ra != "5" {
+				t.Errorf("pending Refresh-After = %q, want 5", ra)
+			}
+			resp.Body.Close()
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		body := readAll(t, resp)
+		return resp.StatusCode, body
+	}
+	t.Fatal("report never left pending state")
+	return 0, nil
+}
+
+func readAll(t *testing.T, resp *http.Response) []byte {
+	t.Helper()
+	defer resp.Body.Close()
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(resp.Body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestScanSucceedsWithFindings(t *testing.T) {
+	ts := newTestServer(t, succeedStub(t))
+	defer ts.Close()
+
+	id := submitScan(t, ts.URL, ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080"},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", MimeType: dockerManifestMimeType, Tag: "3.14"},
+	})
+
+	status, body := pollReport(t, ts.URL, id)
+	if status != http.StatusOK {
+		t.Fatalf("report status = %d, want 200; body=%s", status, body)
+	}
+	var report HarborScanReport
+	if err := json.Unmarshal(body, &report); err != nil {
+		t.Fatalf("unmarshal report: %v", err)
+	}
+	if report.Scanner.Name != "Trivy" || report.Scanner.Version != "0.71.2" {
+		t.Errorf("scanner block = %+v", report.Scanner)
+	}
+	if len(report.Vulnerabilities) != 1 {
+		t.Fatalf("expected 1 vuln, got %d", len(report.Vulnerabilities))
+	}
+	v := report.Vulnerabilities[0]
+	if v.ID != "CVE-2021-3711" || v.Severity != "Critical" || v.Package != "openssl" {
+		t.Errorf("finding mapped incorrectly: %+v", v)
+	}
+}
+
+func TestScanFailsClosed(t *testing.T) {
+	ts := newTestServer(t, failStub(t))
+	defer ts.Close()
+
+	id := submitScan(t, ts.URL, ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080"},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", Tag: "3.14"},
+	})
+
+	status, body := pollReport(t, ts.URL, id)
+	// Fail-closed: a trivy error must be a 500, NEVER a 200-with-empty-report.
+	if status != http.StatusInternalServerError {
+		t.Fatalf("failed scan status = %d, want 500; body=%s", status, body)
+	}
+}
+
+func TestReportPendingReturns302(t *testing.T) {
+	ts := newTestServer(t, slowStub(t))
+	defer ts.Close()
+
+	id := submitScan(t, ts.URL, ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080"},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", Tag: "3.14"},
+	})
+
+	// Immediately after submit the job is Pending/Running -> 302 + Refresh-After.
+	client := noRedirectClient()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/scan/"+id+"/report", nil)
+	req.Header.Set("Accept", reportMimeType)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("get report: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("pending status = %d, want 302", resp.StatusCode)
+	}
+	if ra := resp.Header.Get("Refresh-After"); ra != "5" {
+		t.Errorf("Refresh-After = %q, want integer 5", ra)
+	}
+}
+
+func TestReportUnknownIDReturns404(t *testing.T) {
+	ts := newTestServer(t, succeedStub(t))
+	defer ts.Close()
+
+	client := noRedirectClient()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/v1/scan/deadbeef/report", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("get report: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown id status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestScanRequestValidation(t *testing.T) {
+	ts := newTestServer(t, succeedStub(t))
+	defer ts.Close()
+
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"malformed json", `{not json`},
+		{"missing repository", `{"registry":{"url":"http://b"},"artifact":{"tag":"1"}}`},
+		{"both tag and digest", `{"artifact":{"repository":"r","tag":"1","digest":"sha256:x"}}`},
+		{"neither tag nor digest", `{"artifact":{"repository":"r"}}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := http.Post(ts.URL+"/api/v1/scan", "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestProbeReady(t *testing.T) {
+	// A not-yet-ready server returns 503 until MarkReady.
+	cfg := LoadConfig()
+	srv := NewServer(cfg)
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/probe/ready")
+	if err != nil {
+		t.Fatalf("get ready: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("not-ready status = %d, want 503", resp.StatusCode)
+	}
+
+	srv.MarkReady()
+	resp2, err := http.Get(ts.URL + "/probe/ready")
+	if err != nil {
+		t.Fatalf("get ready: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("ready status = %d, want 200", resp2.StatusCode)
+	}
+}
+
+func TestHealthyProbe(t *testing.T) {
+	ts := newTestServer(t, succeedStub(t))
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/probe/healthy")
+	if err != nil {
+		t.Fatalf("get healthy: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("healthy status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestMetadata(t *testing.T) {
+	ts := newTestServer(t, succeedStub(t))
+	defer ts.Close()
+	resp, err := http.Get(ts.URL + "/api/v1/metadata")
+	if err != nil {
+		t.Fatalf("get metadata: %v", err)
+	}
+	body := readAll(t, resp)
+	var meta ScannerMetadata
+	if err := json.Unmarshal(body, &meta); err != nil {
+		t.Fatalf("unmarshal metadata: %v", err)
+	}
+	if meta.Scanner.Name != "Trivy" || meta.Scanner.Vendor != "Aqua Security" {
+		t.Errorf("scanner info = %+v", meta.Scanner)
+	}
+	if len(meta.Capabilities) != 1 {
+		t.Fatalf("expected 1 capability, got %d", len(meta.Capabilities))
+	}
+	cap0 := meta.Capabilities[0]
+	if len(cap0.ProducesMimeTypes) != 1 || cap0.ProducesMimeTypes[0] != reportMimeType {
+		t.Errorf("produces = %v", cap0.ProducesMimeTypes)
+	}
+	if len(cap0.ConsumesMimeTypes) != 2 {
+		t.Errorf("consumes = %v", cap0.ConsumesMimeTypes)
+	}
+}
+
+func TestScanWithDigestReference(t *testing.T) {
+	ts := newTestServer(t, succeedStub(t))
+	defer ts.Close()
+	id := submitScan(t, ts.URL, ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080", Authorization: "Bearer test.jwt.token"},
+		Artifact: ArtifactRef{
+			Repository: "oci-prod/app",
+			MimeType:   ociManifestMimeType,
+			Digest:     "sha256:cf4501fe4ed427dfc7c81f68be661271ffd164bb2e774caf0e3aa8eac775eb6b",
+		},
+	})
+	status, body := pollReport(t, ts.URL, id)
+	if status != http.StatusOK {
+		t.Fatalf("digest scan status = %d, want 200; body=%s", status, body)
+	}
+}

--- a/docker/scanner-adapter/trivy_json.go
+++ b/docker/scanner-adapter/trivy_json.go
@@ -1,0 +1,31 @@
+package main
+
+// Minimal subset of the trivy `--format json` report we consume. Only the
+// fields mapped into the Harbor report are declared; everything else in trivy's
+// output is ignored by encoding/json.
+
+// TrivyReport is the top-level trivy JSON document.
+type TrivyReport struct {
+	Results []TrivyResult `json:"Results"`
+}
+
+// TrivyResult is one scanned target (an OS package set or a language lockfile).
+type TrivyResult struct {
+	Target          string               `json:"Target"`
+	Class           string               `json:"Class"`
+	Type            string               `json:"Type"`
+	Vulnerabilities []TrivyVulnerability `json:"Vulnerabilities"`
+}
+
+// TrivyVulnerability is a single CVE row inside a result.
+type TrivyVulnerability struct {
+	VulnerabilityID  string   `json:"VulnerabilityID"`
+	PkgName          string   `json:"PkgName"`
+	InstalledVersion string   `json:"InstalledVersion"`
+	FixedVersion     string   `json:"FixedVersion"`
+	Severity         string   `json:"Severity"`
+	Title            string   `json:"Title"`
+	Description      string   `json:"Description"`
+	PrimaryURL       string   `json:"PrimaryURL"`
+	References       []string `json:"References"`
+}


### PR DESCRIPTION
## Summary

Adds an in-house, AK-owned container **image** scanner adapter that the backend
(`TRIVY_ADAPTER_URL`) drives for container image scans, replacing the external
`harbor-scanner-trivy` + Redis dependency with a small stdlib-only Go service we
own and can build multi-arch from source.

`docker/scanner-adapter/` implements the Harbor Pluggable Scanner API v1 that
PR #2090's `image_scanner.rs` already speaks:

- `GET /probe/ready` — 503 until the startup `trivy --version` probe succeeds,
  200 thereafter (the backend gates every scan on this).
- `POST /api/v1/scan` — accepts `{registry:{url,authorization?}, artifact:{repository,mime_type,tag|digest}}`,
  starts an async trivy run, returns `202 {"id":...}`.
- `GET /api/v1/scan/{id}/report` — `Accept: application/vnd.security.vulnerability.report; version=1.1`;
  pending → `302` + integer `Refresh-After: 5`, unknown id → `404`, **failed → `500`**,
  success → `200` Harbor report (`scanner.version`, `vulnerabilities[]` with
  `id/package/version/fix_version/severity/description/links`).
- `GET /api/v1/metadata` + `GET /probe/healthy` for Harbor conformance.

It execs the bundled trivy CLI against the AK registry (host from the request's
`registry.url`; tag vs `@digest` per #1483) and maps trivy severities to the
Harbor Title-case vocabulary the backend expects. Private-repo pulls are
supported by forwarding `registry.authorization` to `TRIVY_REGISTRY_TOKEN`
(never logged).

**Fail-closed (#2088):** any trivy error — unreachable registry, non-zero exit,
unparseable output — marks the job Failed and the report endpoint returns `500`;
it never returns `200` with an empty report. Verified live (see below).

Also:
- `docker/Dockerfile.scanner-adapter` — 3-stage multi-arch build: cross-compiled
  static Go binary + trivy `0.71.2` copied from the multi-arch
  `ghcr.io/aquasecurity/trivy` image + an alpine runtime. Trivy is NOT in the
  backend image (#2059); it lives here.
- `.github/workflows/docker-publish.yml` — `build-scanner-adapter` +
  `merge-scanner-adapter` jobs mirroring the OpenSCAP image (amd64/arm64
  push-by-digest, multi-arch manifest, Docker Hub mirror, cosign, attestation,
  Trivy SARIF, verify-published + summary), new image
  `artifact-keeper-scanner-adapter`.

This is a NEW component. It does **not** change the backend — PR #2090 stays
as-is.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (new component; `feat/*`)

## Test Checklist
- [x] Unit tests added/updated — `harbor_test.go`, `scan_test.go`, `server_test.go`
      (`go test ./...` green; new-code coverage 83%; the fail/succeed/pending
      paths are covered deterministically via a stub `trivy`).
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — built `linux/arm64` and validated end-to-end
      against the #2090 backend (`artifact-keeper-backend:fix-2088`):
  - Pushed `debian:11` (arm64) to a public AK OCI repo and triggered a scan:
    the backend recorded a Trivy **`image`** scan **`completed`** with **185
    real findings** (`scanner_version = trivy-0.71.2`, `source = 'trivy'`); the
    CVE set overlaps grype on the same image (21+ shared CVEs).
  - **Fail-closed:** with the adapter stopped, the same scan went **`failed`**
    with `Bad gateway: Scanner adapter ... is unreachable` — never
    completed-with-zero.
- [x] No regressions in existing tests — no existing files changed except the
      additive workflow wiring.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates
- [ ] Migration is reversible (if applicable)
- [x] N/A — no backend API changes (this is a standalone Go service; the
      backend contract it serves is the frozen Harbor API from #2090)

## Notes
- gofmt/`go vet` clean; jscpd 0% (severity + reference helpers single-sourced).
- Private-repo scanning follow-up is **backend-side**: #2090 ships with the
  token minter (`ImageScanner::with_token_minter`) UNWIRED, so pulls are
  anonymous today — public repos scan, private repos fail closed. The adapter
  side (forwarding `registry.authorization` → `TRIVY_REGISTRY_TOKEN`) is
  complete here; wiring a scanner service account is the backend task.

Closes #2091
