### PR TITLE
refactor(auth): introduce AccessScope enum for repo-scope authz (#1617)

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -25,6 +25,7 @@ use uuid::Uuid;
 
 use crate::api::{CachedRepo, RepoCache, REPO_CACHE_TTL_SECS};
 use crate::error::AppError;
+use crate::models::access_scope::AccessScope;
 use crate::models::user::User;
 use crate::services::auth_service::{AuthService, Claims};
 use crate::services::permission_service::PermissionService;
@@ -96,13 +97,23 @@ impl AuthExtension {
         }
     }
 
+    /// Repo-scope authorization decision for this principal, as an explicit
+    /// [`AccessScope`].
+    ///
+    /// Bridges the legacy `allowed_repo_ids` field to the enum: a `None`
+    /// restriction maps to [`AccessScope::Admin`] (grants all repositories),
+    /// and `Some(v)` maps to [`AccessScope::Restricted`] (deny-by-default
+    /// allowlist). This is the single place the `Option<Vec<Uuid>>` shape is
+    /// interpreted for repo-scope decisions (#1617, Phase 4).
+    pub fn access_scope(&self) -> AccessScope {
+        AccessScope::from(&self.allowed_repo_ids)
+    }
+
     /// Check whether this auth context has access to a specific repository.
-    /// Returns true if unrestricted or if the repo is in the allowed set.
+    /// Returns true if unrestricted (admin scope) or if the repo is in the
+    /// allowed set.
     pub fn can_access_repo(&self, repo_id: Uuid) -> bool {
-        match &self.allowed_repo_ids {
-            None => true,
-            Some(ids) => ids.contains(&repo_id),
-        }
+        self.access_scope().grants(repo_id)
     }
 
     /// Return an authorization error if scope check fails.

