### PR TITLE
fix: replicate Maven package metadata to peers

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1220,6 +1220,16 @@ async fn fetch_maven_metadata_bytes(
         }
     }
 
+    if let Some((group_id, artifact_id, version)) = parse_snapshot_metadata_path(path) {
+        let entries =
+            collect_snapshot_entries(&state.db, repo.id, &group_id, &artifact_id, &version).await;
+        if let Some(xml) =
+            generate_snapshot_metadata_xml(&group_id, &artifact_id, &version, &entries)
+        {
+            return Ok(Bytes::from(xml));
+        }
+    }
+
     Err(AppError::NotFound("Metadata not found".to_string()).into_response())
 }
 
@@ -3090,6 +3100,70 @@ mod tests {
         let xml = r#"<metadata><groupId>g</groupId><artifactId>a</artifactId></metadata>"#;
         let parsed = parse_snapshot_versions_xml(xml);
         assert!(parsed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_hosted_snapshot_metadata_generated_from_replicated_timestamped_rows() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let Some(fx) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        let router = fx.router_with_auth(super::router());
+        let base = "org/example/ak/maven/ak-snapshot/1.0-SNAPSHOT";
+        let timestamped = "1.0-20260702.120000-1";
+        let uploads = [
+            (
+                format!("{base}/ak-snapshot-{timestamped}.jar"),
+                bytes::Bytes::from_static(b"snapshot jar bytes"),
+            ),
+            (
+                format!("{base}/ak-snapshot-{timestamped}.pom"),
+                bytes::Bytes::from_static(
+                    br#"<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example.ak.maven</groupId>
+  <artifactId>ak-snapshot</artifactId>
+  <version>1.0-SNAPSHOT</version>
+</project>"#,
+                ),
+            ),
+        ];
+
+        for (path, body) in uploads {
+            let (status, response_body) = tdh::send(
+                router.clone(),
+                tdh::put(format!("/{}/{}", fx.repo_key, path), body),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::CREATED,
+                "Maven PUT must create {path}; body={}",
+                String::from_utf8_lossy(&response_body)
+            );
+        }
+
+        let metadata_path = format!("/{}/{}/maven-metadata.xml", fx.repo_key, base);
+        let (status, body) = tdh::send(router, tdh::get(metadata_path.clone())).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "hosted target peer must synthesize SNAPSHOT metadata from replicated timestamped rows; body={}",
+            String::from_utf8_lossy(&body)
+        );
+        let xml = String::from_utf8(body.to_vec()).expect("metadata is utf-8");
+        assert!(xml.contains("<groupId>org.example.ak.maven</groupId>"));
+        assert!(xml.contains("<artifactId>ak-snapshot</artifactId>"));
+        assert!(xml.contains("<version>1.0-SNAPSHOT</version>"));
+        assert!(xml.contains("<extension>jar</extension>"));
+        assert!(xml.contains("<extension>pom</extension>"));
+        assert!(xml.contains("<value>1.0-20260702.120000-1</value>"));
     }
 
     // ── DB-backed HTTP-level regression tests (no_op without DATABASE_URL) ──

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -701,7 +701,7 @@ async fn complete(
         PackageService::new(state.db.clone())
             .try_create_or_update_from_artifact(
                 session.repository_id,
-                package_name,
+                &package_name,
                 package_version,
                 session.total_size,
                 &session.checksum_sha256,
@@ -947,21 +947,91 @@ fn completed_format_artifact_version(
     Some(format!("sha256-{}", suffix))
 }
 
+fn replicated_maven_artifact_metadata(
+    session: &upload_service::UploadSession,
+) -> Option<&serde_json::Value> {
+    match session.artifact_metadata_format.as_deref() {
+        Some(format) if format.eq_ignore_ascii_case("maven") => session.artifact_metadata.as_ref(),
+        _ => None,
+    }
+}
+
+fn maven_package_name_from_metadata(metadata: &serde_json::Value) -> Option<String> {
+    let group_id = metadata.get("groupId")?.as_str()?.trim();
+    let artifact_id = metadata.get("artifactId")?.as_str()?.trim();
+    if group_id.is_empty() || artifact_id.is_empty() {
+        return None;
+    }
+    Some(format!("{group_id}:{artifact_id}"))
+}
+
+fn replicated_maven_artifact_is_pom(session: &upload_service::UploadSession) -> bool {
+    let metadata_extension_is_pom = replicated_maven_artifact_metadata(session)
+        .and_then(|metadata| metadata.get("extension"))
+        .and_then(|extension| extension.as_str())
+        .map(|extension| extension.eq_ignore_ascii_case("pom"))
+        .unwrap_or(false);
+
+    metadata_extension_is_pom || session.artifact_path.ends_with(".pom")
+}
+
+fn maven_package_metadata_from_artifact_metadata(
+    session: &upload_service::UploadSession,
+) -> Option<serde_json::Value> {
+    if !replicated_maven_artifact_is_pom(session) {
+        return None;
+    }
+
+    let metadata = replicated_maven_artifact_metadata(session)?;
+    let group_id = metadata.get("groupId")?.as_str()?.trim();
+    let artifact_id = metadata.get("artifactId")?.as_str()?.trim();
+    if group_id.is_empty() || artifact_id.is_empty() {
+        return None;
+    }
+
+    let mut catalog = serde_json::json!({
+        "format": "maven",
+        "groupId": group_id,
+        "artifactId": artifact_id,
+    });
+
+    for key in ["name", "description", "url", "dependencies"] {
+        if let Some(value) = metadata.get(key) {
+            catalog[key] = value.clone();
+        }
+    }
+
+    Some(catalog)
+}
+
 fn completed_package_catalog_entry(
     session: &upload_service::UploadSession,
-) -> Option<(&str, &str)> {
+) -> Option<(String, &str)> {
     let version = completed_artifact_version(session)?;
-    Some((completed_artifact_name(session), version))
+    let name = replicated_maven_artifact_metadata(session)
+        .and_then(maven_package_name_from_metadata)
+        .unwrap_or_else(|| completed_artifact_name(session).to_string());
+    Some((name, version))
 }
 
 fn completed_package_description(session: &upload_service::UploadSession) -> Option<&str> {
-    session.package_description.as_deref()
+    session.package_description.as_deref().or_else(|| {
+        if !replicated_maven_artifact_is_pom(session) {
+            return None;
+        }
+        replicated_maven_artifact_metadata(session)?
+            .get("description")?
+            .as_str()
+    })
 }
 
 fn completed_package_metadata(
     session: &upload_service::UploadSession,
 ) -> Option<serde_json::Value> {
-    session.package_metadata.clone()
+    session
+        .package_metadata
+        .clone()
+        .or_else(|| maven_package_metadata_from_artifact_metadata(session))
 }
 
 async fn cleanup_completed_upload_session(db: &sqlx::PgPool, session_id: Uuid) {
@@ -1346,8 +1416,68 @@ mod tests {
 
         assert_eq!(
             completed_package_catalog_entry(&session),
-            Some(("large-check", "20260603T082854Z"))
+            Some(("large-check".to_string(), "20260603T082854Z"))
         );
+    }
+
+    #[test]
+    fn test_completed_package_catalog_entry_uses_replicated_maven_metadata() {
+        let mut session = test_upload_session(
+            "org/example/ak/maven/ak-core/1.0.0/ak-core-1.0.0.pom",
+            Some("ak-core"),
+            Some("1.0.0"),
+        );
+        session.artifact_metadata_format = Some("maven".to_string());
+        session.artifact_metadata = Some(serde_json::json!({
+            "format": "maven",
+            "groupId": "org.example.ak.maven",
+            "artifactId": "ak-core",
+            "version": "1.0.0",
+            "extension": "pom",
+            "description": "Replicated Maven package",
+            "dependencies": [
+                {"groupId": "com.example", "artifactId": "dep", "version": "2.0.0"}
+            ]
+        }));
+
+        assert_eq!(
+            completed_package_catalog_entry(&session),
+            Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
+        );
+        assert_eq!(
+            completed_package_description(&session),
+            Some("Replicated Maven package")
+        );
+        let metadata = completed_package_metadata(&session).expect("maven package metadata");
+        assert_eq!(metadata["format"], "maven");
+        assert_eq!(metadata["groupId"], "org.example.ak.maven");
+        assert_eq!(metadata["artifactId"], "ak-core");
+        assert_eq!(metadata["description"], "Replicated Maven package");
+        assert_eq!(metadata["dependencies"][0]["artifactId"], "dep");
+    }
+
+    #[test]
+    fn test_completed_package_metadata_does_not_synthesize_for_replicated_maven_jar() {
+        let mut session = test_upload_session(
+            "org/example/ak/maven/ak-core/1.0.0/ak-core-1.0.0.jar",
+            Some("ak-core"),
+            Some("1.0.0"),
+        );
+        session.artifact_metadata_format = Some("maven".to_string());
+        session.artifact_metadata = Some(serde_json::json!({
+            "format": "maven",
+            "groupId": "org.example.ak.maven",
+            "artifactId": "ak-core",
+            "version": "1.0.0",
+            "extension": "jar"
+        }));
+
+        assert_eq!(
+            completed_package_catalog_entry(&session),
+            Some(("org.example.ak.maven:ak-core".to_string(), "1.0.0"))
+        );
+        assert_eq!(completed_package_description(&session), None);
+        assert_eq!(completed_package_metadata(&session), None);
     }
 
     #[test]
@@ -2541,6 +2671,71 @@ mod tests {
         (sessions, chunks)
     }
 
+    fn sha256_hex(payload: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(payload);
+        hex::encode(hasher.finalize())
+    }
+
+    async fn complete_replication_upload(
+        f: &tdh::Fixture,
+        create_body: serde_json::Value,
+        payload: &[u8],
+    ) -> Uuid {
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let create_req = create_replication_session_req(&create_body);
+        let (status, body) = tdh::send(app, create_req).await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "create_session must preserve replication metadata; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let create_resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let session_id: Uuid =
+            serde_json::from_value(create_resp["session_id"].clone()).expect("session_id");
+
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri(format!("/{}", session_id))
+            .header(
+                "content-range",
+                format!("bytes 0-{}/{}", payload.len() - 1, payload.len()),
+            )
+            .header("content-type", "application/octet-stream")
+            .body(axum::body::Body::from(payload.to_vec()))
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "chunk PATCH must succeed; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let req = axum::http::Request::builder()
+            .method("PUT")
+            .uri(format!("/{}/complete", session_id))
+            .header("x-artifact-keeper-replication", "true")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "complete must succeed; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        session_id
+    }
+
     #[tokio::test]
     async fn create_replication_session_removes_stale_replication_session_for_same_path() {
         let Some(f) = tdh::Fixture::setup("local", "generic").await else {
@@ -2877,81 +3072,35 @@ mod tests {
         };
 
         let payload: &[u8] = b"replicated-debian-package-bytes";
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(payload);
-        let checksum = hex::encode(hasher.finalize());
+        let checksum = sha256_hex(payload);
 
         let artifact_path = "pool/main/a/app/app_1_amd64.deb";
-        let auth = tdh::make_auth(f.user_id, &f.username);
-        let app = upload_router_with_auth(f.state.clone(), auth);
-        let create_req = create_replication_session_req(&serde_json::json!({
-            "repository_key": f.repo_key,
-            "artifact_path": artifact_path,
-            "artifact_name": "app",
-            "artifact_version": "1",
-            "artifact_metadata_format": "debian",
-            "artifact_metadata": {
-                "format": "debian",
-                "architecture": "amd64",
-                "component": "main"
-            },
-            "artifact_metadata_properties": {"source": "lux"},
-            "package_description": "replicated Debian package",
-            "package_metadata": {
-                "format": "debian",
-                "component": "main"
-            },
-            "total_size": payload.len() as i64,
-            "checksum_sha256": checksum,
-            "chunk_size": 1024 * 1024_i64,
-        }));
-        let (status, body) = tdh::send(app, create_req).await;
-        assert_eq!(
-            status,
-            StatusCode::CREATED,
-            "create_session must preserve replication metadata; body: {}",
-            String::from_utf8_lossy(&body)
-        );
-        let create_resp: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let session_id: Uuid =
-            serde_json::from_value(create_resp["session_id"].clone()).expect("session_id");
-
-        let auth = tdh::make_auth(f.user_id, &f.username);
-        let app = upload_router_with_auth(f.state.clone(), auth);
-        let req = axum::http::Request::builder()
-            .method("PATCH")
-            .uri(format!("/{}", session_id))
-            .header(
-                "content-range",
-                format!("bytes 0-{}/{}", payload.len() - 1, payload.len()),
-            )
-            .header("content-type", "application/octet-stream")
-            .body(axum::body::Body::from(payload.to_vec()))
-            .unwrap();
-        let (status, body) = tdh::send(app, req).await;
-        assert_eq!(
-            status,
-            StatusCode::OK,
-            "chunk PATCH must succeed; body: {}",
-            String::from_utf8_lossy(&body)
-        );
-
-        let auth = tdh::make_auth(f.user_id, &f.username);
-        let app = upload_router_with_auth(f.state.clone(), auth);
-        let req = axum::http::Request::builder()
-            .method("PUT")
-            .uri(format!("/{}/complete", session_id))
-            .header("x-artifact-keeper-replication", "true")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        let (status, body) = tdh::send(app, req).await;
-        assert_eq!(
-            status,
-            StatusCode::OK,
-            "complete must succeed; body: {}",
-            String::from_utf8_lossy(&body)
-        );
+        let session_id = complete_replication_upload(
+            &f,
+            serde_json::json!({
+                "repository_key": f.repo_key,
+                "artifact_path": artifact_path,
+                "artifact_name": "app",
+                "artifact_version": "1",
+                "artifact_metadata_format": "debian",
+                "artifact_metadata": {
+                    "format": "debian",
+                    "architecture": "amd64",
+                    "component": "main"
+                },
+                "artifact_metadata_properties": {"source": "lux"},
+                "package_description": "replicated Debian package",
+                "package_metadata": {
+                    "format": "debian",
+                    "component": "main"
+                },
+                "total_size": payload.len() as i64,
+                "checksum_sha256": checksum,
+                "chunk_size": 1024 * 1024_i64,
+            }),
+            payload,
+        )
+        .await;
         assert_eq!(
             upload_session_row_counts(&f.pool, session_id).await,
             (0, 0),
@@ -2988,6 +3137,84 @@ mod tests {
         assert_eq!(pkg.0, "1");
         assert_eq!(pkg.1.as_deref(), Some("replicated Debian package"));
         assert_eq!(pkg.2.expect("package metadata")["component"], "main");
+
+        let _ = sqlx::query("DELETE FROM upload_chunks WHERE session_id = $1")
+            .bind(session_id)
+            .execute(&f.pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM upload_sessions WHERE id = $1")
+            .bind(session_id)
+            .execute(&f.pool)
+            .await;
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn complete_materializes_maven_replication_package_catalog_from_metadata() {
+        let Some(f) = tdh::Fixture::setup("local", "maven").await else {
+            return;
+        };
+
+        let payload: &[u8] = br#"<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.example.ak.maven</groupId>
+  <artifactId>ak-core</artifactId>
+  <version>1.0.0</version>
+  <description>Replicated Maven package</description>
+</project>"#;
+        let checksum = sha256_hex(payload);
+
+        let artifact_path = "org/example/ak/maven/ak-core/1.0.0/ak-core-1.0.0.pom";
+        let session_id = complete_replication_upload(
+            &f,
+            serde_json::json!({
+                "repository_key": f.repo_key,
+                "artifact_path": artifact_path,
+                "artifact_name": "ak-core",
+                "artifact_version": "1.0.0",
+                "artifact_metadata_format": "maven",
+                "artifact_metadata": {
+                    "format": "maven",
+                    "groupId": "org.example.ak.maven",
+                    "artifactId": "ak-core",
+                    "version": "1.0.0",
+                    "extension": "pom",
+                    "description": "Replicated Maven package"
+                },
+                "total_size": payload.len() as i64,
+                "checksum_sha256": checksum,
+                "chunk_size": 1024 * 1024_i64,
+                "content_type": "text/xml",
+            }),
+            payload,
+        )
+        .await;
+
+        let artifact: (String, String) = sqlx::query_as(
+            "SELECT name, version FROM artifacts WHERE repository_id = $1 AND path = $2",
+        )
+        .bind(f.repo_id)
+        .bind(artifact_path)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query replicated Maven artifact");
+        assert_eq!(artifact.0, "ak-core");
+        assert_eq!(artifact.1, "1.0.0");
+
+        let package: (String, String, Option<String>, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT name, version, description, metadata FROM packages WHERE repository_id = $1",
+        )
+        .bind(f.repo_id)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query replicated Maven package catalog");
+        assert_eq!(package.0, "org.example.ak.maven:ak-core");
+        assert_eq!(package.1, "1.0.0");
+        assert_eq!(package.2.as_deref(), Some("Replicated Maven package"));
+        let metadata = package.3.expect("Maven package metadata");
+        assert_eq!(metadata["format"], "maven");
+        assert_eq!(metadata["groupId"], "org.example.ak.maven");
+        assert_eq!(metadata["artifactId"], "ak-core");
 
         let _ = sqlx::query("DELETE FROM upload_chunks WHERE session_id = $1")
             .bind(session_id)


### PR DESCRIPTION
## Summary

Fixes #2152

Hosted Maven artifacts could be replicated to a peer with their artifact rows and Maven `artifact_metadata`, but the receiving peer did not materialize an equivalent Maven package catalog. Replicated Maven packages were keyed by the plain `artifactId` instead of the canonical `groupId:artifactId`, and POM-derived package metadata was lost on the target peer.

This PR teaches the replicated chunked upload completion path to use Maven `artifact_metadata` when completing incoming Maven replication writes. The target peer now builds package catalog rows with canonical Maven package names and preserves Maven package metadata from replicated POM metadata. Jar-only replicated artifacts still avoid synthesizing package metadata so they do not overwrite richer POM-derived metadata if replication order varies.

The PR also fixes a related hosted Maven SNAPSHOT replication issue: if a peer has received timestamped SNAPSHOT jar/pom artifact rows but does not have an explicit stored version-level `maven-metadata.xml` asset, the hosted Maven handler can now synthesize equivalent SNAPSHOT metadata from those timestamped rows.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

Added/updated coverage includes:

- replicated Maven upload completion derives the package catalog name from Maven `artifact_metadata` as `groupId:artifactId`
- replicated Maven POM metadata is preserved in package catalog metadata
- replicated Maven jar metadata does not synthesize package metadata that could overwrite richer POM-derived metadata
- completing an incoming replicated Maven upload materializes the expected artifact and package catalog rows
- hosted Maven SNAPSHOT version metadata can be generated from replicated timestamped jar/pom artifact rows when the explicit metadata asset is absent

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [ ] No regressions in existing tests

Validation performed for this branch:

```text
git diff --check
cargo fmt --check
cargo test --workspace --lib test_completed_package_catalog_entry_uses_replicated_maven_metadata
cargo test --workspace --lib test_completed_package_metadata_does_not_synthesize_for_replicated_maven_jar
cargo test --workspace --lib complete_materializes_maven_replication_package_catalog_from_metadata
cargo test --workspace --lib test_hosted_snapshot_metadata_generated_from_replicated_timestamped_rows
```

Manual/live HA validation was run against two Artifact Keeper peers using hosted Maven repositories:

- checksum-negative smoke uploads were rejected in both directions
- single-coordinate Maven replication succeeded in both directions
- a large chunked Maven artifact was interrupted mid-transfer on the target peer after the first successful chunk, then recovered after a 20-minute outage
- uploads continued to the source peer while the target peer was down, including raw Maven uploads, Maven `deploy-file`, Maven reactor deploy, and Gradle `maven-publish`
- after recovery and replication settle, direct artifact verification passed on both peers: 64/64 checked, 0 failures
- Maven metadata verification passed: 21 checked, 0 failures
- package API verification passed: 22 checked, 0 failures
- PostgreSQL verification found no missing rows and no open upload sessions
- Maven/Gradle resolver matrix passed from both peers with no external repository hits

The live HA validation used an S3-compatible storage deployment. This patch does not change storage backend code; the changes are in Maven metadata/package-catalog handling and shared upload completion for incoming replication writes.

The Maven negative-input validation phase exposed separate pre-existing Maven validation gaps around checksum sidecars and malformed POM/GAV handling. Those are not peer-replication failures and are intentionally left for a follow-up fix.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No endpoints, request/response schemas, or migrations are added by this PR

### CI note

The current failing check is `Security Audit`, caused by `quick-xml`
(`RUSTSEC-2026-0194` and `RUSTSEC-2026-0195`; fixed in `quick-xml >=0.41.0`).

I checked the normal dependency-bump path and did not add an audit ignore.
The direct `quick-xml` dependency can be bumped, but the remaining transitive
copy comes through `object_store`. The latest published `object_store` release
on crates.io is `0.14.0`, and it still constrains `quick-xml` to `^0.40.1`, so
Cargo cannot resolve it to `0.41.0`. Apache `object_store` has already bumped
that dependency on `main`, but that change has not been released yet.

I left this PR focused on the Maven peer-replication fix rather than adding a
temporary git dependency, crates.io patch, or audit ignore.