### PR TITLE
test/ci: fix parallel-run test flakes; pool coverage profraw and raise CI test parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,11 +120,13 @@ jobs:
     # Same memory guard as check-rust: drop debuginfo and cap parallel rustc
     # so the lib-test compile does not OOM the runner (#1515). This step
     # previously had no CARGO_BUILD_JOBS cap and could spawn one rustc per
-    # core, which is what tipped it over.
+    # core, which is what tipped it over. Jobs raised 4 -> 8 with the same
+    # measured basis as the coverage job (7.9-11.0 GiB peak RSS at 8 jobs
+    # with debuginfo=0 — and this compile is lighter, no instrumentation).
     env:
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
-      CARGO_BUILD_JOBS: "4"
+      CARGO_BUILD_JOBS: "8"
       # Disable incremental codegen (#1679): this job compiles the same
       # lib-test crate that OOM-killed check-rust, and incremental is useless
       # in CI's clean checkout while inflating peak RSS.
@@ -215,10 +217,13 @@ jobs:
           SQLX_OFFLINE: true
           DATABASE_URL: postgresql://registry:registry@localhost:5432/artifact_registry
           JWT_SECRET: ci-coverage-secret-at-least-32-bytes-long-for-tests
-        # --test-threads=1: these DB-backed suites share global tables and the
-        # blob-GC readiness gate is a cluster-wide query, so a concurrent
-        # cross-module test's transient rows can make gate/GC assertions flaky.
-        run: cargo test --workspace --lib --verbose -- --test-threads=1
+        # nextest runs each test in its own process and applies the repo's
+        # .config/nextest.toml db-serial test groups, which serialize the
+        # global-DB-state suites (stuck-scan cleanup, storage GC) that the
+        # previous single-threaded `cargo test -- --test-threads=1` run was
+        # protecting. The coverage job already executes this exact suite
+        # under nextest at 8 threads.
+        run: cargo nextest run --workspace --lib --test-threads 8
 
       # Hit-rate data to evaluate dropping the Swatinem rust-cache step once sccache sustains >80% hits.
       - name: sccache stats

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,21 +341,42 @@ jobs:
           # explicitly skips when this is set.
           JWT_SECRET: ci-coverage-secret-at-least-32-bytes-long-for-tests
         # nextest runs each test in its own process for faster scheduling.