--- a/backend/src/models/access_scope.rs
+++ b/backend/src/models/access_scope.rs
@@ -1,0 +1,194 @@
+//! Repository-scope authorization decision type.
+//!
+//! Historically, "which repositories may this principal touch?" was modelled
+//! as an `Option<Vec<Uuid>>` (`None` = unrestricted/admin, `Some` = allowlist)
+//! threaded through the auth middleware and the OCI/SBOM services. That
+//! stringly/optionally-typed shape invites the "`None` falls open" bug class:
+//! a reader (or a refactor) can confuse "no restriction / admin" with
+//! "restricted to nothing", and an accidental `None` silently grants full
+//! cross-repo access.
+//!
+//! [`AccessScope`] makes the decision explicit and exhaustively matched. It is
+//! an internal type only — it changes no API/wire representation and bridges
+//! to/from the legacy `Option<Vec<Uuid>>` via `From` so the migration can
+//! proceed incrementally (#1617, Phase 4).
+
+use uuid::Uuid;
+
+/// Explicit repository-scope authorization decision for a token/principal.
+///
+/// Replaces the footgun-prone `Option<Vec<Uuid>>` shape used by
+/// `AuthExtension::allowed_repo_ids` and the SBOM read paths. The point of the
+/// enum is that "no restriction / admin" can never be confused with
+/// "restricted to nothing":
+///
+/// - [`AccessScope::Admin`] — **no** repository restriction; grants access to
+///   every repository. Corresponds to the legacy `None` (admin/root tokens,
+///   JWT sessions, system workers).
+/// - [`AccessScope::Restricted`] — an explicit allowlist. **Deny-by-default:**
+///   `Restricted(vec![])` grants access to *nothing* (it does NOT fall open),
+///   and `Restricted([r])` grants access only to `r`. Corresponds to the
+///   legacy `Some(v)`.
+///
+/// Bridges to/from `Option<Vec<Uuid>>` (and the borrowed `Option<&[Uuid]>`)
+/// via `From`, preserving today's semantics exactly: `None <-> Admin`,
+/// `Some(v) <-> Restricted(v)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessScope {
+    /// No repository restriction; grants access to all repositories.
+    Admin,
+    /// Restricted to an explicit allowlist. An empty allowlist grants access
+    /// to nothing (deny-by-default), never to everything.
+    Restricted(Vec<Uuid>),
+}
+
+impl AccessScope {
+    /// Returns `true` if this scope grants access to `repo_id`.
+    ///
+    /// [`Admin`](AccessScope::Admin) grants everything;
+    /// [`Restricted`](AccessScope::Restricted) grants only repositories present
+    /// in its allowlist — so `Restricted(vec![])` grants nothing.
+    pub fn grants(&self, repo_id: Uuid) -> bool {
+        match self {
+            AccessScope::Admin => true,
+            AccessScope::Restricted(ids) => ids.contains(&repo_id),
+        }
+    }
+
+    /// Borrow this scope as the legacy `Option<&[Uuid]>` view without
+    /// allocating.
+    ///
+    /// `Admin -> None`, `Restricted(v) -> Some(&v)`. Lets service APIs that
+    /// still accept `Option<&[Uuid]>` be driven from an [`AccessScope`] during
+    /// the incremental migration.
+    pub fn as_allowed_repo_ids(&self) -> Option<&[Uuid]> {
+        match self {
+            AccessScope::Admin => None,
+            AccessScope::Restricted(ids) => Some(ids),
+        }
+    }
+}
+
+impl From<Option<Vec<Uuid>>> for AccessScope {
+    fn from(value: Option<Vec<Uuid>>) -> Self {
+        match value {
+            None => AccessScope::Admin,
+            Some(ids) => AccessScope::Restricted(ids),
+        }
+    }
+}
+
+impl From<&Option<Vec<Uuid>>> for AccessScope {
+    fn from(value: &Option<Vec<Uuid>>) -> Self {
+        match value {
+            None => AccessScope::Admin,
+            Some(ids) => AccessScope::Restricted(ids.clone()),
+        }
+    }
+}
+
+impl From<Option<&[Uuid]>> for AccessScope {
+    fn from(value: Option<&[Uuid]>) -> Self {
+        match value {
+            None => AccessScope::Admin,
+            Some(ids) => AccessScope::Restricted(ids.to_vec()),
+        }
+    }
+}
+
+impl From<AccessScope> for Option<Vec<Uuid>> {
+    fn from(scope: AccessScope) -> Self {
+        match scope {
+            AccessScope::Admin => None,
+            AccessScope::Restricted(ids) => Some(ids),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn repo(n: u128) -> Uuid {
+        Uuid::from_u128(n)
+    }
+
+    #[test]
+    fn admin_grants_every_repo() {
+        let scope = AccessScope::Admin;
+        assert!(scope.grants(repo(1)));
+        assert!(scope.grants(repo(2)));
+        assert!(scope.grants(Uuid::nil()));
+    }
+
+    #[test]
+    fn restricted_empty_denies_by_default() {
+        // The load-bearing case: an empty allowlist must grant NOTHING, not
+        // fall open to everything.
+        let scope = AccessScope::Restricted(vec![]);
+        assert!(!scope.grants(repo(1)));
+        assert!(!scope.grants(Uuid::nil()));
+    }
+
+    #[test]
+    fn restricted_single_grants_only_that_repo() {
+        let scope = AccessScope::Restricted(vec![repo(7)]);
+        assert!(scope.grants(repo(7)));
+        assert!(!scope.grants(repo(8)));
+    }
+
+    #[test]
+    fn from_option_none_is_admin() {
+        assert_eq!(AccessScope::from(None::<Vec<Uuid>>), AccessScope::Admin);
+    }
+
+    #[test]
+    fn from_option_some_is_restricted() {
+        assert_eq!(
+            AccessScope::from(Some(vec![repo(3)])),
+            AccessScope::Restricted(vec![repo(3)])
+        );
+        // Empty Some must map to Restricted(empty) (deny), never to Admin.
+        assert_eq!(
+            AccessScope::from(Some(Vec::<Uuid>::new())),
+            AccessScope::Restricted(vec![])
+        );
+    }
+
+    #[test]
+    fn round_trip_option_to_scope_to_option() {
+        for original in [None, Some(vec![]), Some(vec![repo(1), repo(2)])] {
+            let scope = AccessScope::from(original.clone());
+            let back: Option<Vec<Uuid>> = scope.into();
+            assert_eq!(back, original);
+        }
+    }
+
+    #[test]
+    fn from_borrowed_option_matches_owned() {
+        let owned = Some(vec![repo(5)]);
+        assert_eq!(AccessScope::from(&owned), AccessScope::from(owned.clone()));
+        let none: Option<Vec<Uuid>> = None;
+        assert_eq!(AccessScope::from(&none), AccessScope::Admin);
+    }
+
+    #[test]
+    fn from_borrowed_slice_option() {
+        let ids = [repo(1), repo(2)];
+        assert_eq!(
+            AccessScope::from(Some(ids.as_slice())),
+            AccessScope::Restricted(vec![repo(1), repo(2)])
+        );
+        assert_eq!(AccessScope::from(None::<&[Uuid]>), AccessScope::Admin);
+    }
+
+    #[test]
+    fn as_allowed_repo_ids_round_trips() {
+        assert_eq!(AccessScope::Admin.as_allowed_repo_ids(), None);
+        let ids = vec![repo(9)];
+        let scope = AccessScope::Restricted(ids.clone());
+        assert_eq!(scope.as_allowed_repo_ids(), Some(ids.as_slice()));
+        // Reconstructing from the borrowed view yields the same scope.
+        assert_eq!(AccessScope::from(scope.as_allowed_repo_ids()), scope);
+    }
+}

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,5 +1,6 @@
 //! Database models (SQLx).
 
+pub mod access_scope;
 pub mod api_token;
 pub mod artifact;
 pub mod audit_log;

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -1,6 +1,7 @@
 //! SBOM (Software Bill of Materials) generation and management service.
 
 use crate::error::{AppError, Result};
+use crate::models::access_scope::AccessScope;
 use crate::models::sbom::{
     CveHistoryEntry, CveStatus, CveTimelineEntry, CveTrends, LicensePolicy, SbomComponent,
     SbomDocument, SbomFormat, SbomSummary,
@@ -1044,10 +1045,12 @@ impl SbomService {
     ///   `auth.allowed_repo_ids.as_deref()` through unchanged: if auth said
     ///   "no restriction", the service trusts that decision.
     ///
-    /// This is a footgun-prone shape. Tracked for refactor to an explicit
-    /// `enum AccessScope { Admin, Restricted(Vec<Uuid>) }` post v1.2.0 (see
-    /// #1390 follow-up). Until then, treat `None` as a load-bearing comment
-    /// that must read "admin-only".
+    /// This is a footgun-prone shape. Internally it is now interpreted through
+    /// the explicit [`crate::models::access_scope::AccessScope`] enum
+    /// (`None -> Admin`, `Some(v) -> Restricted(v)`), so the "admin-only when
+    /// `None`" contract is exhaustively matched rather than relying on this
+    /// comment (#1617, Phase 4). The public signature still takes
+    /// `Option<&[Uuid]>` while the incremental migration continues.
     ///
     /// Returns an empty vec when the CVE is not present (200 OK, [] body); a
     /// missing CVE is not a 404 in this contract.
@@ -1075,9 +1078,11 @@ impl SbomService {
             .await?;
         // Enforce the repo filter on scan-derived entries (they are synthesized
         // on the fly, so the filter cannot live in the SQL `WHERE`).
-        let mut entries = match allowed_repo_ids {
-            None => scan_entries,
-            Some(repo_ids) => {
+        // `Admin` (legacy `None`) = full cross-repo read; `Restricted` applies
+        // the allowlist, so an empty allowlist filters everything out (#1617).
+        let mut entries = match AccessScope::from(allowed_repo_ids) {
+            AccessScope::Admin => scan_entries,
+            AccessScope::Restricted(repo_ids) => {
                 let allowed: HashSet<Uuid> = repo_ids.iter().copied().collect();
                 self.filter_entries_by_repo(scan_entries, &allowed).await?
             }
@@ -1249,8 +1254,11 @@ impl SbomService {
         id: Uuid,
         allowed_repo_ids: Option<&[Uuid]>,
     ) -> Result<Option<(Uuid, String)>> {
-        let pairs: Vec<(Uuid, String)> = match allowed_repo_ids {
-            None => {
+        // `Admin` (legacy `None`) resolves across every repo; `Restricted`
+        // constrains the candidate set to the allowlist, so an empty allowlist
+        // yields no candidates (deny-by-default) (#1617).
+        let pairs: Vec<(Uuid, String)> = match AccessScope::from(allowed_repo_ids) {
+            AccessScope::Admin => {
                 sqlx::query_as(
                     r#"
                 SELECT DISTINCT sf.artifact_id, sf.cve_id
@@ -1263,7 +1271,7 @@ impl SbomService {
                 .fetch_all(&self.db)
                 .await?
             }
-            Some(repo_ids) => {
+            AccessScope::Restricted(repo_ids) => {
                 sqlx::query_as(
                     r#"
                 SELECT DISTINCT sf.artifact_id, sf.cve_id


### PR DESCRIPTION
## Summary

Introduces an explicit `AccessScope { Admin, Restricted(Vec<Uuid>) }` enum for
repository-scope authorization decisions and migrates the core decision points
to it. Internal-only, type-safety change — **no API/wire/behavior change**.

Repo-scope authz was modelled as `Option<Vec<Uuid>>` / `Option<&[Uuid]>`
throughout (`None` = unrestricted/admin, `Some` = allowlist). That
optionally-typed shape invites the "`None` falls open" bug class: a reader or a
refactor can confuse "no restriction / admin" with "restricted to nothing", and
an accidental `None` silently grants full cross-repo access. The intended enum
previously existed only as a doc comment in `services/sbom_service.rs`.

`AccessScope` makes the decision exhaustively matched, preserving today's
semantics exactly:

- `Admin` grants every repository (legacy `None`).
- `Restricted(vec![])` is **deny-by-default** — grants nothing, never falls
  open to all.
- `Restricted([r])` grants only `r`.
- Bridges to/from the legacy representation via `From` (`None <-> Admin`,
  `Some(v) <-> Restricted(v)`, plus borrowed `&Option<Vec<Uuid>>` and
  `Option<&[Uuid]>` views) so the migration is incremental.

Migrated sites:
- `api/middleware/auth.rs` — `AuthExtension::can_access_repo` now decides via
  `AccessScope::grants` (new `access_scope()` accessor is the single point that
  interprets the `Option<Vec<Uuid>>` field).
- `services/sbom_service.rs` — the two repo-scope filter/resolve paths match on
  `AccessScope` instead of `Option`, and the stale "future refactor" doc
  comment is updated.

The remaining `Option<Vec<Uuid>>` scope sites (token minting in
`auth_service.rs`, the `AuthExtension` field type itself, and the handler
sweep) are tracked as a follow-up (#2194) to keep this PR under the
coverage/duplication gates.

Closes #2193. Part of #1617.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (internal type-safety refactor, no behavior change)

## Test Checklist
- [x] Unit tests added/updated — `models::access_scope` covers Admin-grants-all,
  Restricted(empty)-denies, Restricted([r])-grants-only-r, and From/Into
  round-trips; existing `can_access_repo` and SBOM handler tests still pass.
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — token scoped to repo A: GET A → 200, GET B → 403
  (unchanged); admin token → both 200.
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
