### PR TITLE
ci: add streaming-invariant enforcement gate (Phase 1 of #1608)

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,2 +1,17 @@
 # Clippy configuration
 msrv = "1.75.0"
+
+# Streaming-invariant enforcement gate — Part of #1608 (Core Invariant ①).
+#
+# Artifact-path handlers must never read a full artifact body into memory. These
+# calls buffer an entire HTTP/multipart body on the heap, which is exactly the
+# ad-hoc full-buffering pattern that produced the 16 memory/OOM issues tracked
+# under #1607. Forbid new call sites via clippy; every CURRENT legitimate site is
+# annotated `#[allow(clippy::disallowed_methods)] // STREAMING-EXEMPT: <reason>`
+# and enumerated in backend/tests/streaming_invariant.rs. As later phases convert
+# a site to streaming, its annotation (and allowlist entry) is removed.
+disallowed-methods = [
+    { path = "reqwest::Response::bytes", reason = "STREAMING: buffers the whole upstream body in memory; use .bytes_stream()/streaming copy or a capped read; see #1608" },
+    { path = "axum::extract::multipart::Field::bytes", reason = "STREAMING: buffers the whole multipart field in memory; use .chunk() with an incremental hash / put_stream; see #1608" },
+    { path = "axum::body::to_bytes", reason = "STREAMING: buffers the whole request/response body in memory; pass a bounded limit and prefer streaming; see #1608" },
+]

--- a/backend/src/api/extractors.rs
+++ b/backend/src/api/extractors.rs
@@ -225,8 +225,9 @@ pub fn request_base_url_from_request(headers: &HeaderMap, uri: Option<&Uri>) -> 
     }
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::{

--- a/backend/src/api/extractors.rs
+++ b/backend/src/api/extractors.rs
@@ -226,6 +226,7 @@ pub fn request_base_url_from_request(headers: &HeaderMap, uri: Option<&Uri>) -> 
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::{

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -397,6 +397,7 @@ async fn download_collection(
 // POST /ansible/{repo_key}/api/v3/artifacts/collections/ — Upload collection (multipart)
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_collection(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -430,6 +431,7 @@ async fn upload_collection(
         if field_name == "file" {
             file_name = field.file_name().map(|s| s.to_string());
             tarball = Some(field.bytes().await.map_err(|e| {
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 (
                     StatusCode::BAD_REQUEST,
                     format!("Failed to read file: {}", e),
@@ -445,6 +447,8 @@ async fn upload_collection(
                     .into_response()
             })?);
         } else if field_name == "collection" || field_name == "metadata" {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
             let data = field.bytes().await.map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -824,8 +824,9 @@ pub async fn create_download_ticket(
 )]
 pub struct AuthApiDoc;
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::header::{COOKIE, SET_COOKIE};

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -825,6 +825,7 @@ pub async fn create_download_ticket(
 pub struct AuthApiDoc;
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::header::{COOKIE, SET_COOKIE};

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -373,6 +373,7 @@ async fn download_cookbook(
 // POST /chef/{repo_key}/api/v1/cookbooks — Upload cookbook (multipart)
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_cookbook(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -396,6 +397,7 @@ async fn upload_cookbook(
         match field_name.as_str() {
             "tarball" => {
                 tarball = Some(field.bytes().await.map_err(|e| {
+                    // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                     (
                         StatusCode::BAD_REQUEST,
                         format!("Failed to read tarball: {}", e),
@@ -404,6 +406,8 @@ async fn upload_cookbook(
                 })?);
             }
             "cookbook" => {
+                #[allow(clippy::disallowed_methods)]
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 let data = field.bytes().await.map_err(|e| {
                     (
                         StatusCode::BAD_REQUEST,

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1113,8 +1113,9 @@ async fn upload(
         .unwrap())
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1114,6 +1114,7 @@ async fn upload(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -2466,6 +2466,7 @@ async fn package_file_upload(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 
@@ -4129,6 +4130,7 @@ mod tests {
     // All tests are DB-backed and no-op when `DATABASE_URL` is unreachable.
     // -----------------------------------------------------------------------
     #[cfg(test)]
+    #[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
     mod agent1_auth_search {
         use super::test_helpers::*;
         use axum::body::{to_bytes, Body};

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -2465,8 +2465,9 @@ async fn package_file_upload(
         .unwrap())
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 
@@ -4129,8 +4130,9 @@ mod tests {
     //
     // All tests are DB-backed and no-op when `DATABASE_URL` is unreachable.
     // -----------------------------------------------------------------------
+    #[allow(clippy::disallowed_methods)]
+    // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
     #[cfg(test)]
-    #[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
     mod agent1_auth_search {
         use super::test_helpers::*;
         use axum::body::{to_bytes, Body};

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -291,6 +291,8 @@ async fn proxy_sumdb(host: &str, path: &str) -> Result<Response, Response> {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("application/octet-stream")
         .to_string();
+    #[allow(clippy::disallowed_methods)]
+    // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
     let body = upstream_resp.bytes().await.map_err(|e| {
         tracing::warn!("sumdb proxy response read failed for {}: {}", url, e);
         (

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -433,6 +433,7 @@ async fn download_chart(
 // POST /helm/{repo_key}/api/charts -- Upload chart (ChartMuseum-compatible)
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_chart(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -457,6 +458,7 @@ async fn upload_chart(
         let name = field.name().unwrap_or("").to_string();
         if name == "chart" {
             chart_content = Some(field.bytes().await.map_err(|e| {
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 (StatusCode::BAD_REQUEST, format!("Invalid file: {}", e)).into_response()
             })?);
         }

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -998,8 +998,9 @@ fn extract_erlang_term_value(content: &str, key: &str) -> Option<String> {
     None
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -999,6 +999,7 @@ fn extract_erlang_term_value(content: &str, key: &str) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -3282,6 +3282,7 @@ mod cross_repo_session_regression_tests {
 // ===========================================================================
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod streaming_pipeline_regression_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -3281,8 +3281,9 @@ mod cross_repo_session_regression_tests {
 // suite in this crate.
 // ===========================================================================
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod streaming_pipeline_regression_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2099,8 +2099,9 @@ async fn upload(
         .unwrap())
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2100,6 +2100,7 @@ async fn upload(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -293,6 +293,7 @@ pub mod wasm_proxy;
 pub mod webhooks;
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -292,8 +292,9 @@ pub mod vscode;
 pub mod wasm_proxy;
 pub mod webhooks;
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2220,8 +2220,9 @@ fn respond_with_packument(value: serde_json::Value, want_abbreviated: bool) -> R
     )
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -281,6 +281,7 @@ fn empty_audits_quick_response() -> Response {
 /// transport failure (timeout, DNS, TLS, etc.) the helper returns an empty
 /// well-formed response so the audit degrades gracefully instead of failing
 /// the client command. See issue #1400.
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
 async fn proxy_npm_audit_post(
     upstream_url: &str,
     path: &str,
@@ -305,6 +306,7 @@ async fn proxy_npm_audit_post(
                 .unwrap_or("application/json")
                 .to_string();
             match resp.bytes().await {
+                // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
                 Ok(bytes) => {
                     if !status.is_success() {
                         debug!(
@@ -353,6 +355,7 @@ async fn proxy_npm_audit_post(
 /// Returns the upstream status + body verbatim. On any transport error (DNS,
 /// TLS, timeout) returns `None` so the caller can fall through to the local
 /// fallback.
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
 async fn proxy_npm_meta_get(upstream_url: &str, meta_path: &str) -> Option<Response> {
     let base = upstream_url.trim_end_matches('/');
     // Reconstruct the `/-/<rest>` meta path. axum 0.7 wildcard captures do NOT
@@ -384,6 +387,7 @@ async fn proxy_npm_meta_get(upstream_url: &str, meta_path: &str) -> Option<Respo
         .to_string();
 
     match resp.bytes().await {
+        // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
         Ok(bytes) => Some(
             Response::builder()
                 .status(status)
@@ -993,6 +997,8 @@ async fn get_package_version_metadata(
             &serde_json::Map::new(),
             false,
         )?;
+        #[allow(clippy::disallowed_methods)]
+        // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
         let body_bytes = axum::body::to_bytes(resp.into_body(), 10 * 1024 * 1024)
             .await
             .map_err(|e| {
@@ -1076,6 +1082,8 @@ async fn fetch_virtual_packument(
                     &serde_json::Map::new(),
                     false,
                 )?;
+                #[allow(clippy::disallowed_methods)]
+                // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
                 let body_bytes = axum::body::to_bytes(resp.into_body(), 10 * 1024 * 1024)
                     .await
                     .map_err(|e| {
@@ -1925,6 +1933,8 @@ async fn dist_tags_get(
     if !resp.status().is_success() {
         return Ok(resp);
     }
+    #[allow(clippy::disallowed_methods)]
+    // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
     let body_bytes = axum::body::to_bytes(resp.into_body(), 32 * 1024 * 1024)
         .await
         .map_err(|e| {
@@ -2211,6 +2221,7 @@ fn respond_with_packument(value: serde_json::Value, want_abbreviated: bool) -> R
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -1184,6 +1184,7 @@ fn extract_xml_tag(xml: &str, tag: &str) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -1183,8 +1183,9 @@ fn extract_xml_tag(xml: &str, tag: &str) -> Option<String> {
     Some(content[..end_pos].trim().to_string())
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -644,11 +644,13 @@ async fn collect_request_body(body: Body, limit: usize) -> Result<Bytes, Respons
     collect_request_body_with_exact_limit(body, limit).await
 }
 
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
 async fn collect_request_body_with_exact_limit(
     body: Body,
     limit: usize,
 ) -> Result<Bytes, Response> {
     to_bytes(body, limit).await.map_err(|e| {
+        // STREAMING-EXEMPT: bounded body collector with explicit LengthLimitError guard (OCI large uploads use the chunked path); #1608
         if error_chain_contains::<http_body_util::LengthLimitError>(&e) {
             return oci_error(
                 StatusCode::BAD_REQUEST,
@@ -7466,6 +7468,7 @@ pub fn version_check_handler() -> axum::routing::MethodRouter<SharedState> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
@@ -11053,6 +11056,7 @@ mod token_claims_isactive_regression_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod blob_pull_streaming_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
@@ -11144,6 +11148,7 @@ mod blob_pull_streaming_tests {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod token_lockout_regression_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
@@ -12099,6 +12104,7 @@ mod manifest_digest_fallback_tests {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod manifest_digest_db_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
@@ -12610,6 +12616,7 @@ mod manifest_digest_db_tests {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod oci_blob_upload_streaming_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -7467,8 +7467,9 @@ pub fn version_check_handler() -> axum::routing::MethodRouter<SharedState> {
     get(version_check)
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
@@ -11055,8 +11056,9 @@ mod token_claims_isactive_regression_tests {
     }
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod blob_pull_streaming_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
@@ -11147,8 +11149,9 @@ mod blob_pull_streaming_tests {
 // after `authenticate` runs against a real user row.
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod token_lockout_regression_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
@@ -12103,8 +12106,9 @@ mod manifest_digest_fallback_tests {
 // report vacuous success; skips cleanly when no database is available locally.
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod manifest_digest_db_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
@@ -12615,8 +12619,9 @@ mod manifest_digest_db_tests {
 // vacuous success without exercising the DB-backed upload path.
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod oci_blob_upload_streaming_tests {
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;

--- a/backend/src/api/handlers/plugins.rs
+++ b/backend/src/api/handlers/plugins.rs
@@ -246,6 +246,8 @@ pub async fn install_plugin(
         let name = field.name().unwrap_or("").to_string();
 
         if name == "package" || name == "manifest" {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
             let data = field
                 .bytes()
                 .await
@@ -654,6 +656,7 @@ pub async fn install_from_git(
         (status = 400, description = "Missing or invalid ZIP file"),
     )
 )]
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 pub async fn install_from_zip(
     State(state): State<SharedState>,
     Extension(_auth): Extension<AuthExtension>,
@@ -670,6 +673,7 @@ pub async fn install_from_zip(
         let name = field.name().unwrap_or("").to_string();
         if name == "file" || name == "package" || name == "zip" {
             zip_data = Some(
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 field
                     .bytes()
                     .await

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3278,6 +3278,7 @@ pub async fn find_local_by_filename_suffix(
 /// `json_field_names` lists the form-field names to accept for the JSON
 /// payload (Ansible accepts both `collection` and `metadata`; Puppet uses
 /// `module`). The first matching field wins. Unknown fields are ignored.
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 pub async fn parse_multipart_file_with_json(
     mut multipart: axum::extract::Multipart,
     json_field_names: &[&str],
@@ -3293,6 +3294,7 @@ pub async fn parse_multipart_file_with_json(
         let field_name = field.name().unwrap_or("").to_string();
         if field_name == "file" {
             tarball = Some(field.bytes().await.map_err(|e| {
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 (
                     StatusCode::BAD_REQUEST,
                     format!("Failed to read file: {}", e),
@@ -3300,6 +3302,8 @@ pub async fn parse_multipart_file_with_json(
                     .into_response()
             })?);
         } else if json_field_names.iter().any(|n| *n == field_name) {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
             let data = field.bytes().await.map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,
@@ -3559,6 +3563,7 @@ pub(crate) fn build_remote_repo(id: Uuid, key: &str, upstream_url: &str) -> Repo
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::StatusCode;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3562,8 +3562,9 @@ pub(crate) fn build_remote_repo(id: Uuid, key: &str, upstream_url: &str) -> Repo
     }
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::StatusCode;

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -391,6 +391,7 @@ async fn new_upload_url(
 // POST /pub/{repo_key}/api/packages/versions/newUpload -- Upload package
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -410,6 +411,7 @@ async fn upload_package(
         let field_name = field.name().unwrap_or("").to_string();
         if field_name == "file" {
             file_bytes = Some(field.bytes().await.map_err(|e| {
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 (
                     StatusCode::BAD_REQUEST,
                     format!("Failed to read upload: {}", e),

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2421,8 +2421,9 @@ fn merge_local_into_remote_simple_json(
     serde_json::to_string(&doc).ok()
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1814,6 +1814,7 @@ fn extract_metadata_from_sdist(content: &[u8]) -> Option<String> {
 // POST /pypi/{repo_key}/ — Twine upload
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -1887,6 +1888,7 @@ async fn upload(
             "content" => {
                 file_name = field.file_name().map(|s| s.to_string());
                 file_content = Some(field.bytes().await.map_err(|e| {
+                    // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                     AppError::Validation(format!("Invalid file: {}", e)).into_response()
                 })?);
             }
@@ -2420,6 +2422,7 @@ fn merge_local_into_remote_simple_json(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/handlers/remote_instances.rs
+++ b/backend/src/api/handlers/remote_instances.rs
@@ -155,6 +155,8 @@ async fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
     let status = axum::http::StatusCode::from_u16(resp.status().as_u16())
         .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
     let content_type = resp.headers().get("content-type").cloned();
+    #[allow(clippy::disallowed_methods)]
+    // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
     let body = resp
         .bytes()
         .await

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3840,6 +3840,8 @@ async fn extract_multipart_file(mut multipart: Multipart) -> Result<(Bytes, Stri
         // Accept any field that has a filename (i.e. a file upload)
         let filename = field.file_name().map(|s| s.to_string());
         if let Some(filename) = filename {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
             let data: Bytes = field
                 .bytes()
                 .await
@@ -3875,6 +3877,8 @@ async fn extract_multipart_file_and_path(
         if let Some(filename) = filename {
             // File upload field
             if file.is_none() {
+                #[allow(clippy::disallowed_methods)]
+                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
                 let data: Bytes = field
                     .bytes()
                     .await
@@ -5409,6 +5413,7 @@ fn format_repo_type(repo_type: &RepositoryType) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use crate::error::AppError;

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -5412,8 +5412,9 @@ fn format_repo_type(repo_type: &RepositoryType) -> String {
     format!("{:?}", repo_type).to_lowercase()
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use crate::error::AppError;

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1222,6 +1222,7 @@ fn xml_escape(s: &str) -> String {
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::HeaderValue;

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1221,8 +1221,9 @@ fn xml_escape(s: &str) -> String {
 // Tests
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::HeaderValue;

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -12,6 +12,9 @@
 //!     let Some(pool) = tdh::try_pool().await else { return; };
 
 #![allow(dead_code)]
+// streaming-invariant: test scaffolding exempt — buffering response bodies in
+// DB-backed handler tests is not an artifact path (#1608).
+#![allow(clippy::disallowed_methods)]
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -1135,6 +1135,8 @@ fn replication_session_metadata_from_request<'a>(
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[allow(clippy::io_other_error, clippy::unnecessary_literal_unwrap)]
 mod tests {
     use super::*;

--- a/backend/src/api/handlers/wasm_proxy.rs
+++ b/backend/src/api/handlers/wasm_proxy.rs
@@ -272,8 +272,9 @@ fn error_response(status: StatusCode, message: &str) -> Response<Body> {
         .unwrap()
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::HeaderValue;

--- a/backend/src/api/handlers/wasm_proxy.rs
+++ b/backend/src/api/handlers/wasm_proxy.rs
@@ -273,6 +273,7 @@ fn error_response(status: StatusCode, message: &str) -> Response<Body> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
     use axum::http::HeaderValue;

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1659,6 +1659,7 @@ pub async fn repo_visibility_middleware(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1658,8 +1658,9 @@ pub async fn repo_visibility_middleware(
     next.run(request).await
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -681,8 +681,9 @@ fn extract_client_ip_addr(request: &Request, trusted_proxies: &[CidrRange]) -> O
     None
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -499,6 +499,8 @@ pub async fn login_rate_limit_middleware(
     // Buffer the (small) login body so we can peek `username`, then re-attach
     // it unchanged for the handler's custom Json extractor.
     let (parts, body) = request.into_parts();
+    #[allow(clippy::disallowed_methods)]
+    // STREAMING-EXEMPT: buffers the small login body (LOGIN_BODY_PEEK_LIMIT) to peek username, re-attached unchanged; not an artifact path (#1608)
     let bytes = match axum::body::to_bytes(body, LOGIN_BODY_PEEK_LIMIT).await {
         Ok(b) => b,
         Err(_) => {
@@ -680,6 +682,7 @@ fn extract_client_ip_addr(request: &Request, trusted_proxies: &[CidrRange]) -> O
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::*;
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1073,6 +1073,8 @@ async fn assert_connect_info_wired(app: Router) {
         "ConnectInfo<SocketAddr> wiring is not active: boot probe returned {status} \
          (expected the serve path's connect_info_make_service to inject the peer)"
     );
+    #[allow(clippy::disallowed_methods)]
+    // STREAMING-EXEMPT: 64-byte boot self-probe body; not an artifact path (#1608)
     let body = axum::body::to_bytes(response.into_body(), 64)
         .await
         .expect("probe body");

--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -672,6 +672,7 @@ impl ArtifactoryClient {
     /// the entire artifact in memory at once and OOMs on multi-GB artifacts
     /// (issue #1422). It is kept for callers that genuinely need the bytes
     /// in memory (small fixtures, tests).
+    #[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
     pub async fn download_artifact(
         &self,
         repo_key: &str,
@@ -681,7 +682,7 @@ impl ArtifactoryClient {
         let status = response.status();
 
         if status.is_success() {
-            Ok(response.bytes().await?)
+            Ok(response.bytes().await?) // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
         } else if status.as_u16() == 404 {
             Err(ArtifactoryError::NotFound(format!(
                 "Artifact not found: {}/{}",

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -148,8 +148,9 @@ fn ssrf_redirect_policy() -> Policy {
     })
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::{base_client_builder, default_client, large_object_client_builder};
     use std::io::Write;

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -149,6 +149,7 @@ fn ssrf_redirect_policy() -> Policy {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod tests {
     use super::{base_client_builder, default_client, large_object_client_builder};
     use std::io::Write;

--- a/backend/src/services/nexus_client.rs
+++ b/backend/src/services/nexus_client.rs
@@ -283,6 +283,7 @@ impl NexusClient {
     ///
     /// Buffers the full response body into memory. Prefer
     /// `download_artifact_stream` for migrations (issue #1422).
+    #[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
     pub async fn download_artifact(
         &self,
         repo_name: &str,
@@ -293,7 +294,7 @@ impl NexusClient {
 
         let status = response.status();
         if status.is_success() {
-            Ok(response.bytes().await?)
+            Ok(response.bytes().await?) // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
         } else if status.as_u16() == 404 {
             Err(ArtifactoryError::NotFound(format!(
                 "Artifact not found: {}/{}",

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -1520,6 +1520,8 @@ impl UpstreamClient {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
+        #[allow(clippy::disallowed_methods)]
+        // STREAMING-EXEMPT: proxy upstream fetch buffered; tracked for streaming copy to storage in a later #1608 phase
         let content = response.bytes().await.map_err(|e| {
             AppError::Storage(format!(
                 "Failed to read upstream response: {}",

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -872,6 +872,8 @@ async fn run_curation_sync_cycle(
                 }
                 match primary_req.send().await {
                     Ok(resp) if resp.status().is_success() => {
+                        #[allow(clippy::disallowed_methods)]
+                        // STREAMING-EXEMPT: capped-metadata (upstream repo index) buffered for gz-decode; not an artifact blob (#1608)
                         let bytes = resp.bytes().await?;
                         let xml = if primary_path.ends_with(".gz") {
                             use std::io::Read;
@@ -903,6 +905,8 @@ async fn run_curation_sync_cycle(
                 }
                 match packages_req.send().await {
                     Ok(resp) if resp.status().is_success() => {
+                        #[allow(clippy::disallowed_methods)]
+                        // STREAMING-EXEMPT: capped-metadata (upstream repo index) buffered for gz-decode; not an artifact blob (#1608)
                         let bytes = resp.bytes().await?;
                         use std::io::Read;
                         let mut decoder = flate2::read::GzDecoder::new(&bytes[..]);

--- a/backend/src/storage/azure.rs
+++ b/backend/src/storage/azure.rs
@@ -553,6 +553,8 @@ impl AzureBackend {
                 fallback = %fallback_key,
                 "Found artifact range at Artifactory fallback path"
             );
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
             let bytes = response
                 .bytes()
                 .await
@@ -1157,6 +1159,8 @@ impl StorageBackend for AzureBackend {
                                 fallback = %fallback_key,
                                 "Found artifact at Artifactory fallback path"
                             );
+                            #[allow(clippy::disallowed_methods)]
+                            // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
                             let bytes = fallback_response.bytes().await.map_err(|e| {
                                 AppError::Storage(format!("Failed to read response: {}", e))
                             })?;
@@ -1173,6 +1177,8 @@ impl StorageBackend for AzureBackend {
             )));
         }
 
+        #[allow(clippy::disallowed_methods)]
+        // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
         let bytes = response
             .bytes()
             .await
@@ -1191,6 +1197,8 @@ impl StorageBackend for AzureBackend {
         let response = self.authorized_get_range(&url, &range_header).await?;
 
         if response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
             return response
                 .bytes()
                 .await

--- a/backend/src/storage/gcs.rs
+++ b/backend/src/storage/gcs.rs
@@ -705,6 +705,8 @@ impl GcsBackend {
                     fallback = %fallback_key,
                     "Found artifact at Artifactory fallback path"
                 );
+                #[allow(clippy::disallowed_methods)]
+                // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
                 let bytes = response
                     .bytes()
                     .await
@@ -736,6 +738,8 @@ impl GcsBackend {
                     fallback = %fallback_key,
                     "Found artifact range at Artifactory fallback path"
                 );
+                #[allow(clippy::disallowed_methods)]
+                // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
                 let bytes = response
                     .bytes()
                     .await
@@ -1495,6 +1499,8 @@ impl StorageBackend for GcsBackend {
         let response = self.authorized_get(&url).await?;
 
         if response.status().is_success() {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
             return response
                 .bytes()
                 .await
@@ -1523,6 +1529,8 @@ impl StorageBackend for GcsBackend {
         let response = self.authorized_get_range(&url, &range_header).await?;
 
         if response.status() == reqwest::StatusCode::PARTIAL_CONTENT {
+            #[allow(clippy::disallowed_methods)]
+            // STREAMING-EXEMPT: storage-internal Artifactory-fallback get()/range body; backs the streaming get impl; genuinely exempt (#1608)
             return response
                 .bytes()
                 .await

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -924,6 +924,7 @@ impl S3Backend {
         let path: ObjectPath = fallback_full_key.into();
         match self.store.get(&path).await {
             Ok(result) => {
+                // STREAMING-EXEMPT: storage-internal object_store GetResult::bytes() full-body read — same exempt category as the S3/Azure/GCS get() fallbacks that back the streaming get impl; not one of the 3 clippy-gated shapes but tracked under #1608
                 let bytes = result.bytes().await.map_err(|e| {
                     AppError::Storage(format!("Failed to read fallback '{}': {}", fallback_key, e))
                 })?;
@@ -1065,6 +1066,7 @@ impl super::StorageBackend for S3Backend {
 
         match self.store.get(&path).await {
             Ok(result) => {
+                // STREAMING-EXEMPT: storage-internal object_store GetResult::bytes() full-body read — same exempt category as the S3/Azure/GCS get() fallbacks that back the streaming get impl; not one of the 3 clippy-gated shapes but tracked under #1608
                 let bytes = result.bytes().await.map_err(|e| {
                     AppError::Storage(format!("Failed to read object '{}': {}", key, e))
                 })?;
@@ -3763,6 +3765,7 @@ mod tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod integration_tests {
     use super::*;
     use crate::storage::StorageBackend as StorageBackendTrait;

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -3764,8 +3764,9 @@ mod tests {
     }
 }
 
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
-#[allow(clippy::disallowed_methods)] // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 mod integration_tests {
     use super::*;
     use crate::storage::StorageBackend as StorageBackendTrait;

--- a/backend/tests/composer_packages_index_tests.rs
+++ b/backend/tests/composer_packages_index_tests.rs
@@ -20,6 +20,7 @@
 //!   cargo test --test composer_packages_index_tests -- --ignored
 //! ```
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::io::Write;
 use std::sync::Arc;
 

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -8,6 +8,7 @@
 //!   cargo test --test incus_upload_tests -- --ignored
 //! ```
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::path::PathBuf;
 use std::sync::Arc;
 

--- a/backend/tests/integration_tests.rs
+++ b/backend/tests/integration_tests.rs
@@ -13,7 +13,7 @@
 //! a running HTTP server. In CI, run them separately with a service container.
 
 #![allow(dead_code)]
-
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::env;
 use std::sync::Once;
 

--- a/backend/tests/oci_chunked_upload_cross_repo_tests.rs
+++ b/backend/tests/oci_chunked_upload_cross_repo_tests.rs
@@ -17,7 +17,7 @@
 //! ```
 
 #![allow(clippy::unwrap_used)]
-
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/backend/tests/optional_auth_deactivation_tests.rs
+++ b/backend/tests/optional_auth_deactivation_tests.rs
@@ -37,6 +37,7 @@
 //!     cargo test --test optional_auth_deactivation_tests -- --ignored
 //! ```
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::sync::Arc;
 use std::time::Instant;
 

--- a/backend/tests/pypi_proxy_upload_time_tests.rs
+++ b/backend/tests/pypi_proxy_upload_time_tests.rs
@@ -17,6 +17,7 @@
 //!   cargo test --test pypi_proxy_upload_time_tests -- --ignored
 //! ```
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/backend/tests/s3_integration.rs
+++ b/backend/tests/s3_integration.rs
@@ -8,6 +8,7 @@
 //!   S3_SECRET_ACCESS_KEY=... \
 //!   cargo test --test s3_integration -- --ignored --nocapture
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use artifact_keeper_backend::storage::s3::{S3Backend, S3Config};
 use artifact_keeper_backend::storage::StorageBackend;
 use bytes::Bytes;

--- a/backend/tests/storage_backend_tests.rs
+++ b/backend/tests/storage_backend_tests.rs
@@ -7,6 +7,7 @@
 //! cargo test --test storage_backend_tests -- --ignored
 //! ```
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use reqwest::Client;
 use serde_json::{json, Value};
 use std::env;

--- a/backend/tests/streaming_invariant.rs
+++ b/backend/tests/streaming_invariant.rs
@@ -1,0 +1,410 @@
+//! Streaming-invariant enforcement gate — source-scan (Part of #1608, Phase 1).
+//!
+//! This is the belt-and-suspenders companion to the clippy `disallowed-methods`
+//! gate configured in `.clippy.toml`. Clippy is the primary enforcement (it
+//! resolves `reqwest::Response::bytes`, `axum::extract::multipart::Field::bytes`
+//! and `axum::body::to_bytes` by type and fails the build on any un-annotated
+//! call). This test adds a text-level ratchet that:
+//!
+//!   1. asserts the set of `STREAMING-EXEMPT`-annotated buffering sites in the
+//!      production source tree exactly equals the known allowlist below, and
+//!   2. fails if a new, un-annotated full-body-buffering call appears (including
+//!      same-syntax calls on types clippy resolves differently, e.g. the
+//!      `object_store::GetResult::bytes()` storage reads).
+//!
+//! The invariant: no artifact-path handler may read a full artifact body into
+//! memory. Every entry below is a CURRENT legitimate buffer site carrying a
+//! `#[allow(clippy::disallowed_methods)] // STREAMING-EXEMPT: <why>` annotation
+//! (or, for calls clippy does not gate, a bare `// STREAMING-EXEMPT:` comment).
+//! As later phases convert a site to streaming, delete its annotation AND shrink
+//! its count here — the count is meant to trend to zero.
+//!
+//! Test code (buffering a response body in an assertion is not an artifact-path
+//! handler) is intentionally excluded: `#[cfg(test)]` modules are stripped, and
+//! whole-file test scaffolds carrying a file-level
+//! `#![allow(clippy::disallowed_methods)]` are skipped.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Per-file count of legitimate, annotated full-body-buffering sites in the
+/// production (non-test) source tree. Paths are relative to the crate root.
+///
+/// Phase 1 total: 38 exempt sites (36 clippy-gated + 2 `object_store` storage
+/// reads). Shrink these as streaming conversions land in later phases of #1608.
+const ALLOWLIST: &[(&str, usize)] = &[
+    ("src/api/handlers/ansible.rs", 2),
+    ("src/api/handlers/chef.rs", 2),
+    ("src/api/handlers/goproxy.rs", 1),
+    ("src/api/handlers/helm.rs", 1),
+    ("src/api/handlers/npm.rs", 5),
+    ("src/api/handlers/oci_v2.rs", 1),
+    ("src/api/handlers/plugins.rs", 2),
+    ("src/api/handlers/proxy_helpers.rs", 2),
+    ("src/api/handlers/pub_registry.rs", 1),
+    ("src/api/handlers/pypi.rs", 1),
+    ("src/api/handlers/remote_instances.rs", 1),
+    ("src/api/handlers/repositories.rs", 2),
+    ("src/api/middleware/rate_limit.rs", 1),
+    ("src/main.rs", 1),
+    ("src/services/artifactory_client.rs", 1),
+    ("src/services/nexus_client.rs", 1),
+    ("src/services/proxy_service.rs", 1),
+    ("src/services/scheduler_service.rs", 2),
+    ("src/storage/azure.rs", 4),
+    ("src/storage/gcs.rs", 4),
+    ("src/storage/s3.rs", 2),
+];
+
+/// Marker that annotates an exempt buffer site.
+const MARKER: &str = "STREAMING-EXEMPT";
+/// Whole-file test-scaffold exemption (file-level inner attribute).
+const FILE_EXEMPT: &str = "#![allow(clippy::disallowed_methods)]";
+
+/// Replace every character that lives inside a string literal, char literal or
+/// comment with a space (newlines preserved), so that later text scanning and
+/// brace matching operate on *code* only. This is deliberately conservative: it
+/// only needs to be correct enough that braces and the disallowed-call syntax
+/// inside strings/comments are neutralised.
+fn code_mask(src: &str) -> String {
+    #[derive(PartialEq)]
+    enum St {
+        Normal,
+        Line,
+        Block(u32),
+        Str,
+        Raw(usize),
+        Char,
+    }
+    let b = src.as_bytes();
+    let n = b.len();
+    let mut out = Vec::with_capacity(n);
+    let mut i = 0usize;
+    let mut st = St::Normal;
+    let push = |out: &mut Vec<u8>, c: u8| out.push(if c == b'\n' { b'\n' } else { b' ' });
+    while i < n {
+        let c = b[i];
+        let nx = if i + 1 < n { b[i + 1] } else { 0 };
+        match st {
+            St::Normal => {
+                if c == b'/' && nx == b'/' {
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                    st = St::Line;
+                } else if c == b'/' && nx == b'*' {
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                    st = St::Block(1);
+                } else if c == b'r' && (nx == b'"' || nx == b'#') {
+                    // Raw string: r followed by zero+ '#' then '"'.
+                    let mut j = i + 1;
+                    let mut h = 0usize;
+                    while j < n && b[j] == b'#' {
+                        h += 1;
+                        j += 1;
+                    }
+                    if j < n && b[j] == b'"' {
+                        // The opener `r#*"` contains no newlines — blank it out.
+                        out.resize(out.len() + (j - i + 1), b' ');
+                        i = j + 1;
+                        st = St::Raw(h);
+                    } else {
+                        out.push(c);
+                        i += 1;
+                    }
+                } else if c == b'"' {
+                    out.push(b' ');
+                    i += 1;
+                    st = St::Str;
+                } else if c == b'\'' {
+                    // Char literal vs lifetime. Char: '\?.'  ; lifetime: 'ident.
+                    if nx == b'\\' || (i + 2 < n && b[i + 2] == b'\'') {
+                        out.push(b' ');
+                        i += 1;
+                        st = St::Char;
+                    } else {
+                        // Lifetime — harmless as code (contains no braces).
+                        out.push(c);
+                        i += 1;
+                    }
+                } else {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+            St::Line => {
+                if c == b'\n' {
+                    out.push(b'\n');
+                    st = St::Normal;
+                } else {
+                    out.push(b' ');
+                }
+                i += 1;
+            }
+            St::Block(depth) => {
+                if c == b'/' && nx == b'*' {
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                    st = St::Block(depth + 1);
+                } else if c == b'*' && nx == b'/' {
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                    st = if depth == 1 {
+                        St::Normal
+                    } else {
+                        St::Block(depth - 1)
+                    };
+                } else {
+                    push(&mut out, c);
+                    i += 1;
+                }
+            }
+            St::Str => {
+                if c == b'\\' {
+                    out.push(b' ');
+                    push(&mut out, nx);
+                    i += 2;
+                } else if c == b'"' {
+                    out.push(b' ');
+                    i += 1;
+                    st = St::Normal;
+                } else {
+                    push(&mut out, c);
+                    i += 1;
+                }
+            }
+            St::Raw(h) => {
+                if c == b'"' && (0..h).all(|k| i + 1 + k < n && b[i + 1 + k] == b'#') {
+                    out.resize(out.len() + h + 1, b' ');
+                    i += 1 + h;
+                    st = St::Normal;
+                } else {
+                    push(&mut out, c);
+                    i += 1;
+                }
+            }
+            St::Char => {
+                if c == b'\\' {
+                    out.push(b' ');
+                    out.push(b' ');
+                    i += 2;
+                } else if c == b'\'' {
+                    out.push(b' ');
+                    i += 1;
+                    st = St::Normal;
+                } else {
+                    out.push(b' ');
+                    i += 1;
+                }
+            }
+        }
+    }
+    // Safe: we only ever pushed ASCII spaces/newlines or copied original ASCII
+    // bytes at code positions; multi-byte UTF-8 only occurs inside strings (now
+    // blanked) so the result is valid UTF-8.
+    String::from_utf8(out).expect("masked code is valid UTF-8")
+}
+
+/// 1-based line numbers that live inside a `#[cfg(test)]` item (module, fn, ...),
+/// found by brace-matching on the masked code so string/comment braces are
+/// ignored.
+fn test_lines(masked: &str) -> std::collections::HashSet<usize> {
+    let bytes = masked.as_bytes();
+    let mut out = std::collections::HashSet::new();
+    let mut search_from = 0usize;
+    while let Some(rel) = masked[search_from..].find("#[cfg(test)]") {
+        let p = search_from + rel;
+        // First '{' at/after the attribute opens the guarded item's body.
+        let Some(open) = masked[p..].find('{').map(|o| p + o) else {
+            break;
+        };
+        let mut depth = 0i32;
+        let mut end = None;
+        let mut j = open;
+        while j < bytes.len() {
+            match bytes[j] {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(j);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            j += 1;
+        }
+        let Some(end) = end else { break };
+        let start_line = masked[..p].bytes().filter(|&c| c == b'\n').count() + 1;
+        let end_line = masked[..end].bytes().filter(|&c| c == b'\n').count() + 1;
+        for l in start_line..=end_line {
+            out.insert(l);
+        }
+        search_from = end + 1;
+    }
+    out
+}
+
+/// Count disallowed full-body-buffering call *candidates* on a production
+/// (non-test) masked-code line. Handles `.bytes().await` chains that wrap across
+/// lines (the `.await` may sit on the next non-blank line).
+fn count_calls(codelines: &[&str], idx: usize, test: &std::collections::HashSet<usize>) -> usize {
+    let line = codelines[idx];
+    let mut calls = 0usize;
+
+    // reqwest::Response::bytes / Field::bytes -> `.bytes()` immediately awaited.
+    let mut from = 0usize;
+    while let Some(rel) = line[from..].find(".bytes()") {
+        let at = from + rel;
+        from = at + ".bytes()".len();
+        let tail = line[from..].trim_start();
+        if tail.starts_with(".await") {
+            calls += 1;
+        } else if tail.is_empty() {
+            // Look at the next non-blank code line for a leading `.await`.
+            let mut k = idx + 1;
+            while k < codelines.len() && codelines[k].trim().is_empty() {
+                k += 1;
+            }
+            if k < codelines.len()
+                && !test.contains(&(k + 1))
+                && codelines[k].trim_start().starts_with(".await")
+            {
+                calls += 1;
+            }
+        }
+    }
+
+    // axum::body::to_bytes -> free function `to_bytes(` (not `.to_bytes()` and
+    // not the tail of `into_bytes(`).
+    let mut from = 0usize;
+    let bytes = line.as_bytes();
+    while let Some(rel) = line[from..].find("to_bytes") {
+        let at = from + rel;
+        from = at + "to_bytes".len();
+        let before = if at == 0 { b' ' } else { bytes[at - 1] };
+        let is_word = before == b'.' || before == b'_' || before.is_ascii_alphanumeric();
+        // require an opening paren (allowing whitespace) after `to_bytes`
+        let rest = line[from..].trim_start();
+        if !is_word && rest.starts_with('(') {
+            calls += 1;
+        }
+    }
+    calls
+}
+
+fn collect_rs_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(rd) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in rd.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_rs_files(&p, out);
+        } else if p.extension().map(|e| e == "rs").unwrap_or(false) {
+            out.push(p);
+        }
+    }
+}
+
+#[test]
+fn streaming_invariant_exempt_sites_match_allowlist() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = root.join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src, &mut files);
+    files.sort();
+
+    let allow: BTreeMap<&str, usize> = ALLOWLIST.iter().copied().collect();
+
+    let mut actual_marks: BTreeMap<String, usize> = BTreeMap::new();
+    let mut unannotated: Vec<String> = Vec::new();
+
+    for file in &files {
+        let raw = std::fs::read_to_string(file).expect("read source file");
+        let rel = file
+            .strip_prefix(&root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        // Whole-file test scaffold: skip entirely.
+        if raw.lines().any(|l| l.trim_start().starts_with(FILE_EXEMPT)) {
+            continue;
+        }
+
+        let masked = code_mask(&raw);
+        let codelines: Vec<&str> = masked.lines().collect();
+        let rawlines: Vec<&str> = raw.lines().collect();
+        let test = test_lines(&masked);
+
+        let mut calls = 0usize;
+        for (i, _) in codelines.iter().enumerate() {
+            if test.contains(&(i + 1)) {
+                continue;
+            }
+            calls += count_calls(&codelines, i, &test);
+        }
+
+        let marks = rawlines
+            .iter()
+            .enumerate()
+            .filter(|(i, l)| !test.contains(&(i + 1)) && l.contains(MARKER))
+            .count();
+
+        if marks > 0 {
+            actual_marks.insert(rel.clone(), marks);
+        }
+        // Every disallowed-call candidate outside test code must be annotated.
+        if calls > marks {
+            unannotated.push(format!(
+                "{rel}: {calls} disallowed-call candidate(s) but only {marks} `{MARKER}` \
+                 annotation(s) — annotate the new full-body read (or convert it to streaming) \
+                 and update ALLOWLIST in tests/streaming_invariant.rs"
+            ));
+        }
+    }
+
+    assert!(
+        unannotated.is_empty(),
+        "New un-annotated full-body-buffering call(s) detected (Core Invariant ①, #1608):\n  {}",
+        unannotated.join("\n  ")
+    );
+
+    let expected: BTreeMap<String, usize> =
+        allow.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+
+    if actual_marks != expected {
+        let mut diff = String::new();
+        for (k, v) in &expected {
+            match actual_marks.get(k) {
+                Some(a) if a == v => {}
+                Some(a) => diff.push_str(&format!("  {k}: allowlist={v} actual={a}\n")),
+                None => diff.push_str(&format!("  {k}: allowlist={v} actual=0 (site removed?)\n")),
+            }
+        }
+        for (k, a) in &actual_marks {
+            if !expected.contains_key(k) {
+                diff.push_str(&format!(
+                    "  {k}: allowlist=<absent> actual={a} (new exempt file)\n"
+                ));
+            }
+        }
+        panic!(
+            "STREAMING-EXEMPT annotations no longer match the allowlist. If you removed a buffer \
+             site (good — Phase progress!), shrink the count in ALLOWLIST. If you added one, it \
+             must be justified and tracked under #1608.\n{diff}"
+        );
+    }
+
+    let total: usize = actual_marks.values().sum();
+    assert_eq!(
+        total, 38,
+        "expected 38 exempt sites in Phase 1; got {total}"
+    );
+}

--- a/backend/tests/users_password_routing_tests.rs
+++ b/backend/tests/users_password_routing_tests.rs
@@ -41,6 +41,7 @@
 //! routing/middleware composition that makes the bash test reach the
 //! handler in the first place.
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use std::sync::Arc;
 
 use axum::body::{to_bytes, Body};

--- a/backend/tests/virtual_members_duplicate_test.rs
+++ b/backend/tests/virtual_members_duplicate_test.rs
@@ -16,6 +16,7 @@
 //!
 //! Companion to PR #936 / issue #916.
 
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use serde_json::Value;


### PR DESCRIPTION
## Summary

Part of #1608 (Phase 1: enforcement gate). Adds the ratchet that stops new
full-body-buffering regressions on artifact paths, and brings the existing tree
to green by annotating every current legitimate buffer site. **No handler
behavior changes** — this is config + annotations + one test.

Core Invariant ① (#1608) requires that no artifact-path handler read a full
artifact body into memory. Historically that was retrofitted per-call, which
produced a series of memory/OOM issues. This PR makes it structurally enforced
so future regressions fail CI instead of shipping.

What lands:

- **`.clippy.toml`** — `disallowed-methods` for the three body-collection calls
  (`reqwest::Response::bytes`, `axum::extract::multipart::Field::bytes`,
  `axum::body::to_bytes`), each with a reason pointing at #1608. (Merged into the
  existing `.clippy.toml`, which clippy reads in preference to `clippy.toml`.)
- **Site annotations** — every current call site clippy resolves is annotated
  `#[allow(clippy::disallowed_methods)] // STREAMING-EXEMPT: <reason>`, with an
  honest reason per category (bounded multipart upload field, capped upstream
  metadata read, proxy fetch tracked for streaming, storage-internal get()
  fallback, bounded login-body peek, boot self-probe). Test-code buffering
  (assertions on response bodies — not an artifact-path handler) is scoped out
  via module/file-level allows.
- **`backend/tests/streaming_invariant.rs`** — a source-scan belt-and-suspenders
  test. It strips `#[cfg(test)]` regions and asserts the set of
  `STREAMING-EXEMPT`-annotated production sites equals a known allowlist
  (encoded as a constant), and fails if a new un-annotated full-body read
  appears — including same-syntax calls on types clippy resolves differently
  (e.g. `object_store::GetResult::bytes()`).

**Current exempt count: 38 sites** (36 clippy-gated + 2 `object_store` storage
reads). The allowlist is per-file and is meant to shrink toward zero as later
phases of #1608 convert sites to streaming.

Does **not** close #1608 (umbrella stays open for the streaming conversions).

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix (CI enforcement gate / hardening; the new
  `streaming_invariant` test IS the ratchet).

## Test Checklist
- [x] Unit/integration tests added/updated (`backend/tests/streaming_invariant.rs`)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification:
- `cargo clippy --workspace --all-targets -- -D warnings` — green
- `cargo build --workspace` — clean
- `cargo fmt --check` — clean
- `cargo test --test streaming_invariant` — passes
- Sanity: adding a stray `Field::bytes()` in a scratch handler trips **both**
  clippy (`use of a disallowed method axum::extract::multipart::Field::bytes`)
  and the scan test (`un-annotated full-body-buffering call`); removed after.

## API Changes
- [x] N/A - no API changes
