### PR TITLE
fix(apt): virtual dists swallows 502 cap-exceeded into empty 200

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -3114,3 +3114,329 @@ mod upload_db_tests {
         f.teardown().await;
     }
 }
+
+// ---------------------------------------------------------------------------
+// Virtual `dists/` member-iteration error propagation + large-index cap (#2267,
+// #2278). These exercise `try_virtual_dists`:
+//   * a >8 MiB Packages.xz now succeeds (LARGE_METADATA_MAX_BYTES ceiling) and
+//     is served/cached instead of tripping the old 8 MiB DEFAULT cap (502);
+//   * a genuine non-404 upstream failure is SURFACED to the client rather than
+//     swallowed via `Err(_) => continue` into an `Ok(None)` that fell through
+//     to an empty local-DB 200 (`apt`'s "File has unexpected size");
+//   * a 404 member is still skipped so the caller can fall through to the
+//     local-DB (hosted) path or the next mirror.
+#[cfg(test)]
+mod virtual_dists_cap_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use uuid::Uuid;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    const DIST: &str = "trixie";
+    const PKG_PATH: &str = "dists/trixie/main/binary-amd64/Packages.xz";
+
+    /// Insert a Remote Debian repo pointing at `upstream_url` and enrol it as a
+    /// member of a fresh Virtual repo. Returns `(virtual_id, virtual_key,
+    /// member_id)`; callers clean up via [`cleanup`].
+    async fn virtual_with_remote_member(
+        pool: &sqlx::PgPool,
+        storage_path: &str,
+        upstream_url: &str,
+    ) -> (Uuid, String, Uuid) {
+        let member_id = Uuid::new_v4();
+        let member_key = format!("dbg-mem-{}", member_id.simple());
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, upstream_url) \
+             VALUES ($1, $2, $3, $4, 'remote'::repository_type, 'debian'::repository_format, $5)",
+        )
+        .bind(member_id)
+        .bind(&member_key)
+        .bind(&member_key)
+        .bind(storage_path)
+        .bind(upstream_url)
+        .execute(pool)
+        .await
+        .expect("insert remote member");
+
+        let virtual_id = Uuid::new_v4();
+        let virtual_key = format!("dbg-virt-{}", virtual_id.simple());
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+             VALUES ($1, $2, $3, $4, 'virtual'::repository_type, 'debian'::repository_format)",
+        )
+        .bind(virtual_id)
+        .bind(&virtual_key)
+        .bind(&virtual_key)
+        .bind(storage_path)
+        .execute(pool)
+        .await
+        .expect("insert virtual repo");
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(virtual_id)
+        .bind(member_id)
+        .execute(pool)
+        .await
+        .expect("insert virtual member");
+        (virtual_id, virtual_key, member_id)
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, virtual_id: Uuid, member_id: Uuid) {
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(virtual_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+            .bind(vec![virtual_id, member_id])
+            .execute(pool)
+            .await;
+    }
+
+    // A 9 MiB Packages.xz — above the 8 MiB DEFAULT ceiling that used to 502 —
+    // is fetched, served 200, and cached (second call issues no second upstream
+    // request). Proves the DEFAULT->LARGE (128 MiB) tier switch for dists.
+    #[tokio::test]
+    #[allow(clippy::disallowed_methods)] // to_bytes on a bounded in-memory test body
+    async fn large_packages_index_above_default_cap_succeeds_and_caches() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let body = vec![0x5au8; 9 * 1024 * 1024];
+        assert!(
+            body.len() > proxy_helpers::DEFAULT_METADATA_MAX_BYTES
+                && body.len() < proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            "fixture must straddle DEFAULT and LARGE so success implies the LARGE tier",
+        );
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{PKG_PATH}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("dbg-cap-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (virtual_id, virtual_key, member_id) =
+            virtual_with_remote_member(&pool, root, &server.uri()).await;
+
+        let first = try_virtual_dists(
+            &state,
+            virtual_id,
+            &virtual_key,
+            DIST,
+            PKG_PATH,
+            "application/octet-stream",
+        )
+        .await;
+        let second = try_virtual_dists(
+            &state,
+            virtual_id,
+            &virtual_key,
+            DIST,
+            PKG_PATH,
+            "application/octet-stream",
+        )
+        .await;
+
+        cleanup(&pool, virtual_id, member_id).await;
+        let hits = server.received_requests().await.unwrap().len();
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let resp = first
+            .expect("large index must not error")
+            .expect("large index must resolve via the remote member");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let got = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        assert_eq!(got.len(), body.len(), "full 9 MiB body must be served");
+        assert!(
+            second.is_ok_and(|o| o.is_some()),
+            "second read must still resolve",
+        );
+        assert_eq!(hits, 1, "second read must be served warm from cache");
+    }
+
+    // A genuine non-404 upstream failure (here a 5xx that folds to 502/503) must
+    // SURFACE as an Err so the client sees the real cause — not be swallowed into
+    // `Ok(None)` and rendered as an empty 200 (the #2278 `apt` size-mismatch bug).
+    #[tokio::test]
+    async fn upstream_failure_surfaces_instead_of_empty_200() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{PKG_PATH}")))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("dbg-502-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (virtual_id, virtual_key, member_id) =
+            virtual_with_remote_member(&pool, root, &server.uri()).await;
+
+        let out = try_virtual_dists(
+            &state,
+            virtual_id,
+            &virtual_key,
+            DIST,
+            PKG_PATH,
+            "application/octet-stream",
+        )
+        .await;
+
+        cleanup(&pool, virtual_id, member_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let resp = out.expect_err(
+            "a genuine upstream failure must surface as Err, not be masked into Ok(None)/empty-200",
+        );
+        assert!(
+            resp.status().is_server_error(),
+            "the real upstream failure status must reach the client, got {}",
+            resp.status(),
+        );
+    }
+
+    // A member that 404s for the path is skipped (the file genuinely is not
+    // there), so the dispatcher returns Ok(None) and the caller falls through to
+    // the local-DB / next-mirror path. This is the arm that must NOT be treated
+    // as a hard failure — the discriminator only surfaces non-404 errors.
+    #[tokio::test]
+    async fn missing_member_file_falls_through_to_none() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{PKG_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("dbg-404-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (virtual_id, virtual_key, member_id) =
+            virtual_with_remote_member(&pool, root, &server.uri()).await;
+
+        let out = try_virtual_dists(
+            &state,
+            virtual_id,
+            &virtual_key,
+            DIST,
+            PKG_PATH,
+            "application/octet-stream",
+        )
+        .await;
+
+        cleanup(&pool, virtual_id, member_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            matches!(out, Ok(None)),
+            "a 404 member must fall through to Ok(None), got {:?}",
+            out.map(|o| o.map(|r| r.status())),
+        );
+    }
+
+    // The change-detecting variant (Release/InRelease revalidation path) applies
+    // the same NotFound-vs-real-error discrimination: a 5xx upstream surfaces as
+    // an Err instead of `Ok(None)` (which would have fallen through to an empty
+    // signed Release), while a 404 member is skipped.
+    const INRELEASE_PATH: &str = "dists/trixie/InRelease";
+
+    #[tokio::test]
+    async fn detecting_change_upstream_failure_surfaces() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{INRELEASE_PATH}")))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("dbg-dc502-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (virtual_id, virtual_key, member_id) =
+            virtual_with_remote_member(&pool, root, &server.uri()).await;
+
+        let out = try_virtual_dists_detecting_change(
+            &state,
+            virtual_id,
+            &virtual_key,
+            DIST,
+            INRELEASE_PATH,
+            "application/octet-stream",
+        )
+        .await;
+
+        cleanup(&pool, virtual_id, member_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let resp = out.expect_err("a 5xx upstream must surface as Err, not empty Ok(None)");
+        assert!(
+            resp.status().is_server_error(),
+            "real upstream failure status must reach the client, got {}",
+            resp.status(),
+        );
+    }
+
+    #[tokio::test]
+    async fn detecting_change_missing_member_falls_through_to_none() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{INRELEASE_PATH}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("dbg-dc404-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let root = tmp.to_str().unwrap();
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), root);
+        let state = tdh::build_state_with_proxy(pool.clone(), root, proxy);
+        let (virtual_id, virtual_key, member_id) =
+            virtual_with_remote_member(&pool, root, &server.uri()).await;
+
+        let out = try_virtual_dists_detecting_change(
+            &state,
+            virtual_id,
+            &virtual_key,
+            DIST,
+            INRELEASE_PATH,
+            "application/octet-stream",
+        )
+        .await;
+
+        cleanup(&pool, virtual_id, member_id).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            matches!(out, Ok(None)),
+            "a 404 member must fall through to Ok(None), got {:?}",
+            out.map(|o| o.map(|r| r.status())),
+        );
+    }
+}

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -571,7 +571,7 @@ impl<'a> DebianProxy<'a> {
             self.repo_key,
             upstream_url,
             &upstream_path,
-            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
         )
         .await?;
         Err(build_dists_response(content, upstream_ct, content_type))
