### PR TITLE
fix(terraform): harden terraform mirror URL handling

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,6 +22,7 @@ on:
           - docker
           - protobuf
           - tag-replication
+          - terraform-mirror
         default: smoke
       include_stress:
         description: 'Include stress tests'

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -189,6 +189,28 @@ pub fn reject_direct_upload_if_promotion_only(
     }
 }
 
+/// Strip query strings and fragments before logging a proxy path. Some
+/// split-path proxy callers fetch absolute, signed upstream URLs while caching
+/// under a stable local key; the fetch target must remain raw for the outbound
+/// request, but diagnostics must not preserve credential-bearing URL material.
+fn redact_proxy_path_for_diagnostics(path: &str) -> String {
+    if let Ok(mut parsed) = reqwest::Url::parse(path) {
+        parsed.set_query(None);
+        parsed.set_fragment(None);
+        return parsed.to_string();
+    }
+
+    let query_pos = path.find('?');
+    let fragment_pos = path.find('#');
+    let end = match (query_pos, fragment_pos) {
+        (Some(q), Some(f)) => q.min(f),
+        (Some(q), None) => q,
+        (None, Some(f)) => f,
+        (None, None) => path.len(),
+    };
+    path[..end].to_string()
+}
+
 /// Map a proxy service error to an HTTP error response.
 ///
 /// * `NotFound` → 404 (upstream definitively does not have the artifact)
