### PR TITLE
fix(metrics): collapse unmatched HTTP paths to prevent scanner-driven cardinality explosion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "memmap2",
  "metrics",
  "metrics-exporter-prometheus",
+ "metrics-util",
  "mimalloc",
  "mime_guess",
  "moka",
@@ -2199,6 +2200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3791,11 +3798,15 @@ version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdfb1365fea27e6dd9dc1dbc19f570198bc86914533ad639dae939635f096be4"
 dependencies = [
+ "aho-corasick",
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.16.1",
+ "indexmap 2.13.0",
  "metrics",
+ "ordered-float",
  "quanta",
+ "radix_trie",
  "rand 0.9.2",
  "rand_xoshiro",
  "sketches-ddsketch",
@@ -3948,6 +3959,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
 ]
 
 [[package]]
@@ -4347,6 +4367,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4971,6 +5000,16 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
 
 [[package]]
 name = "rand"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -197,3 +197,4 @@ tonic-build.workspace = true
 tokio-test = "0.4"
 axum-test = "18"
 wiremock = "0.6"
+metrics-util = "0.20"

--- a/backend/src/api/middleware/metrics.rs
+++ b/backend/src/api/middleware/metrics.rs
@@ -4,8 +4,8 @@
 //! `metrics` crate. Path labels are taken from axum's `MatchedPath` when
 //! available, which gives the route pattern (e.g. `/api/v1/repositories/:key`)
 //! instead of the concrete URL. This avoids high-cardinality label explosion.
-//! When no matched path is available (404s, fallback routes), the raw path is
-//! normalized by replacing UUIDs and numeric segments with `:id`.
+//! When no matched path is available (scanner traffic, 404s, fallback routes),
+//! the label is collapsed to the fixed string `"unmatched"`.
 
 use std::time::Instant;
 
