### PR TITLE
fix(proxy): cap buffered upstream metadata reads (#2181)

### DIFF
--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -357,9 +357,15 @@ async fn apk_index(
             (&repo.upstream_url, &state.proxy_service)
         {
             let upstream_path = build_apk_index_upstream_path(&branch, &repository, &arch);
-            let (content, content_type) =
-                proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path)
-                    .await?;
+            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &upstream_path,
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await?;
 
             return Ok(Response::builder()
                 .status(StatusCode::OK)
@@ -390,12 +396,13 @@ async fn apk_index(
                 continue;
             };
 
-            let result = proxy_helpers::proxy_fetch(
+            let result = proxy_helpers::proxy_fetch_capped(
                 proxy,
                 member.id,
                 &member.key,
                 upstream_url,
                 &upstream_path,
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
             )
             .await;
 

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -126,10 +126,16 @@ async fn resolve_upstream_dl_url(
 
     // Fetch config.json from upstream.
     let proxy = state.proxy_service.as_ref()?;
-    let config_bytes =
-        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, base_url, "config.json")
-            .await
-            .ok()?;
+    let config_bytes = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        repo_key,
+        base_url,
+        "config.json",
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    .ok()?;
 
     let config: serde_json::Value = serde_json::from_slice(&config_bytes.0).ok()?;
     let dl_url = config.get("dl")?.as_str()?.to_string();
@@ -870,15 +876,17 @@ async fn download(
                     // upstream URL was resolved so that subsequent requests hit
                     // the proxy cache even after a config.json TTL change.
                     let cache_path = format!("api/v1/crates/{}/{}/download", name_lower, version);
-                    let (content, _content_type) = proxy_helpers::proxy_fetch_with_cache_key(
-                        proxy,
-                        repo.id,
-                        &repo_key,
-                        &dl_base,
-                        &dl_path,
-                        &cache_path,
-                    )
-                    .await?;
+                    let (content, _content_type) =
+                        proxy_helpers::proxy_fetch_capped_with_cache_key(
+                            proxy,
+                            repo.id,
+                            &repo_key,
+                            &dl_base,
+                            &dl_path,
+                            &cache_path,
+                            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                        )
+                        .await?;
 
                     let filename = format!("{}-{}.crate", name_lower, version);
 
@@ -1164,7 +1172,15 @@ async fn try_remote_index(
 
     let base_url = repo.index_upstream_url.as_deref().unwrap_or(upstream_url);
     let index_path = cargo_sparse_index_path_upstream(name_lower);
-    let result = proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, base_url, &index_path).await;
+    let result = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        repo_key,
+        base_url,
+        &index_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await;
 
     Some(match result {
         Ok((content, content_type)) => {
@@ -1295,12 +1311,13 @@ async fn try_virtual_index(
                 let base_url =
                     resolve_remote_index_base_url(&index_url_overrides, member.id, upstream_url);
 
-                if let Ok((content, _content_type)) = proxy_helpers::proxy_fetch(
+                if let Ok((content, _content_type)) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     member.id,
                     &member.key,
                     &base_url,
                     &index_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await
                 {

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -384,8 +384,15 @@ where
             continue;
         };
 
-        match proxy_helpers::proxy_fetch(proxy, member.id, &member.key, upstream_url, upstream_path)
-            .await
+        match proxy_helpers::proxy_fetch_capped(
+            proxy,
+            member.id,
+            &member.key,
+            upstream_url,
+            upstream_path,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        )
+        .await
         {
             Ok((content, content_type)) => {
                 return Ok(build_composer_proxy_response(content, content_type));
@@ -522,12 +529,13 @@ async fn metadata_v2(
                 (&repo.upstream_url, &state.proxy_service)
             {
                 let upstream_path = composer_v2_upstream_path(&full_name);
-                let (content, content_type) = proxy_helpers::proxy_fetch(
+                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     &repo_key,
                     upstream_url,
                     &upstream_path,
+                    proxy_helpers::LARGE_METADATA_MAX_BYTES,
                 )
                 .await?;
                 return Ok(build_composer_proxy_response(content, content_type));
@@ -581,12 +589,13 @@ async fn metadata_v1(
                 (&repo.upstream_url, &state.proxy_service)
             {
                 let upstream_path = composer_v1_upstream_path(&full_name);
-                let (content, content_type) = proxy_helpers::proxy_fetch(
+                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     &repo_key,
                     upstream_url,
                     &upstream_path,
+                    proxy_helpers::LARGE_METADATA_MAX_BYTES,
                 )
                 .await?;
                 return Ok(build_composer_proxy_response(content, content_type));

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -467,7 +467,16 @@ async fn search_recipes_from_remote(
 ) -> Vec<String> {
     let encoded = urlencoding::encode(pattern);
     let upstream_path = format!("v2/conans/search?q={}", encoded);
-    match proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, &upstream_path).await {
+    match proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    {
         Ok((bytes, _ct)) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
             Ok(v) => v
                 .get("results")
@@ -641,7 +650,16 @@ async fn recipe_revisions_from_remote(
         "v2/conans/{}/{}/{}/{}/revisions",
         name, version, user, channel
     );
-    match proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, &upstream_path).await {
+    match proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    {
         Ok((bytes, _ct)) => parse_recipe_revisions_json(&bytes),
         Err(_e) => {
             tracing::debug!(
@@ -675,7 +693,16 @@ async fn package_search_from_remote(
         "v2/conans/{}/{}/{}/{}/revisions/{}/search",
         name, version, user, channel, revision
     );
-    match proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, &upstream_path).await {
+    match proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    {
         Ok((bytes, _ct)) => parse_package_search_json(&bytes),
         Err(_e) => {
             tracing::debug!(
@@ -702,7 +729,16 @@ async fn recipe_latest_from_remote(
     channel: &str,
 ) -> Option<String> {
     let upstream_path = format!("v2/conans/{}/{}/{}/{}/latest", name, version, user, channel);
-    match proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, &upstream_path).await {
+    match proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    {
         Ok((bytes, _ct)) => parse_latest_revision_json(&bytes),
         Err(_e) => {
             tracing::debug!(
@@ -733,7 +769,16 @@ async fn package_revisions_from_remote(
         "v2/conans/{}/{}/{}/{}/revisions/{}/packages/{}/revisions",
         name, version, user, channel, revision, package_id
     );
-    match proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, &upstream_path).await {
+    match proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    {
         Ok((bytes, _ct)) => parse_package_revisions_json(&bytes),
         Err(_e) => {
             tracing::debug!(
@@ -764,7 +809,16 @@ async fn package_latest_from_remote(
         "v2/conans/{}/{}/{}/{}/revisions/{}/packages/{}/latest",
         name, version, user, channel, revision, package_id
     );
-    match proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, &upstream_path).await {
+    match proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await
+    {
         Ok((bytes, _ct)) => parse_latest_revision_json(&bytes),
         Err(_e) => {
             tracing::debug!(

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -1056,12 +1056,13 @@ async fn channeldata_json(
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
-                if let Ok((content, _ct)) = proxy_helpers::proxy_fetch(
+                if let Ok((content, _ct)) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     &repo_key,
                     upstream_url,
                     "channeldata.json",
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await
                 {
@@ -1432,12 +1433,13 @@ async fn serve_repodata(
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let upstream_path = format!("{}/{}", subdir, encoding.upstream_filename());
-                if let Ok((content, _ct)) = proxy_helpers::proxy_fetch(
+                if let Ok((content, _ct)) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     repo_key,
                     upstream_url,
                     &upstream_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await
                 {
@@ -2322,12 +2324,13 @@ async fn download_package(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("{}/{}", subdir, filename);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await?;
                     return Ok(Response::builder()

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -556,9 +556,15 @@ impl<'a> DebianProxy<'a> {
             _ => return Ok(()),
         };
         let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
-        let (content, upstream_ct) =
-            proxy_helpers::proxy_fetch(proxy, repo.id, self.repo_key, upstream_url, &upstream_path)
-                .await?;
+        let (content, upstream_ct) = proxy_helpers::proxy_fetch_capped(
+            proxy,
+            repo.id,
+            self.repo_key,
+            upstream_url,
+            &upstream_path,
+            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await?;
         Err(build_dists_response(content, upstream_ct, content_type))
     }
 
@@ -812,8 +818,15 @@ async fn try_virtual_dists(
         let Some(upstream_url) = remote_member_upstream(member) else {
             continue;
         };
-        match proxy_helpers::proxy_fetch(proxy, member.id, &member.key, upstream_url, upstream_path)
-            .await
+        match proxy_helpers::proxy_fetch_capped(
+            proxy,
+            member.id,
+            &member.key,
+            upstream_url,
+            upstream_path,
+            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await
         {
             Ok((content, upstream_ct)) => {
                 return Ok(Some(build_dists_response(
@@ -1287,8 +1300,15 @@ async fn dists_proxy_catchall(
         _ => return Err((StatusCode::NOT_FOUND, "Not found").into_response()),
     };
 
-    let (content, upstream_ct) =
-        proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &upstream_path).await?;
+    let (content, upstream_ct) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        &repo_key,
+        upstream_url,
+        &upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await?;
 
     let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
 

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -371,9 +371,15 @@ async fn try_proxy_go_metadata(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            if let Ok((content, content_type)) =
-                proxy_helpers::proxy_fetch(proxy, repo.id, &repo.key, upstream_url, upstream_path)
-                    .await
+            if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo.key,
+                upstream_url,
+                upstream_path,
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await
             {
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
@@ -650,12 +656,13 @@ async fn get_mod_file(
                 {
                     let encoded = encode_module_path(module);
                     let upstream_path = format!("{}/@v/{}.mod", encoded, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         repo.id,
                         &repo.key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await?;
                     return Ok(Response::builder()

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -243,8 +243,15 @@ async fn fetch_chart_via_index(
     version: &str,
     filename: &str,
 ) -> Result<(Bytes, Option<String>), Response> {
-    let (index_bytes, _) =
-        proxy_helpers::proxy_fetch(proxy, repo_id, repo_key, upstream_url, "index.yaml").await?;
+    let (index_bytes, _) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo_id,
+        repo_key,
+        upstream_url,
+        "index.yaml",
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await?;
 
     let yaml_str = String::from_utf8(index_bytes.to_vec()).map_err(|_| {
         (
@@ -273,13 +280,14 @@ async fn fetch_chart_via_index(
 
     let fetch_url = resolve_chart_url(upstream_url, &chart_url);
     let cache_path = format!("charts/{}", filename);
-    proxy_helpers::proxy_fetch_with_cache_key(
+    proxy_helpers::proxy_fetch_capped_with_cache_key(
         proxy,
         repo_id,
         repo_key,
         upstream_url,
         &fetch_url,
         &cache_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
     )
     .await
 }

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -91,12 +91,13 @@ async fn package_info(
                 (&repo.upstream_url, &state.proxy_service)
             {
                 let upstream_path = format!("packages/{}", name);
-                let (content, content_type) = proxy_helpers::proxy_fetch(
+                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     &repo_key,
                     upstream_url,
                     &upstream_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await?;
                 return Ok(Response::builder()
@@ -506,9 +507,15 @@ async fn list_names(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, content_type) =
-                proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, "names")
-                    .await?;
+            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                "names",
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await?;
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(
@@ -591,9 +598,15 @@ async fn list_versions(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, content_type) =
-                proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, "versions")
-                    .await?;
+            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                "versions",
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await?;
             return Ok(Response::builder()
                 .status(StatusCode::OK)
                 .header(

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -920,9 +920,15 @@ async fn download(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, _content_type) =
-                    proxy_helpers::proxy_fetch(proxy, repo.id, &repo_key, upstream_url, &path)
-                        .await?;
+                let (content, _content_type) = proxy_helpers::proxy_fetch_capped(
+                    proxy,
+                    repo.id,
+                    &repo_key,
+                    upstream_url,
+                    &path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                )
+                .await?;
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
                     .header(CONTENT_TYPE, "text/plain")
@@ -953,12 +959,13 @@ async fn download(
                     if let (Some(ref upstream_url), Some(ref proxy)) =
                         (&member.upstream_url, &state.proxy_service)
                     {
-                        if let Ok((content, _)) = proxy_helpers::proxy_fetch(
+                        if let Ok((content, _)) = proxy_helpers::proxy_fetch_capped(
                             proxy,
                             member.id,
                             &member.key,
                             upstream_url,
                             &path,
+                            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                         )
                         .await
                         {
@@ -1012,10 +1019,16 @@ async fn fetch_remote_member_metadata(
     }
     let upstream_url = member.upstream_url.as_deref()?;
     let proxy = state.proxy_service.as_ref()?;
-    let (content, _) =
-        proxy_helpers::proxy_fetch(proxy, member.id, &member.key, upstream_url, path)
-            .await
-            .ok()?;
+    let (content, _) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        member.id,
+        &member.key,
+        upstream_url,
+        path,
+        proxy_helpers::LARGE_METADATA_MAX_BYTES,
+    )
+    .await
+    .ok()?;
     std::str::from_utf8(&content).ok().map(|s| s.to_string())
 }
 
@@ -1032,8 +1045,15 @@ async fn fetch_maven_metadata_bytes(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, _) =
-                proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, path).await?;
+            let (content, _) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                repo_key,
+                upstream_url,
+                path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await?;
             return Ok(content);
         }
         return Err(AppError::NotFound("Metadata not found".to_string()).into_response());

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -846,12 +846,13 @@ async fn get_package_metadata(
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let encoded_name = encode_package_name_for_upstream(package_name);
-                let (content, content_type) = proxy_helpers::proxy_fetch(
+                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     repo_key,
                     upstream_url,
                     &encoded_name,
+                    proxy_helpers::LARGE_METADATA_MAX_BYTES,
                 )
                 .await?;
 
@@ -911,12 +912,13 @@ async fn get_package_metadata(
             };
 
             let encoded_name = encode_package_name_for_upstream(package_name);
-            let result = proxy_helpers::proxy_fetch(
+            let result = proxy_helpers::proxy_fetch_capped(
                 proxy,
                 member.id,
                 &member.key,
                 upstream_url,
                 &encoded_name,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
             )
             .await;
 
@@ -1046,8 +1048,15 @@ async fn fetch_remote_packument(
         .as_ref()
         .ok_or_else(|| AppError::NotFound("Package not found".to_string()).into_response())?;
     let encoded_name = encode_package_name_for_upstream(package_name);
-    let (content, _ct) =
-        proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &encoded_name).await?;
+    let (content, _ct) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        repo_key,
+        upstream_url,
+        &encoded_name,
+        proxy_helpers::LARGE_METADATA_MAX_BYTES,
+    )
+    .await?;
     let mut json: serde_json::Value = serde_json::from_slice(&content).map_err(|e| {
         AppError::Internal(format!("Invalid JSON from upstream: {}", e)).into_response()
     })?;
@@ -1111,9 +1120,15 @@ async fn fetch_virtual_packument(
         };
 
         let encoded_name = encode_package_name_for_upstream(package_name);
-        let result =
-            proxy_helpers::proxy_fetch(proxy, member.id, &member.key, upstream_url, &encoded_name)
-                .await;
+        let result = proxy_helpers::proxy_fetch_capped(
+            proxy,
+            member.id,
+            &member.key,
+            upstream_url,
+            &encoded_name,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        )
+        .await;
 
         match result {
             Ok((content, _ct)) => {
@@ -1384,9 +1399,15 @@ async fn serve_tarball(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, _content_type) =
-                proxy_helpers::proxy_fetch(proxy, repo.id, repo_key, upstream_url, &upstream_path)
-                    .await?;
+            let (content, _content_type) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                repo_key,
+                upstream_url,
+                &upstream_path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await?;
 
             // The upstream registry may return application/octet-stream for
             // npm tarballs, which also gets persisted by the proxy cache.

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -402,12 +402,13 @@ async fn registration_index(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, content_type) = proxy_helpers::proxy_fetch(
+                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     &repo_key,
                     upstream_url,
                     &upstream_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await?;
                 return Ok(Response::builder()
@@ -431,12 +432,13 @@ async fn registration_index(
                     let Some(upstream_url) = member.upstream_url.as_deref() else {
                         continue;
                     };
-                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
+                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         member.id,
                         &member.key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await
                     {
@@ -571,12 +573,13 @@ async fn flatcontainer_versions(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, content_type) = proxy_helpers::proxy_fetch(
+                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                     proxy,
                     repo.id,
                     &repo_key,
                     upstream_url,
                     &upstream_path,
+                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                 )
                 .await?;
                 return Ok(Response::builder()
@@ -600,12 +603,13 @@ async fn flatcontainer_versions(
                     let Some(upstream_url) = member.upstream_url.as_deref() else {
                         continue;
                     };
-                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
+                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         member.id,
                         &member.key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await
                     {
@@ -678,12 +682,13 @@ async fn flatcontainer_download(
                         "v3/flatcontainer/{}/{}/{}",
                         package_id_lower, version, filename
                     );
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await?;
                     return Ok(Response::builder()
@@ -773,12 +778,13 @@ async fn flatcontainer_download(
                                 "v3/flatcontainer/{}/{}/{}",
                                 package_id_lower, version, filename
                             );
-                            let (bytes, _content_type) = proxy_helpers::proxy_fetch(
+                            let (bytes, _content_type) = proxy_helpers::proxy_fetch_capped(
                                 proxy,
                                 repo.id,
                                 &repo_key,
                                 upstream_url,
                                 &upstream_path,
+                                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                             )
                             .await?;
                             Ok(bytes)

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2604,12 +2604,13 @@ pub async fn resolve_virtual_blob(
             {
                 for image in candidate_upstream_images(image_name, upstream_url) {
                     let upstream_path = upstream_blob_path(&image, digest);
-                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch(
+                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         member.id,
                         &member.key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await
                     {
@@ -2717,15 +2718,17 @@ pub async fn resolve_virtual_manifest(
             {
                 for image in candidate_upstream_images(image_name, upstream_url) {
                     let upstream_path = upstream_manifest_path(&image, reference);
-                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_with_accept(
-                        proxy,
-                        member.id,
-                        &member.key,
-                        upstream_url,
-                        &upstream_path,
-                        accept,
-                    )
-                    .await
+                    if let Ok((content, content_type)) =
+                        proxy_helpers::proxy_fetch_capped_with_accept(
+                            proxy,
+                            member.id,
+                            &member.key,
+                            upstream_url,
+                            &upstream_path,
+                            accept,
+                            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                        )
+                        .await
                     {
                         // #1348 round 1, concern #3 (CRITICAL):
                         // When the manifest reference is itself a digest
@@ -3074,13 +3077,14 @@ async fn try_upstream_fetch_with_accept(
     let proxy = state.proxy_service.as_ref()?;
     let image = normalize_docker_image(&repo.image, upstream_url);
     let upstream_path = format!("v2/{}/{}", image, path_suffix);
-    proxy_helpers::proxy_fetch_with_accept(
+    proxy_helpers::proxy_fetch_capped_with_accept(
         proxy,
         repo.id,
         &repo.key,
         upstream_url,
         &upstream_path,
         accept,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
     )
     .await
     .ok()

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1319,12 +1319,18 @@ async fn download(
                     {
                         let digest = commit_digest.as_deref().unwrap_or("latest");
                         let upstream_path = format!("modules/{}/commits/{}", module_name, digest);
-                        let (bundle_data, _content_type) = proxy_helpers::proxy_fetch(
+                        // The protobuf bundle is inspected in full below
+                        // (`extract_files_from_bundle`), so it must be buffered
+                        // rather than streamed. Bound the buffered read at
+                        // 16 MiB (#1608 Phase 4b / #2181) so a hostile/broken
+                        // upstream cannot OOM the pod.
+                        let (bundle_data, _content_type) = proxy_helpers::proxy_fetch_capped(
                             proxy,
                             repo.id,
                             &repo_key,
                             upstream_url,
                             &upstream_path,
+                            proxy_helpers::LARGE_METADATA_MAX_BYTES,
                         )
                         .await?;
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -19,6 +19,9 @@ use crate::models::repository::{
 use crate::services::proxy_hydration::{Coordinator, HydrationCoordinator};
 use crate::services::proxy_service::ProxyService;
 pub use crate::services::proxy_service::StreamingFetchResult;
+// Re-export the per-format buffered-metadata byte ceilings (#1608 Phase 4b /
+// #2181) so format handlers select a cap via `proxy_helpers::<CONST>`.
+pub use crate::services::proxy_service::{DEFAULT_METADATA_MAX_BYTES, LARGE_METADATA_MAX_BYTES};
 use crate::storage::StorageLocation;
 use std::future::Future;
 use std::path::{Path, PathBuf};
@@ -417,6 +420,48 @@ pub async fn proxy_fetch_with_accept(
     with_proxy_repo(repo_id, repo_key, upstream_url, path, |repo| async move {
         proxy_service
             .fetch_artifact_with_accept(&repo, path, accept)
+            .await
+    })
+    .await
+}
+
+/// Byte-ceiling-bounded sibling of [`proxy_fetch`] (#1608 Phase 4b / #2181).
+///
+/// Identical to [`proxy_fetch`] except the buffered upstream *metadata* read is
+/// capped at `max` bytes: a hostile or broken upstream that streams more than
+/// `max` yields a 502 instead of an unbounded buffer that OOMs the pod, and no
+/// truncated body is ever cached. Callers pass the per-format ceiling
+/// ([`DEFAULT_METADATA_MAX_BYTES`] for most formats, [`LARGE_METADATA_MAX_BYTES`]
+/// for formats with legitimately large metadata documents). This is the
+/// buffered-metadata path only — large binaries must use [`proxy_fetch_streaming`].
+pub async fn proxy_fetch_capped(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>), Response> {
+    with_proxy_repo(repo_id, repo_key, upstream_url, path, |repo| async move {
+        proxy_service.fetch_artifact_capped(&repo, path, max).await
+    })
+    .await
+}
+
+/// Byte-ceiling-bounded sibling of [`proxy_fetch_with_accept`] (#1608 Phase 4b /
+/// #2181). See [`proxy_fetch_capped`] for the `max` semantics.
+pub async fn proxy_fetch_capped_with_accept(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+    accept: Option<&str>,
+    max: usize,
+) -> Result<(Bytes, Option<String>), Response> {
+    with_proxy_repo(repo_id, repo_key, upstream_url, path, |repo| async move {
+        proxy_service
+            .fetch_artifact_with_accept_capped(&repo, path, accept, max)
             .await
     })
     .await
@@ -1017,6 +1062,60 @@ pub async fn proxy_fetch_with_cache_key_and_accept(
         |repo| async move {
             proxy_service
                 .fetch_artifact_with_cache_path_and_accept(&repo, fetch_path, cache_path, accept)
+                .await
+        },
+    )
+    .await
+}
+
+/// Byte-ceiling-bounded sibling of [`proxy_fetch_with_cache_key`] (#1608 Phase
+/// 4b / #2181). See [`proxy_fetch_capped`] for the `max` semantics.
+pub async fn proxy_fetch_capped_with_cache_key(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>), Response> {
+    with_proxy_repo(
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        |repo| async move {
+            proxy_service
+                .fetch_artifact_with_cache_path_capped(&repo, fetch_path, cache_path, max)
+                .await
+        },
+    )
+    .await
+}
+
+/// Byte-ceiling-bounded sibling of [`proxy_fetch_with_cache_key_and_accept`]
+/// (#1608 Phase 4b / #2181). See [`proxy_fetch_capped`] for the `max` semantics.
+#[allow(clippy::too_many_arguments)]
+pub async fn proxy_fetch_capped_with_cache_key_and_accept(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    accept: Option<&str>,
+    max: usize,
+) -> Result<(Bytes, Option<String>), Response> {
+    with_proxy_repo(
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        |repo| async move {
+            proxy_service
+                .fetch_artifact_with_cache_path_and_accept_capped(
+                    &repo, fetch_path, cache_path, accept, max,
+                )
                 .await
         },
     )

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -295,12 +295,13 @@ async fn fetch_remote_simple_root(
     let proxy = state.proxy_service.as_ref()?;
 
     let (effective_upstream, upstream_path) = pypi_upstream_url_and_path(upstream, "");
-    let (content, _content_type) = match proxy_helpers::proxy_fetch(
+    let (content, _content_type) = match proxy_helpers::proxy_fetch_capped(
         proxy,
         repo_id,
         repo_key,
         &effective_upstream,
         &upstream_path,
+        proxy_helpers::LARGE_METADATA_MAX_BYTES,
     )
     .await
     {
@@ -608,7 +609,7 @@ async fn simple_project(
                 let (content, content_type) = if wants_json {
                     // Request the PEP 691 JSON form from upstream, cached under a
                     // format-qualified key so it never collides with the HTML index.
-                    proxy_helpers::proxy_fetch_with_cache_key_and_accept(
+                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept(
                         proxy,
                         repo.id,
                         &repo_key,
@@ -616,15 +617,17 @@ async fn simple_project(
                         &upstream_path,
                         &format!("{}index.v1+json", upstream_path),
                         Some(PEP691_JSON_CONTENT_TYPE),
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
                     )
                     .await?
                 } else {
-                    proxy_helpers::proxy_fetch(
+                    proxy_helpers::proxy_fetch_capped(
                         proxy,
                         repo.id,
                         &repo_key,
                         &effective_upstream,
                         &upstream_path,
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
                     )
                     .await?
                 };
@@ -765,7 +768,7 @@ async fn simple_project(
                 let (effective_upstream, upstream_path) =
                     pypi_upstream_url_and_path(upstream_url, &format!("{}/", normalized));
                 let result = if wants_json {
-                    proxy_helpers::proxy_fetch_with_cache_key_and_accept(
+                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept(
                         proxy,
                         member.id,
                         &member.key,
@@ -773,15 +776,17 @@ async fn simple_project(
                         &upstream_path,
                         &format!("{}index.v1+json", upstream_path),
                         Some(PEP691_JSON_CONTENT_TYPE),
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
                     )
                     .await
                 } else {
-                    proxy_helpers::proxy_fetch(
+                    proxy_helpers::proxy_fetch_capped(
                         proxy,
                         member.id,
                         &member.key,
                         &effective_upstream,
                         &upstream_path,
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
                     )
                     .await
                 };
@@ -1610,13 +1615,19 @@ async fn fetch_from_pypi_remote(
         resolve_pypi_remote_fetch_target(proxy, repo_id, repo_key, upstream_url, project, filename)
             .await?;
 
-    let (content, _content_type) = proxy_helpers::proxy_fetch_with_cache_key(
+    // Bound the buffered cache-recovery read (#1608 Phase 4b / #2181). This is
+    // the recovery closure for `get_remote_cached_or_refetch_stream`, which
+    // needs the full body to write it back to storage; the primary download
+    // path streams via `fetch_from_pypi_remote_streaming`. Use the 16 MiB
+    // ceiling since the payload is a package file rather than small metadata.
+    let (content, _content_type) = proxy_helpers::proxy_fetch_capped_with_cache_key(
         proxy,
         repo_id,
         repo_key,
         &target.fetch_base,
         &target.fetch_path,
         &target.cache_path,
+        proxy_helpers::LARGE_METADATA_MAX_BYTES,
     )
     .await?;
 

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -129,8 +129,15 @@ async fn try_proxy_repodata(
         _ => return Ok(None),
     };
 
-    let (content, upstream_ct) =
-        proxy_helpers::proxy_fetch(proxy, repo.id, &repo.key, upstream_url, upstream_path).await?;
+    let (content, upstream_ct) = proxy_helpers::proxy_fetch_capped(
+        proxy,
+        repo.id,
+        &repo.key,
+        upstream_url,
+        upstream_path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+    )
+    .await?;
 
     let content_type = upstream_ct.unwrap_or_else(|| default_content_type.to_string());
     Ok(Some(

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -513,12 +513,13 @@ async fn download_archive(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("{}/{}/{}.zip", scope, name, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch(
+                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         repo.id,
                         repo_key,
                         upstream_url,
                         &upstream_path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
                     )
                     .await?;
                     return Ok(Response::builder()

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -1314,12 +1314,13 @@ async fn fetch_upstream_json(
     repo_key: &str,
     path: &str,
 ) -> Result<serde_json::Value, Response> {
-    let (content, _ct) = proxy_helpers::proxy_fetch(
+    let (content, _ct) = proxy_helpers::proxy_fetch_capped(
         remote.proxy,
         remote.repo.id,
         repo_key,
         &remote.upstream_url,
         path,
+        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
     )
     .await?;
     serde_json::from_slice(&content).map_err(|e| {

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -34,6 +34,20 @@ use crate::services::storage_service::StorageService;
 /// Default cache TTL in seconds (24 hours)
 pub const DEFAULT_CACHE_TTL_SECS: i64 = 86400;
 
+/// Default byte ceiling for a buffered upstream *metadata* read (#1608 Phase 4b
+/// / #2181). Every buffered metadata proxy fetch is bounded so a hostile or
+/// broken upstream cannot stream an unbounded body into memory and OOM the pod.
+/// Blob/artifact bodies never take the buffered path — they stream (Phase 4) —
+/// so this ceiling only ever applies to metadata documents.
+pub const DEFAULT_METADATA_MAX_BYTES: usize = 8 * 1024 * 1024;
+
+/// Larger byte ceiling for formats whose metadata documents are legitimately
+/// large and would be truncated by the 8 MiB default: npm packument/meta,
+/// composer packument, pypi simple-index, maven-metadata, and the protobuf
+/// bundle. Matches the existing npm/goproxy capped reads (npm.rs:308/391,
+/// goproxy.rs:295).
+pub const LARGE_METADATA_MAX_BYTES: usize = 16 * 1024 * 1024;
+
 /// HTTP client timeout in seconds
 const HTTP_TIMEOUT_SECS: u64 = 60;
 
@@ -1418,6 +1432,7 @@ impl UpstreamClient {
         url: &str,
         repo_id: Uuid,
         accept: Option<&str>,
+        max: usize,
     ) -> Result<UpstreamResponse> {
         let diagnostic_url = redact_url_for_diagnostics(url);
         tracing::info!(
@@ -1467,7 +1482,7 @@ impl UpstreamClient {
                 })
                 .await?
             {
-                return Self::read_upstream_response(retry_response, url).await;
+                return Self::read_upstream_response_capped(retry_response, url, max).await;
             }
 
             return Err(AppError::Storage(format!(
@@ -1476,15 +1491,26 @@ impl UpstreamClient {
             )));
         }
 
-        Self::read_upstream_response(response, url).await
+        Self::read_upstream_response_capped(response, url, max).await
     }
 
     /// Extract content, content-type, etag, effective URL, and Link header from
-    /// an upstream HTTP response. Callers are responsible for handling 401 before
-    /// invoking. Relocated verbatim from `ProxyService::read_upstream_response`.
-    async fn read_upstream_response(
+    /// an upstream HTTP response, buffering the body under a hard `max`-byte
+    /// ceiling (#1608 Phase 4b / #2181). Callers are responsible for handling
+    /// 401 before invoking.
+    ///
+    /// The body is accumulated chunk-by-chunk from `response.bytes_stream()`
+    /// with a running size guard rather than `response.bytes()` /
+    /// `axum::body::to_bytes` — those buffer the whole body before any bound is
+    /// applied, which is exactly the OOM vector this closes. As soon as the
+    /// accumulated size would exceed `max` the read is abandoned and an
+    /// `AppError::BadGateway` (-> 502) is returned; NOTHING is buffered past the
+    /// ceiling and, because the error propagates before the caller reaches its
+    /// cache write, no truncated/partial body or sidecar is ever persisted.
+    async fn read_upstream_response_capped(
         response: reqwest::Response,
         url: &str,
+        max: usize,
     ) -> Result<UpstreamResponse> {
         let status = response.status();
         let effective_url = response.url().to_string();
@@ -1520,14 +1546,32 @@ impl UpstreamClient {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
 
-        #[allow(clippy::disallowed_methods)]
-        // STREAMING-EXEMPT: proxy upstream fetch buffered; tracked for streaming copy to storage in a later #1608 phase
-        let content = response.bytes().await.map_err(|e| {
-            AppError::Storage(format!(
-                "Failed to read upstream response: {}",
-                e.without_url()
-            ))
-        })?;
+        // Running-bounded accumulation: pull one body frame at a time and
+        // reject the moment the total would exceed `max`. No un-bounded
+        // full-body read (`response.bytes()`) is ever issued.
+        let mut stream = response.bytes_stream();
+        let mut buf = bytes::BytesMut::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|e| {
+                AppError::Storage(format!(
+                    "Failed to read upstream response: {}",
+                    e.without_url()
+                ))
+            })?;
+            if buf.len().saturating_add(chunk.len()) > max {
+                tracing::warn!(
+                    "Upstream metadata body from {} exceeded the {}-byte ceiling; aborting buffered read",
+                    redact_url_for_diagnostics(url),
+                    max
+                );
+                return Err(AppError::BadGateway(format!(
+                    "Upstream metadata response exceeded the {}-byte limit",
+                    max
+                )));
+            }
+            buf.extend_from_slice(&chunk);
+        }
+        let content = buf.freeze();
 
         tracing::info!(
             "Fetched {} bytes from upstream (content_type: {:?}, etag: {:?}, link: {:?})",
@@ -1626,8 +1670,8 @@ impl UpstreamClient {
     /// "Upstream returned error status" error, exactly as before).
     ///
     /// CRITICAL — this helper deliberately returns the raw response and does
-    /// NOT read the body: the caller picks `read_upstream_response` (buffered,
-    /// fully buffered) vs `read_upstream_response_streaming` (streaming, bounded
+    /// NOT read the body: the caller picks `read_upstream_response_capped`
+    /// (buffered, bounded) vs `read_upstream_response_streaming` (streaming, bounded
     /// memory). Reading the body here would collapse streaming into buffering
     /// and break its bounded-memory guarantee (#1618 S8 review).
     ///
@@ -1695,7 +1739,7 @@ impl UpstreamClient {
     }
 
     /// Stream the upstream HTTP response body without buffering. Mirrors
-    /// the shape of [`Self::read_upstream_response`] but returns the body
+    /// the shape of [`Self::read_upstream_response_capped`] but returns the body
     /// as a stream. Status/header validation happens up front; the
     /// stream itself yields one [`Bytes`] chunk per `reqwest` body
     /// frame. Relocated verbatim from
@@ -2021,6 +2065,46 @@ impl ProxyService {
         self.fetch_artifact_with_cache_path(repo, path, path).await
     }
 
+    /// Byte-ceiling-aware sibling of [`Self::fetch_artifact`] (#1608 Phase 4b /
+    /// #2181). Bounds the buffered upstream metadata read at `max` bytes.
+    pub async fn fetch_artifact_capped(
+        &self,
+        repo: &Repository,
+        path: &str,
+        max: usize,
+    ) -> Result<(Bytes, Option<String>)> {
+        self.fetch_artifact_with_cache_path_and_accept_capped(repo, path, path, None, max)
+            .await
+    }
+
+    /// Byte-ceiling-aware sibling of [`Self::fetch_artifact_with_accept`]
+    /// (#1608 Phase 4b / #2181).
+    pub async fn fetch_artifact_with_accept_capped(
+        &self,
+        repo: &Repository,
+        path: &str,
+        accept: Option<&str>,
+        max: usize,
+    ) -> Result<(Bytes, Option<String>)> {
+        self.fetch_artifact_with_cache_path_and_accept_capped(repo, path, path, accept, max)
+            .await
+    }
+
+    /// Byte-ceiling-aware sibling of
+    /// [`Self::fetch_artifact_with_cache_path`] (#1608 Phase 4b / #2181).
+    pub async fn fetch_artifact_with_cache_path_capped(
+        &self,
+        repo: &Repository,
+        fetch_path: &str,
+        cache_path: &str,
+        max: usize,
+    ) -> Result<(Bytes, Option<String>)> {
+        self.fetch_artifact_with_cache_path_and_accept_capped(
+            repo, fetch_path, cache_path, None, max,
+        )
+        .await
+    }
+
     /// Variant of [`Self::fetch_artifact`] that forwards a client-supplied
     /// `Accept` header to the upstream request.
     ///
@@ -2198,6 +2282,31 @@ impl ProxyService {
         cache_path: &str,
         accept: Option<&str>,
     ) -> Result<(Bytes, Option<String>)> {
+        self.fetch_artifact_with_cache_path_and_accept_capped(
+            repo,
+            fetch_path,
+            cache_path,
+            accept,
+            DEFAULT_METADATA_MAX_BYTES,
+        )
+        .await
+    }
+
+    /// Byte-ceiling-aware sibling of
+    /// [`Self::fetch_artifact_with_cache_path_and_accept`] (#1608 Phase 4b /
+    /// #2181). `max` bounds the buffered upstream metadata read: a body that
+    /// would exceed it yields `AppError::BadGateway` (-> 502) and NOTHING is
+    /// written to the proxy cache. Callers pass the per-format ceiling
+    /// ([`DEFAULT_METADATA_MAX_BYTES`] or [`LARGE_METADATA_MAX_BYTES`]); the
+    /// non-capped wrappers delegate here with the 8 MiB default.
+    pub async fn fetch_artifact_with_cache_path_and_accept_capped(
+        &self,
+        repo: &Repository,
+        fetch_path: &str,
+        cache_path: &str,
+        accept: Option<&str>,
+        max: usize,
+    ) -> Result<(Bytes, Option<String>)> {
         let upstream_url = Self::remote_target(repo)?;
 
         // Cache keys use the caller-supplied cache_path
@@ -2266,7 +2375,7 @@ impl ProxyService {
             || async {
                 let full_url = Self::build_upstream_url(upstream_url, fetch_path);
                 let upstream_result = self
-                    .fetch_from_upstream_with_accept(&full_url, repo.id, accept)
+                    .fetch_from_upstream_with_accept(&full_url, repo.id, accept, max)
                     .await;
 
                 match upstream_result {
@@ -2864,7 +2973,9 @@ impl ProxyService {
         let upstream_url = Self::remote_target(repo)?;
 
         let full_url = Self::build_upstream_url(upstream_url, path);
-        let resp = self.fetch_from_upstream(&full_url, repo.id).await?;
+        let resp = self
+            .fetch_from_upstream(&full_url, repo.id, DEFAULT_METADATA_MAX_BYTES)
+            .await?;
         Ok((resp.content, resp.content_type, resp.effective_url))
     }
 
@@ -2881,7 +2992,9 @@ impl ProxyService {
         let upstream_url = Self::remote_target(repo)?;
 
         let full_url = Self::build_upstream_url(upstream_url, path);
-        let resp = self.fetch_from_upstream(&full_url, repo.id).await?;
+        let resp = self
+            .fetch_from_upstream(&full_url, repo.id, DEFAULT_METADATA_MAX_BYTES)
+            .await?;
         Ok((resp.content, resp.content_type, resp.link))
     }
 
@@ -3828,8 +3941,13 @@ impl ProxyService {
     /// a token from the indicated realm and retries the request. Tokens are
     /// cached in memory with their advertised TTL so subsequent requests to
     /// the same registry/scope don't repeat the exchange.
-    async fn fetch_from_upstream(&self, url: &str, repo_id: Uuid) -> Result<UpstreamResponse> {
-        self.fetch_from_upstream_with_accept(url, repo_id, None)
+    async fn fetch_from_upstream(
+        &self,
+        url: &str,
+        repo_id: Uuid,
+        max: usize,
+    ) -> Result<UpstreamResponse> {
+        self.fetch_from_upstream_with_accept(url, repo_id, None, max)
             .await
     }
 
@@ -3845,9 +3963,10 @@ impl ProxyService {
         url: &str,
         repo_id: Uuid,
         accept: Option<&str>,
+        max: usize,
     ) -> Result<UpstreamResponse> {
         self.upstream_client
-            .fetch_buffered(url, repo_id, accept)
+            .fetch_buffered(url, repo_id, accept, max)
             .await
     }
 
@@ -10546,7 +10665,7 @@ SHA256:
         assert!(matches!(err, AppError::Storage(_)));
     }
 
-    // -- fetch_buffered + read_upstream_response (success / error) -----------
+    // -- fetch_buffered + read_upstream_response_capped (success / error) ----
 
     #[tokio::test]
     async fn test_fetch_buffered_returns_body_headers_and_etag() {
@@ -10576,7 +10695,7 @@ SHA256:
         let url = format!("{}/pkg/file.bin", server.uri());
 
         let resp = proxy
-            .fetch_from_upstream(&url, Uuid::new_v4())
+            .fetch_from_upstream(&url, Uuid::new_v4(), DEFAULT_METADATA_MAX_BYTES)
             .await
             .expect("buffered fetch of a 200 upstream must succeed");
         let _ = std::fs::remove_dir_all(&tmp);
@@ -10611,7 +10730,9 @@ SHA256:
         let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
         let url = format!("{}/missing", server.uri());
 
-        let result = proxy.fetch_from_upstream(&url, Uuid::new_v4()).await;
+        let result = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4(), DEFAULT_METADATA_MAX_BYTES)
+            .await;
         let _ = std::fs::remove_dir_all(&tmp);
         assert!(
             result.is_err(),
@@ -10640,7 +10761,9 @@ SHA256:
         let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
         let url = format!("{}/down", server.uri());
 
-        let result = proxy.fetch_from_upstream(&url, Uuid::new_v4()).await;
+        let result = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4(), DEFAULT_METADATA_MAX_BYTES)
+            .await;
         let _ = std::fs::remove_dir_all(&tmp);
         let err = result
             .err()
@@ -10648,6 +10771,169 @@ SHA256:
         assert!(
             matches!(err, AppError::ServiceUnavailable(_)),
             "5xx upstream must map to ServiceUnavailable, got {err:?}",
+        );
+    }
+
+    // -- read_upstream_response_capped: byte-ceiling enforcement (#2181) ------
+
+    #[tokio::test]
+    async fn test_capped_read_accepts_body_at_or_below_max() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // Body is exactly `max` bytes -> the running guard never trips.
+        let max = 4096usize;
+        let body = vec![b'a'; max];
+        Mock::given(method("GET"))
+            .and(path("/atmax"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("cap-atmax-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/atmax", server.uri());
+
+        let resp = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4(), max)
+            .await
+            .expect("a body exactly at the ceiling must be accepted");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert_eq!(resp.content.len(), max);
+    }
+
+    #[tokio::test]
+    async fn test_capped_read_rejects_over_cap_with_bad_gateway() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // Body is one byte over the ceiling -> the running guard trips.
+        let max = 4096usize;
+        let body = vec![b'a'; max + 1];
+        Mock::given(method("GET"))
+            .and(path("/overcap"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("cap-over-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let url = format!("{}/overcap", server.uri());
+
+        let err = proxy
+            .fetch_from_upstream(&url, Uuid::new_v4(), max)
+            .await
+            .err()
+            .expect("a body exceeding the ceiling must error, not OOM");
+        let _ = std::fs::remove_dir_all(&tmp);
+        // BadGateway maps to HTTP 502 (see error::AppError::status_and_code and
+        // proxy_helpers::map_proxy_error).
+        assert!(
+            matches!(err, AppError::BadGateway(_)),
+            "over-cap must surface as BadGateway (502), got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_capped_fetch_over_cap_writes_nothing_to_cache() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let max = 2048usize;
+        let body = vec![b'z'; max * 4]; // comfortably over the ceiling
+        Mock::given(method("GET"))
+            .and(path("/big.json"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("cap-nocache-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("cap-nocache", &server.uri(), tmp.to_str().unwrap());
+
+        let result = proxy.fetch_artifact_capped(&repo, "big.json", max).await;
+        assert!(
+            result.is_err(),
+            "an over-cap upstream body must fail the fetch",
+        );
+
+        // The over-cap read aborts before any cache write, so NO truncated body
+        // or sidecar may be persisted: a follow-up cache probe must miss.
+        let cached = proxy
+            .get_cached_artifact_by_path(&repo.key, "big.json")
+            .await
+            .expect("cache probe must not error");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(
+            cached.is_none(),
+            "over-cap fetch must leave the proxy cache empty (no partial write)",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_large_metadata_9mib_ok_but_17mib_rejected_under_16mib_cap() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // A 9 MiB "packument" is under the 16 MiB LARGE ceiling; a 17 MiB body
+        // is over it.
+        let ok_body = vec![b'n'; 9 * 1024 * 1024];
+        let over_body = vec![b'n'; 17 * 1024 * 1024];
+        Mock::given(method("GET"))
+            .and(path("/packument-ok"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(ok_body))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/packument-huge"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(over_body))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("cap-large-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let ok_url = format!("{}/packument-ok", server.uri());
+        let huge_url = format!("{}/packument-huge", server.uri());
+
+        let ok = proxy
+            .fetch_from_upstream(&ok_url, Uuid::new_v4(), LARGE_METADATA_MAX_BYTES)
+            .await
+            .expect("a 9 MiB packument must succeed under the 16 MiB ceiling");
+        assert_eq!(ok.content.len(), 9 * 1024 * 1024);
+
+        let err = proxy
+            .fetch_from_upstream(&huge_url, Uuid::new_v4(), LARGE_METADATA_MAX_BYTES)
+            .await
+            .err()
+            .expect("a 17 MiB body must be rejected by the 16 MiB ceiling");
+        let _ = std::fs::remove_dir_all(&tmp);
+        assert!(
+            matches!(err, AppError::BadGateway(_)),
+            "a 17 MiB over-cap body must surface as BadGateway (502), got {err:?}",
         );
     }
 
@@ -10991,7 +11277,7 @@ SHA256:
         let url = format!("{}/v2/lib/img/manifests/latest", server.uri());
 
         let err = proxy
-            .fetch_from_upstream(&url, Uuid::new_v4())
+            .fetch_from_upstream(&url, Uuid::new_v4(), DEFAULT_METADATA_MAX_BYTES)
             .await
             .err()
             .expect("a Bearer realm pointing at an internal address must be rejected");
@@ -11028,7 +11314,7 @@ SHA256:
         let url = format!("{}/private", server.uri());
 
         let err = proxy
-            .fetch_from_upstream(&url, Uuid::new_v4())
+            .fetch_from_upstream(&url, Uuid::new_v4(), DEFAULT_METADATA_MAX_BYTES)
             .await
             .err()
             .expect("a non-Bearer 401 must surface as an error");

--- a/backend/tests/streaming_invariant.rs
+++ b/backend/tests/streaming_invariant.rs
@@ -41,6 +41,13 @@ use std::path::{Path, PathBuf};
 /// is now parsed from a single on-disk tar entry and the body is streamed to
 /// storage via `put_artifact_stream`, removing the 1 exempt site in helm.rs:
 /// 33 -> 32.
+///
+/// Phase 4b (#1608 / #2181) capped the last unbounded buffered upstream read.
+/// `ProxyService::read_upstream_response` (the single proxy_service.rs exempt
+/// site) is replaced by `read_upstream_response_capped`, which accumulates
+/// `response.bytes_stream()` under a running byte ceiling instead of calling
+/// `response.bytes()`. With no gated call left, the proxy_service.rs row is
+/// removed: 32 -> 31.
 const ALLOWLIST: &[(&str, usize)] = &[
     ("src/api/handlers/goproxy.rs", 1),
     ("src/api/handlers/npm.rs", 5),
@@ -54,7 +61,6 @@ const ALLOWLIST: &[(&str, usize)] = &[
     ("src/main.rs", 1),
     ("src/services/artifactory_client.rs", 1),
     ("src/services/nexus_client.rs", 1),
-    ("src/services/proxy_service.rs", 1),
     ("src/services/scheduler_service.rs", 2),
     ("src/storage/azure.rs", 4),
     ("src/storage/gcs.rs", 4),
@@ -409,7 +415,8 @@ fn streaming_invariant_exempt_sites_match_allowlist() {
 
     let total: usize = actual_marks.values().sum();
     assert_eq!(
-        total, 32,
-        "expected 32 exempt sites after #1608 Phase 3 (helm streamed); got {total}"
+        total, 31,
+        "expected 31 exempt sites after #1608 Phase 4b (proxy_service buffered \
+         metadata read capped via running-bounded bytes_stream); got {total}"
     );
 }


### PR DESCRIPTION
## Summary

Caps the buffered upstream **metadata** reads on the proxy path and retires the
last unbounded full-body read, shrinking the streaming-invariant allowlist to its
floor.

Every buffered metadata proxy fetch previously funnelled through a single
unbounded read — `UpstreamClient::read_upstream_response` (the lone
`STREAMING-EXEMPT` site left for `proxy_service.rs` after Phase 4), which called
`response.bytes().await` with no byte ceiling. A hostile or broken upstream could
stream an arbitrarily large metadata body straight into memory and OOM the pod.

This change:

1. Replaces `read_upstream_response` with **`read_upstream_response_capped(response,
   url, max)`**, which accumulates `response.bytes_stream()` chunks under a
   *running* size guard. It never issues `response.bytes()` / `axum::body::to_bytes`
   (both clippy-gated), so no gated buffering call remains. On exceeding `max` it
   returns `AppError::BadGateway` (→ **502**) and buffers nothing past the ceiling;
   because the error propagates before the caller's cache write, no truncated body
   or sidecar is ever persisted.
2. Adds `fetch_artifact_capped` (+ `_with_accept` / `_with_cache_path`) and
   `proxy_helpers::proxy_fetch_capped` (+ `_with_accept` / `_with_cache_key` /
   `_with_cache_key_and_accept`) that thread `max` down to the capped read.
3. Introduces a **per-caller byte ceiling**: default **8 MiB**
   (`DEFAULT_METADATA_MAX_BYTES`), and **16 MiB** (`LARGE_METADATA_MAX_BYTES`) for
   formats whose metadata documents are legitimately large — npm packument/meta,
   composer packument, pypi simple-index, maven-metadata, and the protobuf bundle.
   16 MiB matches the existing npm/goproxy capped reads (`npm.rs:308/391`,
   `goproxy.rs:295`).
4. Migrates all buffered metadata callers across alpine/composer/goproxy/cargo/hex/
   debian/helm/terraform/protobuf/conan/rpm/nuget/npm/oci_v2/swift/conda/pypi/maven
   to the capped helpers with the correct per-format ceiling. The streaming blob
   path (Phase 4) is untouched.
5. Deletes the now-unused `read_upstream_response`; keeps
   `read_upstream_response_streaming`.
6. Updates `tests/streaming_invariant.rs`: removes the `proxy_service.rs` row and
   drops the total from **32 → 31**. `proxy_service.rs` now carries zero
   `STREAMING-EXEMPT` markers.

The frozen streaming contract (`Coordinator::coordinate*`, `CachePersister::tee_stream`,
`StreamHandle`) is not touched — this is the buffered metadata path only.

Closes #2181
Part of #1608

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests in `services::proxy_service::tests` drive the real upstream stack
(wiremock → reqwest `bytes_stream`):
- `test_capped_read_accepts_body_at_or_below_max` — a body exactly at the ceiling → `Ok`.
- `test_capped_read_rejects_over_cap_with_bad_gateway` — one byte over → `AppError::BadGateway` (502).
- `test_capped_fetch_over_cap_writes_nothing_to_cache` — over-cap fetch errors AND the proxy cache stays empty (no partial write).
- `test_large_metadata_9mib_ok_but_17mib_rejected_under_16mib_cap` — 9 MiB body → `Ok`, 17 MiB body → 502 under the 16 MiB ceiling.

`tests/streaming_invariant.rs` is updated to assert the shrunk allowlist (31), so a
regression that re-introduced an un-annotated buffered read would fail the gate.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified: `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`
(the streaming disallowed-methods gate now passes at 31), `cargo test --workspace --lib`
(12118 passed), and `cargo test --test streaming_invariant`. Manual end-to-end on an
isolated instance with a mock upstream: a 9 MiB npm packument still returns 200 with
its full body, a 20 MiB body returns 502 (`Upstream metadata response exceeded the
16777216-byte limit`) with the read aborted mid-stream — no OOM — and the pod stays
healthy.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
