### PR TITLE
chore(release): bump version to 1.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.3"
+version = "1.2.4"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.3"
+version = "1.2.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.2.3",
+        version = "1.2.4",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Closes #2116

Version bump 1.2.3 → 1.2.4 (backend): Cargo.toml (workspace.package), backend/src/api/openapi.rs (Swagger), Cargo.lock. Tagging `v1.2.4` after merge triggers the multi-arch image publish (backend + scanner-adapter, now verified by #2115) and the release-gate (incl. the #237 scanner-efficacy check).

Release contents: scanner solution (#2088/#2091/#2093), storage guard (#2025), migration + pypi fixes, #237 efficacy gate.