### PR TITLE
fix(error): map stringified sqlx pool timeout to 503, not 500

### DIFF
--- a/backend/src/api/handlers/error_helpers.rs
+++ b/backend/src/api/handlers/error_helpers.rs
@@ -44,6 +44,16 @@ mod tests {
     }
 
     #[test]
+    fn test_map_db_err_pool_timeout_returns_503() {
+        // Proxy/format handlers funnel sqlx errors through map_db_err after
+        // stringifying them. A pool timeout must surface as 503 (capacity
+        // shed) so saturated clients back off, not 500 (#1437). Reproduce the
+        // exact sqlx Display string rather than a synthetic one.
+        let resp = map_db_err(sqlx::Error::PoolTimedOut.to_string());
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
     fn test_map_storage_err_returns_500() {
         let resp = map_storage_err("disk full");
         assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -9,7 +9,7 @@ use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::api::download_response::try_presigned_redirect;
-use crate::api::handlers::error_helpers::map_storage_err;
+use crate::api::handlers::error_helpers::{map_db_err, map_storage_err};
 use crate::api::AppState;
 use crate::error::AppError;
 use crate::formats::pypi::PypiHandler;
@@ -86,13 +86,10 @@ pub async fn resolve_repo_by_key(
     .bind(repo_key)
     .fetch_optional(db)
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Database error: {}", e),
-        )
-            .into_response()
-    })?
+    // Route through map_db_err so a saturated pool surfaces as 503 (capacity
+    // shed) instead of 500, and so the raw DB error text is not leaked to the
+    // client. This is the first DB acquire on every proxy GET (#1437).
+    .map_err(map_db_err)?
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Repository not found").into_response())?;
 
     let fmt: String = repo.try_get("format").unwrap_or_default();
@@ -126,9 +123,18 @@ pub async fn resolve_repo_by_key(
 /// format!("... error: {}", e)).into_response()` block throughout the
 /// local_fetch helpers.
 pub(crate) fn internal_error(label: &str, e: impl std::fmt::Display) -> Response {
+    let text = e.to_string();
+    // A saturated sqlx pool is a transient capacity event, not a server fault.
+    // Every local/virtual-member artifact-lookup helper funnels DB errors
+    // through here, so route pool timeouts via map_db_err to surface 503 +
+    // Retry-After (clients back off) instead of a bare 500 (#1437). Non-DB
+    // labels (e.g. "Storage") never produce this phrase, so they are unaffected.
+    if crate::error::is_pool_timeout(&text) {
+        return map_db_err(text);
+    }
     (
         StatusCode::INTERNAL_SERVER_ERROR,
-        format!("{} error: {}", label, e),
+        format!("{} error: {}", label, text),
     )
         .into_response()
 }
@@ -1441,13 +1447,9 @@ pub async fn fetch_virtual_members(
     )
     .fetch_all(db)
     .await
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to resolve virtual members: {}", e),
-        )
-            .into_response()
-    })
+    // Route through map_db_err so pool saturation surfaces as 503 (capacity
+    // shed) instead of 500, and to avoid leaking raw DB error text (#1437).
+    .map_err(map_db_err)
 }
 
 /// Decide whether `auth` is allowed to read `member` directly, mirroring the
@@ -2100,7 +2102,7 @@ pub async fn virtual_non_remote_owns_name_version(
         .bind(package_name)
         .fetch_optional(db)
         .await
-        .map_err(|e| shadowing_guard_db_err(virtual_repo_id, e))?;
+        .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "cross-format", e))?;
         return Ok(exists.is_some());
     };
 
@@ -2120,7 +2122,7 @@ pub async fn virtual_non_remote_owns_name_version(
     .bind(package_name)
     .fetch_all(db)
     .await
-    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, e))?;
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "cross-format", e))?;
 
     Ok(pypi_version_owned(version, &stored_versions))
 }
@@ -2149,12 +2151,20 @@ fn pypi_version_owned(requested: &str, stored_versions: &[String]) -> bool {
         })
 }
 
