### PR TITLE
fix(auth): auto-detect HTTPS via X-Forwarded-Proto for cookie Secure flag

### DIFF
--- a/backend/src/api/extractors.rs
+++ b/backend/src/api/extractors.rs
@@ -225,6 +225,30 @@ pub fn request_base_url_from_request(headers: &HeaderMap, uri: Option<&Uri>) -> 
     }
 }
 
+/// Returns `true` when the incoming request reached the trusted edge over
+/// HTTPS, as signalled by `X-Forwarded-Proto: https` (case-insensitive).
+///
+/// This reuses the SAME `X-Forwarded-Proto` signal that
+/// [`request_base_url_from_request`] already trusts for external-URL
+/// construction, so the auth-cookie `Secure` decision and the base-URL
+/// derivation stay consistent behind a TLS-terminating reverse proxy.
+///
+/// SECURITY: trusting `X-Forwarded-Proto` here is the SAME trust posture the
+/// base-URL logic already has — it assumes a trusted reverse proxy that
+/// OVERWRITES (not appends) the header on ingress. A client spoofing
+/// `X-Forwarded-Proto: https` over a real plain-HTTP connection only makes
+/// their OWN cookie `Secure`, which the browser then refuses to resend over
+/// that same HTTP connection — self-defeating, not a privilege escalation.
+/// Operators terminating TLS at a proxy MUST configure the proxy to overwrite
+/// `X-Forwarded-Proto` on requests it forwards.
+pub fn request_scheme_is_https(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .map(|proto| proto.trim().eq_ignore_ascii_case("https"))
+        .unwrap_or(false)
+}
+
 #[allow(clippy::disallowed_methods)]
 // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
@@ -332,6 +356,33 @@ mod tests {
             request_base_url_from_request(&headers, Some(&uri)),
             "https://external.example.com"
         );
+    }
+
+    #[test]
+    fn test_request_scheme_is_https_forwarded_https() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("https"));
+        assert!(request_scheme_is_https(&headers));
+    }
+
+    #[test]
+    fn test_request_scheme_is_https_case_insensitive_and_trimmed() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", HeaderValue::from_static(" HTTPS "));
+        assert!(request_scheme_is_https(&headers));
+    }
+
+    #[test]
+    fn test_request_scheme_is_https_forwarded_http() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-proto", HeaderValue::from_static("http"));
+        assert!(!request_scheme_is_https(&headers));
+    }
+
+    #[test]
+    fn test_request_scheme_is_https_absent_header() {
+        let headers = HeaderMap::new();
+        assert!(!request_scheme_is_https(&headers));
     }
 
     #[tokio::test]

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -14,7 +14,7 @@ use axum::{
 // 400 VALIDATION_ERROR (structured envelope) instead of Axum's stock 422
 // + plain-text body. Drop-in for both request extraction and responses
 // (#1783 LOW: POST /auth/login returned 422 for missing `username`).
-use crate::api::extractors::Json;
+use crate::api::extractors::{request_scheme_is_https, Json};
 use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
@@ -46,9 +46,14 @@ async fn audit_auth(
 }
 
 /// Build a login/refresh response with auth cookies set.
+///
+/// `client_is_https` carries the per-request HTTPS signal (see
+/// [`request_scheme_is_https`]) so the cookie `Secure` flag auto-follows a
+/// TLS-terminating reverse proxy.
 fn login_response(
     tokens: &crate::services::auth_service::TokenPair,
     must_change_password: bool,
+    client_is_https: bool,
 ) -> Response {
     let body = LoginResponse {
         access_token: tokens.access_token.clone(),
@@ -65,6 +70,7 @@ fn login_response(
         &tokens.access_token,
         &tokens.refresh_token,
         tokens.expires_in,
+        client_is_https,
     );
     response
 }
@@ -265,8 +271,10 @@ async fn enforce_local_login_sso_policy(
 )]
 pub async fn login(
     State(state): State<SharedState>,
+    headers: HeaderMap,
     Json(payload): Json<LoginRequest>,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     // The bcrypt-bound auth-concurrency cap (#991, #1088) is enforced
     // inside `AuthService::verify_password` itself, so every entry point
     // that runs bcrypt (local login, API-token verify, basic-auth
@@ -330,7 +338,11 @@ pub async fn login(
     }
     audit_auth(&state, AuditAction::Login, Some(user.id), login_details).await;
 
-    Ok(login_response(&tokens, user.must_change_password))
+    Ok(login_response(
+        &tokens,
+        user.must_change_password,
+        client_is_https,
+    ))
 }
 
 /// Logout current session
@@ -382,7 +394,7 @@ pub async fn logout(
     }
 
     let mut response = ().into_response();
-    clear_auth_cookies(response.headers_mut());
+    clear_auth_cookies(response.headers_mut(), request_scheme_is_https(&headers));
     Ok(response)
 }
 
