### PR TITLE
fix(compose): start hardened backend without a /bin/sh entrypoint

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -3304,4 +3304,76 @@ mod tests {
         assert!(storage_path_error("s3", "", "").is_none());
         assert!(storage_path_error("gcs", "some/prefix", "").is_none());
     }
+
+    /// Extract the text of a top-level `services.<name>` block (a 2-space
+    /// indented key) from a compose file, up to the next sibling service or
+    /// 2-space-indented line. Comment lines are stripped so assertions match
+    /// live configuration, not documentation. Test-only, minimal parser.
+    fn compose_service_block(compose: &str, name: &str) -> String {
+        let mut out = String::new();
+        let mut in_block = false;
+        let key = format!("{name}:");
+        for line in compose.lines() {
+            let is_service_key = line.starts_with("  ")
+                && !line.starts_with("   ")
+                && line.trim_start().starts_with(&key);
+            if is_service_key {
+                in_block = true;
+                continue;
+            }
+            if in_block {
+                let boundary =
+                    line.starts_with("  ") && !line.starts_with("   ") && !line.trim().is_empty();
+                if boundary {
+                    break;
+                }
+                if line.trim_start().starts_with('#') {
+                    continue;
+                }
+                out.push_str(line);
+                out.push('\n');
+            }
+        }
+        out
+    }
+
+    /// Regression guard for #2084: the hardened runtime image (#2059) ships no
+    /// `/bin/sh`, so no compose service that runs that image may be launched
+    /// through a shell. On `main` the `backend` service used
+    /// `entrypoint: ["/bin/sh","-c", <wait-for-DT-key>]` and `dtrack-init` ran
+    /// the backend image via `/bin/sh`; both broke `docker compose up` with
+    /// `exec: "/bin/sh": no such file or directory`.
+    #[test]
+    fn shipped_compose_does_not_run_hardened_image_through_a_shell() {
+        let repo_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("backend crate has a parent directory (repo root)");
+        let compose_path = repo_root.join("docker-compose.yml");
+        let compose = std::fs::read_to_string(&compose_path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", compose_path.display()));
+
+        let backend = compose_service_block(&compose, "backend");
+        assert!(
+            !backend.is_empty(),
+            "backend service not found in docker-compose.yml"
+        );
+        assert!(
+            !backend.contains("/bin/sh") && !backend.contains("/bin/bash"),
+            "backend service must not use a shell entrypoint; the runtime image \
+             has no shell (#2059/#2084). Offending block:\n{backend}"
+        );
+
+        // dtrack-init may legitimately use a shell, but not on the shell-less
+        // backend image — it must run a shell-bearing image instead.
+        let dtrack_init = compose_service_block(&compose, "dtrack-init");
+        assert!(
+            !dtrack_init.is_empty(),
+            "dtrack-init service not found in docker-compose.yml"
+        );
+        assert!(
+            !dtrack_init.contains("artifact-keeper-backend"),
+            "dtrack-init must not run the shell-less backend image (#2084). \
+             Offending block:\n{dtrack_init}"
+        );
+    }
 }

--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -11,6 +11,13 @@
 //! DEPENDENCY_TRACK_ENABLED=true
 //! ```
 //!
+//! The API key may instead be supplied via `DEPENDENCY_TRACK_API_KEY_FILE`
+//! pointing at a file that holds the key (the `*_FILE` secret-mounting
+//! convention). This is how the shell-less hardened runtime image consumes the
+//! key that `docker/init-dtrack.sh` writes to the shared volume, without a
+//! `/bin/sh` entrypoint wrapper (issues #2059/#2084). The direct
+//! `DEPENDENCY_TRACK_API_KEY` value takes precedence when both are set.
+//!
 //! ## Required Dependency-Track team permissions (#1472)
 //!
 //! The API key passed via `DEPENDENCY_TRACK_API_KEY` must belong to a team
@@ -201,13 +208,56 @@ impl DependencyTrackConfig {
         }
 
         let base_url = std::env::var("DEPENDENCY_TRACK_URL").ok()?;
