### PR TITLE
fix(deps): clear cargo-audit advisories (crossbeam-epoch RUSTSEC-2026-0204, crypto-bigint yank)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1607,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a0d26b245348befa0c121944541476763dcc46ede886c88f9d12e1697d27c3"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
@@ -3396,7 +3396,7 @@ dependencies = [
  "aes-gcm",
  "aes-kw",
  "cbc",
- "crypto-bigint 0.7.3",
+ "crypto-bigint 0.7.5",
  "cryptoki",
  "des",
  "digest 0.10.7",


### PR DESCRIPTION
## Summary

Lock-only dependency bumps to clear the error-level `cargo audit` advisory that
is failing the required **Security Audit** job and, through it, the `CI Complete`
gate on `main` — blocking the merge queue.

- **crossbeam-epoch 0.9.18 -> 0.9.20** — `RUSTSEC-2026-0204` (invalid pointer
  dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` when the underlying
  pointer is invalid). Solution per the advisory is `>= 0.9.20`. Transitive
  dependency; bumped via `cargo update -p crossbeam-epoch --precise 0.9.20`, no
  manifest change required. This is the single **error-level** advisory currently
  failing the gate.
- **crypto-bigint 0.7.3 -> 0.7.5** — `RUSTSEC-2026-0186` / yanked (`0.7.0`-`0.7.4`
  are all yanked on crates.io; `0.7.5` is the current non-yanked `0.7` release).
  Transitive via `kryptering`. Warning-level hygiene, carried over from the
  original scope of this PR.

`Cargo.lock` is the only file changed (5 lines). The `quick-xml`
(`RUSTSEC-2026-0194`/`0195`) transitive advisory referenced in earlier drafts is
already handled on `main` (direct `quick-xml` is `0.41`, and the object_store
transitive `0.39.x` instance is covered by the scoped ignores in
`.cargo/audit.toml`, tracked by #2158) — no action needed here.

## Verification

- `cargo audit` -> **0 error-level vulnerabilities** (only the pre-accepted
  allowed warnings: fxhash/paste unmaintained, anyhow/git2/memmap2 unsound).
  Before this PR `crossbeam-epoch 0.9.18` produced 1 error-level advisory.
- `cargo build --lib --workspace` -> clean (a patch bump of transitive crates;
  no source or API impact).

## Regression test (required for `fix/*` PRs)
- [x] N/A — dependency-lockfile hygiene bump; the "regression test" for a
      cargo-audit advisory is the `cargo audit` gate itself, which now passes.

## Test Checklist
- [x] Manually tested locally (`cargo audit` = 0 vulns; `cargo build --lib --workspace` OK)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2156
Closes #2266