@@ -421,7 +433,11 @@ pub async fn refresh_token(
     )
     .await;
 
-    Ok(login_response(&tokens, user.must_change_password))
+    Ok(login_response(
+        &tokens,
+        user.must_change_password,
+        request_scheme_is_https(&headers),
+    ))
 }
 
 /// Get current user info
@@ -552,21 +568,32 @@ pub(crate) fn extract_cookie<'a>(headers: &'a HeaderMap, name: &str) -> Option<&
 /// Returns the `Secure;` cookie flag for the auth cookies, or `""` when the
 /// cookie must be sent over plain HTTP.
 ///
-/// The `Secure` attribute is only emitted when HTTPS is *explicitly* enabled
-/// via `AK_ENFORCE_HTTPS` (truthy = "true"/"1"), mirroring the web `#2222`
-/// tradeoff: a default deployment (unset flag) works over plain HTTP out of
-/// the box, and TLS/ingress deployments opt in to hardened cookies by setting
-/// `AK_ENFORCE_HTTPS=true`.
+/// The `Secure` attribute is emitted when the request is NOT in `development`
+/// mode AND either:
+/// * `AK_ENFORCE_HTTPS` is truthy ("true"/"1") — the static override for
+///   proxies that terminate TLS but do NOT set `X-Forwarded-Proto`; or
+/// * `client_is_https` is true — the request reached the trusted edge over
+///   HTTPS, as signalled per-request by `X-Forwarded-Proto: https` (see
+///   [`request_scheme_is_https`]).
 ///
-/// This is a deliberate, security-relevant default change (#2233): previously
-/// any non-`development` ENVIRONMENT emitted `Secure`, which made login
-/// impossible over HTTP because the browser accepted but never resent the
-/// cookie (login 200 → /auth/me 401). Development mode remains non-`Secure`
-/// regardless of the flag (backwards compat: dev works on localhost HTTP).
+/// This auto-detects HTTPS behind a TLS-terminating reverse proxy (#2233
+/// follow-up): the app receives requests over internal HTTP but honours the
+/// SAME `X-Forwarded-Proto` signal that base-URL construction already trusts,
+/// so `Secure` cookies work without remembering to set a static flag. A plain
+/// HTTP request (no header, no flag) still yields non-`Secure` cookies so a
+/// default deployment works out of the box; `#2233` made this impossible over
+/// HTTP when any non-`development` ENVIRONMENT unconditionally emitted `Secure`
+/// (login 200 → /auth/me 401). Development mode remains non-`Secure`
+/// regardless (backwards compat: dev works on localhost HTTP).
 ///
