### PR TITLE
fix(api): gate direct artifact delete on promotion-only release repos

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -7398,6 +7398,33 @@ async fn handle_delete_manifest(
         return resp;
     }
 
+    // Promotion-only release repositories: deleting a manifest is the symmetric
+    // mutation to the (already-gated) direct push and would let a plain
+    // repo-write principal permanently destroy a released image, bypassing the
+    // promotion/approval controls. Reject it for non-approvers; admins are the
+    // release-approvers (approve_promotion requires is_admin) and retain the
+    // retraction escape hatch. The promotion service writes via its own RAW SQL
+    // path and is unaffected. Mirrors the manifest-PUT promotion_only gate.
+    let promotion_only = sqlx::query_scalar!(
+        "SELECT promotion_only FROM repositories WHERE id = $1",
+        repo.id
+    )
+    .fetch_optional(&state.db)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or(false);
+    if crate::api::handlers::proxy_helpers::promotion_only_blocks_direct_delete(
+        promotion_only,
+        claims.is_admin,
+    ) {
+        return oci_error(
+            StatusCode::FORBIDDEN,
+            "DENIED",
+            "Direct deletes are disabled for this release repository; retract via an approver/promotion workflow",
+        );
+    }
+
     // Resolve the digest the reference (tag name or digest) maps to. For a
     // hosted repo a digest reference is deletable even with no surviving tag
     // row, as long as this repo has committed metadata for it (#1681); the
@@ -13311,6 +13338,149 @@ mod oci_blob_upload_streaming_tests {
             allowed_status,
             StatusCode::BAD_REQUEST,
             "manifest PUT to a normal repo must pass the gate (degenerate -> 400, not 409)"
+        );
+    }
+
+    /// #2237: a direct manifest DELETE on a `promotion_only` release repository
+    /// must be rejected for a non-admin (non-approver) with 403 + OCI code
+    /// DENIED — symmetric with the manifest-PUT gate. Admins (release-approvers)
+    /// keep the retraction escape hatch (delete proceeds), and a normal
+    /// (non-promotion_only) repo is unaffected for the same non-admin caller.
+    #[tokio::test]
+    async fn delete_manifest_gated_on_promotion_only_repo() {
+        let Some(f) = OciUploadFixture::setup().await else {
+            return;
+        };
+        let digest = format!("sha256:{}", "c".repeat(64));
+        let seed_tag = |tag: &'static str| {
+            let pool = f.inner.pool.clone();
+            let repo_id = f.inner.repo_id;
+            let digest = digest.clone();
+            async move {
+                sqlx::query(
+                    "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+                     VALUES ($1, 'app', $2, $3, 'application/vnd.oci.image.manifest.v1+json')",
+                )
+                .bind(repo_id)
+                .bind(tag)
+                .bind(&digest)
+                .execute(&pool)
+                .await
+                .expect("seed tag");
+            }
+        };
+
+        // (a) promotion_only=true, non-admin (default fixture token, is_admin=false):
+        //     DELETE must be rejected 403 DENIED and leave the tag intact.
+        f.inner.set_promotion_only(true).await;
+        seed_tag("rel").await;
+        let (blocked_status, _h, blocked_body) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/rel", f.inner.repo_key),
+                &f.authorization,
+                Bytes::new(),
+            ),
+        )
+        .await;
+        let surviving: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oci_tags WHERE repository_id = $1 AND tag = 'rel'",
+        )
+        .bind(f.inner.repo_id)
+        .fetch_one(&f.inner.pool)
+        .await
+        .expect("count rel tag");
+
+        // (b) promotion_only=true, admin: the retraction escape hatch — the same
+        //     DELETE now proceeds (202) and removes the tag.
+        let admin_auth = {
+            sqlx::query("UPDATE users SET is_admin = true WHERE id = $1")
+                .bind(f.inner.user_id)
+                .execute(&f.inner.pool)
+                .await
+                .expect("promote user to admin");
+            let auth_service = AuthService::new(
+                f.inner.state.db.clone(),
+                Arc::new(f.inner.state.config.clone()),
+            );
+            let user = sqlx::query_as::<_, crate::models::user::User>(
+                r#"SELECT id, username, email, password_hash, display_name, auth_provider,
+                          external_id, is_admin, is_active, is_service_account, must_change_password,
+                          totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,
+                          failed_login_attempts, locked_until, last_failed_login_at,
+                          password_changed_at, last_login_at, created_at, updated_at
+                   FROM users WHERE id = $1"#,
+            )
+            .bind(f.inner.user_id)
+            .fetch_one(&f.inner.pool)
+            .await
+            .expect("fetch admin user");
+            format!(
+                "Bearer {}",
+                auth_service
+                    .generate_tokens(&user)
+                    .expect("mint admin token")
+                    .access_token
+            )
+        };
+        let (admin_status, _ah, _ab) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/rel", f.inner.repo_key),
+                &admin_auth,
+                Bytes::new(),
+            ),
+        )
+        .await;
+
+        // (c) promotion_only=false, non-admin: unaffected — the same delete
+        //     proceeds. Reset the user back to non-admin so the token identity is
+        //     irrelevant; the default fixture token is still non-admin.
+        sqlx::query("UPDATE users SET is_admin = false WHERE id = $1")
+            .bind(f.inner.user_id)
+            .execute(&f.inner.pool)
+            .await
+            .expect("demote user");
+        f.inner.set_promotion_only(false).await;
+        seed_tag("rel2").await;
+        let (normal_status, _nh, _nb) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/rel2", f.inner.repo_key),
+                &f.authorization,
+                Bytes::new(),
+            ),
+        )
+        .await;
+
+        f.teardown().await;
+
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "non-admin manifest DELETE on a promotion_only repo must return 403"
+        );
+        assert!(
+            String::from_utf8_lossy(&blocked_body).contains("DENIED"),
+            "403 body must carry the OCI DENIED code; got: {}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_eq!(
+            surviving, 1,
+            "a blocked delete must leave the released tag intact"
+        );
+        assert_eq!(
+            admin_status,
+            StatusCode::ACCEPTED,
+            "an admin (release-approver) retains the retraction escape hatch (202)"
+        );
+        assert_eq!(
+            normal_status,
+            StatusCode::ACCEPTED,
+            "delete on a normal (non-promotion_only) repo must be unaffected (202)"
         );
     }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -199,6 +199,47 @@ pub fn reject_direct_upload_if_promotion_only(
     }
 }
 
