### PR TITLE
feat(uploads): stream helm chart metadata-parsing upload to storage (#1608)

### DIFF
--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -18,7 +18,6 @@ use axum::routing::{delete, get, post};
 use axum::Extension;
 use axum::Router;
 use bytes::Bytes;
-use sha2::{Digest, Sha256};
 use sqlx::{PgPool, Row};
 use tracing::info;
 
@@ -449,41 +448,37 @@ async fn upload_chart(
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
 
-    // Extract chart file from multipart form (field name: "chart")
-    let mut chart_content: Option<Bytes> = None;
-
+    // Spool the .tgz straight to a bounded scratch file instead of buffering
+    // the whole archive in memory. See proxy_helpers::stage_upload_field.
+    let mut staged: Option<proxy_helpers::StagedUpload> = None;
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         (StatusCode::BAD_REQUEST, format!("Invalid multipart: {}", e)).into_response()
     })? {
         let name = field.name().unwrap_or("").to_string();
         if name == "chart" {
-            chart_content = Some(field.bytes().await.map_err(|e| {
-                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-                (StatusCode::BAD_REQUEST, format!("Invalid file: {}", e)).into_response()
-            })?);
+            staged = Some(proxy_helpers::stage_upload_field(&state, field).await?);
+            break;
         }
     }
 
-    let content = chart_content
-        .ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing 'chart' field").into_response())?;
+    let staged =
+        staged.ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing 'chart' field").into_response())?;
 
-    // Extract and validate Chart.yaml from the package
-    let chart_yaml = HelmHandler::extract_chart_yaml(&content).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid chart package: {}", e),
-        )
-            .into_response()
-    })?;
+    // Extract and validate Chart.yaml from the staged archive on disk, reading
+    // only the Chart.yaml entry (bounded memory) rather than the whole package.
+    let chart_yaml = extract_chart_yaml_from_staged(staged.path())
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid chart package: {}", e),
+            )
+                .into_response()
+        })?;
 
     let chart_name = &chart_yaml.name;
     let chart_version = &chart_yaml.version;
     let filename = format!("{}-{}.tgz", chart_name, chart_version);
-
-    // Compute SHA256
-    let mut hasher = Sha256::new();
-    hasher.update(&content);
-    let computed_sha256 = format!("{:x}", hasher.finalize());
 
     // Build artifact path
     let artifact_path = format!("{}/{}/{}", chart_name, chart_version, filename);
@@ -495,10 +490,13 @@ async fn upload_chart(
     proxy_helpers::ensure_unique_artifact_path(&state.db, repo.id, &artifact_path, &conflict_msg)
         .await?;
 
+    // Stream the staged archive into the repo's StorageBackend via `put_stream`,
+    // which computes the SHA-256 incrementally as it copies (no re-hash pass).
     let storage_key = format!("helm/{}/{}/{}", chart_name, chart_version, filename);
-    proxy_helpers::put_artifact_bytes(&state, &repo, &storage_key, content.clone()).await?;
+    let put = proxy_helpers::put_artifact_stream(&state, &repo, &storage_key, staged).await?;
+    let computed_sha256 = put.checksum_sha256;
 
-    let size_bytes = content.len() as i64;
+    let size_bytes = put.bytes_written as i64;
 
     // Insert artifact record
     let artifact_id = proxy_helpers::insert_artifact(
@@ -549,6 +547,21 @@ async fn upload_chart(
             .unwrap(),
         ))
         .unwrap())
+}
+
+/// Extract Chart.yaml from a staged .tgz archive on disk. The blocking
+/// flate2/tar decode runs on a blocking thread so it never stalls the async
+/// runtime, and only the Chart.yaml entry is read (bounded memory).
+async fn extract_chart_yaml_from_staged(path: &std::path::Path) -> Result<ChartYaml, String> {
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let file = std::fs::File::open(&path)
+            .map_err(|e| format!("Failed to open staged archive: {}", e))?;
+        HelmHandler::extract_chart_yaml_from_reader(std::io::BufReader::new(file))
+            .map_err(|e| e.to_string())
+    })
+    .await
+    .map_err(|e| format!("chart extraction task failed: {}", e))?
 }
 
 // ---------------------------------------------------------------------------
