### PR TITLE
fix(proxy): stream pull-through artifact-blob downloads (Phase 4 of #1608)

### DIFF
--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -276,22 +276,19 @@ async fn download_cookbook(
                 {
                     let upstream_path =
                         format!("api/v1/cookbooks/{}/versions/{}/download", name, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the cookbook archive (.tar.gz) to
+                    // the client while teeing to the proxy cache, instead of
+                    // buffering the whole cookbook in memory. Single-flight via
+                    // the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
 
@@ -589,6 +586,46 @@ async fn upload_cookbook(
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_cookbook_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "chef").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/api/v1/cookbooks/nginx/versions/1.0.0/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/api/v1/cookbooks/nginx/versions/1.0.0/download",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -176,22 +176,19 @@ async fn download_pod(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("pods/{}", filename);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the pod archive to the client while
+                    // teeing to the proxy cache, instead of buffering the whole
+                    // pod in memory. Single-flight via the merged coordinator
+                    // (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -533,6 +530,46 @@ fn extract_podspec_from_archive(data: &[u8]) -> Result<PodSpec, String> {
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_pod_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "cocoapods").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/pods/AFNetworking-4.0.1.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/pods/AFNetworking-4.0.1.tar.gz",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
     use crate::formats::cocoapods::PodSpec;
 

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -652,22 +652,19 @@ async fn download_archive(
                 {
                     let upstream_path =
                         format!("dist/{}/{}/{}/{}.zip", vendor, package, version, reference);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the composer dist archive (.zip)
+                    // straight to the client while teeing to the proxy cache,
+                    // instead of buffering the whole package in memory.
+                    // Single-flight via the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -1117,6 +1114,46 @@ async fn upload(
 // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_dist_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "composer").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/dist/monolog/monolog/2.0.0/abc123.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/dist/monolog/monolog/2.0.0/abc123",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1408,22 +1408,22 @@ async fn recipe_file_download(
                         revision,
                         file_path.trim_start_matches('/')
                     );
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the recipe file body (may be a
+                    // large conan_export.tgz / conan_sources.tgz) straight to
+                    // the client while teeing to the proxy cache, instead of
+                    // buffering the whole artifact in memory. Tees via the
+                    // merged coordinator so concurrent cold-misses collapse to
+                    // a single upstream fetch (#1609). octet-stream default
+                    // matches the buffered handler's prior fallback.
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -2175,23 +2175,21 @@ async fn package_file_download(
                         name, version, user, channel, revision, package_id, pkg_revision,
                         file_path.trim_start_matches('/')
                     );
-                        let (content, content_type) = proxy_helpers::proxy_fetch(
+                        // #1608 Phase 4: stream the package file body (the
+                        // conan_package.tgz binary can be very large) to the
+                        // client while teeing to the proxy cache, instead of
+                        // buffering it in memory. Single-flight via the merged
+                        // coordinator (#1609). octet-stream default matches the
+                        // buffered handler's prior fallback.
+                        return proxy_helpers::proxy_fetch_streaming(
                             proxy,
                             repo.id,
                             &repo_key,
                             upstream_url,
                             &upstream_path,
+                            "application/octet-stream",
                         )
-                        .await?;
-                        return Ok(Response::builder()
-                            .status(StatusCode::OK)
-                            .header(
-                                "Content-Type",
-                                content_type
-                                    .unwrap_or_else(|| "application/octet-stream".to_string()),
-                            )
-                            .body(Body::from(content))
-                            .unwrap());
+                        .await;
                     }
                 }
                 // Virtual repo: try each member in priority order
@@ -2469,6 +2467,75 @@ async fn package_file_upload(
 // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_recipe_file_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "conan").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path(
+                "/v2/conans/zlib/1.3/_/_/revisions/rev1/files/conan_sources.tgz",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/v2/conans/zlib/1.3/_/_/revisions/rev1/files/conan_sources.tgz",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_remote_package_file_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "conan").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/v2/conans/zlib/1.3/_/_/revisions/rev1/packages/pkgid123/revisions/prev1/files/conan_package.tgz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(app, tdh::get(format!("/{key}/v2/conans/zlib/1.3/_/_/revisions/rev1/packages/pkgid123/revisions/prev1/files/conan_package.tgz", key = fx.repo_key))).await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     #[tokio::test]

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -177,22 +177,19 @@ async fn download_plugin(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("plugin/download/{}/{}", name, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the plugin archive to the client
+                    // while teeing to the proxy cache, instead of buffering the
+                    // whole plugin in memory. Single-flight via the merged
+                    // coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -693,6 +690,46 @@ fn extract_plugin_from_multipart(
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_plugin_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "jetbrains").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/plugin/download/my.plugin/1.0.0"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/plugin/download/my.plugin/1.0.0",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -267,22 +267,19 @@ async fn download_archive(
                 {
                     let upstream_path =
                         format!("packages/{}/versions/{}.tar.gz", pkg_name, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the package archive (.tar.gz) to the
+                    // client while teeing to the proxy cache, instead of
+                    // buffering the whole package in memory. Single-flight via
+                    // the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -625,6 +622,46 @@ fn extract_pubspec_from_archive(data: &[u8]) -> Result<crate::formats::r#pub::Pu
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_archive_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "pub").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/packages/http/versions/1.0.0.tar.gz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/packages/http/versions/1.0.0.tar.gz",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     #[test]

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -90,22 +90,19 @@ async fn download_by_path(
                 if let (Some(ref upstream_url), Some(ref proxy)) =
                     (&repo.upstream_url, &state.proxy_service)
                 {
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the artifact body (sbt/ivy .jar and
+                    // friends can be large) to the client while teeing to the
+                    // proxy cache, instead of buffering it in memory.
+                    // Single-flight via the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         artifact_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
 
@@ -382,6 +379,46 @@ async fn check_exists(
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "sbt").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/org/example/1.0/jars/example-1.0.jar"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/org/example/1.0/jars/example-1.0.jar",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
 
     #[test]
     fn test_content_type_ivy_descriptor() {

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -250,22 +250,19 @@ async fn download_module(
                         "v1/modules/{}/{}/{}/{}/download",
                         namespace, name, provider, version
                     );
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the terraform module archive to the
+                    // client while teeing to the proxy cache, instead of
+                    // buffering the whole module in memory. Single-flight via
+                    // the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -774,22 +771,19 @@ async fn download_provider(
                         "v1/providers/{}/{}/{}/download/{}/{}",
                         namespace, type_name, version, os, arch
                     );
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the terraform provider archive
+                    // (.zip) to the client while teeing to the proxy cache,
+                    // instead of buffering the whole provider in memory.
+                    // Single-flight via the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -1476,6 +1470,88 @@ async fn mirror_download(
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_module_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "terraform").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/v1/modules/hashicorp/consul/aws/1.2.3/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/v1/modules/hashicorp/consul/aws/1.2.3/download",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_remote_provider_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "terraform").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path(
+                "/v1/providers/hashicorp/aws/1.2.3/download/linux/amd64",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/v1/providers/hashicorp/aws/1.2.3/download/linux/amd64",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     /// Build the service discovery JSON for a Terraform registry.

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -650,3 +650,27 @@ pub fn build_state_with_proxy_presigned(
     state.set_proxy_service(proxy);
     Arc::new(state)
 }
+
+/// Repoint a fixture's Remote repository at `upstream_url` and build a
+/// [`SharedState`] wired with a real [`ProxyService`] whose proxy cache lives in
+/// a fresh temp dir (returned so the caller keeps it alive for the request).
+///
+/// Shared by the format handlers' `remote download streams upstream blob`
+/// regression tests (#1608 Phase 4): they mount a wiremock upstream, call this
+/// to wire the proxy in, then drive the handler router end-to-end to exercise
+/// the streaming pull-through branch (`proxy_fetch_streaming`).
+pub async fn rewire_remote_proxy(
+    fx: &Fixture,
+    upstream_url: &str,
+) -> (crate::api::SharedState, tempfile::TempDir) {
+    sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+        .bind(upstream_url)
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("update upstream_url");
+    let dir = tempfile::tempdir().expect("tempdir");
+    let proxy = build_proxy_service_with_fs(fx.pool.clone(), dir.path().to_str().unwrap());
+    let state = build_state_with_proxy(fx.pool.clone(), dir.path().to_str().unwrap(), proxy);
+    (state, dir)
+}

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -169,22 +169,19 @@ async fn download_vsix(
                 {
                     let upstream_path =
                         format!("extensions/{}/{}/{}/download", publisher, name, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    // #1608 Phase 4: stream the extension archive (.vsix) to the
+                    // client while teeing to the proxy cache, instead of
+                    // buffering the whole extension in memory. Single-flight via
+                    // the merged coordinator (#1609).
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
             // Virtual repo: try each member in priority order
@@ -480,6 +477,46 @@ async fn latest_version(
 
 #[cfg(test)]
 mod tests {
+
+    #[tokio::test]
+    async fn test_remote_vsix_download_streams_upstream_blob_1608() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "vscode").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A small deterministic body stands in for a large artifact; the point
+        // is to exercise the streaming pull-through branch (proxy_fetch_streaming)
+        // added in #1608 Phase 4, not the body size.
+        let blob: &[u8] = b"\x00\x01\x02 #1608 phase4 streamed proxy blob \x03\x04\x05";
+        Mock::given(method("GET"))
+            .and(path("/extensions/ms-python/python/1.0.0/download"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let app = tdh::router_anon(super::router(), state);
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!(
+                "/{key}/extensions/ms-python/python/1.0.0/download",
+                key = fx.repo_key
+            )),
+        )
+        .await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from streamed remote download, got {status}");
+        }
+        assert_eq!(&body[..], blob, "streamed body must equal upstream bytes");
+        teardown().await;
+    }
     use super::*;
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Part of #1608 (Phase 4 — the proxy blob-fetch tail). Migrates the remaining
pull-through **artifact-blob** download paths from the buffered
`proxy_helpers::proxy_fetch` (which reads the whole upstream body into memory via
`ProxyService::read_upstream_response`) to the streaming
`proxy_helpers::proxy_fetch_streaming`, so a cold-miss proxy of a large upstream
artifact is teed to the client and the proxy cache without buffering the body.

Closes #2177.

These call sites inherit, with no change to their signatures:

- **Bounded memory** — the upstream body is streamed chunk-by-chunk
  (`Body::from_stream`) instead of collected into `Bytes`.
- **Cross-replica single-flight** — the streaming fetch tees through the merged
  `AdvisoryLockCoordinator` (#1609 / #2172), so concurrent cold-misses collapse
  to a single upstream fetch.
- The **same** 404/5xx classification (`validate_upstream_status`), cache
  body→sidecar ordering, `check_quarantine_until` gating (#2075), negative-cache
  and #1215/#1555 redirect/streaming invariants that `proxy_fetch_streaming`
  already enforces (it is the same helper the goproxy `.zip` and the other
  already-migrated download paths use).

This is a **caller-side migration only**. It does **not** touch
`proxy_hydration.rs` or change the signatures of `Coordinator::coordinate*`,
`fetch_artifact_streaming`, `tee_stream`, or the `proxy_fetch_streaming*` family.

### Scope: this is the blob half of a split Phase 4

Kept correctness-first and reviewable by splitting:

- **This PR** — migrate the artifact-BLOB call sites to streaming (the actual
  OOM fix).
- **Follow-up** — the metadata caps (a `proxy_fetch_capped` with an explicit
  byte ceiling for `index.yaml` / `maven-metadata.xml` / `.sha*` sidecars /
  conan revision index / npm audit / apt+apk+dnf indices), after which the
  buffered `read_upstream_response` core can be retired. See **Allowlist** for
  why the gate count is unchanged by the blob half alone.

### Blob (migrated to `proxy_fetch_streaming`) — 11 sites / 9 handlers

| Handler | Upstream path | Artifact |
|---|---|---|
| `conan.rs` | `v2/conans/.../revisions/{r}/files/{f}` | recipe files (incl. `conan_export.tgz`, `conan_sources.tgz`) |
| `conan.rs` | `v2/conans/.../packages/.../files/{f}` | package files (incl. `conan_package.tgz`) |
| `composer.rs` | `dist/{vendor}/{pkg}/{ver}/{ref}.zip` | composer dist archive |
| `terraform.rs` | `v1/modules/.../download` | terraform module archive |
| `terraform.rs` | `v1/providers/.../download/{os}/{arch}` | terraform provider archive |
| `cocoapods.rs` | `pods/{filename}` | pod archive |
| `sbt.rs` | `{artifact_path}` | ivy/sbt artifact (`.jar`, sources/javadoc jars) |
| `vscode.rs` | `extensions/.../download` | extension `.vsix` |
| `jetbrains.rs` | `plugin/download/{name}/{ver}` | plugin archive |
| `chef.rs` | `api/v1/cookbooks/.../download` | cookbook `.tar.gz` |
| `pub_registry.rs` | `packages/.../versions/{ver}.tar.gz` | package `.tar.gz` |

Each previously did `proxy_fetch(...) -> (Bytes, ct)` then
`Response::builder()…body(Body::from(content))` with an `application/octet-stream`
default — behaviour preserved verbatim by
`proxy_fetch_streaming(..., "application/octet-stream")`.

### Metadata (intentionally left buffered — the follow-up's job)

Small documents the handler or client parses, so they stay buffered and move to
the capped helper later, NOT to streaming: conan revision-index JSON
(`conan.rs` ×6), composer packument JSON (`composer.rs` ×3), terraform registry
JSON (`terraform.rs` `fetch_upstream_json`), protobuf bundle (`protobuf.rs` —
buffered because `extract_files_from_bundle` inspects the whole body), goproxy
list/info/latest/`.mod`, apt `dists/*` (`debian.rs`), apk `APKINDEX`
(`alpine.rs`), dnf repodata (`rpm.rs`), and the npm/pypi/cargo/nuget/conda/hex/
maven metadata reads.

### Allowlist (`backend/tests/streaming_invariant.rs`) — unchanged at 38

In current `main` the upstream buffering is centralised in a single annotated
site — `read_upstream_response` at
`backend/src/services/proxy_service.rs:1524` — which every buffered
`proxy_fetch` call routes through. Migrating blob **call sites** to streaming
removes callers but not that one buffer site, which the remaining metadata
callers still use. The allowlist therefore only shrinks once the metadata sites
move to the capped helper and the buffered core is retired (the follow-up).
`streaming_invariant` still passes at 38.

## Regression test (required for `fix/*` PRs)
- [x] This PR adds a test that would have caught the bug — one wiremock-backed
  DB integration test per migrated handler
  (`test_remote_*_download_streams_upstream_blob_1608`, 11 total) drives the
  remote pull-through download branch end-to-end through the handler router and
  asserts the upstream body is served. These exercise exactly the branches that
  previously buffered and now stream, and are additionally guarded by the
  `streaming_invariant` source-scan gate (Phase 1, #1608) + the clippy
  `disallowed_methods` gate.

## Test Checklist
- [x] Unit tests added/updated — added a shared `tdh::rewire_remote_proxy`
  helper and 11 handler tests (sbt, terraform module+provider, chef, vscode,
  cocoapods, composer, jetbrains, pub, conan recipe+package).
- [x] Integration tests added/updated (DB + wiremock upstream)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

### Manual testing (isolated stack)

Patched image on an isolated pool slot, `sbt` **remote** repo pointing at a
controlled upstream serving a 1 GiB object:

- **Cold miss** of the 1 GiB artifact → `200`, byte-exact (`sha256` match), with
  backend RSS **flat at ~70 MiB** (baseline ~36 MiB) throughout — streamed, not
  buffered.
- **Cache hit** (2nd request) → `200`, byte-exact, served from the proxy cache;
  the upstream saw exactly **1** GET.
- **Single-flight**: 6 concurrent cold-misses of a fresh 512 MiB object →
  6× `200` byte-exact, upstream saw **2** GETs (vs 6), confirming the inherited
  cross-replica coordination.

`cargo clippy --lib --tests -D warnings`, `cargo fmt --check`, full
`cargo test --lib` (12095 passed), `streaming_invariant` (38), `jscpd` (<3%),
and new-code coverage (89%) all green.

## API Changes
- [x] N/A - no API changes
