### PR TITLE
fix(storage): GCS rewrite-loop token refresh + S3 copy digest-check and abort-on-drop

### DIFF
--- a/backend/src/storage/gcs.rs
+++ b/backend/src/storage/gcs.rs
@@ -89,6 +89,43 @@ struct RewriteResponse {
     rewrite_token: Option<String>,
 }
 
+/// Default ceiling on GCS server-side rewrite continuations before `copy()`
+/// gives up. GCS rewrite is paginated: each `rewriteTo` continuation copies as
+/// much as GCS chooses and is a fast sub-second metadata op, so even a 5 TiB
+/// object (GCS's max) completes in far fewer than this cap. The cap is purely a
+/// defensive backstop against a non-conformant endpoint that never reports
+/// `done`, matching the explicit limits on the S3 part / Azure block loops. It
+/// is overridable per-backend (see [`GcsBackend::max_rewrite_iterations`]) so
+/// the ceiling branch can be exercised by a unit test.
+const GCS_MAX_REWRITE_ITERATIONS: usize = 100_000;
+
+/// One step of the paginated GCS rewrite loop, derived purely from a
+/// [`RewriteResponse`] so the control flow can be unit-tested without HTTP.
+#[derive(Debug, PartialEq, Eq)]
+enum RewriteStep {
+    /// The rewrite finished; the object has been fully copied.
+    Done,
+    /// The rewrite is incomplete; continue with this `rewriteToken`.
+    Continue(String),
+}
+
+/// Interpret a GCS rewrite response into the next [`RewriteStep`].
+///
+/// A `done` response finishes the copy. An incomplete response must carry a
+/// `rewriteToken` to continue; a missing token is a protocol violation and is
+/// surfaced as an error rather than looping forever.
+fn interpret_rewrite_step(rewrite: RewriteResponse) -> Result<RewriteStep> {
+    if rewrite.done {
+        return Ok(RewriteStep::Done);
+    }
+    match rewrite.rewrite_token {
+        Some(token) => Ok(RewriteStep::Continue(token)),
+        None => Err(AppError::Storage(
+            "GCS rewrite response missing rewriteToken".to_string(),
+        )),
+    }
+}
+
 /// Chunk size for the resumable upload protocol. GCS requires every
 /// non-final chunk to be an exact multiple of 256 KiB. 32 MiB satisfies that
 /// (32 MiB = 128 * 256 KiB) and keeps the in-flight heap footprint bounded
@@ -188,6 +225,17 @@ struct CachedToken {
     expires_at: Instant,
 }
 