-/// NOTE: production HTTPS deployments MUST set `AK_ENFORCE_HTTPS=true` (wired
-/// on the iac/chart side for TLS ingress) to keep `Secure` cookies.
-fn secure_flag() -> &'static str {
+/// SECURITY: trusting `X-Forwarded-Proto` is the SAME trust posture the
+/// base-URL logic already has — it assumes a trusted proxy that OVERWRITES
+/// (not appends) client-supplied `X-Forwarded-Proto`. A client spoofing
+/// `X-Forwarded-Proto: https` over a real HTTP connection only makes their OWN
+/// cookie `Secure` (which the browser then won't resend over that HTTP
+/// connection) — self-defeating, not a privilege escalation. Operators
+/// terminating TLS at a proxy MUST have the proxy overwrite `X-Forwarded-Proto`.
+fn secure_flag(client_is_https: bool) -> &'static str {
     let is_development = std::env::var("ENVIRONMENT").unwrap_or_default() == "development";
     let enforce_https = matches!(
         std::env::var("AK_ENFORCE_HTTPS")
@@ -575,7 +602,7 @@ fn secure_flag() -> &'static str {
             .as_str(),
         "true" | "1"
     );
-    if enforce_https && !is_development {
+    if !is_development && (enforce_https || client_is_https) {
         " Secure;"
     } else {
         ""
@@ -583,13 +610,19 @@ fn secure_flag() -> &'static str {
 }
 
 /// Set httpOnly auth cookies on a response.
+///
+/// `client_is_https` is the per-request HTTPS signal (see
+/// [`request_scheme_is_https`]); it feeds [`secure_flag`] so the `Secure`
+/// attribute auto-follows a TLS-terminating reverse proxy. `HttpOnly` and
+/// `SameSite=Strict` are always set.
 pub(crate) fn set_auth_cookies(
     headers: &mut HeaderMap,
     access_token: &str,
     refresh_token: &str,
     expires_in: u64,
+    client_is_https: bool,
 ) {
-    let flag = secure_flag();
+    let flag = secure_flag(client_is_https);
     let access_cookie = format!(
         "ak_access_token={}; HttpOnly;{} SameSite=Strict; Path=/; Max-Age={}",
         access_token, flag, expires_in
@@ -604,8 +637,12 @@ pub(crate) fn set_auth_cookies(
 }
 
 /// Clear auth cookies by setting Max-Age=0.
-fn clear_auth_cookies(headers: &mut HeaderMap) {
-    let flag = secure_flag();
+///
+/// The cleared cookies carry the same attributes as the ones they replace, so
+/// `client_is_https` gates their `Secure` flag identically to
+/// [`set_auth_cookies`].
+fn clear_auth_cookies(headers: &mut HeaderMap, client_is_https: bool) {
+    let flag = secure_flag(client_is_https);
     let clear_access = format!(
         "ak_access_token=; HttpOnly;{} SameSite=Strict; Path=/; Max-Age=0",
         flag
@@ -1329,7 +1366,7 @@ mod tests {
     #[test]
     fn test_set_auth_cookies_adds_two_cookies() {
         let mut headers = HeaderMap::new();
-        set_auth_cookies(&mut headers, "access_tok", "refresh_tok", 3600);
+        set_auth_cookies(&mut headers, "access_tok", "refresh_tok", 3600, false);
         let cookies: Vec<_> = headers.get_all(SET_COOKIE).iter().collect();
         assert_eq!(cookies.len(), 2);
     }
@@ -1337,7 +1374,7 @@ mod tests {
     #[test]
     fn test_set_auth_cookies_access_token_format() {
         let mut headers = HeaderMap::new();
-        set_auth_cookies(&mut headers, "myaccess", "myrefresh", 3600);
+        set_auth_cookies(&mut headers, "myaccess", "myrefresh", 3600, false);
         let cookies: Vec<_> = headers
             .get_all(SET_COOKIE)
             .iter()
@@ -1357,7 +1394,7 @@ mod tests {
     #[test]
     fn test_set_auth_cookies_refresh_token_path() {
         let mut headers = HeaderMap::new();
-        set_auth_cookies(&mut headers, "acc", "ref", 1800);
+        set_auth_cookies(&mut headers, "acc", "ref", 1800, false);
         let cookies: Vec<_> = headers
             .get_all(SET_COOKIE)
             .iter()
@@ -1374,13 +1411,15 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // secure_flag / cookie Secure gating (#2233)
+    // secure_flag / cookie Secure gating (#2233 + X-Forwarded-Proto follow-up)
     //
-    // The `Secure` attribute must be an *explicit* HTTPS opt-in
-    // (`AK_ENFORCE_HTTPS`), not coupled to `development` mode, so a default
-    // plain-HTTP deployment can actually keep users logged in. Env is
-    // process-global, so these tests serialize on a local mutex and
-    // set-and-restore ENVIRONMENT + AK_ENFORCE_HTTPS around each case.
+    // The `Secure` attribute is emitted when NOT in `development` AND either
+    // `AK_ENFORCE_HTTPS` is truthy (static override) OR the per-request
+    // `client_is_https` signal (from `X-Forwarded-Proto: https`) is set. This
+    // keeps a default plain-HTTP deployment logged in while auto-hardening
+    // cookies behind a TLS-terminating proxy. Env is process-global, so the
+    // env-dependent tests serialize on a local mutex and set-and-restore
+    // ENVIRONMENT + AK_ENFORCE_HTTPS around each case.
     // -----------------------------------------------------------------------
 
     /// Serializes env-dependent secure_flag tests (env is process-global).
@@ -1413,10 +1452,10 @@ mod tests {
         // non-development ENVIRONMENT) must NOT emit Secure, so the browser
         // resends the cookie over plain HTTP.
         with_secure_env(None, None, || {
-            assert_eq!(secure_flag(), "");
+            assert_eq!(secure_flag(false), "");
         });
         with_secure_env(Some("production"), None, || {
-            assert_eq!(secure_flag(), "");
+            assert_eq!(secure_flag(false), "");
         });
     }
 
@@ -1425,7 +1464,7 @@ mod tests {
         for truthy in ["true", "TRUE", "1"] {
             with_secure_env(Some("production"), Some(truthy), || {
                 assert_eq!(
-                    secure_flag(),
+                    secure_flag(false),
                     " Secure;",
                     "AK_ENFORCE_HTTPS={truthy} must enable Secure"
                 );
@@ -1438,10 +1477,10 @@ mod tests {
         // Development stays non-Secure even if HTTPS enforcement is requested
         // (localhost HTTP), preserving backwards-compatible dev behavior.
         with_secure_env(Some("development"), None, || {
-            assert_eq!(secure_flag(), "");
+            assert_eq!(secure_flag(false), "");
         });
         with_secure_env(Some("development"), Some("true"), || {
-            assert_eq!(secure_flag(), "");
+            assert_eq!(secure_flag(false), "");
         });
     }
 
@@ -1450,7 +1489,7 @@ mod tests {
         for falsey in ["false", "0", "", "no"] {
             with_secure_env(Some("production"), Some(falsey), || {
                 assert_eq!(
-                    secure_flag(),
+                    secure_flag(false),
                     "",
                     "AK_ENFORCE_HTTPS={falsey} must not enable Secure"
                 );
@@ -1464,7 +1503,7 @@ mod tests {
         // always present; Secure follows the AK_ENFORCE_HTTPS toggle.
         with_secure_env(Some("production"), None, || {
             let mut headers = HeaderMap::new();
-            set_auth_cookies(&mut headers, "a", "r", 3600);
+            set_auth_cookies(&mut headers, "a", "r", 3600, false);
             for v in headers.get_all(SET_COOKIE).iter() {
                 let c = v.to_str().unwrap();
                 assert!(c.contains("HttpOnly"), "HttpOnly must be present: {c}");
@@ -1480,7 +1519,7 @@ mod tests {
         });
         with_secure_env(Some("production"), Some("true"), || {
             let mut headers = HeaderMap::new();
-            set_auth_cookies(&mut headers, "a", "r", 3600);
+            set_auth_cookies(&mut headers, "a", "r", 3600, false);
             for v in headers.get_all(SET_COOKIE).iter() {
                 let c = v.to_str().unwrap();
                 assert!(c.contains("HttpOnly"), "HttpOnly must be present: {c}");
@@ -1497,13 +1536,96 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // X-Forwarded-Proto auto-detection (follow-up to #2233)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_secure_flag_forwarded_https_enables_secure_without_flag() {
+        // Behind a TLS-terminating proxy (X-Forwarded-Proto: https) the cookie
+        // is Secure even when AK_ENFORCE_HTTPS is unset.
+        with_secure_env(Some("production"), None, || {
+            assert_eq!(
+                secure_flag(true),
+                " Secure;",
+                "X-Forwarded-Proto: https must enable Secure without the flag"
+            );
+        });
+    }
+
+    #[test]
+    fn test_secure_flag_no_forwarded_no_flag_is_not_secure() {
+        // Plain HTTP: no X-Forwarded-Proto and no flag stays non-Secure so the
+        // browser resends the cookie over HTTP.
+        with_secure_env(Some("production"), None, || {
+            assert_eq!(secure_flag(false), "");
+        });
+    }
+
+    #[test]
+    fn test_secure_flag_enforce_https_overrides_missing_forwarded() {
+        // AK_ENFORCE_HTTPS=true forces Secure regardless of the per-request
+        // scheme (for proxies that terminate TLS but don't set the header).
+        with_secure_env(Some("production"), Some("true"), || {
+            assert_eq!(secure_flag(false), " Secure;");
+            assert_eq!(secure_flag(true), " Secure;");
+        });
+    }
+
+    #[test]
+    fn test_secure_flag_development_never_secure_even_with_forwarded_https() {
+        // Development stays non-Secure even when the client is HTTPS, so local
+        // dev over localhost keeps working.
+        with_secure_env(Some("development"), None, || {
+            assert_eq!(secure_flag(true), "");
+        });
+        with_secure_env(Some("development"), Some("true"), || {
+            assert_eq!(secure_flag(true), "");
+        });
+    }
+
+    #[test]
+    fn test_set_auth_cookies_secure_follows_forwarded_proto() {
+        // End-to-end through set_auth_cookies: client_is_https=true yields
+        // Secure (no flag needed); false yields non-Secure. HttpOnly +
+        // SameSite=Strict are always present in both cases.
+        with_secure_env(Some("production"), None, || {
+            let mut secure_headers = HeaderMap::new();
+            set_auth_cookies(&mut secure_headers, "a", "r", 3600, true);
+            for v in secure_headers.get_all(SET_COOKIE).iter() {
+                let c = v.to_str().unwrap();
+                assert!(c.contains("HttpOnly"), "HttpOnly must be present: {c}");
+                assert!(
+                    c.contains("SameSite=Strict"),
+                    "SameSite=Strict must be present: {c}"
+                );
+                assert!(
+                    c.contains("Secure"),
+                    "X-Forwarded-Proto: https must be Secure: {c}"
+                );
+            }
+
+            let mut plain_headers = HeaderMap::new();
+            set_auth_cookies(&mut plain_headers, "a", "r", 3600, false);
+            for v in plain_headers.get_all(SET_COOKIE).iter() {
+                let c = v.to_str().unwrap();
+                assert!(c.contains("HttpOnly"), "HttpOnly must be present: {c}");
+                assert!(
+                    c.contains("SameSite=Strict"),
+                    "SameSite=Strict must be present: {c}"
+                );
+                assert!(!c.contains("Secure"), "plain HTTP must be non-Secure: {c}");
+            }
+        });
+    }
+
+    // -----------------------------------------------------------------------
     // clear_auth_cookies
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_clear_auth_cookies_sets_max_age_zero() {
         let mut headers = HeaderMap::new();
-        clear_auth_cookies(&mut headers);
+        clear_auth_cookies(&mut headers, false);
         let cookies: Vec<_> = headers
             .get_all(SET_COOKIE)
             .iter()
@@ -1522,7 +1644,7 @@ mod tests {
     #[test]
     fn test_clear_auth_cookies_empties_values() {
         let mut headers = HeaderMap::new();
-        clear_auth_cookies(&mut headers);
+        clear_auth_cookies(&mut headers, false);
         let cookies: Vec<_> = headers
             .get_all(SET_COOKIE)
             .iter()

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Path, Query, State},
+    http::HeaderMap,
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
     Json, Router,
@@ -14,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
-use crate::api::extractors::{trusted_external_url, RequestBaseUrl};
+use crate::api::extractors::{request_scheme_is_https, trusted_external_url, RequestBaseUrl};
 use crate::api::handlers::auth::set_auth_cookies;
 use crate::api::validation::validate_outbound_sso_url;
 
@@ -314,8 +315,10 @@ pub async fn oidc_callback(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
     Query(params): Query<OidcCallbackQuery>,
+    headers: HeaderMap,
     base_url: RequestBaseUrl,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     // Resolve parameter shape BEFORE hitting the session store. Empty state or
     // code is a malformed callback (400), an IdP error redirect is a 401, not a
     // CSRF failure. See `resolve_oidc_callback` doc comment.
@@ -342,6 +345,7 @@ pub async fn oidc_callback(
         session.nonce,
         session.pkce_code_verifier,
         base_url,
+        client_is_https,
     )
     .await
 }
@@ -355,8 +359,10 @@ pub async fn oidc_callback(
 pub async fn oidc_callback_generic(
     State(state): State<SharedState>,
     Query(params): Query<OidcCallbackQuery>,
+    headers: HeaderMap,
     base_url: RequestBaseUrl,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     // Resolve parameter shape BEFORE hitting the session store. See
     // `resolve_oidc_callback` doc comment.
     let (auth_code, sso_state) = resolve_oidc_callback(&params)?;
@@ -370,6 +376,7 @@ pub async fn oidc_callback_generic(
         session.nonce,
         session.pkce_code_verifier,
         base_url,
+        client_is_https,
     )
     .await
 }
@@ -383,6 +390,7 @@ async fn oidc_callback_inner(
     session_nonce: Option<String>,
     pkce_code_verifier: Option<String>,
     base_url: RequestBaseUrl,
+    client_is_https: bool,
 ) -> Result<Response> {
     // 1. Get decrypted OIDC config
     let (row, client_secret) =
@@ -571,6 +579,7 @@ async fn oidc_callback_inner(
         &tokens.access_token,
         &tokens.refresh_token,
         tokens.expires_in,
+        client_is_https,
     )
 }
 
@@ -603,8 +612,10 @@ pub struct LdapLoginRequest {
 pub async fn ldap_login(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
     Json(req): Json<LdapLoginRequest>,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     // Get decrypted LDAP config
     let (row, bind_password) = AuthConfigService::get_ldap_decrypted(&state.db, id).await?;
 
@@ -684,6 +695,7 @@ pub async fn ldap_login(
         &tokens.access_token,
         &tokens.refresh_token,
         3600,
+        client_is_https,
     );
     Ok(response)
 }
@@ -831,8 +843,10 @@ pub struct SamlAcsForm {
 pub async fn saml_acs(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
     axum::extract::Form(form): axum::extract::Form<SamlAcsForm>,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     // Get SAML config from DB
     let row = AuthConfigService::get_saml_decrypted(&state.db, id).await?;
 
@@ -927,6 +941,7 @@ pub async fn saml_acs(
         &tokens.access_token,
         &tokens.refresh_token,
         tokens.expires_in,
+        client_is_https,
     )
 }
 
@@ -960,8 +975,10 @@ struct ExchangeCodeResponse {
 )]
 pub async fn exchange_code(
     State(state): State<SharedState>,
+    headers: HeaderMap,
     Json(req): Json<ExchangeCodeRequest>,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     let (access_token, refresh_token) =
         AuthConfigService::exchange_code(&state.db, &req.code).await?;
 
@@ -973,7 +990,13 @@ pub async fn exchange_code(
 
     // Default expires_in for SSO tokens (1 hour = 3600 seconds)
     let mut response = Json(body).into_response();
-    set_auth_cookies(response.headers_mut(), &access_token, &refresh_token, 3600);
+    set_auth_cookies(
+        response.headers_mut(),
+        &access_token,
+        &refresh_token,
+        3600,
+        client_is_https,
+    );
     Ok(response)
 }
 
@@ -1035,6 +1058,7 @@ pub(crate) fn build_sso_callback_redirect(
     access_token: &str,
     refresh_token: &str,
     expires_in: u64,
+    client_is_https: bool,
 ) -> Result<Response> {
     let mut response = Redirect::temporary(frontend_url).into_response();
     set_auth_cookies(
@@ -1042,6 +1066,7 @@ pub(crate) fn build_sso_callback_redirect(
         access_token,
         refresh_token,
         expires_in,
+        client_is_https,
     );
     Ok(response)
 }
@@ -1835,6 +1860,7 @@ mod tests {
             "access_token_value",
             "refresh_token_value",
             3600,
+            false,
         )
         .expect("build_sso_callback_redirect must succeed");
         assert_eq!(
@@ -1861,6 +1887,7 @@ mod tests {
             "the_access_token",
             "the_refresh_token",
             7200,
+            false,
         )
         .expect("build_sso_callback_redirect must succeed");
         let cookies: Vec<String> = response
@@ -1913,6 +1940,7 @@ mod tests {
             "at",
             "rt",
             1800, // 30 minutes
+            false,
         )
         .expect("build_sso_callback_redirect must succeed");
         let access_cookie = response

--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::State,
+    http::HeaderMap,
     response::{IntoResponse, Response},
     routing::post,
     Extension, Json, Router,
@@ -13,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use totp_rs::{Algorithm, Secret, TOTP};
 use utoipa::{OpenApi, ToSchema};
 
+use crate::api::extractors::request_scheme_is_https;
 use crate::api::handlers::auth::set_auth_cookies;
 use crate::api::middleware::auth::{AuthExtension, TokenIat};
 use crate::api::SharedState;
@@ -329,8 +331,10 @@ pub struct TotpVerifyRequest {
 )]
 pub async fn verify_totp(
     State(state): State<SharedState>,
+    headers: HeaderMap,
     Json(payload): Json<TotpVerifyRequest>,
 ) -> Result<Response> {
+    let client_is_https = request_scheme_is_https(&headers);
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
 
     // Validate the pending token, then atomically consume its `jti` so it is
@@ -481,6 +485,7 @@ pub async fn verify_totp(
         &tokens.access_token,
         &tokens.refresh_token,
         tokens.expires_in,
+        client_is_https,
     );
     Ok(response)
 }
@@ -1385,6 +1390,7 @@ mod totp_verify_hardening_tests {
 
         let first = verify_totp(
             State(state.clone()),
+            HeaderMap::new(),
             Json(TotpVerifyRequest {
                 totp_token: pending.clone(),
                 code: code.clone(),
@@ -1397,6 +1403,7 @@ mod totp_verify_hardening_tests {
         let code2 = totp.generate_current().expect("code");
         let replay = verify_totp(
             State(state.clone()),
+            HeaderMap::new(),
             Json(TotpVerifyRequest {
                 totp_token: pending,
                 code: code2,
@@ -1455,6 +1462,7 @@ mod totp_verify_hardening_tests {
             handles.push(tokio::spawn(async move {
                 verify_totp(
                     State(st),
+                    HeaderMap::new(),
                     Json(TotpVerifyRequest {
                         totp_token: token,
                         code: "1YUU-4B8U".to_string(),


### PR DESCRIPTION
## Summary

Follow-up to #2233. The auth-cookie `Secure` decision (`secure_flag()` in `backend/src/api/handlers/auth.rs`) was a purely static env flag: `Secure` was emitted iff `AK_ENFORCE_HTTPS` was truthy AND `ENVIRONMENT != development`.

Behind a TLS-terminating reverse proxy the backend receives requests over internal HTTP, so it cannot tell the client actually used HTTPS unless an operator remembers to set `AK_ENFORCE_HTTPS=true`. Forgetting the flag silently ships auth cookies without `Secure` over a public HTTPS deployment.

The backend already trusts `X-Forwarded-Proto` for external-URL construction (`request_base_url_from_request`, `backend/src/api/extractors.rs`). This change makes the cookie `Secure` decision honor the same per-request signal, so it works correctly behind a TLS proxy without needing the static flag.

### Behavior

`Secure` is now emitted iff `ENVIRONMENT != development` AND (`AK_ENFORCE_HTTPS` truthy OR the request's `X-Forwarded-Proto == https`, case-insensitive):

- behind a TLS proxy (`X-Forwarded-Proto: https`) => `Secure` automatically;
- explicit `AK_ENFORCE_HTTPS=true` still forces `Secure` (for proxies that don't set the header);
- plain HTTP (no header, no flag) => non-`Secure` (default deployment keeps working — the regression #2233 fixed stays fixed);
- development => non-`Secure` even with `X-Forwarded-Proto: https`.

`HttpOnly` and `SameSite=Strict` are unchanged.

### Implementation

- New shared helper `request_scheme_is_https(headers) -> bool` in `extractors.rs`, reusing the same `X-Forwarded-Proto` detection the base-URL logic uses.
- `secure_flag()` becomes a function of `(env + client_is_https)`.
- The per-request scheme is threaded through `set_auth_cookies` / `clear_auth_cookies` / `login_response` / `build_sso_callback_redirect` and all call sites: login, refresh, logout, TOTP verify, and SSO (OIDC callback, LDAP login, SAML ACS, exchange).

### Security note

Trusting `X-Forwarded-Proto` here is the SAME trust posture the base-URL logic already has: it assumes a trusted reverse proxy that overwrites (not appends) client-supplied `X-Forwarded-Proto`. A client spoofing `X-Forwarded-Proto: https` over a real plain-HTTP connection only makes their OWN cookie `Secure` — which the browser then won't resend over that HTTP connection — so it is self-defeating, not a privilege escalation. Operators terminating TLS at a proxy MUST configure the proxy to overwrite `X-Forwarded-Proto` on forwarded requests (documented in the code comment on `secure_flag` / `request_scheme_is_https`).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added unit tests: `X-Forwarded-Proto: https` (no flag) => `Secure`; no header + no flag => non-`Secure`; `X-Forwarded-Proto: http` => non-`Secure`; `AK_ENFORCE_HTTPS=true` => `Secure` regardless of header; `ENVIRONMENT=development` => non-`Secure` even with `X-Forwarded-Proto: https`; `HttpOnly` + `SameSite=Strict` always present. Plus `request_scheme_is_https` header-parsing tests (present/absent/http/case-insensitive). Env-var tests serialized per the existing repo pattern.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

### Verification

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo nextest run --workspace --lib` (12249 tests) all green. Deployed a built image behind a simulated proxy:

- `POST /api/v1/auth/login` **without** `X-Forwarded-Proto` (no `AK_ENFORCE_HTTPS`) => `ak_access_token=...; HttpOnly; SameSite=Strict; ...` (non-Secure);
- same **with** `X-Forwarded-Proto: https` => `...; HttpOnly; Secure; SameSite=Strict; ...`;
- with `AK_ENFORCE_HTTPS=true` and **no** header => `...; HttpOnly; Secure; SameSite=Strict; ...` (override still forces Secure).

Closes #2235.
