### PR TITLE
test(sso): add OIDC login/callback e2e regression harness against a mock IdP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,7 +709,10 @@ jobs:
       #     virtual_members_atomicity_test, virtual_members_duplicate_test,
       #     grpc_sbom_tests (in-process gRPC, no HTTP server),
       #     oci_chunked_upload_cross_repo_tests (#1317 cross-repo session
-      #     rejection regression).
+      #     rejection regression),
+      #     sso_oidc_login_callback_e2e_tests (#1617 OIDC login/callback
+      #     regression harness; drives the real sso handlers against an
+      #     in-process wiremock IdP bound to a non-loopback interface).
       #
       # Deliberately excluded (would panic on first .expect() without
       # extra infra, so `--ignored` stays the right gate):
@@ -745,6 +748,7 @@ jobs:
             --test virtual_members_atomicity_test \
             --test virtual_members_duplicate_test \
             --test oci_chunked_upload_cross_repo_tests \
+            --test sso_oidc_login_callback_e2e_tests \
             -- --ignored --test-threads=1
 
       # `incus_upload_tests::test_chunked_upload_cross_repo_session_rejected`

--- a/backend/tests/common/mod.rs
+++ b/backend/tests/common/mod.rs
@@ -9,6 +9,7 @@
 #![allow(unused_imports)]
 
 pub mod fixtures;
+pub mod sso_support;
 
 use axum::Router;
 use sqlx::PgPool;

--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -1,0 +1,118 @@
+//! Shared SSO end-to-end test support (#1617, epic #1615).
+//!
+//! Cross-cutting helpers used by the OIDC (and, in the companion PR, SAML)
+//! end-to-end harnesses that drive the real `api::handlers::sso` axum routes
+//! against a mock identity provider backed by a throwaway Postgres.
+//!
+//! The load-bearing piece here is [`non_loopback_bind_ip`] +
+//! [`allow_private_sso_ip`]: the OIDC handler performs three server-side
+//! first-hop fetches (discovery, token, JWKS), each screened by the outbound
+//! SSRF guard. Loopback (`127.0.0.0/8`) is a HARD block that no toggle relaxes
+//! (`api::validation::is_hard_blocked_ipv4`), so a mock IdP on wiremock's
+//! default `127.0.0.1` bind is unreachable. The harness instead binds the mock
+//! to the host's primary non-loopback interface (an RFC1918/CGNAT private IP in
+//! CI/ARC pods) and opts that single address into the private-IP allowlist via
+//! `AK_SSRF_ALLOW_PRIVATE_CIDRS`, which relaxes private IPs only.
+
+use std::collections::HashMap;
+use std::net::{IpAddr, UdpSocket};
+use std::sync::Arc;
+
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::{AppState, SharedState};
+use artifact_keeper_backend::config::Config;
+
+/// `AuthConfigService` encrypts the stored OIDC client secret with a key read
+/// from `SSO_ENCRYPTION_KEY`/`JWT_SECRET` in the *process* environment (not the
+/// `Config`). CI sets `JWT_SECRET`; for local runs we install a stable key so
+/// `create_oidc` (encrypt) and `get_oidc_decrypted` (decrypt) agree. Setting it
+/// to a fixed value is idempotent across the tests in a serial binary.
+pub fn ensure_sso_encryption_key() {
+    if std::env::var("SSO_ENCRYPTION_KEY").is_err() && std::env::var("JWT_SECRET").is_err() {
+        std::env::set_var(
+            "SSO_ENCRYPTION_KEY",
+            "test-sso-encryption-key-at-least-32-bytes-long",
+        );
+    }
+}
+
+/// Connect to the throwaway Postgres named by `DATABASE_URL`, or return `None`
+/// so the caller can skip cleanly (matching the repo `--ignored` convention).
+pub async fn try_pool() -> Option<PgPool> {
+    let url = std::env::var("DATABASE_URL").ok()?;
+    sqlx::postgres::PgPoolOptions::new()
+        .max_connections(3)
+        .acquire_timeout(std::time::Duration::from_secs(3))
+        .connect(&url)
+        .await
+        .ok()
+}
+
+/// Minimal `Config` for building `AppState` in the SSO e2e tests.
+pub fn test_config() -> Config {
+    Config {
+        database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
+        storage_path: std::env::temp_dir()
+            .join(format!("ak-sso-e2e-{}", Uuid::new_v4()))
+            .to_string_lossy()
+            .into_owned(),
+        jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+        ..Default::default()
+    }
+}
+
+/// Build a `SharedState` over the given pool with a filesystem storage backend.
+pub fn build_state(pool: PgPool) -> SharedState {
+    let cfg = test_config();
+    std::fs::create_dir_all(&cfg.storage_path).expect("create storage dir");
+    let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = Arc::new(
+        artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(&cfg.storage_path),
+    );
+    let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+        HashMap::new(),
+        "filesystem".to_string(),
+    ));
+    Arc::new(AppState::new(cfg, pool, storage, registry))
+}
+
+/// Wrap the public SSO router in `with_state` (no auth layer — these are
+/// pre-auth public endpoints).
+pub fn sso_app(state: SharedState) -> axum::Router {
+    artifact_keeper_backend::api::handlers::sso::router().with_state(state)
+}
+
+/// Discover a non-loopback local IP for binding the mock IdP.
+///
+/// Opens a UDP socket and `connect()`s it to a public address — no packets are
+/// actually sent; the kernel just selects the primary outbound interface, whose
+/// `local_addr()` is the address we bind the mock server to. Returns `None` when
+/// the only reachable local address is loopback (isolated runner) so the caller
+/// can skip the test the same way it skips when `DATABASE_URL` is unset.
+pub fn non_loopback_bind_ip() -> Option<IpAddr> {
+    let sock = UdpSocket::bind("0.0.0.0:0").ok()?;
+    sock.connect("8.8.8.8:80").ok()?;
+    let ip = sock.local_addr().ok()?.ip();
+    if ip.is_loopback() {
+        None
+    } else {
+        Some(ip)
+    }
+}
+
+/// Opt a single mock-IdP IP into the outbound SSRF private-IP allowlist by
+/// setting `AK_SSRF_ALLOW_PRIVATE_CIDRS=<ip>/32` (or `/128` for IPv6).
+///
+/// This is a process-global env write, which is why the SSO e2e suites run
+/// `--test-threads=1`. The allowlist relaxes only private RFC1918/CGNAT/ULA
+/// addresses; loopback and cloud-metadata IPs stay hard-blocked. If the primary
+/// interface IP happens to be public the guard already permits it and this call
+/// is harmless.
+pub fn allow_private_sso_ip(ip: IpAddr) {
+    let cidr = match ip {
+        IpAddr::V4(_) => format!("{ip}/32"),
+        IpAddr::V6(_) => format!("{ip}/128"),
+    };
+    std::env::set_var("AK_SSRF_ALLOW_PRIVATE_CIDRS", cidr);
+}