+/// Whether a cached token must be refreshed. A token is considered stale once
+/// it is within 60s of expiry (or absent), leaving a margin so a long-running
+/// caller that re-checks each iteration always holds a token valid for the next
+/// request. Pure so the refresh boundary can be unit-tested without a clock.
+fn token_needs_refresh(cached: Option<&CachedToken>, now: Instant) -> bool {
+    match cached {
+        Some(cached) => cached.expires_at <= now + Duration::from_secs(60),
+        None => true,
+    }
+}
+
 /// Where tokens come from.
 enum TokenSource {
     /// Self-signed JWT exchanged at Google's token endpoint (service account key).
@@ -220,20 +268,16 @@ impl GcsTokenProvider {
         // Fast path: read lock
         {
             let cache = self.cache.read().await;
-            if let Some(ref cached) = *cache {
-                if cached.expires_at > Instant::now() + Duration::from_secs(60) {
-                    return Ok(cached.token.clone());
-                }
+            if !token_needs_refresh(cache.as_ref(), Instant::now()) {
+                return Ok(cache.as_ref().expect("fresh token present").token.clone());
             }
         }
 
         // Slow path: write lock
         let mut cache = self.cache.write().await;
         // Double-check: another task may have refreshed while we waited
-        if let Some(ref cached) = *cache {
-            if cached.expires_at > Instant::now() + Duration::from_secs(60) {
-                return Ok(cached.token.clone());
-            }
+        if !token_needs_refresh(cache.as_ref(), Instant::now()) {
+            return Ok(cache.as_ref().expect("fresh token present").token.clone());
         }
 
         let (token, expires_in) = match &self.source {
@@ -253,6 +297,13 @@ impl GcsTokenProvider {
         });
 
         Ok(token)
+    }
+
+    /// Drop any cached token so the next [`get_token`](Self::get_token) forces a
+    /// fresh fetch. Used when a request is rejected as `401 Unauthorized`
+    /// mid-operation (e.g. a token revoked or expired earlier than advertised).
+    async fn invalidate(&self) {
+        *self.cache.write().await = None;
     }
 
     /// Mint a self-signed JWT and exchange it for an access token.
@@ -471,6 +522,11 @@ pub struct GcsBackend {
     path_format: StoragePathFormat,
     /// API base URL (overridable in tests via `with_base_url`).
     base_url: String,
+    /// Ceiling on GCS rewrite continuations in [`copy`](Self::copy). Defaults to
+    /// [`GCS_MAX_REWRITE_ITERATIONS`]; overridable (via
+    /// [`with_max_rewrite_iterations`](Self::with_max_rewrite_iterations)) so a
+    /// unit test can drive the loop into its ceiling branch cheaply.
+    max_rewrite_iterations: usize,
 }
 
 impl GcsBackend {
@@ -538,7 +594,16 @@ impl GcsBackend {
             auth,
             path_format,
             base_url: GCS_BASE_URL.to_string(),
+            max_rewrite_iterations: GCS_MAX_REWRITE_ITERATIONS,
         })
+    }
+
+    /// Builder (test-only): override the rewrite-iteration ceiling used by
+    /// [`copy`](Self::copy) so the ceiling branch can be exercised cheaply.
+    #[cfg(test)]
+    fn with_max_rewrite_iterations(mut self, max: usize) -> Self {
+        self.max_rewrite_iterations = max;
+        self
     }
 
     /// Return the bucket name this backend is configured to use.
@@ -554,6 +619,16 @@ impl GcsBackend {
         match &self.auth {
             GcsAuthMode::ServiceAccountKey { provider, .. } => provider.get_token().await,
             GcsAuthMode::Adc { provider } => provider.get_token().await,
+        }
+    }
+
+    /// Drop the cached bearer token so the next [`get_bearer_token`](Self::get_bearer_token)
+    /// re-fetches. Called when a bearer-authed request is rejected with
+    /// `401 Unauthorized` so the operation can retry with a fresh token.
+    async fn invalidate_bearer_token(&self) {
+        match &self.auth {
+            GcsAuthMode::ServiceAccountKey { provider, .. } => provider.invalidate().await,
+            GcsAuthMode::Adc { provider } => provider.invalidate().await,
         }
     }
 
@@ -836,9 +911,36 @@ impl GcsBackend {
         Ok(all_keys)
     }
 
-    /// Copy an object within the same bucket.
-    pub async fn copy(&self, source: &str, dest: &str) -> Result<()> {
+    /// Issue a single GCS `rewriteTo` POST with a freshly obtained bearer token.
+    ///
+    /// The token is fetched per call via [`get_bearer_token`](Self::get_bearer_token),
+    /// which returns the cached token and only performs a network refresh when it
+    /// is within 60s of expiry. A small single-iteration copy therefore fetches
+    /// exactly one token (unchanged behavior), while a long multi-iteration
+    /// rewrite of a large object transparently picks up a refreshed token before
+    /// the old one can expire.
+    async fn send_rewrite(&self, url: &str) -> Result<reqwest::Response> {
         let token = self.get_bearer_token().await?;
+        self.client
+            .post(url)
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Length", "0")
+            .send()
+            .await
+            .map_err(|e| AppError::Storage(format!("GCS rewrite failed: {}", e)))
+    }
+
+    /// Copy an object within the same bucket.
+    ///
+    /// GCS server-side rewrite is paginated: each continuation copies as much as
+    /// GCS chooses (we set no `maxBytesRewrittenPerCall`) and is a fast
+    /// sub-second metadata op. The bearer token is (re)validated on every
+    /// iteration (see [`send_rewrite`](Self::send_rewrite)); if a request is
+    /// nonetheless rejected as `401 Unauthorized` mid-rewrite (a token revoked
+    /// or expired earlier than advertised), the cached token is dropped and the
+    /// iteration retried once with a fresh token, so a pathologically long
+    /// multi-iteration rewrite of a large object cannot outlive its token.
+    pub async fn copy(&self, source: &str, dest: &str) -> Result<()> {
         let bucket_enc = urlencoding::encode(&self.config.bucket);
         let base_url = format!(
             "{}/storage/v1/b/{}/o/{}/rewriteTo/b/{}/o/{}",
@@ -850,56 +952,34 @@ impl GcsBackend {
         );
         let mut rewrite_token: Option<String> = None;
 
-        // GCS server-side rewrite is paginated: each continuation copies as much
-        // as GCS chooses (we set no `maxBytesRewrittenPerCall`) and is a fast
-        // sub-second metadata op, so even a 5 TiB object (GCS's max) completes in
-        // far fewer than this cap, reusing the single bearer token fetched above
-        // well within its lifetime. The cap is purely a defensive backstop
-        // against a non-conformant endpoint that never reports `done` (or rotates
-        // a token without progressing), matching the explicit limits on the S3
-        // part / Azure block loops.
-        const MAX_REWRITE_ITERATIONS: usize = 100_000;
-
-        for _ in 0..MAX_REWRITE_ITERATIONS {
+        for _ in 0..self.max_rewrite_iterations {
             let url = match rewrite_token.as_deref() {
                 Some(token) => format!("{}?rewriteToken={}", base_url, urlencoding::encode(token)),
                 None => base_url.clone(),
             };
 
-            let response = self
-                .client
-                .post(&url)
-                .header("Authorization", format!("Bearer {}", token))
-                .header("Content-Length", "0")
-                .send()
-                .await
-                .map_err(|e| AppError::Storage(format!("GCS rewrite failed: {}", e)))?;
+            let mut response = self.send_rewrite(&url).await?;
+            if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+                // The token was rejected mid-rewrite; drop it and retry once
+                // with a freshly minted one before surfacing the failure.
+                self.invalidate_bearer_token().await;
+                response = self.send_rewrite(&url).await?;
+            }
 
             let response = require_success(response, "GCS rewrite failed").await?;
             let rewrite: RewriteResponse = response.json().await.map_err(|e| {
                 AppError::Storage(format!("Failed to parse GCS rewrite response: {}", e))
             })?;
 
-            if rewrite.done {
-                return Ok(());
-            }
-
-            rewrite_token = rewrite.rewrite_token;
-            if rewrite_token.is_none() {
-                tracing::warn!(
-                    source = %source,
-                    dest = %dest,
-                    "GCS rewrite response was incomplete and did not include rewriteToken"
-                );
-                return Err(AppError::Storage(
-                    "GCS rewrite response missing rewriteToken".to_string(),
-                ));
+            match interpret_rewrite_step(rewrite)? {
+                RewriteStep::Done => return Ok(()),
+                RewriteStep::Continue(token) => rewrite_token = Some(token),
             }
         }
 
         Err(AppError::Storage(format!(
             "GCS rewrite of '{}' -> '{}' did not complete within {} iterations",
-            source, dest, MAX_REWRITE_ITERATIONS
+            source, dest, self.max_rewrite_iterations
         )))
     }
 
@@ -2564,6 +2644,7 @@ mod tests {
             auth: GcsAuthMode::Adc { provider },
             path_format,
             base_url: base_url.to_string(),
+            max_rewrite_iterations: GCS_MAX_REWRITE_ITERATIONS,
         }
     }
 
@@ -3475,6 +3556,254 @@ mod tests {
             "continuation request must forward rewriteToken=t1, got {}",
             requests[1].url
         );
+    }
+
+    // ---- interpret_rewrite_step (pure rewrite-loop control flow) ----
+
+    #[test]
+    fn test_interpret_rewrite_step_done() {
+        let step = interpret_rewrite_step(RewriteResponse {
+            done: true,
+            rewrite_token: None,
+        })
+        .expect("a done response is valid");
+        assert_eq!(step, RewriteStep::Done);
+    }
+
+    #[test]
+    fn test_interpret_rewrite_step_continue() {
+        let step = interpret_rewrite_step(RewriteResponse {
+            done: false,
+            rewrite_token: Some("next-token".to_string()),
+        })
+        .expect("an incomplete response with a token continues");
+        assert_eq!(step, RewriteStep::Continue("next-token".to_string()));
+    }
+
+    #[test]
+    fn test_interpret_rewrite_step_missing_token_errors() {
+        let err = interpret_rewrite_step(RewriteResponse {
+            done: false,
+            rewrite_token: None,
+        })
+        .expect_err("an incomplete response without a token is a protocol error");
+        assert!(
+            err.to_string().contains("rewriteToken"),
+            "unexpected error: {err}"
+        );
+    }
+
+    // ---- token refresh boundary (pure) ----
+
+    #[test]
+    fn test_token_needs_refresh_when_absent() {
+        assert!(token_needs_refresh(None, Instant::now()));
+    }
+
+    #[test]
+    fn test_token_needs_refresh_when_near_expiry() {
+        let now = Instant::now();
+        // Expires in 30s, inside the 60s refresh margin.
+        let cached = CachedToken {
+            token: "stale".to_string(),
+            expires_at: now + Duration::from_secs(30),
+        };
+        assert!(token_needs_refresh(Some(&cached), now));
+    }
+
+    #[test]
+    fn test_token_fresh_outside_margin() {
+        let now = Instant::now();
+        // Expires in 10 minutes, well outside the 60s refresh margin.
+        let cached = CachedToken {
+            token: "fresh".to_string(),
+            expires_at: now + Duration::from_secs(600),
+        };
+        assert!(!token_needs_refresh(Some(&cached), now));
+    }
+
+    #[tokio::test]
+    async fn test_invalidate_bearer_token_clears_cache() {
+        // A backend with a pre-seeded token cache; invalidation must clear it so
+        // the next fetch re-mints (the 401-recovery path in copy()).
+        let backend = mock_backend("https://example.invalid").await;
+        let GcsAuthMode::Adc { provider } = &backend.auth else {
+            panic!("mock backend is ADC mode");
+        };
+        assert!(
+            provider.cache.read().await.is_some(),
+            "mock backend starts with a seeded token"
+        );
+        backend.invalidate_bearer_token().await;
+        assert!(
+            provider.cache.read().await.is_none(),
+            "invalidate must drop the cached token"
+        );
+    }
+
+    // ---- copy() rewrite-iteration ceiling (injectable cap) ----
+
+    #[tokio::test]
+    async fn test_copy_hits_rewrite_iteration_ceiling() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        // A non-conformant endpoint that always reports "not done" but keeps
+        // handing back a continuation token, so the loop can only terminate at
+        // the ceiling.
+        Mock::given(method("POST"))
+            .and(path_regex("/storage/v1/b/.*/o/.*/rewriteTo/b/.*/o/.*"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": false,
+                "rewriteToken": "never-done"
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = mock_backend(&server.uri())
+            .await
+            .with_max_rewrite_iterations(3);
+        let err = backend
+            .copy("src.txt", "dest.txt")
+            .await
+            .expect_err("an endpoint that never reports done must hit the ceiling");
+        assert!(
+            err.to_string()
+                .contains("did not complete within 3 iterations"),
+            "unexpected error: {err}"
+        );
+
+        // Exactly `max_rewrite_iterations` POSTs were issued before giving up.
+        let requests = server
+            .received_requests()
+            .await
+            .expect("recorded requests should be available");
+        assert_eq!(
+            requests.len(),
+            3,
+            "copy must stop at the injected iteration ceiling"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_invalidates_token_and_retries_on_401() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // The rewrite endpoint rejects the (cached) bearer token as expired.
+        // copy() must drop the cached token and retry the iteration with a fresh
+        // one; in this test the ADC token source is unreachable, so the retry
+        // fails — but only after the cached token has been invalidated.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex("/storage/v1/b/.*/o/.*/rewriteTo/b/.*/o/.*"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("token expired"))
+            .mount(&server)
+            .await;
+
+        let backend = mock_backend(&server.uri()).await;
+        let GcsAuthMode::Adc { provider } = &backend.auth else {
+            panic!("mock backend is ADC mode");
+        };
+        assert!(
+            provider.cache.read().await.is_some(),
+            "backend starts with a seeded token"
+        );
+
+        let result = backend.copy("src.txt", "dest.txt").await;
+        assert!(
+            result.is_err(),
+            "a 401 with no reachable token source must ultimately fail"
+        );
+        assert!(
+            provider.cache.read().await.is_none(),
+            "a 401 must invalidate the cached bearer token before retrying"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_single_iteration_small_object_unchanged() {
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // A small object completes in a single rewrite: exactly one POST, done.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex("/storage/v1/b/.*/o/.*/rewriteTo/b/.*/o/.*"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": true,
+                "resource": {"name": "dest.txt"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = mock_backend(&server.uri()).await;
+        backend
+            .copy("src.txt", "dest.txt")
+            .await
+            .expect("a small single-iteration copy must still succeed");
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("recorded requests should be available");
+        assert_eq!(
+            requests.len(),
+            1,
+            "a small copy must issue exactly one rewrite POST"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_refetches_bearer_token_each_iteration() {
+        use wiremock::matchers::{header_exists, method, path_regex};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // Two-iteration rewrite: assert every request (including the
+        // continuation) carries a freshly obtained bearer token, i.e. the token
+        // is (re)validated inside the loop rather than fetched once up front.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path_regex("/storage/v1/b/.*/o/.*/rewriteTo/b/.*/o/.*"))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": false,
+                "rewriteToken": "t1"
+            })))
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path_regex("/storage/v1/b/.*/o/.*/rewriteTo/b/.*/o/.*"))
+            .and(header_exists("authorization"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "done": true,
+                "resource": {"name": "dest.txt"}
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let backend = mock_backend(&server.uri()).await;
+        backend
+            .copy("src.txt", "dest.txt")
+            .await
+            .expect("multi-iteration copy with a bearer token on each call succeeds");
+
+        let requests = server
+            .received_requests()
+            .await
+            .expect("recorded requests should be available");
+        assert_eq!(requests.len(), 2, "expected two rewrite POSTs");
+        for request in &requests {
+            assert!(
+                request.headers.contains_key("authorization"),
+                "every rewrite iteration must carry a bearer token"
+            );
+        }
     }
 
     #[tokio::test]

--- a/backend/src/storage/s3.rs
+++ b/backend/src/storage/s3.rs
@@ -256,6 +256,112 @@ async fn abort_s3_multipart(
     }
 }
 
+/// RAII guard that aborts an in-progress S3 multipart upload unless it is
+/// explicitly finished.
+///
+/// It closes the cancellation window called out in [`S3Backend::put_stream`]:
+/// if the `put_stream` future is dropped after `create_multipart` but before
+/// completion (client disconnect, request timeout, task cancellation), the
+/// server-side multipart upload would otherwise linger until a bucket
+/// `AbortIncompleteMultipartUpload` lifecycle rule reclaimed it. On drop while
+/// still armed, the guard spawns a best-effort `AbortMultipartUpload` (a `Drop`
+/// impl cannot `await`).
+///
+/// Exit paths that handle the upload themselves defuse the guard first:
+/// - [`abort_now`](Self::abort_now) awaits an inline abort (used on the existing
+///   error paths, so exactly one abort is issued — not a redundant second one).
+/// - [`disarm`](Self::disarm) is called after a successful completion so a
+///   COMPLETED upload is never aborted.
+struct MultipartAbortGuard {
+    store: AmazonS3,
+    path: ObjectPath,
+    key: String,
+    /// `Some` while an upload is in flight and not yet finished; `None` once the
+    /// guard has been defused (completed or already aborted).
+    upload_id: Option<object_store::MultipartId>,
+}
+
+impl MultipartAbortGuard {
+    /// Create a disarmed guard; call [`arm`](Self::arm) once the multipart
+    /// upload has actually been created.
+    fn new(store: AmazonS3, path: ObjectPath, key: String) -> Self {
+        Self {
+            store,
+            path,
+            key,
+            upload_id: None,
+        }
+    }
+
+    /// Arm the guard with the id of a freshly created multipart upload.
+    fn arm(&mut self, upload_id: object_store::MultipartId) {
+        self.upload_id = Some(upload_id);
+    }
+
+    /// Defuse the guard without aborting: the upload completed successfully.
+    fn disarm(&mut self) {
+        self.upload_id = None;
+    }
+
+    /// Defuse the guard and abort the upload inline (awaited). No-op if the
+    /// guard is not armed (no multipart upload was ever created).
+    async fn abort_now(&mut self) {
+        if let Some(upload_id) = self.upload_id.take() {
+            abort_s3_multipart(&self.store, &self.path, &upload_id, &self.key).await;
+        }
+    }
+}
+
+impl Drop for MultipartAbortGuard {
+    fn drop(&mut self) {
+        let Some(upload_id) = self.upload_id.take() else {
+            return;
+        };
+        // A completed/aborted upload defuses the guard above, so reaching here
+        // means the future was dropped mid-upload. Drop can't await, so spawn a
+        // detached best-effort abort. Guard against running outside a Tokio
+        // runtime (e.g. a synchronous drop in a plain test) to avoid a panic.
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            tracing::warn!(
+                key = %self.key,
+                upload_id = %upload_id,
+                "S3 multipart upload dropped with no Tokio runtime to abort it"
+            );
+            return;
+        };
+        let store = self.store.clone();
+        let path = self.path.clone();
+        let key = std::mem::take(&mut self.key);
+        handle.spawn(async move {
+            abort_s3_multipart(&store, &path, &upload_id, &key).await;
+        });
+    }
+}
+
+/// Cross-check a streamed large-object copy against the source content.
+///
+/// The `>5 GiB` copy path streams the source through [`S3Backend::put_stream`],
+/// which returns the SHA-256 of the bytes it wrote. `put_stream`'s result is
+/// otherwise discarded, so a truncated or corrupted transfer would go unnoticed.
+/// This compares that digest against the SHA-256 computed independently over the
+/// source stream and rejects any mismatch. Pure so the mismatch branch is
+/// unit-testable without S3.
+fn ensure_copy_digest_matches(
+    source: &str,
+    dest: &str,
+    source_sha256: &str,
+    result: &PutStreamResult,
+) -> Result<()> {
+    if result.checksum_sha256 != source_sha256 {
+        return Err(AppError::Storage(format!(
+            "S3 streamed copy of '{}' -> '{}' failed integrity check: source SHA-256 {} \
+             but copied object hashed to {}",
+            source, dest, source_sha256, result.checksum_sha256
+        )));
+    }
+    Ok(())
+}
+
 /// S3 storage backend configuration
 #[derive(Debug, Clone)]
 pub struct S3Config {
@@ -1317,12 +1423,11 @@ impl super::StorageBackend for S3Backend {
     ///
     /// Cancellation note: if this future is dropped after the multipart upload
     /// is created but before it finishes (client disconnect, request timeout,
-    /// task cancellation), the in-flight part tasks are aborted but the
-    /// server-side multipart upload is NOT explicitly aborted — it is reclaimed
-    /// by the bucket's `AbortIncompleteMultipartUpload` lifecycle rule (set one
-    /// in deployment). The OCI upload path issues each PATCH chunk as its own
-    /// short-lived `put_stream` to a discrete key, so the cancellation window is
-    /// small.
+    /// task cancellation), the in-flight part tasks are aborted and a
+    /// [`MultipartAbortGuard`] spawns a best-effort server-side
+    /// `AbortMultipartUpload` on drop, so the upload does not linger until the
+    /// bucket's `AbortIncompleteMultipartUpload` lifecycle rule reclaims it. A
+    /// successfully completed upload defuses the guard and is never aborted.
     async fn put_stream(
         &self,
         key: &str,
@@ -1331,6 +1436,11 @@ impl super::StorageBackend for S3Backend {
         let full_key = self.full_key(key);
         let path: ObjectPath = full_key.into();
 
+        // Aborts the multipart upload if this future is dropped mid-flight.
+        // Armed once `create_multipart` succeeds; defused on completion or by
+        // the inline abort on an error path.
+        let mut abort_guard =
+            MultipartAbortGuard::new(self.store.clone(), path.clone(), key.to_string());
         let mut upload_id: Option<object_store::MultipartId> = None;
         let mut upload_tasks: JoinSet<S3PartUploadResult> = JoinSet::new();
         let mut uploaded_parts: Vec<(usize, PartId)> = Vec::new();
@@ -1355,6 +1465,7 @@ impl super::StorageBackend for S3Backend {
                                 key, e
                             ))
                         })?;
+                        abort_guard.arm(id.clone());
                         upload_id = Some(id);
                     }
                     let mut data = data;
@@ -1384,10 +1495,8 @@ impl super::StorageBackend for S3Backend {
                             )
                             .await
                             {
-                                if let Some(upload_id) = upload_id.as_ref() {
-                                    upload_tasks.shutdown().await;
-                                    abort_s3_multipart(&self.store, &path, upload_id, key).await;
-                                }
+                                upload_tasks.shutdown().await;
+                                abort_guard.abort_now().await;
                                 return Err(e);
                             }
                             continue;
@@ -1415,10 +1524,8 @@ impl super::StorageBackend for S3Backend {
                             )
                             .await
                             {
-                                if let Some(upload_id) = upload_id.as_ref() {
-                                    upload_tasks.shutdown().await;
-                                    abort_s3_multipart(&self.store, &path, upload_id, key).await;
-                                }
+                                upload_tasks.shutdown().await;
+                                abort_guard.abort_now().await;
                                 return Err(e);
                             }
                         }
@@ -1427,10 +1534,8 @@ impl super::StorageBackend for S3Backend {
                 Err(e) => {
                     // Abort the multipart upload on stream error to avoid
                     // leaving partial objects in S3.
-                    if let Some(upload_id) = upload_id.as_ref() {
-                        upload_tasks.shutdown().await;
-                        abort_s3_multipart(&self.store, &path, upload_id, key).await;
-                    }
+                    upload_tasks.shutdown().await;
+                    abort_guard.abort_now().await;
                     return Err(e);
                 }
             }
@@ -1453,14 +1558,14 @@ impl super::StorageBackend for S3Backend {
                 .await
                 {
                     upload_tasks.shutdown().await;
-                    abort_s3_multipart(&self.store, &path, &upload_id, key).await;
+                    abort_guard.abort_now().await;
                     return Err(e);
                 }
             }
             if let Err(e) = drain_s3_part_uploads(&mut upload_tasks, &mut uploaded_parts, key).await
             {
                 upload_tasks.shutdown().await;
-                abort_s3_multipart(&self.store, &path, &upload_id, key).await;
+                abort_guard.abort_now().await;
                 return Err(e);
             }
             uploaded_parts.sort_by_key(|(part_index, _)| *part_index);
@@ -1473,12 +1578,14 @@ impl super::StorageBackend for S3Backend {
                 .complete_multipart(&path, &upload_id, parts)
                 .await
             {
-                abort_s3_multipart(&self.store, &path, &upload_id, key).await;
+                abort_guard.abort_now().await;
                 return Err(AppError::Storage(format!(
                     "Failed to complete multipart upload for '{}': {}",
                     key, e
                 )));
             }
+            // Upload completed: defuse the guard so drop never aborts it.
+            abort_guard.disarm();
         } else {
             self.put(key, Bytes::new()).await?;
         }
@@ -1529,7 +1636,35 @@ impl S3Backend {
                 "S3 source is too large for CopyObject; streaming through multipart upload"
             );
             let stream = <Self as super::StorageBackend>::get_stream(self, source).await?;
-            <Self as super::StorageBackend>::put_stream(self, dest, stream).await?;
+
+            // Hash the source bytes as they stream past so the copied object's
+            // digest (returned by `put_stream`) can be cross-checked end-to-end
+            // instead of silently discarded. The hasher is shared with the
+            // stream adapter and read back after the transfer completes.
+            let source_hasher = std::sync::Arc::new(std::sync::Mutex::new(Sha256::new()));
+            let tap = source_hasher.clone();
+            let hashing_stream = stream
+                .map(move |chunk| {
+                    if let Ok(ref bytes) = chunk {
+                        tap.lock()
+                            .expect("source hash mutex poisoned")
+                            .update(bytes);
+                    }
+                    chunk
+                })
+                .boxed();
+
+            let result =
+                <Self as super::StorageBackend>::put_stream(self, dest, hashing_stream).await?;
+            let source_sha256 = format!(
+                "{:x}",
+                source_hasher
+                    .lock()
+                    .expect("source hash mutex poisoned")
+                    .clone()
+                    .finalize()
+            );
+            ensure_copy_digest_matches(source, dest, &source_sha256, &result)?;
             return Ok(());
         }
 
@@ -3644,6 +3779,145 @@ mod tests {
                 .iter()
                 .any(|request| request.headers.contains_key("x-amz-copy-source")),
             "large copy must not use single-request S3 CopyObject"
+        );
+    }
+
+    // ---- ensure_copy_digest_matches (pure large-copy integrity check) ----
+
+    #[test]
+    fn test_ensure_copy_digest_matches_ok_when_equal() {
+        let result = PutStreamResult {
+            checksum_sha256: "deadbeef".to_string(),
+            bytes_written: 42,
+        };
+        ensure_copy_digest_matches("src", "dst", "deadbeef", &result)
+            .expect("matching digests must pass the integrity check");
+    }
+
+    #[test]
+    fn test_ensure_copy_digest_matches_errors_on_mismatch() {
+        let result = PutStreamResult {
+            checksum_sha256: "0000".to_string(),
+            bytes_written: 42,
+        };
+        let err = ensure_copy_digest_matches("src", "dst", "ffff", &result)
+            .expect_err("a digest mismatch must be rejected");
+        let msg = err.to_string();
+        assert!(msg.contains("integrity check"), "unexpected error: {msg}");
+        assert!(msg.contains("ffff") && msg.contains("0000"), "err: {msg}");
+    }
+
+    // ---- MultipartAbortGuard (abort-on-drop for cancelled multipart copies) ----
+
+    /// Poll the mock's DELETE (AbortMultipartUpload) count until it reaches
+    /// `expected`, giving the guard's detached abort task time to run. Returns
+    /// the final observed count.
+    async fn wait_for_abort_count(guard: &wiremock::MockGuard, expected: usize) -> usize {
+        for _ in 0..50 {
+            let n = guard.received_requests().await.len();
+            if n >= expected {
+                return n;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        guard.received_requests().await.len()
+    }
+
+    #[tokio::test]
+    async fn test_multipart_abort_guard_aborts_on_drop() {
+        use wiremock::matchers::{method, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let abort_mock = Mock::given(method("DELETE"))
+            .and(query_param("uploadId", "drop-upload-id"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount_as_scoped(&server)
+            .await;
+
+        let backend = mock_s3_backend(&server.uri(), false).await;
+        {
+            let mut guard = MultipartAbortGuard::new(
+                backend.store.clone(),
+                "dropped/object".into(),
+                "dropped/object".to_string(),
+            );
+            guard.arm("drop-upload-id".to_string());
+            // guard dropped here while still armed -> spawns AbortMultipartUpload
+        }
+
+        let count = wait_for_abort_count(&abort_mock, 1).await;
+        assert_eq!(count, 1, "dropping an armed guard must abort the multipart");
+    }
+
+    #[tokio::test]
+    async fn test_multipart_abort_guard_disarmed_does_not_abort() {
+        use wiremock::matchers::{method, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let abort_mock = Mock::given(method("DELETE"))
+            .and(query_param("uploadId", "done-upload-id"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount_as_scoped(&server)
+            .await;
+
+        let backend = mock_s3_backend(&server.uri(), false).await;
+        {
+            let mut guard = MultipartAbortGuard::new(
+                backend.store.clone(),
+                "completed/object".into(),
+                "completed/object".to_string(),
+            );
+            guard.arm("done-upload-id".to_string());
+            // A completed upload defuses the guard.
+            guard.disarm();
+        }
+
+        // Give any (erroneously) spawned abort a chance to land before asserting.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            abort_mock.received_requests().await.len(),
+            0,
+            "a completed (disarmed) upload must never be aborted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multipart_abort_guard_abort_now_aborts_once() {
+        use wiremock::matchers::{method, query_param};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let abort_mock = Mock::given(method("DELETE"))
+            .and(query_param("uploadId", "err-upload-id"))
+            .respond_with(ResponseTemplate::new(204))
+            .mount_as_scoped(&server)
+            .await;
+
+        let backend = mock_s3_backend(&server.uri(), false).await;
+        {
+            let mut guard = MultipartAbortGuard::new(
+                backend.store.clone(),
+                "errored/object".into(),
+                "errored/object".to_string(),
+            );
+            guard.arm("err-upload-id".to_string());
+            // The error path aborts inline and defuses the guard...
+            guard.abort_now().await;
+            assert_eq!(
+                abort_mock.received_requests().await.len(),
+                1,
+                "abort_now must issue exactly one AbortMultipartUpload"
+            );
+            // ...so the subsequent drop must NOT abort a second time.
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            abort_mock.received_requests().await.len(),
+            1,
+            "drop after abort_now must not issue a redundant abort"
         );
     }
 


### PR DESCRIPTION
## Summary

Storage-backend copy robustness follow-ups from #1533 (post-merge hygiene for the
#1448 OCI streaming upload work). LOW-severity and behavior-preserving. Scope is
limited to `backend/src/storage/gcs.rs` and `backend/src/storage/s3.rs`.

Closes #2197. Part of #1533.

**GCS (`gcs.rs`)**
- `GcsBackend::copy()` fetched a single bearer token before the `rewriteTo` loop
  and reused it for every continuation. A pathologically long multi-iteration
  rewrite of a large object could outlive that token. The token is now
  (re)obtained on every iteration via `get_bearer_token()`, which returns the
  cached token and only performs a network refresh within 60s of expiry — a small
  single-iteration copy still fetches exactly one token. On a `401 Unauthorized`
  the cached token is dropped and the iteration is retried once with a fresh one.
- The `MAX_REWRITE_ITERATIONS` ceiling (checklist item **TQ-4**) was a hard-coded
  local constant and its error branch was untested. It is now a module constant
  `GCS_MAX_REWRITE_ITERATIONS` with a per-backend override
  (`max_rewrite_iterations`), so a unit test can drive the loop into the ceiling
  branch cheaply. The rewrite-loop control flow was extracted into a pure
  `interpret_rewrite_step` helper, and the token refresh boundary into
  `token_needs_refresh`, so both are unit-tested without HTTP.

**S3 (`s3.rs`)**
- `S3Backend::copy()` of a `>5 GiB` source streamed `get_stream -> put_stream` and
  discarded `put_stream`'s returned SHA-256. The source bytes are now hashed
  independently as they stream through, and the resulting digest is cross-checked
  against `put_stream`'s digest (`ensure_copy_digest_matches`); a mismatch is now
  an error instead of a silent partial/corrupt copy.
- A `put_stream` future dropped after `create_multipart` but before completion
  left a server-side multipart upload lingering until a bucket
  `AbortIncompleteMultipartUpload` lifecycle rule reclaimed it. A new
  `MultipartAbortGuard` aborts a dropped/failed multipart (best-effort, spawned
  from `Drop`) but is defused on a successful completion, so a COMPLETED upload is
  never aborted. The guard also consolidates the previously duplicated inline
  abort blocks on the existing error paths (exactly one abort per failure, as
  before).

No API changes, no migration, no `sqlx` query changes.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests (all in the `gcs`/`s3` `#[cfg(test)]` modules):
- GCS: `test_interpret_rewrite_step_{done,continue,missing_token_errors}`,
  `test_token_needs_refresh_{when_absent,when_near_expiry}`,
  `test_token_fresh_outside_margin`, `test_invalidate_bearer_token_clears_cache`,
  `test_copy_hits_rewrite_iteration_ceiling` (injected low ceiling),
  `test_copy_single_iteration_small_object_unchanged`,
  `test_copy_refetches_bearer_token_each_iteration`,
  `test_copy_invalidates_token_and_retries_on_401`.
- S3: `test_ensure_copy_digest_matches_{ok_when_equal,errors_on_mismatch}`,
  `test_multipart_abort_guard_aborts_on_drop`,
  `test_multipart_abort_guard_disarmed_does_not_abort`,
  `test_multipart_abort_guard_abort_now_aborts_once`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
