### PR TITLE
fix(pub,maven): dart pub publish handshake + maven proxy reserved-prefix probe

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -819,14 +819,25 @@ async fn download(
 
     // 3. Check if this is a checksum request for a stored file
     if let Some((base_path, checksum_type)) = parse_checksum_path(&path) {
-        // First try to find a stored checksum file
-        let checksum_storage_key = format!("maven/{}", path);
-        if let Ok(content) = storage.get(&checksum_storage_key).await {
-            return Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(CONTENT_TYPE, "text/plain")
-                .body(Body::from(content))
-                .unwrap());
+        // The `maven/` storage prefix is reserved for Hosted/Staging repos —
+        // only the PUT handler ever writes there. Remote proxy repos serve
+        // cached content exclusively from `proxy-cache/`, and Virtual repos
+        // resolve through their members, so probing `maven/{path}` for them
+        // always misses and needlessly touches the reserved prefix (#1547).
+        // Restrict the stored-sidecar lookup to repo types that can own objects
+        // under `maven/`. (The SNAPSHOT branch below is inherently hosted-only:
+        // `resolve_snapshot_artifact` reads the `artifacts` table, which never
+        // has rows for Remote/Virtual repos, so it short-circuits for them.)
+        if checksum_compute_eligible(&repo.repo_type) {
+            // First try to find a stored checksum file
+            let checksum_storage_key = format!("maven/{}", path);
+            if let Ok(content) = storage.get(&checksum_storage_key).await {
+                return Ok(Response::builder()
+                    .status(StatusCode::OK)
+                    .header(CONTENT_TYPE, "text/plain")
+                    .body(Body::from(content))
+                    .unwrap());
+            }
         }
 
         // If this is a SNAPSHOT path, try the stored checksum under the
@@ -4102,6 +4113,75 @@ mod remote_skip_tests {
         let (status, body) = tdh::send(app, tdh::get(format!("/{}/{}", fx.repo_key, alias))).await;
         assert_eq!(status, axum::http::StatusCode::OK);
         assert_eq!(&body[..], b"snap-bytes");
+        fx.teardown().await;
+    }
+}
+
+#[cfg(test)]
+mod maven_prefix_reserved_tests {
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    // #1547 (regression, hosted path preserved): a Hosted repo may still serve
+    // a checksum sidecar stored under the reserved `maven/` prefix. PUT a
+    // `.sha1` sidecar (which the upload handler stores at `maven/{path}`), then
+    // GET it and assert the stored bytes are returned. This exercises the
+    // eligibility-gated stored-sidecar lookup in `download`.
+    #[tokio::test]
+    async fn test_hosted_serves_stored_maven_checksum_sidecar() {
+        let Some(fx) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+        let path = "com/example/lib/1.0/lib-1.0.jar.sha1";
+        let sha1 = "0123456789abcdef0123456789abcdef01234567";
+        let app = fx.router_with_auth(super::router());
+        let (status, _) = tdh::send(
+            app,
+            tdh::put(
+                format!("/{}/{}", fx.repo_key, path),
+                bytes::Bytes::from(sha1),
+            ),
+        )
+        .await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::CREATED,
+            "sidecar PUT stored"
+        );
+
+        let app = fx.router_with_auth(super::router());
+        let (status, body) = tdh::send(app, tdh::get(format!("/{}/{}", fx.repo_key, path))).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(&body[..], sha1.as_bytes());
+        // The reserved prefix is legitimately populated for a Hosted repo.
+        assert!(
+            fx.storage_dir.join("maven").exists(),
+            "hosted checksum sidecar must live under the maven/ prefix"
+        );
+        fx.teardown().await;
+    }
+
+    // #1547 (fix): a Remote proxy repo must NOT touch the reserved `maven/`
+    // prefix when a Maven/Gradle client probes for a checksum sidecar. With no
+    // proxy service configured the request 404s, and crucially no `maven/`
+    // directory hierarchy is materialised — proxy content belongs under
+    // `proxy-cache/`, never `maven/`.
+    #[tokio::test]
+    async fn test_remote_checksum_probe_leaves_maven_prefix_untouched() {
+        let Some(fx) = tdh::Fixture::setup("remote", "maven").await else {
+            return;
+        };
+        let path = "com/example/lib/1.0/lib-1.0.jar.sha1";
+        let app = fx.router_with_auth(super::router());
+        let (status, _) = tdh::send(app, tdh::get(format!("/{}/{}", fx.repo_key, path))).await;
+        assert_ne!(
+            status,
+            axum::http::StatusCode::OK,
+            "remote repo has no proxy service; checksum request must not succeed"
+        );
+        assert!(
+            !fx.storage_dir.join("maven").exists(),
+            "remote proxy checksum probe must not create anything under maven/ (#1547)"
+        );
         fx.teardown().await;
     }
 }

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -36,7 +36,10 @@ pub fn router() -> Router<SharedState> {
     Router::new()
         // Upload flow (must be registered before the parameterized routes
         // so that literal segments match before `:name` captures them)
-        .route("/:repo_key/api/packages/versions/new", post(new_upload_url))
+        // Spec: the "get upload URL" step is an HTTP GET, not POST. The Dart
+        // SDK issues `GET /api/packages/versions/new`; serving it as POST made
+        // the SDK receive 405 and abort with "Invalid server response" (#1997).
+        .route("/:repo_key/api/packages/versions/new", get(new_upload_url))
         .route(
             "/:repo_key/api/packages/versions/newUpload",
             post(upload_package),
@@ -540,11 +543,14 @@ async fn upload_package(
         pkg_name, pkg_version, filename, repo_key
     );
 
-    // Redirect to finalize endpoint per the Pub spec
+    // Per the Pub spec the upload POST must respond `204 No Content` with a
+    // `Location` header pointing at the finalize endpoint. The Dart SDK sets
+    // `followRedirects = false` and reads `Location` manually; a 3xx redirect
+    // is treated as an unexpected response and the publish aborts (#1997).
     let finish_url = format!("/pub/{}/api/packages/versions/newUploadFinish", repo_key);
 
     Ok(Response::builder()
-        .status(StatusCode::FOUND)
+        .status(StatusCode::NO_CONTENT)
         .header("Location", finish_url)
         .body(Body::empty())
         .unwrap())
@@ -726,6 +732,122 @@ mod db_cov_tests {
             let app = fx.router_with_auth(super::router());
             let _ = tdh::send(app, tdh::get(uri)).await;
         }
+        fx.teardown().await;
+    }
+}
+
+#[cfg(test)]
+mod publish_protocol_tests {
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::http::StatusCode;
+
+    /// Build a minimal, valid Pub package archive (a gzipped tar containing a
+    /// `pubspec.yaml` with the given name/version).
+    fn pub_archive(name: &str, version: &str) -> Vec<u8> {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let pubspec = format!("name: {}\nversion: {}\n", name, version);
+        let mut tar_builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_path("pubspec.yaml").unwrap();
+        header.set_size(pubspec.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar_builder
+            .append(&header, pubspec.as_bytes())
+            .expect("append pubspec");
+        let tar_bytes = tar_builder.into_inner().expect("finish tar");
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar_bytes).expect("gzip write");
+        encoder.finish().expect("gzip finish")
+    }
+
+    /// Encode a single-field (`file`) multipart/form-data body and return the
+    /// `(content_type, body)` pair for the request builder.
+    fn multipart_file(archive: &[u8]) -> (String, bytes::Bytes) {
+        let boundary = "ak1997boundary";
+        let mut body: Vec<u8> = Vec::new();
+        body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"pkg.tar.gz\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(archive);
+        body.extend_from_slice(format!("\r\n--{}--\r\n", boundary).as_bytes());
+        (
+            format!("multipart/form-data; boundary={}", boundary),
+            bytes::Bytes::from(body),
+        )
+    }
+
+    // #1997 (DEV-1): the "get upload URL" step MUST be served on HTTP GET.
+    // Serving it as POST made the Dart SDK receive 405 and abort with
+    // "Invalid server response". After the fix a GET returns 200 with the
+    // `{url, fields}` envelope, and a POST to the same path is 405.
+    #[tokio::test]
+    async fn test_new_upload_url_is_get_not_post() {
+        let Some(fx) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+        let uri = format!("/{}/api/packages/versions/new", fx.repo_key);
+
+        let app = fx.router_with_auth(super::router());
+        let (status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+        assert_eq!(status, StatusCode::OK, "GET .../versions/new must be 200");
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            json.get("url").is_some(),
+            "response must carry an upload url"
+        );
+        assert!(json.get("fields").is_some(), "response must carry fields");
+
+        // The old POST route must no longer exist.
+        let app = fx.router_with_auth(super::router());
+        let (status, _) =
+            tdh::send(app, tdh::post(uri, "application/json", bytes::Bytes::new())).await;
+        assert_eq!(
+            status,
+            StatusCode::METHOD_NOT_ALLOWED,
+            "POST .../versions/new must be 405 after the GET fix"
+        );
+        fx.teardown().await;
+    }
+
+    // #1997 (DEV-2): the multipart upload POST MUST answer 204 No Content with
+    // a `Location` header. The Dart SDK sets followRedirects=false and reads
+    // Location manually; a 3xx made it treat the response as unexpected. Drive
+    // the full handshake and assert 204 + Location, then that the finalize
+    // endpoint returns the success envelope.
+    #[tokio::test]
+    async fn test_upload_returns_204_with_location() {
+        let Some(fx) = tdh::Fixture::setup("local", "pub").await else {
+            return;
+        };
+        let archive = pub_archive("ak_test_pkg", "1.2.3");
+        let (ct, body) = multipart_file(&archive);
+
+        let upload_uri = format!("/{}/api/packages/versions/newUpload", fx.repo_key);
+        let app = fx.router_with_auth(super::router());
+        let (status, _) = tdh::send(app, tdh::post(upload_uri, &ct, body)).await;
+        assert_eq!(
+            status,
+            StatusCode::NO_CONTENT,
+            "upload POST must be 204 No Content per the Pub spec (not a redirect)"
+        );
+
+        // Finalize step returns the spec's success envelope.
+        let finish_uri = format!("/{}/api/packages/versions/newUploadFinish", fx.repo_key);
+        let app = fx.router_with_auth(super::router());
+        let (status, fbody) = tdh::send(app, tdh::get(finish_uri)).await;
+        assert_eq!(status, StatusCode::OK, "finalize must be 200");
+        let json: serde_json::Value = serde_json::from_slice(&fbody).expect("json body");
+        assert!(
+            json.get("success").and_then(|s| s.get("message")).is_some(),
+            "finalize must return {{\"success\": {{\"message\": ...}}}}"
+        );
         fx.teardown().await;
     }
 }