@@ -227,11 +249,12 @@ pub fn reject_direct_upload_if_promotion_only(
 ///   failures, body read errors) stays at `warn` because those genuinely
 ///   warrant operator attention.
 fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Response {
+    let diagnostic_path = redact_proxy_path_for_diagnostics(path);
     match &e {
         crate::error::AppError::NotFound(_) => {
             tracing::info!(
                 repo_key = %repo_key,
-                path = %path,
+                path = %diagnostic_path,
                 "Upstream returned 404 (artifact or tag does not exist): {}",
                 e
             );
@@ -247,7 +270,7 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
         crate::error::AppError::Validation(_) => {
             tracing::warn!(
                 repo_key = %repo_key,
-                path = %path,
+                path = %diagnostic_path,
                 "Proxy rejected request path: {}",
                 e
             );
@@ -260,7 +283,7 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
         crate::error::AppError::ServiceUnavailable(_) => {
             tracing::warn!(
                 repo_key = %repo_key,
-                path = %path,
+                path = %diagnostic_path,
                 "Upstream transient failure (5xx); returning 503: {}",
                 e
             );
@@ -278,7 +301,7 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
         crate::error::AppError::Conflict(msg) => {
             tracing::info!(
                 repo_key = %repo_key,
-                path = %path,
+                path = %diagnostic_path,
                 "Proxy download blocked by quarantine policy: {}",
                 e
             );
@@ -289,7 +312,7 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
         crate::error::AppError::Authorization(msg) => {
             tracing::info!(
                 repo_key = %repo_key,
-                path = %path,
+                path = %diagnostic_path,
                 "Proxy download forbidden by quarantine policy: {}",
                 e
             );
@@ -298,7 +321,7 @@ fn map_proxy_error(repo_key: &str, path: &str, e: crate::error::AppError) -> Res
         _ => {
             tracing::warn!(
                 repo_key = %repo_key,
-                path = %path,
+                path = %diagnostic_path,
                 "Proxy fetch failed: {}",
                 e
             );
@@ -3015,6 +3038,20 @@ mod tests {
             "upstream".into()
         )));
         assert!(!is_quarantine_block(&AppError::Storage("io".into())));
+    }
+
+    #[test]
+    fn test_redact_proxy_path_for_diagnostics_strips_signed_url_query() {
+        let signed = "https://provider-bucket.s3.amazonaws.com/releases/pkg.zip\
+                      ?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIAEXAMPLE#frag";
+        assert_eq!(
+            redact_proxy_path_for_diagnostics(signed),
+            "https://provider-bucket.s3.amazonaws.com/releases/pkg.zip"
+        );
+        assert_eq!(
+            redact_proxy_path_for_diagnostics("packages/pkg.zip?token=secret#frag"),
+            "packages/pkg.zip"
+        );
     }
 
     #[test]

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -896,6 +896,36 @@ pub async fn proxy_fetch_streaming_with_cache_key(
     .await
 }
 
+/// Response-producing sibling of [`proxy_fetch_streaming_with_cache_key`]:
+/// fetches with split fetch/cache paths and builds the outbound streaming
+/// [`Response`] via [`stream_fetch_result`], the same way [`proxy_fetch_streaming`]
+/// does for the common (single-path) case. Format handlers whose upstream
+/// download URL cannot double as a safe proxy-cache path — e.g. Terraform/
+/// OpenTofu network-mirror archive downloads, where the registry-provided
+/// `download_url` is an absolute URL and `https://` trips the cache path's
+/// empty-segment guard — use this instead of `proxy_fetch_streaming` (#1998).
+pub async fn proxy_fetch_streaming_response_with_cache_key(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    default_content_type: &str,
+) -> Result<Response, Response> {
+    let result = proxy_fetch_streaming_with_cache_key(
+        proxy_service,
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        cache_path,
+    )
+    .await?;
+
+    stream_fetch_result(result, default_content_type, None)
+}
+
 /// Streaming sibling of [`proxy_check_cache`]: probe the proxy cache for
 /// `cache_path` and stream a hit straight from storage instead of buffering
 /// the cached body in memory. Returns `None` on miss or on any probe error
@@ -5900,6 +5930,72 @@ mod tests {
         );
         assert!(h.get("content-length").is_none());
         assert!(h.get("content-disposition").is_none());
+    }
+
+    /// End-to-end pin for [`proxy_fetch_streaming_response_with_cache_key`]
+    /// (#1998): the upstream fetch and the proxy cache key must be allowed to
+    /// diverge. This mirrors the Terraform/OpenTofu network-mirror archive
+    /// download bug, where the registry-provided `download_url` is an
+    /// absolute URL (fine as a fetch target) but unsafe as a cache path (its
+    /// `https://` scheme's `//` trips `validate_cache_path`'s empty-segment
+    /// guard). `fetch_path` here is deliberately an absolute URL while
+    /// `cache_path` is a canonical, scheme-less path, so a regression that
+    /// collapses the wrapper back to `fetch_path == cache_path` would fail
+    /// cache-path validation rather than just silently caching under the
+    /// wrong key.
+    ///
+    /// Skipped when `DATABASE_URL` is unset (CI always sets it).
+    #[tokio::test]
+    async fn test_proxy_fetch_streaming_response_with_cache_key_streams_split_paths_1998() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let server = MockServer::start().await;
+        let archive_bytes = b"fake-provider-archive-bytes";
+        Mock::given(method("GET"))
+            .and(path("/terraform-provider-null_3.2.3_linux_arm64.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(archive_bytes.as_ref()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("tf-mirror-cache-key-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp dir");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+
+        // The absolute-URL fetch target, exactly as an upstream registry's
+        // download document would provide it.
+        let fetch_path = format!(
+            "{}/terraform-provider-null_3.2.3_linux_arm64.zip",
+            server.uri()
+        );
+        // The canonical, scheme-less cache path `mirror_archive_cache_path`
+        // derives for this archive.
+        let cache_path =
+            "hashicorp/null/3.2.3/linux/arm64/terraform-provider-null_3.2.3_linux_arm64.zip";
+
+        let response = proxy_fetch_streaming_response_with_cache_key(
+            &proxy,
+            Uuid::new_v4(),
+            "tf-mirror",
+            &server.uri(),
+            &fetch_path,
+            cache_path,
+            "application/zip",
+        )
+        .await
+        .expect("streaming response must succeed for a split fetch/cache path");
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("read response body");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(&body[..], archive_bytes.as_ref());
     }
 
     // -------------------------------------------------------------------

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -1293,6 +1293,34 @@ fn resolve_archive_url(download: &serde_json::Value) -> Result<&str, Response> {
     })
 }
 
+/// Derive a scheme-less proxy-cache path for a network-mirror archive
+/// download from the registry-provided (frequently absolute) `download_url`.
+///
+/// `archive_url` is used directly as the upstream fetch target (absolute
+/// `http(s)://` URLs pass through `ProxyService::build_upstream_url`
+/// unchanged), but it cannot double as the proxy-cache path: the `https://`
+/// scheme's `//` trips `ProxyService::validate_cache_path`'s empty-segment
+/// guard. This instead derives a canonical
+/// `<namespace>/<type>/<version>/<os>/<arch>/<filename>` path from the
+/// archive URL's own filename, keeping cache keys stable regardless of which
+/// host or path shape the upstream registry serves archives from (#1998).
+fn mirror_archive_cache_path(
+    namespace: &str,
+    type_name: &str,
+    version: &str,
+    os: &str,
+    arch: &str,
+    archive_url: &str,
+) -> String {
+    let filename = archive_url
+        .rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("provider.zip");
+
+    format!("{namespace}/{type_name}/{version}/{os}/{arch}/{filename}")
+}
+
 /// Validated context for serving a network-mirror request against a remote
 /// Terraform repository: the resolved repo plus its upstream registry URL.
 struct MirrorRemote<'a> {
@@ -1443,14 +1471,21 @@ async fn mirror_download(
 
     let archive_url = resolve_archive_url(&download)?;
 
-    // `proxy_fetch_streaming` passes absolute URLs through unchanged, so the
-    // archive is streamed (and cached) directly from the registry-provided URL.
-    proxy_helpers::proxy_fetch_streaming(
+    // `archive_url` is frequently an absolute `https://` URL (#1998): fine as
+    // the upstream fetch target (absolute URLs pass through unchanged), but
+    // not as the proxy-cache path (its `https://` scheme trips the
+    // empty-segment guard). Fetch from `archive_url` but cache under a
+    // derived, scheme-less canonical path instead.
+    let cache_path =
+        mirror_archive_cache_path(&namespace, &type_name, &version, &os, &arch, archive_url);
+
+    proxy_helpers::proxy_fetch_streaming_response_with_cache_key(
         remote.proxy,
         remote.repo.id,
         &repo_key,
         &remote.upstream_url,
         archive_url,
+        &cache_path,
         "application/zip",
     )
     .await
@@ -2483,6 +2518,80 @@ mod tests {
 
         let err2 = resolve_archive_url(&serde_json::json!({ "download_url": "" })).unwrap_err();
         assert_eq!(err2.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
+    fn test_mirror_archive_cache_path_hashicorp_release_url() {
+        // Reproduces the exact #1998 repro: an absolute releases.hashicorp.com
+        // archive URL must derive a clean, scheme-less canonical cache path.
+        let cache_path = mirror_archive_cache_path(
+            "hashicorp",
+            "null",
+            "3.2.3",
+            "linux",
+            "arm64",
+            "https://releases.hashicorp.com/terraform-provider-null/3.2.3/terraform-provider-null_3.2.3_linux_arm64.zip",
+        );
+        assert_eq!(
+            cache_path,
+            "hashicorp/null/3.2.3/linux/arm64/terraform-provider-null_3.2.3_linux_arm64.zip"
+        );
+    }
+
+    #[test]
+    fn test_mirror_archive_cache_path_third_party_host() {
+        // OpenTofu-style / third-party mirrors (e.g. a provider hosted on
+        // GitHub Releases) serve from a different host and path shape; only
+        // the archive's filename should influence the derived cache path.
+        let cache_path = mirror_archive_cache_path(
+            "carlpett",
+            "sops",
+            "1.0.0",
+            "darwin",
+            "arm64",
+            "https://github.com/carlpett/terraform-provider-sops/releases/download/v1.0.0/terraform-provider-sops_1.0.0_darwin_arm64.zip",
+        );
+        assert_eq!(
+            cache_path,
+            "carlpett/sops/1.0.0/darwin/arm64/terraform-provider-sops_1.0.0_darwin_arm64.zip"
+        );
+    }
+
+    #[test]
+    fn test_mirror_archive_cache_path_trailing_slash_falls_back_to_default_filename() {
+        // A URL ending in `/` has no filename segment; falling back to a
+        // fixed name avoids producing an empty final path segment.
+        let cache_path = mirror_archive_cache_path(
+            "hashicorp",
+            "null",
+            "3.2.3",
+            "linux",
+            "arm64",
+            "https://example.com/download/",
+        );
+        assert_eq!(cache_path, "hashicorp/null/3.2.3/linux/arm64/provider.zip");
+    }
+
+    #[test]
+    fn test_mirror_archive_cache_path_accepted_by_cache_storage_key_1998() {
+        // Regression guard for #1998: the raw absolute archive URL must NOT
+        // be usable as a proxy-cache path (its `https://` scheme's `//`
+        // trips the empty-segment guard), but the derived cache path must be.
+        use crate::services::proxy_service::ProxyService;
+
+        let archive_url = "https://releases.hashicorp.com/terraform-provider-null/3.2.3/terraform-provider-null_3.2.3_linux_arm64.zip";
+
+        let raw_err = ProxyService::cache_storage_key("tf-mirror", archive_url).unwrap_err();
+        assert!(
+            raw_err.to_string().contains("empty segments"),
+            "raw absolute archive URL must be rejected as a cache path, got: {}",
+            raw_err
+        );
+
+        let cache_path =
+            mirror_archive_cache_path("hashicorp", "null", "3.2.3", "linux", "arm64", archive_url);
+        ProxyService::cache_storage_key("tf-mirror", &cache_path)
+            .expect("derived cache path must be a valid proxy-cache path");
     }
 
     #[test]

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -35,6 +35,7 @@ use tracing::info;
 
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
+use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
 use crate::models::repository::RepositoryType;
 
@@ -1304,6 +1305,11 @@ fn resolve_archive_url(download: &serde_json::Value) -> Result<&str, Response> {
 /// `<namespace>/<type>/<version>/<os>/<arch>/<filename>` path from the
 /// archive URL's own filename, keeping cache keys stable regardless of which
 /// host or path shape the upstream registry serves archives from (#1998).
+///
+/// Parses `archive_url` instead of splitting the raw string so that a signed
+/// URL's query string (e.g. `?X-Amz-Signature=...`) or fragment is dropped
+/// along with everything else outside the path: query material must never
+/// end up embedded in a proxy-cache object key.
 fn mirror_archive_cache_path(
     namespace: &str,
     type_name: &str,
@@ -1312,11 +1318,11 @@ fn mirror_archive_cache_path(
     arch: &str,
     archive_url: &str,
 ) -> String {
-    let filename = archive_url
-        .rsplit('/')
-        .next()
+    let filename = reqwest::Url::parse(archive_url)
+        .ok()
+        .and_then(|url| url.path_segments()?.next_back().map(str::to_string))
         .filter(|name| !name.is_empty())
-        .unwrap_or("provider.zip");
+        .unwrap_or_else(|| "provider.zip".to_string());
 
     format!("{namespace}/{type_name}/{version}/{os}/{arch}/{filename}")
 }
@@ -1470,6 +1476,33 @@ async fn mirror_download(
     let download = fetch_upstream_json(&remote, &repo_key, &dl_path).await?;
 
     let archive_url = resolve_archive_url(&download)?;
+
+    // A malicious/compromised upstream registry could return an internal
+    // address (e.g. the cloud metadata endpoint) as `download_url`. Validate
+    // it against the same anti-SSRF policy used for other registries'
+    // registry-discovered download URLs (see cargo.rs's `download` handler
+    // and pypi.rs's `find_upstream_url_for_file` path) before fetching it.
+    validate_outbound_url(archive_url, "Terraform upstream archive URL").map_err(|e| {
+        // Deliberately omit `archive_url` from this log line: it is
+        // registry-controlled and frequently a signed URL (e.g.
+        // `?X-Amz-Signature=...`), so logging it verbatim would leak
+        // credential-bearing query material. `e` already names the
+        // specific blocked host/IP without echoing the query string.
+        tracing::warn!(
+            "SSRF check rejected upstream download_url for {}/{} {} {}/{}: {}",
+            namespace,
+            type_name,
+            version,
+            os,
+            arch,
+            e
+        );
+        (
+            StatusCode::BAD_GATEWAY,
+            format!("Upstream registry returned a disallowed download_url: {e}"),
+        )
+            .into_response()
+    })?;
 
     // `archive_url` is frequently an absolute `https://` URL (#1998): fine as
     // the upstream fetch target (absolute URLs pass through unchanged), but
@@ -2518,6 +2551,59 @@ mod tests {
 
         let err2 = resolve_archive_url(&serde_json::json!({ "download_url": "" })).unwrap_err();
         assert_eq!(err2.status(), StatusCode::BAD_GATEWAY);
+    }
+
+    /// Regression guard for the SSRF gap found in review of #1998: a
+    /// malicious/compromised upstream Terraform registry must not be able to
+    /// redirect `mirror_download` at an internal address via `download_url`.
+    /// Mirrors `test_build_download_url_rejects_internal_addresses` in
+    /// cargo.rs — one realistic bypass case pins the integration; the full
+    /// bypass matrix lives in `api::validation::tests`.
+    #[test]
+    fn test_resolve_archive_url_rejects_ssrf_targets() {
+        let metadata =
+            serde_json::json!({ "download_url": "http://169.254.169.254/latest/meta-data/" });
+        let archive_url = resolve_archive_url(&metadata).unwrap();
+        let err = validate_outbound_url(archive_url, "Terraform upstream archive URL")
+            .expect_err("cloud metadata download_url must be rejected");
+        assert!(
+            err.to_string().contains("private/internal network")
+                || err.to_string().contains("not allowed"),
+            "expected SSRF rejection reason in error message, got: {err}"
+        );
+
+        let legit = serde_json::json!({
+            "download_url": "https://releases.hashicorp.com/terraform-provider-null/3.2.3/terraform-provider-null_3.2.3_linux_arm64.zip"
+        });
+        let archive_url = resolve_archive_url(&legit).unwrap();
+        assert!(
+            validate_outbound_url(archive_url, "Terraform upstream archive URL").is_ok(),
+            "legitimate external archive URL should be accepted"
+        );
+    }
+
+    #[test]
+    fn test_mirror_archive_cache_path_strips_signed_url_query_string() {
+        // A signed archive URL (e.g. an S3 presigned link) must not leak its
+        // query-string credentials into the derived cache path / storage
+        // object key.
+        let cache_path = mirror_archive_cache_path(
+            "hashicorp",
+            "null",
+            "3.2.3",
+            "linux",
+            "arm64",
+            "https://provider-bucket.s3.amazonaws.com/terraform-provider-null_3.2.3_linux_arm64.zip\
+             ?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIAEXAMPLE%2F20260630%2Fus-east-1",
+        );
+        assert_eq!(
+            cache_path,
+            "hashicorp/null/3.2.3/linux/arm64/terraform-provider-null_3.2.3_linux_arm64.zip"
+        );
+        assert!(
+            !cache_path.contains("X-Amz"),
+            "cache path must not contain signed-URL query material, got: {cache_path}"
+        );
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -252,6 +252,26 @@ fn parse_release_file_paths(release_content: &str) -> Vec<String> {
     paths
 }
 
+/// Remove credential-bearing URL material before rendering an upstream target
+/// into logs or [`AppError`] messages.
+fn redact_url_for_diagnostics(url: &str) -> String {
+    if let Ok(mut parsed) = reqwest::Url::parse(url) {
+        parsed.set_query(None);
+        parsed.set_fragment(None);
+        return parsed.to_string();
+    }
+
+    let query_pos = url.find('?');
+    let fragment_pos = url.find('#');
+    let end = match (query_pos, fragment_pos) {
+        (Some(q), Some(f)) => q.min(f),
+        (Some(q), None) => q,
+        (None, Some(f)) => f,
+        (None, None) => url.len(),
+    };
+    url[..end].to_string()
+}
+
 /// * `404` → `AppError::NotFound` (cache-miss-class error; callers treat
 ///   as a real "upstream doesn't have it" signal, not a backend failure)
 /// * Other 5xx → `AppError::ServiceUnavailable` (transient upstream failure;
@@ -266,22 +286,23 @@ fn parse_release_file_paths(release_content: &str) -> Vec<String> {
 ///   503 would be misleading.
 /// * 2xx → `Ok(())`
 fn validate_upstream_status(status: StatusCode, url: &str) -> Result<()> {
+    let diagnostic_url = redact_url_for_diagnostics(url);
     if status == StatusCode::NOT_FOUND {
         return Err(AppError::NotFound(format!(
             "Artifact not found at upstream: {}",
-            url
+            diagnostic_url
         )));
     }
     if status.is_server_error() {
         return Err(AppError::ServiceUnavailable(format!(
             "Upstream returned error status {}: {}",
-            status, url
+            status, diagnostic_url
         )));
     }
     if !status.is_success() {
         return Err(AppError::BadGateway(format!(
             "Upstream returned error status {}: {}",
-            status, url
+            status, diagnostic_url
         )));
     }
     Ok(())
@@ -1356,9 +1377,10 @@ impl UpstreamClient {
         repo_id: Uuid,
         accept: Option<&str>,
     ) -> Result<UpstreamResponse> {
+        let diagnostic_url = redact_url_for_diagnostics(url);
         tracing::info!(
             "Fetching artifact from upstream: {} (accept={:?})",
-            url,
+            diagnostic_url,
             accept
         );
 
@@ -1376,10 +1398,13 @@ impl UpstreamClient {
             request = request.header(ACCEPT, accept_value);
         }
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to fetch from upstream: {}", e)))?;
+        let response = request.send().await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to fetch from upstream {}: {}",
+                diagnostic_url,
+                e.without_url()
+            ))
+        })?;
 
         let status = response.status();
 
@@ -1405,7 +1430,7 @@ impl UpstreamClient {
 
             return Err(AppError::Storage(format!(
                 "Upstream returned error status {}: {}",
-                status, url
+                status, diagnostic_url
             )));
         }
 
@@ -1453,10 +1478,12 @@ impl UpstreamClient {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
-        let content = response
-            .bytes()
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to read upstream response: {}", e)))?;
+        let content = response.bytes().await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to read upstream response: {}",
+                e.without_url()
+            ))
+        })?;
 
         tracing::info!(
             "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?}, link: {:?})",
@@ -1488,7 +1515,11 @@ impl UpstreamClient {
     /// buffered variant; only the body extraction differs — and, critically,
     /// the streaming path sets NO `Accept` header anywhere (see below).
     async fn fetch_stream(&self, url: &str, repo_id: Uuid) -> Result<UpstreamStream> {
-        tracing::info!("Fetching artifact from upstream (streaming): {}", url);
+        let diagnostic_url = redact_url_for_diagnostics(url);
+        tracing::info!(
+            "Fetching artifact from upstream (streaming): {}",
+            diagnostic_url
+        );
 
         let upstream_auth =
             crate::services::upstream_auth::load_upstream_auth(&self.db, repo_id).await?;
@@ -1502,10 +1533,13 @@ impl UpstreamClient {
         // both the initial request and the retry. This asymmetry is deliberate
         // and MUST NOT be "unified" — do not add `Accept` here (#1618 S8 review).
 
-        let response = request
-            .send()
-            .await
-            .map_err(|e| AppError::Storage(format!("Failed to fetch from upstream: {}", e)))?;
+        let response = request.send().await.map_err(|e| {
+            AppError::Storage(format!(
+                "Failed to fetch from upstream {}: {}",
+                diagnostic_url,
+                e.without_url()
+            ))
+        })?;
 
         let status = response.status();
 
@@ -1522,7 +1556,7 @@ impl UpstreamClient {
 
             return Err(AppError::Storage(format!(
                 "Upstream returned error status {}: {}",
-                status, url
+                status, diagnostic_url
             )));
         }
 
@@ -1600,10 +1634,12 @@ impl UpstreamClient {
                 // method doc on the intentional asymmetry (#1618 S8).
                 let retry_request = build_request(self.http_client.get(url).bearer_auth(&token));
 
+                let retry_diagnostic_url = redact_url_for_diagnostics(url);
                 let retry_response = retry_request.send().await.map_err(|e| {
                     AppError::Storage(format!(
-                        "Failed to fetch from upstream after token exchange: {}",
-                        e
+                        "Failed to fetch from upstream {} after token exchange: {}",
+                        retry_diagnostic_url,
+                        e.without_url()
                     ))
                 })?;
 
@@ -1628,7 +1664,12 @@ impl UpstreamClient {
         let (content_type, etag, content_length) = extract_streaming_headers(response.headers());
 
         let body = response.bytes_stream().map(|r| {
-            r.map_err(|e| AppError::Storage(format!("Failed to read upstream stream: {}", e)))
+            r.map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to read upstream stream: {}",
+                    e.without_url()
+                ))
+            })
         });
 
         Ok(UpstreamStream {
@@ -7553,6 +7594,21 @@ SHA256:
     // -----------------------------------------------------------------------
 
     #[test]
+    fn test_redact_url_for_diagnostics_strips_query_and_fragment() {
+        let signed = "https://provider-bucket.s3.amazonaws.com/releases/pkg.zip\
+                      ?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIAEXAMPLE#section";
+        assert_eq!(
+            redact_url_for_diagnostics(signed),
+            "https://provider-bucket.s3.amazonaws.com/releases/pkg.zip"
+        );
+
+        assert_eq!(
+            redact_url_for_diagnostics("packages/pkg.zip?token=secret#frag"),
+            "packages/pkg.zip"
+        );
+    }
+
+    #[test]
     fn test_validate_upstream_status_2xx_is_ok() {
         validate_upstream_status(StatusCode::OK, "http://x").expect("200 must pass");
         validate_upstream_status(StatusCode::PARTIAL_CONTENT, "http://x")
@@ -7631,6 +7687,23 @@ SHA256:
         match validate_upstream_status(StatusCode::UNAUTHORIZED, "http://up/x") {
             Err(AppError::BadGateway(_)) => {}
             other => panic!("401 must map to AppError::BadGateway; got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_validate_upstream_status_redacts_signed_url_diagnostics() {
+        let signed_url = "https://provider-bucket.s3.amazonaws.com/releases/pkg.zip\
+                          ?X-Amz-Signature=deadbeef&X-Amz-Credential=AKIAEXAMPLE#frag";
+
+        match validate_upstream_status(StatusCode::FORBIDDEN, signed_url) {
+            Err(AppError::BadGateway(msg)) => {
+                assert!(msg.contains("https://provider-bucket.s3.amazonaws.com/releases/pkg.zip"));
+                assert!(
+                    !msg.contains("X-Amz") && !msg.contains("deadbeef") && !msg.contains("#frag"),
+                    "signed URL material must not appear in diagnostics: {msg}"
+                );
+            }
+            other => panic!("403 must map to redacted AppError::BadGateway; got {other:?}"),
         }
     }
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -105,7 +105,7 @@ services:
       retries: 30
     networks:
       - e2e-test-network
-    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "redteam", "tag-replication", "curation", "cache-correctness"]
+    profiles: ["pypi", "npm", "cargo", "maven", "go", "rpm", "deb", "helm", "conda", "docker", "smoke", "all", "proxy", "docker-proxy", "terraform-mirror", "redteam", "tag-replication", "curation", "cache-correctness"]
 
   # PKI service: uses pre-generated files from .pki/ if available (CI), otherwise generates them (local)
   pki:
@@ -395,6 +395,36 @@ services:
     networks:
       - e2e-test-network
     profiles: ["hex", "all"]
+
+  # ==========================================================================
+  # TERRAFORM / OPENTOFU NETWORK MIRROR TESTS
+  # ==========================================================================
+
+  terraform-mirror-test:
+    image: hashicorp/terraform:1.13.0
+    container_name: e2e-test-terraform-mirror
+    depends_on:
+      setup:
+        condition: service_healthy
+    environment:
+      REGISTRY_URL: http://backend:8080
+      ADMIN_USER: admin
+      ADMIN_PASS: TestRunner!2026secure
+      TF_UPSTREAM_URL: https://registry.terraform.io
+      TF_HOSTNAME: registry.terraform.io
+      TF_NAMESPACE: hashicorp
+      TF_TYPE: null
+      TF_VERSION: 3.2.3
+      TF_OS: linux
+      TF_ARCH: amd64
+      RUN_TERRAFORM_CLI: "1"
+    volumes:
+      - ./scripts/native-tests:/scripts:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command: ["apk add --no-cache bash curl jq coreutils >/dev/null 2>&1 && bash /scripts/test-terraform-mirror.sh"]
+    networks:
+      - e2e-test-network
+    profiles: ["terraform-mirror"]
 
   # ==========================================================================
   # PROXY + VIRTUAL REPOSITORY TESTS

--- a/scripts/native-tests/run-all.sh
+++ b/scripts/native-tests/run-all.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Run all native client tests
 # Usage: ./run-all.sh [profile]
-# Profiles: smoke (default), all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, proxy, health-probes, curation
+# Profiles: smoke (default), all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, proxy, terraform-mirror, health-probes, curation
 set -euo pipefail
 
 PROFILE="${1:-smoke}"
@@ -26,12 +26,12 @@ case "$PROFILE" in
     proxy)
         TESTS=("proxy-virtual")
         ;;
-    pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|protobuf|incus|hex|proxy-virtual|health-probes|tag-replication|curation)
+    pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|protobuf|incus|hex|proxy-virtual|terraform-mirror|health-probes|tag-replication|curation)
         TESTS=("$PROFILE")
         ;;
     *)
         echo "ERROR: Unknown profile: $PROFILE"
-        echo "Available profiles: smoke, all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, protobuf, incus, hex, proxy, tag-replication, curation"
+        echo "Available profiles: smoke, all, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, protobuf, incus, hex, proxy, terraform-mirror, tag-replication, curation"
         exit 1
         ;;
 esac

--- a/scripts/native-tests/test-terraform-mirror.sh
+++ b/scripts/native-tests/test-terraform-mirror.sh
@@ -1,0 +1,410 @@
+#!/usr/bin/env bash
+# Terraform/OpenTofu network-mirror archive download regression test (#1998).
+#
+# This is a black-box reproduction of:
+#
+#   GET /terraform/<repo>/registry.terraform.io/hashicorp/null/3.2.3/download/linux/arm64
+#   -> historically 400 "Invalid artifact path"
+#
+# The failure only appears on the network-mirror archive endpoint: service
+# discovery, index.json, and <version>.json all work first. The archive endpoint
+# must fetch the registry-provided absolute download_url but cache it under a
+# safe local path.
+#
+# Usage against the local E2E backend:
+#   ./scripts/native-tests/test-terraform-mirror.sh
+#
+# Usage against a live instance with a token:
+#   REGISTRY_URL=https://ak.cazlab.link AK_TOKEN=... \
+#     TF_OS=linux TF_ARCH=arm64 ./scripts/native-tests/test-terraform-mirror.sh
+#
+# Usage against an existing remote repo without creating/deleting it:
+#   REGISTRY_URL=https://ak.cazlab.link AK_TOKEN=... TF_REPO_KEY=my-tf-remote \
+#     CREATE_TF_REPO=0 ./scripts/native-tests/test-terraform-mirror.sh
+#
+# The real Terraform CLI phase runs automatically when `terraform` is present.
+# Use RUN_TERRAFORM_CLI=1 to require it, or RUN_TERRAFORM_CLI=0 for HTTP-only.
+#
+# Requires: bash, curl, jq, od, wc. Optional: terraform.
+set -uo pipefail
+
+REGISTRY_URL="${REGISTRY_URL:-http://localhost:8080}"
+REGISTRY_URL="${REGISTRY_URL%/}"
+API_URL="$REGISTRY_URL/api/v1"
+
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-TestRunner!2026secure}"
+TOKEN="${AK_TOKEN:-${ARTIFACT_KEEPER_TOKEN:-}}"
+
+TF_UPSTREAM_URL="${TF_UPSTREAM_URL:-https://registry.terraform.io}"
+TF_UPSTREAM_URL="${TF_UPSTREAM_URL%/}"
+host_from_upstream="${TF_UPSTREAM_URL#http://}"
+host_from_upstream="${host_from_upstream#https://}"
+host_from_upstream="${host_from_upstream%%/*}"
+TF_HOSTNAME="${TF_HOSTNAME:-$host_from_upstream}"
+
+TF_NAMESPACE="${TF_NAMESPACE:-hashicorp}"
+TF_TYPE="${TF_TYPE:-null}"
+TF_VERSION="${TF_VERSION:-3.2.3}"
+TF_OS="${TF_OS:-linux}"
+TF_ARCH="${TF_ARCH:-amd64}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-120}"
+RUN_TERRAFORM_CLI="${RUN_TERRAFORM_CLI:-auto}"
+TERRAFORM_BIN="${TERRAFORM_BIN:-terraform}"
+
+if [ -n "${TF_REPO_KEY:-}" ]; then
+    REPO_KEY="$TF_REPO_KEY"
+    CREATE_TF_REPO="${CREATE_TF_REPO:-0}"
+else
+    REPO_KEY="tf-mirror-1998-$(date +%s)-$$"
+    CREATE_TF_REPO="${CREATE_TF_REPO:-1}"
+fi
+
+KEEP_TF_REPO="${KEEP_TF_REPO:-0}"
+RECREATE_TF_REPO="${RECREATE_TF_REPO:-0}"
+CREATED_REPO=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+SKIPPED=0
+
+pass() { echo -e "  ${GREEN}PASS${NC}: $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC}: $1"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "  ${YELLOW}SKIP${NC}: $1"; SKIPPED=$((SKIPPED + 1)); }
+
+TMPDIR_TEST="$(mktemp -d)"
+AUTH_ARGS=()
+
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+
+    if [ "$CREATED_REPO" = "1" ] && [ "$KEEP_TF_REPO" != "1" ]; then
+        curl -sS -o /dev/null -X DELETE "$API_URL/repositories/$REPO_KEY" \
+            "${AUTH_ARGS[@]}" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+require_cmd() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "ERROR: required command not found: $1"
+        exit 1
+    fi
+}
+
+require_cmd curl
+require_cmd jq
+require_cmd od
+require_cmd wc
+
+host_from_url() {
+    local url="$1"
+    url="${url#http://}"
+    url="${url#https://}"
+    url="${url%%/*}"
+    printf '%s' "$url"
+}
+
+curl_code() {
+    local out="$1"
+    local url="$2"
+    local code
+
+    if ! code=$(curl -sS --max-time "$CURL_MAX_TIME" -o "$out" -w "%{http_code}" \
+        "${AUTH_ARGS[@]}" "$url"); then
+        code="000"
+    fi
+    printf '%s' "$code"
+}
+
+body_preview() {
+    local file="$1"
+    if [ ! -s "$file" ]; then
+        printf '<empty>'
+        return
+    fi
+    tr '\n' ' ' < "$file" | cut -c 1-240
+}
+
+authenticate() {
+    echo "==> Authenticating..."
+
+    if [ -n "$TOKEN" ]; then
+        AUTH_ARGS=(-H "Authorization: Bearer $TOKEN")
+        pass "using bearer token from AK_TOKEN/ARTIFACT_KEEPER_TOKEN"
+        echo ""
+        return
+    fi
+
+    local login_body="$TMPDIR_TEST/login.json"
+    local login_code
+    if ! login_code=$(curl -sS --max-time "$CURL_MAX_TIME" -o "$login_body" -w "%{http_code}" \
+        -X POST "$API_URL/auth/login" \
+        -H 'Content-Type: application/json' \
+        -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}"); then
+        login_code="000"
+    fi
+
+    if [ "$login_code" != "200" ]; then
+        echo "ERROR: authentication failed with HTTP $login_code"
+        echo "Set AK_TOKEN/ARTIFACT_KEEPER_TOKEN, or ADMIN_USER/ADMIN_PASS."
+        echo "Response: $(body_preview "$login_body")"
+        exit 1
+    fi
+
+    TOKEN="$(jq -r '.access_token // empty' "$login_body")"
+    if [ -z "$TOKEN" ]; then
+        echo "ERROR: login response did not include access_token"
+        exit 1
+    fi
+
+    AUTH_ARGS=(-H "Authorization: Bearer $TOKEN")
+    pass "logged in as $ADMIN_USER"
+    echo ""
+}
+
+create_remote_repo() {
+    if [ "$CREATE_TF_REPO" != "1" ]; then
+        skip "using existing Terraform remote repo '$REPO_KEY'"
+        return
+    fi
+
+    echo "==> Creating Terraform remote repo..."
+
+    if [ "$RECREATE_TF_REPO" = "1" ]; then
+        curl -sS -o /dev/null -X DELETE "$API_URL/repositories/$REPO_KEY" \
+            "${AUTH_ARGS[@]}" 2>/dev/null || true
+    fi
+
+    local repo_body="$TMPDIR_TEST/create-repo.json"
+    local payload
+    payload=$(jq -n \
+        --arg key "$REPO_KEY" \
+        --arg name "Terraform Mirror 1998 Regression" \
+        --arg upstream "$TF_UPSTREAM_URL" \
+        '{
+            key: $key,
+            name: $name,
+            format: "terraform",
+            repo_type: "remote",
+            is_public: true,
+            upstream_url: $upstream
+        }')
+
+    local code
+    if ! code=$(curl -sS --max-time "$CURL_MAX_TIME" -o "$repo_body" -w "%{http_code}" \
+        -X POST "$API_URL/repositories" \
+        "${AUTH_ARGS[@]}" \
+        -H 'Content-Type: application/json' \
+        -d "$payload"); then
+        code="000"
+    fi
+
+    case "$code" in
+        200|201)
+            CREATED_REPO=1
+            pass "created remote repo '$REPO_KEY' -> $TF_UPSTREAM_URL"
+            ;;
+        *)
+            echo "ERROR: failed to create repo '$REPO_KEY' (HTTP $code)"
+            echo "Response: $(body_preview "$repo_body")"
+            exit 1
+            ;;
+    esac
+    echo ""
+}
+
+assert_json_200() {
+    local label="$1"
+    local url="$2"
+    local jq_expr="$3"
+    shift 3
+    local out="$TMPDIR_TEST/$label.json"
+    local code
+
+    code=$(curl_code "$out" "$url")
+    if [ "$code" != "200" ]; then
+        fail "$label returned HTTP $code (expected 200): $(body_preview "$out")"
+        return
+    fi
+
+    if jq -e "$@" "$jq_expr" "$out" >/dev/null 2>&1; then
+        pass "$label returned 200 with expected JSON"
+    else
+        fail "$label returned 200 but JSON did not match: $(body_preview "$out")"
+    fi
+}
+
+assert_archive_download() {
+    local label="$1"
+    local url="$2"
+    local out="$TMPDIR_TEST/$label.zip"
+    local code
+    local bytes
+    local magic
+
+    code=$(curl_code "$out" "$url")
+    bytes=$(wc -c < "$out" | tr -d ' ')
+
+    if [ "$code" != "200" ]; then
+        if [ "$code" = "400" ]; then
+            fail "$label returned HTTP 400; this reproduces #1998: $(body_preview "$out")"
+        else
+            fail "$label returned HTTP $code (expected 200): $(body_preview "$out")"
+        fi
+        return
+    fi
+
+    magic=$(head -c 4 "$out" | od -An -tx1 | tr -d ' \n')
+    case "$magic" in
+        504b0304|504b0506|504b0708)
+            pass "$label returned a zip archive (HTTP 200, ${bytes} bytes)"
+            ;;
+        *)
+            fail "$label returned 200 but did not look like a zip (magic=$magic, bytes=$bytes)"
+            ;;
+    esac
+}
+
+terraform_source_address() {
+    if [ "$TF_HOSTNAME" = "registry.terraform.io" ]; then
+        printf '%s/%s' "$TF_NAMESPACE" "$TF_TYPE"
+    else
+        printf '%s/%s/%s' "$TF_HOSTNAME" "$TF_NAMESPACE" "$TF_TYPE"
+    fi
+}
+
+run_terraform_cli_init() {
+    case "$RUN_TERRAFORM_CLI" in
+        0|false|False|FALSE|no|No|NO)
+            skip "terraform CLI phase disabled by RUN_TERRAFORM_CLI=$RUN_TERRAFORM_CLI"
+            return
+            ;;
+        auto)
+            if ! command -v "$TERRAFORM_BIN" >/dev/null 2>&1; then
+                skip "terraform CLI phase skipped; '$TERRAFORM_BIN' not found"
+                return
+            fi
+            ;;
+        1|true|True|TRUE|yes|Yes|YES)
+            if ! command -v "$TERRAFORM_BIN" >/dev/null 2>&1; then
+                fail "terraform CLI phase requested, but '$TERRAFORM_BIN' was not found"
+                return
+            fi
+            ;;
+        *)
+            fail "invalid RUN_TERRAFORM_CLI value '$RUN_TERRAFORM_CLI' (use auto, 1, or 0)"
+            return
+            ;;
+    esac
+
+    echo "==> Running Terraform CLI network_mirror init..."
+
+    local tf_work="$TMPDIR_TEST/terraform-cli"
+    local tf_config="$tf_work/terraformrc"
+    local tf_plugin_cache="$tf_work/plugin-cache"
+    local tf_out="$TMPDIR_TEST/terraform-init.out"
+    local mirror_url="$REGISTRY_URL/terraform/$REPO_KEY/"
+    local mirror_include="$TF_HOSTNAME/$TF_NAMESPACE/$TF_TYPE"
+    local source_addr
+    local registry_host
+
+    source_addr="$(terraform_source_address)"
+    registry_host="$(host_from_url "$REGISTRY_URL")"
+
+    mkdir -p "$tf_work" "$tf_plugin_cache"
+
+    cat > "$tf_work/main.tf" <<EOF
+terraform {
+  required_providers {
+    subject = {
+      source  = "$source_addr"
+      version = "$TF_VERSION"
+    }
+  }
+}
+EOF
+
+    cat > "$tf_config" <<EOF
+credentials "$registry_host" {
+  token = "$TOKEN"
+}
+
+provider_installation {
+  network_mirror {
+    url     = "$mirror_url"
+    include = ["$mirror_include"]
+  }
+
+  direct {
+    exclude = ["$mirror_include"]
+  }
+}
+EOF
+
+    if TF_CLI_CONFIG_FILE="$tf_config" \
+        TF_DATA_DIR="$tf_work/.terraform" \
+        TF_PLUGIN_CACHE_DIR="$tf_plugin_cache" \
+        CHECKPOINT_DISABLE=1 \
+        "$TERRAFORM_BIN" -chdir="$tf_work" init -input=false -no-color >"$tf_out" 2>&1; then
+        pass "terraform init installed $source_addr $TF_VERSION through network_mirror"
+        return
+    fi
+
+    if grep -Eq 'bad response code: 400|Invalid artifact path|Failed to install provider' "$tf_out"; then
+        fail "terraform init failed through network_mirror; this reproduces #1998: $(body_preview "$tf_out")"
+    else
+        fail "terraform init failed: $(body_preview "$tf_out")"
+    fi
+}
+
+echo "=============================================="
+echo "Terraform/OpenTofu Mirror Archive E2E (#1998)"
+echo "=============================================="
+echo "Registry:       $REGISTRY_URL"
+echo "Repo key:       $REPO_KEY"
+echo "Upstream:       $TF_UPSTREAM_URL"
+echo "Mirror host:    $TF_HOSTNAME"
+echo "Provider:       $TF_NAMESPACE/$TF_TYPE $TF_VERSION ($TF_OS/$TF_ARCH)"
+echo "Create repo:    $CREATE_TF_REPO"
+echo "Terraform CLI:  $RUN_TERRAFORM_CLI ($TERRAFORM_BIN)"
+echo ""
+
+authenticate
+create_remote_repo
+
+SERVICE_URL="$REGISTRY_URL/terraform/$REPO_KEY/.well-known/terraform.json"
+INDEX_URL="$REGISTRY_URL/terraform/$REPO_KEY/$TF_HOSTNAME/$TF_NAMESPACE/$TF_TYPE/index.json"
+VERSION_URL="$REGISTRY_URL/terraform/$REPO_KEY/$TF_HOSTNAME/$TF_NAMESPACE/$TF_TYPE/$TF_VERSION.json"
+DOWNLOAD_URL="$REGISTRY_URL/terraform/$REPO_KEY/$TF_HOSTNAME/$TF_NAMESPACE/$TF_TYPE/$TF_VERSION/download/$TF_OS/$TF_ARCH"
+
+echo "==> Exercising network-mirror protocol..."
+assert_json_200 "service-discovery" "$SERVICE_URL" 'has("providers.v1")'
+assert_json_200 "provider-index" "$INDEX_URL" '.versions[$version] != null' \
+    --arg version "$TF_VERSION"
+assert_json_200 "provider-version" "$VERSION_URL" \
+    '.archives[$archive_key].url != null' --arg archive_key "${TF_OS}_${TF_ARCH}"
+assert_archive_download "provider-archive" "$DOWNLOAD_URL"
+assert_archive_download "provider-archive-second-fetch" "$DOWNLOAD_URL"
+run_terraform_cli_init
+echo ""
+
+echo "=============================================="
+echo "Terraform Mirror Test Summary"
+echo "=============================================="
+echo "Passed:  $PASSED"
+echo "Failed:  $FAILED"
+echo "Skipped: $SKIPPED"
+
+if [ "$FAILED" -gt 0 ]; then
+    echo ""
+    echo "Result: FAILED"
+    exit 1
+fi
+
+echo ""
+echo "Result: PASSED"