--- a/backend/tests/sso_oidc_login_callback_e2e_tests.rs
+++ b/backend/tests/sso_oidc_login_callback_e2e_tests.rs
@@ -12,6 +12,13 @@
 //!   3. `/jwks` — publishes the RSA public key so `validate_id_token` can
 //!      verify the signature.
 //!
+//! **Non-loopback bind (load-bearing):** the OIDC handler screens every
+//! outbound fetch (discovery/token/JWKS) through the SSRF guard, which HARD
+//! blocks loopback under every relaxation (`api::validation::is_hard_blocked_ipv4`).
+//! wiremock's default `MockServer::start()` binds `127.0.0.1`, so the mock IdP
+//! must instead bind the host's primary non-loopback interface and opt that IP
+//! into `AK_SSRF_ALLOW_PRIVATE_CIDRS` — see `common::sso_support`.
+//!
 //! The flow exercised:
 //!
 //!   GET /oidc/{id}/login   -> 307 to authorize URL (assert client_id,
@@ -22,27 +29,31 @@
 //!                             provisions the user, and 307-redirects to the
 //!                             frontend `/callback` with auth cookies set.
 //!
-//! Error cases covered to lock the historical wiring bugs in place:
-//!   - IdP error redirect `?error=access_denied` (RFC 6749 4.1.2.1, #1662)
-//!     -> 401, no user provisioned.
-//!   - Invalid / unknown `state` (CSRF replay defense)              -> 401.
-//!   - Missing `code`/`state` (malformed callback, #1369)           -> 400.
-//!   - Token-exchange failure (token endpoint 400s)                 -> 500
-//!     (the 400/401 split for *parameter* shape is asserted separately).
+//! Error / regression cases covered:
+//!   - IdP error redirect `?error=access_denied` (RFC 6749 4.1.2.1, #1662) -> 401.
+//!   - Invalid / unknown `state` (CSRF replay defense)                     -> 401.
+//!   - Missing `code`/`state` (malformed callback, #1369 400/401 split)    -> 400.
+//!   - Token-exchange failure (token endpoint 400s)                        -> not 401.
+//!   - nonce mismatch / wrong audience / expired ID token                  -> 401.
+//!   - claim-key mapping overrides (username/email/groups claim names).
+//!   - `map_groups_to_groups` on (sync + prune) vs off (no local groups).
+//!   - audit LOGIN on success / LOGIN_FAILED on federated-auth failure.
 //!
-//! Requires PostgreSQL with all migrations applied. Skips cleanly when
-//! `DATABASE_URL` is unset (matching the repo convention via `try_pool`).
+//! Requires PostgreSQL with all migrations applied AND a non-loopback local IP.
+//! Skips cleanly when `DATABASE_URL` is unset or no non-loopback IP exists
+//! (matching the repo `--ignored` convention via `try_pool`).
 //!
 //! ```sh
 //! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
-//!   cargo test --test sso_oidc_login_callback_e2e_tests -- --ignored
+//!   cargo test --test sso_oidc_login_callback_e2e_tests -- --ignored --test-threads=1
 //! ```
 
 #![allow(clippy::unwrap_used)]
 #![allow(clippy::expect_used)]
 