@@ -626,6 +639,57 @@ async fn delete_chart(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sha2::{Digest, Sha256};
+
+    /// Build a gzip-compressed tar (`.tgz`) holding a single `path`/`body`
+    /// entry, matching the on-disk layout the upload staging path reads.
+    fn build_tgz(path: &str, body: &[u8]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write;
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, path, body).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        encoder.write_all(&tar_buf).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_extract_chart_yaml_from_staged_parses_metadata() {
+        let tgz = build_tgz(
+            "nginx/Chart.yaml",
+            b"apiVersion: v2\nname: nginx\nversion: 9.8.7\n",
+        );
+        let dir = std::env::temp_dir().join(format!("helm-staged-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("chart.tgz");
+        std::fs::write(&path, &tgz).unwrap();
+
+        let chart = extract_chart_yaml_from_staged(&path).await.unwrap();
+        assert_eq!(chart.name, "nginx");
+        assert_eq!(chart.version, "9.8.7");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_extract_chart_yaml_from_staged_malformed_errors() {
+        let dir = std::env::temp_dir().join(format!("helm-staged-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("bad.tgz");
+        std::fs::write(&path, b"this is not a gzip archive").unwrap();
+
+        assert!(extract_chart_yaml_from_staged(&path).await.is_err());
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     // -----------------------------------------------------------------------
     // resolve_chart_url

--- a/backend/src/formats/helm.rs
+++ b/backend/src/formats/helm.rs
@@ -152,9 +152,17 @@ impl HelmHandler {
         )))
     }
 
-    /// Extract Chart.yaml from chart package
+    /// Extract Chart.yaml from chart package.
     pub fn extract_chart_yaml(content: &[u8]) -> Result<ChartYaml> {
-        let gz = GzDecoder::new(content);
+        Self::extract_chart_yaml_from_reader(content)
+    }
+
+    /// Extract Chart.yaml from a chart package `reader`, decoding the gzip
+    /// stream incrementally so the whole archive is never held in memory. Only
+    /// the Chart.yaml entry is read (capped by `read_capped_entry_to_string`),
+    /// so peak memory is a single metadata entry rather than the full artifact.
+    pub fn extract_chart_yaml_from_reader<R: Read>(reader: R) -> Result<ChartYaml> {
+        let gz = GzDecoder::new(reader);
         let mut archive = Archive::new(gz);
 
         for entry in archive

--- a/backend/tests/streaming_invariant.rs
+++ b/backend/tests/streaming_invariant.rs
@@ -36,9 +36,13 @@ use std::path::{Path, PathBuf};
 /// Phase 2 (#1608) streamed the light-format multipart uploads to storage via
 /// `put_artifact_stream`, removing all 5 exempt sites in ansible.rs (2),
 /// chef.rs (2) and pub_registry.rs (1): 38 -> 33.
+///
+/// Phase 3 (#1608) streamed the helm chart upload — the metadata (Chart.yaml)
+/// is now parsed from a single on-disk tar entry and the body is streamed to
+/// storage via `put_artifact_stream`, removing the 1 exempt site in helm.rs:
+/// 33 -> 32.
 const ALLOWLIST: &[(&str, usize)] = &[
     ("src/api/handlers/goproxy.rs", 1),
-    ("src/api/handlers/helm.rs", 1),
     ("src/api/handlers/npm.rs", 5),
     ("src/api/handlers/oci_v2.rs", 1),
     ("src/api/handlers/plugins.rs", 2),
@@ -405,7 +409,7 @@ fn streaming_invariant_exempt_sites_match_allowlist() {
 
     let total: usize = actual_marks.values().sum();
     assert_eq!(
-        total, 33,
-        "expected 33 exempt sites after #1608 Phase 2; got {total}"
+        total, 32,
+        "expected 32 exempt sites after #1608 Phase 3 (helm streamed); got {total}"
     );
 }


### PR DESCRIPTION
## Summary

Streams the Helm chart upload (`POST /helm/{repo_key}/api/charts`) to storage
instead of buffering the whole `.tgz` in heap. Part of the #1608 streaming-uploads
epic (Phase 3), building on Phase 2's `stage_upload_field` / `put_artifact_stream`
helpers.

Previously the handler read the entire multipart `chart` field into memory via
`Field::bytes()`, extracted `Chart.yaml` from the in-memory archive, then hashed the
buffered body a second time — peak RAM scaled with artifact size. Now the handler:

- spools the upload to a bounded scratch file with `proxy_helpers::stage_upload_field`
  (413 at `MAX_UPLOAD_SIZE`, RAII cleanup on every early return);
- parses `Chart.yaml` by reading only that single tar entry off the on-disk archive
  (peak RAM = one metadata entry, already capped at 4 MiB against tar/gzip bombs via
  the existing `read_capped_entry_to_string`);
- streams the body to storage via `proxy_helpers::put_artifact_stream`, using its
  incremental SHA-256 (the separate post-buffer re-hash is removed).

Behavior is preserved exactly: metadata is parsed identically, a malformed archive
still returns 400, and the duplicate/conflict backstop still returns 409.

`extract_chart_yaml` is refactored to delegate to a new
`extract_chart_yaml_from_reader<R: Read>`, so the `&[u8]` callers and the new
staged-file reader path share one implementation.

The streaming-invariant allowlist (`backend/tests/streaming_invariant.rs`) drops the
helm.rs annotation: total **33 → 32**.

### Scope note (pypi / nuget deferred)
The original Phase 3 note also named pypi and nuget, but their upload paths do not fit
the Phase 2 helper pattern and were found to need an architect re-scope (see #2179):
pypi stores via content-addressed `artifact_service::upload_with_sync_options`
(multi-checksum + dedup + plugin hooks + release-immutability backstop) with no
streaming equivalent, and nuget ingests a raw `Bytes` body with hand-rolled multipart
parsing rather than axum `Multipart`. They are tracked separately under #1608.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a `feat/`-style streaming conversion, not a bug fix

## Test Checklist
- [x] Unit tests added/updated — new `extract_chart_yaml_from_staged` parse + malformed
  cases; existing `formats::helm` reader/cap tests now exercise the shared reader path
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — 40 MiB chart push held flat ~38 MiB backend RSS
  (streamed, not buffered), download SHA-256 matched, `index.yaml` metadata parsed
  identically, malformed → 400, duplicate → 409
- [x] No regressions in existing tests — `cargo test --lib` helm suites + the
  `streaming_invariant` gate pass at total 32

## API Changes
- [x] N/A - no API changes

Closes #2179
Part of #1608