+/// Decide whether a direct user delete must be rejected because the target
+/// repository is flagged `promotion_only`.
+///
+/// A `promotion_only` repository is a release/production repository whose
+/// contents may only be mutated through the promotion workflow (staging ->
+/// promotion -> approval). The write gate already blocks direct uploads to
+/// such repos; a direct DELETE is the symmetric mutation and would let a
+/// principal with plain repo-write access permanently destroy a released
+/// artifact, bypassing the same controls.
+///
+/// Unlike the upload gate, delete keeps an escape hatch for release-approvers
+/// (`is_admin` == approver here: `approve_promotion` requires `is_admin`) so a
+/// genuinely bad release can still be retracted through the API — mirroring the
+/// admin exemption in `delete_blocked_by_immutability`. Non-admins are rejected.
+///
+/// The promotion service writes through its own RAW SQL path, which does not
+/// traverse the HTTP delete handlers, so promotions are unaffected. A repo with
+/// `promotion_only = false` is never affected (no-op for all callers).
+pub fn promotion_only_blocks_direct_delete(promotion_only: bool, is_admin: bool) -> bool {
+    promotion_only && !is_admin
+}
+
+/// 403 plain-text response for a rejected direct delete on a `promotion_only`
+/// repository. Provided for `Response`-returning call sites so both delete
+/// handlers share one message/shape.
+#[allow(clippy::result_large_err)]
+pub fn reject_direct_delete_if_promotion_only(
+    promotion_only: bool,
+    is_admin: bool,
+) -> Result<(), Response> {
+    if promotion_only_blocks_direct_delete(promotion_only, is_admin) {
+        Err((
+            StatusCode::FORBIDDEN,
+            "Direct deletes are disabled for this release repository; retract via an approver/promotion workflow",
+        )
+            .into_response())
+    } else {
+        Ok(())
+    }
+}
+
 /// Strip query strings and fragments before logging a proxy path. Some
 /// split-path proxy callers fetch absolute, signed upstream URLs while caching
 /// under a stable local key; the fetch target must remain raw for the outbound
