### PR TITLE
fix(scanner-adapter): scope registry pull credential to the target image so the trivy DB pull is not rejected

### DIFF
--- a/docker/scanner-adapter/main.go
+++ b/docker/scanner-adapter/main.go
@@ -19,23 +19,43 @@ func main() {
 	cfg := LoadConfig()
 	srv := NewServer(cfg)
 
-	// Probe the trivy version at startup (unless pinned via env). Readiness is
-	// gated on a successful probe so the backend does not dispatch scans to an
+	// Probe the trivy version at startup (unless pinned via env). A failed probe
+	// leaves the adapter not-ready so the backend does not dispatch scans to an
 	// adapter whose trivy binary is missing/broken.
+	versionOK := true
 	if cfg.ScannerVersion == "" {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		version, err := ProbeVersion(ctx, cfg)
 		cancel()
 		if err != nil {
 			log.Printf("trivy version probe failed (staying not-ready): %v", err)
+			versionOK = false
 		} else {
 			cfg.ScannerVersion = version
 			log.Printf("trivy version probed: %s", version)
-			srv.MarkReady()
 		}
 	} else {
 		log.Printf("trivy version pinned via env: %s", cfg.ScannerVersion)
-		srv.MarkReady()
+	}
+
+	// DB-presence readiness gate (#2167): do NOT advertise ready until the trivy
+	// vuln DB is actually loaded. Without a DB, trivy exits 0 with empty Results
+	// (a FALSE CLEAN); staying not-ready makes the backend fail every scan closed
+	// instead. When DB updates are enabled, download it now so it is present
+	// before the readiness flag flips (rather than racing the first scan).
+	if versionOK {
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.ScanTimeout)
+		if !cfg.SkipDBUpdate {
+			if err := DownloadDB(ctx, cfg); err != nil {
+				log.Printf("trivy DB download failed (staying not-ready): %v", err)
+			}
+		}
+		cancel()
+		if srv.markReadyIfDBPresent(func() bool { return DBReady(cfg) }) {
+			log.Printf("trivy vuln DB present; adapter ready (trivy=%s)", cfg.ScannerVersion)
+		} else {
+			log.Printf("trivy vuln DB not present in %s (staying not-ready)", cfg.CacheDir)
+		}
 	}
 
 	stop := make(chan struct{})

--- a/docker/scanner-adapter/scan.go
+++ b/docker/scanner-adapter/scan.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 )
 
@@ -83,6 +85,127 @@ func registryToken(authorization string) string {
 	return ""
 }
 