+mod common;
+
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
@@ -59,10 +70,15 @@ use uuid::Uuid;
 use wiremock::matchers::{method, path as wm_path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use artifact_keeper_backend::api::{AppState, SharedState};
-use artifact_keeper_backend::config::Config;
+use artifact_keeper_backend::api::SharedState;
+use artifact_keeper_backend::services::audit_service::AuditService;
 use artifact_keeper_backend::services::auth_config_service::{
     AuthConfigService, CreateOidcConfigRequest,
+};
+
+use common::sso_support::{
+    allow_private_sso_ip, build_state, ensure_sso_encryption_key, non_loopback_bind_ip, sso_app,
+    try_pool,
 };
 
 // ===========================================================================
@@ -71,61 +87,6 @@ use artifact_keeper_backend::services::auth_config_service::{
 
 const TEST_CLIENT_ID: &str = "ak-e2e-client";
 const TEST_KID: &str = "ak-e2e-kid";
-
-/// `AuthConfigService` encrypts the stored OIDC client secret with a key read
-/// from `SSO_ENCRYPTION_KEY`/`JWT_SECRET` in the *process* environment (not the
-/// `Config`). CI sets `JWT_SECRET`; for local runs we install a stable key so
-/// `create_oidc` (encrypt) and `get_oidc_decrypted` (decrypt) agree. Setting it
-/// to a fixed value is idempotent across the parallel tests in this binary.
-fn ensure_sso_encryption_key() {
-    if std::env::var("SSO_ENCRYPTION_KEY").is_err() && std::env::var("JWT_SECRET").is_err() {
-        std::env::set_var(
-            "SSO_ENCRYPTION_KEY",
-            "test-sso-encryption-key-at-least-32-bytes-long",
-        );
-    }
-}
-
-async fn try_pool() -> Option<PgPool> {
-    let url = std::env::var("DATABASE_URL").ok()?;
-    sqlx::postgres::PgPoolOptions::new()
-        .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(3))
-        .connect(&url)
-        .await
-        .ok()
-}
-
-fn test_config() -> Config {
-    Config {
-        database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
-        storage_path: std::env::temp_dir()
-            .join(format!("ak-sso-e2e-{}", Uuid::new_v4()))
-            .to_string_lossy()
-            .into_owned(),
-        jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
-        ..Default::default()
-    }
-}
-
-fn build_state(pool: PgPool) -> SharedState {
-    let cfg = test_config();
-    std::fs::create_dir_all(&cfg.storage_path).expect("create storage dir");
-    let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = Arc::new(
-        artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(&cfg.storage_path),
-    );
-    let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
-        HashMap::new(),
-        "filesystem".to_string(),
-    ));
-    Arc::new(AppState::new(cfg, pool, storage, registry))
-}
-
-/// Wrap the public SSO router in `with_state` (no auth layer — these are
-/// pre-auth public endpoints).
-fn sso_app(state: SharedState) -> axum::Router {
-    artifact_keeper_backend::api::handlers::sso::router().with_state(state)
-}
 
 // ===========================================================================
 // Mock OIDC IdP