-fn shadowing_guard_db_err(virtual_repo_id: Uuid, e: sqlx::Error) -> Response {
+fn shadowing_guard_db_err(virtual_repo_id: Uuid, format: &str, e: sqlx::Error) -> Response {
+    let text = e.to_string();
+    // Pool saturation is transient capacity, not a guard failure: shed to 503 +
+    // Retry-After so clients back off, instead of failing closed to 500 (#1437).
+    // Real query failures still fail closed to a non-leaking 500 below.
+    if crate::error::is_pool_timeout(&text) {
+        return map_db_err(text);
+    }
     tracing::error!(
         event = "shadowing_guard_db_error",
         virtual_repo_id = %virtual_repo_id,
-        error = %e,
-        "cross-format shadowing-guard DB query failed; failing closed to 500",
+        format = format,
+        error = %text,
+        "shadowing-guard DB query failed; failing closed to 500",
     );
     (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response()
 }
@@ -2205,7 +2215,7 @@ pub async fn pypi_virtual_isolates_name(
     .bind(normalized_name)
     .fetch_all(db)
     .await
-    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, e))?;
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "cross-format", e))?;
 
     if owning_ids.is_empty() {
         // Name is not owned by any local member: no confusion risk, proxy normally.
@@ -2223,7 +2233,7 @@ pub async fn pypi_virtual_isolates_name(
     .bind(normalized_name)
     .fetch_one(db)
     .await
-    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, e))?;
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "cross-format", e))?;
 
     Ok(tracked == 0)
 }
@@ -2278,16 +2288,7 @@ pub async fn virtual_non_remote_owns_path(
     .bind(path)
     .fetch_optional(db)
     .await
-    .map_err(|e| {
-        tracing::error!(
-            event = "shadowing_guard_db_error",
-            virtual_repo_id = %virtual_repo_id,
-            format = "generic",
-            error = %e,
-            "generic exact-path shadowing-guard DB query failed; failing closed to 500",
-        );
-        (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response()
-    })?;
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "generic", e))?;
 
     Ok(exists.is_some())
 }
@@ -2363,16 +2364,7 @@ pub async fn virtual_non_remote_owns_maven_ga(
     .bind(&prefix)
     .fetch_optional(db)
     .await
-    .map_err(|e| {
-        tracing::error!(
-            event = "shadowing_guard_db_error",
-            virtual_repo_id = %virtual_repo_id,
-            format = "maven",
-            error = %e,
-            "Maven shadowing-guard DB query failed; failing closed to 500",
-        );
-        (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response()
-    })?;
+    .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "maven", e))?;
 
     Ok(exists.is_some())
 }