--- a/scripts/run-e2e-tests.sh
+++ b/scripts/run-e2e-tests.sh
@@ -16,7 +16,9 @@
 # Profiles:
 #   smoke  - Quick tests: Playwright E2E + PyPI, NPM, Cargo native clients (default)
 #   all    - All tests: Playwright E2E + all native clients
-#   pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, docker-proxy, hex - Individual native client tests
+#   pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, docker-proxy, hex,
+#   terraform-mirror - Individual native client tests (terraform-mirror requires
+#   live registry.terraform.io access; not included in smoke/all)
 #
 
 set -e
@@ -76,7 +78,7 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: $0 [OPTIONS]"
             echo ""
             echo "Options:"
-            echo "  --profile PROFILE  Test profile to run (smoke, all, proxy, docker-proxy, redteam, storage-gc, curation, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, docker-proxy, hex)"
+            echo "  --profile PROFILE  Test profile to run (smoke, all, proxy, docker-proxy, redteam, storage-gc, curation, pypi, npm, cargo, maven, go, rpm, deb, helm, conda, docker, docker-proxy, hex, terraform-mirror)"
             echo "  --build            Force rebuild all containers"
             echo "  --clean            Clean up containers and volumes after tests"
             echo "  --stress           Run stress tests after E2E tests"
