### PR TITLE
feat(scanner): private-repo image scans via short-lived repo-scoped tokens

### DIFF
--- a/.sqlx/query-fe6d259321ba086abb5cf2b3279f786c2f39fd969eb76ae7c0a02a1ea69e1cc4.json
+++ b/.sqlx/query-fe6d259321ba086abb5cf2b3279f786c2f39fd969eb76ae7c0a02a1ea69e1cc4.json
@@ -1,0 +1,158 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE username = '_ak_scanner'\n              AND is_service_account = true\n              AND is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "fe6d259321ba086abb5cf2b3279f786c2f39fd969eb76ae7c0a02a1ea69e1cc4"
+}

--- a/backend/migrations/138_scanner_service_account.sql
+++ b/backend/migrations/138_scanner_service_account.sql
@@ -1,0 +1,40 @@
+-- Dedicated, non-login scanner service account (#2093).
+--
+-- Private-repo container-image scanning needs an authenticated identity so the
+-- scanner (Harbor adapter + grype) can pull internal/private images that anon
+-- pulls 401 on. Rather than reuse a human or admin account, seed a minimal,
+-- purpose-built service account:
+--   * password_hash NULL  -> cannot log in interactively (no password grant).
+--   * is_service_account  -> excluded from human-user surfaces.
+--   * is_admin = false     -> NOT privileged; least privilege.
+--   * no role assignments, no API token -> not user-reachable / cannot pull-all
+--     on its own. The only credential that ever leaves the process is an
+--     ephemeral, single-repo-scoped JWT minted per scan (see
+--     AuthService::generate_scan_token + the scan_pull_repo claim enforced on
+--     the OCI pull handlers).
+--
+-- Idempotent: seeded by username so re-running the migration (or a second
+-- replica applying it) is a no-op.
+INSERT INTO users (
+    username,
+    email,
+    auth_provider,
+    is_active,
+    is_admin,
+    is_service_account,
+    must_change_password,
+    password_hash,
+    display_name
+)
+VALUES (
+    '_ak_scanner',
+    'scanner@artifact-keeper.internal',
+    'local',
+    true,
+    false,
+    true,
+    false,
+    NULL,
+    'Image Scanner (system)'
+)
+ON CONFLICT (username) DO NOTHING;

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3066,6 +3066,7 @@ mod tests {
                 smtp_password: None,
                 smtp_from_address: "noreply@artifact-keeper.local".to_string(),
                 smtp_tls_mode: "starttls".to_string(),
+                scan_token_ttl_seconds: 300,
             }
         }
 

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -416,6 +416,28 @@ fn oci_denied_repo_access() -> Response {
     )
 }
 
+/// Per-repository read gate for scanner-scoped pull tokens (#2093).
+///
+/// A token minted by [`crate::services::auth_service::AuthService::generate_scan_token`]
+/// carries a `scan_pull_repo` claim pinning it to exactly one repository key.
+/// On the OCI blob/manifest *read* handlers, reject any pull whose target
+/// repository key differs — a scan token issued for `repoA` must not be usable
+/// to pull `repoB`, even though the scanner account is otherwise a valid
+/// identity. Normal tokens (login / refresh / API-token exchange) have no
+/// `scan_pull_repo` claim, so this is a no-op for them: it only ever *narrows*.
+///
+/// Pure decision fn (no I/O) so it is directly unit-testable.
+#[allow(clippy::result_large_err)] // Response-as-error is used throughout this module
+fn enforce_scan_pull_scope(
+    claims: &crate::services::auth_service::Claims,
+    repo_key: &str,
+) -> Result<(), Response> {
+    match &claims.scan_pull_repo {
+        Some(scoped) if scoped != repo_key => Err(oci_denied_repo_access()),
+        _ => Ok(()),
+    }
+}
+
 /// OCI v2 write/delete authorization — parity with the REST artifact-write gate.
 ///
 /// The REST artifact path enforces a private-repository members-only gate
@@ -3286,21 +3308,45 @@ async fn token(
                     }
                 };
 
-                let tokens = match auth_service.generate_tokens(&user) {
-                    Ok(t) => t,
-                    Err(_) => {
-                        return oci_error(
-                            StatusCode::INTERNAL_SERVER_ERROR,
-                            "INTERNAL_ERROR",
-                            "token generation failed",
-                        )
-                    }
-                };
+                // Preserve a scanner-scoped pull claim across the exchange
+                // (#2093). grype presents its scoped JWT here to obtain a
+                // registry access token; re-minting a full token would drop
+                // `scan_pull_repo` and re-widen the token to pull-all. Re-issue
+                // a single-repo scan token instead. This only ever *narrows*:
+                // a normal exchange (no incoming claim) is unaffected.
+                let (access_token, expires_in) =
+                    if let Some(repo_key) = claims.scan_pull_repo.as_deref() {
+                        match auth_service.generate_scan_token(
+                            &user,
+                            repo_key,
+                            state.config.scan_token_ttl_seconds as i64,
+                        ) {
+                            Ok(t) => (t, state.config.scan_token_ttl_seconds),
+                            Err(_) => {
+                                return oci_error(
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    "INTERNAL_ERROR",
+                                    "token generation failed",
+                                )
+                            }
+                        }
+                    } else {
+                        match auth_service.generate_tokens(&user) {
+                            Ok(t) => (t.access_token, t.expires_in),
+                            Err(_) => {
+                                return oci_error(
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                    "INTERNAL_ERROR",
+                                    "token generation failed",
+                                )
+                            }
+                        }
+                    };
 
                 let resp = TokenResponse {
-                    token: tokens.access_token.clone(),
-                    access_token: tokens.access_token,
-                    expires_in: tokens.expires_in,
+                    token: access_token.clone(),
+                    access_token,
+                    expires_in,
                     issued_at: chrono::Utc::now().to_rfc3339(),
                 };
 