@@ -3506,6 +3498,35 @@ mod tests {
     #[test]
     fn test_internal_error_returns_500() {
         let response = internal_error("Storage", "disk full");
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_internal_error_pool_timeout_returns_503() {
+        // Every local/virtual artifact-lookup helper funnels DB errors through
+        // internal_error. A saturated pool must surface as 503 (capacity shed)
+        // so clients back off, not a bare 500 (#1437). Reproduce the exact sqlx
+        // Display string, which does not contain the "PoolTimedOut" variant name.
+        let response = internal_error("Database", sqlx::Error::PoolTimedOut.to_string());
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn test_shadowing_guard_db_err_pool_timeout_returns_503() {
+        // The shadowing guard fails closed to 500 on real DB errors, but a
+        // saturated pool is transient capacity: it must shed to 503 so clients
+        // back off instead of paging ops (#1437).
+        let response =
+            shadowing_guard_db_err(uuid::Uuid::new_v4(), "maven", sqlx::Error::PoolTimedOut);
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn test_shadowing_guard_db_err_other_error_fails_closed_500() {
+        // Non-timeout DB failures must still fail closed to 500 (no 503 shed)
+        // and must not leak the raw error text in the body.
+        let response =
+            shadowing_guard_db_err(uuid::Uuid::new_v4(), "generic", sqlx::Error::RowNotFound);
         assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -31,6 +31,21 @@ pub(crate) fn is_name_too_long(msg: &str) -> bool {
         || lower.contains("enametoolong")
 }
 
+/// Detect SQLx connection-pool saturation across both the typed
+/// `sqlx::Error::PoolTimedOut` and its stringified forms.
+///
+/// The hot proxy path wraps DB errors as `AppError::Database(e.to_string())`,
+/// which erases the typed variant. `e.to_string()` for `PoolTimedOut` renders
+/// "pool timed out while waiting for an open connection" (sqlx 0.8), which does
+/// NOT contain the literal "PoolTimedOut". Matching only the variant name
+/// therefore missed every stringified pool timeout on the proxy hot path and
+/// surfaced 500 instead of 503 (#1437 follow-up). We match both fragments so
+/// the mapping holds whether the error arrived typed or stringified.
+pub(crate) fn is_pool_timeout(msg: &str) -> bool {
+    let lower = msg.to_ascii_lowercase();
+    lower.contains("pool timed out") || lower.contains("pooltimedout")
+}
+
 /// Application error types.
 #[derive(Error, Debug)]
 pub enum AppError {
@@ -116,7 +131,7 @@ impl AppError {
             Self::Sqlx(sqlx::Error::PoolTimedOut) => {
                 (StatusCode::SERVICE_UNAVAILABLE, "POOL_EXHAUSTED")
             }
-            Self::Database(msg) if msg.contains("PoolTimedOut") => {
+            Self::Database(msg) if is_pool_timeout(msg) => {
                 (StatusCode::SERVICE_UNAVAILABLE, "POOL_EXHAUSTED")
             }
             Self::Database(_) | Self::Sqlx(_) => {
@@ -167,7 +182,7 @@ impl AppError {
             Self::Sqlx(sqlx::Error::PoolTimedOut) => {
                 "Database connection pool is saturated, retry shortly".to_string()
             }
-            Self::Database(msg) if msg.contains("PoolTimedOut") => {
+            Self::Database(msg) if is_pool_timeout(msg) => {
                 "Database connection pool is saturated, retry shortly".to_string()
             }
             Self::Database(_) | Self::Sqlx(_) => "Database operation failed".to_string(),
@@ -271,12 +286,23 @@ mod tests {
 
     #[test]
     fn test_pool_timeout_string_wrapped_as_database_also_503s() {
-        // Some callers stringify the sqlx error (`map_err(|e| e.to_string())`)
-        // before wrapping it as `AppError::Database`. The 503 mapping must
-        // still fire so wrapped pool timeouts don't slip back to 500.
-        let err = AppError::Database("pool error: PoolTimedOut".into());
-        let (status, _) = err.status_and_code();
+        // The proxy hot path stringifies sqlx errors
+        // (`map_err(|e| AppError::Database(e.to_string()))`) before wrapping
+        // them, which erases the typed variant. Reproduce the EXACT string
+        // sqlx produces for a pool timeout rather than a synthetic string that
+        // merely contains the variant name -- the real Display does NOT contain
+        // "PoolTimedOut", so a guard keyed off the variant name silently let
+        // saturated proxy requests fall back to 500 (#1437).
+        let real = sqlx::Error::PoolTimedOut.to_string();
+        assert!(
+            !real.contains("PoolTimedOut"),
+            "guard must not rely on the Debug variant name; sqlx Display = {real:?}"
+        );
+        let err = AppError::Database(real);
+        let (status, code) = err.status_and_code();
         assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(code, "POOL_EXHAUSTED");
+        assert!(err.user_message().contains("retry"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #2082.

Fixes a mis-mapping where sqlx connection-pool exhaustion on the proxy hot path surfaced as **500 `DATABASE_ERROR`** instead of **503 `POOL_EXHAUSTED` + `Retry-After`**, so clients didn't back off and pool saturation tripped 500 alerts.

The hot path wraps DB errors as `AppError::Database(e.to_string())` (~741 call sites). For `sqlx::Error::PoolTimedOut`, `Display` renders `"pool timed out while waiting for an open connection"` (sqlx 0.8), which does **not** contain the literal `"PoolTimedOut"` the guard matched on, so every stringified pool timeout fell through to 500. A prior fix (#1437/#1442) added the guard but keyed it off the Debug variant name; its test passed only because it used a synthetic string literally containing `"PoolTimedOut"`.

- `error.rs`: add `is_pool_timeout()` matching both the real `Display` fragment and the Debug variant name; use it in `status_and_code` and `user_message`. This covers every `AppError::Database(e.to_string())` site (including `map_db_err`).
- `proxy_helpers.rs`: route `resolve_repo_by_key` (the first DB acquire on every proxy GET) and `fetch_virtual_members` through `map_db_err` instead of a raw 500 tuple, so pool timeouts there also map to 503 and the raw DB error text is no longer leaked to clients. Make `internal_error()` pool-timeout aware (covers the ~9 local/virtual-member artifact-lookup helpers). Route the three virtual-repo shadowing-guard DB paths through a single pool-timeout-aware helper (503 on timeout, else the existing non-leaking fail-closed 500).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The rewritten `test_pool_timeout_string_wrapped_as_database_also_503s` reproduces the exact `sqlx::Error::PoolTimedOut.to_string()` (not a synthetic string) and asserts 503 + `POOL_EXHAUSTED`; it fails on `main` and passes here. Additional regression tests cover `map_db_err`, `internal_error`, and `shadowing_guard_db_err` pool-timeout → 503, plus the non-timeout fail-closed 500.

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local gates: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib`, new-line coverage 95% (≥70% gate), duplication 0% (≤3% gate).

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No new endpoints, schemas, or migrations. The only externally-visible change is the HTTP status on DB pool exhaustion (500 → 503 + `Retry-After`), which is the intended fix.
