### PR TITLE
refactor(authz): thread AccessScope through SBOM + search read-path scope sites (#2194)

### DIFF
--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -891,7 +891,7 @@ async fn get_cve_history(
         }
         CveHistoryPath::Cve(cve_id) => {
             let entries = service
-                .get_cve_history_by_cve_id(&cve_id, auth.allowed_repo_ids.as_deref())
+                .get_cve_history_by_cve_id(&cve_id, auth.access_scope())
                 .await?;
             Ok(Json(entries))
         }
@@ -972,7 +972,7 @@ async fn get_cve_history_by_cve(
     }
     let service = SbomService::new(state.db.clone());
     let entries = service
-        .get_cve_history_by_cve_id(&cve_id, auth.allowed_repo_ids.as_deref())
+        .get_cve_history_by_cve_id(&cve_id, auth.access_scope())
         .await?;
     Ok(Json(entries))
 }
@@ -1020,7 +1020,7 @@ async fn update_cve_status(
             status,
             Some(auth.user_id),
             body.reason.as_deref(),
-            auth.allowed_repo_ids.as_deref(),
+            auth.access_scope(),
         )
         .await
         .map_err(|e| match e {

--- a/backend/src/api/handlers/search.rs
+++ b/backend/src/api/handlers/search.rs
@@ -22,6 +22,7 @@ use uuid::Uuid;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::models::access_scope::AccessScope;
 use crate::services::search_service::{SearchFacets, SearchQuery, SearchResult, SearchService};
 
 // ---------------------------------------------------------------------------
@@ -191,25 +192,28 @@ pub(crate) fn resolve_checksum_column(algorithm: &str) -> Result<&'static str> {
 ///
 /// The returned value is passed directly to SearchService methods as the
 /// `accessible_repo_ids` parameter.
-/// Intersect a user-visible repo set with an API token's repository scope
-/// (`allowed_repo_ids`), so a token scoped to repo X cannot enumerate other
-/// repos via search (#1803).
+/// Intersect a user-visible repo set with an API token's repository
+/// [`AccessScope`], so a token scoped to repo X cannot enumerate other repos
+/// via search (#1803).
 ///
-/// * `visible = None` means "no filter" (admin). A repo-scoped token narrows
+/// * `visible = Admin` means "no filter" (admin). A repo-scoped token narrows
 ///   this to exactly its scoped ids.
-/// * `visible = Some(ids)` is intersected with the token scope.
-/// * `token_scope = None` (unrestricted / JWT / anonymous) leaves `visible`
+/// * `visible = Restricted(ids)` is intersected with the token scope.
+/// * `token_scope = Admin` (unrestricted / JWT / anonymous) leaves `visible`
 ///   unchanged.
+///
+/// Deny-by-default is preserved by the type: a `Restricted([])` token scope
+/// intersects to `Restricted([])` (nothing visible), it never falls open.
 pub(crate) fn intersect_token_scope(
-    visible: Option<Vec<Uuid>>,
-    token_scope: Option<&[Uuid]>,
-) -> Option<Vec<Uuid>> {
+    visible: AccessScope,
+    token_scope: &AccessScope,
+) -> AccessScope {
     match token_scope {
-        None => visible,
-        Some(scope) => match visible {
+        AccessScope::Admin => visible,
+        AccessScope::Restricted(scope) => match visible {
             // Admin (no filter) restricted to the token's scoped repos.
-            None => Some(scope.to_vec()),
-            Some(ids) => Some(
+            AccessScope::Admin => AccessScope::Restricted(scope.clone()),
+            AccessScope::Restricted(ids) => AccessScope::Restricted(
                 ids.into_iter()
                     .filter(|id| scope.contains(id))
                     .collect::<Vec<_>>(),
@@ -221,10 +225,16 @@ pub(crate) fn intersect_token_scope(
 async fn resolve_accessible_repos(
     db: &PgPool,
     auth: &Option<AuthExtension>,
-) -> Result<Option<Vec<Uuid>>> {
+) -> Result<AccessScope> {
     let visible = resolve_visible_repos(db, auth).await?;
-    let token_scope = auth.as_ref().and_then(|a| a.allowed_repo_ids.as_deref());
-    Ok(intersect_token_scope(visible, token_scope))
+    let token_scope = auth
+        .as_ref()
+        .map(|a| a.access_scope())
+        .unwrap_or(AccessScope::Admin);
+    Ok(intersect_token_scope(
+        AccessScope::from(visible),
+        &token_scope,
+    ))
 }
 
 /// Resolve the caller's *visibility* set (public + role grants), ignoring any
@@ -366,7 +376,8 @@ pub async fn quick_search(
         }));
     }
 
-    let accessible_repo_ids = resolve_accessible_repos(&state.db, &auth).await?;
+    let accessible_repo_ids: Option<Vec<Uuid>> =
+        resolve_accessible_repos(&state.db, &auth).await?.into();
 
     let search_query = SearchQuery {
         q: Some(query_text),
@@ -439,7 +450,8 @@ pub async fn advanced_search(
     // per_page=0 is an explicit request for zero results: return an empty
     // page with the right total so paginated UIs still render counts.
     if matches!(params.per_page, Some(0)) {
-        let accessible_repo_ids = resolve_accessible_repos(&state.db, &auth).await?;
+        let accessible_repo_ids: Option<Vec<Uuid>> =
+            resolve_accessible_repos(&state.db, &auth).await?.into();
         let count_query = SearchQuery {
             q: params.query.clone(),
             format: params.format.clone(),
@@ -471,7 +483,8 @@ pub async fn advanced_search(
     let per_page = params.per_page.unwrap_or(20).clamp(1, 100);
     let offset = ((page - 1) * per_page) as i64;
 
-    let accessible_repo_ids = resolve_accessible_repos(&state.db, &auth).await?;
+    let accessible_repo_ids: Option<Vec<Uuid>> =
+        resolve_accessible_repos(&state.db, &auth).await?.into();
 
     let search_query = SearchQuery {
         q: params.query.clone(),
@@ -600,7 +613,7 @@ pub async fn checksum_search(
 
     let rows: Vec<ChecksumRow> = sqlx::query_as(&sql)
         .bind(&checksum)
-        .bind(&accessible_repo_ids)
+        .bind(accessible_repo_ids.as_allowed_repo_ids())
         .fetch_all(&state.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
@@ -680,11 +693,11 @@ pub async fn suggest(
     }
     let limit = clamp_positive_limit(params.limit, 10, 1, 50);
 
-    let accessible_repo_ids = resolve_accessible_repos(&state.db, &auth).await?;
+    let scope = resolve_accessible_repos(&state.db, &auth).await?;
 
     let service = SearchService::new(state.db.clone());
     let suggestions = service
-        .suggest(&params.prefix, limit, accessible_repo_ids.as_deref(), false)
+        .suggest(&params.prefix, limit, scope.as_allowed_repo_ids(), false)
         .await?;
 
     Ok(Json(SuggestResponse { suggestions }))
@@ -721,11 +734,11 @@ pub async fn trending(
     }
     let limit = clamp_positive_limit(params.limit, 20, 1, 100);
 
-    let accessible_repo_ids = resolve_accessible_repos(&state.db, &auth).await?;
+    let scope = resolve_accessible_repos(&state.db, &auth).await?;
 
     let service = SearchService::new(state.db.clone());
     let results = service
-        .trending(days, limit, false, accessible_repo_ids.as_deref())
+        .trending(days, limit, false, scope.as_allowed_repo_ids())
         .await?;
 
     let items = results.into_iter().map(build_search_result_item).collect();
@@ -764,11 +777,11 @@ pub async fn recent(
     }
     let limit = clamp_positive_limit(params.limit, 20, 1, 100);
 
-    let accessible_repo_ids = resolve_accessible_repos(&state.db, &auth).await?;
+    let scope = resolve_accessible_repos(&state.db, &auth).await?;
 
     let service = SearchService::new(state.db.clone());
     let results = service
-        .recent(limit, false, accessible_repo_ids.as_deref())
+        .recent(limit, false, scope.as_allowed_repo_ids())
         .await?;
 
     let items = results.into_iter().map(build_search_result_item).collect();
@@ -1354,27 +1367,35 @@ mod tests {
         assert_eq!(classify_repo_access(&auth), RepoAccessMode::PublicOnly);
     }
 
-    // intersect_token_scope (pure function) — #1803 search scope tightening
+    // intersect_token_scope (pure function) — #1803 search scope tightening,
+    // now expressed over the AccessScope enum (#1617, Phase 4).
     #[test]
     fn test_intersect_unrestricted_token_leaves_visible_unchanged() {
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
-        let visible = Some(vec![a, b]);
+        let visible = AccessScope::Restricted(vec![a, b]);
         assert_eq!(
-            intersect_token_scope(visible.clone(), None),
+            intersect_token_scope(visible.clone(), &AccessScope::Admin),
             visible,
             "no token scope means no intersection"
         );
-        // Admin no-filter stays no-filter when token is unrestricted.
-        assert_eq!(intersect_token_scope(None, None), None);
+        // Admin no-filter stays no-filter when the token is unrestricted, i.e.
+        // an admin (None-origin) principal keeps access to every repo.
+        assert_eq!(
+            intersect_token_scope(AccessScope::Admin, &AccessScope::Admin),
+            AccessScope::Admin
+        );
     }
 
     #[test]
     fn test_intersect_narrows_admin_no_filter_to_token_scope() {
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
-        // Admin (None = all repos) with a repo-scoped token is clamped to scope.
-        assert_eq!(intersect_token_scope(None, Some(&[a, b])), Some(vec![a, b]));
+        // Admin (all repos) with a repo-scoped token is clamped to scope.
+        assert_eq!(
+            intersect_token_scope(AccessScope::Admin, &AccessScope::Restricted(vec![a, b])),
+            AccessScope::Restricted(vec![a, b])
+        );
     }
 
     #[test]
@@ -1382,9 +1403,13 @@ mod tests {
         let a = Uuid::new_v4();
         let b = Uuid::new_v4();
         let c = Uuid::new_v4();
-        // Visible {a,b,c}, token scoped to {a,c}, out-of-scope b dropped.
-        let out = intersect_token_scope(Some(vec![a, b, c]), Some(&[a, c]));
-        assert_eq!(out, Some(vec![a, c]));
+        // Visible {a,b,c}, token scoped to {a,c}, out-of-scope b dropped. The
+        // in-scope repos (a, c) are granted; the unlisted repo (b) is not.
+        let out = intersect_token_scope(
+            AccessScope::Restricted(vec![a, b, c]),
+            &AccessScope::Restricted(vec![a, c]),
+        );
+        assert_eq!(out, AccessScope::Restricted(vec![a, c]));
     }
 
     #[test]
@@ -1393,8 +1418,29 @@ mod tests {
         let b = Uuid::new_v4();
         // Token scoped to a repo not in the visible set -> nothing visible.
         assert_eq!(
-            intersect_token_scope(Some(vec![a]), Some(&[b])),
-            Some(vec![])
+            intersect_token_scope(
+                AccessScope::Restricted(vec![a]),
+                &AccessScope::Restricted(vec![b]),
+            ),
+            AccessScope::Restricted(vec![])
+        );
+    }
+
+    #[test]
+    fn test_intersect_empty_token_scope_denies_all() {
+        // Deny-by-default: an empty token allowlist grants nothing, even when
+        // the visible set is Admin (all repos). It must never fall open (#1617).
+        let a = Uuid::new_v4();
+        assert_eq!(
+            intersect_token_scope(AccessScope::Admin, &AccessScope::Restricted(vec![])),
+            AccessScope::Restricted(vec![])
+        );
+        assert_eq!(
+            intersect_token_scope(
+                AccessScope::Restricted(vec![a]),
+                &AccessScope::Restricted(vec![]),
+            ),
+            AccessScope::Restricted(vec![])
         );
     }
 

--- a/backend/src/grpc/sbom_server.rs
+++ b/backend/src/grpc/sbom_server.rs
@@ -1,5 +1,6 @@
 //! gRPC server implementations for SBOM services.
 
+use crate::models::access_scope::AccessScope;
 use crate::models::sbom::{CveStatus, SbomFormat};
 use crate::services::sbom_service::{DependencyInfo, SbomService};
 use sqlx::PgPool;
@@ -312,10 +313,10 @@ impl CveHistoryServiceTrait for CveHistoryGrpcServer {
 
         let entry = self
             .service
-            // `None` repo scope: the gRPC surface is an admin/system path
+            // Admin repo scope: the gRPC surface is an admin/system path
             // (no per-call repo restriction), so synth-id resolution (#1561)
-            // runs unrestricted, matching the admin-when-`None` contract.
-            .update_cve_status(id, status, None, Some(&req.reason), None)
+            // runs unrestricted, matching the admin contract.
+            .update_cve_status(id, status, None, Some(&req.reason), AccessScope::Admin)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -4934,9 +4934,8 @@ mod tests {
         seed_finding(&pool, scan_a, artifact_a, "CVE-2024-5150", "high").await;
 
         let service = SbomService::new(pool.clone());
-        let sees_artifact = |entries: &[CveHistoryEntry]| {
-            entries.iter().any(|e| e.artifact_id == artifact_a)
-        };
+        let sees_artifact =
+            |entries: &[CveHistoryEntry]| entries.iter().any(|e| e.artifact_id == artifact_a);
 
         // Admin: full cross-repo read even though repo_a was never listed.
         let admin = service
@@ -4947,20 +4946,14 @@ mod tests {
 
         // Restricted to the owning repo: visible.
         let scoped = service
-            .get_cve_history_by_cve_id(
-                "CVE-2024-5150",
-                AccessScope::Restricted(vec![repo_a]),
-            )
+            .get_cve_history_by_cve_id("CVE-2024-5150", AccessScope::Restricted(vec![repo_a]))
             .await
             .expect("in-scope read must succeed");
         assert!(sees_artifact(&scoped), "in-scope repo must see the finding");
 
         // Restricted to a different repo: denied.
         let other = service
-            .get_cve_history_by_cve_id(
-                "CVE-2024-5150",
-                AccessScope::Restricted(vec![repo_b]),
-            )
+            .get_cve_history_by_cve_id("CVE-2024-5150", AccessScope::Restricted(vec![repo_b]))
             .await
             .expect("out-of-scope read must still return Ok([])");
         assert!(

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -1045,12 +1045,11 @@ impl SbomService {
     ///   `auth.allowed_repo_ids.as_deref()` through unchanged: if auth said
     ///   "no restriction", the service trusts that decision.
     ///
-    /// This is a footgun-prone shape. Internally it is now interpreted through
-    /// the explicit [`crate::models::access_scope::AccessScope`] enum
-    /// (`None -> Admin`, `Some(v) -> Restricted(v)`), so the "admin-only when
-    /// `None`" contract is exhaustively matched rather than relying on this
-    /// comment (#1617, Phase 4). The public signature still takes
-    /// `Option<&[Uuid]>` while the incremental migration continues.
+    /// This is a footgun-prone shape, so the repo scope is now carried as the
+    /// explicit [`crate::models::access_scope::AccessScope`] enum
+    /// ([`AccessScope::Admin`] = full cross-repo read; [`AccessScope::Restricted`]
+    /// = deny-by-default allowlist), matched exhaustively rather than relying on
+    /// this comment (#1617, Phase 4).
     ///
     /// Returns an empty vec when the CVE is not present (200 OK, [] body); a
     /// missing CVE is not a 404 in this contract.
@@ -1060,7 +1059,7 @@ impl SbomService {
     pub async fn get_cve_history_by_cve_id(
         &self,
         cve_id: &str,
-        allowed_repo_ids: Option<&[Uuid]>,
+        scope: AccessScope,
     ) -> Result<Vec<CveHistoryEntry>> {
         // Normalize: NVD shape is upper-case; lower-case is a common typo.
         // Schema does not constrain `cve_id` case in either `cve_history` or
@@ -1080,7 +1079,7 @@ impl SbomService {
         // on the fly, so the filter cannot live in the SQL `WHERE`).
         // `Admin` (legacy `None`) = full cross-repo read; `Restricted` applies
         // the allowlist, so an empty allowlist filters everything out (#1617).
-        let mut entries = match AccessScope::from(allowed_repo_ids) {
+        let mut entries = match scope {
             AccessScope::Admin => scan_entries,
             AccessScope::Restricted(repo_ids) => {
                 let allowed: HashSet<Uuid> = repo_ids.iter().copied().collect();
@@ -1190,18 +1189,18 @@ impl SbomService {
     ///   3. If neither matches, surface the original `RowNotFound` so the
     ///      handler still maps a genuinely-unknown id to 404.
     ///
-    /// `allowed_repo_ids` follows the same admin-when-`None` contract as
-    /// [`Self::get_cve_history_by_cve_id`]: `None` means no repo restriction
-    /// (admin/system callers); `Some(&[...])` scopes the synth-id resolution
-    /// to those repositories so a non-admin caller cannot acknowledge a CVE on
-    /// an artifact they cannot see.
+    /// `scope` follows the same admin-vs-allowlist contract as
+    /// [`Self::get_cve_history_by_cve_id`]: [`AccessScope::Admin`] means no repo
+    /// restriction (admin/system callers); [`AccessScope::Restricted`] scopes the
+    /// synth-id resolution to those repositories so a non-admin caller cannot
+    /// acknowledge a CVE on an artifact they cannot see.
     pub async fn update_cve_status(
         &self,
         id: Uuid,
         status: CveStatus,
         user_id: Option<Uuid>,
         reason: Option<&str>,
-        allowed_repo_ids: Option<&[Uuid]>,
+        scope: AccessScope,
     ) -> Result<CveHistoryEntry> {
         let curated = sqlx::query_as::<_, CveHistoryEntry>(
             r#"
@@ -1228,8 +1227,7 @@ impl SbomService {
 
         // No curated `cve_history` row: treat `id` as a synthetic id derived
         // from `scan_findings` and resolve it back to (artifact_id, cve_id).
-        if let Some((artifact_id, cve_id)) = self.resolve_synth_cve_id(id, allowed_repo_ids).await?
-        {
+        if let Some((artifact_id, cve_id)) = self.resolve_synth_cve_id(id, scope).await? {
             return self
                 .update_cve_status_by_artifact_cve(artifact_id, &cve_id, status, user_id, reason)
                 .await;
@@ -1245,19 +1243,19 @@ impl SbomService {
     /// hash for every distinct `scan_findings` pair and matching `id`.
     ///
     /// The synth id is a one-way hash, so reversal is by recomputation, not
-    /// arithmetic. `allowed_repo_ids` scopes the candidate set to artifacts in
-    /// the listed repositories (`None` = no restriction; admin-only, same
-    /// contract as [`Self::get_cve_history_by_cve_id`]). Returns `None` when
-    /// no `scan_findings` pair hashes to `id`. (#1561)
+    /// arithmetic. `scope` constrains the candidate set to artifacts the caller
+    /// can access ([`AccessScope::Admin`] = no restriction; same contract as
+    /// [`Self::get_cve_history_by_cve_id`]). Returns `None` when no
+    /// `scan_findings` pair hashes to `id`. (#1561)
     pub(crate) async fn resolve_synth_cve_id(
         &self,
         id: Uuid,
-        allowed_repo_ids: Option<&[Uuid]>,
+        scope: AccessScope,
     ) -> Result<Option<(Uuid, String)>> {
-        // `Admin` (legacy `None`) resolves across every repo; `Restricted`
-        // constrains the candidate set to the allowlist, so an empty allowlist
-        // yields no candidates (deny-by-default) (#1617).
-        let pairs: Vec<(Uuid, String)> = match AccessScope::from(allowed_repo_ids) {
+        // `Admin` resolves across every repo; `Restricted` constrains the
+        // candidate set to the allowlist, so an empty allowlist yields no
+        // candidates (deny-by-default) (#1617).
+        let pairs: Vec<(Uuid, String)> = match scope {
             AccessScope::Admin => {
                 sqlx::query_as(
                     r#"
@@ -4798,7 +4796,7 @@ mod tests {
                 CveStatus::Acknowledged,
                 None,
                 Some("ack via legacy synth-id endpoint"),
-                None,
+                AccessScope::Admin,
             )
             .await
             .expect("synth-id ack must succeed via scan_findings fallback");
@@ -4837,7 +4835,7 @@ mod tests {
                 CveStatus::Acknowledged,
                 None,
                 Some("nope"),
-                None,
+                AccessScope::Admin,
             )
             .await
             .expect_err("unknown id must 404");
@@ -4874,7 +4872,7 @@ mod tests {
                 CveStatus::Acknowledged,
                 None,
                 Some("cross-repo attempt"),
-                Some(&[repo_b]),
+                AccessScope::Restricted(vec![repo_b]),
             )
             .await
             .expect_err("synth id outside repo scope must 404");
@@ -4886,6 +4884,20 @@ mod tests {
             .expect("finding present");
         assert!(!ack, "ack must not persist for out-of-scope caller");
 
+        // Empty allowlist (Restricted([])) is deny-by-default: it must resolve
+        // nothing, never fall open to the whole instance (#1617).
+        let err = service
+            .update_cve_status(
+                synth_id,
+                CveStatus::Acknowledged,
+                None,
+                Some("empty-scope attempt"),
+                AccessScope::Restricted(vec![]),
+            )
+            .await
+            .expect_err("empty scope must deny (404)");
+        assert!(matches!(err, AppError::Sqlx(sqlx::Error::RowNotFound)));
+
         // Scoped to repo_a: now it resolves and persists.
         let entry = service
             .update_cve_status(
@@ -4893,11 +4905,78 @@ mod tests {
                 CveStatus::Acknowledged,
                 None,
                 Some("in-scope ack"),
-                Some(&[repo_a]),
+                AccessScope::Restricted(vec![repo_a]),
             )
             .await
             .expect("in-scope synth id must resolve");
         assert_eq!(entry.status, "acknowledged");
+
+        teardown(&pool, repo_a).await;
+        teardown(&pool, repo_b).await;
+    }
+
+    #[tokio::test]
+    async fn test_get_cve_history_by_cve_id_respects_access_scope() {
+        // The read path now takes an AccessScope (#1617, Phase 4). Prove the
+        // three load-bearing cases at the converted call site:
+        //   - Admin (None-origin) grants a repo it was never explicitly listed
+        //     for;
+        //   - Restricted([repo_a]) grants repo_a but Restricted([repo_b]) does
+        //     not (grants r1 not r2);
+        //   - Restricted([]) denies everything (deny-by-default).
+        let Some(pool) = try_pool().await else {
+            return;
+        };
+        let repo_a = seed_repo(&pool).await;
+        let repo_b = seed_repo(&pool).await;
+        let artifact_a = seed_artifact(&pool, repo_a).await;
+        let scan_a = seed_scan_result(&pool, artifact_a, repo_a).await;
+        seed_finding(&pool, scan_a, artifact_a, "CVE-2024-5150", "high").await;
+
+        let service = SbomService::new(pool.clone());
+        let sees_artifact = |entries: &[CveHistoryEntry]| {
+            entries.iter().any(|e| e.artifact_id == artifact_a)
+        };
+
+        // Admin: full cross-repo read even though repo_a was never listed.
+        let admin = service
+            .get_cve_history_by_cve_id("CVE-2024-5150", AccessScope::Admin)
+            .await
+            .expect("admin read must succeed");
+        assert!(sees_artifact(&admin), "admin scope must see the finding");
+
+        // Restricted to the owning repo: visible.
+        let scoped = service
+            .get_cve_history_by_cve_id(
+                "CVE-2024-5150",
+                AccessScope::Restricted(vec![repo_a]),
+            )
+            .await
+            .expect("in-scope read must succeed");
+        assert!(sees_artifact(&scoped), "in-scope repo must see the finding");
+
+        // Restricted to a different repo: denied.
+        let other = service
+            .get_cve_history_by_cve_id(
+                "CVE-2024-5150",
+                AccessScope::Restricted(vec![repo_b]),
+            )
+            .await
+            .expect("out-of-scope read must still return Ok([])");
+        assert!(
+            !sees_artifact(&other),
+            "out-of-scope repo must not see the finding"
+        );
+
+        // Restricted([]): deny-by-default, nothing visible.
+        let empty = service
+            .get_cve_history_by_cve_id("CVE-2024-5150", AccessScope::Restricted(vec![]))
+            .await
+            .expect("empty-scope read must return Ok([])");
+        assert!(
+            !sees_artifact(&empty),
+            "empty scope must deny (deny-by-default), never fall open"
+        );
 
         teardown(&pool, repo_a).await;
         teardown(&pool, repo_b).await;


### PR DESCRIPTION
Closes #2194

## Summary

Part of #1617 (Phase 4). Follow-up sweep to #2193/#2195, which introduced the
`AccessScope` enum (`Admin` = no restriction / grants all; `Restricted(v)` =
deny-by-default allowlist) and converted the primary write-gate call site. This
PR continues the incremental migration of the remaining repo-scope read-path
sites off the footgun-prone `Option<Vec<Uuid>>` shape (`None` = admin,
`Some(empty)` = deny) and onto the explicit enum, so the `None -> Admin` /
`empty -> deny` semantics are enforced by the type at the decision points rather
than re-implemented by each caller.

This is a **behavior-preserving type refactor**, not a policy change: every
`None` stays `Admin` (grants all), every `Some(empty)` stays deny-by-default.
The `AccessScope <-> Option<Vec<Uuid>>` bridge from #2193 backs the conversion at
the SQL-binding sinks (`AccessScope::as_allowed_repo_ids()`), preserving the
exact values bound into every query.

### Sites converted
- `SbomService::get_cve_history_by_cve_id`, `SbomService::update_cve_status`,
  `SbomService::resolve_synth_cve_id` — parameter changed from
  `allowed_repo_ids: Option<&[Uuid]>` to `scope: AccessScope`; the internal
  `AccessScope::from(...)` bridges are dropped and the decision is matched
  directly on the enum.
- `api/handlers/sbom.rs` — the three call sites now thread `auth.access_scope()`.
- `grpc/sbom_server.rs` — the admin/system path passes `AccessScope::Admin`.
- `api/handlers/search.rs` — `intersect_token_scope` and
  `resolve_accessible_repos` now operate on / return `AccessScope`; the
  SQL-binding sinks (`SearchService::{suggest,trending,recent}`, `search()`'s
  `SearchQuery`, and `checksum_search`) are fed via
  `AccessScope::as_allowed_repo_ids()` / `AccessScope::into()`, preserving the
  exact bind values.

### Deliberately NOT changed (deferred, tracked for follow-ups)
- `AuthExtension.allowed_repo_ids` and `ApiTokenValidation.allowed_repo_ids`
  field-type swaps (#2194 bullets 1–2): these ripple to ~50+ test fixture
  literals across 30+ files; the issue explicitly says to migrate incrementally
  to stay under the coverage/duplication gates, so they are left for dedicated
  follow-ups.
- `SearchQuery.accessible_repo_ids` field: kept as `Option<Vec<Uuid>>` because
  `SearchQuery` derives `Default` and is built with `..Default::default()`;
  converting the field would force `AccessScope: Default`, reintroducing the
  "default falls open" footgun the enum exists to prevent. The scope decision is
  still threaded through `AccessScope`; only the DTO boundary keeps the option.
- `SearchService::{suggest,trending,recent}` signatures remain
  `Option<&[Uuid]>` — they are pure SQL-parameter sinks, not decision points;
  the meaningful decision (`intersect_token_scope`/`resolve_accessible_repos`) is
  converted, and the sinks are fed from `AccessScope`. Flipping the sink
  signatures is a mechanical follow-up.
- `oci_v2.rs`/`pypi.rs`/`helm.rs`/`npm.rs`/`swift.rs` were left untouched to
  avoid signature drift with the in-flight PR #2203. None of them construct
  `AuthExtension`/`ApiTokenValidation` or carry a genuine scope-thread that
  needed conversion here (oci_v2 only `Debug`-logs the field via `tracing`).
- Unrelated `Option<Vec<Uuid>>` sites (backup include/target repositories,
  bulk-delete id lists, label-service id filters, token-creation request
  payloads, visibility binds) are **not** repo-access-scope semantics and were
  left alone.

No pre-existing "empty falls open" bug was found in any converted site — the
SBOM read paths and search SQL already denied on an empty allowlist, and the
conversion preserves that exactly.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is a behavior-preserving `refactor/*` (type-safety migration),
  not a bug fix. Existing and new tests assert the preserved semantics.

## Test Checklist
- [x] Unit tests added/updated — `intersect_token_scope` tests rewritten over
  `AccessScope` with an added deny-by-default (empty scope) case; new DB-backed
  `test_get_cve_history_by_cve_id_respects_access_scope` proves Admin grants an
  unlisted repo, `Restricted([r1])` grants r1 but not r2, and `Restricted([])`
  denies everything; the existing synth-id repo-scope test gains an empty-scope
  deny assertion.
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo fmt --check`, `cargo clippy --workspace
  --all-targets -- -D warnings`, and `cargo test --workspace --lib` all green;
  the new/updated DB-backed scope tests pass against a live Postgres; new-code
  coverage measured at 78% (>= 70%); jscpd duplication gate passes.
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (internal type refactor only; no routes, request or
  response types, or wire representation change)

