### PR TITLE
chore(auth): consolidate require_admin onto AuthExtension gate (#1617 Phase 3)

### DIFF
--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -171,10 +171,6 @@ pub struct TokenListResponse {
 // Helper
 // ---------------------------------------------------------------------------
 
-pub(crate) fn require_admin(auth: &AuthExtension) -> Result<()> {
-    auth.require_admin()
-}
-
 pub(crate) fn validate_create_token_exclusivity(
     repo_selector: &Option<serde_json::Value>,
     repository_ids: &Option<Vec<Uuid>>,
@@ -255,7 +251,7 @@ pub async fn list_service_accounts(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<ServiceAccountListResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     let svc = ServiceAccountService::new(state.db.clone());
     let accounts = svc.list(true).await?;
@@ -284,7 +280,7 @@ pub async fn create_service_account(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateServiceAccountRequest>,
 ) -> Result<Json<ServiceAccountResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     let svc = ServiceAccountService::new(state.db.clone());
     let user = svc
@@ -325,7 +321,7 @@ pub async fn get_service_account(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ServiceAccountResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     let svc = ServiceAccountService::new(state.db.clone());
     let user = svc.get(id).await?;
@@ -360,7 +356,7 @@ pub async fn update_service_account(
     Path(id): Path<Uuid>,
     Json(payload): Json<UpdateServiceAccountRequest>,
 ) -> Result<Json<ServiceAccountResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     // Pre-mark the cache invalidation BEFORE the SQL UPDATE so any concurrent
     // request that might still hit the cache during the update is rejected.
@@ -411,7 +407,7 @@ pub async fn delete_service_account(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<axum::http::StatusCode> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     // Pre-mark the cache invalidation BEFORE the SQL DELETE. Hard-deleting a
     // service account must also evict cached API-token validations for that
@@ -448,7 +444,7 @@ pub async fn list_tokens(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<TokenListResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     // Verify the service account exists
     let svc = ServiceAccountService::new(state.db.clone());
@@ -533,7 +529,7 @@ pub async fn create_token(
     Path(id): Path<Uuid>,
     Json(payload): Json<CreateTokenRequest>,
 ) -> Result<Json<CreateTokenResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     // Validate mutual exclusivity
     validate_create_token_exclusivity(&payload.repo_selector, &payload.repository_ids)?;
@@ -610,7 +606,7 @@ pub async fn preview_repo_selector(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<PreviewRepoSelectorRequest>,
 ) -> Result<Json<PreviewRepoSelectorResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     use crate::services::repo_selector_service::{RepoSelector, RepoSelectorService};
 
@@ -657,7 +653,7 @@ pub async fn revoke_token(
     Extension(auth): Extension<AuthExtension>,
     Path((id, token_id)): Path<(Uuid, Uuid)>,
 ) -> Result<axum::http::StatusCode> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
 
     // Verify the service account exists
     let svc = ServiceAccountService::new(state.db.clone());
@@ -757,13 +753,13 @@ mod tests {
     #[test]
     fn test_require_admin_allows_admin() {
         let auth = admin_auth();
-        assert!(require_admin(&auth).is_ok());
+        assert!(auth.require_admin().is_ok());
     }
 
     #[test]
     fn test_require_admin_rejects_non_admin() {
         let auth = non_admin_auth();
-        let err = require_admin(&auth).unwrap_err();
+        let err = auth.require_admin().unwrap_err();
         match err {
             AppError::Authorization(msg) => assert_eq!(msg, "Admin access required"),
             other => panic!("Expected Authorization error, got: {:?}", other),

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -767,6 +767,89 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Admin gate is enforced at the top of every route handler
+    // -----------------------------------------------------------------------
+
+    // Every service-account handler calls `auth.require_admin()?` before any
+    // database access, so a non-admin caller is rejected with the canonical
+    // 403 even against a lazy (never-connected) pool.
+    fn expect_forbidden<T>(res: Result<T>) {
+        match res {
+            Err(AppError::Authorization(msg)) => assert_eq!(msg, "Admin access required"),
+            Err(other) => panic!("expected admin denial, got error: {other}"),
+            Ok(_) => panic!("expected admin denial, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_admin_denied_on_every_service_account_route() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let dir = std::env::temp_dir().join(format!("ph-svc-acct-{}", Uuid::new_v4()));
+        let state = tdh::build_state(tdh::lazy_pool(), dir.to_str().unwrap());
+        let auth = non_admin_auth();
+        let id = Uuid::new_v4();
+
+        expect_forbidden(
+            list_service_accounts(State(state.clone()), Extension(auth.clone())).await,
+        );
+        expect_forbidden(
+            create_service_account(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Json(serde_json::from_value(serde_json::json!({"name": "ci"})).unwrap()),
+            )
+            .await,
+        );
+        expect_forbidden(
+            get_service_account(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        expect_forbidden(
+            update_service_account(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(serde_json::json!({})).unwrap()),
+            )
+            .await,
+        );
+        expect_forbidden(
+            delete_service_account(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        expect_forbidden(
+            list_tokens(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        expect_forbidden(
+            create_token(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(
+                    serde_json::from_value(serde_json::json!({"name": "t", "scopes": ["read"]}))
+                        .unwrap(),
+                ),
+            )
+            .await,
+        );
+        expect_forbidden(
+            preview_repo_selector(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Json(serde_json::from_value(serde_json::json!({"repo_selector": {}})).unwrap()),
+            )
+            .await,
+        );
+        expect_forbidden(
+            revoke_token(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path((id, Uuid::new_v4())),
+            )
+            .await,
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // From<ServiceAccountSummary> for ServiceAccountSummaryResponse
     // -----------------------------------------------------------------------
 

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -49,14 +49,6 @@ pub fn router() -> Router<SharedState> {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn require_admin(auth: &AuthExtension) -> Result<()> {
-    auth.require_admin()
-}
-
-// ---------------------------------------------------------------------------
 // OIDC
 // ---------------------------------------------------------------------------
 
@@ -76,7 +68,7 @@ pub async fn list_oidc(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<OidcConfigResponse>>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::list_oidc(&state.db).await?;
     Ok(Json(result))
 }
@@ -102,7 +94,7 @@ pub async fn get_oidc(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<OidcConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::get_oidc(&state.db, id).await?;
     Ok(Json(result))
 }
@@ -125,7 +117,7 @@ pub async fn create_oidc(
     Extension(auth): Extension<AuthExtension>,
     Json(req): Json<CreateOidcConfigRequest>,
 ) -> Result<Json<OidcConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::create_oidc(&state.db, req).await?;
     Ok(Json(result))
 }
@@ -153,7 +145,7 @@ pub async fn update_oidc(
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateOidcConfigRequest>,
 ) -> Result<Json<OidcConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::update_oidc(&state.db, id, req).await?;
     Ok(Json(result))
 }
@@ -179,7 +171,7 @@ pub async fn delete_oidc(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<()> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     AuthConfigService::delete_oidc(&state.db, id).await?;
     Ok(())
 }
@@ -207,7 +199,7 @@ pub async fn toggle_oidc(
     Path(id): Path<Uuid>,
     Json(req): Json<ToggleRequest>,
 ) -> Result<()> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     AuthConfigService::toggle_oidc(&state.db, id, req).await?;
     Ok(())
 }
@@ -232,7 +224,7 @@ pub async fn list_ldap(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<LdapConfigResponse>>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::list_ldap(&state.db).await?;
     Ok(Json(result))
 }
@@ -258,7 +250,7 @@ pub async fn get_ldap(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LdapConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::get_ldap(&state.db, id).await?;
     Ok(Json(result))
 }
@@ -281,7 +273,7 @@ pub async fn create_ldap(
     Extension(auth): Extension<AuthExtension>,
     Json(req): Json<CreateLdapConfigRequest>,
 ) -> Result<Json<LdapConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     crate::api::validation::validate_outbound_ldap_url(&req.server_url, "LDAP server URL")?;
     let result = AuthConfigService::create_ldap(&state.db, req).await?;
     Ok(Json(result))
@@ -310,7 +302,7 @@ pub async fn update_ldap(
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateLdapConfigRequest>,
 ) -> Result<Json<LdapConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     if let Some(server_url) = &req.server_url {
         crate::api::validation::validate_outbound_ldap_url(server_url, "LDAP server URL")?;
     }
@@ -339,7 +331,7 @@ pub async fn delete_ldap(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<()> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     AuthConfigService::delete_ldap(&state.db, id).await?;
     Ok(())
 }
@@ -367,7 +359,7 @@ pub async fn toggle_ldap(
     Path(id): Path<Uuid>,
     Json(req): Json<ToggleRequest>,
 ) -> Result<()> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     AuthConfigService::toggle_ldap(&state.db, id, req).await?;
     Ok(())
 }
@@ -393,7 +385,7 @@ pub async fn test_ldap(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LdapTestResult>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::test_ldap_connection(&state.db, id).await?;
     Ok(Json(result))
 }
@@ -418,7 +410,7 @@ pub async fn list_saml(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<SamlConfigResponse>>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::list_saml(&state.db).await?;
     Ok(Json(result))
 }
@@ -444,7 +436,7 @@ pub async fn get_saml(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<SamlConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::get_saml(&state.db, id).await?;
     Ok(Json(result))
 }
@@ -467,7 +459,7 @@ pub async fn create_saml(
     Extension(auth): Extension<AuthExtension>,
     Json(req): Json<CreateSamlConfigRequest>,
 ) -> Result<Json<SamlConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::create_saml(&state.db, req).await?;
     Ok(Json(result))
 }
@@ -495,7 +487,7 @@ pub async fn update_saml(
     Path(id): Path<Uuid>,
     Json(req): Json<UpdateSamlConfigRequest>,
 ) -> Result<Json<SamlConfigResponse>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::update_saml(&state.db, id, req).await?;
     Ok(Json(result))
 }
@@ -521,7 +513,7 @@ pub async fn delete_saml(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<()> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     AuthConfigService::delete_saml(&state.db, id).await?;
     Ok(())
 }
@@ -549,7 +541,7 @@ pub async fn toggle_saml(
     Path(id): Path<Uuid>,
     Json(req): Json<ToggleRequest>,
 ) -> Result<()> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     AuthConfigService::toggle_saml(&state.db, id, req).await?;
     Ok(())
 }
@@ -575,7 +567,7 @@ pub async fn list_providers(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<SsoProviderInfo>>> {
-    require_admin(&auth)?;
+    auth.require_admin()?;
     let result = AuthConfigService::list_enabled_providers(&state.db).await?;
     Ok(Json(result))
 }
@@ -642,7 +634,7 @@ mod tests {
             scopes: None,
             allowed_repo_ids: None,
         };
-        assert!(require_admin(&auth).is_ok());
+        assert!(auth.require_admin().is_ok());
     }
 
     #[test]
@@ -657,7 +649,7 @@ mod tests {
             scopes: None,
             allowed_repo_ids: None,
         };
-        let err = require_admin(&auth).unwrap_err();
+        let err = auth.require_admin().unwrap_err();
         assert!(
             format!("{}", err).contains("Admin access required"),
             "Expected 'Admin access required' in error: {}",
@@ -677,7 +669,7 @@ mod tests {
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             allowed_repo_ids: None,
         };
-        assert!(require_admin(&auth).is_err());
+        assert!(auth.require_admin().is_err());
     }
 
     #[test]
@@ -692,7 +684,7 @@ mod tests {
             scopes: Some(vec!["admin".to_string()]),
             allowed_repo_ids: None,
         };
-        assert!(require_admin(&auth).is_ok());
+        assert!(auth.require_admin().is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -688,6 +688,167 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Admin gate is enforced at the top of every route handler
+    // -----------------------------------------------------------------------
+
+    // Assert that a handler result is the canonical 403 admin-denial. The gate
+    // runs before any database access, so these calls short-circuit on a lazy
+    // (never-connected) pool.
+    fn assert_admin_denied<T>(res: crate::error::Result<T>) {
+        match res {
+            Err(crate::error::AppError::Authorization(msg)) => {
+                assert_eq!(msg, "Admin access required")
+            }
+            Err(other) => panic!("expected admin denial, got error: {other}"),
+            Ok(_) => panic!("expected admin denial, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_admin_denied_on_every_sso_admin_route() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let dir = std::env::temp_dir().join(format!("ph-sso-admin-{}", Uuid::new_v4()));
+        let state = tdh::build_state(tdh::lazy_pool(), dir.to_str().unwrap());
+        let auth = tdh::make_auth(Uuid::new_v4(), "not-admin");
+        let id = Uuid::new_v4();
+
+        // OIDC
+        assert_admin_denied(list_oidc(State(state.clone()), Extension(auth.clone())).await);
+        assert_admin_denied(
+            get_oidc(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        assert_admin_denied(
+            create_oidc(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Json(
+                    serde_json::from_value(json!({
+                        "name": "x",
+                        "issuer_url": "https://issuer.example.com",
+                        "client_id": "c",
+                        "client_secret": "s"
+                    }))
+                    .unwrap(),
+                ),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            update_oidc(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(json!({})).unwrap()),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            delete_oidc(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        assert_admin_denied(
+            toggle_oidc(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(json!({"enabled": true})).unwrap()),
+            )
+            .await,
+        );
+
+        // LDAP
+        assert_admin_denied(list_ldap(State(state.clone()), Extension(auth.clone())).await);
+        assert_admin_denied(
+            get_ldap(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        assert_admin_denied(
+            create_ldap(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Json(
+                    serde_json::from_value(json!({
+                        "name": "x",
+                        "server_url": "ldaps://ldap.example.com:636",
+                        "user_base_dn": "ou=u,dc=example,dc=com"
+                    }))
+                    .unwrap(),
+                ),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            update_ldap(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(json!({})).unwrap()),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            delete_ldap(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        assert_admin_denied(
+            toggle_ldap(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(json!({"enabled": false})).unwrap()),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            test_ldap(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+
+        // SAML
+        assert_admin_denied(list_saml(State(state.clone()), Extension(auth.clone())).await);
+        assert_admin_denied(
+            get_saml(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        assert_admin_denied(
+            create_saml(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Json(
+                    serde_json::from_value(json!({
+                        "name": "x",
+                        "entity_id": "urn:entity",
+                        "sso_url": "https://sso.example.com",
+                        "certificate": "cert"
+                    }))
+                    .unwrap(),
+                ),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            update_saml(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(json!({})).unwrap()),
+            )
+            .await,
+        );
+        assert_admin_denied(
+            delete_saml(State(state.clone()), Extension(auth.clone()), Path(id)).await,
+        );
+        assert_admin_denied(
+            toggle_saml(
+                State(state.clone()),
+                Extension(auth.clone()),
+                Path(id),
+                Json(serde_json::from_value(json!({"enabled": true})).unwrap()),
+            )
+            .await,
+        );
+
+        // Providers
+        assert_admin_denied(list_providers(State(state.clone()), Extension(auth.clone())).await);
+    }
+
+    // -----------------------------------------------------------------------
     // CreateOidcConfigRequest deserialization
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Part of #1617 (Phase 3). Removes the two private free-function `require_admin`
wrappers in the service-account and SSO-admin handlers and calls the canonical
gate `AuthExtension::require_admin` (`backend/src/api/middleware/auth.rs`)
directly at every call site.

Each wrapper was a one-line delegate (`fn require_admin(auth) { auth.require_admin() }`),
so the change is behavior-preserving:

- `backend/src/api/handlers/service_accounts.rs` — dropped the `pub(crate)` wrapper; 9 call sites now call `auth.require_admin()?`.
- `backend/src/api/handlers/sso_admin.rs` — dropped the private wrapper; 20 call sites now call `auth.require_admin()?`.

Non-admin callers still receive `403 Forbidden` on every `/service-accounts`
and `/sso` admin route; admins are unaffected. No other modules referenced the
removed wrappers.

Because the wrapper deletion surfaces the handlers' admin-gate lines to the
new-code coverage gate, this PR also adds two table-style unit tests
(`non_admin_denied_on_every_service_account_route`,
`non_admin_denied_on_every_sso_admin_route`) that invoke each handler with a
non-admin identity against a lazy (never-connected) pool and assert the
canonical `Authorization` (403) error. The gate runs before any DB access, so
these tests need no database.

Closes #2184

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (chore/refactor; behavior-preserving)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
