### PR TITLE
fix(deps): bump bcrypt to 0.19.2 to resolve RUSTSEC-2026-0199

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64",
  "blowfish 0.10.0",
@@ -6353,7 +6353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",


### PR DESCRIPTION
## Summary

`RUSTSEC-2026-0199` (medium, 5.3 — *panic in `bcrypt::verify` on non-ASCII hash
input*) synced into the advisory DB and now fails the repo-wide `Security Audit`
(`cargo audit`) gate on every open PR, blocking the v1.3.0 pipeline and the release
cut.

`bcrypt` was pinned to `0.19.1` in `Cargo.lock`. The advisory's fixed version is
`>=0.19.2`. The workspace root `Cargo.toml` already declares `bcrypt = "0.19"`
(caret), so `0.19.2` is permitted without any manifest change — this PR updates the
lockfile only:

```
cargo update -p bcrypt --precise 0.19.2
```

Diff is minimal: `bcrypt 0.19.1 -> 0.19.2` plus one benign lock-heal where
`tempfile 3.27.0`'s `getrandom` edge was corrected `0.4.2 -> 0.3.4` (both versions
already present in the tree; no crate added/removed, no other package version
changed). Total lockfile diff is 6 lines.

`0.19.1 -> 0.19.2` is a patch bump with no public API change. `bcrypt` is on the
password + TOTP verify hot path, so this was validated behaviourally, not just for
compilation:

- `cargo audit` no longer reports `RUSTSEC-2026-0199`.
- `cargo build --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`
  are clean — no bcrypt API breakage.
- The bcrypt-touching unit tests pass (password hash/verify, dummy-hash timing pad,
  password-history reuse, legacy webhook-secret bcrypt) — `cargo test --workspace --lib`
  green (12174 lib tests).
- Behavioural proof of the advisory: `bcrypt::verify` on a non-ASCII hash now returns
  `Err` (malformed-hash) instead of panicking; correct/incorrect password round-trips
  still return `true`/`false`.
- Deployed the patched image on an isolated stack and smoke-tested the live auth
  flows: admin password login (bcrypt verify), user creation (bcrypt hash), new-user
  password login, TOTP setup + enable, and TOTP login verification via a **backup
  code** (the bcrypt verify hot path) — all succeed.

Closes #2215

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

The vulnerability is in a third-party crate, not application logic, so the regression
guard is the repo-wide `Security Audit` (`cargo audit`) CI gate itself: it fails on
`main` (bcrypt 0.19.1) and passes on this branch (bcrypt 0.19.2). The existing
`services::auth_service::tests::test_verify_password_invalid_hash` also exercises the
malformed-hash rejection path.

## Test Checklist
- [ ] Unit tests added/updated (existing bcrypt unit tests re-run and green; no new source code to test — lockfile-only change)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