@@ -4680,6 +4721,46 @@ mod tests {
         let repo = promo_repo_info(false);
         assert!(repo.reject_if_promotion_only(false).is_ok());
         assert!(repo.reject_if_promotion_only(true).is_ok());
+    }
+
+    // ── promotion_only direct-delete gate ───────────────────────────
+
+    #[test]
+    fn test_promotion_only_blocks_non_admin_direct_delete() {
+        // Non-admin (non-approver) + promotion_only repo => delete blocked.
+        assert!(promotion_only_blocks_direct_delete(true, false));
+    }
+
+    #[test]
+    fn test_promotion_only_admin_retains_delete_escape_hatch() {
+        // Admins are the release-approvers and keep the retraction escape hatch,
+        // unlike the upload gate: (promotion_only=true, is_admin=true) => allowed.
+        assert!(!promotion_only_blocks_direct_delete(true, true));
+    }
+
+    #[test]
+    fn test_promotion_only_delete_normal_repo_not_blocked() {
+        // promotion_only = false => never blocked, for any caller (no regression
+        // for normal repos).
+        assert!(!promotion_only_blocks_direct_delete(false, false));
+        assert!(!promotion_only_blocks_direct_delete(false, true));
+    }
+
+    #[test]
+    fn test_reject_direct_delete_if_promotion_only_returns_403() {
+        // Non-admin delete on a promotion_only repo is rejected 403 FORBIDDEN.
+        let err = reject_direct_delete_if_promotion_only(true, false)
+            .expect_err("non-admin direct delete on promotion_only repo must be rejected");
+        assert_eq!(err.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn test_reject_direct_delete_if_promotion_only_admin_and_normal_ok() {
+        // Admin delete on a promotion_only repo passes (retraction hatch); a
+        // normal repo is a no-op for any caller.
+        assert!(reject_direct_delete_if_promotion_only(true, true).is_ok());
+        assert!(reject_direct_delete_if_promotion_only(false, false).is_ok());
+        assert!(reject_direct_delete_if_promotion_only(false, true).is_ok());
     }
 
     // ── LocalLookup dispatch tests ──────────────────────────────────

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4530,6 +4530,23 @@ pub async fn delete_artifact(
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
 
+    // Promotion-only release repositories: a direct DELETE is the symmetric
+    // mutation to the (already-gated) direct upload and would let a principal
+    // with plain repo-write permanently destroy a released artifact, bypassing
+    // the promotion/approval controls. Reject it for non-approvers. Admins are
+    // the release-approvers (approve_promotion requires is_admin) and keep the
+    // retraction escape hatch; trusted service accounts (e.g. peer replication)
+    // are exempt too, mirroring the immutability guard's exemptions below. The
+    // promotion service writes via its own RAW SQL path and is unaffected.
+    if crate::api::handlers::proxy_helpers::promotion_only_blocks_direct_delete(
+        repo.promotion_only,
+        auth.is_admin || auth.is_service_account,
+    ) {
+        return Err(AppError::Authorization(
+            "Direct deletes are disabled for this release repository; retract via an approver/promotion workflow".to_string(),
+        ));
+    }
+
     // Release immutability: a versioned (immutable) artifact must never be
     // mutated after publication. Deleting one would re-open its coordinates for
     // a different-bytes re-upload (the upload path already rejects an existing
@@ -8483,6 +8500,118 @@ mod tests {
             remaining.as_deref(),
             Some(original_sha.as_str()),
             "the released content must be unchanged after a blocked swap"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #2237: a direct DELETE on a `promotion_only` release repository is
+    /// rejected for a non-admin (non-approver) with 403 FORBIDDEN, while an
+    /// admin (release-approver) retains the retraction escape hatch, and a
+    /// normal (non-promotion_only) repo is unaffected for the same non-admin.
+    #[tokio::test]
+    async fn delete_artifact_gated_on_promotion_only_repo_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = Some(tdh::make_auth(user_id, &username));
+        let mut admin_ext = tdh::make_auth(user_id, &username);
+        admin_ext.is_admin = true;
+        let admin = Some(admin_ext);
+
+        let set_promotion_only = |value: bool| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query("UPDATE repositories SET promotion_only = $1 WHERE id = $2")
+                    .bind(value)
+                    .bind(repo_id)
+                    .execute(&pool)
+                    .await
+                    .expect("set promotion_only");
+            }
+        };
+
+        // Publish a release artifact (generic classifies this coordinate mutable,
+        // so the immutability guard is a no-op — the promotion gate is the only
+        // control under test).
+        let path = "app/1.0.0/app-1.0.0.bin".to_string();
+        upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"RELEASE-BYTES"),
+        )
+        .await
+        .expect("initial publish must succeed");
+
+        // (1) promotion_only=true, non-admin -> 403 FORBIDDEN, artifact intact.
+        set_promotion_only(true).await;
+        let blocked = delete_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(
+            matches!(blocked, Err(AppError::Authorization(_))),
+            "non-admin DELETE on a promotion_only repo must be rejected 403, got: {blocked:?}"
+        );
+        let surviving: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM artifacts WHERE repository_id = $1 AND path = $2 AND is_deleted = false",
+        )
+        .bind(repo_id)
+        .bind(&path)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            surviving, 1,
+            "a blocked delete must leave the release intact"
+        );
+
+        // (2) promotion_only=true, admin -> retraction escape hatch: proceeds.
+        let admin_del = delete_artifact(
+            State(state.clone()),
+            Extension(admin.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(
+            admin_del.is_ok(),
+            "an admin (release-approver) must retain the retraction path, got: {admin_del:?}"
+        );
+
+        // (3) promotion_only=false, non-admin -> unaffected: proceeds.
+        set_promotion_only(false).await;
+        let path2 = "app/2.0.0/app-2.0.0.bin".to_string();
+        upload_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path2.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"NORMAL-REPO-BYTES"),
+        )
+        .await
+        .expect("publish to normal repo must succeed");
+        let normal_del = delete_artifact(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path((key.clone(), path2.clone())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(
+            normal_del.is_ok(),
+            "delete on a normal (non-promotion_only) repo must be unaffected, got: {normal_del:?}"
         );
 
         tdh::cleanup(&pool, repo_id, user_id).await;


### PR DESCRIPTION
## Summary

The `promotion_only` repository flag (migration 129) marks release/production
repositories that may only be mutated through the promotion workflow
(staging → promotion → approval). Today that flag is enforced on every **write**
path — generic `upload_artifact`, OCI blob-finalize, and OCI `put_manifest` all
reject a direct push — but it is **absent from both delete paths**. As a result a
principal with plain repo-write access (a non-approver) can permanently destroy a
released artifact by issuing a direct DELETE; the subsequent re-create is then
blocked by the intact write gate, so the release is left destroyed with no
recovery path short of raw DB access.

This PR extends the existing promotion-only gate to the delete path, symmetric
with the upload gate, so a release repository can only be mutated by
release-approvers or the promotion workflow. It addresses the R3 delete/re-PUT
immutability threat model for promotion-only repos.

Changes:
- `proxy_helpers.rs`: add a shared, pure, unit-tested predicate
  `promotion_only_blocks_direct_delete(promotion_only, is_admin)` plus a
  `reject_direct_delete_if_promotion_only(...)` helper, mirroring the existing
  upload helpers so both call sites share one message/shape.
- `repositories.rs::delete_artifact`: after the write-access check, reject a
  direct delete on a `promotion_only` repo for a non-admin with `403 FORBIDDEN`.
- `oci_v2.rs::handle_delete_manifest`: mirror the manifest-PUT `promotion_only`
  lookup and reject a non-admin manifest delete on a `promotion_only` repo with
  `403` + OCI code `DENIED`.

Unlike the upload gate (no exemption), the delete gate preserves an escape hatch
for **release-approvers** — admins retain the ability to retract a genuinely bad
release through the API, matching the admin exemption that
`delete_blocked_by_immutability` already grants (approver == admin here:
`approve_promotion` requires `is_admin`). Trusted service accounts (e.g. peer
replication) are exempt on the generic path for parity with the existing
`replication_exemption_trusted` guard. The promotion service writes through its
own RAW-SQL path, which does not traverse these HTTP handlers, so approved
promotions are unaffected; normal (non-`promotion_only`) repositories are a no-op
for all callers. No schema migration.

Closes #2237

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added:
- Pure-predicate unit tests covering all four `(promotion_only × is_admin)`
  combinations plus the `reject_direct_delete_if_promotion_only` 403 shape
  (`proxy_helpers.rs`).
- A DB-backed generic `delete_artifact` handler test: non-admin delete on a
  `promotion_only` repo → 403 (artifact intact), admin delete → proceeds
  (retraction), non-`promotion_only` repo → unaffected (`repositories.rs`).
- A DB-backed OCI `handle_delete_manifest` test: non-admin manifest delete on a
  `promotion_only` repo → 403 `DENIED` (tag intact), admin → proceeds, normal
  repo → unaffected (`oci_v2.rs`).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
