### PR TITLE
chore(release): bump backend version 1.2.4 -> 1.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.4"
+version = "1.2.5"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.4"
+version = "1.2.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.2.4",
+        version = "1.2.5",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
## Summary
Bumps the backend version `1.2.4` -> `1.2.5` for the v1.2.5 patch release. Touches every known backend version spot (these are known to drift):

- **`Cargo.toml`** (`[workspace.package]` version) — `1.2.4` -> `1.2.5`. Backend crates inherit via `version.workspace = true`, so `env!("CARGO_PKG_VERSION")` (used by `/health`, telemetry, SBOM, ansible endpoints) now reports `1.2.5`.
- **`backend/src/api/openapi.rs`** — hardcoded OpenAPI `version = "1.2.4"` -> `"1.2.5"`. This is the decoupled spot that otherwise causes a stale UI/swagger version.
- **`Cargo.lock`** — regenerated via `cargo update -w`; only the workspace member `artifact-keeper-backend` moves `1.2.4` -> `1.2.5`, no dependency versions changed.

Closes #2164

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation performed locally:
- `grep -rn "1\.2\.4" --include=*.rs --include=*.toml backend/ Cargo.toml` — no stale backend-version hits (remaining matches are unrelated scanner/semver test fixtures).
- `cargo build --workspace` — clean.
- `cargo fmt --check` — clean.

## API Changes
- [x] N/A - no API changes (version string only; OpenAPI `info.version` bumped to match)