-        let api_key = std::env::var("DEPENDENCY_TRACK_API_KEY").ok()?;
+        let api_key = resolve_api_key(
+            std::env::var("DEPENDENCY_TRACK_API_KEY").ok(),
+            std::env::var("DEPENDENCY_TRACK_API_KEY_FILE").ok(),
+        )?;
 
         Some(Self {
             base_url,
             api_key,
             enabled,
         })
+    }
+}
+
+/// Resolve the Dependency-Track API key from either the direct
+/// `DEPENDENCY_TRACK_API_KEY` value or a path in `DEPENDENCY_TRACK_API_KEY_FILE`.
+///
+/// The `*_FILE` fallback mirrors the common secret-mounting convention and
+/// lets the hardened, shell-less runtime image (issue #2059) read the key that
+/// [`docker/init-dtrack.sh`](../../../docker/init-dtrack.sh) writes to a shared
+/// volume — without wrapping the entrypoint in `/bin/sh -c 'export ...=$(cat
+/// /shared/dtrack-api-key)'`, which the image no longer supports (issue #2084).
+///
+/// The direct value takes precedence when both are set. File contents are
+/// trimmed of surrounding whitespace/newlines (the bootstrap script writes the
+/// bare key, but a trailing newline is tolerated). A blank variable, an empty
+/// path, a missing file, or an empty/whitespace-only file all yield `None`.
+fn resolve_api_key(direct: Option<String>, key_file: Option<String>) -> Option<String> {
+    if let Some(key) = direct {
+        let key = key.trim();
+        if !key.is_empty() {
+            return Some(key.to_string());
+        }
+    }
+
+    let path = key_file?;
+    let path = path.trim();
+    if path.is_empty() {
+        return None;
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let key = contents.trim();
+            if key.is_empty() {
+                None
+            } else {
+                Some(key.to_string())
+            }
+        }
+        Err(_) => None,
     }
 }
 
