### PR TITLE
refactor(storage): require StorageBackend::put_stream so backends can't inherit in-memory buffering

### DIFF
--- a/backend/src/api/download_response.rs
+++ b/backend/src/api/download_response.rs
@@ -478,6 +478,13 @@ mod tests {
                 source: PresignedUrlSource::S3,
             }))
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     /// A mock backend that does not support presigned URLs.
@@ -496,6 +503,13 @@ mod tests {
         }
         async fn delete(&self, _key: &str) -> AppResult<()> {
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 

--- a/backend/src/api/handlers/health.rs
+++ b/backend/src/api/handlers/health.rs
@@ -1065,6 +1065,13 @@ mod tests {
         async fn health_check(&self) -> crate::error::Result<()> {
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     /// Mock storage backend that reports unhealthy.
@@ -1088,6 +1095,13 @@ mod tests {
             Err(crate::error::AppError::Storage(
                 "connection refused".to_string(),
             ))
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -13513,6 +13513,13 @@ mod oci_blob_upload_streaming_tests {
                 .insert(dest.to_string(), content);
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     struct DeferredCommitFailureTrigger {
@@ -13754,6 +13761,13 @@ mod oci_blob_upload_streaming_tests {
                 .insert(dest.to_string(), content);
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     struct LockProbeStorage {
@@ -13981,6 +13995,13 @@ mod oci_blob_upload_streaming_tests {
                 .insert(dest.to_string(), content);
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     struct DeleteRepoOnCopyStorage {
@@ -14051,6 +14072,13 @@ mod oci_blob_upload_streaming_tests {
                 .map_err(AppError::from)?;
 
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 
@@ -14156,6 +14184,13 @@ mod oci_blob_upload_streaming_tests {
             .map_err(AppError::from)?;
 
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 

--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -2973,6 +2973,13 @@ mod tests {
             let chunks: Vec<crate::error::Result<Bytes>> = vec![Ok(first), Ok(second)];
             Ok(Box::pin(futures::stream::iter(chunks)))
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     /// A target backend that captures whatever was streamed into it via

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -5392,6 +5392,13 @@ mod tests {
                 source: crate::storage::PresignedUrlSource::S3,
             }))
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     // Facade-trait impl so `RecordingStorage` can be driven directly through
@@ -5595,6 +5602,13 @@ mod tests {
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             *self.content.lock().await = None;
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -3834,6 +3834,13 @@ mod tests {
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     /// Returns the configured bytes for any `get` call, simulating a healthy
@@ -3859,6 +3866,13 @@ mod tests {
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     /// Returns a non-`NotFound` storage error for every `get`, simulating an
@@ -3882,6 +3896,13 @@ mod tests {
 
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 
@@ -3950,6 +3971,13 @@ mod tests {
 
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 
@@ -4149,6 +4177,13 @@ mod tests {
                 .expect("deletes mutex")
                 .push(key.to_string());
             Ok(())
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -1722,6 +1722,13 @@ mod tests {
         async fn delete(&self, _key: &str) -> crate::error::Result<()> {
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     fn make_pool() -> PgPool {

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -1127,6 +1127,13 @@ mod tests {
                 source: PresignedUrlSource::S3,
             }))
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     #[test]

--- a/backend/src/services/sync_worker.rs
+++ b/backend/src/services/sync_worker.rs
@@ -1916,6 +1916,13 @@ mod tests {
             let end = start.saturating_add(length).min(self.data.len());
             Ok(self.data.slice(start..end))
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     fn test_task(storage_backend: &str) -> TaskRow {
@@ -2024,6 +2031,13 @@ mod tests {
             _length: usize,
         ) -> crate::error::Result<Bytes> {
             Err(crate::error::AppError::Storage("boom-range".to_string()))
+        }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, crate::error::Result<bytes::Bytes>>,
+        ) -> crate::error::Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
         }
     }
 

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -227,36 +227,20 @@ pub trait StorageBackend: Send + Sync {
     }
 
     /// Store content from a byte stream, computing a SHA-256 checksum
-    /// incrementally as data arrives. The default implementation collects
-    /// the stream into memory and delegates to `put()`.
+    /// incrementally as data arrives.
+    ///
+    /// This is a **required** method: it deliberately has no default body so
+    /// that a new backend (or a wrapper that forgets to forward the call)
+    /// cannot silently inherit in-memory buffering of a full artifact body —
+    /// the exact multi-GB OOM hazard Phase-4 removed (#1608). Every backend
+    /// must explicitly choose real streaming or opt into the named buffered
+    /// fallback via [`buffered_put_stream_fallback`]. This turns "accidentally
+    /// buffers a whole body" into a compile error.
     async fn put_stream(
         &self,
         key: &str,
         stream: BoxStream<'static, Result<Bytes>>,
-    ) -> Result<PutStreamResult> {
-        use futures::StreamExt;
-        use sha2::{Digest, Sha256};
-
-        tracing::debug!(key, "put_stream falling back to in-memory buffering");
-
-        let mut hasher = Sha256::new();
-        let mut buf = Vec::new();
-        let mut total: u64 = 0;
-
-        tokio::pin!(stream);
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
-            hasher.update(&chunk);
-            total += chunk.len() as u64;
-            buf.extend_from_slice(&chunk);
-        }
-
-        self.put(key, Bytes::from(buf)).await?;
-        Ok(PutStreamResult {
-            checksum_sha256: format!("{:x}", hasher.finalize()),
-            bytes_written: total,
-        })
-    }
+    ) -> Result<PutStreamResult>;
 
     /// Perform a lightweight connectivity probe against the storage backend.
     ///
@@ -266,6 +250,50 @@ pub trait StorageBackend: Send + Sync {
     async fn health_check(&self) -> Result<()> {
         Ok(())
     }
+}
+
+/// Buffered `put_stream` implementation of last resort.
+///
+/// This carries the body that used to be the `StorageBackend::put_stream`
+/// trait default (removed in #1608 Phase-6 so no backend can inherit it by
+/// omission). It collects the whole stream into memory, computes a SHA-256
+/// checksum incrementally, and delegates to [`StorageBackend::put`]. Because
+/// it buffers the entire body, it is only appropriate for small/in-memory
+/// backends (test doubles, tiny fixtures) that explicitly opt in — production
+/// backends stream to disk/object storage in their own `put_stream` override.
+///
+/// Currently every non-test `StorageBackend` streams, so the only callers are
+/// in-memory test doubles (compiled under `#[cfg(test)]`); the `allow` keeps
+/// this named opt-in available to a future small backend without tripping
+/// `dead_code` in production builds.
+#[allow(dead_code)]
+pub(crate) async fn buffered_put_stream_fallback<B: StorageBackend + ?Sized>(
+    backend: &B,
+    key: &str,
+    stream: BoxStream<'static, Result<Bytes>>,
+) -> Result<PutStreamResult> {
+    use futures::StreamExt;
+    use sha2::{Digest, Sha256};
+
+    tracing::debug!(key, "put_stream falling back to in-memory buffering");
+
+    let mut hasher = Sha256::new();
+    let mut buf = Vec::new();
+    let mut total: u64 = 0;
+
+    tokio::pin!(stream);
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        hasher.update(&chunk);
+        total += chunk.len() as u64;
+        buf.extend_from_slice(&chunk);
+    }
+
+    backend.put(key, Bytes::from(buf)).await?;
+    Ok(PutStreamResult {
+        checksum_sha256: format!("{:x}", hasher.finalize()),
+        bytes_written: total,
+    })
 }
 
 #[cfg(test)]
@@ -366,6 +394,13 @@ mod tests {
         async fn delete(&self, _key: &str) -> Result<()> {
             Ok(())
         }
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: BoxStream<'static, Result<Bytes>>,
+        ) -> Result<PutStreamResult> {
+            buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     #[test]
@@ -437,36 +472,49 @@ mod tests {
         assert_eq!(collected, b"test");
     }
 
+    /// Records every `put` so tests can assert what content/key reached the
+    /// backend. `get` returns a fixed body for the `copy` default-path test.
+    /// `put_stream` delegates to the shared buffered fallback (#1608 Phase-6),
+    /// so this double also exercises `buffered_put_stream_fallback` end to end.
+    struct CopyBackend {
+        writes: std::sync::Arc<std::sync::Mutex<Vec<(String, Bytes)>>>,
+    }
+
+    #[async_trait]
+    impl StorageBackend for CopyBackend {
+        async fn put(&self, key: &str, content: Bytes) -> Result<()> {
+            self.writes.lock().unwrap().push((key.to_string(), content));
+            Ok(())
+        }
+
+        async fn get(&self, key: &str) -> Result<Bytes> {
+            assert_eq!(key, "source-key");
+            Ok(Bytes::from_static(b"copied bytes"))
+        }
+
+        // `copy` routes through get_stream/put_stream and the fallback only
+        // touches `put`; these are never called on either path, so fail loudly
+        // if that ever changes.
+        async fn exists(&self, _key: &str) -> Result<bool> {
+            unreachable!("copy/put_stream fallback path must not call exists")
+        }
+
+        async fn delete(&self, _key: &str) -> Result<()> {
+            unreachable!("copy/put_stream fallback path must not call delete")
+        }
+
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: BoxStream<'static, Result<Bytes>>,
+        ) -> Result<PutStreamResult> {
+            buffered_put_stream_fallback(self, key, stream).await
+        }
+    }
+
     #[tokio::test]
     async fn test_default_copy_reads_source_and_writes_dest() {
         use std::sync::{Arc, Mutex};
-
-        struct CopyBackend {
-            writes: Arc<Mutex<Vec<(String, Bytes)>>>,
-        }
-
-        #[async_trait]
-        impl StorageBackend for CopyBackend {
-            async fn put(&self, key: &str, content: Bytes) -> Result<()> {
-                self.writes.lock().unwrap().push((key.to_string(), content));
-                Ok(())
-            }
-
-            async fn get(&self, key: &str) -> Result<Bytes> {
-                assert_eq!(key, "source-key");
-                Ok(Bytes::from_static(b"copied bytes"))
-            }
-
-            // `copy` routes through get_stream/put_stream only; these are never
-            // touched by this test, so fail loudly if that ever changes.
-            async fn exists(&self, _key: &str) -> Result<bool> {
-                unreachable!("copy default path must not call exists")
-            }
-
-            async fn delete(&self, _key: &str) -> Result<()> {
-                unreachable!("copy default path must not call delete")
-            }
-        }
 
         let writes = Arc::new(Mutex::new(Vec::new()));
         let backend = CopyBackend {
@@ -573,6 +621,44 @@ mod tests {
             result.checksum_sha256,
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
+    }
+
+    /// #1608 Phase-6: `put_stream` is now a required trait method and the old
+    /// buffering default lives in `buffered_put_stream_fallback`. Prove the
+    /// named fallback still round-trips the exact bytes to `put` (behavior
+    /// preserved) and reports the correct digest + length. `CopyBackend` from
+    /// `test_default_copy_reads_source_and_writes_dest` records writes and now
+    /// delegates `put_stream` to the fallback exactly like every in-memory
+    /// test double, so we drive it directly here.
+    #[tokio::test]
+    async fn test_buffered_put_stream_fallback_round_trips_bytes_to_put() {
+        use std::sync::{Arc, Mutex};
+
+        let writes = Arc::new(Mutex::new(Vec::new()));
+        let backend = CopyBackend {
+            writes: writes.clone(),
+        };
+
+        let chunks: Vec<Result<Bytes>> = vec![
+            Ok(Bytes::from_static(b"hello ")),
+            Ok(Bytes::from_static(b"world")),
+        ];
+        let stream = Box::pin(futures::stream::iter(chunks)) as BoxStream<'static, Result<Bytes>>;
+
+        let result = buffered_put_stream_fallback(&backend, "cas-key", stream)
+            .await
+            .unwrap();
+
+        assert_eq!(result.bytes_written, 11);
+        assert_eq!(
+            result.checksum_sha256,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+
+        let writes = writes.lock().unwrap();
+        assert_eq!(writes.len(), 1);
+        assert_eq!(writes[0].0, "cas-key");
+        assert_eq!(writes[0].1, Bytes::from_static(b"hello world"));
     }
 
     // -------------------------------------------------------------------

--- a/backend/src/storage/registry.rs
+++ b/backend/src/storage/registry.rs
@@ -117,6 +117,14 @@ mod tests {
         async fn delete(&self, _key: &str) -> Result<()> {
             Ok(())
         }
+
+        async fn put_stream(
+            &self,
+            key: &str,
+            stream: futures::stream::BoxStream<'static, Result<Bytes>>,
+        ) -> Result<crate::storage::PutStreamResult> {
+            crate::storage::buffered_put_stream_fallback(self, key, stream).await
+        }
     }
 
     fn make_registry() -> StorageRegistry {


### PR DESCRIPTION
## Summary

Part of #1608 — **Phase-6 (streaming-trilogy capstone).**

Make `crate::storage::StorageBackend::put_stream` a **required** trait method so a
backend can no longer *silently inherit* the in-memory-buffering default. Prior phases
removed the full-body buffering from the live upload paths; the remaining latent hazard
was the trait **default** body of `put_stream` (in `backend/src/storage/mod.rs`): being a
default, any new production backend — or a wrapper that forgets to forward the call —
would inherit whole-body-in-RAM buffering with **no compiler signal**, reintroducing the
multi-GB OOM that Phase-4 eliminated.

This is a pure, behavior-preserving refactor that converts "a backend accidentally buffers
a real artifact body" into a **compile error**:

- `put_stream` loses its default body and becomes a required signature, with a doc-comment
  stating the guarantee ("required so no backend silently buffers").
- The old default body is moved **verbatim** into a loudly-named `pub(crate)` free helper
  `buffered_put_stream_fallback(backend, key, stream)` in the same module, so a
  small/in-memory backend can still *explicitly* opt into buffering.
- Every in-memory **test double** that previously inherited the default now carries a
  one-line delegate to that helper — no behavior change, they buffer exactly as before.

The **digest** half of the hazard needs no change: it is already type-enforced by the
required `ContentDigests { sha256, sha1, md5 }` argument on
`ArtifactService::upload_stream_with_sync_options`. The four production backends
(filesystem/S3/GCS/Azure) already override `put_stream` with real streaming and are
untouched.

### Scope note
`services::storage_service::StorageBackend` (the proxy-cache facade trait) has the same
buffering-default shape. Its symmetric lock-off is **deferred to a follow-up** (same
pattern, ~15 more proxy-cache test doubles, `FilesystemBackend` already overrides it there).
This PR does **not** change `storage_service.rs` production/facade logic — the only edit to
that file is a compile-required one-line delegate on the `crate::storage::StorageBackend`
test double `MockPresignedInner`.

### Test doubles given the one-line delegate (24 total)
- `storage/mod.rs`: `TestBackend`, `CopyBackend`
- `storage/registry.rs`: `MockBackend`
- `api/handlers/oci_v2.rs`: `RecordingStorage`, `BlockingCopyStorage`,
  `DeleteAfterSessionGoneStorage`, `DeleteRepoOnCopyStorage`, `RejectBlobInsertStorage`
- `api/handlers/pypi.rs`: `MissingStorage`, `PresentStorage`, `BrokenStorage`,
  `WriteFailingStorage`, `RecordingStorage`
- `api/download_response.rs`: `RedirectBackend`, `NoRedirectBackend`
- `api/handlers/health.rs`: `HealthyMockBackend`, `UnhealthyMockBackend`
- `api/handlers/proxy_helpers.rs`: `RecordingStorage`, `MissingThenPresentStorage`
- `services/sync_worker.rs`: `RangeRecordingBackend`, `FailingReadBackend`
- `api/handlers/promotion.rs`: `ChunkedSource`
- `services/storage_gc_service.rs`: `MockStorage`
- `services/storage_service.rs`: `MockPresignedInner`

(The test doubles that already override `put_stream` — e.g. `FirstPatchRaceStorage`,
`LockProbeStorage`, `CapturingTarget`, `ChunkRecordingBackend`, the migration-worker
`CountingStorage`s — were left as-is.)

The compile-time guarantee is enforced structurally by the required-method signature: a
`StorageBackend` impl without `put_stream` now fails with `not all trait items
implemented: put_stream`. (trybuild is not a dev-dependency, so no UI test was added.)

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a `refactor/*` compile-time hardening, not a runtime bug fix

Added `test_buffered_put_stream_fallback_round_trips_bytes_to_put` proving the named
fallback still reassembles and forwards the exact bytes to `put` with the correct
SHA-256 + length; the existing `test_default_put_stream*` cases now exercise the fallback
through a test double's delegate (behavior preserved).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verification on an isolated filesystem-backed instance: uploaded a generic artifact, it
stored + served (download SHA-256 round-trip matched), and resolved via
`GET /search/checksum` by **sha256, sha1, and md5** — full digests persisted, no
regression. `cargo test --workspace --lib`: 12168 passed / 0 failed. `cargo clippy
--workspace --all-targets -- -D warnings` clean. `cargo fmt --check` clean. jscpd on
changed source: 1.96% (< 3%).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (internal trait refactor; no public callable signatures change)