@@ -3538,13 +3584,16 @@ async fn handle_head_blob(
 ) -> Response {
     let scope = pull_scope(image_name);
     let is_anon = is_anonymous_token(headers);
-    if !is_anon
-        && authenticate_oci(&state.db, &state.config, headers)
-            .await
-            .is_err()
-    {
-        return unauthorized_challenge_with_scope(base_url, Some(&scope));
-    }
+    // Bind the authenticated claims (don't discard) so scanner-scoped pull
+    // tokens can be enforced per-repository below (#2093).
+    let claims = if is_anon {
+        None
+    } else {
+        match authenticate_oci(&state.db, &state.config, headers).await {
+            Ok(c) => Some(c),
+            Err(()) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
+        }
+    };
 
     let repo = match resolve_repo(&state.db, image_name).await {
         Ok(r) => r,
@@ -3554,6 +3603,14 @@ async fn handle_head_blob(
     // Anonymous tokens may only access public repositories.
     if is_anon && !repo.is_public {
         return unauthorized_challenge_with_scope(base_url, Some(&scope));
+    }
+
+    // A scanner-scoped pull token is pinned to a single repository key; reject
+    // a read of any other repo (#2093). No-op for normal tokens.
+    if let Some(claims) = &claims {
+        if let Err(resp) = enforce_scan_pull_scope(claims, &repo.key) {
+            return resp;
+        }
     }
 
     // Check oci_blobs table. Look up by the canonical digest so an upper-case
@@ -3678,13 +3735,16 @@ async fn handle_get_blob(
 ) -> Response {
     let scope = pull_scope(image_name);
     let is_anon = is_anonymous_token(headers);
-    if !is_anon
-        && authenticate_oci(&state.db, &state.config, headers)
-            .await
-            .is_err()
-    {
-        return unauthorized_challenge_with_scope(base_url, Some(&scope));
-    }
+    // Bind the authenticated claims (don't discard) so scanner-scoped pull
+    // tokens can be enforced per-repository below (#2093).
+    let claims = if is_anon {
+        None
+    } else {
+        match authenticate_oci(&state.db, &state.config, headers).await {
+            Ok(c) => Some(c),
+            Err(()) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
+        }
+    };
 
     let repo = match resolve_repo(&state.db, image_name).await {
         Ok(r) => r,
@@ -3694,6 +3754,14 @@ async fn handle_get_blob(
     // Anonymous tokens may only access public repositories.
     if is_anon && !repo.is_public {
         return unauthorized_challenge_with_scope(base_url, Some(&scope));
+    }
+
+    // A scanner-scoped pull token is pinned to a single repository key; reject
+    // a read of any other repo (#2093). No-op for normal tokens.
+    if let Some(claims) = &claims {
+        if let Err(resp) = enforce_scan_pull_scope(claims, &repo.key) {
+            return resp;
+        }
     }
 
     // Look up by the canonical digest so an upper-case pull still resolves a
@@ -5715,13 +5783,16 @@ async fn handle_head_manifest(
 ) -> Response {
     let scope = pull_scope(image_name);
     let is_anon = is_anonymous_token(headers);
-    if !is_anon
-        && authenticate_oci(&state.db, &state.config, headers)
-            .await
-            .is_err()
-    {
-        return unauthorized_challenge_with_scope(base_url, Some(&scope));
-    }
+    // Bind the authenticated claims (don't discard) so scanner-scoped pull
+    // tokens can be enforced per-repository below (#2093).
+    let claims = if is_anon {
+        None
+    } else {
+        match authenticate_oci(&state.db, &state.config, headers).await {
+            Ok(c) => Some(c),
+            Err(()) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
+        }
+    };
 
     let repo = match resolve_repo(&state.db, image_name).await {
         Ok(r) => r,
@@ -5731,6 +5802,14 @@ async fn handle_head_manifest(
     // Anonymous tokens may only access public repositories.
     if is_anon && !repo.is_public {
         return unauthorized_challenge_with_scope(base_url, Some(&scope));
+    }
+
+    // A scanner-scoped pull token is pinned to a single repository key; reject
+    // a read of any other repo (#2093). No-op for normal tokens.
+    if let Some(claims) = &claims {
+        if let Err(resp) = enforce_scan_pull_scope(claims, &repo.key) {
+            return resp;
+        }
     }
 
     // Reference can be a tag or a digest. Resolve locally first: a surviving
@@ -5855,13 +5934,16 @@ async fn handle_get_manifest(
 ) -> Response {
     let scope = pull_scope(image_name);
     let is_anon = is_anonymous_token(headers);
-    if !is_anon
-        && authenticate_oci(&state.db, &state.config, headers)
-            .await
-            .is_err()
-    {
-        return unauthorized_challenge_with_scope(base_url, Some(&scope));
-    }
+    // Bind the authenticated claims (don't discard) so scanner-scoped pull
+    // tokens can be enforced per-repository below (#2093).
+    let claims = if is_anon {
+        None
+    } else {
+        match authenticate_oci(&state.db, &state.config, headers).await {
+            Ok(c) => Some(c),
+            Err(()) => return unauthorized_challenge_with_scope(base_url, Some(&scope)),
+        }
+    };
 
     let repo = match resolve_repo(&state.db, image_name).await {
         Ok(r) => r,
@@ -5871,6 +5953,14 @@ async fn handle_get_manifest(
     // Anonymous tokens may only access public repositories.
     if is_anon && !repo.is_public {
         return unauthorized_challenge_with_scope(base_url, Some(&scope));
+    }
+
+    // A scanner-scoped pull token is pinned to a single repository key; reject
+    // a read of any other repo (#2093). No-op for normal tokens.
+    if let Some(claims) = &claims {
+        if let Err(resp) = enforce_scan_pull_scope(claims, &repo.key) {
+            return resp;
+        }
     }
 
     // Resolve locally first: a surviving tag row, or — for a digest this hosted
@@ -7365,6 +7455,49 @@ pub fn version_check_handler() -> axum::routing::MethodRouter<SharedState> {
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+
+    // -----------------------------------------------------------------------
+    // enforce_scan_pull_scope (#2093)
+    // -----------------------------------------------------------------------
+
+    fn claims_with_scan_scope(scope: Option<&str>) -> crate::services::auth_service::Claims {
+        crate::services::auth_service::Claims {
+            sub: uuid::Uuid::new_v4(),
+            username: "_ak_scanner".to_string(),
+            email: "scanner@artifact-keeper.internal".to_string(),
+            is_admin: false,
+            iat: 0,
+            iat_ms: None,
+            exp: i64::MAX,
+            token_type: "access".to_string(),
+            jti: None,
+            family_id: None,
+            scan_pull_repo: scope.map(|s| s.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_enforce_scan_pull_scope_allows_matching_repo() {
+        let claims = claims_with_scan_scope(Some("repo-a"));
+        assert!(enforce_scan_pull_scope(&claims, "repo-a").is_ok());
+    }
+
+    #[test]
+    fn test_enforce_scan_pull_scope_denies_other_repo() {
+        let claims = claims_with_scan_scope(Some("repo-a"));
+        let err = enforce_scan_pull_scope(&claims, "repo-b")
+            .expect_err("scoped token must be denied on a different repo");
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_enforce_scan_pull_scope_noop_for_normal_token() {
+        // A normal (unscoped) token has no scan_pull_repo claim: the gate is a
+        // no-op and any repo is allowed (existing authz still applies upstream).
+        let claims = claims_with_scan_scope(None);
+        assert!(enforce_scan_pull_scope(&claims, "repo-a").is_ok());
+        assert!(enforce_scan_pull_scope(&claims, "any-other-repo").is_ok());
+    }
 
     // -----------------------------------------------------------------------
     // oci_error

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4886,6 +4886,7 @@ mod tests {
                 smtp_password: None,
                 smtp_from_address: "noreply@test.local".to_string(),
                 smtp_tls_mode: "starttls".to_string(),
+                scan_token_ttl_seconds: 300,
             }
         }
 

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -1879,6 +1879,10 @@ mod tests {
             Arc::new(crate::services::scan_result_service::ScanResultService::new(fx.pool.clone()));
         let scan_config_service =
             Arc::new(crate::services::scan_config_service::ScanConfigService::new(fx.pool.clone()));
+        let scanner_auth = Arc::new(crate::services::auth_service::AuthService::new(
+            fx.pool.clone(),
+            Arc::new(crate::config::Config::test_config()),
+        ));
         let scanner = Arc::new(crate::services::scanner_service::ScannerService::new(
             fx.pool.clone(),
             advisory_client,
@@ -1892,6 +1896,9 @@ mod tests {
             "/tmp/scan".to_string(),
             None, // openscap_url
             "standard".to_string(),
+            scanner_auth,
+            None, // scan_identity: anonymous pulls in test
+            300,  // scan_token_ttl_seconds
         ));
 
         // The fixture's SharedState is `Arc<AppState>` with `scanner_service:

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -145,6 +145,7 @@ fn cfg(storage_path: &str) -> Config {
         smtp_password: None,
         smtp_from_address: "noreply@test.local".to_string(),
         smtp_tls_mode: "starttls".to_string(),
+        scan_token_ttl_seconds: 300,
     }
 }
 

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1806,6 +1806,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let ext = AuthExtension::from(claims);
@@ -1830,6 +1831,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let ext = AuthExtension::from(claims);

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -208,6 +208,14 @@ pub struct Config {
     /// fs/incus scanners use. See #2088.
     pub trivy_adapter_url: Option<String>,
 
+    /// Lifetime, in seconds, of the short-lived per-repository pull token the
+    /// scanner mints for private-image scans (#2093). Env
+    /// `SCAN_TOKEN_TTL_SECONDS`, default 300. Kept intentionally short: the
+    /// token only has to live long enough for the adapter / grype to complete
+    /// the OCI pull, and a shorter window bounds the blast radius if one leaks
+    /// (it is also single-repo-scoped via the `scan_pull_repo` claim).
+    pub scan_token_ttl_seconds: u64,
+
     /// OpenSCAP wrapper URL for compliance scanning (optional)
     pub openscap_url: Option<String>,
 
@@ -585,6 +593,7 @@ redacted_debug!(Config {
     show ldap_base_dn,
     show trivy_url,
     show trivy_adapter_url,
+    show scan_token_ttl_seconds,
     show openscap_url,
     show openscap_profile,
     show opensearch_url,
@@ -678,6 +687,7 @@ impl Default for Config {
             ldap_base_dn: None,
             trivy_url: None,
             trivy_adapter_url: None,
+            scan_token_ttl_seconds: 300,
             openscap_url: None,
             openscap_profile: "xccdf_org.ssgproject.content_profile_standard".into(),
             opensearch_url: None,
@@ -797,6 +807,7 @@ impl Config {
             // is off, and registering the image scanner with an empty URL would
             // make every image scan fail closed instead of not running at all.
             trivy_adapter_url: env::var("TRIVY_ADAPTER_URL").ok().filter(|s| !s.is_empty()),
+            scan_token_ttl_seconds: env_parse("SCAN_TOKEN_TTL_SECONDS", 300),
             openscap_url: env::var("OPENSCAP_URL").ok(),
             openscap_profile: env::var("OPENSCAP_PROFILE")
                 .unwrap_or_else(|_| "xccdf_org.ssgproject.content_profile_standard".into()),

--- a/backend/src/grpc/auth_interceptor.rs
+++ b/backend/src/grpc/auth_interceptor.rs
@@ -151,6 +151,7 @@ mod tests {
             token_type: token_type.to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         encode(
             &Header::default(),
@@ -277,6 +278,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         let token = encode(
             &Header::default(),
@@ -316,6 +318,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         encode(
             &Header::default(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -547,6 +547,32 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     let advisory_client = Arc::new(AdvisoryClient::new(std::env::var("GITHUB_TOKEN").ok()));
     let scan_result_service = Arc::new(ScanResultService::new(db_pool.clone()));
     let scan_config_service = Arc::new(ScanConfigService::new(db_pool.clone()));
+
+    // #2093: token minter + scanner identity for private-repo image pulls.
+    // Load the dedicated `_ak_scanner` service account (migration 138). When it
+    // is present, the image/grype scanners mint short-lived, single-repo-scoped
+    // pull tokens so they can pull private images; when absent (not yet
+    // migrated), pulls fall back to anonymous — public repos only.
+    let scanner_auth = Arc::new(AuthService::new(db_pool.clone(), Arc::new(config.clone())));
+    let scanner_identity = match scanner_auth.load_scanner_identity().await {
+        Ok(Some(u)) => {
+            tracing::info!("Scanner service account loaded; private-repo image scanning enabled");
+            Some(u)
+        }
+        Ok(None) => {
+            tracing::warn!(
+                "Scanner service account (_ak_scanner) not found; image scans will pull \
+                 anonymously (public repositories only). Run migrations to enable private-repo \
+                 scanning."
+            );
+            None
+        }
+        Err(e) => {
+            tracing::error!("Failed to load scanner service account: {}", e);
+            None
+        }
+    };
+
     let mut scanner_service = ScannerService::new(
         db_pool.clone(),
         advisory_client,
@@ -560,6 +586,9 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         config.scan_workspace_path.clone(),
         config.openscap_url.clone(),
         config.openscap_profile.clone(),
+        scanner_auth,
+        scanner_identity,
+        config.scan_token_ttl_seconds,
     );
 
     // Initialize Dependency-Track integration (before wrapping scanner in Arc,

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -103,6 +103,15 @@ pub struct Claims {
     /// family. Set on refresh tokens only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub family_id: Option<Uuid>,
+    /// Repository routing key this token is authorized to *pull* from, and
+    /// ONLY that repository (#2093). Present only on scanner-minted tokens
+    /// (see [`AuthService::generate_scan_token`]); enforced by
+    /// `oci_v2::enforce_scan_pull_scope` on the OCI blob/manifest read
+    /// handlers. `None` on every normal (login / refresh / API-token-exchange)
+    /// token, where it is a no-op — normal tokens are unaffected. `Option`
+    /// with a serde default so pre-existing tokens deserialize unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_pull_repo: Option<String>,
 }
 
 impl Claims {
@@ -1036,6 +1045,7 @@ impl AuthService {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let refresh_jti = Uuid::new_v4();
@@ -1050,6 +1060,7 @@ impl AuthService {
             token_type: "refresh".to_string(),
             jti: Some(refresh_jti),
             family_id: Some(family_id),
+            scan_pull_repo: None,
         };
 
         let access_token = encode(&Header::default(), &access_claims, &self.encoding_key)
@@ -1063,6 +1074,50 @@ impl AuthService {
             refresh_token,
             expires_in: (self.config.jwt_access_token_expiry_minutes * 60) as u64,
         })
+    }
+
+    /// Mint a short-lived, single-repository *pull* token for the scanner
+    /// service account (#2093).
+    ///
+    /// Unlike [`generate_tokens`], this returns a bare access-token string
+    /// carrying a `scan_pull_repo` claim that pins the token to exactly one
+    /// repository routing key. `oci_v2::enforce_scan_pull_scope` rejects any
+    /// blob/manifest read whose repository key does not match, so a leaked
+    /// scan token cannot be used to pull *other* private repositories — it is
+    /// narrower than a normal JWT, never wider.
+    ///
+    /// * `ttl_seconds` is a hard, short expiry (config `scan_token_ttl_seconds`,
+    ///   default 300s) — far below the 30-minute interactive access-token TTL.
+    /// * `is_admin` mirrors the passed identity (the scanner account is a
+    ///   non-admin service account) — an admin claim would bypass the per-repo
+    ///   gate, so this MUST never be forced to `true`.
+    /// * No refresh token is issued and the result is NEVER logged.
+    pub fn generate_scan_token(
+        &self,
+        user: &User,
+        repo_key: &str,
+        ttl_seconds: i64,
+    ) -> Result<String> {
+        let now = Utc::now();
+        let now_ms = now.timestamp_millis();
+        let exp = now + Duration::seconds(ttl_seconds);
+
+        let claims = Claims {
+            sub: user.id,
+            username: user.username.clone(),
+            email: user.email.clone(),
+            is_admin: user.is_admin,
+            iat: now.timestamp(),
+            iat_ms: Some(now_ms),
+            exp: exp.timestamp(),
+            token_type: "access".to_string(),
+            jti: None,
+            family_id: None,
+            scan_pull_repo: Some(repo_key.to_string()),
+        };
+
+        encode(&Header::default(), &claims, &self.encoding_key)
+            .map_err(|e| AppError::Internal(format!("Token encoding failed: {}", e)))
     }
 
     /// Persist a refresh-token `jti` so future presentations can detect
@@ -1349,6 +1404,36 @@ impl AuthService {
         .await
         .map_err(|e| AppError::Database(e.to_string()))?
         .ok_or_else(|| AppError::Authentication("User not found".to_string()))
+    }
+
+    /// Load the dedicated, non-login scanner service account (`_ak_scanner`,
+    /// migration 138) used to mint per-repository scan pull tokens (#2093).
+    ///
+    /// Returns `Ok(None)` when the account has not been seeded yet (e.g. before
+    /// migrations run), in which case image scans fall back to anonymous pulls
+    /// (public repositories only) rather than failing. The lookup is pinned to
+    /// `is_service_account = true` so it can never resolve a same-named human
+    /// account.
+    pub async fn load_scanner_identity(&self) -> Result<Option<User>> {
+        sqlx::query_as!(
+            User,
+            r#"
+            SELECT
+                id, username, email, password_hash, display_name,
+                auth_provider as "auth_provider: AuthProvider",
+                external_id, is_admin, is_active, is_service_account, must_change_password,
+                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,
+                failed_login_attempts, locked_until, last_failed_login_at,
+                password_changed_at, last_login_at, created_at, updated_at
+            FROM users
+            WHERE username = '_ak_scanner'
+              AND is_service_account = true
+              AND is_active = true
+            "#
+        )
+        .fetch_optional(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))
     }
 
     /// Revoke every refresh token in every active family for `user_id`. Called
@@ -2386,6 +2471,7 @@ impl AuthService {
             token_type: "totp_pending".to_string(),
             jti: Some(Uuid::new_v4()),
             family_id: None,
+            scan_pull_repo: None,
         };
         encode(&Header::default(), &claims, &self.encoding_key)
             .map_err(|e| AppError::Internal(format!("Token encoding failed: {}", e)))
@@ -2834,6 +2920,7 @@ mod tests {
             smtp_password: None,
             smtp_from_address: "noreply@artifact-keeper.local".to_string(),
             smtp_tls_mode: "starttls".to_string(),
+            scan_token_ttl_seconds: 300,
         })
     }
 
@@ -2868,6 +2955,82 @@ mod tests {
     // need JWT encoding/decoding, we directly use jsonwebtoken's encode/decode
     // with the same keys the AuthService would use.
 
+    /// Build an `AuthService` whose pool never actually connects (`connect_lazy`)
+    /// so pure token-minting/validation methods can be unit-tested with no DB.
+    fn make_lazy_auth_service() -> AuthService {
+        let pool = sqlx::PgPool::connect_lazy("postgres://unused:unused@127.0.0.1:1/unused")
+            .expect("connect_lazy never errors on construction");
+        AuthService::new(pool, make_test_config())
+    }
+
+    #[tokio::test]
+    async fn test_generate_scan_token_is_scoped_short_lived_and_validates() {
+        let auth = make_lazy_auth_service();
+        let user = make_test_user(); // is_admin = false
+        let ttl = 300;
+
+        let token = auth
+            .generate_scan_token(&user, "docker-private-a", ttl)
+            .expect("scan token must mint");
+
+        // Round-trips through the normal access-token validator (#2093 scanner
+        // pull path presents this exact token to the OCI handlers).
+        let claims = auth
+            .validate_access_token(&token)
+            .expect("scan token must validate as an access token");
+
+        assert_eq!(claims.token_type, "access");
+        assert_eq!(claims.scan_pull_repo.as_deref(), Some("docker-private-a"));
+        // Must NOT be admin — an admin claim would bypass the per-repo gate.
+        assert!(!claims.is_admin, "scan token must not carry admin");
+        assert_eq!(claims.sub, user.id);
+
+        // Expiry is bounded by the short scan TTL, far under the 30-minute
+        // interactive access-token expiry.
+        let lifetime = claims.exp - claims.iat;
+        assert!(
+            lifetime <= ttl && lifetime >= ttl - 5,
+            "scan token lifetime {}s must be ~{}s (well under 30min)",
+            lifetime,
+            ttl
+        );
+        assert!(
+            lifetime < 30 * 60,
+            "scan token must be much shorter than the interactive TTL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_scan_token_preserves_identity_admin_flag() {
+        // A scan token minted for an admin identity keeps is_admin=true (the
+        // helper never forces false); the scanner account is seeded non-admin,
+        // so in production the gate is real. This guards the identity mapping.
+        let auth = make_lazy_auth_service();
+        let mut user = make_test_user();
+        user.is_admin = true;
+        let token = auth.generate_scan_token(&user, "repo-x", 300).unwrap();
+        let claims = auth.validate_access_token(&token).unwrap();
+        assert!(claims.is_admin);
+        assert_eq!(claims.scan_pull_repo.as_deref(), Some("repo-x"));
+    }
+
+    #[tokio::test]
+    async fn test_legacy_access_token_without_scan_claim_still_validates() {
+        // Backward-compat: a token minted before this change (no
+        // scan_pull_repo field on the wire) must deserialize via the serde
+        // default to None and remain a valid, unscoped access token.
+        let auth = make_lazy_auth_service();
+        let user = make_test_user();
+        let tokens = auth.generate_tokens(&user).expect("tokens");
+        let claims = auth
+            .validate_access_token(&tokens.access_token)
+            .expect("normal access token must validate");
+        assert!(
+            claims.scan_pull_repo.is_none(),
+            "normal tokens carry no scan scope (no-op for enforcement)"
+        );
+    }
+
     #[test]
     fn test_generate_tokens_and_validate_access_token() {
         let config = make_test_config();
@@ -2891,6 +3054,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let refresh_claims = Claims {
@@ -2904,6 +3068,7 @@ mod tests {
             token_type: "refresh".to_string(),
             jti: Some(Uuid::new_v4()),
             family_id: Some(Uuid::new_v4()),
+            scan_pull_repo: None,
         };
 
         let access_token = encode(&Header::default(), &access_claims, &encoding_key).unwrap();
@@ -2951,6 +3116,7 @@ mod tests {
             token_type: "refresh".to_string(),
             jti: Some(Uuid::new_v4()),
             family_id: Some(Uuid::new_v4()),
+            scan_pull_repo: None,
         };
 
         let token = encode(&Header::default(), &refresh_claims, &encoding_key).unwrap();
@@ -2981,6 +3147,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let token = encode(&Header::default(), &claims, &encoding_key).unwrap();
@@ -3005,6 +3172,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let token = encode(&Header::default(), &claims, &encoding_key).unwrap();
@@ -3030,6 +3198,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
 
         let json = serde_json::to_string(&claims).unwrap();
@@ -3057,6 +3226,7 @@ mod tests {
             token_type: "refresh".to_string(),
             jti: Some(jti),
             family_id: Some(family),
+            scan_pull_repo: None,
         };
         let json = serde_json::to_string(&claims).unwrap();
         assert!(json.contains("jti"));
@@ -3884,6 +4054,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         encode(
             &Header::default(),
@@ -4182,6 +4353,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         // The fallback is exactly `iat * 1000`.
         assert_eq!(legacy.effective_iat_ms(), iat_sec.saturating_mul(1000));
@@ -4550,6 +4722,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         let payload_json = serde_json::to_vec(&claims).unwrap();
         let payload_b64 = {
@@ -5203,6 +5376,7 @@ mod tests {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         encode(
             &Header::default(),

--- a/backend/src/services/grype_scanner.rs
+++ b/backend/src/services/grype_scanner.rs
@@ -22,12 +22,15 @@ use bytes::Bytes;
 use futures::StreamExt;
 use serde::{Deserialize, Deserializer};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use tracing::info;
 
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::models::security::{RawFinding, RawPackage, Severity};
+use crate::models::user::User;
+use crate::services::auth_service::AuthService;
 use crate::services::scanner_service::{
     cached_cli_version, capture_cli_version, fail_scan, format_grype_version,
     is_oci_image_artifact, join_oci_image_ref, parse_oci_manifest_path, resolve_scan_reference,
@@ -285,6 +288,16 @@ pub struct GrypeScanner {
     /// does not pay an extra subprocess; failed probes expire after 60s so
     /// the field starts populating once the binary becomes available.
     cached_version: VersionCache,
+    /// Optional token minter for private-repo registry pulls (#2093). When
+    /// wired, a registry-mode scan of a known repository injects a short-lived,
+    /// single-repo-scoped JWT into grype's child process via
+    /// `GRYPE_REGISTRY_AUTH_*` so grype can pull internal/private images that
+    /// anonymous pulls 401 on. Absent in the default (anonymous) wiring.
+    auth: Option<Arc<AuthService>>,
+    scan_identity: Option<User>,
+    /// TTL (seconds) for the per-repo scan token (config
+    /// `scan_token_ttl_seconds`). Only consulted when a minter is wired.
+    scan_token_ttl_seconds: i64,
 }
 
 struct LocalOciBlob {
@@ -427,7 +440,71 @@ impl GrypeScanner {
         Self {
             scan_workspace,
             cached_version: VersionCache::new(),
+            auth: None,
+            scan_identity: None,
+            scan_token_ttl_seconds: 300,
         }
+    }
+
+    /// Attach a token minter so registry-mode scans of a known repository pull
+    /// with a short-lived, single-repo-scoped JWT (#2093). The identity is the
+    /// scanner service account; the token is minted per scan via
+    /// `AuthService::generate_scan_token` and injected into grype's child
+    /// process env — NEVER written to a file or logged.
+    #[must_use]
+    pub fn with_token_minter(
+        mut self,
+        auth: Arc<AuthService>,
+        identity: User,
+        ttl_seconds: i64,
+    ) -> Self {
+        self.auth = Some(auth);
+        self.scan_identity = Some(identity);
+        self.scan_token_ttl_seconds = ttl_seconds;
+        self
+    }
+
+    /// Assemble the `GRYPE_REGISTRY_AUTH_*` child-process env pairs for a
+    /// registry pull. Pure fn (no minting / no I/O) so it is directly
+    /// unit-testable: given the resolved registry `authority` (host) and an
+    /// optional bearer `token`, it returns the env vars grype's registry
+    /// client consumes. Returns an empty vec when there is no token (anonymous
+    /// pull — the legacy behavior). `GRYPE_REGISTRY_INSECURE_USE_HTTP` is set
+    /// because the in-cluster / dev registry endpoint is plain HTTP.
+    fn grype_registry_auth_env(
+        authority: &str,
+        token: Option<&str>,
+    ) -> Vec<(&'static str, String)> {
+        match token {
+            Some(t) => vec![
+                ("GRYPE_REGISTRY_AUTH_AUTHORITY", authority.to_string()),
+                ("GRYPE_REGISTRY_AUTH_TOKEN", t.to_string()),
+                ("GRYPE_REGISTRY_INSECURE_USE_HTTP", "true".to_string()),
+            ],
+            None => Vec::new(),
+        }
+    }
+
+    /// Mint the registry-auth env for a scoped registry pull of `repo_key`, or
+    /// an empty vec for an anonymous pull (no minter wired, or no repo key).
+    /// The minted token is single-repo-scoped and short-lived; NEVER logged.
+    fn registry_auth_env_for_repo(&self, repo_key: Option<&str>) -> Vec<(&'static str, String)> {
+        let token = match (repo_key, &self.auth, &self.scan_identity) {
+            (Some(key), Some(auth), Some(user)) => {
+                match auth.generate_scan_token(user, key, self.scan_token_ttl_seconds) {
+                    Ok(t) => Some(t),
+                    Err(e) => {
+                        // Degrade to an anonymous pull; the scan still
+                        // fails-closed downstream if the (now anonymous) pull
+                        // is rejected. Never include token material in the log.
+                        info!("Grype registry token minting failed: {}", e);
+                        None
+                    }
+                }
+            }
+            _ => None,
+        };
+        Self::grype_registry_auth_env(&resolve_registry_host(), token.as_deref())
     }
 
     /// Build the `<host>/<name><sep><reference>` image ref that Grype's
@@ -519,11 +596,16 @@ impl GrypeScanner {
         &self,
         artifact: &Artifact,
         image_ref: String,
+        repo_key: Option<&str>,
     ) -> Result<ScanOutput> {
         let target = format!("registry:{}", image_ref);
         info!("Grype OCI registry scan target: {}", target);
 
-        let report = match self.run_grype_target(&target).await {
+        // Mint a per-repository scoped pull token when a minter is wired and we
+        // know the owning repo (production `scan_target` path). Legacy keyless
+        // scans pull anonymously (empty env), preserving prior behavior.
+        let auth_env = self.registry_auth_env_for_repo(repo_key);
+        let report = match self.run_grype_target(&target, &auth_env).await {
             Ok(report) => report,
             Err(e) => {
                 return Err(
@@ -568,7 +650,8 @@ impl GrypeScanner {
 
         let grype_target = format!("oci-dir:{}", layout_dir.to_string_lossy());
         info!("Grype OCI local layout scan target: {}", grype_target);
-        let result = match self.run_grype_target(&grype_target).await {
+        // Local OCI layout: no registry pull, so no registry-auth env.
+        let result = match self.run_grype_target(&grype_target, &[]).await {
             Ok(report) => {
                 let findings = Self::convert_findings(&report);
                 let packages = Self::convert_packages(&report);
@@ -806,7 +889,9 @@ impl GrypeScanner {
     /// Run grype against the workspace directory.
     async fn run_grype(&self, workspace: &Path) -> Result<GrypeReport> {
         let dir_arg = format!("dir:{}", workspace.to_string_lossy());
-        self.run_grype_target(&dir_arg).await
+        // Directory (local layout) scans never touch the registry, so no
+        // registry-auth env is needed.
+        self.run_grype_target(&dir_arg, &[]).await
     }
 
     /// Run grype against an arbitrary target string (e.g. `dir:/path`,
@@ -834,7 +919,11 @@ impl GrypeScanner {
     ///    keeps working under deployment configs that wipe inherited env
     ///    (Helm charts, k8s `env:` blocks that replace rather than append).
     ///    See artifact-keeper#1001 and PR #1002 (commit 23d9743).
-    async fn run_grype_target(&self, target: &str) -> Result<GrypeReport> {
+    async fn run_grype_target(
+        &self,
+        target: &str,
+        auth_env: &[(&'static str, String)],
+    ) -> Result<GrypeReport> {
         // Issue #1465: detect "grype binary missing from PATH" via the
         // io::ErrorKind of the spawn failure, NOT a substring search on
         // stderr. The previous implementation classified any non-zero exit
@@ -847,11 +936,19 @@ impl GrypeScanner {
         // ref, sending operators down a wild-goose chase patching their
         // Docker image. The kernel already gives us a precise NotFound
         // signal when execve() cannot resolve "grype"; use that.
-        let output = tokio::process::Command::new("grype")
+        let mut command = tokio::process::Command::new("grype");
+        command
             .args([target, "-o", "json"])
             .env("GRYPE_DB_AUTO_UPDATE", "false")
             .env("GRYPE_DB_VALIDATE_AGE", "false")
-            .env("GRYPE_CHECK_FOR_APP_UPDATE", "false")
+            .env("GRYPE_CHECK_FOR_APP_UPDATE", "false");
+        // Registry-auth env for a scoped private-repo pull (#2093). Applied as
+        // child-process env only — never persisted or logged. Empty for local
+        // (dir-mode) and anonymous registry scans.
+        for (key, value) in auth_env {
+            command.env(key, value);
+        }
+        let output = command
             .output()
             .await
             .map_err(|e| classify_grype_spawn_error(&e))?;
@@ -1199,7 +1296,8 @@ impl Scanner for GrypeScanner {
                             .to_string(),
                     )
                 })?;
-            return self.scan_oci_registry_ref(artifact, image_ref).await;
+            // Legacy keyless path: no owning repository key, anonymous pull.
+            return self.scan_oci_registry_ref(artifact, image_ref, None).await;
         }
 
         let workspace =
@@ -1265,7 +1363,10 @@ impl Scanner for GrypeScanner {
                             .to_string(),
                     )
                 })?;
-            return self.scan_oci_registry_ref(artifact, image_ref).await;
+            // Repository-aware path: mint a pull token scoped to this repo.
+            return self
+                .scan_oci_registry_ref(artifact, image_ref, Some(target.repository_key))
+                .await;
         }
 
         self.scan(artifact, metadata, content).await
@@ -1279,6 +1380,69 @@ mod tests {
 
     fn make_artifact(name: &str, content_type: &str) -> Artifact {
         make_test_artifact(name, content_type, &format!("test/{}", name))
+    }
+
+    // ---- #2093: registry-auth env builder --------------------------------
+
+    use crate::services::scanner_service::test_helpers::{make_scanner_auth, make_scanner_user};
+
+    #[test]
+    fn test_grype_registry_auth_env_empty_without_token() {
+        // Anonymous pull: no token -> no GRYPE_REGISTRY_AUTH_* env, so grype
+        // keeps its prior public-only behavior.
+        let env = GrypeScanner::grype_registry_auth_env("host:8080", None);
+        assert!(env.is_empty());
+    }
+
+    #[test]
+    fn test_grype_registry_auth_env_sets_authority_and_token() {
+        let env = GrypeScanner::grype_registry_auth_env("host:8080", Some("jwt-abc"));
+        let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+        assert_eq!(
+            map.get("GRYPE_REGISTRY_AUTH_AUTHORITY").map(String::as_str),
+            Some("host:8080")
+        );
+        assert_eq!(
+            map.get("GRYPE_REGISTRY_AUTH_TOKEN").map(String::as_str),
+            Some("jwt-abc")
+        );
+        // Plain-HTTP dev/in-cluster registry endpoint.
+        assert_eq!(
+            map.get("GRYPE_REGISTRY_INSECURE_USE_HTTP")
+                .map(String::as_str),
+            Some("true")
+        );
+    }
+
+    #[test]
+    fn test_registry_auth_env_for_repo_empty_without_minter() {
+        let scanner = GrypeScanner::new("/tmp/grype-2093-noauth".to_string());
+        assert!(scanner
+            .registry_auth_env_for_repo(Some("docker-private-a"))
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_registry_auth_env_for_repo_mints_scoped_token() {
+        let auth = make_scanner_auth();
+        let scanner = GrypeScanner::new("/tmp/grype-2093-auth".to_string()).with_token_minter(
+            auth.clone(),
+            make_scanner_user(),
+            300,
+        );
+
+        // No repo key -> anonymous even with a minter wired.
+        assert!(scanner.registry_auth_env_for_repo(None).is_empty());
+
+        let env = scanner.registry_auth_env_for_repo(Some("docker-private-a"));
+        let map: std::collections::HashMap<_, _> = env.into_iter().collect();
+        let token = map
+            .get("GRYPE_REGISTRY_AUTH_TOKEN")
+            .expect("scoped pull must inject a token");
+        let claims = auth
+            .validate_access_token(token)
+            .expect("minted token must validate");
+        assert_eq!(claims.scan_pull_repo.as_deref(), Some("docker-private-a"));
     }
 
     /// Canonical config/layer digests reused by the local-OCI-layout tests.

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -285,6 +285,10 @@ pub struct ImageScanner {
     /// it is an ops follow-up (see PR notes).
     auth: Option<Arc<AuthService>>,
     scan_identity: Option<User>,
+    /// TTL (seconds) for the per-repo scan token minted for each scan request
+    /// (config `scan_token_ttl_seconds`). Only consulted when a minter is
+    /// wired.
+    scan_token_ttl_seconds: i64,
     /// Scanner version reported by the adapter on the most recent successful
     /// scan (e.g. `trivy-0.71.2`). The in-image `trivy --version` probe is
     /// gone (#2059), so this is the only available provenance.
@@ -306,6 +310,7 @@ impl ImageScanner {
                 .unwrap_or_default(),
             auth: None,
             scan_identity: None,
+            scan_token_ttl_seconds: 300,
             last_scanner_version: Mutex::new(None),
         }
     }
@@ -313,11 +318,18 @@ impl ImageScanner {
     /// Attach a token minter so private-repo image pulls carry a short-lived
     /// scoped JWT in `registry.authorization`. The identity is a scanner /
     /// system account; the token is minted per scan via
-    /// `AuthService::generate_tokens` and is NEVER logged.
+    /// `AuthService::generate_scan_token` — pinned to the repository being
+    /// scanned and short-lived (`ttl_seconds`) — and is NEVER logged.
     #[must_use]
-    pub fn with_token_minter(mut self, auth: Arc<AuthService>, identity: User) -> Self {
+    pub fn with_token_minter(
+        mut self,
+        auth: Arc<AuthService>,
+        identity: User,
+        ttl_seconds: i64,
+    ) -> Self {
         self.auth = Some(auth);
         self.scan_identity = Some(identity);
+        self.scan_token_ttl_seconds = ttl_seconds;
         self
     }
 
@@ -339,22 +351,26 @@ impl ImageScanner {
     }
 
     /// Mint the `registry.authorization` value for a scan request, or `None`
-    /// for an anonymous pull. The token is short-lived (the configured access
-    /// token expiry) and scoped to the scan identity. NEVER log the result.
-    fn registry_authorization(&self) -> Option<String> {
+    /// for an anonymous pull. The token is short-lived (`scan_token_ttl_seconds`)
+    /// and scoped to exactly the repository being scanned (`repo_key`, matched
+    /// against the OCI pull handler's `scan_pull_repo` gate), so a leaked scan
+    /// token cannot pull any other repository. NEVER log the result.
+    fn registry_authorization(&self, repo_key: &str) -> Option<String> {
         match (&self.auth, &self.scan_identity) {
-            (Some(auth), Some(user)) => match auth.generate_tokens(user) {
-                Ok(tokens) => Some(format!("Bearer {}", tokens.access_token)),
-                Err(e) => {
-                    // Token minting failure degrades to an anonymous pull
-                    // rather than failing the scan outright: the scan still
-                    // fails-closed downstream if the (now anonymous) pull is
-                    // rejected by the adapter. Do not include the error's
-                    // token material.
-                    warn!("Image scan registry token minting failed: {}", e);
-                    None
+            (Some(auth), Some(user)) => {
+                match auth.generate_scan_token(user, repo_key, self.scan_token_ttl_seconds) {
+                    Ok(token) => Some(format!("Bearer {}", token)),
+                    Err(e) => {
+                        // Token minting failure degrades to an anonymous pull
+                        // rather than failing the scan outright: the scan still
+                        // fails-closed downstream if the (now anonymous) pull is
+                        // rejected by the adapter. Do not include the error's
+                        // token material.
+                        warn!("Image scan registry token minting failed: {}", e);
+                        None
+                    }
                 }
-            },
+            }
             _ => None,
         }
     }
@@ -578,13 +594,17 @@ impl ImageScanner {
         &self,
         artifact: &AdapterScanArtifact,
         mime_type: &str,
+        repo_key: Option<&str>,
     ) -> Result<ScanOutput> {
         // Readiness gate first so a down adapter fails the scan with a clear
         // BadGateway rather than mid-stream.
         self.check_adapter_health().await?;
 
         let registry_url = Self::registry_url();
-        let authorization = self.registry_authorization();
+        // Mint a per-repository scoped pull token only when we know which repo
+        // is being scanned (the repository-aware `scan_target` path). The
+        // legacy keyless `scan` path pulls anonymously as before.
+        let authorization = repo_key.and_then(|k| self.registry_authorization(k));
         let body =
             Self::build_scan_request(&registry_url, authorization.as_deref(), artifact, mime_type);
 
@@ -688,7 +708,8 @@ impl Scanner for ImageScanner {
             }
         };
         let mime = Self::manifest_mime_type(&artifact.content_type);
-        self.run_image_scan(&target, &mime).await
+        // Legacy keyless path: no owning repository key, so pull anonymously.
+        self.run_image_scan(&target, &mime, None).await
     }
 
     /// Repository-aware scan hook used by the orchestrator. Prepends the owning
@@ -717,7 +738,9 @@ impl Scanner for ImageScanner {
             ))
         })?;
         let mime = Self::manifest_mime_type(&target.artifact.content_type);
-        self.run_image_scan(&scan_target, &mime).await
+        // Repository-aware path: mint a pull token scoped to this repository.
+        self.run_image_scan(&scan_target, &mime, Some(target.repository_key))
+            .await
     }
 }
 
@@ -749,6 +772,41 @@ mod tests {
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         }
+    }
+
+    use crate::services::scanner_service::test_helpers::{make_scanner_auth, make_scanner_user};
+
+    #[test]
+    fn test_registry_authorization_none_without_minter() {
+        // Default (anonymous) wiring: no token minter -> no Authorization,
+        // preserving the public-only pull behavior.
+        let scanner = ImageScanner::new("http://trivy:8090".to_string());
+        assert!(scanner.registry_authorization("docker-private-a").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_registry_authorization_mints_repo_scoped_bearer() {
+        let auth = make_scanner_auth();
+        let scanner = ImageScanner::new("http://trivy:8090".to_string()).with_token_minter(
+            auth.clone(),
+            make_scanner_user(),
+            300,
+        );
+
+        let header = scanner
+            .registry_authorization("docker-private-a")
+            .expect("minter wired -> Authorization present");
+        let token = header
+            .strip_prefix("Bearer ")
+            .expect("registry.authorization must be a Bearer credential");
+
+        // The minted token must be pinned to exactly the scanned repository so
+        // the OCI pull gate (enforce_scan_pull_scope) admits this repo only.
+        let claims = auth
+            .validate_access_token(token)
+            .expect("minted scan token must validate");
+        assert_eq!(claims.scan_pull_repo.as_deref(), Some("docker-private-a"));
+        assert!(!claims.is_admin);
     }
 
     #[test]

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -824,6 +824,7 @@ mod tests {
             smtp_password: None,
             smtp_from_address: "noreply@artifact-keeper.local".to_string(),
             smtp_tls_mode: "starttls".to_string(),
+            scan_token_ttl_seconds: 300,
         }
     }
 

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -831,6 +831,7 @@ mod tests {
             smtp_password: None,
             smtp_from_address: "noreply@artifact-keeper.local".to_string(),
             smtp_tls_mode: "starttls".to_string(),
+            scan_token_ttl_seconds: 300,
         };
 
         let oidc_config = OidcConfig::from_config(&config);
@@ -934,6 +935,7 @@ mod tests {
             smtp_password: None,
             smtp_from_address: "noreply@artifact-keeper.local".to_string(),
             smtp_tls_mode: "starttls".to_string(),
+            scan_token_ttl_seconds: 300,
         }
     }
 

--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -29,6 +29,8 @@ use uuid::Uuid;
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::models::security::{RawFinding, RawPackage, Severity};
+use crate::models::user::User;
+use crate::services::auth_service::AuthService;
 use crate::services::grype_scanner::GrypeScanner;
 use crate::services::image_scanner::ImageScanner;
 use crate::services::scan_config_service::ScanConfigService;
@@ -2636,7 +2638,16 @@ impl ScannerService {
         scan_workspace_path: String,
         openscap_url: Option<String>,
         openscap_profile: String,
+        // #2093: token minter for private-repo image pulls. `auth` mints the
+        // per-repo scoped scan tokens; `scan_identity` is the loaded
+        // `_ak_scanner` service account (None when it is not seeded yet, in
+        // which case image pulls fall back to anonymous — public repos only);
+        // `scan_token_ttl_seconds` bounds each token's lifetime.
+        auth: Arc<AuthService>,
+        scan_identity: Option<User>,
+        scan_token_ttl_seconds: u64,
     ) -> Self {
+        let scan_token_ttl_seconds = scan_token_ttl_seconds as i64;
         let dep_scanner: Arc<dyn Scanner> = Arc::new(DependencyScanner::new(advisory_client));
         let mut scanners: Vec<Arc<dyn Scanner>> = vec![dep_scanner];
 
@@ -2649,7 +2660,15 @@ impl ScannerService {
                 "Container image scanner (Harbor adapter) enabled at {}",
                 adapter_url
             );
-            scanners.push(Arc::new(ImageScanner::new(adapter_url)));
+            let mut image_scanner = ImageScanner::new(adapter_url);
+            // Wire the per-repo token minter so the adapter can pull private
+            // images (#2093). Only when the scanner identity is loaded;
+            // otherwise pulls stay anonymous (public repos only).
+            if let Some(identity) = scan_identity.clone() {
+                image_scanner =
+                    image_scanner.with_token_minter(auth.clone(), identity, scan_token_ttl_seconds);
+            }
+            scanners.push(Arc::new(image_scanner));
         }
 
         // Trivy filesystem + incus (rootfs) scanners drive the trivy server
@@ -2671,7 +2690,14 @@ impl ScannerService {
 
         // Grype scanner (CLI-based, degrades gracefully if binary not available)
         info!("Grype scanner enabled");
-        scanners.push(Arc::new(GrypeScanner::new(scan_workspace_path.clone())));
+        let mut grype_scanner = GrypeScanner::new(scan_workspace_path.clone());
+        // Wire the per-repo token minter so grype's registry pull is
+        // authenticated for private images (#2093).
+        if let Some(identity) = scan_identity.clone() {
+            grype_scanner =
+                grype_scanner.with_token_minter(auth.clone(), identity, scan_token_ttl_seconds);
+        }
+        scanners.push(Arc::new(grype_scanner));
 
         // OpenSCAP compliance scanner (optional sidecar)
         if let Some(url) = openscap_url {
@@ -4183,6 +4209,48 @@ pub(crate) mod test_helpers {
             expected_label,
             err_msg
         );
+    }
+
+    /// A non-login scanner service-account `User` fixture (#2093). Shared by the
+    /// image- and grype-scanner token-minter tests so the fixture is defined
+    /// once.
+    pub fn make_scanner_user() -> crate::models::user::User {
+        crate::models::user::User {
+            id: uuid::Uuid::new_v4(),
+            username: "_ak_scanner".to_string(),
+            email: "scanner@artifact-keeper.internal".to_string(),
+            password_hash: None,
+            auth_provider: crate::models::user::AuthProvider::Local,
+            external_id: None,
+            display_name: Some("Image Scanner (system)".to_string()),
+            is_active: true,
+            is_admin: false,
+            is_service_account: true,
+            must_change_password: false,
+            totp_secret: None,
+            totp_enabled: false,
+            totp_backup_codes: None,
+            totp_verified_at: None,
+            failed_login_attempts: 0,
+            locked_until: None,
+            last_failed_login_at: None,
+            password_changed_at: chrono::Utc::now(),
+            last_login_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    /// An `AuthService` whose pool never connects (`connect_lazy`), for
+    /// unit-testing pure token-minting/validation with no DB. MUST be called
+    /// from within a tokio runtime (`#[tokio::test]`).
+    pub fn make_scanner_auth() -> std::sync::Arc<crate::services::auth_service::AuthService> {
+        let pool = sqlx::PgPool::connect_lazy("postgres://unused:unused@127.0.0.1:1/unused")
+            .expect("connect_lazy never errors on construction");
+        std::sync::Arc::new(crate::services::auth_service::AuthService::new(
+            pool,
+            std::sync::Arc::new(crate::config::Config::test_config()),
+        ))
     }
 }
 
@@ -11830,6 +11898,10 @@ mod tests {
         let scan_result_service = Arc::new(ScanResultService::new(pool.clone()));
         let scan_config_service =
             Arc::new(crate::services::scan_config_service::ScanConfigService::new(pool.clone()));
+        let auth = Arc::new(AuthService::new(
+            pool.clone(),
+            Arc::new(crate::config::Config::test_config()),
+        ));
         Arc::new(ScannerService::new(
             pool,
             advisory_client,
@@ -11843,6 +11915,9 @@ mod tests {
             "/tmp/scan-1469-tests".to_string(),
             None, // openscap_url
             "standard".to_string(),
+            auth,
+            None, // scan_identity: anonymous pulls in tests
+            300,  // scan_token_ttl_seconds
         ))
     }
 

--- a/backend/tests/composer_packages_index_tests.rs
+++ b/backend/tests/composer_packages_index_tests.rs
@@ -61,6 +61,7 @@ fn test_config(storage_path: &str) -> Config {
         ldap_base_dn: None,
         trivy_url: None,
         trivy_adapter_url: None,
+        scan_token_ttl_seconds: 300,
         openscap_url: None,
         openscap_profile: "standard".into(),
         opensearch_url: None,

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -49,6 +49,7 @@ fn test_config(storage_path: &str) -> Config {
         ldap_base_dn: None,
         trivy_url: None,
         trivy_adapter_url: None,
+        scan_token_ttl_seconds: 300,
         openscap_url: None,
         openscap_profile: "standard".into(),
         opensearch_url: None,

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -387,6 +387,7 @@ mod credential_change_grpc {
             token_type: "access".to_string(),
             jti: None,
             family_id: None,
+            scan_pull_repo: None,
         };
         encode(
             &Header::default(),


### PR DESCRIPTION
Closes #2093 (supersedes #2095, which GitHub auto-closed when its stacked base branch #2090 was merged+deleted).

Minimal scanner service account + short-lived, single-repo-scoped pull tokens (`scan_pull_repo` claim) enforced on the OCI pull handlers and propagated through `/v2/token`; wired into both ImageScanner (Harbor `registry.authorization`) and GrypeScanner (`GRYPE_REGISTRY_AUTH_*` env). Private-repo image scans now authenticate and return findings on both backends; also hardens the OCI read path with a per-repo pull gate that did not exist before.

Validated live on an isolated worker slot: private-repo scan → trivy 185 / grype 166 findings; token scoped to repoA → repoA 200 / repoB 403 DENIED; `/v2/token` re-mint preserves scope; expired/garbage token → 401 → scan `failed` (never completed-with-0); public repo scan still returns findings. Regression-test box: the new tests fail on main, pass here.

Depends on #2090 (merged) which introduced the token-minter surface.