@@ -192,7 +194,7 @@ PLAYWRIGHT_EXIT=$?
 
 # Run native client tests if profile is smoke or all
 NATIVE_EXIT=0
-if [ "$PROFILE" = "smoke" ] || [ "$PROFILE" = "all" ] || [ "$PROFILE" = "proxy" ] || [[ "$PROFILE" =~ ^(pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|hex)$ ]]; then
+if [ "$PROFILE" = "smoke" ] || [ "$PROFILE" = "all" ] || [ "$PROFILE" = "proxy" ] || [[ "$PROFILE" =~ ^(pypi|npm|cargo|maven|go|rpm|deb|helm|conda|docker|hex|terraform-mirror)$ ]]; then
     echo ""
     echo -e "${BLUE}Running native client tests (profile: $PROFILE)...${NC}"
     docker compose -f docker-compose.test.yml --profile "$PROFILE" up \


### PR DESCRIPTION
## Summary

Fixes Terraform/OpenTofu provider `network_mirror` archive downloads returning
HTTP 400 when the upstream registry's download document carries an absolute
`download_url` (e.g. `releases.hashicorp.com`, or any third-party provider
mirror). `mirror_download` now still fetches from that registry-provided
absolute URL, but caches the response under a derived, scheme-less canonical
path (`<namespace>/<type>/<version>/<os>/<arch>/<filename>`) instead of using
the absolute URL as the cache key.

