### PR TITLE
fix(proxy): stream buffered blob fallback paths instead of capping them

### DIFF
--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -17,7 +17,6 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::Extension;
 use axum::Router;
-use bytes::Bytes;
 use sqlx::{PgPool, Row};
 use tracing::info;
 
@@ -242,7 +241,9 @@ async fn fetch_chart_via_index(
     name: &str,
     version: &str,
     filename: &str,
-) -> Result<(Bytes, Option<String>), Response> {
+) -> Result<Response, Response> {
+    // The `index.yaml` lookup stays buffered/capped by design: it is a small
+    // metadata document that must be parsed in-process.
     let (index_bytes, _) = proxy_helpers::proxy_fetch_capped(
         proxy,
         repo_id,
@@ -280,16 +281,22 @@ async fn fetch_chart_via_index(
 
     let fetch_url = resolve_chart_url(upstream_url, &chart_url);
     let cache_path = format!("charts/{}", filename);
-    proxy_helpers::proxy_fetch_capped_with_cache_key(
+    // #2192 / #1608 Phase 4c: the chart itself is a package BLOB, not metadata.
+    // The buffered fallback (#2181) capped it at DEFAULT_METADATA_MAX_BYTES and
+    // 502'd charts larger than the cap even though the primary download path
+    // streams. Route the chart download through the streaming helper (teed into
+    // the proxy cache under the same stable `charts/{filename}` key) so large
+    // charts succeed with 200 and subsequent requests are served warm.
+    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key(
         proxy,
         repo_id,
         repo_key,
         upstream_url,
         &fetch_url,
         &cache_path,
-        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
     )
-    .await
+    .await?;
+    proxy_helpers::stream_fetch_result(result, "application/gzip", Some(filename))
 }
 
 /// Attempt to download a chart from a Remote or Virtual repo by resolving the
@@ -313,7 +320,7 @@ async fn download_chart_via_index(
         let Some(upstream_url) = repo.upstream_url.as_deref() else {
             return Ok(None);
         };
-        let (content, content_type) = fetch_chart_via_index(
+        let response = fetch_chart_via_index(
             proxy,
             repo.id,
             &repo.key,
@@ -323,12 +330,7 @@ async fn download_chart_via_index(
             filename,
         )
         .await?;
-        return Ok(Some(proxy_helpers::build_download_response(
-            content,
-            content_type,
-            "application/gzip",
-            Some(filename),
-        )));
+        return Ok(Some(response));
     }
 
     if repo.repo_type == RepositoryType::Virtual {
@@ -369,13 +371,8 @@ async fn download_chart_via_index(
             )
             .await
             {
-                Ok((content, content_type)) => {
-                    return Ok(Some(proxy_helpers::build_download_response(
-                        content,
-                        content_type,
-                        "application/gzip",
-                        Some(filename),
-                    )));
+                Ok(response) => {
+                    return Ok(Some(response));
                 }
                 Err(_) => {
                     tracing::debug!(
@@ -980,6 +977,8 @@ entries:
     // the DB. Tests that return before any HTTP call can use a fake lazy pool.
 
     #[tokio::test]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    #[allow(clippy::disallowed_methods)]
     async fn test_fetch_chart_via_index_success_relative_url() {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1022,12 +1021,26 @@ entries:
         let _ = std::fs::remove_dir_all(&tmp);
 
         match result {
-            Ok((bytes, _)) => assert_eq!(&bytes[..], chart_bytes),
+            Ok(resp) => {
+                assert_eq!(resp.status(), StatusCode::OK);
+                assert_eq!(
+                    resp.headers()
+                        .get("content-disposition")
+                        .and_then(|v| v.to_str().ok()),
+                    Some("attachment; filename=\"mychart-1.0.0.tgz\"")
+                );
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .expect("collect streamed chart body");
+                assert_eq!(&body[..], chart_bytes);
+            }
             Err(_) => panic!("fetch_chart_via_index should succeed"),
         }
     }
 
     #[tokio::test]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    #[allow(clippy::disallowed_methods)]
     async fn test_fetch_chart_via_index_success_absolute_url() {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -1071,9 +1084,93 @@ entries:
         let _ = std::fs::remove_dir_all(&tmp);
 
         match result {
-            Ok((bytes, _)) => assert_eq!(&bytes[..], chart_bytes),
+            Ok(resp) => {
+                assert_eq!(resp.status(), StatusCode::OK);
+                let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                    .await
+                    .expect("collect streamed chart body");
+                assert_eq!(&body[..], chart_bytes);
+            }
             Err(_) => panic!("fetch_chart_via_index (absolute URL) should succeed"),
         }
+    }
+
+    // #2192 / #1608 Phase 4c: a chart larger than the old buffered cap
+    // (DEFAULT_METADATA_MAX_BYTES = 8 MiB) must now STREAM with 200 instead of
+    // 502, and the second request must be served WARM from the teed proxy cache
+    // without a second upstream round-trip for the chart blob.
+    #[tokio::test]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    #[allow(clippy::disallowed_methods)]
+    async fn test_fetch_chart_via_index_streams_large_chart_and_warms_cache() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let server = MockServer::start().await;
+        let upstream_url = server.uri();
+        let index_yaml = make_index_yaml("big", "3.0.0", "charts/big-3.0.0.tgz");
+        // 9 MiB > 8 MiB DEFAULT_METADATA_MAX_BYTES: would 502 on the buffered path.
+        let chart_bytes = vec![0x42u8; 9 * 1024 * 1024];
+
+        Mock::given(method("GET"))
+            .and(path("/index.yaml"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(index_yaml.as_bytes()))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/charts/big-3.0.0.tgz"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(chart_bytes.clone()))
+            // Cache warm proof: the chart blob is fetched from upstream at most
+            // once across the two requests below.
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = proxy_tmp_dir();
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo_id = uuid::Uuid::new_v4();
+
+        for i in 0..2 {
+            // Before the second request, wait for the streaming write-back to
+            // commit so the cache is deterministically WARM.
+            if i == 1 {
+                tdh::wait_for_cached_blob(&tmp, chart_bytes.len() as u64).await;
+            }
+            let result = fetch_chart_via_index(
+                &proxy,
+                repo_id,
+                "helm-proxy-big",
+                &upstream_url,
+                "big",
+                "3.0.0",
+                "big-3.0.0.tgz",
+            )
+            .await;
+            match result {
+                Ok(resp) => {
+                    assert_eq!(resp.status(), StatusCode::OK);
+                    assert_eq!(
+                        resp.headers()
+                            .get("content-disposition")
+                            .and_then(|v| v.to_str().ok()),
+                        Some("attachment; filename=\"big-3.0.0.tgz\"")
+                    );
+                    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                        .await
+                        .expect("collect streamed chart body");
+                    assert_eq!(body.len(), chart_bytes.len());
+                }
+                Err(_) => panic!("large chart must stream with 200, not 502"),
+            }
+        }
+
+        // `.expect(1)` on the chart mock is verified on server drop.
+        drop(server);
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1163,32 +1163,6 @@ async fn fetch_virtual_packument(
 /// artifact contents.
 const NPM_TARBALL_CONTENT_TYPE: &str = "application/gzip";
 
-/// Build an HTTP response for an npm tarball download.
-///
-/// All three download paths (remote, virtual, local) return the same response
-/// shape: the tarball bytes with `application/gzip` content type, a
-/// `Content-Disposition` attachment header, and the content length. This helper
-/// eliminates the repeated response-builder blocks.
-fn build_tarball_response(
-    content: Bytes,
-    filename: &str,
-    content_type: Option<String>,
-) -> Response {
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            CONTENT_TYPE,
-            content_type.unwrap_or_else(|| NPM_TARBALL_CONTENT_TYPE.to_string()),
-        )
-        .header(
-            "Content-Disposition",
-            format!("attachment; filename=\"{}\"", filename),
-        )
-        .header(CONTENT_LENGTH, content.len().to_string())
-        .body(Body::from(content))
-        .unwrap()
-}
-
 /// Build a streaming tarball response from a storage stream.
 fn build_tarball_response_stream(
     stream: futures::stream::BoxStream<'static, crate::error::Result<Bytes>>,
@@ -1399,13 +1373,19 @@ async fn serve_tarball(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, _content_type) = proxy_helpers::proxy_fetch_capped(
+            // #2192 / #1608 Phase 4c: an npm tarball is a package BLOB, not
+            // metadata. The buffered fallback (#2181) capped it at
+            // LARGE_METADATA_MAX_BYTES and 502'd a tarball larger than the cap
+            // even though other download paths already stream. Stream it (teed
+            // into the proxy cache under `upstream_path`) so a large tarball
+            // succeeds with 200 and subsequent pulls are served warm.
+            let result = proxy_helpers::proxy_fetch_streaming_with_cache_key(
                 proxy,
                 repo.id,
                 repo_key,
                 upstream_url,
                 &upstream_path,
-                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+                &upstream_path,
             )
             .await?;
 
@@ -1415,7 +1395,16 @@ async fn serve_tarball(
             // security scanners can identify the file as a gzip archive.
             correct_cached_tarball_content_type(&state.db, repo.id, &upstream_path).await;
 
-            return Ok(build_tarball_response(content, filename, None));
+            // Force the outbound Content-Type to application/gzip regardless of
+            // what the upstream advertised — parity with the buffered path
+            // (build_tarball_response(None)) and the virtual path
+            // (npm_virtual_tarball_content_type).
+            return Ok(build_tarball_response_stream(
+                result.body,
+                filename,
+                npm_virtual_tarball_content_type(result.content_type),
+                result.content_length,
+            ));
         }
         return Err(AppError::NotFound("Tarball not found".to_string()).into_response());
     }
@@ -4113,6 +4102,104 @@ mod tests {
             .expect("read body");
         assert_eq!(&body_bytes[..], tarball_bytes.as_ref());
 
+        cleanup().await;
+    }
+
+    // #2192 / #1608 Phase 4c: an npm tarball larger than the old buffered cap
+    // (LARGE_METADATA_MAX_BYTES = 16 MiB) must now STREAM with 200 instead of
+    // 502, the outbound Content-Type must still be forced to application/gzip,
+    // and the second request must be served WARM from the teed proxy cache
+    // without a second upstream round-trip.
+    #[tokio::test]
+    async fn test_remote_proxy_streams_large_tarball_and_warms_cache() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+
+        let mock_server = MockServer::start().await;
+        // 17 MiB > 16 MiB LARGE_METADATA_MAX_BYTES: 502s on the buffered path.
+        let mut tarball_bytes = vec![0x1fu8, 0x8b, 0x08];
+        tarball_bytes.resize(17 * 1024 * 1024, 0x7e);
+
+        Mock::given(method("GET"))
+            .and(path("/bigpkg/-/bigpkg-1.0.0.tgz"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(tarball_bytes.clone()),
+            )
+            // Warm-cache proof: fetched from upstream at most once across the
+            // two requests below.
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock_server.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+
+        let cleanup_pool = fx.pool.clone();
+        let cleanup_repo = fx.repo_id;
+        let cleanup_user = fx.user_id;
+        let cleanup_dir = fx.storage_dir.clone();
+        let cleanup = || async move {
+            tdh::cleanup(&cleanup_pool, cleanup_repo, cleanup_user).await;
+            let _ = std::fs::remove_dir_all(&cleanup_dir);
+        };
+
+        for i in 0..2 {
+            // Before the second request, wait for the streaming write-back to
+            // commit so the cache is deterministically WARM.
+            if i == 1 {
+                tdh::wait_for_cached_blob(&fx.storage_dir, tarball_bytes.len() as u64).await;
+            }
+            let result = super::download_tarball(
+                axum::extract::State(state.clone()),
+                axum::extract::Path((
+                    fx.repo_key.clone(),
+                    "bigpkg".to_string(),
+                    "bigpkg-1.0.0.tgz".to_string(),
+                )),
+            )
+            .await;
+
+            let response = match result {
+                Ok(r) => r,
+                Err(r) => {
+                    let status = r.status();
+                    cleanup().await;
+                    panic!("large tarball must stream with 200, got {status}");
+                }
+            };
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                response
+                    .headers()
+                    .get(CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok()),
+                Some(NPM_TARBALL_CONTENT_TYPE),
+                "outbound tarball content type must be forced to application/gzip"
+            );
+            let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read streamed body");
+            assert_eq!(body_bytes.len(), tarball_bytes.len());
+        }
+
+        // `.expect(1)` on the mock is verified on server drop.
+        drop(mock_server);
         cleanup().await;
     }
 

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2674,6 +2674,13 @@ pub async fn resolve_virtual_blob(
             {
                 for image in candidate_upstream_images(image_name, upstream_url) {
                     let upstream_path = upstream_blob_path(&image, digest);
+                    // #2192 / #1608 Phase 4c: this virtual-member blob fallback
+                    // stays BUFFERED (unlike the plain-Remote blob download,
+                    // which now streams). `finalize_upstream_blob` below
+                    // content-address-verifies the whole body against the
+                    // requested digest before serving — a security-critical
+                    // check that requires the complete payload in memory, so it
+                    // cannot be streamed without sacrificing verification.
                     if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
                         proxy,
                         member.id,
@@ -2788,6 +2795,12 @@ pub async fn resolve_virtual_manifest(
             {
                 for image in candidate_upstream_images(image_name, upstream_url) {
                     let upstream_path = upstream_manifest_path(&image, reference);
+                    // #2192 / #1608 Phase 4c: manifest fallbacks stay BUFFERED
+                    // and capped by design. A manifest is a small parsed-JSON
+                    // document (blob-ref resolution) that must be read in-process,
+                    // and there is no streaming `_with_accept` sibling; when the
+                    // reference is a digest, `finalize_upstream_manifest` below
+                    // content-address-verifies the whole body before serving.
                     if let Ok((content, content_type)) =
                         proxy_helpers::proxy_fetch_capped_with_accept(
                             proxy,
@@ -3147,6 +3160,12 @@ async fn try_upstream_fetch_with_accept(
     let proxy = state.proxy_service.as_ref()?;
     let image = normalize_docker_image(&repo.image, upstream_url);
     let upstream_path = format!("v2/{}/{}", image, path_suffix);
+    // #2192 / #1608 Phase 4c: the manifest GET/HEAD fallback stays BUFFERED and
+    // capped by design — a manifest is a small parsed-JSON document that must be
+    // read in-process for blob-ref resolution, and there is no streaming
+    // `_with_accept` sibling that could forward the content-negotiation `Accept`
+    // header. Blob downloads no longer flow through here: the Remote GET-blob
+    // path streams via `try_upstream_fetch_streaming_blob`.
     proxy_helpers::proxy_fetch_capped_with_accept(
         proxy,
         repo.id,
@@ -3283,6 +3302,72 @@ fn build_oci_proxy_response(
         .header(CONTENT_LENGTH, content.len().to_string())
         .header(CONTENT_TYPE, ct)
         .body(body)
+        .unwrap()
+}
+
+/// Streaming sibling of [`try_upstream_fetch`] for BLOB downloads (#2192 /
+/// #1608 Phase 4c).
+///
+/// A blob is an opaque image layer that can legitimately exceed the buffered
+/// per-caller cap (#2181). Route the Remote-repo blob download through the
+/// streaming proxy helper — teed into the proxy cache — so a >cap layer returns
+/// 200 (streamed) instead of 502, and subsequent pulls are served warm.
+///
+/// Manifests deliberately stay on the buffered [`try_upstream_fetch_with_accept`]
+/// path: they are parsed JSON (blob-ref resolution) and, when referenced by
+/// digest, content-address-verified before serving, so they must be buffered.
+async fn try_upstream_fetch_streaming_blob(
+    repo: &OciRepoInfo,
+    state: &SharedState,
+    digest: &str,
+) -> Option<Response> {
+    if repo.repo_type != RepositoryType::Remote {
+        return None;
+    }
+    let upstream_url = repo.upstream_url.as_ref()?;
+    let proxy = state.proxy_service.as_ref()?;
+    let image = normalize_docker_image(&repo.image, upstream_url);
+    let upstream_path = format!("v2/{}/blobs/{}", image, digest);
+    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key(
+        proxy,
+        repo.id,
+        &repo.key,
+        upstream_url,
+        &upstream_path,
+        &upstream_path,
+    )
+    .await
+    .ok()?;
+    Some(build_oci_streaming_proxy_response(
+        result,
+        digest,
+        "application/octet-stream",
+    ))
+}
+
+/// Streaming sibling of [`build_oci_proxy_response`] for blob GETs (#2192 /
+/// #1608 Phase 4c). Preserves the mandatory `Docker-Content-Digest` header and
+/// forwards the upstream content-type / content-length while driving the body
+/// straight from the streaming fetch, never buffering the layer in heap.
+fn build_oci_streaming_proxy_response(
+    result: crate::services::proxy_service::StreamingFetchResult,
+    digest: &str,
+    default_ct: &str,
+) -> Response {
+    let ct = result
+        .content_type
+        .unwrap_or_else(|| default_ct.to_string());
+    let mut builder = Response::builder()
+        .status(StatusCode::OK)
+        .header("Docker-Content-Digest", digest)
+        .header(CONTENT_TYPE, ct);
+    if let Some(len) = result.content_length {
+        builder = builder.header(CONTENT_LENGTH, len.to_string());
+    }
+    builder
+        .body(Body::from_stream(result.body.map(|chunk| {
+            chunk.map_err(|e| std::io::Error::other(e.to_string()))
+        })))
         .unwrap()
 }
 
@@ -3946,11 +4031,17 @@ async fn handle_get_blob(
         }
     }
 
-    // For remote repos, try fetching blob from upstream
-    if let Some((content, ct)) =
-        try_upstream_fetch(&repo, state, &format!("blobs/{}", digest)).await
-    {
-        return build_oci_proxy_response(&content, ct, digest, "application/octet-stream", true);
+    // For remote repos, STREAM the blob from upstream. Blobs are opaque
+    // binaries (image layers) that routinely reach many GiB; the buffered
+    // fallback (#2181) capped them at DEFAULT_METADATA_MAX_BYTES and 502'd a
+    // layer larger than the cap even though the CAS-hit path already streams.
+    // Route the download through the streaming proxy helper (teed into the
+    // proxy cache) so large blobs succeed with 200 and later pulls are served
+    // warm. Unlike the virtual-blob resolver, this plain-Remote path does not
+    // content-address-verify the digest before serving, so streaming
+    // introduces no verification regression. (#2192 / #1608 Phase 4c)
+    if let Some(resp) = try_upstream_fetch_streaming_blob(&repo, state, digest).await {
+        return resp;
     }
 
     oci_error(StatusCode::NOT_FOUND, "BLOB_UNKNOWN", "blob not found")
@@ -11293,6 +11384,153 @@ mod blob_pull_streaming_tests {
             &body_bytes[..],
             "streamed body must round-trip the stored blob bytes"
         );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #2192 / #1608 Phase 4c: the Remote-repo blob DOWNLOAD fallback streams (so a
+// >cap layer is 200, not 502) while the manifest fallback stays buffered/capped.
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
+#[cfg(test)]
+mod remote_blob_streaming_fallback_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    fn remote_repo(key: &str, upstream_url: &str, image: &str) -> OciRepoInfo {
+        OciRepoInfo {
+            id: Uuid::new_v4(),
+            key: key.to_string(),
+            location: crate::storage::StorageLocation {
+                backend: "filesystem".to_string(),
+                path: "/data/docker".to_string(),
+            },
+            repo_type: "remote".to_string(),
+            upstream_url: Some(upstream_url.to_string()),
+            is_public: true,
+            image: image.to_string(),
+        }
+    }
+
+    /// A blob larger than the old buffered cap (DEFAULT_METADATA_MAX_BYTES =
+    /// 8 MiB) must STREAM with 200 (Docker-Content-Digest preserved) instead of
+    /// 502, and the second request must be served WARM from the teed proxy cache
+    /// without a second upstream round-trip.
+    #[tokio::test]
+    async fn remote_blob_streams_large_layer_and_warms_cache() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let digest = format!("sha256:{}", "d".repeat(64));
+        // 9 MiB > 8 MiB DEFAULT_METADATA_MAX_BYTES: 502s on the buffered path.
+        let layer = vec![0x5au8; 9 * 1024 * 1024];
+
+        Mock::given(method("GET"))
+            .and(path(format!("/v2/myorg/app/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(layer.clone()),
+            )
+            // Warm-cache proof: fetched from upstream at most once.
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-blob-stream-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool, tmp.to_str().unwrap(), proxy);
+        let repo = remote_repo("docker-remote", &server.uri(), "myorg/app");
+
+        for i in 0..2 {
+            // Before the second request, wait for the streaming write-back to
+            // commit so the cache is deterministically WARM.
+            if i == 1 {
+                tdh::wait_for_cached_blob(&tmp, layer.len() as u64).await;
+            }
+            let resp = super::try_upstream_fetch_streaming_blob(&repo, &state, &digest)
+                .await
+                .expect("large blob must stream with 200, not 502");
+            assert_eq!(resp.status(), StatusCode::OK);
+            assert_eq!(
+                resp.headers()
+                    .get("Docker-Content-Digest")
+                    .and_then(|v| v.to_str().ok()),
+                Some(digest.as_str())
+            );
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("collect streamed layer");
+            assert_eq!(body.len(), layer.len());
+        }
+
+        drop(server);
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// The manifest fallback stays BUFFERED and capped by design: a manifest
+    /// larger than DEFAULT_METADATA_MAX_BYTES must NOT be served (the capped
+    /// buffered fetch fails, yielding `None`), proving it is not routed through
+    /// the streaming path. A small manifest still parses (returns `Some`).
+    #[tokio::test]
+    async fn remote_manifest_fallback_stays_buffered_and_capped() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+
+        // Small manifest: buffered fetch succeeds.
+        Mock::given(method("GET"))
+            .and(path("/v2/myorg/app/manifests/small"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/vnd.oci.image.manifest.v1+json")
+                    .set_body_bytes(br#"{"schemaVersion":2}"#.as_ref()),
+            )
+            .mount(&server)
+            .await;
+
+        // Oversized "manifest": 9 MiB > 8 MiB cap. The buffered+capped fetch
+        // rejects it (502 -> None); a streaming path would have returned it.
+        Mock::given(method("GET"))
+            .and(path("/v2/myorg/app/manifests/huge"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/vnd.oci.image.manifest.v1+json")
+                    .set_body_bytes(vec![0x20u8; 9 * 1024 * 1024]),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-manifest-cap-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool, tmp.to_str().unwrap(), proxy);
+        let repo = remote_repo("docker-remote", &server.uri(), "myorg/app");
+
+        let small =
+            super::try_upstream_fetch_with_accept(&repo, &state, "manifests/small", None).await;
+        assert!(small.is_some(), "a small manifest must still be served");
+
+        let huge =
+            super::try_upstream_fetch_with_accept(&repo, &state, "manifests/huge", None).await;
+        assert!(
+            huge.is_none(),
+            "an over-cap manifest must be rejected by the buffered/capped fallback, \
+             proving manifests are NOT streamed"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1223,7 +1223,7 @@ async fn serve_file(
             // logic for remote members because external registries (e.g.
             // pypi.org) host files on a different domain than the simple
             // index. We iterate members manually and delegate to
-            // fetch_from_pypi_remote for each remote member.
+            // fetch_from_pypi_remote_streaming for each remote member.
             if repo.repo_type == RepositoryType::Virtual {
                 let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
 
@@ -1391,10 +1391,10 @@ async fn serve_file(
             (&repo.upstream_url, &state.proxy_service)
         {
             get_remote_cached_or_refetch_stream(
-                storage.as_ref(),
+                storage.clone(),
                 &artifact.storage_key,
                 || async move {
-                    fetch_from_pypi_remote(
+                    fetch_from_pypi_remote_streaming(
                         proxy,
                         repo.id,
                         repo_key,
@@ -1448,18 +1448,24 @@ async fn serve_file(
 }
 
 /// Streaming variant of the PyPI proxy cache read. Streams a cache hit
-/// straight from storage; on a miss it re-fetches the wheel from upstream
-/// (buffered, since the recovery payload must also be written back to the
-/// cache to avoid a thundering herd) and re-wraps the recovered bytes as a
-/// one-shot stream so the caller always receives a `BoxStream`.
+/// straight from storage; on a miss it re-fetches the wheel from upstream and
+/// STREAMS it to the caller while teeing it back into storage so the next
+/// request is served warm.
+///
+/// #2192 / #1608 Phase 4c: the previous recovery path buffered the refetch
+/// (capped at 16 MiB by #2181) and 502'd a wheel larger than the cap even
+/// though the primary download path streams. The refetch now yields a
+/// [`StreamingFetchResult`] (via `fetch_from_pypi_remote_streaming`) and the
+/// body is teed into `storage_key` as it flows to the client — preserving the
+/// thundering-herd write-back (PR #1283) without ever buffering the whole wheel.
 async fn get_remote_cached_or_refetch_stream<F, Fut>(
-    storage: &dyn crate::storage::StorageBackend,
+    storage: std::sync::Arc<dyn crate::storage::StorageBackend>,
     storage_key: &str,
     refetch: F,
 ) -> Result<BoxStream<'static, Result<Bytes, std::io::Error>>, Response>
 where
     F: FnOnce() -> Fut,
-    Fut: Future<Output = Result<Bytes, Response>>,
+    Fut: Future<Output = Result<crate::services::proxy_service::StreamingFetchResult, Response>>,
 {
     match storage.get_stream(storage_key).await {
         Ok(stream) => Ok(stream
@@ -1468,27 +1474,117 @@ where
         Err(AppError::NotFound(_)) => {
             tracing::warn!(
                 storage_key = %storage_key,
-                "remote PyPI proxy cache entry is missing on disk; re-fetching from upstream"
+                "remote PyPI proxy cache entry is missing on disk; re-fetching from upstream (streaming)"
             );
-            let bytes = refetch().await?;
-            // Best-effort write-back: persist the refetched payload so the
-            // next request hits the cache instead of re-traversing the
-            // simple index and re-downloading from upstream. Without this,
-            // N concurrent `uv` clients each issue a fresh upstream fetch
-            // for the same wheel (thundering herd; see PR #1283 review).
-            // We swallow write errors to keep serving the current request,
-            // but log them so operators can spot a broken backend.
-            if let Err(e) = storage.put(storage_key, bytes.clone()).await {
-                tracing::warn!(
-                    storage_key = %storage_key,
-                    error = %e,
-                    "failed to write back refetched PyPI proxy payload; subsequent requests will re-fetch from upstream"
-                );
-            }
-            Ok(futures::stream::once(async { Ok(bytes) }).boxed())
+            let result = refetch().await?;
+            Ok(tee_refetch_to_storage(
+                storage,
+                storage_key.to_string(),
+                result.content_length,
+                result.body,
+            ))
         }
         Err(e) => Err(map_storage_err(e)),
     }
+}
+
+/// Tee a streaming refetch body into repo storage at `storage_key` while
+/// forwarding it to the caller (#2192 / #1608 Phase 4c).
+///
+/// Replaces the buffered `storage.put(storage_key, bytes)` write-back the
+/// recovery path used to perform, without buffering the whole payload:
+///
+/// * The body is forwarded to the client verbatim.
+/// * A clone of each chunk is streamed, in order and with backpressure, to a
+///   background `put_stream` so the cached blob is byte-exact.
+/// * The client stream awaits the write-back at EOF, so a subsequent request
+///   deterministically observes the warmed entry.
+/// * Best-effort: a write failure is logged but never fails the in-flight
+///   download. A truncated write-back (client disconnect, short read, or upstream
+///   error mid-stream) is detected against `expected_len` and the partial cache
+///   entry is deleted so no corrupt blob is ever served warm.
+fn tee_refetch_to_storage(
+    storage: std::sync::Arc<dyn crate::storage::StorageBackend>,
+    storage_key: String,
+    expected_len: Option<u64>,
+    upstream: BoxStream<'static, crate::error::Result<Bytes>>,
+) -> BoxStream<'static, Result<Bytes, std::io::Error>> {
+    // Bounded channel: a slow backend applies backpressure to the upstream read
+    // instead of letting chunks pile up in memory. Order is preserved and no
+    // chunk is dropped, so the written-back blob matches the served bytes.
+    let (tx, rx) = tokio::sync::mpsc::channel::<crate::error::Result<Bytes>>(16);
+    let writer_key = storage_key.clone();
+    let writer = tokio::spawn(async move {
+        let rx_stream =
+            futures::stream::unfold(rx, |mut rx| async move { rx.recv().await.map(|i| (i, rx)) });
+        match storage.put_stream(&writer_key, Box::pin(rx_stream)).await {
+            Ok(w) => {
+                // Compensate for a partial write (the default put_stream commits
+                // whatever it received when the channel closes cleanly): if the
+                // written length does not match the advertised length, delete the
+                // truncated entry so it is never served as a warm hit.
+                if let Some(expected) = expected_len {
+                    if w.bytes_written != expected {
+                        tracing::warn!(
+                            storage_key = %writer_key,
+                            expected,
+                            written = w.bytes_written,
+                            "streaming write-back of refetched PyPI payload was truncated; \
+                             deleting partial cache entry"
+                        );
+                        let _ = storage.delete(&writer_key).await;
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    storage_key = %writer_key,
+                    error = %e,
+                    "streaming write-back of refetched PyPI payload failed; \
+                     subsequent requests will re-fetch from upstream"
+                );
+            }
+        }
+    });
+
+    futures::stream::unfold(
+        (upstream, Some(tx), Some(writer)),
+        |(mut upstream, mut tx, mut writer)| async move {
+            match upstream.next().await {
+                Some(Ok(bytes)) => {
+                    if let Some(sender) = tx.as_ref() {
+                        // Backpressure on the writer; drop the tee (not the
+                        // client stream) if the writer has gone away.
+                        if sender.send(Ok(bytes.clone())).await.is_err() {
+                            tx = None;
+                        }
+                    }
+                    Some((Ok(bytes), (upstream, tx, writer)))
+                }
+                Some(Err(e)) => {
+                    // Propagate the error to the writer so the default put_stream
+                    // aborts (no partial commit), then stop teeing.
+                    if let Some(sender) = tx.as_ref() {
+                        let _ = sender
+                            .send(Err(crate::error::AppError::Internal(e.to_string())))
+                            .await;
+                    }
+                    let io_err = std::io::Error::other(e.to_string());
+                    Some((Err(io_err), (upstream, None, writer)))
+                }
+                None => {
+                    // EOF: closing the channel lets put_stream commit; await it so
+                    // a subsequent request observes the warmed entry.
+                    drop(tx);
+                    if let Some(handle) = writer.take() {
+                        let _ = handle.await;
+                    }
+                    None
+                }
+            }
+        },
+    )
+    .boxed()
 }
 
 /// Resolved upstream download target for a PyPI remote file, produced by
@@ -1594,45 +1690,6 @@ async fn resolve_pypi_remote_fetch_target(
     })
 }
 
-/// Fetch a file from a remote PyPI upstream using the format-specific URL
-/// resolution logic, buffering the whole body in memory.
-///
-/// **Prefer [`fetch_from_pypi_remote_streaming`] on download paths.** This
-/// buffered variant exists only for callers that genuinely need the full
-/// `Bytes` in-process — currently the cache-recovery closure in
-/// [`get_remote_cached_or_refetch_stream`], which must write the refetched
-/// payload back to storage.
-async fn fetch_from_pypi_remote(
-    proxy: &crate::services::proxy_service::ProxyService,
-    repo_id: uuid::Uuid,
-    repo_key: &str,
-    upstream_url: &str,
-    project: &str,
-    filename: &str,
-) -> Result<Bytes, Response> {
-    let target =
-        resolve_pypi_remote_fetch_target(proxy, repo_id, repo_key, upstream_url, project, filename)
-            .await?;
-
-    // Bound the buffered cache-recovery read (#1608 Phase 4b / #2181). This is
-    // the recovery closure for `get_remote_cached_or_refetch_stream`, which
-    // needs the full body to write it back to storage; the primary download
-    // path streams via `fetch_from_pypi_remote_streaming`. Use the 16 MiB
-    // ceiling since the payload is a package file rather than small metadata.
-    let (content, _content_type) = proxy_helpers::proxy_fetch_capped_with_cache_key(
-        proxy,
-        repo_id,
-        repo_key,
-        &target.fetch_base,
-        &target.fetch_path,
-        &target.cache_path,
-        proxy_helpers::LARGE_METADATA_MAX_BYTES,
-    )
-    .await?;
-
-    Ok(content)
-}
-
 /// #1555: presigned-redirect fast path for a fresh proxy-cache hit on a remote
 /// PyPI member. Returns `Some(307 redirect)` only when presigned downloads are
 /// enabled and the cache is fresh, signing the cache key through the proxy's own
@@ -1674,11 +1731,14 @@ async fn pypi_proxy_cache_redirect(
     .await
 }
 
-/// Streaming sibling of [`fetch_from_pypi_remote`] (#895 OOM relief).
+/// Fetch a PyPI package file from a remote upstream as a stream (#895 OOM
+/// relief).
 ///
-/// Resolves the real download URL via the simple index exactly like the
-/// buffered variant, then streams the package file from upstream — teed
-/// into the proxy cache — instead of buffering it in memory. Large wheels
+/// Resolves the real download URL via the simple index (buffered, in-process),
+/// then streams the package file from upstream — teed into the proxy cache —
+/// instead of buffering it in memory. This is the single fetch path for remote
+/// PyPI downloads, including the cache-recovery write-back in
+/// [`get_remote_cached_or_refetch_stream`]. Large wheels
 /// (CUDA / ML packages routinely exceed 400 MiB) previously OOM-killed
 /// memory-constrained pods when several `pip install` runs downloaded
 /// concurrently through the buffered path.
@@ -3726,6 +3786,18 @@ mod tests {
         Bytes::from(buf)
     }
 
+    /// Wrap static bytes as a one-shot [`StreamingFetchResult`] so the recovery
+    /// tests can drive the streaming refetch closure (#2192).
+    fn one_shot_result(
+        content: &'static [u8],
+    ) -> crate::services::proxy_service::StreamingFetchResult {
+        crate::services::proxy_service::StreamingFetchResult {
+            body: futures::stream::once(async move { Ok(Bytes::from_static(content)) }).boxed(),
+            content_type: Some("application/octet-stream".to_string()),
+            content_length: Some(content.len() as u64),
+        }
+    }
+
     /// Storage double that reports the entry as missing on every `get`, and
     /// records every `put` so tests can assert the write-back path persists
     /// refetched payloads (PR #1283 follow-up: thundering-herd fix).
@@ -3817,21 +3889,22 @@ mod tests {
     async fn test_get_remote_cached_or_refetch_refetches_on_missing_storage() {
         // Streaming refetch path is DB-free (storage doubles only), so this runs
         // in Tier-1 `cargo test --lib` without a live Postgres.
-        let storage = MissingStorage::new();
+        let storage = std::sync::Arc::new(MissingStorage::new());
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
         let storage_key =
             "proxy-cache/pypi-remote/simple/fastapi/fastapi-0.136.1-py3-none-any.whl/__content__";
-        let stream = super::get_remote_cached_or_refetch_stream(&storage, storage_key, move || {
-            let refetch_calls_clone = refetch_calls_clone.clone();
-            async move {
-                refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                Ok(Bytes::from_static(b"refetched-bytes"))
-            }
-        })
-        .await
-        .expect("refetch should succeed");
+        let stream =
+            super::get_remote_cached_or_refetch_stream(storage.clone(), storage_key, move || {
+                let refetch_calls_clone = refetch_calls_clone.clone();
+                async move {
+                    refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                    Ok(one_shot_result(b"refetched-bytes"))
+                }
+            })
+            .await
+            .expect("refetch should succeed");
         let content = collect_stream(stream).await;
 
         assert_eq!(content, Bytes::from_static(b"refetched-bytes"));
@@ -3886,11 +3959,11 @@ mod tests {
         // disk is full or read-only the user still gets their wheel; the
         // next request will simply re-fetch from upstream until the backend
         // recovers.
-        let storage = WriteFailingStorage;
+        let storage = std::sync::Arc::new(WriteFailingStorage);
         let stream = super::get_remote_cached_or_refetch_stream(
-            &storage,
+            storage.clone(),
             "proxy-cache/pypi-remote/simple/urllib3/urllib3-2.2.0-py3-none-any.whl/__content__",
-            move || async move { Ok(Bytes::from_static(b"refetched-when-disk-full")) },
+            move || async move { Ok(one_shot_result(b"refetched-when-disk-full")) },
         )
         .await
         .expect("write-back failures must not fail the current request");
@@ -3903,20 +3976,20 @@ mod tests {
     async fn test_get_remote_cached_or_refetch_returns_cached_without_refetch() {
         // Happy path: cache hits should return the stored bytes verbatim and
         // must NEVER invoke the upstream refetch closure.
-        let storage = PresentStorage {
+        let storage = std::sync::Arc::new(PresentStorage {
             bytes: Bytes::from_static(b"cached-wheel-bytes"),
-        };
+        });
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
         let stream = super::get_remote_cached_or_refetch_stream(
-            &storage,
+            storage.clone(),
             "proxy-cache/pypi-remote/simple/numpy/numpy-2.0.0-cp312-cp312-manylinux.whl/__content__",
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
                     refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    Ok(Bytes::from_static(b"should-not-be-used"))
+                    Ok(one_shot_result(b"should-not-be-used"))
                 }
             },
         )
@@ -3937,18 +4010,18 @@ mod tests {
         // A storage backend error that is NOT `NotFound` (e.g. permission
         // denied, I/O error) must be surfaced as a 500 instead of silently
         // re-fetching, otherwise we mask infra issues from operators.
-        let storage = BrokenStorage;
+        let storage = std::sync::Arc::new(BrokenStorage);
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
         let result = super::get_remote_cached_or_refetch_stream(
-            &storage,
+            storage.clone(),
             "proxy-cache/pypi-remote/simple/six/six-1.16.0.tar.gz/__content__",
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
                     refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    Ok(Bytes::from_static(b"never-reached"))
+                    Ok(one_shot_result(b"never-reached"))
                 }
             },
         )
@@ -3973,12 +4046,12 @@ mod tests {
         // When the cache is stale AND the upstream refetch also fails, the
         // upstream error response must reach the caller untouched so the
         // client sees the correct upstream status (e.g. 502).
-        let storage = MissingStorage::new();
+        let storage = std::sync::Arc::new(MissingStorage::new());
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
         let result = super::get_remote_cached_or_refetch_stream(
-            &storage,
+            storage.clone(),
             "proxy-cache/pypi-remote/simple/requests/requests-2.32.0-py3-none-any.whl/__content__",
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
@@ -4010,20 +4083,20 @@ mod tests {
         // still a cache hit and must be returned without triggering a
         // refetch. This guards against accidentally treating empty bodies
         // as "missing".
-        let storage = PresentStorage {
+        let storage = std::sync::Arc::new(PresentStorage {
             bytes: Bytes::new(),
-        };
+        });
         let refetch_calls = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let refetch_calls_clone = refetch_calls.clone();
 
         let stream = super::get_remote_cached_or_refetch_stream(
-            &storage,
+            storage.clone(),
             "proxy-cache/pypi-remote/simple/empty/empty-0.0.0.tar.gz/__content__",
             move || {
                 let refetch_calls_clone = refetch_calls_clone.clone();
                 async move {
                     refetch_calls_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                    Ok(Bytes::from_static(b"unexpected"))
+                    Ok(one_shot_result(b"unexpected"))
                 }
             },
         )
@@ -4036,6 +4109,109 @@ mod tests {
             refetch_calls.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "empty cached payload is a cache hit, not a stale miss"
+        );
+    }
+
+    /// Storage double that reports missing on `get` but records both `put`
+    /// (write-back) and `delete` (truncation compensation).
+    struct RecordingStorage {
+        puts: std::sync::Mutex<Vec<(String, Bytes)>>,
+        deletes: std::sync::Mutex<Vec<String>>,
+    }
+
+    impl RecordingStorage {
+        fn new() -> Self {
+            Self {
+                puts: std::sync::Mutex::new(Vec::new()),
+                deletes: std::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::storage::StorageBackend for RecordingStorage {
+        async fn put(&self, key: &str, content: Bytes) -> crate::error::Result<()> {
+            self.puts
+                .lock()
+                .expect("puts mutex")
+                .push((key.to_string(), content));
+            Ok(())
+        }
+        async fn get(&self, _key: &str) -> crate::error::Result<Bytes> {
+            Err(AppError::NotFound("missing cache entry".to_string()))
+        }
+        async fn exists(&self, _key: &str) -> crate::error::Result<bool> {
+            Ok(false)
+        }
+        async fn delete(&self, key: &str) -> crate::error::Result<()> {
+            self.deletes
+                .lock()
+                .expect("deletes mutex")
+                .push(key.to_string());
+            Ok(())
+        }
+    }
+
+    fn multi_chunk_result(
+        chunks: Vec<&'static [u8]>,
+        content_length: Option<u64>,
+    ) -> crate::services::proxy_service::StreamingFetchResult {
+        crate::services::proxy_service::StreamingFetchResult {
+            body: futures::stream::iter(chunks.into_iter().map(|c| Ok(Bytes::from_static(c))))
+                .boxed(),
+            content_type: Some("application/octet-stream".to_string()),
+            content_length,
+        }
+    }
+
+    /// #2192: a multi-chunk streaming refetch must serve every chunk to the
+    /// caller AND write the full, byte-exact payload back for the next request.
+    #[tokio::test]
+    async fn test_streaming_refetch_tees_multi_chunk_body_to_cache() {
+        let storage = std::sync::Arc::new(RecordingStorage::new());
+        let key = "proxy-cache/pypi-remote/simple/big/big-9.9.9-py3-none-any.whl/__content__";
+        let stream =
+            super::get_remote_cached_or_refetch_stream(storage.clone(), key, move || async move {
+                Ok(multi_chunk_result(vec![b"aaaa", b"bbbb", b"cc"], Some(10)))
+            })
+            .await
+            .expect("streaming refetch should succeed");
+        let content = collect_stream(stream).await;
+
+        assert_eq!(content, Bytes::from_static(b"aaaabbbbcc"));
+        let puts = storage.puts.lock().expect("puts mutex");
+        assert_eq!(puts.len(), 1, "full body must be written back exactly once");
+        assert_eq!(puts[0].0, key);
+        assert_eq!(puts[0].1, Bytes::from_static(b"aaaabbbbcc"));
+        assert!(
+            storage.deletes.lock().expect("deletes mutex").is_empty(),
+            "a complete write-back must not be deleted"
+        );
+    }
+
+    /// #2192: if the written-back length does not match the advertised
+    /// `content_length` (truncation / short read), the partial cache entry must
+    /// be deleted so it is never served as a corrupt warm hit.
+    #[tokio::test]
+    async fn test_streaming_refetch_deletes_truncated_writeback() {
+        let storage = std::sync::Arc::new(RecordingStorage::new());
+        let key = "proxy-cache/pypi-remote/simple/trunc/trunc-1.0.0-py3-none-any.whl/__content__";
+        // Advertise 100 bytes but only deliver 4: the guard must delete.
+        let stream =
+            super::get_remote_cached_or_refetch_stream(storage.clone(), key, move || async move {
+                Ok(multi_chunk_result(vec![b"abcd"], Some(100)))
+            })
+            .await
+            .expect("streaming refetch should succeed even when truncated");
+        let content = collect_stream(stream).await;
+
+        // The caller still receives whatever bytes arrived.
+        assert_eq!(content, Bytes::from_static(b"abcd"));
+        let deletes = storage.deletes.lock().expect("deletes mutex");
+        assert_eq!(
+            deletes.as_slice(),
+            &[key.to_string()],
+            "a truncated write-back must be deleted, not served warm"
         );
     }
 

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -513,23 +513,21 @@ async fn download_archive(
                     (&repo.upstream_url, &state.proxy_service)
                 {
                     let upstream_path = format!("{}/{}/{}.zip", scope, name, version);
-                    let (content, content_type) = proxy_helpers::proxy_fetch_capped(
+                    // #2192 / #1608 Phase 4c: the release `.zip` is a package
+                    // BLOB, not metadata. The buffered fallback (#2181) capped it
+                    // at DEFAULT_METADATA_MAX_BYTES and 502'd an archive larger
+                    // than the cap. Stream it (teed into the proxy cache) so a
+                    // large release archive succeeds with 200 and subsequent
+                    // requests are served warm.
+                    return proxy_helpers::proxy_fetch_streaming(
                         proxy,
                         repo.id,
                         repo_key,
                         upstream_url,
                         &upstream_path,
-                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                        "application/octet-stream",
                     )
-                    .await?;
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(
-                            "Content-Type",
-                            content_type.unwrap_or_else(|| "application/octet-stream".to_string()),
-                        )
-                        .body(Body::from(content))
-                        .unwrap());
+                    .await;
                 }
             }
 
@@ -1479,5 +1477,83 @@ mod db_cov_tests {
             let _ = tdh::send(app, tdh::get(uri)).await;
         }
         fx.teardown().await;
+    }
+
+    // #2192 / #1608 Phase 4c: a Swift release archive larger than the old
+    // buffered cap (DEFAULT_METADATA_MAX_BYTES = 8 MiB) must now STREAM with 200
+    // instead of 502, and the second request must be served WARM from the teed
+    // proxy cache without a second upstream round-trip.
+    #[tokio::test]
+    // streaming-invariant: test-only body buffering for assertions (#1608).
+    #[allow(clippy::disallowed_methods)]
+    async fn test_remote_download_streams_large_archive_and_warms_cache() {
+        use axum::http::StatusCode;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "swift").await else {
+            return;
+        };
+
+        let mock_server = MockServer::start().await;
+        // 9 MiB > 8 MiB DEFAULT_METADATA_MAX_BYTES: 502s on the buffered path.
+        let zip_bytes = vec![0x50u8; 9 * 1024 * 1024];
+
+        Mock::given(method("GET"))
+            .and(path("/apple/swift-nio/2.40.0.zip"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/zip")
+                    .set_body_bytes(zip_bytes.clone()),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock_server.uri())
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("update upstream_url");
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+
+        for i in 0..2 {
+            // Before the second request, wait for the streaming write-back to
+            // commit so the cache is deterministically WARM.
+            if i == 1 {
+                tdh::wait_for_cached_blob(&fx.storage_dir, zip_bytes.len() as u64).await;
+            }
+            let result = super::download_archive(
+                state.clone(),
+                &fx.repo_key,
+                "apple",
+                "swift-nio",
+                "2.40.0",
+            )
+            .await;
+            let response = match result {
+                Ok(r) => r,
+                Err(r) => {
+                    let status = r.status();
+                    tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;
+                    let _ = std::fs::remove_dir_all(&fx.storage_dir);
+                    panic!("large archive must stream with 200, got {status}");
+                }
+            };
+            assert_eq!(response.status(), StatusCode::OK);
+            let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .expect("read streamed body");
+            assert_eq!(body_bytes.len(), zip_bytes.len());
+        }
+
+        drop(mock_server);
+        tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;
+        let _ = std::fs::remove_dir_all(&fx.storage_dir);
     }
 }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -365,6 +365,37 @@ pub async fn grant_repo_access(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     .expect("grant developer role");
 }
 
+/// Recursively find the largest file (in bytes) under `dir`, or 0 if none.
+fn dir_max_file_size(dir: &std::path::Path) -> u64 {
+    let mut max = 0u64;
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            max = max.max(dir_max_file_size(&path));
+        } else if let Ok(meta) = std::fs::metadata(&path) {
+            max = max.max(meta.len());
+        }
+    }
+    max
+}
+
+/// Poll `dir` until a file of at least `min_size` bytes appears (the committed
+/// proxy-cache blob) or a bounded timeout elapses. The streaming write-back tee
+/// commits the cache asynchronously after the response body drains, so tests
+/// that assert a WARM second request must wait for the commit deterministically
+/// instead of racing it (#2192 / #1608 Phase 4c).
+pub async fn wait_for_cached_blob(dir: &std::path::Path, min_size: u64) {
+    for _ in 0..200 {
+        if dir_max_file_size(dir) >= min_size {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+}
+
 pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
         .bind(repo_id)

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2973,8 +2973,14 @@ impl ProxyService {
         let upstream_url = Self::remote_target(repo)?;
 
         let full_url = Self::build_upstream_url(upstream_url, path);
+        // #2192 / #1608 Phase 4c: use the 16 MiB LARGE ceiling, not the 8 MiB
+        // DEFAULT. The sole caller is the PyPI download-URL-resolution simple-
+        // index fetch (`resolve_pypi_remote_fetch_target`); its *primary*
+        // simple-index path already reads at LARGE_METADATA_MAX_BYTES, so the
+        // secondary path here inherited a mismatched 8 MiB cap that could 502 a
+        // large simple-index page. Align the two.
         let resp = self
-            .fetch_from_upstream(&full_url, repo.id, DEFAULT_METADATA_MAX_BYTES)
+            .fetch_from_upstream(&full_url, repo.id, LARGE_METADATA_MAX_BYTES)
             .await?;
         Ok((resp.content, resp.content_type, resp.effective_url))
     }
@@ -10975,6 +10981,45 @@ SHA256:
             effective.ends_with("/simple/foo/"),
             "effective url: {effective}"
         );
+    }
+
+    // #2192 / #1608 Phase 4c: the direct (uncached) PyPI simple-index fetch must
+    // read up to the 16 MiB LARGE ceiling, not the old 8 MiB DEFAULT. A body
+    // between the two caps must succeed (it would have 502'd at 8 MiB).
+    #[tokio::test]
+    async fn test_fetch_upstream_direct_uses_large_cap_for_secondary_index() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        // 9 MiB: above DEFAULT_METADATA_MAX_BYTES (8 MiB), below
+        // LARGE_METADATA_MAX_BYTES (16 MiB).
+        let big = vec![0x2eu8; 9 * 1024 * 1024];
+        assert!(big.len() > DEFAULT_METADATA_MAX_BYTES && big.len() < LARGE_METADATA_MAX_BYTES);
+        Mock::given(method("GET"))
+            .and(path("/simple/foo/"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "text/html")
+                    .set_body_bytes(big.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("s8-direct-large-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+        let repo = wiremock_remote_repo("s8-direct-large", &server.uri(), tmp.to_str().unwrap());
+
+        let outcome = proxy.fetch_upstream_direct(&repo, "simple/foo/").await;
+        let _ = std::fs::remove_dir_all(&tmp);
+        let (body, _ct, _effective) =
+            outcome.expect("a 9 MiB simple index must succeed under the 16 MiB cap");
+        assert_eq!(body.len(), big.len());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #2181 (Phase 4b), which gave every buffered proxy fetch a per-caller
byte ceiling (8 MiB `DEFAULT` / 16 MiB `LARGE`). Most capped callers are metadata
and correctly stay buffered, but several are package **blobs** on
recovery/fallback paths whose primary download already streams — so a genuinely
large artifact hitting one of these fallbacks now returns **502** instead of
succeeding. This routes those blob fallbacks through the existing streaming
helpers (merged in #2182) so large artifacts return **200 (streamed, teed to
cache)** and subsequent requests are served warm, without ever buffering the
whole blob in memory.

Converted fallbacks (each still teed into the proxy cache under its stable key):

- **helm** `fetch_chart_via_index` — the chart `.tgz` now streams via
  `proxy_fetch_streaming_with_cache_key`; the `index.yaml` lookup stays
  buffered/capped (it is parsed metadata).
- **npm** remote-repo tarball fallback — streams via
  `proxy_fetch_streaming_with_cache_key`; the outbound `Content-Type` is still
  forced to `application/gzip` and `correct_cached_tarball_content_type` is
  preserved.
- **swift** remote-repo release `.zip` fallback — streams via
  `proxy_fetch_streaming`.
- **oci** Remote-repo blob **download** fallback (`handle_get_blob`) — streams
  via a thin `try_upstream_fetch_streaming_blob`, preserving the mandatory
  `Docker-Content-Digest` header.
- **pypi** wheel cache-recovery — `get_remote_cached_or_refetch_stream` now
  refetches via `fetch_from_pypi_remote_streaming` and **tees the body back into
  storage** as it flows to the client, preserving the thundering-herd write-back
  (PR #1283) without buffering. A truncated write-back (client disconnect / short
  read / upstream error) is detected against the advertised length and the
  partial cache entry is deleted so no corrupt blob is served warm.
- **pypi** secondary simple-index fetch (`fetch_upstream_direct`, used only by
  the download-URL-resolution path) was inheriting the 8 MiB `DEFAULT` cap while
  the primary simple-index path uses 16 MiB `LARGE`; aligned to 16 MiB.

Left **deliberately buffered/capped** (documented in code + tests): the OCI
**manifest** fallbacks (`try_upstream_fetch_with_accept`, virtual
`resolve_virtual_manifest`) and the virtual-blob resolver
(`resolve_virtual_blob`). Manifests are parsed JSON with no
`proxy_fetch_streaming_with_accept` sibling; the virtual-blob resolver
content-address-verifies the whole body against the requested digest before
serving (a security-critical check that requires the complete payload). The
plain-Remote blob download path that now streams does **not** perform that
verification, so streaming it introduces no verification regression.

Frozen contract respected: no changes to `Coordinator`, `tee_stream`, or
`fetch_artifact_streaming` signatures — only call sites plus a thin pypi
streaming-refetch write-back wrapper. Presigned-redirect fast paths,
virtual-member fan-out, and content-type correction are preserved.

Part of #1608.
Closes #2192.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Per converted fallback, a mocked upstream returns a body larger than the old cap
and the test asserts **200 STREAMED (not 502)**, content-type/disposition
preserved, and the second request served **WARM** from the teed cache (verified
via a `.expect(1)` upstream mock after waiting for the async cache commit):

- `helm::tests::test_fetch_chart_via_index_streams_large_chart_and_warms_cache` (9 MiB > 8 MiB)
- `npm::tests::test_remote_proxy_streams_large_tarball_and_warms_cache` (17 MiB > 16 MiB; asserts `application/gzip`)
- `swift::db_cov_tests::test_remote_download_streams_large_archive_and_warms_cache` (9 MiB > 8 MiB)
- `oci_v2::remote_blob_streaming_fallback_tests::remote_blob_streams_large_layer_and_warms_cache` (9 MiB; `Docker-Content-Digest` preserved)
- `oci_v2::remote_blob_streaming_fallback_tests::remote_manifest_fallback_stays_buffered_and_capped` (small parses; 9 MiB rejected → proves manifests are NOT streamed)
- `pypi::tests::test_streaming_refetch_tees_multi_chunk_body_to_cache` and `test_streaming_refetch_deletes_truncated_writeback` (write-back preserved + truncation guard); existing recovery tests migrated to the streaming closure
- `proxy_service::tests::test_fetch_upstream_direct_uses_large_cap_for_secondary_index` (9 MiB accepted under the 16 MiB cap)

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full workspace lib suite green (`cargo nextest run --lib`: 12149 passed, 0
failed); `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt
--check` clean; Docker backend image builds cleanly. Patched image deployed on an
isolated pool slot and confirmed healthy with OCI/repo routes serving normally.

## API Changes
- [x] N/A - no API changes
