### PR TITLE
fix(security): require admin for global security-policy create/update/delete

### DIFF
--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -887,9 +887,10 @@ async fn list_policies(
 )]
 async fn create_policy(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Json(body): Json<CreatePolicyRequest>,
 ) -> Result<Json<PolicyResponse>> {
+    auth.require_admin()?;
     let svc = PolicyService::new(state.db.clone());
     let p = svc
         .create_policy(
@@ -949,10 +950,11 @@ async fn get_policy(
 )]
 async fn update_policy(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(body): Json<UpdatePolicyRequest>,
 ) -> Result<Json<PolicyResponse>> {
+    auth.require_admin()?;
     let svc = PolicyService::new(state.db.clone());
     // PUT is partial-update friendly: any field client omits is left at its
     // current DB value via COALESCE in the service layer. See #1374.
@@ -989,9 +991,10 @@ async fn update_policy(
 )]
 async fn delete_policy(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
+    auth.require_admin()?;
     let svc = PolicyService::new(state.db.clone());
     svc.delete_policy(id).await?;
     Ok(Json(serde_json::json!({ "deleted": true })))
@@ -1236,6 +1239,32 @@ mod tests {
                 body_of(reader).contains("require_visible("),
                 "{} must call require_visible (xtenant)",
                 reader
+            );
+        }
+    }
+
+    /// Admin gate on the GLOBAL security-policy write handlers. The global
+    /// /api/v1/security/policies write endpoints must be admin-only, matching
+    /// every sibling governance endpoint; otherwise any authenticated user can
+    /// disable/delete org-wide scan policies. String-grep because the handlers
+    /// need a full DB-backed `SharedState` to run.
+    #[test]
+    fn test_global_policy_write_handlers_require_admin() {
+        let source = include_str!("security.rs");
+        let body_of = |handler: &str| -> &str {
+            let marker = format!("async fn {}(", handler);
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler `{}` not found", handler));
+            let rest = &source[start + marker.len()..];
+            let end = rest.find("\nasync fn ").unwrap_or(rest.len());
+            &rest[..end]
+        };
+        for writer in ["create_policy", "update_policy", "delete_policy"] {
+            assert!(
+                body_of(writer).contains("require_admin("),
+                "{} must call require_admin (global policy write is admin-only)",
+                writer
             );
         }
     }


### PR DESCRIPTION
Closes #2224

## Summary

The global security-policy write endpoints under `/api/v1/security/policies` were
missing the admin authorization gate that every sibling governance endpoint
enforces. `create_policy`, `update_policy`, and `delete_policy` bound the auth
extension as `_auth` (discarded) and performed no authorization check, so any
authenticated user could create, modify, or delete org-wide vulnerability-scan
policies (`repository_id: null`) — including flipping `is_enabled` / `block_on_fail`
on admin-authored policies to silently disable supply-chain scan gates.

This adds `auth.require_admin()?` as the first statement of each of the three write
handlers, matching the flat pattern already used by the sibling governance handlers
(`service_accounts`, `quality/gates`, `curation/rules`, `signing/keys`,
`sbom/license-policies`). `require_admin()` returns `Authorization("Admin access
required")` → HTTP 403.

Reads (`list_policies`, `get_policy`) are intentionally left open so the non-admin
security dashboard keeps working. The separate repo-owner scan-config path
(`PUT /repositories/{key}/security`, gated by `require_repo_write_access`) is not
touched.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added `test_global_policy_write_handlers_require_admin` (DB-free string-grep,
mirroring the existing `test_repo_security_handlers_enforce_tenant_gate`) asserting
each of the three write-handler bodies contains `require_admin(`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance:
- Non-admin `POST /api/v1/security/policies` → 403 `{"code":"FORBIDDEN","message":"Admin access required"}`
- Non-admin `PUT` / `DELETE /api/v1/security/policies/{id}` of an admin-created policy → 403
- Admin `POST` / `PUT` / `DELETE /api/v1/security/policies` → 200
- Non-admin `GET /api/v1/security/policies` → 200 (read remains open)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

