### PR TITLE
fix(maven): repair lib-test compile against post-#2100 signatures

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -4197,6 +4197,7 @@ mod tests {
             &["3.0.0".to_string()],
             "3.0.0",
             Some("3.0.0"),
+            "20240101000000",
         );
         let mock = MockServer::start().await;
         Mock::given(method("GET"))
@@ -4253,6 +4254,7 @@ mod tests {
             State(state.clone()),
             Extension(Some(auth.clone())),
             Path((virtual_key.clone(), meta_path.clone())),
+            HeaderMap::new(),
         )
         .await
         .expect("virtual metadata download must succeed");


### PR DESCRIPTION
## Summary

Hotfix for the main lib-test compile break (`E0061`) tracked in #2140.

A parallel-merge interaction left two stale test call sites in
`backend/src/api/handlers/maven.rs`:

- #2100 added a `last_updated: &str` argument to
  `formats::maven::generate_metadata_xml` and updated every real call site
  (see the handlers at `maven.rs:1094` and `maven.rs:1261`).
- #2100 also added a `HeaderMap` parameter to the maven `download` handler.
- #2074 merged afterward carrying test code that still called the pre-#2100
  signatures, so `cargo build --lib --tests` (Check Rust + Backend Unit
  Tests) failed on main and on every open PR.

This change updates only the two lagging `#[cfg(test)]` call sites to the
current signatures — no production code changes, no behavior changes:

- `generate_metadata_xml(...)` in the `cov2069merge` test now passes a
  `last_updated` value (`"20240101000000"`), matching the constant already
  used by the sibling tests in this module and the format the real handlers
  emit.
- `download(...)` in the virtual-metadata merge test now passes
  `HeaderMap::new()`, matching the other `download` call sites in the same
  test module.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

The repaired tests are themselves the regression guard: they exercise the
current `generate_metadata_xml` / `download` signatures, so any future
signature drift breaks the build again. With this change the lib-test target
compiles clean and the full workspace lib suite passes.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2140