@@ -2793,5 +2843,70 @@ mod tests {
             AppError::ServiceUnavailable(ref m) => assert!(m.contains("unreachable")),
             _ => panic!("expected ServiceUnavailable"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_api_key: DEPENDENCY_TRACK_API_KEY vs *_FILE fallback (#2084)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_api_key_prefers_direct_value() {
+        // A non-empty direct value wins even when a (would-be) file is present.
+        let got = resolve_api_key(
+            Some("direct-key".to_string()),
+            Some("/nonexistent".to_string()),
+        );
+        assert_eq!(got.as_deref(), Some("direct-key"));
+    }
+
+    #[test]
+    fn resolve_api_key_trims_direct_value() {
+        let got = resolve_api_key(Some("  spaced-key\n".to_string()), None);
+        assert_eq!(got.as_deref(), Some("spaced-key"));
+    }
+
+    #[test]
+    fn resolve_api_key_reads_file_when_direct_absent() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(f.path(), "file-key\n").unwrap();
+        let got = resolve_api_key(None, Some(f.path().to_string_lossy().into_owned()));
+        assert_eq!(got.as_deref(), Some("file-key"));
+    }
+
+    #[test]
+    fn resolve_api_key_reads_file_when_direct_is_blank() {
+        // An empty/whitespace direct value must not shadow the file fallback.
+        let f = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(f.path(), "  from-file  ").unwrap();
+        let got = resolve_api_key(
+            Some("   ".to_string()),
+            Some(f.path().to_string_lossy().into_owned()),
+        );
+        assert_eq!(got.as_deref(), Some("from-file"));
+    }
+
+    #[test]
+    fn resolve_api_key_none_when_nothing_set() {
+        assert_eq!(resolve_api_key(None, None), None);
+        assert_eq!(resolve_api_key(Some(String::new()), None), None);
+    }
+
+    #[test]
+    fn resolve_api_key_none_for_empty_path() {
+        assert_eq!(resolve_api_key(None, Some("   ".to_string())), None);
+    }
+
+    #[test]
+    fn resolve_api_key_none_when_file_missing() {
+        let got = resolve_api_key(None, Some("/nonexistent/dtrack-api-key-xyz".to_string()));
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    fn resolve_api_key_none_when_file_empty() {
+        let f = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(f.path(), "\n  \n").unwrap();
+        let got = resolve_api_key(None, Some(f.path().to_string_lossy().into_owned()));
+        assert_eq!(got, None);
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,9 +107,15 @@ services:
   # Gated behind the `dtrack` profile so the default stack does not pull in
   # Dependency-Track (issue #1432: DT consumes ~4 GiB RAM and pegs the
   # bundled Postgres while idle).
-  # Docker Hub alternative: artifactkeeper/backend:${ARTIFACT_KEEPER_VERSION:-latest}
+  #
+  # This runs on a small shell-bearing image (alpine) rather than the backend
+  # image: the hardened runtime image (issue #2059) has no /bin/sh — nor the
+  # `jq` that init-dtrack.sh needs — so it can no longer host this bootstrap
+  # script (issue #2084). alpine keeps the hardening intact (the app image stays
+  # shell-free) while providing sh + curl + jq. Mirrors the pg-certs init
+  # container's `apk add` pattern above.
   dtrack-init:
-    image: ghcr.io/artifact-keeper/artifact-keeper-backend:${ARTIFACT_KEEPER_VERSION:-latest}
+    image: alpine:3.23
     container_name: artifact-keeper-dtrack-init
     profiles:
       - dtrack  # Only starts with: docker compose --profile dtrack up
@@ -124,7 +130,11 @@ services:
     environment:
       DTRACK_INIT_FORCE_ROTATE: ${DTRACK_INIT_FORCE_ROTATE:-false}
       DEPENDENCY_TRACK_ADMIN_PASSWORD: ${DEPENDENCY_TRACK_ADMIN_PASSWORD:-ArtifactKeeper2026!}
-    entrypoint: ["/bin/sh", "/init-dtrack.sh"]
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        apk add --no-cache curl jq >/dev/null 2>&1
+        exec /bin/sh /init-dtrack.sh
     restart: "no"
     healthcheck:
       disable: true
@@ -186,26 +196,14 @@ services:
       dtrack-init:
         condition: service_completed_successfully
         required: false
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        # Wait for dtrack-init to provision the API key (up to 5 min)
-        if [ "$${DEPENDENCY_TRACK_ENABLED}" != "false" ]; then
-          echo "backend: waiting for Dependency-Track API key..."
-          for i in $$(seq 1 60); do
-            if [ -f /shared/dtrack-api-key ] && [ -s /shared/dtrack-api-key ]; then
-              export DEPENDENCY_TRACK_API_KEY="$$(cat /shared/dtrack-api-key)"
-              echo "backend: Dependency-Track API key loaded"
-              break
-            fi
-            if [ "$$i" -eq 60 ]; then
-              echo "backend: WARNING - Dependency-Track API key not found after 5 min, starting without it"
-            fi
-            sleep 5
-          done
-        fi
-        exec artifact-keeper
+    # No entrypoint override: the hardened runtime image (issue #2059) has no
+    # /bin/sh, so the previous `["/bin/sh","-c", <wait-for-DT-key>]` wrapper
+    # broke `docker compose up` with `exec: "/bin/sh": no such file or
+    # directory` (issue #2084). We run the image CMD (`["artifact-keeper"]`)
+    # directly instead. The Dependency-Track API key is read from the shared
+    # volume via DEPENDENCY_TRACK_API_KEY_FILE below; the dtrack-init
+    # dependency above (service_completed_successfully) already guarantees the
+    # key file exists before the backend starts, so no in-shell wait is needed.
     environment:
       DATABASE_URL: postgresql://registry:registry@postgres:5432/artifact_registry?sslmode=require
       STORAGE_PATH: /data/storage
@@ -226,6 +224,10 @@ services:
       OPENSEARCH_URL: http://opensearch:9200
       # Dependency-Track integration (API key auto-provisioned by dtrack-init)
       DEPENDENCY_TRACK_URL: http://dependency-track-apiserver:8080
+      # The dtrack-init container writes the provisioned API key to this shared
+      # path; the backend reads it via the *_FILE convention (no shell needed).
+      # Only consumed when DEPENDENCY_TRACK_ENABLED=true (dtrack profile).
+      DEPENDENCY_TRACK_API_KEY_FILE: /shared/dtrack-api-key
       # Default off: Dependency-Track is an optional integration that runs a
       # heavyweight Java service plus its own NVD mirror. Operators opt in by
       # setting DEPENDENCY_TRACK_ENABLED=true *and* starting the dtrack


### PR DESCRIPTION
## Summary

Closes #2084.

The hardened runtime image (#2059) removed `/bin/sh` (and `bash`), but the
shipped `docker-compose.yml` still launched two services **through a shell**, so
`docker compose up` failed before the app ever ran:

```
OCI runtime create failed: ... exec: "/bin/sh": stat /bin/sh: no such file or directory
```

This keeps the no-shell hardening (the app image stays shell-free) and makes
compose start cleanly again:

- **`backend`** — dropped the `entrypoint: ["/bin/sh","-c", <wait-for-DT-key>]`
  wrapper. The service now runs the image `CMD` (`["artifact-keeper"]`)
  directly. The Dependency-Track API key that `dtrack-init` writes to the shared
  volume is now consumed via a new `DEPENDENCY_TRACK_API_KEY_FILE` env
  (the standard `*_FILE` secret-mounting convention), so no in-shell
  `export …=$(cat …)` is needed. The existing
  `depends_on: dtrack-init (service_completed_successfully)` already guarantees
  the key file exists before the backend starts, so the shell wait-loop was
  redundant.
- **`dtrack-init`** — moved off the (now shell-less, `jq`-less) backend image to
  a small `alpine:3.23` image that provides `sh` + `curl` + `jq`, mirroring the
  existing `pg-certs` init container's `apk add` pattern. `docker/init-dtrack.sh`
  is unchanged.

Backend change is a small, testable helper (`resolve_api_key`) added to
`services/dependency_track_service.rs`: it prefers the direct
`DEPENDENCY_TRACK_API_KEY` value and falls back to reading
`DEPENDENCY_TRACK_API_KEY_FILE`, trimming whitespace and treating a
blank/missing/empty source as "unset".

### Before / after (published hardened image `:1.2.3`, same image both runs)

```console
# BEFORE — main compose, /bin/sh entrypoint on the shell-less image
$ ARTIFACT_KEEPER_VERSION=1.2.3 docker compose -f docker-compose.yml run --no-deps --rm backend
Error response from daemon: ... exec: "/bin/sh": stat /bin/sh: no such file or directory

# AFTER — this PR's compose, no shell entrypoint
$ ARTIFACT_KEEPER_VERSION=1.2.3 docker compose -f docker-compose.yml run --no-deps --rm backend
WARN artifact_keeper_backend::config: PEER_API_KEY not set, generated random key.
Error: Config("JWT_SECRET is unsuitable: ... shorter than 32 characters ...")
# -> backend now runs the app binary and reaches config validation, not the /bin/sh exec error
```

Hardening is intact — the image still has no shell:

```console
$ docker run --rm --entrypoint /bin/sh ghcr.io/artifact-keeper/artifact-keeper-backend:1.2.3 -c true
... exec: "/bin/sh": stat /bin/sh: no such file or directory   # exit 127
```

## Regression test (required for `fix/*` PRs)
<!--
Hardening Core requires every bug-fix PR to land with a regression test that
fails on `main` and passes on this PR.
-->
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`config::tests::shipped_compose_does_not_run_hardened_image_through_a_shell`
parses the shipped `docker-compose.yml` and asserts the `backend` service uses
no shell entrypoint and `dtrack-init` does not run the shell-less backend image.
It **fails on `main`** (`backend` uses `entrypoint: ["/bin/sh","-c", …]`) and
**passes on this PR**. `resolve_api_key` is covered by 8 unit tests
(direct value, `*_FILE` fallback, precedence, blank/missing/empty cases).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Note: demo compose (`artifact-keeper-iac`)

The demo compose (`artifact-keeper-iac/demo/docker-compose.demo.yml`) is **not**
affected by #2084 and needs no companion fix: its `backend` service already runs
the image `CMD` directly (no entrypoint override), and its only `sh -c`
entrypoint is on the `seed` service, which runs on `postgres:15-alpine` (a
shell-bearing image), not the hardened backend image.
