### PR TITLE
ci(release): verify scanner-adapter image before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,9 +213,11 @@ jobs:
             "ghcr.io|artifact-keeper/artifact-keeper-backend:${VERSION}"
             "ghcr.io|artifact-keeper/artifact-keeper-openscap:${VERSION}"
             "ghcr.io|artifact-keeper/artifact-keeper-web:${VERSION}"
+            "ghcr.io|artifact-keeper/artifact-keeper-scanner-adapter:${VERSION}"
             "docker.io|artifactkeeper/backend:${VERSION}"
             "docker.io|artifactkeeper/openscap:${VERSION}"
             "docker.io|artifactkeeper/web:${VERSION}"
+            "docker.io|artifactkeeper/scanner-adapter:${VERSION}"
           )
 
           # Common Accept headers cover OCI index, Docker manifest list,


### PR DESCRIPTION
Closes #2114

Adds `artifact-keeper-scanner-adapter` (ghcr.io + docker.io) to release.yml's required-images verification, so the release gate holds the GH Release DRAFT unless the multi-arch adapter is published on both registries — same safety the other components already have. The image is already built/mirrored multi-arch by docker-publish.yml's `merge-scanner-adapter` job; this only gates the release on its presence.