### PR DESCRIPTION
## Summary

Two patch-level bug fixes for the **v1.2.5** milestone, both isolated to their
respective format handlers.

### 1. `dart pub publish` fails — Pub upload protocol non-compliance (Closes #1997)

The Pub upload handshake deviated from the pub.dev Repository Spec v2 in two
ways that made `dart pub publish` abort before completing:

- **Step 1 used the wrong HTTP method.** `GET /api/packages/versions/new` was
  registered as `POST`, so the Dart SDK's `GET` received `405 Method Not
  Allowed` and aborted with *"Invalid server response"*. Changed the route to
  `get(new_upload_url)`.
- **Step 2 returned the wrong status.** The multipart upload `POST` responded
  `302 Found` instead of `204 No Content`. The Dart SDK sets
  `followRedirects = false` and reads the `Location` header manually; a redirect
  status is treated as unexpected. Changed the response to
  `StatusCode::NO_CONTENT` (the `Location` header is retained).

The full 3-step protocol now succeeds: `GET .../versions/new` → `200` with
`{url, fields}`, `POST .../newUpload` → `204` + `Location`, `GET
.../newUploadFinish` → `200` with the `{success: {message}}` envelope.

This is the protocol bug-fix subset only; the broader Remote/Virtual metadata
proxy and response-fidelity work (DEV-3/4/5/6/7/8/9 in the issue) is left to the
in-flight Pub feature PR (#2008) to avoid collision.

### 2. Maven remote proxy touches the reserved `maven/` prefix (Closes #1547)

The `maven/` storage prefix is reserved for Hosted/Staging repos (only the PUT
handler ever writes there). For Remote proxy repos the download handler still
issued a stored-checksum probe against `maven/{path}` on every `.sha1`/`.md5`
request before falling through to the upstream proxy — a lookup that always
misses (proxy content lives under `proxy-cache/`) and needlessly reaches into
the reserved prefix. The stored-sidecar lookup is now gated behind
`checksum_compute_eligible(&repo.repo_type)`, so Remote and Virtual repos skip
it entirely and resolve straight through the proxy/member path. Hosted/Staging
behaviour is unchanged.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New DB-backed unit tests (`cargo test --workspace --lib`):

- `pub_registry::publish_protocol_tests::test_new_upload_url_is_get_not_post` —
  asserts `GET .../versions/new` is `200` and `POST` is `405`.
- `pub_registry::publish_protocol_tests::test_upload_returns_204_with_location` —
  drives the multipart upload and asserts `204 No Content`, then finalize `200`.
- `maven::maven_prefix_reserved_tests::test_hosted_serves_stored_maven_checksum_sidecar`
  — hosted repos still serve a stored sidecar from the `maven/` prefix.
- `maven::maven_prefix_reserved_tests::test_remote_checksum_probe_leaves_maven_prefix_untouched`
  — a remote proxy checksum probe returns non-200 and creates nothing under
  `maven/`.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validated on an isolated worker-pool instance:
- `dart pub publish` handshake: `GET` new → `200`; old `POST` → `405`; multipart
  upload → `204` + `Location: .../newUploadFinish`; finalize → `200` success;
  package resolvable afterward.
- Maven remote proxy of `commons-io:2.11.0` (pom, jar, both `.sha1`,
  `maven-metadata.xml` + `.sha1`): all `200`; storage contained only
  `proxy-cache/maven-central/...` with **no `maven/` directory**.
- Full lib suite green (11940 passed); fmt/clippy clean; new-code coverage 93%
  (maven) / 97% (pub_registry); jscpd 0%.

## API Changes
- [x] N/A - no API changes

Behavioural fixes only; no new endpoints, schemas, or migrations. The Pub
routes already existed — only the HTTP method and status code changed to match
the published protocol.