Hardens the same archive URL path by validating the registry-provided
`download_url` with the existing outbound anti-SSRF guard before fetching it,
dropping signed URL query/fragment material before deriving cache/storage keys,
and redacting signed upstream URLs from shared proxy diagnostics and
client-facing upstream error messages while preserving the raw URL for the
actual outbound fetch.

Adds a new `proxy_fetch_streaming_response_with_cache_key` helper in
`proxy_helpers.rs` for handlers that need this fetch/cache path split — it
delegates to the existing `proxy_fetch_streaming_with_cache_key` +
`stream_fetch_result` rather than duplicating response-building logic.

Closes #1998

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

---

### Notes for reviewers

- **Root cause:** `proxy_fetch_streaming` used the absolute `archive_url` as
  both the upstream fetch target and the proxy-cache path.
  `ProxyService::validate_cache_path` rejects `//` as an empty path segment,
  and `https://` contains one, so every mirror archive download 400'd with
  `Proxy cache path must not contain empty segments`.
- **Unit tests:** `mirror_archive_cache_path` derivation (HashiCorp release
  URL, third-party host, trailing-slash fallback), a regression guard
  asserting the raw absolute URL is rejected by
  `ProxyService::cache_storage_key` while the derived path is accepted, and a
  DB-gated wiremock test pinning the fetch-path/cache-path split end to end
  (`backend/src/api/handlers/terraform.rs`, `proxy_helpers.rs`). Also covers
  SSRF rejection and signed URL redaction from cache keys and proxy
  diagnostics.
- **E2E test:** `scripts/native-tests/test-terraform-mirror.sh` (new), wired
  into `run-all.sh`'s `terraform-mirror` profile and
  `docker-compose.test.yml`'s `terraform-mirror-test` service
  (`./scripts/run-e2e-tests.sh --profile terraform-mirror`). Exercises service
  discovery, `index.json`, `<version>.json`, the archive download (twice, to
  cover the cache path), and a real `terraform init` through `network_mirror`
  when the `terraform` CLI is present.
- **Manually tested locally:** ran `test-terraform-mirror.sh` with
  `RUN_TERRAFORM_CLI=1` against a live deployed instance running this exact
  build — 8/8 passed, including a real `terraform init` through
  `network_mirror`, both before the fix (RED: HTTP 400 on the archive
  download reproducing bug report behavior exactly) and after (GREEN).
- **Scope:** backend-only, `network_mirror` provider archive path only. Does
  not change Terraform module upload/download behavior. The issue also
  mentions the native registry-protocol `download_provider` route returning
  the download document instead of following the archive URL — treated as
  related follow-up, out of scope here, to keep this PR focused and
  reviewable.