+// dockerAuthEntry is a single registry credential in a Docker config.json. Only
+// registrytoken (a bearer token) is populated; trivy/go-containerregistry sends
+// it as `Authorization: Bearer <registrytoken>` for pulls from the keyed host.
+type dockerAuthEntry struct {
+	RegistryToken string `json:"registrytoken"`
+}
+
+// dockerConfig is the minimal Docker config.json shape trivy reads via
+// DOCKER_CONFIG: a per-host auth map. Credentials are resolved PER registry
+// host, so an entry keyed to the target host is never applied to trivy's
+// vuln-DB OCI pull from its mirrors.
+type dockerConfig struct {
+	Auths map[string]dockerAuthEntry `json:"auths"`
+}
+
+// dockerConfigJSON builds a Docker config.json that scopes token to a single
+// registry host. Because credentials are resolved per host, the token is sent
+// ONLY for pulls from host; the vuln-DB pull (mirror.gcr.io /
+// ghcr.io/aquasec/trivy-db / public.ecr.aws) has no matching entry and pulls
+// anonymously. Never log the return value (it embeds the token).
+func dockerConfigJSON(host, token string) ([]byte, error) {
+	return json.Marshal(dockerConfig{
+		Auths: map[string]dockerAuthEntry{
+			host: {RegistryToken: token},
+		},
+	})
+}
+
+// scanCredential carries the per-scan registry credential material: extra env
+// for trivy (DOCKER_CONFIG when a host-scoped config was written) and a cleanup
+// that removes the temp config dir. It never exposes the token as a field.
+type scanCredential struct {
+	env     []string
+	cleanup func()
+}
+
+// buildCredential prepares the target-image pull credential. When the request
+// carries a Bearer token it writes a host-scoped Docker config.json into a
+// private 0700 temp dir and returns DOCKER_CONFIG pointing at it, so the bearer
+// applies ONLY to the target registry host (trimRegistryHost(URL), incl. port)
+// and NOT to trivy's anonymous vuln-DB pull. An anonymous request yields an
+// empty credential (no config, no DOCKER_CONFIG). Callers MUST defer cleanup.
+// This replaces the flat, host-unscoped TRIVY_REGISTRY_TOKEN, which trivy
+// applied to EVERY registry request (including the DB mirrors, which reject the
+// target-scoped bearer -> no DB -> empty results -> false clean).
+func buildCredential(req *ScanRequest) (*scanCredential, error) {
+	token := registryToken(req.Registry.Authorization)
+	if token == "" {
+		return &scanCredential{cleanup: func() {}}, nil
+	}
+	host := trimRegistryHost(req.Registry.URL)
+	data, err := dockerConfigJSON(host, token)
+	if err != nil {
+		return nil, err
+	}
+	dir, err := os.MkdirTemp("", "scanner-dockercfg-")
+	if err != nil {
+		return nil, fmt.Errorf("create docker config dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	if err := os.Chmod(dir, 0o700); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("chmod docker config dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), data, 0o600); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("write docker config: %w", err)
+	}
+	return &scanCredential{env: []string{"DOCKER_CONFIG=" + dir}, cleanup: cleanup}, nil
+}
+
+// trivyDBErrorMarkers are stderr substrings (matched case-insensitively) that
+// indicate trivy failed to load its vulnerability DB. trivy can exit 0 with
+// empty Results in this case, which would surface as a FALSE CLEAN. The set is
+// kept tight to DB-fatal signals so a legitimately clean image (0 findings, no
+// DB error, e.g. distroless/FROM scratch) is never flagged.
+var trivyDBErrorMarkers = []string{
+	"unauthorized",
+	"failed to download vulnerability db",
+	"vulnerability db does not exist",
+	"db error",
+}
+
+// trivyOutputIndicatesDBFailure reports whether trivy stderr contains a
+// DB-fatal marker. Pure fn (unit-tested) so the exit-0 fail-closed path has no
+// false fire on benign output.
+func trivyOutputIndicatesDBFailure(stderr string) bool {
+	low := strings.ToLower(stderr)
+	for _, m := range trivyDBErrorMarkers {
+		if strings.Contains(low, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// dbPresent reports whether a trivy vulnerability DB is loaded in cacheDir.
+// trivy stores it at <cacheDir>/db/metadata.json (+ trivy.db); a present,
+// non-empty metadata file is the readiness signal.
+func dbPresent(cacheDir string) bool {
+	info, err := os.Stat(filepath.Join(cacheDir, "db", "metadata.json"))
+	return err == nil && !info.IsDir() && info.Size() > 0
+}
+
+// DBReady reports whether the trivy vuln DB is present in cfg.CacheDir.
+// Readiness is gated on this in addition to the version probe so the adapter
+// never advertises ready with no DB (which trivy treats as 0 vulnerabilities).
+func DBReady(cfg *Config) bool { return dbPresent(cfg.CacheDir) }
+
+// DownloadDB triggers a trivy DB download into cfg.CacheDir. It is run at
+// startup when DB updates are enabled so the DB is present before the adapter
+// marks itself ready (rather than lazily on the first scan, which would race the
+// readiness gate). Output is captured for the log; it never carries a token.
+func DownloadDB(ctx context.Context, cfg *Config) error {
+	cmd := exec.CommandContext(ctx, cfg.TrivyPath, "image", "--download-db-only", "--cache-dir", cfg.CacheDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("trivy --download-db-only failed: %v: %s", err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
 // Scan runs trivy for the given request and returns the Harbor report. Any
 // non-zero exit or parse failure is an error (the caller marks the job Failed
 // and the report endpoint 500s — fail-closed, never a silent empty report).
@@ -96,13 +219,17 @@ func (s *Scanner) Scan(ctx context.Context, req *ScanRequest) (*HarborScanReport
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, s.cfg.TrivyPath, s.buildArgs(imageRef)...)
-	// Inherit the adapter's environment; add a per-scan registry token for
-	// private pulls. TRIVY_REGISTRY_TOKEN is consumed by trivy's registry
-	// client. The token is NEVER logged.
-	cmd.Env = cmd.Environ()
-	if token := registryToken(req.Registry.Authorization); token != "" {
-		cmd.Env = append(cmd.Env, "TRIVY_REGISTRY_TOKEN="+token)
+	// Inherit the adapter's environment; add a HOST-SCOPED registry credential
+	// for private pulls via a per-scan Docker config (DOCKER_CONFIG). The bearer
+	// is applied ONLY to the target registry host, so trivy's vuln-DB OCI pull
+	// goes anonymously to its mirror (a flat TRIVY_REGISTRY_TOKEN would be sent
+	// to the DB mirror too and be rejected -> no DB -> false clean). Never logged.
+	cred, err := buildCredential(req)
+	if err != nil {
+		return nil, fmt.Errorf("prepare registry credential for %s: %w", imageRef, err)
 	}
+	defer cred.cleanup()
+	cmd.Env = append(cmd.Environ(), cred.env...)
 
 	var stdout, stderr strings.Builder
 	cmd.Stdout = &stdout
@@ -110,6 +237,16 @@ func (s *Scanner) Scan(ctx context.Context, req *ScanRequest) (*HarborScanReport
 
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("trivy scan failed for %s: %v: %s", imageRef, err, strings.TrimSpace(stderr.String()))
+	}
+
+	// Exit-0 DB-failure detection: trivy can exit 0 with empty Results when its
+	// vuln DB failed to load (auth-rejected mirror pull, missing/corrupt DB).
+	// That is a FALSE CLEAN; treat a DB-fatal stderr marker on a zero-exit run as
+	// an error so the job fails closed (report 500) instead of reporting no
+	// findings. Gated on markers, not on empty Results (a distroless image can
+	// legitimately catalog 0 packages).
+	if trivyOutputIndicatesDBFailure(stderr.String()) {
+		return nil, fmt.Errorf("trivy scan for %s reported a vulnerability-DB failure: %s", imageRef, strings.TrimSpace(stderr.String()))
 	}
 
 	var trivyReport TrivyReport

--- a/docker/scanner-adapter/scan_fix_test.go
+++ b/docker/scanner-adapter/scan_fix_test.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestBuildCredentialHostScopedConfig proves the target-image bearer is written
+// to a host-scoped Docker config.json (keyed by trimRegistryHost(URL)) and
+// exposed via DOCKER_CONFIG — and that the flat, host-unscoped
+// TRIVY_REGISTRY_TOKEN is never set. This is the #2167 root fix: the bearer must
+// not bleed to trivy's vuln-DB pull.
+func TestBuildCredentialHostScopedConfig(t *testing.T) {
+	const url = "http://backend:8080"
+	const token = "abc.def.ghi"
+	req := &ScanRequest{
+		Registry: RegistryRef{URL: url, Authorization: "Bearer " + token},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", Tag: "3.14"},
+	}
+	cred, err := buildCredential(req)
+	if err != nil {
+		t.Fatalf("buildCredential: %v", err)
+	}
+	defer cred.cleanup()
+
+	// DOCKER_CONFIG is set; TRIVY_REGISTRY_TOKEN is NOT.
+	var dockerConfigDir string
+	for _, e := range cred.env {
+		if strings.HasPrefix(e, "TRIVY_REGISTRY_TOKEN=") {
+			t.Fatalf("flat TRIVY_REGISTRY_TOKEN must not be set; got env %q", e)
+		}
+		if v, ok := strings.CutPrefix(e, "DOCKER_CONFIG="); ok {
+			dockerConfigDir = v
+		}
+	}
+	if dockerConfigDir == "" {
+		t.Fatalf("DOCKER_CONFIG not set; env=%v", cred.env)
+	}
+
+	// The generated config.json is host-keyed to trimRegistryHost(URL) with the
+	// bearer as registrytoken, and no other host entry exists.
+	raw, err := os.ReadFile(filepath.Join(dockerConfigDir, "config.json"))
+	if err != nil {
+		t.Fatalf("read config.json: %v", err)
+	}
+	var cfg dockerConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unmarshal config.json: %v", err)
+	}
+	wantHost := trimRegistryHost(url)
+	if len(cfg.Auths) != 1 {
+		t.Fatalf("expected exactly 1 auth entry, got %d: %v", len(cfg.Auths), cfg.Auths)
+	}
+	entry, ok := cfg.Auths[wantHost]
+	if !ok {
+		t.Fatalf("config missing host key %q; auths=%v", wantHost, cfg.Auths)
+	}
+	if entry.RegistryToken != token {
+		t.Fatalf("registrytoken = %q, want %q", entry.RegistryToken, token)
+	}
+}
+
+// TestBuildCredentialAnonymous proves an anonymous request writes no config and
+// sets no DOCKER_CONFIG (the DB pull and the image pull both go anonymously).
+func TestBuildCredentialAnonymous(t *testing.T) {
+	cred, err := buildCredential(&ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080"},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", Tag: "3.14"},
+	})
+	if err != nil {
+		t.Fatalf("buildCredential: %v", err)
+	}
+	defer cred.cleanup()
+	if len(cred.env) != 0 {
+		t.Fatalf("anonymous request must add no env; got %v", cred.env)
+	}
+}
+
+// TestBuildCredentialHostKeyWithPort proves the config key preserves the port so
+// private-image pulls keep authenticating (the key must equal the target host).
+func TestBuildCredentialHostKeyWithPort(t *testing.T) {
+	cred, err := buildCredential(&ScanRequest{
+		Registry: RegistryRef{URL: "https://registry.example.com:5000/", Authorization: "Bearer tkn"},
+		Artifact: ArtifactRef{Repository: "team/app", Tag: "1.0"},
+	})
+	if err != nil {
+		t.Fatalf("buildCredential: %v", err)
+	}
+	defer cred.cleanup()
+	dir := strings.TrimPrefix(cred.env[0], "DOCKER_CONFIG=")
+	raw, _ := os.ReadFile(filepath.Join(dir, "config.json"))
+	var cfg dockerConfig
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := cfg.Auths["registry.example.com:5000"]; !ok {
+		t.Fatalf("host key missing port; auths=%v", cfg.Auths)
+	}
+}
+
+func TestDockerConfigJSONShape(t *testing.T) {
+	raw, err := dockerConfigJSON("host:8080", "tok")
+	if err != nil {
+		t.Fatalf("dockerConfigJSON: %v", err)
+	}
+	want := `{"auths":{"host:8080":{"registrytoken":"tok"}}}`
+	if string(raw) != want {
+		t.Fatalf("config json = %s, want %s", raw, want)
+	}
+}
+
+func TestTrivyOutputIndicatesDBFailure(t *testing.T) {
+	fires := []string{
+		"2024-01-01 UNAUTHORIZED: authentication required",
+		"FATAL failed to download vulnerability DB",
+		"error: vulnerability DB does not exist",
+		"trivy: DB error occurred",
+		"pull rejected: unauthorized: invalid token", // case-insensitive
+	}
+	for _, s := range fires {
+		if !trivyOutputIndicatesDBFailure(s) {
+			t.Errorf("expected DB-failure marker to fire on %q", s)
+		}
+	}
+	benign := []string{
+		"",
+		"2024-01-01 INFO Vulnerability scanning is enabled",
+		"2024-01-01 INFO Detected OS: alpine",
+		"2024-01-01 INFO Number of language-specific files: 0",
+		"warn: no vulnerabilities found",
+	}
+	for _, s := range benign {
+		if trivyOutputIndicatesDBFailure(s) {
+			t.Errorf("DB-failure marker false-fired on benign output %q", s)
+		}
+	}
+}
+
+func TestDBPresent(t *testing.T) {
+	cache := t.TempDir()
+	if dbPresent(cache) {
+		t.Fatal("empty cache should not be DB-present")
+	}
+	dbDir := filepath.Join(cache, "db")
+	if err := os.MkdirAll(dbDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Empty metadata file -> still not present.
+	meta := filepath.Join(dbDir, "metadata.json")
+	if err := os.WriteFile(meta, nil, 0o644); err != nil {
+		t.Fatalf("write empty meta: %v", err)
+	}
+	if dbPresent(cache) {
+		t.Fatal("empty metadata.json should not count as DB-present")
+	}
+	// Non-empty metadata file -> present.
+	if err := os.WriteFile(meta, []byte(`{"Version":2}`), 0o644); err != nil {
+		t.Fatalf("write meta: %v", err)
+	}
+	if !dbPresent(cache) {
+		t.Fatal("non-empty metadata.json should count as DB-present")
+	}
+}
+
+// TestMarkReadyIfDBPresentGate proves the readiness flag (and /probe/ready) stays
+// 503 while the DB-presence check fails, and flips to 200 once it passes.
+func TestMarkReadyIfDBPresentGate(t *testing.T) {
+	srv := NewServer(LoadConfig())
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	if srv.markReadyIfDBPresent(func() bool { return false }) {
+		t.Fatal("markReadyIfDBPresent returned true on failing DB check")
+	}
+	if code := getStatus(t, ts.URL+"/probe/ready"); code != http.StatusServiceUnavailable {
+		t.Fatalf("not-ready status = %d, want 503", code)
+	}
+
+	if !srv.markReadyIfDBPresent(func() bool { return true }) {
+		t.Fatal("markReadyIfDBPresent returned false on passing DB check")
+	}
+	if code := getStatus(t, ts.URL+"/probe/ready"); code != http.StatusOK {
+		t.Fatalf("ready status = %d, want 200", code)
+	}
+}
+
+func getStatus(t *testing.T, url string) int {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	resp.Body.Close()
+	return resp.StatusCode
+}
+
+// dbErrorStub emits a trivy that exits 0 with empty Results but logs a DB-auth
+// failure to stderr — the exact false-clean shape #2167 must fail closed on.
+func dbErrorStub(t *testing.T) string {
+	return writeStub(t, "#!/bin/sh\n"+stubVersion+`
+echo '{"Results":[]}'
+echo "2024-01-01 FATAL UNAUTHORIZED: failed to download vulnerability DB" 1>&2
+exit 0
+`)
+}
+
+// TestScanExit0DBErrorFailsClosed proves a trivy run that exits 0 while logging a
+// DB failure returns an error (job Failed -> report 500), not an empty report.
+func TestScanExit0DBErrorFailsClosed(t *testing.T) {
+	ts := newTestServer(t, dbErrorStub(t))
+	defer ts.Close()
+
+	id := submitScan(t, ts.URL, ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080"},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", Tag: "3.14"},
+	})
+	status, body := pollReport(t, ts.URL, id)
+	if status != http.StatusInternalServerError {
+		t.Fatalf("exit-0 DB-error scan status = %d, want 500; body=%s", status, body)
+	}
+}
+
+// TestScanExit0DBErrorUnitLevel exercises Scan directly (no HTTP) for the same
+// exit-0-with-DB-error contract.
+func TestScanExit0DBErrorUnitLevel(t *testing.T) {
+	cfg := LoadConfig()
+	cfg.TrivyPath = dbErrorStub(t)
+	cfg.CacheDir = t.TempDir()
+	cfg.ScanTimeout = 10 * time.Second
+	_, err := NewScanner(cfg).Scan(context.Background(), &ScanRequest{
+		Registry: RegistryRef{URL: "http://backend:8080", Authorization: "Bearer tkn"},
+		Artifact: ArtifactRef{Repository: "docker-local/alpine", Tag: "3.14"},
+	})
+	if err == nil {
+		t.Fatal("expected exit-0-with-DB-error to return an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "vulnerability-DB failure") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/docker/scanner-adapter/server.go
+++ b/docker/scanner-adapter/server.go
@@ -31,6 +31,19 @@ func NewServer(cfg *Config) *Server {
 // MarkReady flips the readiness gate on (called after a successful version probe).
 func (s *Server) MarkReady() { s.ready.Store(true) }
 
+// markReadyIfDBPresent flips readiness on only when dbReady reports a loaded
+// vuln DB, and reports whether it did. Extracted as a seam so the DB-presence
+// readiness gate is unit-testable without a real trivy cache. A missing DB
+// keeps the adapter not-ready so the backend fails every scan closed rather than
+// dispatching to a scanner that would exit 0 with empty (false-clean) results.
+func (s *Server) markReadyIfDBPresent(dbReady func() bool) bool {
+	if dbReady() {
+		s.MarkReady()
+		return true
+	}
+	return false
+}
+
 // Handler returns the adapter's HTTP router.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary

Part of #2167 (scanner-adapter credential scoping + DB-readiness).

The scanner-adapter passed the per-scan target-image bearer to trivy via a flat,
host-unscoped `TRIVY_REGISTRY_TOKEN`. trivy applies that credential to **every**
registry request — including its own vulnerability-DB OCI pull from the public
mirrors (`mirror.gcr.io`, `ghcr.io/aquasec/trivy-db`, `public.ecr.aws`). Those
mirrors reject the target-scoped bearer, so trivy could not fetch its DB and
returned empty results. This PR makes container scanning actually work while
keeping the existing fail-closed contract intact. Three changes:

1. **Host-scoped pull credential (`scan.go`).** Instead of the flat env token,
   `Scan` now writes a per-scan Docker `config.json` into a private `0700` temp
   dir (`config.json` `0600`, `defer` removed) with a single `auths` entry keyed
   to the **target registry host** (`trimRegistryHost(req.Registry.URL)`, port
   preserved) and points trivy at it via `DOCKER_CONFIG`. Because
   trivy/go-containerregistry resolve credentials per host, the bearer is sent
   **only** for the target image pull; the vuln-DB pull has no matching entry and
   goes **anonymously** (correct). The flat `TRIVY_REGISTRY_TOKEN` is no longer
   set. Private-image auth is preserved — the config key exactly matches the host
   used to build the image reference. The token is never logged.

2. **DB-presence readiness gate (`main.go`, `server.go`).** Readiness previously
   flipped on after only a `trivy --version` probe. It now additionally requires
   the vulnerability DB to be present in the cache dir
   (`<cache>/db/metadata.json`). When DB updates are enabled the adapter
   downloads the DB at startup (`trivy image --download-db-only`) before marking
   ready. If the DB is not present the adapter stays **not-ready** (503), so the
   backend fails every scan closed rather than dispatching to a scanner with no
   DB (which would report a false clean).

3. **Exit-0 DB-error detection (`scan.go`).** trivy can exit `0` with empty
   `Results` when its DB failed to load. `Scan` now inspects stderr on a
   zero-exit run and returns an error (→ job Failed → `/report` 500 →
   backend fail-closed) when it matches a tight set of DB-fatal markers
   (`UNAUTHORIZED`, `failed to download vulnerability DB`,
   `vulnerability DB does not exist`, `DB error`). It does **not** gate on empty
   results alone, so a legitimately clean image (e.g. distroless / `FROM scratch`
   with 0 OS packages) is not falsely failed.

The existing fail-closed path (trivy non-zero exit → error → job Failed → 500 →
backend `BadGateway`/`fail_scan`) is unchanged. The scanner-adapter image is
independently versioned; the image publish is separate from this Go source
change.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New tests in `docker/scanner-adapter/scan_fix_test.go`:
- `TestBuildCredentialHostScopedConfig` / `TestBuildCredentialHostKeyWithPort` /
  `TestBuildCredentialAnonymous` — assert a host-keyed `config.json` +
  `DOCKER_CONFIG` are written, the host key equals `trimRegistryHost(URL)`
  (incl. port), the flat `TRIVY_REGISTRY_TOKEN` is never set, and anonymous
  requests add no credential.
- `TestTrivyOutputIndicatesDBFailure` — fires on the DB-fatal markers,
  no-fires on benign trivy stderr (regression guard against false fails).
- `TestDBPresent` / `TestMarkReadyIfDBPresentGate` — readiness stays 503 while
  the DB check fails and flips to 200 once present.
- `TestScanExit0DBErrorFailsClosed` / `TestScanExit0DBErrorUnitLevel` — an
  exit-0 trivy run with a DB-error on stderr fails closed (500), not empty/clean.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`gofmt -l`, `go vet ./...`, `go test ./...` — all pass; static Docker build compiles)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