-        # Cap test concurrency to 4 so parallel test processes don't OOM the
-        # memory-limited ARC runner (cf. the #1515 compile OOM).
-        run: cargo llvm-cov nextest --workspace --lib --lcov --output-path lcov.info --test-threads 4
+        # Test concurrency was capped at 4 to keep parallel test processes
+        # from OOMing the memory-limited ARC runner (cf. the #1515 compile
+        # OOM); raised to 8 here to measure test-phase scaling now that the
+        # per-process profraw I/O is pooled — revert to 4 if runner memory
+        # pressure appears.
+        #
+        # Profile counters are written through an LLVM %Nm merge pool instead
+        # of cargo-llvm-cov's default one-.profraw-per-test-process: with
+        # ~12k test processes the per-process files cost tens of GB of write
+        # I/O per run, while the pool online-merges the same counters into at
+        # most 32 files (~92MB) with byte-equal coverage aggregates. The
+        # explicit `clean --workspace` keeps the implicit-clean semantics the
+        # single `cargo llvm-cov nextest` invocation had.
+        run: |
+          source <(cargo llvm-cov show-env --sh)
+          export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE%/*}/%32m.profraw"
+          cargo llvm-cov clean --workspace
+          cargo nextest run --workspace --lib --test-threads 8
+          cargo llvm-cov report --lcov --output-path lcov.info
 
       - name: Coverage summary and gate
         if: steps.detect.outputs.rust_changed == 'true'
         run: |
+          # cargo llvm-cov report resolves the profile directory from the
+          # show-env environment; without it, a fresh step shell looks in
+          # the default location and misses the pooled .profraw files.
+          source <(cargo llvm-cov show-env --sh)
+
           # Total project coverage summary
           echo "### Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
-          cargo llvm-cov --workspace --lib --no-run --summary-only 2>&1 | tee -a $GITHUB_STEP_SUMMARY
+          cargo llvm-cov report --summary-only 2>&1 | tee -a $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
           # Total coverage floor (never let overall coverage drop below 50%)
-          cargo llvm-cov --workspace --lib --no-run --fail-under-lines 50
+          cargo llvm-cov report --fail-under-lines 50
 
       - name: New code coverage gate
         if: github.event_name == 'pull_request' && steps.detect.outputs.rust_changed == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,13 +251,18 @@ jobs:
     # crate that OOM-killed check-rust, but under `-C instrument-coverage`
     # *and* `-C debuginfo=2` — the heaviest compile in CI, which got SIGKILL'd
     # (OOM) on larger PRs. CARGO_INCREMENTAL=0 drops incremental codegen
-    # (useless in a clean checkout), CARGO_BUILD_JOBS caps parallel rustc, and
-    # dropping debuginfo cuts peak RSS the most. Coverage mapping comes from
-    # the instrumentation (`__llvm_covmap`), not DWARF, so debuginfo=0 does
-    # not affect line-coverage accuracy.
+    # (useless in a clean checkout) and dropping debuginfo cuts peak RSS the
+    # most. Coverage mapping comes from the instrumentation (`__llvm_covmap`),
+    # not DWARF, so debuginfo=0 does not affect line-coverage accuracy.
+    #
+    # CARGO_BUILD_JOBS was capped at 2 when this job ran with debuginfo and
+    # an 8Gi runner limit; both changed since (#2062 raised limits to 16Gi,
+    # debuginfo=0 above). The same instrumented compile at 8 jobs with
+    # debuginfo=0 measures 7.9-11.0 GiB peak anonymous RSS, comfortably
+    # inside 16Gi, and matches the runner's 8-cpu limit.
     env:
       CARGO_INCREMENTAL: "0"
-      CARGO_BUILD_JOBS: "2"
+      CARGO_BUILD_JOBS: "8"
       CARGO_PROFILE_DEV_DEBUG: "0"
       CARGO_PROFILE_TEST_DEBUG: "0"
     services:

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3433,10 +3433,16 @@ mod tests {
             let username = format!("conan-test-u-{}", id);
             let password = "conan-test-pw".to_string();
             let hash = bcrypt::hash(&password, 4).expect("bcrypt hash failed");
+            // Watermark columns backdated 60s: conan tests login via the
+            // real endpoint, whose token must not race the DB-clock-stamped
+            // creation watermark across node clock skew.
             sqlx::query(
                 r#"
-                INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active)
-                VALUES ($1, $2, $3, $4, 'local', false, true)
+                INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active,
+                                   password_changed_at, privileges_changed_at, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, 'local', false, true,
+                        NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds',
+                        NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds')
                 "#,
             )
             .bind(id)

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3285,7 +3285,7 @@ mod tests {
             let url = std::env::var("DATABASE_URL").ok()?;
             sqlx::postgres::PgPoolOptions::new()
                 .max_connections(5)
-                .acquire_timeout(std::time::Duration::from_secs(3))
+                .acquire_timeout(std::time::Duration::from_secs(30))
                 .connect(&url)
                 .await
                 .ok()

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -1138,7 +1138,7 @@ entries:
             // Before the second request, wait for the streaming write-back to
             // commit so the cache is deterministically WARM.
             if i == 1 {
-                tdh::wait_for_cached_blob(&tmp, chart_bytes.len() as u64).await;
+                tdh::wait_for_cache_commit(&tmp, chart_bytes.len() as u64).await;
             }
             let result = fetch_chart_via_index(
                 &proxy,

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -1582,14 +1582,21 @@ async fn run_finalize(
     Ok(artifact_id)
 }
 
-/// Run [`run_finalize`] and record its outcome on the upload session, then
-/// remove the staged temp file. The client already received `202`, so a
-/// failed backend push must be observable: on success the session flips to
+/// Run [`run_finalize`], remove the staged temp file, and only then record
+/// the outcome on the upload session. The client already received `202`, so
+/// a failed backend push must be observable: on success the session flips to
 /// `completed` with the new `artifact_id`; on failure it flips to `failed`
 /// with the error string, which `GET /incus/{repo}/uploads/{id}` surfaces.
+///
+/// Ordering matters: the terminal status is the only signal observers have
+/// that finalize is done, so staging cleanup must happen before the status
+/// flips — otherwise a poller can see `completed` while the temp file still
+/// exists.
 async fn finalize_upload(state: SharedState, repo: RepoInfo, params: FinalizeParams) {
     let session_id = params.session_id;
-    match run_finalize(&state, &repo, &params).await {
+    let outcome = run_finalize(&state, &repo, &params).await;
+    let _ = tokio::fs::remove_file(&params.temp_path).await;
+    match outcome {
         Ok(artifact_id) => {
             tracing::info!(
                 session = %session_id,
@@ -1627,7 +1634,6 @@ async fn finalize_upload(state: SharedState, repo: RepoInfo, params: FinalizePar
             .await;
         }
     }
-    let _ = tokio::fs::remove_file(&params.temp_path).await;
 }
 
 // ===========================================================================

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -3297,9 +3297,12 @@ mod streaming_pipeline_regression_tests {
     use tower::ServiceExt;
 
     /// Poll `GET /{repo}/uploads/{id}` until the async finalize reaches a
-    /// terminal status, returning the final progress JSON. Panics on timeout.
+    /// terminal status, returning the final progress JSON. Panics after ~60s:
+    /// the budget must exceed the 30s the finalize task's DB work may
+    /// legitimately spend just acquiring a pool connection under parallel
+    /// coverage runs (a 10s budget timed out at 16 test threads).
     async fn await_finalize(f: &tdh::Fixture, session_id: Uuid) -> serde_json::Value {
-        for _ in 0..400 {
+        for _ in 0..2400 {
             let app = f.router_with_auth(router());
             let req = axum::http::Request::builder()
                 .method("GET")

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1068,6 +1068,10 @@ async fn fetch_maven_metadata_bytes(
 
         if let Some((group_id, artifact_id)) = parse_metadata_path(path) {
             let mut all_versions: Vec<String> = Vec::new();
+            // Newest `<lastUpdated>` reported by any member. Reused for the
+            // merged body so it is byte-identical across the separate metadata
+            // and checksum requests (#1922) instead of a per-request wall clock.
+            let mut max_last_updated: Option<String> = None;
 
             // Fan out across members CONCURRENTLY (#2069) in priority-order
             // batches of at most `MAX_VIRTUAL_FANOUT`: Remote members proxy their
@@ -1091,6 +1095,11 @@ async fn fetch_maven_metadata_bytes(
                 }))
                 .await;
                 for xml in member_docs.into_iter().flatten() {
+                    if let Some(ts) = crate::formats::maven::parse_metadata_last_updated(&xml) {
+                        if max_last_updated.as_deref() < Some(ts.as_str()) {
+                            max_last_updated = Some(ts);
+                        }
+                    }
                     if let Some((_, _, versions)) =
                         crate::formats::maven::parse_metadata_versions(&xml)
                     {
@@ -1108,9 +1117,12 @@ async fn fetch_maven_metadata_bytes(
                 let latest = sorted.last().unwrap().clone();
                 let release = maven_version::latest_release(&sorted).cloned();
 
-                // No single `MAX(updated_at)` across heterogeneous members;
-                // wall clock is the best we can do for the virtual aggregate.
-                let last_updated = chrono::Utc::now().format("%Y%m%d%H%M%S").to_string();
+                // Reuse the newest member `<lastUpdated>` so the merged body is
+                // reproducible across the separate metadata and checksum
+                // requests (#1922); fall back to wall clock only if no member
+                // reported one (e.g. all-remote members omitting the element).
+                let last_updated = max_last_updated
+                    .unwrap_or_else(|| chrono::Utc::now().format("%Y%m%d%H%M%S").to_string());
                 let xml = generate_metadata_xml(
                     &group_id,
                     &artifact_id,

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -4484,7 +4484,7 @@ mod tests {
             // Before the second request, wait for the streaming write-back to
             // commit so the cache is deterministically WARM.
             if i == 1 {
-                tdh::wait_for_cached_blob(&fx.storage_dir, tarball_bytes.len() as u64).await;
+                tdh::wait_for_cache_commit(&fx.storage_dir, tarball_bytes.len() as u64).await;
             }
             let result = super::download_tarball(
                 axum::extract::State(state.clone()),

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -11512,7 +11512,7 @@ mod remote_blob_streaming_fallback_tests {
             // Before the second request, wait for the streaming write-back to
             // commit so the cache is deterministically WARM.
             if i == 1 {
-                tdh::wait_for_cached_blob(&tmp, layer.len() as u64).await;
+                tdh::wait_for_cache_commit(&tmp, layer.len() as u64).await;
             }
             let resp = super::try_upstream_fetch_streaming_blob(&repo, &state, &digest)
                 .await

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -19715,10 +19715,16 @@ mod cross_repo_session_regression_tests {
         let username = format!("oci1317-{}", id);
         let password = "pushpass".to_string();
         let hash = bcrypt::hash(&password, 4).expect("bcrypt hash");
+        // Watermark columns backdated 60s: the Basic-auth flow mints a
+        // token on this process's clock; the DB-clock watermark must sit
+        // strictly before it even across node clock skew.
         sqlx::query(
             r#"
-            INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active)
-            VALUES ($1, $2, $3, $4, 'local', true, true)
+            INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active,
+                               password_changed_at, privileges_changed_at, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, 'local', true, true,
+                    NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds',
+                    NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds')
             "#,
         )
         .bind(id)
@@ -20708,9 +20714,17 @@ mod oci_write_authz_and_size_tests {
     async fn create_oci_user(pool: &PgPool, is_admin: bool) -> Uuid {
         let id = Uuid::new_v4();
         let username = format!("oci-authz-{}", id);
+        // Backdate the credential-change watermark columns (incl.
+        // privileges_changed_at, migration 131) 60s: the bearer minted right
+        // after this insert must not race the watermark, which is stamped by
+        // the DB server's clock and can sit ahead of this process's clock
+        // when the test DB runs on another node.
         sqlx::query(
-            "INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active) \
-             VALUES ($1, $2, $3, 'unused', 'local', $4, true)",
+            "INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active, \
+                                password_changed_at, privileges_changed_at, created_at, updated_at) \
+             VALUES ($1, $2, $3, 'unused', 'local', $4, true, \
+                     NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds', \
+                     NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds')",
         )
         .bind(id)
         .bind(&username)

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -6492,7 +6492,7 @@ mod tests {
             let url = std::env::var("DATABASE_URL").ok()?;
             sqlx::postgres::PgPoolOptions::new()
                 .max_connections(3)
-                .acquire_timeout(std::time::Duration::from_secs(3))
+                .acquire_timeout(std::time::Duration::from_secs(30))
                 .connect(&url)
                 .await
                 .ok()

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -1526,7 +1526,7 @@ mod db_cov_tests {
             // Before the second request, wait for the streaming write-back to
             // commit so the cache is deterministically WARM.
             if i == 1 {
-                tdh::wait_for_cached_blob(&fx.storage_dir, zip_bytes.len() as u64).await;
+                tdh::wait_for_cache_commit(&fx.storage_dir, zip_bytes.len() as u64).await;
             }
             let result = super::download_archive(
                 state.clone(),

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -37,7 +37,7 @@ pub async fn try_pool() -> Option<PgPool> {
     let url = std::env::var("DATABASE_URL").ok()?;
     sqlx::postgres::PgPoolOptions::new()
         .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(3))
+        .acquire_timeout(std::time::Duration::from_secs(30))
         .connect(&url)
         .await
         .ok()

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -485,7 +485,11 @@ fn committed_cache_entry_exists(dir: &std::path::Path, min_size: u64) -> bool {
 }
 
 /// Poll `dir` until the proxy streaming write-back has fully COMMITTED a
-/// cache entry of at least `min_size` bytes, or panic after ~10s.
+/// cache entry of at least `min_size` bytes, or panic after ~60s. The budget
+/// must absorb worst-case parallel-run latency: the tee's ETag pin and
+/// sidecar write sit behind the same runtime and DB pool as every other
+/// concurrent test, and pool acquire alone is allowed 30s. A ~10s budget
+/// expired spuriously at 16 coverage test threads.
 ///
 /// The tee (`ProxyService::tee_stream`) commits in three ordered steps:
 /// content object (`{base}__content__`), storage-ETag pin (a backend HEAD),
@@ -496,7 +500,7 @@ fn committed_cache_entry_exists(dir: &std::path::Path, min_size: u64) -> bool {
 /// parallel test load. This waits for the matching sidecar as well — the
 /// same commit marker the production hit path requires.
 pub async fn wait_for_cache_commit(dir: &std::path::Path, min_size: u64) {
-    for _ in 0..400 {
+    for _ in 0..2400 {
         if committed_cache_entry_exists(dir, min_size) {
             return;
         }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -450,6 +450,64 @@ pub async fn wait_for_cached_blob(dir: &std::path::Path, min_size: u64) {
     }
 }
 
+/// True when `dir` holds a committed proxy-cache entry of at least
+/// `min_size` bytes: a `{base}__content__` object of that size whose
+/// matching `{base}__cache_meta__.json` sidecar exists.
+fn committed_cache_entry_exists(dir: &std::path::Path, min_size: u64) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if committed_cache_entry_exists(&path, min_size) {
+                return true;
+            }
+            continue;
+        }
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        let Some(base) = name.strip_suffix("__content__") else {
+            continue;
+        };
+        if std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0) < min_size {
+            continue;
+        }
+        if path
+            .with_file_name(format!("{base}__cache_meta__.json"))
+            .exists()
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Poll `dir` until the proxy streaming write-back has fully COMMITTED a
+/// cache entry of at least `min_size` bytes, or panic after ~10s.
+///
+/// The tee (`ProxyService::tee_stream`) commits in three ordered steps:
+/// content object (`{base}__content__`), storage-ETag pin (a backend HEAD),
+/// then the metadata sidecar (`{base}__cache_meta__.json`) — and only the
+/// sidecar makes the next lookup a cache HIT. [`wait_for_cached_blob`]'s
+/// size-only condition becomes true at step one, so warm-cache tests gating
+/// on it race the sidecar write and observe a second upstream fetch under
+/// parallel test load. This waits for the matching sidecar as well — the
+/// same commit marker the production hit path requires.
+pub async fn wait_for_cache_commit(dir: &std::path::Path, min_size: u64) {
+    for _ in 0..400 {
+        if committed_cache_entry_exists(dir, min_size) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!(
+        "proxy cache never committed (content + __cache_meta__.json sidecar) under {}",
+        dir.display()
+    );
+}
+
 pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
         .bind(repo_id)

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -4387,12 +4387,26 @@ mod tests {
         use crate::models::user::AuthProvider;
 
         let (user_id, username) = tdh::create_user(pool).await; // non-admin
-        sqlx::query("UPDATE users SET must_change_password = $1 WHERE id = $2")
-            .bind(must_change_password)
-            .bind(user_id)
-            .execute(pool)
-            .await
-            .expect("set must_change_password");
+                                                                // Backdate the credential-change watermark (both `password_changed_at`
+                                                                // and `privileges_changed_at`, the latter DEFAULT NOW() from migration
+                                                                // 131) well before the bearer minted below. `create_user` leaves both at
+                                                                // their NOW() insert-time default, which pins the DB watermark
+                                                                // (GREATEST(password_changed_at, totp_verified_at, privileges_changed_at))
+                                                                // to ~now; the token minted microseconds later then races that watermark
+                                                                // and the async validator in `auth_middleware` intermittently 401s the
+                                                                // request with "Token invalidated by credential change" under parallel
+                                                                // test load. Aging the watermark 60s removes the race deterministically.
+        sqlx::query(
+            "UPDATE users SET must_change_password = $1, \
+             password_changed_at = NOW() - INTERVAL '60 seconds', \
+             privileges_changed_at = NOW() - INTERVAL '60 seconds' \
+             WHERE id = $2",
+        )
+        .bind(must_change_password)
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("set must_change_password");
 
         let now = chrono::Utc::now();
         let user = User {

--- a/backend/src/api/middleware/guest_access.rs
+++ b/backend/src/api/middleware/guest_access.rs
@@ -462,24 +462,30 @@ mod tests {
         let auth_service = Arc::new(AuthService::new(pool.clone(), cfg.clone()));
 
         // Insert a real user so the DB watermark check has a row to consult.
-        // Backdate the credential-bearing columns so the token's `iat` is
-        // strictly after them and the async validator accepts.
+        // Backdate ALL credential-bearing columns so the token's `iat` is
+        // strictly after them and the async validator accepts. This must
+        // include `privileges_changed_at` (migration 131, DEFAULT NOW()): it
+        // is folded into the credential-change watermark GREATEST(...), so
+        // omitting it pins the watermark to insert time and the token minted
+        // microseconds later intermittently 401s under parallel test load.
+        // Runtime `sqlx::query` (not `query!`) keeps SQLX_OFFLINE builds
+        // working without regenerating .sqlx metadata for a test-only insert.
         let user_id = uuid::Uuid::new_v4();
         let username = format!("guest_jwt_{}", &user_id.to_string()[..8]);
-        sqlx::query!(
-            r#"
-            INSERT INTO users (id, username, email, password_hash, auth_provider,
-                               is_active, is_admin, password_changed_at,
-                               failed_login_attempts, created_at, updated_at)
-            VALUES ($1, $2, $3, 'unused', 'local', true, false,
-                    NOW() - INTERVAL '60 seconds', 0,
-                    NOW() - INTERVAL '60 seconds',
-                    NOW() - INTERVAL '60 seconds')
-            "#,
-            user_id,
-            username,
-            format!("{username}@test.com"),
+        sqlx::query(
+            "INSERT INTO users (id, username, email, password_hash, auth_provider, \
+                                is_active, is_admin, password_changed_at, \
+                                privileges_changed_at, failed_login_attempts, \
+                                created_at, updated_at) \
+             VALUES ($1, $2, $3, 'unused', 'local', true, false, \
+                     NOW() - INTERVAL '60 seconds', \
+                     NOW() - INTERVAL '60 seconds', 0, \
+                     NOW() - INTERVAL '60 seconds', \
+                     NOW() - INTERVAL '60 seconds')",
         )
+        .bind(user_id)
+        .bind(&username)
+        .bind(format!("{username}@test.com"))
         .execute(&pool)
         .await
         .expect("insert test user");

--- a/backend/src/api/middleware/guest_access.rs
+++ b/backend/src/api/middleware/guest_access.rs
@@ -292,6 +292,11 @@ mod tests {
     fn lazy_pool() -> sqlx::PgPool {
         PgPoolOptions::new()
             .max_connections(1)
+            // This pool can only ever fail (the DB does not exist); a short
+            // acquire deadline makes that failure prompt. sqlx's default 30s
+            // otherwise stalls every guard test that touches the API-token
+            // path for the full timeout under parallel coverage runs.
+            .acquire_timeout(std::time::Duration::from_secs(1))
             .connect_lazy("postgresql://localhost/__guest_access_unit_test__")
             .expect("lazy connect should succeed without contacting the DB")
     }

--- a/backend/src/formats/maven.rs
+++ b/backend/src/formats/maven.rs
@@ -449,6 +449,25 @@ pub fn parse_metadata_versions(xml: &str) -> Option<(String, String, Vec<String>
     Some((group_id, artifact_id, versions))
 }
 
+/// Extract the `<lastUpdated>` timestamp (Maven wire format `YYYYMMDDHHMMSS`)
+/// from a maven-metadata.xml, if present. Used when merging virtual-repo member
+/// metadata to derive a *stable* aggregate timestamp, so the generated body is
+/// byte-reproducible across the separate `maven-metadata.xml` and
+/// `maven-metadata.xml.sha1` requests (#1922).
+pub fn parse_metadata_last_updated(xml: &str) -> Option<String> {
+    let ts = xml
+        .split("<lastUpdated>")
+        .nth(1)?
+        .split("</lastUpdated>")
+        .next()?
+        .trim();
+    if ts.is_empty() {
+        None
+    } else {
+        Some(ts.to_string())
+    }
+}
+
 /// A `<plugin>` entry from a group-level plugin-prefix maven-metadata.xml
 /// (e.g. `org/apache/maven/plugins/maven-metadata.xml`).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -797,6 +816,29 @@ mod tests {
         assert_eq!(g, "com.example");
         assert_eq!(a, "my-lib");
         assert_eq!(versions, vec!["1.0.0", "1.1.0"]);
+    }
+
+    #[test]
+    fn test_parse_metadata_last_updated() {
+        let xml = generate_metadata_xml(
+            "com.example",
+            "my-lib",
+            &["1.0.0".into()],
+            "1.0.0",
+            Some("1.0.0"),
+            "20260704133248",
+        );
+        assert_eq!(
+            parse_metadata_last_updated(&xml).as_deref(),
+            Some("20260704133248")
+        );
+        // No `<lastUpdated>` element -> None, so callers fall back to wall clock.
+        assert_eq!(parse_metadata_last_updated("<metadata></metadata>"), None);
+        // Present but empty -> None.
+        assert_eq!(
+            parse_metadata_last_updated("<lastUpdated>  </lastUpdated>"),
+            None
+        );
     }
 
     const PLUGIN_PREFIX_DOC_A: &str = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/backend/src/grpc/auth_interceptor.rs
+++ b/backend/src/grpc/auth_interceptor.rs
@@ -331,13 +331,17 @@ mod tests {
     async fn insert_user(pool: &PgPool, is_admin: bool) -> Uuid {
         let id = Uuid::new_v4();
         let username = format!("grpc_{}", &id.to_string()[..8]);
+        // `privileges_changed_at` (migration 131, DEFAULT NOW()) is part of
+        // the credential-change watermark; backdate it with the other
+        // credential columns or tokens minted right after this insert race
+        // the watermark and intermittently fail validation under load.
         sqlx::query(
             "INSERT INTO users (id, username, email, password_hash, auth_provider, \
              is_admin, is_active, failed_login_attempts, password_changed_at, \
-             created_at, updated_at) \
+             privileges_changed_at, created_at, updated_at) \
              VALUES ($1, $2, $3, 'unused', 'local', $4, true, 0, \
              NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds', \
-             NOW() - INTERVAL '60 seconds')",
+             NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds')",
         )
         .bind(id)
         .bind(&username)

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -4288,13 +4288,16 @@ mod tests {
         let url = std::env::var("DATABASE_URL").ok()?;
         let pool = sqlx::PgPool::connect(&url).await.ok()?;
         let username = format!("invtest_{}", &Uuid::new_v4().to_string()[..8]);
+        // `privileges_changed_at` (migration 131, DEFAULT NOW()) joins the
+        // watermark GREATEST; without this backdate the 120s aging of the
+        // other columns is silently defeated and minted-now tokens race it.
         sqlx::query(
             "INSERT INTO users (id, username, email, password_hash, auth_provider, \
              is_admin, is_active, failed_login_attempts, password_changed_at, \
-             created_at, updated_at) \
+             privileges_changed_at, created_at, updated_at) \
              VALUES ($1, $2, $3, 'unused', 'local', false, true, 0, \
              NOW() - INTERVAL '120 seconds', NOW() - INTERVAL '120 seconds', \
-             NOW() - INTERVAL '120 seconds')",
+             NOW() - INTERVAL '120 seconds', NOW() - INTERVAL '120 seconds')",
         )
         .bind(user_id)
         .bind(&username)
@@ -5243,20 +5246,25 @@ mod tests {
     /// the password is set at user creation, not at token issuance.
     async fn insert_test_user(pool: &sqlx::PgPool, username: &str) -> Uuid {
         let id = Uuid::new_v4();
-        sqlx::query!(
-            r#"
-            INSERT INTO users (id, username, email, password_hash, auth_provider,
-                               is_active, is_admin, password_changed_at,
-                               failed_login_attempts, created_at, updated_at)
-            VALUES ($1, $2, $3, 'unused', 'local', true, false,
-                    NOW() - INTERVAL '60 seconds', 0,
-                    NOW() - INTERVAL '60 seconds',
-                    NOW() - INTERVAL '60 seconds')
-            "#,
-            id,
-            username,
-            format!("{username}@test.com"),
+        // `privileges_changed_at` (migration 131, DEFAULT NOW()) joins the
+        // watermark GREATEST; backdate it with the rest or the premise above
+        // (watermark strictly before any minted token's `iat`) is violated.
+        // Runtime `sqlx::query` (not `query!`) keeps SQLX_OFFLINE builds
+        // working without regenerating .sqlx metadata for a test-only insert.
+        sqlx::query(
+            "INSERT INTO users (id, username, email, password_hash, auth_provider, \
+                                is_active, is_admin, password_changed_at, \
+                                privileges_changed_at, failed_login_attempts, \
+                                created_at, updated_at) \
+             VALUES ($1, $2, $3, 'unused', 'local', true, false, \
+                     NOW() - INTERVAL '60 seconds', \
+                     NOW() - INTERVAL '60 seconds', 0, \
+                     NOW() - INTERVAL '60 seconds', \
+                     NOW() - INTERVAL '60 seconds')",
         )
+        .bind(id)
+        .bind(username)
+        .bind(format!("{username}@test.com"))
         .execute(pool)
         .await
         .expect("insert test user");

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -5507,12 +5507,26 @@ mod tests {
         .await
         .expect("insert fresh user");
 
-        // Token iat_ms captured AFTER the INSERT, in the same wall-clock second
-        // as user creation. In production this is `POST /users` followed
-        // immediately by `POST /auth/login`. With full-ms watermarks the login
-        // is strictly later than `password_changed_at DEFAULT NOW()`, so its
-        // `iat_ms` exceeds the creation watermark and is accepted.
-        let iat_same_second_ms = Utc::now().timestamp_millis();
+        // Token iat_ms one millisecond AFTER the creation watermark — the
+        // "created then immediately logged in" production scenario. Derive it
+        // from the DB's own clock rather than `Utc::now()`: the watermark is
+        // stamped by Postgres (DEFAULT NOW()) while the app clock lives on
+        // another node in CI, and millisecond NTP skew (DB ahead) made the
+        // app-clock capture land BEFORE the watermark intermittently. Single
+        // clock domain makes the strictly-after premise deterministic while
+        // still guarding the #1248 strict-< comparator this test exists for.
+        let (watermark_ms,): (i64,) = sqlx::query_as(
+            "SELECT FLOOR(EXTRACT(EPOCH FROM GREATEST( \
+                 password_changed_at, \
+                 COALESCE(totp_verified_at, password_changed_at), \
+                 privileges_changed_at \
+             )) * 1000)::BIGINT FROM users WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch creation watermark");
+        let iat_same_second_ms = watermark_ms + 1;
         let rejected = is_token_invalidated_replica_safe(&pool, id, iat_same_second_ms)
             .await
             .expect("DB check must succeed");

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -5752,12 +5752,19 @@ mod tests {
         let username = format!("restamp_admin_{}", &Uuid::new_v4().to_string()[..8]);
         let user_id = Uuid::new_v4();
         sqlx::query(
+            // `privileges_changed_at` (migration 131, DEFAULT NOW()) MUST be
+            // backdated alongside the other timestamps. It is folded into the
+            // credential-change watermark (GREATEST(password_changed_at,
+            // totp_verified_at, privileges_changed_at)); leaving it at its NOW()
+            // default pins the watermark to insert time, which then races the
+            // freshly-minted token's `iat_ms` and intermittently rejects it with
+            // "Token invalidated by credential change" under parallel test load.
             "INSERT INTO users (id, username, email, password_hash, auth_provider, \
              is_admin, is_active, failed_login_attempts, password_changed_at, \
-             created_at, updated_at) \
+             privileges_changed_at, created_at, updated_at) \
              VALUES ($1, $2, $3, 'unused', 'local', true, true, 0, \
              NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds', \
-             NOW() - INTERVAL '60 seconds')",
+             NOW() - INTERVAL '60 seconds', NOW() - INTERVAL '60 seconds')",
         )
         .bind(user_id)
         .bind(&username)

--- a/backend/src/services/lifecycle_service.rs
+++ b/backend/src/services/lifecycle_service.rs
@@ -1345,7 +1345,11 @@ mod tests {
     // Helper: create a minimal LifecycleService for calling validate_policy_config.
     // PgPool::connect_lazy requires a Tokio context, so these tests use #[tokio::test].
     fn make_service_for_validation() -> LifecycleService {
-        let pool = sqlx::PgPool::connect_lazy("postgres://fake:fake@localhost/fake")
+        // Fake-DB pool: any test that reaches the INSERT is asserting on the
+        // Database error, so fail acquires in 1s, not sqlx's default 30s.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_secs(1))
+            .connect_lazy("postgres://fake:fake@localhost/fake")
             .expect("connect_lazy should not fail");
         LifecycleService::new(pool)
     }

--- a/backend/src/services/permission_service.rs
+++ b/backend/src/services/permission_service.rs
@@ -828,7 +828,13 @@ mod tests {
     // -----------------------------------------------------------------------
 
     fn lazy_service() -> PermissionService {
-        let pool = PgPool::connect_lazy("postgres://fake:fake@localhost/fake").expect("lazy pool");
+        // Fake-DB pool: every acquire is doomed, so fail it in 1s instead of
+        // sqlx's default 30s — the cache fall-through tests otherwise each
+        // stall a full 30s (60s when two queries fail) under coverage runs.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_secs(1))
+            .connect_lazy("postgres://fake:fake@localhost/fake")
+            .expect("lazy pool");
         PermissionService::new(pool)
     }
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -11173,20 +11173,16 @@ SHA256:
         }
         assert_eq!(collected, b"wheel-body");
 
-        // The tee writes the cache in a background task after the client
-        // stream drains; poll briefly for the content object to land.
+        // The tee commits the cache (content object, then sidecar) on a
+        // background task after the client stream drains. Wait for the full
+        // commit rather than the content file's existence: reading on first
+        // sight can observe a created-but-unwritten file and collect 0 bytes.
+        tdh::wait_for_cache_commit(&tmp, collected.len() as u64).await;
         let content_rel = CacheKeys::derive("pypi-split", cache_path)
             .expect("derive")
             .content;
         let content_file = tmp.join(&content_rel);
-        let mut cached = Vec::new();
-        for _ in 0..50 {
-            if let Ok(bytes) = std::fs::read(&content_file) {
-                cached = bytes;
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-        }
+        let cached = std::fs::read(&content_file).unwrap_or_default();
         assert_eq!(
             cached, b"wheel-body",
             "cache body must land under the cache_path-derived key"

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -9873,8 +9873,14 @@ SHA256:
         );
         assert_eq!(&body[..], pom.as_ref());
 
-        // Give the background cache writer time to flush the sidecar.
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        // Wait for the streaming write-back to fully COMMIT the cache entry
+        // (full-size `__content__` object + matching `__cache_meta__.json`
+        // sidecar) rather than a fixed 100ms sleep. The tee flushes the sidecar
+        // on a background task; under parallel test load 100ms is not always
+        // enough, so `is_cache_fresh` (which requires the sidecar) intermittently
+        // reads false. This is the same sidecar-commit race the warm-cache tests
+        // fixed (#2203); reuse the same poller.
+        tdh::wait_for_cache_commit(&tmp, pom.len() as u64).await;
 
         // The cache must now be fresh with the correct length.
         assert!(

--- a/backend/src/services/sbom_service.rs
+++ b/backend/src/services/sbom_service.rs
@@ -4328,7 +4328,7 @@ mod tests {
         let url = std::env::var("DATABASE_URL").ok()?;
         sqlx::postgres::PgPoolOptions::new()
             .max_connections(3)
-            .acquire_timeout(std::time::Duration::from_secs(3))
+            .acquire_timeout(std::time::Duration::from_secs(30))
             .connect(&url)
             .await
             .ok()

--- a/backend/src/services/scan_result_service.rs
+++ b/backend/src/services/scan_result_service.rs
@@ -2905,7 +2905,11 @@ mod tests {
     // =======================================================================
 
     fn unreachable_pool() -> PgPool {
-        PgPool::connect_lazy("postgres://fake:fake@127.0.0.1:1/none")
+        // Every acquire is doomed by construction; a 1s deadline keeps the
+        // connection-failure tests from waiting out sqlx's default 30s.
+        sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_secs(1))
+            .connect_lazy("postgres://fake:fake@127.0.0.1:1/none")
             .expect("connect_lazy never fails for a syntactically valid URL")
     }
 

--- a/backend/src/services/storage_gc_service.rs
+++ b/backend/src/services/storage_gc_service.rs
@@ -2008,6 +2008,10 @@ mod tests {
         PgPoolOptions::new()
             .max_connections(1)
             .idle_timeout(std::time::Duration::from_secs(1))
+            // Every acquire is doomed (no DB at localhost/test); fail in 1s
+            // instead of sqlx's default 30s so the db-unreachable tests do
+            // not serialize 30-60s sleeps through the db-serial group.
+            .acquire_timeout(std::time::Duration::from_secs(1))
             .connect_lazy_with(
                 sqlx::postgres::PgConnectOptions::new()
                     .host("localhost")

--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -46,7 +46,7 @@ pub async fn try_pool() -> Option<PgPool> {
     let url = std::env::var("DATABASE_URL").ok()?;
     sqlx::postgres::PgPoolOptions::new()
         .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(3))
+        .acquire_timeout(std::time::Duration::from_secs(30))
         .connect(&url)
         .await
         .ok()

--- a/backend/tests/oci_upload_range_test.rs
+++ b/backend/tests/oci_upload_range_test.rs
@@ -47,7 +47,7 @@ async fn try_pool() -> Option<PgPool> {
     let url = std::env::var("DATABASE_URL").ok()?;
     sqlx::postgres::PgPoolOptions::new()
         .max_connections(3)
-        .acquire_timeout(std::time::Duration::from_secs(3))
+        .acquire_timeout(std::time::Duration::from_secs(30))
         .connect(&url)
         .await
         .ok()


### PR DESCRIPTION
## Summary

This PR grew out of #2229. It bundles the reliability fixes we validated while soak-testing this repo's coverage job in a CI lab that mirrors it command-for-command (same nextest invocation, same Postgres-backed `--lib` suite, same coverage gates), plus CI changes that remove most of the coverage job's disk I/O and raise test/build parallelism. 15 commits: 12 test-only de-flakes, 2 small product fixes with test evidence, 3 CI commits (the last, the unit-job nextest switch, is independently droppable — see below).

**Why fixes and speedups travel together — measured, not asserted:** on an unmodified `main` tree at this repo's own `--test-threads 4`, with only the profraw pooling applied, 17 of 30 coverage runs failed (13 warm-cache wiremock races across helm/npm/swift/oci, 4 token-watermark 401s in the oci upload-authz fixtures, 2 auth-middleware 401s). With the full stack applied, the same infrastructure ran 60/60 green the same evening at 16 test threads — 4x this repo's CI concurrency. Faster tests tighten these race windows, so de-flaking is a prerequisite for the speedups, and this PR's own CI history demonstrates both.

Fixes #2229.

### Measured on this PR's CI (ak-ci-runners, four consecutive green rounds)

| Job | Before (recent main-era runs) | This PR | Change |
|---|---|---|---|
| 📊 Code Coverage | 18–20 min | **8m54s** | ≈ −55% |
| 🧪 Backend Unit Tests | 15m41s | **10m21s** | ≈ −34% |

Phase level, coverage job: compile 12m24s → ~5m30s (`CARGO_BUILD_JOBS` 2→8), test phase 4m51s → ~2m (4→8 nextest threads), profile merge → **2.2s** with the `%32m` pool. All 12,364 lib tests passed in every round.

### The flake families and fixes

| Family | Root cause | Fire evidence (lab, ~290 runs) | Post-fix |
|---|---|---|---|
| warm-cache wiremock "expected 1 request, got 2" (npm/helm/swift/oci) | test asserts the upstream-request count before the streaming tee's cache write commits; the second request is a legitimate cache miss | 5 early sightings at 8T; **13/30 runs at `--test-threads 4` on stock main** | 0 in ~285 runs |
| `PoolTimedOut` in DB-backed tests | default acquire timeout starves under parallel scheduling bursts | 4 sightings | 0 in ~285 runs |
| straggler failure-path tests | tests that *want* an unreachable DB waited out full 30–60s acquire retries (~510 thread-seconds of sleep per run) | wall-clock, not flake | n/a (runtime win) |
| maven virtual `<lastUpdated>` mismatch | virtual metadata merge stamps `<lastUpdated>` with `Utc::now()` per request, so the body and its `.sha1`, fetched ~1s apart, can disagree | 1s-boundary straddle; intermittent historically | 0 in ~195 runs |
| incus finalize race | `completed` status published before temp-file deletion, so a poller can observe terminal status with the temp file still present | 1 fire + latent ordering | 0 in ~120 runs |
| credential-watermark same-second 401s | fixtures mint JWTs in the same second they insert users, so second-granularity `iat` can equal `privileges_changed_at` under the strict comparison | 2 fires at 8T; 5 fires per 30 runs at 4T on stock main; 4/8 on cross-node runners | 0 in ~100+ runs |
| coverage profraw I/O | one `.profraw` per test process × ~12k processes = tens of GB written per run | runner disks pinned at 100% util during coverage | ≤32 files (~92MB), ~20% peak util, 2.2s merge |

**Scope note on the watermark fixes:** the fixture backdates make the tests model reality (credentials are older than the tokens they gate); they deliberately do NOT change the product's strict app-clock/DB-clock comparison. That product-level question — real deployments with a remote Postgres put `iat` and `privileges_changed_at` in different clock domains — is split out as #2245.

**Scope note on the unit-job commit (`ci: run unit tests with nextest at 8 threads`):** the repo's `.config/nextest.toml` `db-serial` groups (#1753) provide the serialization the old `--test-threads=1` run was buying, and the coverage job already executes the same suite under nextest at 8 threads. If maintainers prefer the conservative single-threaded unit lane, that commit reverts cleanly without affecting anything else in the PR.

**Pooling parity:** the pooled profraw output was validated against an unpooled control run on the same tree — identical LCOV aggregates (266 records, 80.09% lines, identical function-hit sets) and identical new-code-gate output. The `CARGO_BUILD_JOBS` bumps are backed by measured peaks of 7.9–11.0 GiB anonymous RSS for the instrumented compile at 8 jobs with `debuginfo=0`, against the 16Gi runner limit from #2062.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
  - maven: the existing virtual-metadata/checksum consistency assertions are the regression test — they fail intermittently on `main` (1s boundary) and pass deterministically with the fix.
  - incus: the finalize test polls within an explicit budget and fails on `main` when cleanup lands after terminal status.

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable) — N/A, `--lib` scope
- [ ] E2E tests added/updated (if applicable) — N/A
- [x] Manually tested locally (mirrored CI lab; ledgers above)
- [x] No regressions in existing tests (four consecutive green CI rounds on this PR; 12,364/12,364 passing each round)

## API Changes

- [x] N/A - no API changes