@@ -49,15 +49,21 @@ impl Drop for InFlightGuard {
 ///   seconds. Labels: `method`, `path`, `status`.
 /// - `ak_http_requests_in_flight` (gauge): number of requests currently being
 ///   processed. Labels: `method`, `path`.
+///
+/// The `path` label uses axum's `MatchedPath` (the route pattern) when
+/// available. When no route matched (scanner probes, 404s, fallback routes),
+/// it collapses to `"unmatched"` to prevent high-cardinality label explosion.
 pub async fn metrics_middleware(request: Request, next: Next) -> Response {
     let method = request.method().to_string();
 
-    // Prefer the matched route pattern for low-cardinality labels.
+    // Prefer the matched route pattern for low-cardinality labels. When no
+    // route matched, collapse to "unmatched" to avoid per-URL label explosion
+    // from scanner traffic (which accounts for >99% of unmatched requests).
     let path = request
         .extensions()
         .get::<MatchedPath>()
         .map(|mp| mp.as_str().to_owned())
-        .unwrap_or_else(|| normalize_path(request.uri().path()));
+        .unwrap_or_else(|| "unmatched".to_string());
 
     let start = Instant::now();
 
@@ -97,92 +103,57 @@ pub async fn metrics_middleware(request: Request, next: Next) -> Response {
     response
 }
 
-/// Normalize URL paths to reduce label cardinality when `MatchedPath` is
-/// unavailable. Replaces UUID-shaped segments and bare numeric segments
-/// with `:id`.
-fn normalize_path(path: &str) -> String {
-    let segments: Vec<&str> = path.split('/').collect();
-    let normalized: Vec<String> = segments
-        .iter()
-        .map(|seg| {
-            if seg.len() == 36 && seg.chars().filter(|c| *c == '-').count() == 4 {
-                // UUID pattern (xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx)
-                ":id".to_string()
-            } else if !seg.is_empty() && seg.parse::<i64>().is_ok() {
-                // Numeric ID
-                ":id".to_string()
-            } else {
-                seg.to_string()
-            }
-        })
-        .collect();
-    normalized.join("/")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use axum::{body::Body, middleware, routing::get, Router};
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
     use tower::ServiceExt;
+
+    /// A captured metric: (name, labels, value).
+    type CapturedMetric = (String, Vec<(String, String)>, DebugValue);
 
     async fn test_handler() -> &'static str {
         "OK"
     }
 
-    #[test]
-    fn test_normalize_path_uuid() {
-        let path = "/api/v1/repositories/550e8400-e29b-41d4-a716-446655440000/artifacts";
-        let result = normalize_path(path);
-        assert_eq!(result, "/api/v1/repositories/:id/artifacts");
+    /// Run the middleware against `app` with a `DebuggingRecorder` and return
+    /// the captured counter values keyed by (name, labels).
+    fn run_with_recorder(app: Router, uri: &str) -> Vec<CapturedMetric> {
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        metrics::with_local_recorder(&recorder, || {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(async {
+                    let request = Request::builder().uri(uri).body(Body::empty()).unwrap();
+                    let _ = app.oneshot(request).await.unwrap();
+                });
+        });
+
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .map(|(ck, _, _, value)| {
+                let (_kind, key) = ck.into_parts();
+                let name = key.name().to_string();
+                let labels: Vec<(String, String)> = key
+                    .into_parts()
+                    .1
+                    .into_iter()
+                    .map(|l| (l.key().to_string(), l.value().to_string()))
+                    .collect();
+                (name, labels, value)
+            })
+            .collect()
     }
 
     #[test]
-    fn test_normalize_path_numeric() {
-        let path = "/api/v1/users/123";
-        let result = normalize_path(path);
-        assert_eq!(result, "/api/v1/users/:id");
-    }
-
-    #[test]
-    fn test_normalize_path_no_change() {
-        let path = "/api/v1/health";
-        let result = normalize_path(path);
-        assert_eq!(result, "/api/v1/health");
-    }
-
-    #[test]
-    fn test_normalize_path_multiple_ids() {
-        let path = "/api/v1/repos/42/artifacts/550e8400-e29b-41d4-a716-446655440000";
-        let result = normalize_path(path);
-        assert_eq!(result, "/api/v1/repos/:id/artifacts/:id");
-    }
-
-    #[test]
-    fn test_normalize_path_root() {
-        assert_eq!(normalize_path("/"), "/");
-    }
-
-    #[test]
-    fn test_normalize_path_empty() {
-        assert_eq!(normalize_path(""), "");
-    }
-
-    #[test]
-    fn test_normalize_path_preserves_named_segments() {
-        let path = "/api/v1/repositories/my-repo/artifacts/my-package";
-        let result = normalize_path(path);
-        assert_eq!(result, "/api/v1/repositories/my-repo/artifacts/my-package");
-    }
-
-    #[test]
-    fn test_normalize_path_negative_number_treated_as_id() {
-        let path = "/api/v1/items/-5";
-        let result = normalize_path(path);
-        assert_eq!(result, "/api/v1/items/:id");
-    }
-
-    #[tokio::test]
-    async fn test_middleware_returns_response() {
+    fn test_middleware_returns_response() {
         // Install a no-op recorder so the metrics macros don't panic when no
         // global recorder is set. In production, init_metrics() sets one up.
         let _ = metrics::NoopRecorder;
@@ -193,12 +164,16 @@ mod tests {
 
         let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
 
-        let response = app.oneshot(request).await.unwrap();
+        let response = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { app.oneshot(request).await.unwrap() });
         assert_eq!(response.status(), axum::http::StatusCode::OK);
     }
 
-    #[tokio::test]
-    async fn test_middleware_handles_not_found() {
+    #[test]
+    fn test_middleware_handles_not_found() {
+        let _ = metrics::NoopRecorder;
+
         let app = Router::new()
             .route("/exists", get(test_handler))
             .layer(middleware::from_fn(metrics_middleware));
@@ -208,7 +183,75 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let response = app.oneshot(request).await.unwrap();
+        let response = tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { app.oneshot(request).await.unwrap() });
         assert_eq!(response.status(), axum::http::StatusCode::NOT_FOUND);
+    }
+
+    /// Find a captured metric by name and return its labels.
+    fn find_labels<'a>(metrics: &'a [CapturedMetric], name: &str) -> &'a [(String, String)] {
+        metrics
+            .iter()
+            .find(|(n, _, _)| n == name)
+            .map(|(_, labels, _)| labels.as_slice())
+            .unwrap_or(&[])
+    }
+
+    #[test]
+    fn test_matched_route_uses_route_pattern_label() {
+        let app = Router::new()
+            .route("/exists", get(test_handler))
+            .layer(middleware::from_fn(metrics_middleware));
+
+        let metrics = run_with_recorder(app, "/exists");
+
+        let labels = find_labels(&metrics, "ak_http_requests_total");
+        let path = labels
+            .iter()
+            .find(|(k, _)| k == "path")
+            .map(|(_, v)| v.as_str())
+            .expect("path label should exist");
+        assert_eq!(path, "/exists");
+    }
+
+    #[test]
+    fn test_unmatched_route_collapses_to_unmatched_label() {
+        let app = Router::new()
+            .route("/exists", get(test_handler))
+            .layer(middleware::from_fn(metrics_middleware));
+
+        // A scanner-style URL that doesn't match any route.
+        let metrics = run_with_recorder(app, "/scanner-probe/.env");
+
+        let labels = find_labels(&metrics, "ak_http_requests_total");
+        let path = labels
+            .iter()
+            .find(|(k, _)| k == "path")
+            .map(|(_, v)| v.as_str())
+            .expect("path label should exist");
+        assert_eq!(path, "unmatched");
+    }
+
+    #[test]
+    fn test_unmatched_routes_share_single_label_value() {
+        // Two different unmatched URLs must produce the same "unmatched" path
+        // label, proving cardinality is bounded.
+        let app = Router::new()
+            .route("/exists", get(test_handler))
+            .layer(middleware::from_fn(metrics_middleware));
+
+        let metrics1 = run_with_recorder(app.clone(), "/scanner/.git/config");
+        let metrics2 = run_with_recorder(app, "/artifactory/libs-release/com/example");
+
+        for metrics in [metrics1, metrics2] {
+            let labels = find_labels(&metrics, "ak_http_requests_total");
+            let path = labels
+                .iter()
+                .find(|(k, _)| k == "path")
+                .map(|(_, v)| v.as_str())
+                .expect("path label should exist");
+            assert_eq!(path, "unmatched");
+        }
     }
 }


### PR DESCRIPTION
Closes #2220

## Summary

The HTTP metrics middleware produces unbounded cardinality when requests don't match a route. Bots and attack scanners probe paths like `/.env`, `/.git/config`, `/wp-admin`, and enumerate Nexus/Artifactory/Maven Central URL shapes (`/repository/maven-central/org/eclipse/microprofile/...`). These requests have no `MatchedPath`, so they fall through to `normalize_path`, which only collapses UUID and numeric segments — alphabetic package paths pass through untouched, each producing a distinct time series.

Observed in a production deployment: ~400K distinct `path` label values across `ak_http_requests_total`, `ak_http_responses_total`, `ak_http_request_duration_seconds`, and `ak_http_requests_in_flight`, accounting for over 99% of all series. The vast majority are 404s; the rest are 401s and other status codes, all from automated scanner traffic.

**Fix:** When `MatchedPath` is unavailable, the `path` label is collapsed to the fixed string `"unmatched"` instead of attempting to normalize the raw URL. Explicit routes (with `MatchedPath`) are unaffected.

**Investigating specific requests:** If you need to inspect individual unmatched requests (source IP, exact path, user agent, etc.), check OpenTelemetry traces/logs.

## Regression test

- [x] This PR is `fix/*` AND adds/updates a test that would have caught the bug
  - `test_unmatched_route_collapses_to_unmatched_label`: verifies the `path` label is `"unmatched"` for unmatched routes
  - `test_unmatched_routes_share_single_label_value`: verifies two different scanner URLs produce the same label value
  - `test_matched_route_uses_route_pattern_label`: verifies matched routes still use the route pattern as the label
  - Tests use `DebuggingRecorder` + `with_local_recorder` to capture actual label values, not just verify that a metric was recorded

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable) — N/A, pure middleware change, no DB needed
- [ ] E2E tests added/updated (if applicable) — N/A
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes