### PR TITLE
fix(deps): bump quick-xml to 0.41 for XML-parser DoS hardening

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -26,4 +26,20 @@ ignore = [
     # rand::rng(), so the unsound code path is unreachable from artifact-keeper.
     # Re-evaluate once upstream deps bump their rand pins.
     "RUSTSEC-2026-0097",
+
+    # quick-xml XML-parser DoS batch (RUSTSEC-2026-0194: O(N^2) start-tag
+    # duplicate-attribute check; RUSTSEC-2026-0195: unbounded NsReader
+    # namespace-declaration allocation; both fixed in quick-xml >= 0.41.0).
+    # Our DIRECT quick-xml dependency is now 0.41.0, which patches every
+    # attacker-reachable parse path (SAML response parsing, proxied
+    # maven-metadata/nuget, rpm, and artifactory import). The ONLY remaining
+    # 0.39.x instance is bundled transitively by object_store 0.13.2, which we
+    # use solely to parse trusted operator-configured storage responses
+    # (S3/GCS/Azure ListBucket, multipart, and delete XML) -- never attacker
+    # input. No published object_store release depends on quick-xml >= 0.41 yet
+    # (0.13.2 and 0.14.0 both cap at ^0.39/^0.40.1), so it cannot be upgraded
+    # out today. Removal of the object_store-transitive 0.39.x is tracked in
+    # issue #2158.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,7 +234,7 @@ dependencies = [
  "pgp",
  "prost",
  "prost-types",
- "quick-xml",
+ "quick-xml 0.41.0",
  "rand 0.8.5",
  "rand 0.9.2",
  "regex",
@@ -4111,7 +4111,7 @@ dependencies = [
  "md-5",
  "parking_lot",
  "percent-encoding",
- "quick-xml",
+ "quick-xml 0.39.2",
  "rand 0.10.0",
  "reqwest 0.12.28",
  "ring",
@@ -4844,6 +4844,16 @@ name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -111,7 +111,7 @@ rand08 = { package = "rand", version = "0.8" }
 pgp = "0.14.2"
 
 # Format parsing
-quick-xml = { version = "0.39", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 flate2 = "1.0"
 tar = "0.4"
 xz2 = "0.1"

--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -1438,6 +1438,48 @@ mod tests {
         assert!(response.status_code.ends_with(":Success"));
     }
 
+    /// Regression guard for RUSTSEC-2026-0194: quick-xml 0.39's start-tag
+    /// duplicate-attribute check compared every attribute against all previous
+    /// ones (O(N^2)), so a SAML `<Response>` carrying thousands of attributes
+    /// could pin a CPU core (HIGH DoS). quick-xml >= 0.41 makes this check
+    /// linear. Each attribute below has a unique name so the full duplicate
+    /// scan runs (unique names never short-circuit on a duplicate error),
+    /// exercising exactly the quadratic path. We assert the parse completes
+    /// well within a generous bound rather than hanging; on the fixed parser
+    /// it returns near-instantly.
+    #[tokio::test]
+    async fn test_parse_saml_response_many_attributes_is_bounded() {
+        use std::time::{Duration, Instant};
+
+        let service = make_test_saml_service();
+
+        let attrs = (0..8000)
+            .map(|i| format!("a{i}=\"x\""))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_response123" {attrs}>
+    <saml:Issuer>https://idp.example.com</saml:Issuer>
+</samlp:Response>"#
+        );
+
+        let start = Instant::now();
+        // We only care that parsing terminates promptly; the concrete result is
+        // covered by the other parser tests.
+        let _ = service.parse_saml_response(&xml);
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "parse_saml_response took {elapsed:?} for an attribute-heavy SAML \
+             response; the O(N^2) quick-xml duplicate-attribute DoS \
+             (RUSTSEC-2026-0194) may have regressed"
+        );
+    }
+
     #[tokio::test]
     async fn test_parse_saml_response_assertion_fields() {
         let service = make_test_saml_service();


### PR DESCRIPTION
## Summary

Bumps the direct `quick-xml` dependency from `0.39` to `0.41` for upstream
XML-parser hardening, and adds a scoped, justified `cargo audit` ignore for the
single remaining `0.39.x` instance that is pulled in transitively by
`object_store`.

Two advisories flag `quick-xml < 0.41.0` as a DoS risk:

- **RUSTSEC-2026-0194** — O(N²) CPU in the start-tag duplicate-attribute check.
- **RUSTSEC-2026-0195** — unbounded `NsReader` namespace-declaration allocation.

The `Security Audit` CI gate (`cargo audit`) was failing main-wide on these, which
blocks the v1.2.5 cascade.

### What changed

- `backend/Cargo.toml`: `quick-xml` `0.39` → `0.41` (features unchanged:
  `["serialize"]`).
- `Cargo.lock`: regenerated with the minimum necessary change. The direct
  dependency and every attacker-reachable consumer now resolve to `quick-xml
  0.41.0`. `object_store 0.13.2` is left untouched and keeps its own
  transitive `quick-xml 0.39.2` (it requires `^0.39.0`, so it cannot resolve to
  `0.41`). Verified via `cargo tree -i`:
  - `quick-xml 0.41.0` → `artifact-keeper-backend`
  - `quick-xml 0.39.2` → **only** `object_store 0.13.2` → `artifact-keeper-backend`
- `.cargo/audit.toml`: add a justified `[advisories].ignore` for
  `RUSTSEC-2026-0194` / `RUSTSEC-2026-0195`, scoped to the object_store-transitive
  instance. Our direct parser (which handles all attacker-reachable XML — SAML
  responses, proxied maven-metadata / nuget, rpm, and artifactory import) is now
  on the patched `0.41.0`. The only remaining `0.39.x` is inside `object_store`,
  which parses solely trusted operator-configured storage responses
  (S3/GCS/Azure `ListBucket`, multipart, delete XML), never attacker input. No
  published `object_store` release depends on `quick-xml >= 0.41` yet, so it
  cannot be upgraded out today; removal is tracked in **#2158**.

The upgrade is behavior-preserving: the five consumers use only the stable
`Reader`/event API, the `escape::unescape` free function, and serde
`de::from_str` / `se::to_string` — no `NsReader`, `read_text`, or
`Attribute::unescape_value`. All existing SAML/maven/nuget/rpm/artifactory-import
parser tests pass unchanged, confirming SAML response-validation semantics are
intact.

Closes #2159

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit test `saml_service::tests::test_parse_saml_response_many_attributes_is_bounded`
parses a SAML `<Response>` carrying several thousand attributes and asserts the
parse completes within a bounded time. On the pre-fix O(N²) parser this path
degrades sharply; on `0.41` it is linear and returns near-instantly.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local validation:
- `cargo tree -i quick-xml` — `0.41.0` for the direct/attacker-reachable deps;
  `0.39.2` only under `object_store 0.13.2`.
- `cargo audit` — exits `0` (quick-xml advisories now scoped-ignored).
- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- SAML (8) / maven (38) / nuget (38) / rpm (38) / artifactory-import (58) parser
  tests — all pass unchanged.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
