### PR TITLE
feat(uploads): stream chef/ansible/pub multipart uploads to storage (#1608)

### DIFF
--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -25,7 +25,9 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Extension;
 use axum::Router;
+#[cfg(test)]
 use bytes::Bytes;
+#[cfg(test)]
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tracing::info;
@@ -397,7 +399,6 @@ async fn download_collection(
 // POST /ansible/{repo_key}/api/v3/artifacts/collections/ — Upload collection (multipart)
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_collection(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -417,7 +418,10 @@ async fn upload_collection(
     // older clients still send a `collection` or `metadata` JSON field, so
     // accept either source for the namespace/name/version. The filename
     // takes precedence because it is what the CLI ships with.
-    let mut tarball: Option<Bytes> = None;
+    // Spool the tarball straight to a bounded scratch file instead of buffering
+    // the whole body in memory; the small text/JSON fields are still read
+    // in-hand. See proxy_helpers::stage_upload_field / put_artifact_stream.
+    let mut staged: Option<proxy_helpers::StagedUpload> = None;
     let mut file_name: Option<String> = None;
     let mut declared_sha256: Option<String> = None;
     let mut collection_json: Option<serde_json::Value> = None;
@@ -430,14 +434,7 @@ async fn upload_collection(
         let field_name = field.name().unwrap_or("").to_string();
         if field_name == "file" {
             file_name = field.file_name().map(|s| s.to_string());
-            tarball = Some(field.bytes().await.map_err(|e| {
-                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Failed to read file: {}", e),
-                )
-                    .into_response()
-            })?);
+            staged = Some(proxy_helpers::stage_upload_field(&state, field).await?);
         } else if field_name == "sha256" {
             declared_sha256 = Some(field.text().await.map_err(|e| {
                 (
@@ -447,16 +444,16 @@ async fn upload_collection(
                     .into_response()
             })?);
         } else if field_name == "collection" || field_name == "metadata" {
-            #[allow(clippy::disallowed_methods)]
-            // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-            let data = field.bytes().await.map_err(|e| {
+            // Small JSON metadata field (not the artifact body): read as text (a
+            // length-limited extractor) and parse in-hand.
+            let data = field.text().await.map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,
                     format!("Failed to read metadata JSON: {}", e),
                 )
                     .into_response()
             })?;
-            collection_json = Some(serde_json::from_slice(&data).map_err(|e| {
+            collection_json = Some(serde_json::from_str(&data).map_err(|e| {
                 (
                     StatusCode::BAD_REQUEST,
                     format!("Invalid metadata JSON: {}", e),
@@ -466,9 +463,9 @@ async fn upload_collection(
         }
     }
 
-    let tarball =
-        tarball.ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing file field").into_response())?;
-    if tarball.is_empty() {
+    let staged =
+        staged.ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing file field").into_response())?;
+    if staged.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty tarball").into_response());
     }
 
@@ -539,16 +536,31 @@ async fn upload_collection(
         namespace, collection_name, collection_version
     );
 
-    // Compute SHA256
-    let mut hasher = Sha256::new();
-    hasher.update(&tarball);
-    let computed_sha256 = format!("{:x}", hasher.finalize());
+    let artifact_path = format!("{}/{}/{}", full_name, collection_version, filename);
+
+    proxy_helpers::ensure_unique_artifact_path(
+        &state.db,
+        repo.id,
+        &artifact_path,
+        "Collection version already exists",
+    )
+    .await?;
+
+    // Stream the staged tarball into the repo's StorageBackend via `put_stream`,
+    // which computes the SHA-256 incrementally as it copies (no re-hash).
+    let storage_key = format!("ansible/{}/{}/{}", full_name, collection_version, filename);
+    let put = proxy_helpers::put_artifact_stream(&state, &repo, &storage_key, staged).await?;
+    let computed_sha256 = put.checksum_sha256;
 
     // If the client supplied a digest, verify the upload was not corrupted in
-    // transit. ansible-galaxy CLI always sends one.
+    // transit. ansible-galaxy CLI always sends one. On mismatch, remove the
+    // just-written object so a corrupt upload leaves nothing behind.
     if let Some(declared) = declared_sha256.as_deref() {
         let declared = declared.trim();
         if !declared.is_empty() && !declared.eq_ignore_ascii_case(&computed_sha256) {
+            if let Ok(storage) = state.storage_for_repo(&repo.storage_location()) {
+                let _ = storage.delete(&storage_key).await;
+            }
             return Err((
                 StatusCode::BAD_REQUEST,
                 format!(
@@ -560,19 +572,6 @@ async fn upload_collection(
         }
     }
 
-    let artifact_path = format!("{}/{}/{}", full_name, collection_version, filename);
-
-    proxy_helpers::ensure_unique_artifact_path(
-        &state.db,
-        repo.id,
-        &artifact_path,
-        "Collection version already exists",
-    )
-    .await?;
-
-    let storage_key = format!("ansible/{}/{}/{}", full_name, collection_version, filename);
-    proxy_helpers::put_artifact_bytes(&state, &repo, &storage_key, tarball.clone()).await?;
-
     let ansible_metadata = serde_json::json!({
         "namespace": namespace,
         "collection_name": collection_name,
@@ -581,7 +580,7 @@ async fn upload_collection(
         "collection_json": collection_json,
     });
 
-    let size_bytes = tarball.len() as i64;
+    let size_bytes = put.bytes_written as i64;
 
     let artifact_id = proxy_helpers::insert_artifact(
         &state.db,

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -17,6 +17,7 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::Extension;
 use axum::Router;
+#[cfg(test)]
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tracing::info;
@@ -373,7 +374,6 @@ async fn download_cookbook(
 // POST /chef/{repo_key}/api/v1/cookbooks — Upload cookbook (multipart)
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_cookbook(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -385,7 +385,10 @@ async fn upload_cookbook(
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
 
-    let mut tarball: Option<bytes::Bytes> = None;
+    // Spool the tarball straight to a bounded scratch file instead of buffering
+    // the whole body in memory; the small `cookbook` JSON field is still read
+    // in-hand. See proxy_helpers::stage_upload_field / put_artifact_stream.
+    let mut staged: Option<proxy_helpers::StagedUpload> = None;
     let mut cookbook_json: Option<serde_json::Value> = None;
 
     while let Some(field) = multipart
@@ -396,26 +399,19 @@ async fn upload_cookbook(
         let field_name = field.name().unwrap_or("").to_string();
         match field_name.as_str() {
             "tarball" => {
-                tarball = Some(field.bytes().await.map_err(|e| {
-                    // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-                    (
-                        StatusCode::BAD_REQUEST,
-                        format!("Failed to read tarball: {}", e),
-                    )
-                        .into_response()
-                })?);
+                staged = Some(proxy_helpers::stage_upload_field(&state, field).await?);
             }
             "cookbook" => {
-                #[allow(clippy::disallowed_methods)]
-                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-                let data = field.bytes().await.map_err(|e| {
+                // Small JSON metadata field (not the artifact body): read as
+                // text (a length-limited extractor) and parse in-hand.
+                let data = field.text().await.map_err(|e| {
                     (
                         StatusCode::BAD_REQUEST,
                         format!("Failed to read cookbook JSON: {}", e),
                     )
                         .into_response()
                 })?;
-                cookbook_json = Some(serde_json::from_slice(&data).map_err(|e| {
+                cookbook_json = Some(serde_json::from_str(&data).map_err(|e| {
                     (
                         StatusCode::BAD_REQUEST,
                         format!("Invalid cookbook JSON: {}", e),
@@ -427,10 +423,10 @@ async fn upload_cookbook(
         }
     }
 
-    let tarball = tarball
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing tarball field").into_response())?;
+    let staged =
+        staged.ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing tarball field").into_response())?;
 
-    if tarball.is_empty() {
+    if staged.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty tarball").into_response());
     }
 
@@ -475,11 +471,6 @@ async fn upload_cookbook(
 
     let filename = format!("{}-{}.tar.gz", cookbook_name, cookbook_version);
 
-    // Compute SHA256
-    let mut hasher = Sha256::new();
-    hasher.update(&tarball);
-    let computed_sha256 = format!("{:x}", hasher.finalize());
-
     let artifact_path = format!("{}/{}/{}", cookbook_name, cookbook_version, filename);
 
     // Check for duplicate
@@ -498,21 +489,11 @@ async fn upload_cookbook(
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
 
-    // Store the file
+    // Stream the staged tarball into the repo's StorageBackend via `put_stream`,
+    // which computes the SHA-256 incrementally as it copies (no re-hash).
     let storage_key = format!("chef/{}/{}/{}", cookbook_name, cookbook_version, filename);
-    let storage = state
-        .storage_for_repo(&repo.storage_location())
-        .map_err(|e| e.into_response())?;
-    storage
-        .put(&storage_key, tarball.clone())
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Storage error: {}", e),
-            )
-                .into_response()
-        })?;
+    let put = proxy_helpers::put_artifact_stream(&state, &repo, &storage_key, staged).await?;
+    let computed_sha256 = put.checksum_sha256;
 
     let chef_metadata = serde_json::json!({
         "cookbook_name": cookbook_name,
@@ -521,7 +502,7 @@ async fn upload_cookbook(
         "cookbook_json": cookbook_json,
     });
 
-    let size_bytes = tarball.len() as i64;
+    let size_bytes = put.bytes_written as i64;
 
     let artifact_id = sqlx::query_scalar!(
         r#"
@@ -754,6 +735,118 @@ mod db_cov_tests {
             let app = fx.router_with_auth(super::router());
             let _ = tdh::send(app, tdh::get(uri)).await;
         }
+        fx.teardown().await;
+    }
+}
+
+#[cfg(test)]
+mod upload_stream_tests {
+    use crate::api::handlers::test_db_helpers as tdh;
+    use axum::http::StatusCode;
+    use sha2::{Digest, Sha256};
+
+    /// Build a `knife`-style cookbook upload body: a `cookbook` JSON metadata
+    /// part plus a `tarball` file part.
+    fn cookbook_multipart(
+        boundary: &str,
+        name: &str,
+        version: &str,
+        tarball: &[u8],
+    ) -> bytes::Bytes {
+        let meta = format!("{{\"cookbook_name\":\"{name}\",\"cookbook_version\":\"{version}\"}}");
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(b"Content-Disposition: form-data; name=\"cookbook\"\r\n\r\n");
+        body.extend_from_slice(meta.as_bytes());
+        body.extend_from_slice(format!("\r\n--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            format!(
+                "Content-Disposition: form-data; name=\"tarball\"; filename=\"{name}-{version}.tar.gz\"\r\n"
+            )
+            .as_bytes(),
+        );
+        body.extend_from_slice(b"Content-Type: application/gzip\r\n\r\n");
+        body.extend_from_slice(tarball);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        bytes::Bytes::from(body)
+    }
+
+    #[tokio::test]
+    async fn test_chef_upload_streams_and_records_checksum() {
+        let Some(fx) = tdh::Fixture::setup("local", "chef").await else {
+            return;
+        };
+        // A padded payload much larger than one stream chunk, so the upload
+        // exercises the spool-to-disk streaming path rather than a small buffer.
+        let tarball = b"cookbook-payload-".repeat(8192); // ~135 KB
+        let body = cookbook_multipart("CHEFBND", "apache2", "8.0.0", &tarball);
+
+        let app = fx.router_with_auth(super::router());
+        let (status, resp) = tdh::send(
+            app,
+            tdh::post(
+                format!("/{}/api/v1/cookbooks", fx.repo_key),
+                "multipart/form-data; boundary=CHEFBND",
+                body,
+            ),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "unexpected status, body={}",
+            String::from_utf8_lossy(&resp)
+        );
+
+        // The artifact row carries the checksum computed incrementally by
+        // put_stream and the true streamed size. Use the runtime query API so
+        // this test needs no offline sqlx cache entry.
+        use sqlx::Row;
+        let row = sqlx::query(
+            "SELECT checksum_sha256, size_bytes, storage_key FROM artifacts \
+             WHERE repository_id = $1 AND is_deleted = false",
+        )
+        .bind(fx.repo_id)
+        .fetch_one(&fx.pool)
+        .await
+        .expect("artifact row");
+        let checksum: String = row.get("checksum_sha256");
+        let size_bytes: i64 = row.get("size_bytes");
+        let storage_key: String = row.get("storage_key");
+        let mut hasher = Sha256::new();
+        hasher.update(&tarball);
+        assert_eq!(checksum, format!("{:x}", hasher.finalize()));
+        assert_eq!(size_bytes, tarball.len() as i64);
+
+        // The bytes really landed in the configured backend under the key.
+        let stored = fx
+            .state
+            .storage
+            .get(&storage_key)
+            .await
+            .expect("stored object");
+        assert_eq!(stored.len(), tarball.len());
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_chef_upload_rejects_empty_tarball() {
+        let Some(fx) = tdh::Fixture::setup("local", "chef").await else {
+            return;
+        };
+        let body = cookbook_multipart("CHEFBND", "apache2", "8.0.0", b"");
+        let app = fx.router_with_auth(super::router());
+        let (status, _) = tdh::send(
+            app,
+            tdh::post(
+                format!("/{}/api/v1/cookbooks", fx.repo_key),
+                "multipart/form-data; boundary=CHEFBND",
+                body,
+            ),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
         fx.teardown().await;
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -21,6 +21,7 @@ use crate::services::proxy_service::ProxyService;
 pub use crate::services::proxy_service::StreamingFetchResult;
 use crate::storage::StorageLocation;
 use std::future::Future;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 // ---------------------------------------------------------------------------
@@ -3354,6 +3355,181 @@ pub async fn put_artifact_bytes(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Streaming artifact uploads (#1608 Phase 2)
+// ---------------------------------------------------------------------------
+//
+// Light-format upload handlers (chef, ansible, pub, ...) historically buffered
+// the entire artifact body in memory via `Field::bytes()` before handing it to
+// `put_artifact_bytes` -> `storage.put(Bytes)`. `stage_upload_field` +
+// `put_artifact_stream` replace that with a memory-bounded path: the multipart
+// field is spooled chunk-by-chunk to a scratch temp file (peak RAM =
+// STREAM_STAGE_CHUNK), then streamed into the repo's `StorageBackend` through
+// its native `put_stream` primitive (S3 multipart / GCS resumable / Azure
+// block-blob / filesystem temp-and-rename), which computes the SHA-256
+// incrementally as it copies. Mirrors the incus monolithic-upload pattern
+// (`stream_body_to_file` + `open_temp_file_as_stream`). `put_artifact_bytes`
+// is retained for the small metadata writers that still need the bytes in hand.
+//
+// This pair is the shared entry point later #1608 phases (helm/pypi/nuget)
+// build on: `stage_upload_field` decouples the (borrowed, non-`'static`)
+// multipart field lifetime from the `'static` stream `put_stream` requires,
+// and lets a handler parse archive metadata off the staged file before the
+// storage key is known.
+
+/// Chunk size for reading a staged scratch file back into `put_stream`.
+const STREAM_STAGE_CHUNK: usize = 256 * 1024;
+
+/// A multipart upload body spooled to a bounded scratch file on local disk.
+///
+/// The scratch file is removed on drop (RAII), so every early return — a
+/// mid-receive stream error, a `?`-propagated failure, or a storage failure in
+/// [`put_artifact_stream`] — unlinks it instead of leaking an orphan (#1573).
+/// The file is staged under the shared upload staging root, so the orphan
+/// sweep reaps it as a backstop if the process dies mid-request.
+pub struct StagedUpload {
+    path: PathBuf,
+    size_bytes: i64,
+}
+
+impl StagedUpload {
+    /// On-disk path of the staged scratch file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Number of bytes spooled to disk (== the eventual artifact size).
+    pub fn size_bytes(&self) -> i64 {
+        self.size_bytes
+    }
+
+    /// Whether the spooled body is empty (no bytes received).
+    pub fn is_empty(&self) -> bool {
+        self.size_bytes == 0
+    }
+}
+
+impl Drop for StagedUpload {
+    fn drop(&mut self) {
+        // Synchronous best-effort unlink: Drop can't await and the file is
+        // local scratch, so a blocking unlink is negligible.
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Spool one multipart field to a bounded scratch temp file, aborting with
+/// `413 Payload Too Large` once `max_upload_size_bytes` is exceeded (a value of
+/// 0 disables the limit, matching the `DefaultBodyLimit` config semantics).
+///
+/// Never buffers the whole field in memory: chunks are written straight to
+/// disk. The returned [`StagedUpload`] owns the scratch file and removes it on
+/// drop. Feed it to [`put_artifact_stream`] once the storage key is known.
+#[allow(clippy::result_large_err)]
+pub async fn stage_upload_field(
+    state: &crate::api::SharedState,
+    mut field: axum::extract::multipart::Field<'_>,
+) -> Result<StagedUpload, Response> {
+    use tokio::io::AsyncWriteExt;
+
+    let path =
+        crate::api::handlers::incus::temp_upload_path(&state.config.storage_path, &Uuid::new_v4());
+    if let Some(parent) = path.parent() {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| internal_error("Staging directory", e))?;
+    }
+
+    // Arm the RAII cleanup before the first write so any early return below
+    // unlinks the partial file rather than leaking it.
+    let mut staged = StagedUpload {
+        path: path.clone(),
+        size_bytes: 0,
+    };
+
+    let mut file = tokio::fs::File::create(&path)
+        .await
+        .map_err(|e| internal_error("Staging file", e))?;
+
+    let max = state.config.max_upload_size_bytes;
+    let mut written: u64 = 0;
+    while let Some(chunk) = field.chunk().await.map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Failed to read upload body: {e}"),
+        )
+            .into_response()
+    })? {
+        written = written.saturating_add(chunk.len() as u64);
+        if max != 0 && written > max {
+            return Err((
+                StatusCode::PAYLOAD_TOO_LARGE,
+                format!("Upload exceeds the maximum allowed size of {max} bytes"),
+            )
+                .into_response());
+        }
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| internal_error("Staging write", e))?;
+    }
+
+    file.flush()
+        .await
+        .map_err(|e| internal_error("Staging flush", e))?;
+    file.sync_all()
+        .await
+        .map_err(|e| internal_error("Staging sync", e))?;
+
+    staged.size_bytes = written as i64;
+    Ok(staged)
+}
+
+/// Stream a [`StagedUpload`] scratch file into the repository's configured
+/// `StorageBackend` via its native `put_stream`, computing the SHA-256
+/// checksum incrementally as it copies (no separate hashing pass over a
+/// buffered body). Returns the incremental checksum + byte count for building
+/// the artifact row.
+///
+/// Consumes the `StagedUpload`: the scratch file is removed when this returns,
+/// on success or on error.
+#[allow(clippy::result_large_err)]
+pub async fn put_artifact_stream(
+    state: &crate::api::SharedState,
+    repo: &RepoInfo,
+    storage_key: &str,
+    staged: StagedUpload,
+) -> Result<crate::storage::PutStreamResult, Response> {
+    let storage = state
+        .storage_for_repo(&repo.storage_location())
+        .map_err(|e| e.into_response())?;
+
+    let stream = open_staged_stream(staged.path()).await?;
+    let result = storage
+        .put_stream(storage_key, stream)
+        .await
+        .map_err(|e| internal_error("Storage", e))?;
+    Ok(result)
+    // `staged` drops here -> scratch file removed.
+}
+
+/// Open a staged scratch file as a `'static` byte stream ready to feed
+/// `StorageBackend::put_stream`. A buffered `ReaderStream` keeps the
+/// disk->backend copy bounded to `STREAM_STAGE_CHUNK`.
+#[allow(clippy::result_large_err)]
+async fn open_staged_stream(
+    path: &Path,
+) -> Result<futures::stream::BoxStream<'static, crate::error::Result<Bytes>>, Response> {
+    use tokio::io::BufReader;
+    use tokio_util::io::ReaderStream;
+
+    let file = tokio::fs::File::open(path)
+        .await
+        .map_err(|e| internal_error("Staging reopen", e))?;
+    let reader = BufReader::with_capacity(STREAM_STAGE_CHUNK, file);
+    let stream = ReaderStream::with_capacity(reader, STREAM_STAGE_CHUNK)
+        .map(|r| r.map_err(|e| crate::error::AppError::Storage(format!("staged read: {e}"))));
+    Ok(Box::pin(stream))
+}
+
 /// Borrowed handle to the columns required to insert a new artifact row.
 /// The lifetime ties the supplied string slices to the surrounding scope so
 /// the helper can avoid extra allocations.
@@ -6601,6 +6777,108 @@ mod tests {
         assert!(cd.to_str().unwrap().contains("foo.tar.gz"));
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // ── stage_upload_field + put_artifact_stream (#1608 Phase 2) ─────────
+
+    /// Encode a single-field (`file`) multipart/form-data body.
+    fn one_field_multipart(boundary: &str, payload: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"file\"; filename=\"f.tar.gz\"\r\n",
+        );
+        body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+        body.extend_from_slice(payload);
+        body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+        body
+    }
+
+    /// Extract the first multipart field from an in-memory body.
+    async fn first_field(body: Vec<u8>) -> axum::extract::Multipart {
+        use axum::extract::FromRequest;
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .header("content-type", "multipart/form-data; boundary=BND")
+            .body(axum::body::Body::from(body))
+            .unwrap();
+        axum::extract::Multipart::from_request(req, &())
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_stage_and_put_artifact_stream_roundtrip() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, storage_dir) =
+            db_helpers::create_repo(&pool, "local", "chef").await;
+        let state = db_helpers::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let repo = RepoInfo {
+            id: repo_id,
+            key: repo_key,
+            storage_path: storage_dir.to_string_lossy().into_owned(),
+            storage_backend: "filesystem".to_string(),
+            repo_type: "local".to_string(),
+            upstream_url: None,
+            promotion_only: false,
+        };
+
+        let payload = b"streamed-artifact-body".repeat(64);
+        let mut mp = first_field(one_field_multipart("BND", &payload)).await;
+        let field = mp.next_field().await.unwrap().unwrap();
+
+        let staged = stage_upload_field(&state, field).await.expect("stage");
+        assert!(!staged.is_empty());
+        assert_eq!(staged.size_bytes(), payload.len() as i64);
+        // Field bytes really landed on disk (spooled, not buffered).
+        assert_eq!(tokio::fs::read(staged.path()).await.unwrap(), payload);
+        let scratch = staged.path().to_path_buf();
+
+        let put = put_artifact_stream(&state, &repo, "chef/x/1.0/x.tar.gz", staged)
+            .await
+            .expect("put_stream");
+
+        // Checksum computed incrementally by put_stream matches a direct hash.
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(&payload);
+        assert_eq!(put.checksum_sha256, format!("{:x}", hasher.finalize()));
+        assert_eq!(put.bytes_written, payload.len() as u64);
+
+        // Scratch file removed once the StagedUpload dropped.
+        assert!(!scratch.exists());
+
+        // Bytes are retrievable from the backend under the storage key.
+        let storage = state.storage_for_repo(&repo.storage_location()).unwrap();
+        let got = storage.get("chef/x/1.0/x.tar.gz").await.unwrap();
+        assert_eq!(got.as_ref(), payload.as_slice());
+
+        db_helpers::cleanup(&pool, repo_id, Uuid::nil()).await;
+    }
+
+    #[tokio::test]
+    async fn test_stage_upload_field_reports_empty_body() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let (repo_id, _repo_key, storage_dir) =
+            db_helpers::create_repo(&pool, "local", "pub").await;
+        let state = db_helpers::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let mut mp = first_field(one_field_multipart("BND", b"")).await;
+        let field = mp.next_field().await.unwrap().unwrap();
+
+        let staged = stage_upload_field(&state, field).await.expect("stage");
+        assert!(staged.is_empty());
+        assert_eq!(staged.size_bytes(), 0);
+        // Even an empty spool leaves a scratch file that is cleaned up on drop.
+        let scratch = staged.path().to_path_buf();
+        drop(staged);
+        assert!(!scratch.exists());
+
+        db_helpers::cleanup(&pool, repo_id, Uuid::nil()).await;
     }
 
     // ── record_artifact_metadata ────────────────────────────────────────

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -19,7 +19,6 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::Extension;
 use axum::Router;
-use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tracing::info;
 
@@ -391,7 +390,6 @@ async fn new_upload_url(
 // POST /pub/{repo_key}/api/packages/versions/newUpload -- Upload package
 // ---------------------------------------------------------------------------
 
-#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (assignment expr); the exempt call is marked inline below (#1608)
 async fn upload_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
@@ -403,41 +401,38 @@ async fn upload_package(
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
 
-    // Extract the tar.gz file from multipart form data
-    let mut file_bytes: Option<bytes::Bytes> = None;
+    // Spool the tar.gz straight to a bounded scratch file instead of buffering
+    // the whole archive in memory. See proxy_helpers::stage_upload_field.
+    let mut staged: Option<proxy_helpers::StagedUpload> = None;
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         (StatusCode::BAD_REQUEST, format!("Invalid multipart: {}", e)).into_response()
     })? {
         let field_name = field.name().unwrap_or("").to_string();
         if field_name == "file" {
-            file_bytes = Some(field.bytes().await.map_err(|e| {
-                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Failed to read upload: {}", e),
-                )
-                    .into_response()
-            })?);
+            staged = Some(proxy_helpers::stage_upload_field(&state, field).await?);
             break;
         }
     }
 
-    let body = file_bytes.ok_or_else(|| {
+    let staged = staged.ok_or_else(|| {
         (StatusCode::BAD_REQUEST, "Missing 'file' field in upload").into_response()
     })?;
 
-    if body.is_empty() {
+    if staged.is_empty() {
         return Err((StatusCode::BAD_REQUEST, "Empty package archive").into_response());
     }
 
-    // Extract pubspec.yaml from the tar.gz archive
-    let pubspec = extract_pubspec_from_archive(&body).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid Pub package: {}", e),
-        )
-            .into_response()
-    })?;
+    // Extract pubspec.yaml from the staged archive on disk, decoding the gzip
+    // stream incrementally so we never hold the whole archive in memory.
+    let pubspec = extract_pubspec_from_staged(staged.path())
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid Pub package: {}", e),
+            )
+                .into_response()
+        })?;
 
     let pkg_name = &pubspec.name;
     let pkg_version = &pubspec.version;
@@ -449,11 +444,6 @@ async fn upload_package(
         )
             .into_response());
     }
-
-    // Compute SHA256
-    let mut hasher = Sha256::new();
-    hasher.update(&body);
-    let computed_sha256 = format!("{:x}", hasher.finalize());
 
     let filename = format!("{}-{}.tar.gz", pkg_name, pkg_version);
     let artifact_path = format!("{}/{}/{}", pkg_name, pkg_version, filename);
@@ -474,18 +464,11 @@ async fn upload_package(
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
 
-    // Store the file
+    // Stream the staged archive into the repo's StorageBackend via `put_stream`,
+    // which computes the SHA-256 incrementally as it copies (no re-hash).
     let storage_key = format!("pub/{}/{}/{}", pkg_name, pkg_version, filename);
-    let storage = state
-        .storage_for_repo(&repo.storage_location())
-        .map_err(|e| e.into_response())?;
-    storage.put(&storage_key, body.clone()).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    let put = proxy_helpers::put_artifact_stream(&state, &repo, &storage_key, staged).await?;
+    let computed_sha256 = put.checksum_sha256;
 
     // Build metadata JSON
     let pub_metadata = serde_json::json!({
@@ -493,7 +476,7 @@ async fn upload_package(
         "filename": filename,
     });
 
-    let size_bytes = body.len() as i64;
+    let size_bytes = put.bytes_written as i64;
 
     // Insert artifact record
     let artifact_id = sqlx::query_scalar!(
@@ -586,13 +569,16 @@ async fn finalize_upload(
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Extract pubspec.yaml from a Pub package tar.gz archive.
-fn extract_pubspec_from_archive(data: &[u8]) -> Result<crate::formats::r#pub::PubSpec, String> {
+/// Extract pubspec.yaml from a Pub package tar.gz `reader`, decoding the gzip
+/// stream incrementally so the whole archive is never held in memory.
+fn extract_pubspec_from_reader<R: std::io::Read>(
+    reader: R,
+) -> Result<crate::formats::r#pub::PubSpec, String> {
     use flate2::read::GzDecoder;
     use std::io::Read;
     use tar::Archive;
 
-    let decoder = GzDecoder::new(data);
+    let decoder = GzDecoder::new(reader);
     let mut archive = Archive::new(decoder);
 
     let entries = archive
@@ -621,6 +607,28 @@ fn extract_pubspec_from_archive(data: &[u8]) -> Result<crate::formats::r#pub::Pu
     }
 
     Err("pubspec.yaml not found in archive".to_string())
+}
+
+/// Extract pubspec.yaml from a staged tar.gz archive on disk. The blocking
+/// flate2/tar decode runs on a blocking thread so it never stalls the async
+/// runtime, and the gzip stream is decoded incrementally (bounded memory).
+async fn extract_pubspec_from_staged(
+    path: &std::path::Path,
+) -> Result<crate::formats::r#pub::PubSpec, String> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&path)
+            .map_err(|e| format!("Failed to open staged archive: {}", e))?;
+        extract_pubspec_from_reader(std::io::BufReader::new(file))
+    })
+    .await
+    .map_err(|e| format!("pubspec extraction task failed: {}", e))?
+}
+
+/// In-memory variant retained for unit tests.
+#[cfg(test)]
+fn extract_pubspec_from_archive(data: &[u8]) -> Result<crate::formats::r#pub::PubSpec, String> {
+    extract_pubspec_from_reader(data)
 }
 
 #[cfg(test)]

--- a/backend/tests/streaming_invariant.rs
+++ b/backend/tests/streaming_invariant.rs
@@ -32,16 +32,17 @@ use std::path::{Path, PathBuf};
 ///
 /// Phase 1 total: 38 exempt sites (36 clippy-gated + 2 `object_store` storage
 /// reads). Shrink these as streaming conversions land in later phases of #1608.
+///
+/// Phase 2 (#1608) streamed the light-format multipart uploads to storage via
+/// `put_artifact_stream`, removing all 5 exempt sites in ansible.rs (2),
+/// chef.rs (2) and pub_registry.rs (1): 38 -> 33.
 const ALLOWLIST: &[(&str, usize)] = &[
-    ("src/api/handlers/ansible.rs", 2),
-    ("src/api/handlers/chef.rs", 2),
     ("src/api/handlers/goproxy.rs", 1),
     ("src/api/handlers/helm.rs", 1),
     ("src/api/handlers/npm.rs", 5),
     ("src/api/handlers/oci_v2.rs", 1),
     ("src/api/handlers/plugins.rs", 2),
     ("src/api/handlers/proxy_helpers.rs", 2),
-    ("src/api/handlers/pub_registry.rs", 1),
     ("src/api/handlers/pypi.rs", 1),
     ("src/api/handlers/remote_instances.rs", 1),
     ("src/api/handlers/repositories.rs", 2),
@@ -404,7 +405,7 @@ fn streaming_invariant_exempt_sites_match_allowlist() {
 
     let total: usize = actual_marks.values().sum();
     assert_eq!(
-        total, 38,
-        "expected 38 exempt sites in Phase 1; got {total}"
+        total, 33,
+        "expected 33 exempt sites after #1608 Phase 2; got {total}"
     );
 }


### PR DESCRIPTION
## Summary

Phase 2 of #1608 (Core Invariant ①: *no artifact-path handler may read a full
artifact body into memory*). Streams the **light-format multipart uploads** to
storage instead of buffering the whole artifact on the heap.

Before, the chef (`upload_cookbook`), ansible (`upload_collection`) and pub
(`upload_package`) handlers read the entire uploaded artifact into memory via
`Field::bytes()` and then called `proxy_helpers::put_artifact_bytes` →
`storage.put(Bytes)`, so peak RAM scaled with upload size.

This PR adds a reusable streaming pair in `proxy_helpers` and migrates all three
handlers onto it:

- **`stage_upload_field(state, field)`** spools one multipart field straight to a
  bounded scratch temp file (peak RAM = one 256 KiB chunk), aborting with
  `413 Payload Too Large` once `MAX_UPLOAD_SIZE` (`config.max_upload_size_bytes`,
  `0` = unlimited) is exceeded. The scratch file is staged under the shared
  upload staging root and removed on drop (RAII), so any early return unlinks it
  rather than leaking an orphan.
- **`put_artifact_stream(state, repo, key, staged)`** streams the scratch file
  into the repository's configured `StorageBackend` via its native `put_stream`
  primitive (S3 multipart / GCS resumable / Azure block-blob / filesystem
  temp-and-rename), which computes the SHA-256 **incrementally** as it copies —
  so the artifact row is built from the returned checksum/size with no separate
  hashing pass over a buffered body. This mirrors the existing incus
  monolithic-upload pattern (`stream_body_to_file` + `open_temp_file_as_stream`).

`put_artifact_bytes` is kept for the small metadata writers that still need the
bytes in hand. The small JSON/text metadata parts (chef `cookbook`, ansible
`collection`/`metadata`) now read via `Field::text()` (a length-limited
extractor) rather than `Field::bytes()`.

Handler-specific notes:
- **pub**: `pubspec.yaml` is now parsed from the staged archive on disk
  (`extract_pubspec_from_staged`), gzip-decoded incrementally on a blocking
  thread — the whole archive is never held in memory.
- **ansible**: the client-declared `sha256` is verified against the incremental
  checksum; on mismatch the just-written object is removed and the request is
  rejected `400`.

The `stage_upload_field` / `put_artifact_stream` signatures are deliberately
clean and reusable: **Phase 3 (helm/pypi/nuget) will build on them.**

Gate bookkeeping: the now-unnecessary `#[allow(clippy::disallowed_methods)] //
STREAMING-EXEMPT` annotations are removed from the migrated upload sites and the
per-file counts in `backend/tests/streaming_invariant.rs` are decremented
(ansible 2→0, chef 2→0, pub_registry 1→0). Total exempt sites: **38 → 33**.

Does **not** touch the proxy pull-through core (`proxy_service` coordinate/tee,
`proxy_hydration`) — that is #1609 / Phase 4 and stays frozen here.

Part of #1608.
Closes #2175.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix (feature/hardening for #1608). New tests are
  added regardless (see below).

## Test Checklist
- [x] Unit tests added/updated — `proxy_helpers`: `stage_upload_field` +
  `put_artifact_stream` roundtrip (checksum/size correct, bytes land in storage,
  scratch file cleaned up) and empty-body detection.
- [x] Integration tests added/updated — chef upload end-to-end
  (`upload_stream_tests`): a padded (~135 KB) cookbook streams through, the row
  records the incremental checksum + true size, and the bytes are retrievable
  from the backend; empty tarball → 400. Existing ansible (galaxy-CLI 202,
  sha256-mismatch 400, bad filename 400) and pub (204 + Location, real gzip
  archive) upload tests continue to pass against the streamed path.
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo clippy --workspace --all-targets -D
  warnings` (incl. the streaming disallowed-methods gate) green; full
  `cargo test --workspace --lib` green; `streaming_invariant` passes at 33;
  `cargo fmt --check` clean; new-code coverage 91%.
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (no HTTP surface, request/response, or schema changes)
