### PR TITLE
fix(admin): grantable promote scope, webhook-secret 4xx, signing repo validation

### DIFF
--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -425,12 +425,20 @@ async fn enforce_release_target_link(
 /// approval/governance workflow could be bypassed by promoting directly via
 /// the `/promote` routes.
 ///
-/// Split into a pure helper so the admin-gate decision is shared by the single
-/// and bulk promote handlers and can be unit tested without a DB or storage.
-fn ensure_promotion_authorized(is_admin: bool) -> Result<()> {
-    if !is_admin {
+/// Split into a pure helper so the gate decision is shared by the single and
+/// bulk promote handlers and can be unit tested without a DB or storage.
+///
+/// Promotion is authorized when the caller is an admin OR presents an API token
+/// carrying the grantable `promote:artifacts` scope. The scope is admin-only to
+/// mint (see [`crate::services::token_service::ADMIN_ONLY_SCOPES`]) and only ever
+/// consulted for API-token principals at the call sites, so a JWT/session user
+/// cannot acquire promote capability through it. The tenant-ownership and
+/// approval/governance gates run independently and still apply to scoped tokens.
+fn ensure_promotion_authorized(is_admin: bool, has_promote_scope: bool) -> Result<()> {
+    if !is_admin && !has_promote_scope {
         return Err(AppError::Authorization(
-            "Only admins can promote artifacts".to_string(),
+            "Only admins or tokens with the 'promote:artifacts' scope can promote artifacts"
+                .to_string(),
         ));
     }
     Ok(())
@@ -549,7 +557,12 @@ pub async fn promote_artifact(
     Path((repo_key, artifact_id)): Path<(String, Uuid)>,
     Json(req): Json<PromoteArtifactRequest>,
 ) -> Result<Json<PromotionResponse>> {
-    ensure_promotion_authorized(auth.is_admin)?;
+    // `promote:artifacts` is a grantable, admin-only-to-mint API-token scope.
+    // Only trust it for API-token principals: `has_scope` returns true for JWT
+    // sessions, so the `is_api_token` guard prevents a session user from gaining
+    // promote capability they were never granted.
+    let has_promote_scope = auth.is_api_token && auth.has_scope("promote:artifacts");
+    ensure_promotion_authorized(auth.is_admin, has_promote_scope)?;
 
     let repo_service = RepositoryService::new(state.db.clone());
 
@@ -846,7 +859,12 @@ pub async fn promote_artifacts_bulk(
     Path(repo_key): Path<String>,
     Json(req): Json<BulkPromoteRequest>,
 ) -> Result<Json<BulkPromotionResponse>> {
-    ensure_promotion_authorized(auth.is_admin)?;
+    // `promote:artifacts` is a grantable, admin-only-to-mint API-token scope.
+    // Only trust it for API-token principals: `has_scope` returns true for JWT
+    // sessions, so the `is_api_token` guard prevents a session user from gaining
+    // promote capability they were never granted.
+    let has_promote_scope = auth.is_api_token && auth.has_scope("promote:artifacts");
+    ensure_promotion_authorized(auth.is_admin, has_promote_scope)?;
 
     let repo_service = RepositoryService::new(state.db.clone());
 
@@ -1558,7 +1576,17 @@ mod tests {
 
     #[test]
     fn test_ensure_promotion_authorized_admin_ok() {
-        assert!(ensure_promotion_authorized(true).is_ok());
+        // Admin passes regardless of scope.
+        assert!(ensure_promotion_authorized(true, false).is_ok());
+        assert!(ensure_promotion_authorized(true, true).is_ok());
+    }
+
+    #[test]
+    fn test_ensure_promotion_authorized_promote_scope_ok() {
+        // A non-admin caller presenting the `promote:artifacts` scope is
+        // authorized (the scope is admin-only to mint and is only consulted
+        // for API-token principals at the call sites).
+        assert!(ensure_promotion_authorized(false, true).is_ok());
     }
 
     // -----------------------------------------------------------------------
@@ -1622,11 +1650,12 @@ mod tests {
 
     #[test]
     fn test_ensure_promotion_authorized_non_admin_denied() {
-        let err = ensure_promotion_authorized(false).unwrap_err();
+        // Neither admin nor promote scope -> denied.
+        let err = ensure_promotion_authorized(false, false).unwrap_err();
         // Non-admin promotion is an authorization failure (HTTP 403), matching
         // the approval workflow's approve/reject endpoints.
         assert!(matches!(err, AppError::Authorization(_)));
-        assert!(err.to_string().contains("admin"));
+        assert!(err.to_string().contains("promote"));
     }
 
     // -----------------------------------------------------------------------
@@ -3175,6 +3204,23 @@ mod tests {
             }
         }
 
+        /// A NON-admin service-account API token bearing the given scopes. Used to
+        /// exercise the grantable `promote:artifacts` capability (#2042): promote
+        /// is authorized for such a token, but the tenant-ownership gate still
+        /// applies via the user's per-repo role grants.
+        fn scoped_token_ext(user_id: Uuid, scopes: &[&str]) -> AuthExtension {
+            AuthExtension {
+                user_id,
+                username: "pr2042-sa".to_string(),
+                email: "pr2042-sa@test.local".to_string(),
+                is_admin: false,
+                is_api_token: true,
+                is_service_account: true,
+                scopes: Some(scopes.iter().map(|s| s.to_string()).collect()),
+                allowed_repo_ids: None,
+            }
+        }
+
         /// Storage backend resolved through the repo's own storage_location().
         async fn storage_for(
             state: &SharedState,
@@ -3390,6 +3436,93 @@ mod tests {
             assert!(target_has_artifact(&pool, tgt, "st").await);
 
             cleanup(&pool, &[src, tgt], corp_admin).await;
+        }
+
+        // ---- #2042: grantable promote:artifacts scope on service-account tokens
+
+        /// A non-admin SERVICE-ACCOUNT token that holds the `promote:artifacts`
+        /// scope AND owns both repos (per-repo grants) may promote: the scope
+        /// satisfies the promote-authorization gate and the tenant gate passes.
+        #[tokio::test]
+        async fn test_single_promote_scoped_token_with_grant_allowed() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr2042-ok-s-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr2042-ok-t-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "sa-ok-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "sa-ok-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let sa = make_tenant_admin(&pool, "sa-ok").await;
+            grant_repo(&pool, sa, src).await;
+            grant_repo(&pool, sa, tgt).await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "saok").await;
+
+            let res = promote_artifact(
+                State(state.clone()),
+                Extension(scoped_token_ext(sa, &["promote:artifacts"])),
+                Path((src_key.clone(), artifact)),
+                Json(PromoteArtifactRequest {
+                    target_repository: Some(tgt_key.clone()),
+                    skip_policy_check: false,
+                    notes: None,
+                }),
+            )
+            .await
+            .expect("scoped-token promote with grants must succeed");
+            assert!(res.0.promoted, "scoped-token promote must promote");
+            assert!(target_has_artifact(&pool, tgt, "saok").await);
+
+            cleanup(&pool, &[src, tgt], sa).await;
+        }
+
+        /// A non-admin service-account token WITHOUT the `promote:artifacts`
+        /// scope is denied at the promote-authorization gate (403), even when it
+        /// owns both repos — the scope is the grantable promote capability.
+        #[tokio::test]
+        async fn test_single_promote_scoped_token_without_scope_blocked() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let sdir = std::env::temp_dir().join(format!("pr2042-no-s-{}", Uuid::new_v4()));
+            let tdir = std::env::temp_dir().join(format!("pr2042-no-t-{}", Uuid::new_v4()));
+            let src_key = make_repo_key(&pool, "sa-no-s", &sdir).await;
+            let tgt_key = make_repo_key(&pool, "sa-no-t", &tdir).await;
+            let src = repo_id_for_key(&pool, &src_key).await;
+            let tgt = repo_id_for_key(&pool, &tgt_key).await;
+            let sa = make_tenant_admin(&pool, "sa-no").await;
+            grant_repo(&pool, sa, src).await;
+            grant_repo(&pool, sa, tgt).await;
+            let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+            let storage = storage_for(&state, &pool, src).await;
+            let artifact = make_artifact(&pool, src, &storage, "sano").await;
+
+            let err = promote_artifact(
+                State(state.clone()),
+                Extension(scoped_token_ext(sa, &["read:artifacts", "write:artifacts"])),
+                Path((src_key.clone(), artifact)),
+                Json(PromoteArtifactRequest {
+                    target_repository: Some(tgt_key.clone()),
+                    skip_policy_check: false,
+                    notes: None,
+                }),
+            )
+            .await
+            .expect_err("token without promote:artifacts must be rejected");
+            assert!(
+                matches!(err, AppError::Authorization(_)),
+                "missing promote scope must be a 403; got {:?}",
+                err
+            );
+            assert!(
+                !target_has_artifact(&pool, tgt, "sano").await,
+                "a denied promote must NOT copy the artifact"
+            );
+
+            cleanup(&pool, &[src, tgt], sa).await;
         }
 
         /// Cross-tenant BULK promote: tenant admin lacks the target tenant -> 403.

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -13,6 +13,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::signing_key::{RepositorySigningConfig, SigningKeyPublic};
+use crate::services::repository_service::RepositoryService;
 use crate::services::signing_service::{CreateKeyRequest, SigningService};
 
 /// Create signing key management routes.
@@ -114,6 +115,7 @@ async fn list_keys(
     responses(
         (status = 200, description = "Created signing key", body = SigningKeyPublic),
         (status = 401, description = "Unauthorized", body = crate::api::openapi::ErrorResponse),
+        (status = 404, description = "Repository not found", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
 )]
@@ -123,6 +125,18 @@ async fn create_key(
     Json(payload): Json<CreateKeyPayload>,
 ) -> Result<Json<SigningKeyPublic>> {
     require_signing_admin(&auth)?;
+
+    // Validate a repository-scoped key names an existing repository before
+    // handing off to the signing service. Without this, a nonexistent
+    // repository_id hits the FK constraint at INSERT and surfaces as an opaque
+    // 500 DATABASE_ERROR; `get_by_id` returns a clean NotFound (404) instead.
+    // Global keys (repository_id = None) carry no FK and skip the lookup.
+    if let Some(repo_id) = payload.repository_id {
+        RepositoryService::new(state.db.clone())
+            .get_by_id(repo_id)
+            .await?;
+    }
+
     let svc = signing_service(&state);
     let key = svc
         .create_key(CreateKeyRequest {
@@ -846,5 +860,117 @@ mod tests {
         assert!(merged_meta);
         assert!(merged_pkg);
         assert!(merged_req);
+    }
+
+    // -----------------------------------------------------------------------
+    // #2044: create_key validates a repository-scoped key names an existing
+    // repository BEFORE the signing service, so a bad repository_id yields a
+    // clean 404 instead of an opaque 500 from the FK violation at INSERT.
+    // DB-backed: runtime-skips when DATABASE_URL is unset (no-op locally,
+    // runs in CI which seeds Postgres).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_create_key_nonexistent_repository_id_is_not_found() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let sdir = std::env::temp_dir().join(format!("sk2044-nf-{}", Uuid::new_v4()));
+        let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+        let payload = CreateKeyPayload {
+            repository_id: Some(Uuid::new_v4()), // random, does not exist
+            name: format!("k-{}", &Uuid::new_v4().to_string()[..8]),
+            key_type: Some("rsa".to_string()),
+            algorithm: Some("rsa2048".to_string()),
+            uid_name: None,
+            uid_email: None,
+        };
+        let err = create_key(State(state), Extension(admin_jwt()), Json(payload))
+            .await
+            .expect_err("nonexistent repository_id must error");
+        assert!(
+            matches!(err, AppError::NotFound(_)),
+            "nonexistent repo must be 404 NotFound, not a 500 DATABASE_ERROR; got {:?}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_key_existing_repository_id_succeeds() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _key, _dir) = tdh::create_repo(&pool, "local", "generic").await;
+        // signing_keys.created_by is FK -> users(id); use a real admin user.
+        let (user_id, _uname) = tdh::create_user(&pool).await;
+        let mut admin = admin_jwt();
+        admin.user_id = user_id;
+        let sdir = std::env::temp_dir().join(format!("sk2044-ok-{}", Uuid::new_v4()));
+        let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+        let payload = CreateKeyPayload {
+            repository_id: Some(repo_id),
+            name: format!("k-{}", &Uuid::new_v4().to_string()[..8]),
+            key_type: Some("rsa".to_string()),
+            algorithm: Some("rsa2048".to_string()),
+            uid_name: None,
+            uid_email: None,
+        };
+        let res = create_key(State(state), Extension(admin), Json(payload)).await;
+        assert!(
+            res.is_ok(),
+            "create_key against an existing repo must succeed; got {:?}",
+            res.err()
+        );
+        let _ = sqlx::query("DELETE FROM signing_keys WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn test_create_key_global_no_repository_id_succeeds() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // signing_keys.created_by is FK -> users(id); use a real admin user.
+        let (user_id, _uname) = tdh::create_user(&pool).await;
+        let mut admin = admin_jwt();
+        admin.user_id = user_id;
+        let sdir = std::env::temp_dir().join(format!("sk2044-gl-{}", Uuid::new_v4()));
+        let state = tdh::build_state(pool.clone(), sdir.to_str().unwrap());
+        let name = format!("global-k-{}", &Uuid::new_v4().to_string()[..8]);
+        let payload = CreateKeyPayload {
+            repository_id: None, // global key: skips the repo lookup
+            name: name.clone(),
+            key_type: Some("rsa".to_string()),
+            algorithm: Some("rsa2048".to_string()),
+            uid_name: None,
+            uid_email: None,
+        };
+        let res = create_key(State(state), Extension(admin), Json(payload)).await;
+        assert!(
+            res.is_ok(),
+            "global (no repository_id) create_key must succeed; got {:?}",
+            res.err()
+        );
+        let _ = sqlx::query("DELETE FROM signing_keys WHERE name = $1")
+            .bind(&name)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await;
     }
 }

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -390,8 +390,7 @@ pub async fn list_webhooks(
     request_body = CreateWebhookRequest,
     responses(
         (status = 200, description = "Webhook created. Body includes the raw secret exactly once (omitted when created unsigned).", body = WebhookSecretCreatedResponse),
-        (status = 422, description = "Validation error"),
-        (status = 503, description = "A secret was supplied but AK_WEBHOOK_SECRET_KEY is not configured, so the secret cannot be encrypted at rest"),
+        (status = 422, description = "Validation error, including: a secret was supplied but AK_WEBHOOK_SECRET_KEY is not configured, so the secret cannot be encrypted at rest (create the webhook without a secret, or have an administrator configure the signing key)"),
         (status = 500, description = "Internal server error")
     ),
     security(("bearer_auth" = []))
@@ -507,8 +506,10 @@ struct PreparedSecret {
 /// Behavior (B4 fix):
 /// - Caller supplied a secret, key configured: encrypt and store it.
 /// - Caller supplied a secret, NO key configured: return a clear
-///   `ServiceUnavailable` (503) error, never a bare 500. The caller asked
-///   to sign but the deployment cannot encrypt the secret at rest.
+///   `Validation` (4xx) error, never a bare 500 or a retryable 503. The
+///   caller asked to sign but the deployment cannot encrypt the secret at
+///   rest; this is a permanent client-side condition, and the secret is
+///   never stored in the clear.
 /// - No secret supplied, key configured: generate a fresh secret, encrypt
 ///   and store it (preserves the pre-fix signing-by-default behavior).
 /// - No secret supplied, NO key configured: store nothing. The webhook is
@@ -526,12 +527,17 @@ fn prepare_secret_for_storage(
     let supplied = supplied_secret.filter(|s| !s.trim().is_empty());
 
     let raw_secret = match (supplied, key_configured) {
-        // Caller wants signing but we cannot encrypt: clear, non-500 error.
+        // Caller wants signing but the deployment has no signing key, so the
+        // secret cannot be encrypted at rest. This is a permanent client-side
+        // condition, not a transient server fault: returning 503 wrongly
+        // implies the request is retryable and drives CI retry loops. Surface
+        // a clear validation (4xx) error and never store the secret in the
+        // clear. Enabling signing is an operator action (see #950).
         (Some(_), false) => {
-            return Err(AppError::ServiceUnavailable(
-                "webhook secret signing is not configured on this deployment \
+            return Err(AppError::Validation(
+                "webhook secret signing is not enabled on this deployment \
                  (AK_WEBHOOK_SECRET_KEY is unset); create the webhook without \
-                 a secret or configure the key"
+                 a secret, or ask an administrator to configure the signing key"
                     .to_string(),
             ));
         }
@@ -3059,36 +3065,43 @@ mod tests {
     #[test]
     fn prepare_secret_supplied_secret_without_key_is_clear_non_500_error() {
         // The one case that must error: caller wants signing but the
-        // deployment cannot encrypt at rest. Must be a clear, non-500 error,
-        // not a bare AppError::Internal (which maps to 500 INTERNAL_ERROR).
+        // deployment cannot encrypt at rest. Must be a clear client-side
+        // Validation error, not a bare AppError::Internal (500) nor a
+        // retryable AppError::ServiceUnavailable (503) that drives CI retry
+        // loops. The message must name the missing env var.
         let err = prepare_secret_for_storage(Some("whsec_caller_supplied"), false, || {
             panic!("must not generate")
         })
         .expect_err("supplied secret with no key must error");
         match err {
-            AppError::ServiceUnavailable(msg) => {
+            AppError::Validation(msg) => {
                 assert!(
                     msg.contains("AK_WEBHOOK_SECRET_KEY"),
                     "error should name the missing key var, got: {msg}"
                 );
             }
-            other => panic!("expected ServiceUnavailable (503), got {other:?}"),
+            other => panic!("expected Validation, got {other:?}"),
         }
     }
 
     #[test]
-    fn prepare_secret_supplied_secret_without_key_maps_to_503_not_500() {
+    fn prepare_secret_supplied_secret_without_key_maps_to_client_error_not_5xx() {
         use axum::response::IntoResponse;
         let err = prepare_secret_for_storage(Some("whsec_x"), false, || unreachable!())
             .expect_err("must error");
         // Drive the error through the real IntoResponse path the handler uses
         // so we assert the wire status, not an internal detail. The whole
-        // point of B4: never a bare 500 on a normal-ish create.
+        // point: a permanent client-side condition must be a 4xx, never a 5xx
+        // (500 looks like a server fault; 503 looks retryable).
         let response = err.into_response();
-        assert_eq!(
-            response.status(),
-            axum::http::StatusCode::SERVICE_UNAVAILABLE,
-            "supplied-secret-no-key must map to 503, not 500"
+        let status = response.status();
+        assert!(
+            status.is_client_error(),
+            "supplied-secret-no-key must map to a 4xx client error, got {status}"
+        );
+        assert!(
+            !status.is_server_error(),
+            "supplied-secret-no-key must not be a 5xx, got {status}"
         );
     }
 

--- a/backend/src/services/token_service.rs
+++ b/backend/src/services/token_service.rs
@@ -92,6 +92,7 @@ pub(crate) const ALLOWED_SCOPES: &[&str] = &[
     "read:artifacts",
     "write:artifacts",
     "delete:artifacts",
+    "promote:artifacts",
     "read:repositories",
     "write:repositories",
     "delete:repositories",
@@ -128,6 +129,10 @@ pub(crate) fn validate_scopes_pure(scopes: &[String]) -> std::result::Result<(),
 ///     authorization decision rests solely on the token's scope set).
 ///   * `delete:artifacts`, `delete:repositories` — destructive
 ///     scope-gated operations.
+///   * `promote:artifacts` — promotes artifacts across repositories and
+///     is a privileged release-management capability; only an admin may
+///     mint a token that carries it (the holder still passes the tenant
+///     and approval gates at promote time).
 ///   * `write:users` — user-management write capability.
 ///
 /// `write:artifacts` and `write:repositories` are deliberately NOT on
@@ -140,6 +145,7 @@ pub(crate) const ADMIN_ONLY_SCOPES: &[&str] = &[
     "*",
     "delete:artifacts",
     "delete:repositories",
+    "promote:artifacts",
     "write:users",
 ];
 
@@ -815,6 +821,26 @@ mod tests {
         let res = enforce_admin_only_scopes(&scopes, false);
         assert!(res.is_err());
         assert!(res.unwrap_err().contains('*'));
+    }
+
+    #[test]
+    fn test_validate_scopes_promote_artifacts_allowed() {
+        // `promote:artifacts` is a first-class, grantable scope.
+        let scopes = vec!["promote:artifacts".to_string()];
+        assert!(validate_scopes_pure(&scopes).is_ok());
+        assert!(ALLOWED_SCOPES.contains(&"promote:artifacts"));
+    }
+
+    #[test]
+    fn test_promote_artifacts_scope_is_admin_only() {
+        // Minting `promote:artifacts` is a privileged release-management
+        // capability: an admin may grant it, a non-admin may not.
+        assert!(ADMIN_ONLY_SCOPES.contains(&"promote:artifacts"));
+        let scopes = vec!["promote:artifacts".to_string()];
+        assert!(enforce_admin_only_scopes(&scopes, true).is_ok());
+        let res = enforce_admin_only_scopes(&scopes, false);
+        assert!(res.is_err());
+        assert!(res.unwrap_err().contains("promote:artifacts"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three related admin-surface fixes from the campaign-7 review. Each is a small,
self-contained patch; no migrations.

**#2042 — grantable `promote:artifacts` capability for service-account tokens.**
Direct promotion (`POST /api/v1/promotion/.../promote`, single + bulk) gated only
on `is_admin`, so a service account could never be delegated promote rights
without full admin. This adds a first-class `promote:artifacts` scope:
- Added to `ALLOWED_SCOPES` (valid to grant) and `ADMIN_ONLY_SCOPES` (only an
  admin may mint a token carrying it) in `token_service.rs`.
- `ensure_promotion_authorized` now takes `(is_admin, has_promote_scope)` and
  allows either. Both call sites compute
  `has_promote_scope = auth.is_api_token && auth.has_scope("promote:artifacts")`.
  The `is_api_token` guard is required: `has_scope` returns `true` for JWT
  sessions, so without it a session user would silently gain promote. JWT users
  do not gain promote through this path.
- The tenant-ownership gate, approval-required consumption, promotion rules, and
  the admin-only approve step are all unchanged — four-eyes governance is intact.
  A scoped token still must pass the per-repo tenant gate.

**#2043 — clearer status when webhook secret signing is unconfigured.**
`prepare_secret_for_storage` returned `503 ServiceUnavailable` when a secret was
supplied but `AK_WEBHOOK_SECRET_KEY` was unset. A 503 implies a transient,
retryable fault, so CI clients retry-loop on a permanent misconfiguration. The
branch now returns a client `Validation` error whose message names
`AK_WEBHOOK_SECRET_KEY` and tells the caller to create the webhook without a
secret or ask an administrator to enable signing. Secrets are still never stored
in the clear. The `utoipa` response annotation was updated accordingly.

Note this is the DX/status-code half. Actually *enabling* webhook secret signing
in the deployment (provisioning the key) is tracked separately in #950; this PR
does not change the enablement path.

**#2044 — validate `repository_id` on signing-key creation.**
`create_key` forwarded a caller-supplied `repository_id` straight to the INSERT,
so a nonexistent id tripped the FK constraint and surfaced as an opaque
`500 DATABASE_ERROR`. It now validates the repository exists via
`RepositoryService::get_by_id` before the signing service, propagating a clean
`404 NotFound`. The admin gate still runs first; global (`None`) keys skip the
lookup; the INSERT is unchanged.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Tests added/updated:
- `token_service`: `promote:artifacts` is accepted by `validate_scopes_pure` and
  is admin-only to mint; existing `ALLOWED_SCOPES`/`ADMIN_ONLY_SCOPES` iteration
  tests cover the new entry.
- `promotion`: `ensure_promotion_authorized` unit tests updated to the 2-arg form
  `(true,false)=Ok, (false,false)=Err, (false,true)=Ok, (true,true)=Ok`; plus
  DB-backed handler tests — a scoped service-account token with per-repo grants
  promotes (200), and the same token without the scope is rejected (403).
- `webhooks`: `prepare_secret_for_storage` test now expects the `Validation`
  error naming `AK_WEBHOOK_SECRET_KEY`, and the wire-status test asserts a 4xx
  client error (never a 5xx).
- `signing`: DB-backed `create_key` tests — existing repo → 200, random uuid →
  404 (was 500), no `repository_id` → 200 global.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation on an isolated stack (full lib suite green: 11935 passed; fmt + clippy
`-D warnings` clean; jscpd 1.47% on changed files):
- #2042: non-admin minting `promote:artifacts` → 403 admin-only; admin minting →
  200; service-account token without the scope → promote 403; service-account
  token with the scope but no repo grant → 403 tenant; admin → passes auth+tenant
  gates.
- #2043: `AK_WEBHOOK_SECRET_KEY` unset + secret supplied → 4xx naming the env var
  (was 503); no secret → 200.
- #2044: existing `repository_id` → 200; random uuid → 404 (was 500); no
  `repository_id` → 200 global.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

`utoipa` response annotations updated: webhook create drops the 503 branch;
signing create_key documents 404.

Closes #2042
Closes #2043
Closes #2044