@@ -138,11 +99,20 @@ struct MockIdp {
 }
 
 impl MockIdp {
-    /// Boot a mock IdP. Mounts discovery + JWKS immediately; the token
-    /// endpoint is mounted later (per-test) so each test can return a token
-    /// carrying the exact nonce minted during its own login redirect.
-    async fn start() -> Self {
-        let server = MockServer::start().await;
+    /// Boot a mock IdP bound to a **non-loopback** interface (the OIDC SSRF
+    /// guard hard-blocks loopback). Mounts discovery + JWKS immediately; the
+    /// token endpoint is mounted later (per-test) so each test can return a
+    /// token carrying the exact nonce minted during its own login redirect.
+    ///
+    /// Returns `None` when there is no non-loopback local IP (isolated runner),
+    /// so the caller can skip the test the same way it skips on missing DB.
+    async fn start() -> Option<Self> {
+        let ip = non_loopback_bind_ip()?;
+        // Opt the mock IdP's IP into the SSRF private-IP allowlist so the
+        // handler's discovery/token/JWKS fetches are permitted.
+        allow_private_sso_ip(ip);
+        let listener = std::net::TcpListener::bind((ip, 0)).ok()?;
+        let server = MockServer::builder().listener(listener).start().await;
 
         let mut rng = rsa::rand_core::OsRng;
         let private_key = RsaPrivateKey::new(&mut rng, 2048).expect("gen rsa key");
@@ -183,18 +153,19 @@ impl MockIdp {
             .mount(&server)
             .await;
 
-        Self {
+        Some(Self {
             server,
             encoding_key,
-        }
+        })
     }
 
     fn issuer(&self) -> String {
         self.server.uri()
     }
 
-    /// Sign an RS256 ID token with the IdP key. `claims` are merged onto a
-    /// well-formed default (iss/aud/sub/exp/iat + the supplied nonce).
+    /// Sign an RS256 ID token with the IdP key. `extra_claims` are merged onto a
+    /// well-formed default (iss/aud/sub/exp/iat + the supplied nonce), so a case
+    /// can override `aud`/`exp`/etc. simply by providing that key.
     fn sign_id_token(&self, nonce: &str, extra_claims: Value) -> String {
         let now = chrono::Utc::now().timestamp();
         let mut claims = json!({
@@ -231,6 +202,24 @@ impl MockIdp {
             .await;
     }
 
+    /// Like [`mount_token_endpoint`] but the mock only matches once, so a
+    /// subsequent (later-mounted) token mock takes over the next exchange.
+    /// Used to drive two consecutive callbacks with different group claims.
+    async fn mount_token_endpoint_once(&self, nonce: &str, extra_claims: Value) {
+        let id_token = self.sign_id_token(nonce, extra_claims);
+        Mock::given(method("POST"))
+            .and(wm_path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "access_token": "mock-access-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "id_token": id_token,
+            })))
+            .up_to_n_times(1)
+            .mount(&self.server)
+            .await;
+    }
+
     /// Mount a token endpoint that fails the code exchange (IdP rejects the
     /// authorization code).
     async fn mount_token_endpoint_failure(&self) {
@@ -249,9 +238,40 @@ impl MockIdp {
 // Provider config + login helpers
 // ===========================================================================
 
+/// Options for the OIDC provider fixture.
+struct ProviderOpts {
+    /// Extra `attribute_mapping` keys merged onto the pinned `redirect_uri`.
+    attr_extra: Value,
+    map_groups_to_groups: bool,
+    auto_create_users: bool,
+}
+
+impl Default for ProviderOpts {
+    fn default() -> Self {
+        Self {
+            attr_extra: json!({}),
+            map_groups_to_groups: false,
+            auto_create_users: true,
+        }
+    }
+}
+
 /// Insert an enabled OIDC provider config whose issuer points at `idp`.
 async fn create_provider(pool: &PgPool, idp: &MockIdp) -> Uuid {
+    create_provider_with(pool, idp, ProviderOpts::default()).await
+}
+
+async fn create_provider_with(pool: &PgPool, idp: &MockIdp, opts: ProviderOpts) -> Uuid {
     ensure_sso_encryption_key();
+    // Pin a fixed redirect_uri so we can assert it on the login redirect
+    // without relying on request Host headers, then merge any case-specific
+    // claim overrides on top.
+    let mut attr = json!({
+        "redirect_uri": "https://ak.example.test/api/v1/auth/sso/oidc/callback"
+    });
+    if let (Value::Object(base), Value::Object(more)) = (&mut attr, opts.attr_extra) {
+        base.extend(more);
+    }
     let resp = AuthConfigService::create_oidc(
         pool,
         CreateOidcConfigRequest {
@@ -264,15 +284,11 @@ async fn create_provider(pool: &PgPool, idp: &MockIdp) -> Uuid {
                 "profile".to_string(),
                 "email".to_string(),
             ]),
-            // Pin a fixed redirect_uri so we can assert it on the login redirect
-            // without relying on request Host headers.
-            attribute_mapping: Some(json!({
-                "redirect_uri": "https://ak.example.test/api/v1/auth/sso/oidc/callback"
-            })),
+            attribute_mapping: Some(attr),
             is_enabled: Some(true),
-            auto_create_users: Some(true),
+            auto_create_users: Some(opts.auto_create_users),
             pkce_enabled: Some(true),
-            map_groups_to_groups: Some(false),
+            map_groups_to_groups: Some(opts.map_groups_to_groups),
         },
     )
     .await
@@ -296,6 +312,30 @@ async fn delete_user_by_sub(pool: &PgPool, external_id: &str) {
         .bind(external_id)
         .execute(pool)
         .await;
+}
+
+/// Look up a provisioned federated user by `external_id`.
+async fn get_user(pool: &PgPool, external_id: &str) -> Option<(Uuid, String, Option<String>)> {
+    sqlx::query_as("SELECT id, username, email FROM users WHERE external_id = $1")
+        .bind(external_id)
+        .fetch_optional(pool)
+        .await
+        .expect("user lookup")
+}
+
+/// OIDC-managed group names the user is currently a member of, sorted.
+async fn oidc_group_names(pool: &PgPool, user_id: Uuid) -> Vec<String> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT g.name FROM groups g \
+         JOIN user_group_members m ON m.group_id = g.id \
+         WHERE m.user_id = $1 AND g.external_source = 'oidc' \
+         ORDER BY g.name",
+    )
+    .bind(user_id)
+    .fetch_all(pool)
+    .await
+    .expect("group lookup");
+    rows.into_iter().map(|(n,)| n).collect()
 }
 
 /// Parsed query parameters from a login redirect's `Location` header.
@@ -343,6 +383,17 @@ async fn do_login(
     (status, redirect)
 }
 
+/// login, returning the fresh (state, nonce) pair for the created SSO session.
+async fn login_state_nonce(pool: &PgPool, provider_id: Uuid) -> (String, String) {
+    let (status, redirect) = do_login(build_state(pool.clone()), provider_id).await;
+    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
+    let redirect = redirect.expect("login Location");
+    (
+        redirect.get("state").expect("state").to_string(),
+        redirect.get("nonce").expect("nonce").to_string(),
+    )
+}
+
 /// Parse `a=b&c=d` (percent-encoded) into a map.
 fn url_decode_query(query: &str) -> HashMap<String, String> {
     query
@@ -376,19 +427,35 @@ async fn do_callback(
     .expect("callback oneshot")
 }
 
+/// Convenience: callback with `code=mock-auth-code&state=<state>`.
+async fn do_callback_state(
+    pool: &PgPool,
+    provider_id: Uuid,
+    state: &str,
+) -> axum::response::Response {
+    do_callback(
+        build_state(pool.clone()),
+        provider_id,
+        &format!("code=mock-auth-code&state={}", urlencoding::encode(state)),
+    )
+    .await
+}
+
 // ===========================================================================
 // Tests
 // ===========================================================================
 
 /// Login must 307 to the IdP authorize endpoint with all OIDC params present
-/// and correct (closes the #453 "login 404" regression class).
+/// and correct (locks the #453 "login 404" regression class).
 #[tokio::test]
-#[ignore = "requires DATABASE_URL"]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
 async fn test_oidc_login_redirects_with_correct_params() {
     let Some(pool) = try_pool().await else {
         return;
     };
-    let idp = MockIdp::start().await;
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
     let provider_id = create_provider(&pool, &idp).await;
     let state = build_state(pool.clone());
 
@@ -439,22 +506,19 @@ async fn test_oidc_login_redirects_with_correct_params() {
 
 /// Full happy path: login -> extract state/nonce -> callback exchanges the
 /// code, validates the ID token, provisions a user, and 307s to the frontend
-/// with auth cookies set (closes the #530 "callback 404" regression class).
+/// with auth cookies set (locks the #530 "callback 404" regression class).
 #[tokio::test]
-#[ignore = "requires DATABASE_URL"]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
 async fn test_oidc_login_callback_full_roundtrip() {
     let Some(pool) = try_pool().await else {
         return;
     };
-    let idp = MockIdp::start().await;
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
     let provider_id = create_provider(&pool, &idp).await;
 
-    // --- login ---
-    let (status, redirect) = do_login(build_state(pool.clone()), provider_id).await;
-    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
-    let redirect = redirect.expect("login Location");
-    let sso_state = redirect.get("state").expect("state").to_string();
-    let nonce = redirect.get("nonce").expect("nonce").to_string();
+    let (sso_state, nonce) = login_state_nonce(&pool, provider_id).await;
 
     // The token endpoint must echo the login nonce inside the signed ID token.
     let external_id = format!("oidc-sub-roundtrip-{}", Uuid::new_v4().as_simple());
@@ -469,16 +533,7 @@ async fn test_oidc_login_callback_full_roundtrip() {
     )
     .await;
 
-    // --- callback ---
-    let resp = do_callback(
-        build_state(pool.clone()),
-        provider_id,
-        &format!(
-            "code=mock-auth-code&state={}",
-            urlencoding::encode(&sso_state)
-        ),
-    )
-    .await;
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
 
     assert_eq!(
         resp.status(),
@@ -500,31 +555,410 @@ async fn test_oidc_login_callback_full_roundtrip() {
         "callback redirect must set auth cookies"
     );
 
-    // The user must have been provisioned.
-    let provisioned: Option<(String,)> =
-        sqlx::query_as("SELECT username FROM users WHERE external_id = $1")
-            .bind(&external_id)
-            .fetch_optional(&pool)
-            .await
-            .expect("user lookup");
+    // The user must have been provisioned with the mapped username/email.
+    let user = get_user(&pool, &external_id).await;
+    let (_, username, email) = user.expect("callback must provision the federated user");
+    assert_eq!(username, "e2e-user");
+    assert_eq!(email.as_deref(), Some("e2e-user@example.test"));
+
+    delete_user_by_sub(&pool, &external_id).await;
+    delete_provider(&pool, provider_id).await;
+}
+
+/// Claim-key mapping: `attribute_mapping` overrides `username_claim`/
+/// `email_claim`/`groups_claim`; the ID token carries the *non-default* claim
+/// keys, and the provisioned user's username/email + synced groups must come
+/// from the overridden keys (exercises `resolve_oidc_claim_name` /
+/// `extract_oidc_groups`).
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_claim_key_mapping() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let provider_id = create_provider_with(
+        &pool,
+        &idp,
+        ProviderOpts {
+            attr_extra: json!({
+                "username_claim": "upn",
+                "email_claim": "mail",
+                "groups_claim": "roles",
+            }),
+            map_groups_to_groups: true,
+            ..ProviderOpts::default()
+        },
+    )
+    .await;
+
+    let (sso_state, nonce) = login_state_nonce(&pool, provider_id).await;
+
+    let external_id = format!("oidc-sub-claimmap-{}", Uuid::new_v4().as_simple());
+    let mapped_group = format!("claim-mapped-{}", Uuid::new_v4().as_simple());
+    idp.mount_token_endpoint(
+        &nonce,
+        json!({
+            "sub": external_id,
+            // Non-default claim keys carry the identity; the *default* keys are
+            // deliberately absent/wrong to prove the override is honored.
+            "upn": "mapped-user",
+            "mail": "mapped-user@corp.test",
+            "roles": [mapped_group],
+            // Default keys present but must be IGNORED.
+            "preferred_username": "WRONG-default-username",
+            "email": "wrong-default@corp.test",
+        }),
+    )
+    .await;
+
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+
+    let (user_id, username, email) = get_user(&pool, &external_id)
+        .await
+        .expect("user provisioned");
+    assert_eq!(
+        username, "mapped-user",
+        "username must come from `upn` claim"
+    );
+    assert_eq!(
+        email.as_deref(),
+        Some("mapped-user@corp.test"),
+        "email must come from `mail` claim"
+    );
+    let groups = oidc_group_names(&pool, user_id).await;
     assert!(
-        provisioned.is_some(),
-        "callback must provision the federated user"
+        groups.contains(&mapped_group),
+        "group must come from the overridden `roles` claim, got {groups:?}"
     );
 
     delete_user_by_sub(&pool, &external_id).await;
     delete_provider(&pool, provider_id).await;
 }
 
+/// nonce mismatch: the ID token's `nonce` differs from the login nonce -> 401
+/// (`validate_id_token` nonce check). State-CSRF is covered separately; this
+/// pins the nonce leg.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_nonce_mismatch_returns_401() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let provider_id = create_provider(&pool, &idp).await;
+
+    let (sso_state, _nonce) = login_state_nonce(&pool, provider_id).await;
+
+    // Mint a token whose nonce does NOT match the session nonce.
+    idp.mount_token_endpoint(
+        "totally-different-nonce",
+        json!({ "sub": "oidc-sub-nonce-mismatch" }),
+    )
+    .await;
+
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "nonce mismatch must map to 401"
+    );
+
+    delete_provider(&pool, provider_id).await;
+}
+
+/// wrong audience: the ID token's `aud` != provider `client_id` -> 401
+/// (`validate_id_token` `set_audience`).
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_wrong_audience_returns_401() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let provider_id = create_provider(&pool, &idp).await;
+
+    let (sso_state, nonce) = login_state_nonce(&pool, provider_id).await;
+    idp.mount_token_endpoint(
+        &nonce,
+        json!({ "sub": "oidc-sub-wrong-aud", "aud": "some-other-client" }),
+    )
+    .await;
+
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "wrong audience must map to 401"
+    );
+
+    delete_provider(&pool, provider_id).await;
+}
+
+/// expired token: the ID token's `exp` is in the past -> 401 (jsonwebtoken exp
+/// validation).
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_expired_token_returns_401() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let provider_id = create_provider(&pool, &idp).await;
+
+    let (sso_state, nonce) = login_state_nonce(&pool, provider_id).await;
+    let past = chrono::Utc::now().timestamp() - 3600;
+    idp.mount_token_endpoint(
+        &nonce,
+        json!({ "sub": "oidc-sub-expired", "exp": past, "iat": past - 60 }),
+    )
+    .await;
+
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "expired token must map to 401"
+    );
+
+    delete_provider(&pool, provider_id).await;
+}
+
+/// `map_groups_to_groups=true`: first login with groups `[dev, sec]` creates
+/// both local `external_source='oidc'` groups with membership; a second login
+/// with `[dev]` prunes the `sec` membership (but keeps `dev`) via
+/// `sync_oidc_groups_to_local_groups`.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_map_groups_sync_and_prune() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let provider_id = create_provider_with(
+        &pool,
+        &idp,
+        ProviderOpts {
+            map_groups_to_groups: true,
+            ..ProviderOpts::default()
+        },
+    )
+    .await;
+
+    let external_id = format!("oidc-sub-groups-{}", Uuid::new_v4().as_simple());
+    let g_dev = format!("dev-{}", Uuid::new_v4().as_simple());
+    let g_sec = format!("sec-{}", Uuid::new_v4().as_simple());
+
+    // --- first login: groups [dev, sec] ---
+    let (state1, nonce1) = login_state_nonce(&pool, provider_id).await;
+    idp.mount_token_endpoint_once(
+        &nonce1,
+        json!({ "sub": external_id, "groups": [g_dev, g_sec] }),
+    )
+    .await;
+    let resp1 = do_callback_state(&pool, provider_id, &state1).await;
+    assert_eq!(resp1.status(), StatusCode::TEMPORARY_REDIRECT);
+
+    let (user_id, _, _) = get_user(&pool, &external_id)
+        .await
+        .expect("user provisioned");
+    let after1 = oidc_group_names(&pool, user_id).await;
+    assert!(
+        after1.contains(&g_dev) && after1.contains(&g_sec),
+        "both groups present after first login, got {after1:?}"
+    );
+
+    // --- second login: groups [dev] only -> sec pruned ---
+    let (state2, nonce2) = login_state_nonce(&pool, provider_id).await;
+    idp.mount_token_endpoint(&nonce2, json!({ "sub": external_id, "groups": [g_dev] }))
+        .await;
+    let resp2 = do_callback_state(&pool, provider_id, &state2).await;
+    assert_eq!(resp2.status(), StatusCode::TEMPORARY_REDIRECT);
+
+    let after2 = oidc_group_names(&pool, user_id).await;
+    assert!(
+        after2.contains(&g_dev),
+        "dev membership must persist, got {after2:?}"
+    );
+    assert!(
+        !after2.contains(&g_sec),
+        "sec membership must be pruned after it dropped from the claim, got {after2:?}"
+    );
+
+    // cleanup: membership + the auto-created oidc groups.
+    delete_user_by_sub(&pool, &external_id).await;
+    let _ = sqlx::query("DELETE FROM groups WHERE external_provider_id = $1")
+        .bind(provider_id)
+        .execute(&pool)
+        .await;
+    delete_provider(&pool, provider_id).await;
+}
+
+/// `map_groups_to_groups=false`: even with a non-empty groups claim, NO local
+/// groups are created for the provider (legacy role-mapping behavior preserved).
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_map_groups_disabled_creates_no_groups() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let provider_id = create_provider_with(
+        &pool,
+        &idp,
+        ProviderOpts {
+            map_groups_to_groups: false,
+            ..ProviderOpts::default()
+        },
+    )
+    .await;
+
+    let external_id = format!("oidc-sub-nogroups-{}", Uuid::new_v4().as_simple());
+    let (sso_state, nonce) = login_state_nonce(&pool, provider_id).await;
+    idp.mount_token_endpoint(
+        &nonce,
+        json!({ "sub": external_id, "groups": ["dev", "sec"] }),
+    )
+    .await;
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+
+    let created: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM groups WHERE external_provider_id = $1")
+            .bind(provider_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count groups");
+    assert_eq!(
+        created.0, 0,
+        "no local groups may be created when map_groups_to_groups is off"
+    );
+
+    delete_user_by_sub(&pool, &external_id).await;
+    delete_provider(&pool, provider_id).await;
+}
+
+/// Audit: a happy-path login emits exactly a `LOGIN` audit row for the
+/// provisioned user with `details.provider="oidc"`; a federated-auth failure
+/// (auto-create disabled + unknown user) emits a `LOGIN_FAILED` row with
+/// `details.provider="oidc"`.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
+async fn test_oidc_callback_emits_audit_records() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
+    let audit = AuditService::new(pool.clone());
+
+    // --- success -> LOGIN ---
+    let provider_id = create_provider(&pool, &idp).await;
+    let external_id = format!("oidc-sub-audit-ok-{}", Uuid::new_v4().as_simple());
+    let (state_ok, nonce_ok) = login_state_nonce(&pool, provider_id).await;
+    idp.mount_token_endpoint_once(
+        &nonce_ok,
+        json!({ "sub": external_id, "preferred_username": "audit-ok-user" }),
+    )
+    .await;
+    let resp = do_callback_state(&pool, provider_id, &state_ok).await;
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+
+    let (user_id, _, _) = get_user(&pool, &external_id).await.expect("provisioned");
+    let (login_rows, _) = audit
+        .query(Some(user_id), Some("LOGIN"), None, None, None, None, 0, 50)
+        .await
+        .expect("audit query LOGIN");
+    assert!(
+        login_rows.iter().any(|r| {
+            r.resource_type == "user"
+                && r.details
+                    .as_ref()
+                    .and_then(|d| d.get("provider"))
+                    .and_then(|p| p.as_str())
+                    == Some("oidc")
+        }),
+        "a LOGIN audit row with details.provider=oidc must exist for the user"
+    );
+
+    // --- failure -> LOGIN_FAILED ---
+    // auto_create_users=false + a brand-new sub -> authenticate_federated errors,
+    // the handler fires a LOGIN_FAILED audit before returning.
+    let fail_provider = create_provider_with(
+        &pool,
+        &idp,
+        ProviderOpts {
+            auto_create_users: false,
+            ..ProviderOpts::default()
+        },
+    )
+    .await;
+    let fail_username = format!("audit-fail-{}", Uuid::new_v4().as_simple());
+    let (state_fail, nonce_fail) = login_state_nonce(&pool, fail_provider).await;
+    idp.mount_token_endpoint(
+        &nonce_fail,
+        json!({
+            "sub": format!("oidc-sub-audit-fail-{}", Uuid::new_v4().as_simple()),
+            "preferred_username": fail_username,
+        }),
+    )
+    .await;
+    let resp = do_callback_state(&pool, fail_provider, &state_fail).await;
+    assert!(
+        resp.status().is_client_error() || resp.status().is_server_error(),
+        "federated-auth failure must surface an error status, got {}",
+        resp.status()
+    );
+
+    let (fail_rows, _) = audit
+        .query(None, Some("LOGIN_FAILED"), None, None, None, None, 0, 200)
+        .await
+        .expect("audit query LOGIN_FAILED");
+    assert!(
+        fail_rows.iter().any(|r| {
+            let details = r.details.as_ref();
+            details
+                .and_then(|d| d.get("provider"))
+                .and_then(|p| p.as_str())
+                == Some("oidc")
+                && details
+                    .and_then(|d| d.get("username"))
+                    .and_then(|u| u.as_str())
+                    == Some(fail_username.as_str())
+        }),
+        "a LOGIN_FAILED audit row with details.provider=oidc for the attempted username must exist"
+    );
+
+    delete_user_by_sub(&pool, &external_id).await;
+    delete_provider(&pool, provider_id).await;
+    delete_provider(&pool, fail_provider).await;
+}
+
 /// IdP error redirect (RFC 6749 4.1.2.1): `?error=access_denied` -> 401, and
 /// crucially NOT a 400 or a CSRF-style 500 (locks in #1662 + the #1369 split).
 #[tokio::test]