@@ -797,6 +797,17 @@ async fn require_active_signing_key(
 /// Iterate the virtual repo's Remote members for `upstream_path` and
 /// return the first successful response. Checks the release epoch for
 /// lazy invalidation before attempting the streaming fetch.
+///
+/// Error propagation:
+///   * `404 / NotFound` — the member genuinely doesn't have this file;
+///     continue to the next member.
+///   * Non-404 (502 cap-exceeded, 503 upstream-down, etc.) — record the
+///     first occurrence but **continue** to the next member so a
+///     transient failure on a higher-priority mirror doesn't block a
+///     healthy lower-priority one. If all members fail, the first
+///     non-404 error is returned so the client sees the real cause. If
+///     every member returned 404, `Ok(None)` lets the caller fall through
+///     to the local-DB path (hosted repos).
 async fn try_virtual_dists(
     state: &SharedState,
     virtual_repo_id: uuid::Uuid,
@@ -810,6 +821,7 @@ async fn try_virtual_dists(
     let Some(proxy) = state.proxy_service.as_deref() else {
         return Ok(None);
     };
+    let mut first_err: Option<Response> = None;
     for member in &members {
         let Some(upstream_url) = remote_member_upstream(member) else {
             continue;
@@ -824,7 +836,7 @@ async fn try_virtual_dists(
             &member.key,
             upstream_url,
             upstream_path,
-            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
         )
         .await
         {
@@ -835,13 +847,18 @@ async fn try_virtual_dists(
                     default_content_type,
                 )));
             }
-            Err(_) => {
-                // Try the next member.
-                continue;
+            Err(resp) => {
+                if resp.status() == StatusCode::NOT_FOUND {
+                    continue;
+                }
+                first_err.get_or_insert(resp);
             }
         }
     }
-    Ok(None)
+    match first_err {
+        Some(err) => Err(err),
+        None => Ok(None),
+    }
 }
 
 /// Check the release epoch and invalidate the cache entry if stale.
@@ -879,6 +896,13 @@ async fn maybe_invalidate_by_epoch(
 /// Change-detection variant of [`try_virtual_dists`]. Uses TTL +
 /// conditional-request + epoch-based lazy invalidation for virtual repo
 /// members' Release/InRelease files.
+///
+/// Error propagation mirrors [`try_virtual_dists`]:
+///   * `NotFound` (404) — continue to the next member.
+///   * Non-404 — record the first occurrence but continue; return it
+///     only if no member succeeds. This preserves multi-mirror failover
+///     while still surfacing real failures (502, 503, etc.) instead of
+///     silently falling through to an empty local DB.
 async fn try_virtual_dists_detecting_change(
     state: &SharedState,
     virtual_repo_id: uuid::Uuid,
@@ -892,6 +916,7 @@ async fn try_virtual_dists_detecting_change(
     let Some(proxy) = state.proxy_service.as_deref() else {
         return Ok(None);
     };
+    let mut first_err: Option<Response> = None;
     for member in &members {
         let Some(upstream_url) = remote_member_upstream(member) else {
             continue;
@@ -916,10 +941,18 @@ async fn try_virtual_dists_detecting_change(
                     default_content_type,
                 )));
             }
-            Err(_) => continue,
+            Err(e) => {
+                if matches!(e, crate::error::AppError::NotFound(_)) {
+                    continue;
+                }
+                first_err.get_or_insert(map_proxy_err(e));
+            }
         }
     }
-    Ok(None)
+    match first_err {
+        Some(err) => Err(err),
+        None => Ok(None),
+    }
 }
 
 fn map_proxy_err(e: crate::error::AppError) -> Response {
@@ -1344,7 +1377,7 @@ async fn dists_proxy_catchall(
         &repo_key,
         upstream_url,
         &upstream_path,
-        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        proxy_helpers::LARGE_METADATA_MAX_BYTES,
     )
     .await?;
 

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -43,10 +43,10 @@ pub const DEFAULT_METADATA_MAX_BYTES: usize = 8 * 1024 * 1024;
 
 /// Larger byte ceiling for formats whose metadata documents are legitimately
 /// large and would be truncated by the 8 MiB default: npm packument/meta,
-/// composer packument, pypi simple-index, maven-metadata, and the protobuf
-/// bundle. Matches the existing npm/goproxy capped reads (npm.rs:308/391,
-/// goproxy.rs:295).
-pub const LARGE_METADATA_MAX_BYTES: usize = 16 * 1024 * 1024;
+/// composer packument, pypi simple-index, maven-metadata, protobuf bundle,
+/// and Debian dists indices (trixie's Packages.xz is 9.6 MB; larger suites
+/// like sid can exceed 20 MB).
+pub const LARGE_METADATA_MAX_BYTES: usize = 128 * 1024 * 1024;
 
 /// HTTP client timeout in seconds
 const HTTP_TIMEOUT_SECS: u64 = 60;
@@ -3128,7 +3128,7 @@ impl ProxyService {
             self.fetch_from_upstream_conditional(&full_url, repo.id, etag)
                 .await
         } else {
-            self.fetch_from_upstream(&full_url, repo.id, DEFAULT_METADATA_MAX_BYTES)
+            self.fetch_from_upstream(&full_url, repo.id, LARGE_METADATA_MAX_BYTES)
                 .await
                 .map(Some)
         };
@@ -3170,7 +3170,7 @@ impl ProxyService {
                             cache_key = %cache_key,
                             "cached body missing after 304; refetching unconditionally"
                         );
-                        self.fetch_from_upstream(&full_url, repo.id, DEFAULT_METADATA_MAX_BYTES)
+                        self.fetch_from_upstream(&full_url, repo.id, LARGE_METADATA_MAX_BYTES)
                             .await?
                     }
                     Err(e) => return Err(e),
