### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.2.5"
+version = "1.3.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.2.5",
+        version = "1.3.0",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
## Summary
Mechanical version bump of the backend workspace from **1.2.5 → 1.3.0** for the v1.3.0 release cut. Version strings and the lockfile only — no logic changes.

Changed:
- `Cargo.toml` — `[workspace.package] version` `1.2.5` → `1.3.0`
- `backend/src/api/openapi.rs` — hardcoded OpenAPI `info.version` `1.2.5` → `1.3.0` (decoupled spot; keeps the served spec / UI version in sync so it does not report a stale version)
- `Cargo.lock` — `artifact-keeper-backend` package entry `1.2.5` → `1.3.0` (lock stays consistent for `--locked` CI builds)

`/health` and other runtime version surfaces read `env!("CARGO_PKG_VERSION")`, which now resolves to `1.3.0` from the workspace bump — no separate constant to change. No other hardcoded `1.2.5` app-version constants exist in `backend/src` (the lone remaining `1.2.5` in `incus_scanner.rs` is mock CVE `fixed_version` test data, not the app version, and is intentionally left untouched).

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

## Validation
- `cargo build --workspace --locked` — succeeds (lockfile consistent)
- `cargo clippy --workspace --all-targets --locked -- -D warnings` — clean
- `cargo fmt --check` — clean