-#[ignore = "requires DATABASE_URL"]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
 async fn test_oidc_callback_idp_access_denied_returns_401() {
     let Some(pool) = try_pool().await else {
         return;
     };
-    let idp = MockIdp::start().await;
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
     let provider_id = create_provider(&pool, &idp).await;
 
     let resp = do_callback(
@@ -546,12 +980,14 @@ async fn test_oidc_callback_idp_access_denied_returns_401() {
 /// Unknown / non-empty `state` that matches no SSO session -> 401 (CSRF replay
 /// defense). The token endpoint must NOT be reached.
 #[tokio::test]
-#[ignore = "requires DATABASE_URL"]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
 async fn test_oidc_callback_invalid_state_returns_401() {
     let Some(pool) = try_pool().await else {
         return;
     };
-    let idp = MockIdp::start().await;
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
     let provider_id = create_provider(&pool, &idp).await;
 
     let resp = do_callback(
@@ -572,12 +1008,14 @@ async fn test_oidc_callback_invalid_state_returns_401() {
 
 /// Missing `code` and `state` -> 400 malformed callback (#1369 400/401 split).
 #[tokio::test]
-#[ignore = "requires DATABASE_URL"]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
 async fn test_oidc_callback_missing_params_returns_400() {
     let Some(pool) = try_pool().await else {
         return;
     };
-    let idp = MockIdp::start().await;
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
     let provider_id = create_provider(&pool, &idp).await;
 
     let resp = do_callback(build_state(pool.clone()), provider_id, "code=&state=").await;
@@ -592,36 +1030,23 @@ async fn test_oidc_callback_missing_params_returns_400() {
 
 /// Token-exchange failure (IdP rejects the code) must NOT be a 401 (which would
 /// imply a CSRF / state problem) — the state was valid; the exchange itself
-/// failed. Asserts the handler does not collapse exchange errors into the CSRF
-/// 401 path.
+/// failed.
 #[tokio::test]
-#[ignore = "requires DATABASE_URL"]
+#[ignore = "requires DATABASE_URL + non-loopback IP"]
 async fn test_oidc_callback_token_exchange_failure_is_not_401() {
     let Some(pool) = try_pool().await else {
         return;
     };
-    let idp = MockIdp::start().await;
+    let Some(idp) = MockIdp::start().await else {
+        return;
+    };
     let provider_id = create_provider(&pool, &idp).await;
 
-    let (status, redirect) = do_login(build_state(pool.clone()), provider_id).await;
-    assert_eq!(status, StatusCode::TEMPORARY_REDIRECT);
-    let sso_state = redirect
-        .expect("login Location")
-        .get("state")
-        .unwrap()
-        .to_string();
+    let (sso_state, _nonce) = login_state_nonce(&pool, provider_id).await;
 
     idp.mount_token_endpoint_failure().await;
 
-    let resp = do_callback(
-        build_state(pool.clone()),
-        provider_id,
-        &format!(
-            "code=mock-auth-code&state={}",
-            urlencoding::encode(&sso_state)
-        ),
-    )
-    .await;
+    let resp = do_callback_state(&pool, provider_id, &sso_state).await;
 
     assert_ne!(
         resp.status(),


### PR DESCRIPTION
Closes #2211

## Summary

Adds an end-to-end **OIDC** SSO login/callback regression harness that drives the
real axum handlers in `api::handlers::sso` (`oidc_login` → `oidc_callback`) against
an in-process mock identity provider, so the v1.2.x OIDC correctness fixes cannot
silently regress. This is the OIDC half of the #1617 SSO E2E work; a companion PR
adds the SAML ACS signed-assertion harness. **Test infrastructure only — no
production code is changed.**

### What it covers
The harness spins up a wiremock-backed mock IdP (discovery / JWKS / token endpoints,
RS256-signed id_tokens minted at runtime from an ephemeral RSA key) and a throwaway
Postgres, then exercises the real router end to end:

- **login → authorize redirect** — 307 with `response_type`/`client_id`/`redirect_uri`/
  `scope`/`state`/`nonce`/PKCE `S256` params (login-route wiring, ref #453).
- **login → callback full roundtrip** — code exchange, id_token verification against
  JWKS, user provisioning, 307 to the frontend `/callback` with auth cookies set
  (callback-route wiring, ref #530).
- **claim-key mapping** — `username_claim`/`email_claim`/`groups_claim` overrides are
  honored (username/email/groups sourced from the overridden keys, not the defaults).
- **nonce mismatch → 401**, **wrong audience → 401**, **expired id_token → 401**.
- **`map_groups_to_groups` on** — groups synced as local `external_source='oidc'`
  groups, and a subsequent login with a narrower claim **prunes** the dropped
  membership; **off** — no local groups are created.
- **IdP error redirect `?error=access_denied` → 401** (RFC 6749 §4.1.2.1, ref #1662).
- **unknown `state` → 401** (CSRF replay defense); **missing `code`/`state` → 400**
  (the 400/401 malformed-vs-auth split, ref #1369); **token-exchange failure ≠ 401**.
- **audit** — a happy-path login emits a `LOGIN` audit row (`details.provider="oidc"`)
  for the provisioned user, and a federated-auth failure emits `LOGIN_FAILED`.

### Design notes
- **Non-loopback mock IdP bind (load-bearing).** The OIDC handler screens every
  server-side fetch (discovery/token/JWKS) through the outbound SSRF guard, which
  hard-blocks loopback under every relaxation. wiremock defaults to `127.0.0.1`, so
  the harness binds the mock to the host's primary non-loopback interface
  (`MockServer::builder().listener(...)`) and opts that single IP into
  `AK_SSRF_ALLOW_PRIVATE_CIDRS=<ip>/32` (private IPs are relaxable; loopback is not).
  This repairs the previously-dead scaffold, which bound loopback and so could never
  complete a fetch.
- **CI wiring.** The suite was previously never registered in CI. It is now added to
  the postgres-backed `--ignored` integration block in `.github/workflows/ci.yml`,
  run `--test-threads=1` (the harness sets process-global env, so serial execution
  is required).
- **Shared helper.** `backend/tests/common/sso_support.rs` holds the pool/state
  builders and the non-loopback-bind helpers; the companion SAML suite will reuse it
  (keeps duplication under the jscpd gate).
- **No new dependencies.** Uses existing dev-deps `wiremock 0.6`, `jsonwebtoken`,
  `rsa`. No migration.
- Skips cleanly when `DATABASE_URL` is unset or no non-loopback IP exists (matching
  the repo `--ignored` convention).

Part of #1617 (epic #1615). References #453, #530, #1369, #1662 — the OIDC
login/callback wiring and 400/401-split defects whose fixes this harness now pins
against regression (all already-closed code-behavior fixes, referenced not closed).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (test-infrastructure only; no production change)

## Test Checklist
- [ ] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified locally against a throwaway Postgres:
`cargo test --test sso_oidc_login_callback_e2e_tests -- --ignored --test-threads=1`
→ 13 passed; `cargo clippy --workspace --all-targets -- -D warnings`,
`cargo fmt --check`, `cargo test --workspace --lib` all green; jscpd < 3%.

## API Changes
- [x] N/A - no API changes