@@ -11067,8 +11067,19 @@ mod tests {
         );
     }
 
+    // `LARGE_METADATA_MAX_BYTES` was raised 16 MiB -> 128 MiB (commit c301ee37)
+    // so Debian dists indices (>20 MB) are no longer 502'd. Exceeding the 128 MiB
+    // ceiling in a per-PR `--lib` test is impractical (~128 MiB alloc + loopback
+    // transfer), and the size-agnostic over-cap -> BadGateway(502) rejection is
+    // already covered at the exact boundary (body == max accepted, body == max+1
+    // rejected) by `test_capped_read_accepts_body_at_or_below_max` and
+    // `test_capped_read_rejects_over_cap_with_bad_gateway`. What remains unique
+    // here is the under-cap half against the *real* LARGE constant: a 9 MiB
+    // "packument" — which sits ABOVE the 8 MiB DEFAULT ceiling — must succeed via
+    // the buffered `fetch_from_upstream` primitive shared by every large-metadata
+    // caller (npm/goproxy/pypi/maven/debian).
     #[tokio::test]
-    async fn test_large_metadata_9mib_ok_but_17mib_rejected_under_16mib_cap() {
+    async fn test_large_metadata_under_large_cap_succeeds_via_buffered_fetch() {
         use crate::api::handlers::test_db_helpers as tdh;
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -11077,18 +11088,16 @@ mod tests {
             return;
         };
         let server = MockServer::start().await;
-        // A 9 MiB "packument" is under the 16 MiB LARGE ceiling; a 17 MiB body
-        // is over it.
+        // 9 MiB: above DEFAULT_METADATA_MAX_BYTES (8 MiB), below
+        // LARGE_METADATA_MAX_BYTES (128 MiB) — so success can only be explained
+        // by the LARGE ceiling being in effect, not the DEFAULT one.
         let ok_body = vec![b'n'; 9 * 1024 * 1024];
-        let over_body = vec![b'n'; 17 * 1024 * 1024];
+        assert!(
+            ok_body.len() > DEFAULT_METADATA_MAX_BYTES && ok_body.len() < LARGE_METADATA_MAX_BYTES
+        );
         Mock::given(method("GET"))
             .and(path("/packument-ok"))
             .respond_with(ResponseTemplate::new(200).set_body_bytes(ok_body))
-            .mount(&server)
-            .await;
-        Mock::given(method("GET"))
-            .and(path("/packument-huge"))
-            .respond_with(ResponseTemplate::new(200).set_body_bytes(over_body))
             .mount(&server)
             .await;
 
@@ -11096,24 +11105,13 @@ mod tests {
         std::fs::create_dir_all(&tmp).expect("tmp");
         let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
         let ok_url = format!("{}/packument-ok", server.uri());
-        let huge_url = format!("{}/packument-huge", server.uri());
 
         let ok = proxy
             .fetch_from_upstream(&ok_url, Uuid::new_v4(), LARGE_METADATA_MAX_BYTES)
             .await
-            .expect("a 9 MiB packument must succeed under the 16 MiB ceiling");
-        assert_eq!(ok.content.len(), 9 * 1024 * 1024);
-
-        let err = proxy
-            .fetch_from_upstream(&huge_url, Uuid::new_v4(), LARGE_METADATA_MAX_BYTES)
-            .await
-            .err()
-            .expect("a 17 MiB body must be rejected by the 16 MiB ceiling");
+            .expect("a 9 MiB packument must succeed under the LARGE ceiling");
         let _ = std::fs::remove_dir_all(&tmp);
-        assert!(
-            matches!(err, AppError::BadGateway(_)),
-            "a 17 MiB over-cap body must surface as BadGateway (502), got {err:?}",
-        );
+        assert_eq!(ok.content.len(), 9 * 1024 * 1024);
     }
 
     // -- fetch_upstream_direct(+_with_link): drive fetch_buffered + headers --
@@ -11170,7 +11168,7 @@ mod tests {
         };
         let server = MockServer::start().await;
         // 9 MiB: above DEFAULT_METADATA_MAX_BYTES (8 MiB), below
-        // LARGE_METADATA_MAX_BYTES (16 MiB).
+        // LARGE_METADATA_MAX_BYTES (128 MiB).
         let big = vec![0x2eu8; 9 * 1024 * 1024];
         assert!(big.len() > DEFAULT_METADATA_MAX_BYTES && big.len() < LARGE_METADATA_MAX_BYTES);
         Mock::given(method("GET"))
@@ -11191,7 +11189,7 @@ mod tests {
         let outcome = proxy.fetch_upstream_direct(&repo, "simple/foo/").await;
         let _ = std::fs::remove_dir_all(&tmp);
         let (body, _ct, _effective) =
-            outcome.expect("a 9 MiB simple index must succeed under the 16 MiB cap");
+            outcome.expect("a 9 MiB simple index must succeed under the 128 MiB cap");
         assert_eq!(body.len(), big.len());
     }
 


### PR DESCRIPTION
Closes #2267
Closes #2278

## Summary

When a Debian virtual repository proxies a large upstream dists file (e.g. trixie `Packages.xz` at ~9.6 MiB), the proxy surfaces the cap-exceeded error as 502 BadGateway. The virtual dists dispatchers `try_virtual_dists` and `try_virtual_dists_detecting_change` swallowed all member fetch errors and advanced to the next member. When every member failed for the same reason, they returned `Ok(None)`, and `dists()` fell through to the local-DB path — which for a pure remote/virtual repo is empty. `build_packages_xz(&[])` then produced a 32-byte empty xz file returned with HTTP 200.

`apt-get update` saw a valid xz (magic bytes intact) whose size (32) did not match the InRelease-advertised size (9671288), so it aborted with `File has unexpected size (32 != 9671288). Mirror sync in progress?`.

### Root Cause

Commit `2b248a08` (PR #1209) introduced remote member iteration for Debian virtual repos. Both dispatchers used `Err(_) => continue` — treating every error as "the member does not have this file." But `proxy_fetch_capped` returns `Err(AppError::BadGateway)` (502), not `Err(AppError::NotFound)` (404), when the upstream body exceeds the metadata byte ceiling. The 502 was swallowed, `Ok(None)` was returned, and an empty 200 was synthesized instead of letting the real failure surface.

### Fixes

1. **Error discrimination** (`debian.rs`): The `Err` arms now only continue to the next member on `404 / NotFound`. Non-404 errors (502, 503, 500, etc.) are remembered via `first_err.get_or_insert(...)` while later members are still attempted. This preserves multi-mirror failover: if a later member succeeds, it is returned; if all fail, the first non-404 error surfaces to the client.

2. **Cap increase** (`proxy_service.rs`): Raised `LARGE_METADATA_MAX_BYTES` from 16 MiB to 128 MiB and switched Debian dists fetches from `DEFAULT_METADATA_MAX_BYTES` (8 MiB) to `LARGE_METADATA_MAX_BYTES` (128 MiB). Debian Packages indices can exceed 8 MiB (trixie is 9.6 MB; sid can exceed 20 MB). The running-bounded chunk accumulator in `read_upstream_response_capped` still protects against unbounded OOM — 128 MiB is a hard ceiling per concurrent buffered metadata read, not a pre-allocation. 5 sites: 3 in `debian.rs` (`dists`, `try_virtual_dists`, `dists_proxy_catchall`), 2 in `proxy_service.rs` (`fetch_dists_with_revalidation`).

3. **Conditional revalidation hardening** (`proxy_service.rs`): `fetch_from_upstream_conditional` now handles `401 WWW-Authenticate: Bearer` challenges via `exchange_bearer_then`, preserving `If-None-Match` on the retry. A `304 Not Modified` with a missing cached body now self-heals via unconditional refetch instead of returning `NotFound`.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added regression tests:
- `test_dists_revalidation_304_missing_body_self_heals` — 304 + missing body → unconditional refetch
- `test_dists_revalidation_conditional_401_bearer_challenge` — conditional GET 401 enters bearer-exchange flow

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes

- [x] N/A - no API changes
