### PR TITLE
feat(npm): cross-replica single-flight for SWR background refreshes

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -256,13 +256,12 @@ async fn get_package_metadata_cached(
                 let repo_key = repo_key.to_string();
                 let package_name = package_name.to_string();
                 let base_url = base_url.to_string();
-                let flight = flight.clone();
                 tokio::spawn(async move {
                     // The claim dedups a stale burst within this process; the
                     // cross-replica lease inside `refresh_under_lease` dedups
                     // it across replicas sharing a cache backend (#2248).
                     let refreshed = cache
-                        .refresh_under_lease(claim, &flight, || {
+                        .refresh_under_lease(claim, || {
                             compute_and_store_packument(
                                 &state,
                                 &cache,
@@ -6011,12 +6010,17 @@ mod db_cov_tests {
 
     /// Backend wrapper reporting the cross-replica refresh lease as held by
     /// another replica (#2248), storage delegated to a real in-process map.
-    struct LeaseDeniedBackend(crate::services::npm_packument_cache::InProcessPackumentCache);
+    /// Denials are counted so the test can synchronize on "the spawned
+    /// refresh consulted the lease" instead of sleeping.
+    struct LeaseDeniedBackend {
+        store: crate::services::npm_packument_cache::InProcessPackumentCache,
+        denials: std::sync::atomic::AtomicUsize,
+    }
 
     #[async_trait::async_trait]
     impl crate::services::npm_packument_cache::PackumentCacheBackend for LeaseDeniedBackend {
         async fn get(&self, key: &str) -> Option<crate::services::npm_packument_cache::CacheHit> {
-            self.0.get(key).await
+            self.store.get(key).await
         }
         async fn set(
             &self,
@@ -6024,16 +6028,18 @@ mod db_cov_tests {
             prefix: &str,
             entry: crate::services::npm_packument_cache::CachedPackument,
         ) {
-            self.0.set(key, prefix, entry).await
+            self.store.set(key, prefix, entry).await
         }
         async fn invalidate_prefix(&self, prefix: &str) {
-            self.0.invalidate_prefix(prefix).await
+            self.store.invalidate_prefix(prefix).await
         }
         async fn try_acquire_refresh_lease(
             &self,
             _flight_key: &str,
             _ttl: std::time::Duration,
         ) -> Option<crate::services::npm_packument_cache::RefreshLease> {
+            self.denials
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             None
         }
     }
@@ -6065,14 +6071,16 @@ mod db_cov_tests {
 
         // Zero fresh window (every warm hit classifies stale) over a backend
         // whose refresh lease is always held elsewhere.
+        let backend = std::sync::Arc::new(LeaseDeniedBackend {
+            store: crate::services::npm_packument_cache::InProcessPackumentCache::new(
+                std::time::Duration::from_secs(3600),
+            ),
+            denials: std::sync::atomic::AtomicUsize::new(0),
+        });
         let mut app_state = build_app_state_with_fresh_ttl(&fx, 0);
         app_state.npm_packument_cache = Some(std::sync::Arc::new(
             crate::services::npm_packument_cache::NpmPackumentCache::new(
-                std::sync::Arc::new(LeaseDeniedBackend(
-                    crate::services::npm_packument_cache::InProcessPackumentCache::new(
-                        std::time::Duration::from_secs(3600),
-                    ),
-                )),
+                backend.clone(),
                 std::time::Duration::ZERO,
             ),
         ));
@@ -6092,9 +6100,17 @@ mod db_cov_tests {
         assert_eq!(status, StatusCode::OK);
         assert!(stale["versions"]["1.0.0"].is_object(), "got {stale:?}");
 
-        // Give a wrongly-spawned refresh time to reach the upstream before
-        // asserting none did.
-        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        // Deterministic synchronization: wait until the spawned refresh has
+        // consulted (and been denied) the lease. A regression that runs the
+        // compute without consulting the lease never increments the counter
+        // and falls through to the assertion after the full window, by which
+        // point its upstream request has landed and fails the count below.
+        for _ in 0..500 {
+            if backend.denials.load(std::sync::atomic::Ordering::SeqCst) >= 1 {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
         let upstream_hits = mock_server
             .received_requests()
             .await

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -256,23 +256,25 @@ async fn get_package_metadata_cached(
                 let repo_key = repo_key.to_string();
                 let package_name = package_name.to_string();
                 let base_url = base_url.to_string();
+                let flight = flight.clone();
                 tokio::spawn(async move {
-                    // Hold the claim for the task's lifetime so a stale burst
-                    // triggers exactly one refresh; dropping it (success,
-                    // failure, or cancellation) re-arms the next refresh.
-                    let _claim = claim;
-                    if compute_and_store_packument(
-                        &state,
-                        &cache,
-                        &repo_key,
-                        &package_name,
-                        &base_url,
-                        want_abbreviated,
-                        want_gzip,
-                    )
-                    .await
-                    .is_err()
-                    {
+                    // The claim dedups a stale burst within this process; the
+                    // cross-replica lease inside `refresh_under_lease` dedups
+                    // it across replicas sharing a cache backend (#2248).
+                    let refreshed = cache
+                        .refresh_under_lease(claim, &flight, || {
+                            compute_and_store_packument(
+                                &state,
+                                &cache,
+                                &repo_key,
+                                &package_name,
+                                &base_url,
+                                want_abbreviated,
+                                want_gzip,
+                            )
+                        })
+                        .await;
+                    if matches!(refreshed, Some(Err(_))) {
                         debug!(
                             repo_key,
                             package = package_name,
@@ -5877,6 +5879,15 @@ mod db_cov_tests {
         fx: &tdh::Fixture,
         fresh_ttl_secs: u64,
     ) -> crate::api::SharedState {
+        std::sync::Arc::new(build_app_state_with_fresh_ttl(fx, fresh_ttl_secs))
+    }
+
+    /// Un-shared variant of [`build_state_with_fresh_ttl`] for tests that
+    /// need to swap state fields (e.g. the packument cache) before use.
+    fn build_app_state_with_fresh_ttl(
+        fx: &tdh::Fixture,
+        fresh_ttl_secs: u64,
+    ) -> crate::api::AppState {
         let mut config = crate::config::Config::test_config();
         config.storage_path = fx.storage_dir.to_string_lossy().into_owned();
         config.npm_packument_cache_fresh_ttl_secs = fresh_ttl_secs;
@@ -5892,7 +5903,7 @@ mod db_cov_tests {
             fx.pool.clone(),
             fx.storage_dir.to_str().unwrap(),
         ));
-        std::sync::Arc::new(state)
+        state
     }
 
     /// Upstream packument body for the wiremock server.
@@ -5995,6 +6006,107 @@ mod db_cov_tests {
         assert!(
             refreshed["versions"]["2.0.0"].is_object(),
             "the background refresh must replace the stale entry; got {refreshed:?}"
+        );
+    }
+
+    /// Backend wrapper reporting the cross-replica refresh lease as held by
+    /// another replica (#2248), storage delegated to a real in-process map.
+    struct LeaseDeniedBackend(crate::services::npm_packument_cache::InProcessPackumentCache);
+
+    #[async_trait::async_trait]
+    impl crate::services::npm_packument_cache::PackumentCacheBackend for LeaseDeniedBackend {
+        async fn get(&self, key: &str) -> Option<crate::services::npm_packument_cache::CacheHit> {
+            self.0.get(key).await
+        }
+        async fn set(
+            &self,
+            key: &str,
+            prefix: &str,
+            entry: crate::services::npm_packument_cache::CachedPackument,
+        ) {
+            self.0.set(key, prefix, entry).await
+        }
+        async fn invalidate_prefix(&self, prefix: &str) {
+            self.0.invalidate_prefix(prefix).await
+        }
+        async fn try_acquire_refresh_lease(
+            &self,
+            _flight_key: &str,
+            _ttl: std::time::Duration,
+        ) -> Option<crate::services::npm_packument_cache::RefreshLease> {
+            None
+        }
+    }
+
+    /// #2248: when another replica already holds the cross-replica refresh
+    /// lease, a stale hit must serve the cached body WITHOUT spawning its own
+    /// upstream refresh (the holder's result reaches this replica through the
+    /// shared cache). The raw proxy cache is wiped after the first fetch, so
+    /// a wrongly-spawned refresh would be observable as a second upstream
+    /// request.
+    #[tokio::test]
+    async fn test_swr_refresh_skipped_when_lease_held_by_another_replica() {
+        use axum::http::StatusCode;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "npm").await else {
+            return;
+        };
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/leasepkg"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(upstream_packument("leasepkg", "1.0.0")),
+            )
+            .mount(&mock_server)
+            .await;
+        repoint_upstream_and_wipe_proxy_cache(&fx, &mock_server.uri()).await;
+
+        // Zero fresh window (every warm hit classifies stale) over a backend
+        // whose refresh lease is always held elsewhere.
+        let mut app_state = build_app_state_with_fresh_ttl(&fx, 0);
+        app_state.npm_packument_cache = Some(std::sync::Arc::new(
+            crate::services::npm_packument_cache::NpmPackumentCache::new(
+                std::sync::Arc::new(LeaseDeniedBackend(
+                    crate::services::npm_packument_cache::InProcessPackumentCache::new(
+                        std::time::Duration::from_secs(3600),
+                    ),
+                )),
+                std::time::Duration::ZERO,
+            ),
+        ));
+        let state = std::sync::Arc::new(app_state);
+
+        // Miss: computes v1 inline — the one permitted upstream request.
+        let (status, first) = fetch_packument_json(&state, &fx.repo_key, "leasepkg").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(first["versions"]["1.0.0"].is_object(), "got {first:?}");
+
+        // Drop the raw proxy cache so a (wrongly spawned) refresh could not
+        // be satisfied locally and would have to hit the upstream.
+        repoint_upstream_and_wipe_proxy_cache(&fx, &mock_server.uri()).await;
+
+        // Stale hit: served from cache; the refresh must be lease-skipped.
+        let (status, stale) = fetch_packument_json(&state, &fx.repo_key, "leasepkg").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(stale["versions"]["1.0.0"].is_object(), "got {stale:?}");
+
+        // Give a wrongly-spawned refresh time to reach the upstream before
+        // asserting none did.
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let upstream_hits = mock_server
+            .received_requests()
+            .await
+            .expect("recorded requests")
+            .len();
+
+        fx.teardown().await;
+
+        assert_eq!(
+            upstream_hits, 1,
+            "a denied cross-replica lease must skip the background refresh; \
+             the miss-compute is the only permitted upstream request"
         );
     }
 

--- a/backend/src/services/npm_packument_cache.rs
+++ b/backend/src/services/npm_packument_cache.rs
@@ -86,6 +86,22 @@ const REDIS_KEY_NAMESPACE: &str = "ak:npm-packument:";
 /// (sibling of the proxy path's `proxy-cache:` / `proxy-stream:` prefixes).
 const FLIGHT_LEASE_NAMESPACE: &str = "npm-packument:";
 
+/// Key prefix (under [`REDIS_KEY_NAMESPACE`]) for cross-replica background
+/// refresh leases (#2248).
+const REFRESH_LEASE_KEY_PREFIX: &str = "refresh-lease:";
+
+/// TTL on the cross-replica refresh lease (#2248). A live holder completes
+/// (and releases) well inside this: a refresh's compute is bounded by the
+/// same limits as the miss path, whose single-flight wait deadline is 65 s.
+/// A holder that dies without releasing only delays the next cross-replica
+/// refresh until expiry — it can never block refreshes permanently.
+const REFRESH_LEASE_TTL: Duration = Duration::from_secs(90);
+
+/// Compare-and-delete for lease release: frees the lease only while `token`
+/// still owns it, so a holder that outlived its TTL cannot drop a successor
+/// replica's lease.
+const REFRESH_LEASE_RELEASE_SCRIPT: &str = r#"if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end"#;
+
 /// Bound on each Redis connection attempt, so a request never stalls behind
 /// an unreachable Redis host (the in-process layer answers instead).
 const REDIS_CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
@@ -243,6 +259,20 @@ fn key_invalidation_prefix(key: &str) -> String {
 // Backend traits
 // ---------------------------------------------------------------------------
 
+/// Cross-replica claim on one background refresh (#2248). Complements the
+/// process-local [`RefreshClaim`]: the claim dedups a stale burst within one
+/// process, this lease dedups the same burst across replicas that share a
+/// cache backend.
+#[derive(Debug)]
+pub enum RefreshLease {
+    /// No shared lease is held: either no shared backend is configured, or it
+    /// was unreachable and refresh dedup degraded to per-process only.
+    Local,
+    /// Held in the shared backend; the unique `token` proves ownership, so a
+    /// release can never drop a lease acquired later by another replica.
+    Shared { flight_key: String, token: String },
+}
+
 /// Storage backend for computed packument responses.
 ///
 /// Implementations must degrade gracefully: a backend problem surfaces as a
@@ -258,6 +288,25 @@ pub trait PackumentCacheBackend: Send + Sync {
     async fn set(&self, key: &str, prefix: &str, entry: CachedPackument);
     /// Drop every entry whose key starts with `prefix`.
     async fn invalidate_prefix(&self, prefix: &str);
+    /// Try to acquire the cross-replica background-refresh lease for
+    /// `flight_key` (#2248). `None` means another replica is already
+    /// refreshing this packument and the caller must skip. Backends without
+    /// shared state grant a [`RefreshLease::Local`]: the per-process claim
+    /// set is the only dedup needed there.
+    async fn try_acquire_refresh_lease(
+        &self,
+        flight_key: &str,
+        ttl: Duration,
+    ) -> Option<RefreshLease> {
+        let _ = (flight_key, ttl);
+        Some(RefreshLease::Local)
+    }
+    /// Release a lease returned by [`Self::try_acquire_refresh_lease`]. An
+    /// unreleased lease (holder crash, task cancellation) expires on its own
+    /// after the TTL.
+    async fn release_refresh_lease(&self, lease: RefreshLease) {
+        let _ = lease;
+    }
 }
 
 /// The shared cache is unreachable or misbehaving; the caller should use the
@@ -279,6 +328,21 @@ trait SharedCacheBackend: Send + Sync {
         entry: CachedPackument,
     ) -> Result<(), SharedCacheUnavailable>;
     async fn try_invalidate_prefix(&self, prefix: &str) -> Result<(), SharedCacheUnavailable>;
+    /// Acquire the cross-replica refresh lease (#2248). `Ok(Some(token))` —
+    /// acquired; `Ok(None)` — held by another replica; `Err` — shared store
+    /// unreachable (the caller decides the degraded behavior).
+    async fn try_acquire_refresh_lease(
+        &self,
+        flight_key: &str,
+        ttl: Duration,
+    ) -> Result<Option<String>, SharedCacheUnavailable>;
+    /// Release a held lease. Implementations must be compare-and-delete on
+    /// `token` so an expired holder cannot free a successor's lease.
+    async fn try_release_refresh_lease(
+        &self,
+        flight_key: &str,
+        token: &str,
+    ) -> Result<(), SharedCacheUnavailable>;
 }
 
 // ---------------------------------------------------------------------------
@@ -576,6 +640,14 @@ impl RedisPackumentCache {
     fn index_key(prefix: &str) -> String {
         format!("{}idx:{}", REDIS_KEY_NAMESPACE, prefix)
     }
+
+    /// The cross-replica refresh-lease key for one flight (#2248).
+    fn lease_key(flight_key: &str) -> String {
+        format!(
+            "{}{}{}",
+            REDIS_KEY_NAMESPACE, REFRESH_LEASE_KEY_PREFIX, flight_key
+        )
+    }
 }
 
 #[async_trait]
@@ -657,6 +729,49 @@ impl SharedCacheBackend for RedisPackumentCache {
         self.note_success();
         Ok(())
     }
+
+    async fn try_acquire_refresh_lease(
+        &self,
+        flight_key: &str,
+        ttl: Duration,
+    ) -> Result<Option<String>, SharedCacheUnavailable> {
+        let mut conn = self.connection().await?;
+        let token = uuid::Uuid::new_v4().simple().to_string();
+        // NX: the first replica in wins the refresh; EX: a crashed holder
+        // frees the lease by expiry instead of blocking refreshes forever.
+        let acquired: Option<String> = redis::cmd("SET")
+            .arg(Self::lease_key(flight_key))
+            .arg(&token)
+            .arg("NX")
+            .arg("EX")
+            .arg(ttl.as_secs().max(1))
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| self.command_error("refresh-lease-acquire", &e))?;
+        self.note_success();
+        Ok(acquired.map(|_| token))
+    }
+
+    async fn try_release_refresh_lease(
+        &self,
+        flight_key: &str,
+        token: &str,
+    ) -> Result<(), SharedCacheUnavailable> {
+        let mut conn = self.connection().await?;
+        // Plain EVAL (the `script` cargo feature is not enabled): the release
+        // runs once per completed refresh, so re-sending the short script
+        // body costs nothing worth an EVALSHA cache.
+        let _: i64 = redis::cmd("EVAL")
+            .arg(REFRESH_LEASE_RELEASE_SCRIPT)
+            .arg(1)
+            .arg(Self::lease_key(flight_key))
+            .arg(token)
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| self.command_error("refresh-lease-release", &e))?;
+        self.note_success();
+        Ok(())
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -702,6 +817,32 @@ impl PackumentCacheBackend for LayeredPackumentCache {
     async fn invalidate_prefix(&self, prefix: &str) {
         self.local.invalidate_prefix(prefix).await;
         let _ = self.shared.try_invalidate_prefix(prefix).await;
+    }
+
+    async fn try_acquire_refresh_lease(
+        &self,
+        flight_key: &str,
+        ttl: Duration,
+    ) -> Option<RefreshLease> {
+        match self.shared.try_acquire_refresh_lease(flight_key, ttl).await {
+            Ok(Some(token)) => Some(RefreshLease::Shared {
+                flight_key: flight_key.to_string(),
+                token,
+            }),
+            Ok(None) => None,
+            // Same failure posture as reads and writes: an unreachable shared
+            // store degrades to per-process dedup, it never drops refreshes.
+            Err(SharedCacheUnavailable) => Some(RefreshLease::Local),
+        }
+    }
+
+    async fn release_refresh_lease(&self, lease: RefreshLease) {
+        if let RefreshLease::Shared { flight_key, token } = lease {
+            let _ = self
+                .shared
+                .try_release_refresh_lease(&flight_key, &token)
+                .await;
+        }
     }
 }
 
@@ -889,6 +1030,41 @@ impl NpmPackumentCache {
             flights: self.refresh_flights.clone(),
             key: flight_key.to_string(),
         })
+    }
+
+    /// Run one background refresh under both dedup layers (#2248): `claim` is
+    /// the process-local guard (held for the task's lifetime), and the
+    /// backend's cross-replica lease gates the actual work. When another
+    /// replica already holds the lease the refresh is skipped — that
+    /// replica's result reaches everyone through the shared cache anyway.
+    /// Returns `None` when skipped, `Some(refresh result)` otherwise.
+    pub async fn refresh_under_lease<T, E, F, Fut>(
+        &self,
+        claim: RefreshClaim,
+        flight_key: &str,
+        refresh: F,
+    ) -> Option<Result<T, E>>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<T, E>>,
+    {
+        let _claim = claim;
+        let Some(lease) = self
+            .backend
+            .try_acquire_refresh_lease(flight_key, REFRESH_LEASE_TTL)
+            .await
+        else {
+            tracing::debug!(
+                flight_key,
+                "npm packument refresh skipped; another replica holds the refresh lease"
+            );
+            return None;
+        };
+        let result = refresh().await;
+        // Free the lease on completion (success or failure) so the next
+        // stale hit can refresh; an abandoned lease expires via its TTL.
+        self.backend.release_refresh_lease(lease).await;
+        Some(result)
     }
 
     /// Serve one packument request through the cache.
@@ -1369,13 +1545,87 @@ mod tests {
             .await;
     }
 
+    #[tokio::test]
+    async fn redis_integration_refresh_lease_nx_ttl_and_compare_and_delete() {
+        let Some(backend) = redis_integration_backend() else {
+            return;
+        };
+        let flight = format!("it-lease-{}", uuid::Uuid::new_v4().simple());
+        let ttl = Duration::from_secs(30);
+        let token = backend
+            .try_acquire_refresh_lease(&flight, ttl)
+            .await
+            .expect("acquire against live Redis")
+            .expect("first acquire must be granted");
+
+        // NX: while held, no other replica can acquire.
+        assert!(
+            backend
+                .try_acquire_refresh_lease(&flight, ttl)
+                .await
+                .expect("second acquire")
+                .is_none(),
+            "a held lease must deny concurrent acquires"
+        );
+
+        // The lease must carry a TTL so a crashed holder cannot block
+        // refreshes forever.
+        let mut conn = backend.connection().await.expect("raw connection");
+        let pttl: i64 = redis::cmd("PTTL")
+            .arg(RedisPackumentCache::lease_key(&flight))
+            .query_async(&mut conn)
+            .await
+            .expect("PTTL");
+        assert!(
+            pttl > 0 && pttl <= ttl.as_millis() as i64,
+            "lease must expire on its own; PTTL={pttl}"
+        );
+
+        // Releasing with a stale token (an expired holder racing a new one)
+        // must not free the current holder's lease.
+        backend
+            .try_release_refresh_lease(&flight, "stale-token")
+            .await
+            .expect("wrong-token release");
+        assert!(
+            backend
+                .try_acquire_refresh_lease(&flight, ttl)
+                .await
+                .expect("acquire after wrong-token release")
+                .is_none(),
+            "a wrong-token release must leave the lease held"
+        );
+
+        // The holder's release frees the key for the next refresh cycle.
+        backend
+            .try_release_refresh_lease(&flight, &token)
+            .await
+            .expect("release");
+        let second = backend
+            .try_acquire_refresh_lease(&flight, ttl)
+            .await
+            .expect("reacquire")
+            .expect("acquire after release must be granted");
+        assert_ne!(second, token, "tokens are unique per acquisition");
+        backend
+            .try_release_refresh_lease(&flight, &second)
+            .await
+            .expect("cleanup release");
+    }
+
     // -- layered backend ------------------------------------------------------------
 
     /// Scriptable shared cache: a real in-process store behind a health
-    /// toggle, so outage / recovery transitions are deterministic.
+    /// toggle, so outage / recovery transitions are deterministic. Refresh
+    /// leases are scriptable too: `lease_grants` remaining grants
+    /// (`usize::MAX` = always grant), with every acquire/release recorded.
     struct ScriptableSharedCache {
         healthy: AtomicBool,
         store: InProcessPackumentCache,
+        lease_grants: AtomicUsize,
+        lease_acquires: std::sync::Mutex<Vec<String>>,
+        lease_releases: std::sync::Mutex<Vec<(String, String)>>,
+        granted_tokens: std::sync::Mutex<Vec<String>>,
     }
 
     impl ScriptableSharedCache {
@@ -1383,11 +1633,31 @@ mod tests {
             Self {
                 healthy: AtomicBool::new(healthy),
                 store: InProcessPackumentCache::new(Duration::from_secs(3600)),
+                lease_grants: AtomicUsize::new(usize::MAX),
+                lease_acquires: std::sync::Mutex::new(Vec::new()),
+                lease_releases: std::sync::Mutex::new(Vec::new()),
+                granted_tokens: std::sync::Mutex::new(Vec::new()),
             }
         }
 
         fn set_healthy(&self, healthy: bool) {
             self.healthy.store(healthy, Ordering::SeqCst);
+        }
+
+        fn set_lease_grants(&self, remaining: usize) {
+            self.lease_grants.store(remaining, Ordering::SeqCst);
+        }
+
+        fn lease_acquires(&self) -> Vec<String> {
+            self.lease_acquires.lock().unwrap().clone()
+        }
+
+        fn lease_releases(&self) -> Vec<(String, String)> {
+            self.lease_releases.lock().unwrap().clone()
+        }
+
+        fn granted_tokens(&self) -> Vec<String> {
+            self.granted_tokens.lock().unwrap().clone()
         }
 
         fn check(&self) -> Result<(), SharedCacheUnavailable> {
@@ -1418,6 +1688,40 @@ mod tests {
         async fn try_invalidate_prefix(&self, prefix: &str) -> Result<(), SharedCacheUnavailable> {
             self.check()?;
             self.store.invalidate_prefix(prefix).await;
+            Ok(())
+        }
+        async fn try_acquire_refresh_lease(
+            &self,
+            flight_key: &str,
+            _ttl: Duration,
+        ) -> Result<Option<String>, SharedCacheUnavailable> {
+            self.check()?;
+            self.lease_acquires
+                .lock()
+                .unwrap()
+                .push(flight_key.to_string());
+            let granted = self
+                .lease_grants
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                .is_ok();
+            if !granted {
+                return Ok(None);
+            }
+            let mut tokens = self.granted_tokens.lock().unwrap();
+            let token = format!("token-{}", tokens.len());
+            tokens.push(token.clone());
+            Ok(Some(token))
+        }
+        async fn try_release_refresh_lease(
+            &self,
+            flight_key: &str,
+            token: &str,
+        ) -> Result<(), SharedCacheUnavailable> {
+            self.check()?;
+            self.lease_releases
+                .lock()
+                .unwrap()
+                .push((flight_key.to_string(), token.to_string()));
             Ok(())
         }
     }
@@ -1489,6 +1793,170 @@ mod tests {
         assert!(
             backend.get("outage-key").await.is_none(),
             "a healthy shared-cache miss is authoritative again after recovery"
+        );
+    }
+
+    // -- cross-replica refresh lease (#2248) --------------------------------------
+
+    fn lease_facade(shared: Arc<ScriptableSharedCache>) -> NpmPackumentCache {
+        NpmPackumentCache::new(
+            Arc::new(LayeredPackumentCache::new(
+                shared,
+                InProcessPackumentCache::new(Duration::from_secs(3600)),
+            )),
+            Duration::from_secs(300),
+        )
+    }
+
+    #[tokio::test]
+    async fn refresh_under_lease_runs_refresh_and_releases_the_shared_lease() {
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        let cache = lease_facade(shared.clone());
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let ran = AtomicUsize::new(0);
+        let result = cache
+            .refresh_under_lease(claim, "flight", || async {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(())
+            })
+            .await;
+        assert_eq!(result, Some(Ok(())));
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert_eq!(shared.lease_acquires(), vec!["flight".to_string()]);
+        let releases = shared.lease_releases();
+        assert_eq!(releases.len(), 1, "the holder must release on completion");
+        assert_eq!(releases[0].0, "flight");
+        assert_eq!(
+            releases[0].1,
+            shared.granted_tokens()[0],
+            "release must present the token the acquire was granted"
+        );
+        assert!(
+            cache.try_claim_refresh("flight").is_some(),
+            "the local claim must be freed afterwards"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_under_lease_skips_when_another_replica_holds_the_lease() {
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        shared.set_lease_grants(0);
+        let cache = lease_facade(shared.clone());
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let ran = AtomicUsize::new(0);
+        let result = cache
+            .refresh_under_lease(claim, "flight", || async {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(())
+            })
+            .await;
+        assert!(result.is_none(), "a denied lease must skip the refresh");
+        assert_eq!(ran.load(Ordering::SeqCst), 0);
+        assert!(
+            shared.lease_releases().is_empty(),
+            "no lease was held, so none may be released"
+        );
+        assert!(
+            cache.try_claim_refresh("flight").is_some(),
+            "the local claim must be freed so a later stale hit can retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_under_lease_degrades_to_per_process_dedup_when_shared_unavailable() {
+        let shared = Arc::new(ScriptableSharedCache::new(false));
+        let cache = lease_facade(shared.clone());
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let ran = AtomicUsize::new(0);
+        let result = cache
+            .refresh_under_lease(claim, "flight", || async {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(())
+            })
+            .await;
+        assert_eq!(
+            result,
+            Some(Ok(())),
+            "an unreachable shared store must not lose refreshes"
+        );
+        assert_eq!(ran.load(Ordering::SeqCst), 1);
+        assert!(
+            shared.lease_releases().is_empty(),
+            "no shared lease was held during the outage, so none is released"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_under_lease_releases_lease_when_refresh_fails() {
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        let cache = lease_facade(shared.clone());
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let result = cache
+            .refresh_under_lease(claim, "flight", || async { Err::<(), _>("boom") })
+            .await;
+        assert_eq!(result, Some(Err("boom")));
+        assert_eq!(
+            shared.lease_releases().len(),
+            1,
+            "a failed refresh still releases the lease so the next stale hit can retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_under_lease_in_process_backend_always_proceeds() {
+        let cache = NpmPackumentCache::new(
+            Arc::new(InProcessPackumentCache::new(Duration::from_secs(3600))),
+            Duration::from_secs(300),
+        );
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let ran = AtomicUsize::new(0);
+        let result = cache
+            .refresh_under_lease(claim, "flight", || async {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(())
+            })
+            .await;
+        assert_eq!(result, Some(Ok(())));
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            1,
+            "without a shared backend the per-process claim is the only gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_under_lease_two_replicas_race_exactly_one_refreshes() {
+        // Two facades over one shared store model two replicas: each wins its
+        // own per-process claim, so only the shared lease dedups them.
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        shared.set_lease_grants(1);
+        let replica_a = lease_facade(shared.clone());
+        let replica_b = lease_facade(shared.clone());
+        let claim_a = replica_a.try_claim_refresh("flight").expect("claim a");
+        let claim_b = replica_b.try_claim_refresh("flight").expect("claim b");
+        let ran = AtomicUsize::new(0);
+        let (a, b) = tokio::join!(
+            replica_a.refresh_under_lease(claim_a, "flight", || async {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(())
+            }),
+            replica_b.refresh_under_lease(claim_b, "flight", || async {
+                ran.fetch_add(1, Ordering::SeqCst);
+                Ok::<_, &str>(())
+            }),
+        );
+        assert_eq!(
+            ran.load(Ordering::SeqCst),
+            1,
+            "a cross-replica stale burst must collapse to one upstream refresh"
+        );
+        assert_eq!(
+            [a.is_some(), b.is_some()]
+                .iter()
+                .filter(|ran| **ran)
+                .count(),
+            1,
+            "exactly one replica runs the refresh, the other skips"
         );
     }
 

--- a/backend/src/services/npm_packument_cache.rs
+++ b/backend/src/services/npm_packument_cache.rs
@@ -90,17 +90,32 @@ const FLIGHT_LEASE_NAMESPACE: &str = "npm-packument:";
 /// refresh leases (#2248).
 const REFRESH_LEASE_KEY_PREFIX: &str = "refresh-lease:";
 
-/// TTL on the cross-replica refresh lease (#2248). A live holder completes
-/// (and releases) well inside this: a refresh's compute is bounded by the
-/// same limits as the miss path, whose single-flight wait deadline is 65 s.
-/// A holder that dies without releasing only delays the next cross-replica
-/// refresh until expiry — it can never block refreshes permanently.
+/// TTL on the cross-replica refresh lease (#2248). A live holder always
+/// completes (and releases) inside this: [`NpmPackumentCache::refresh_under_lease`]
+/// bounds the refresh with [`REFRESH_LEASE_COMPUTE_TIMEOUT`], which sits
+/// under this TTL by a margin. A holder that dies without releasing (panic,
+/// runtime teardown) only delays the next cross-replica refresh until
+/// expiry — it can never block refreshes permanently.
 const REFRESH_LEASE_TTL: Duration = Duration::from_secs(90);
 
-/// Compare-and-delete for lease release: frees the lease only while `token`
-/// still owns it, so a holder that outlived its TTL cannot drop a successor
-/// replica's lease.
-const REFRESH_LEASE_RELEASE_SCRIPT: &str = r#"if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end"#;
+/// Bound on a leased background refresh. Keeping the compute strictly under
+/// [`REFRESH_LEASE_TTL`] guarantees a lease can never expire mid-refresh, so
+/// a slow holder cannot race a successor and overwrite its newer entry with
+/// an older upstream snapshot.
+const REFRESH_LEASE_COMPUTE_TIMEOUT: Duration = Duration::from_secs(80);
+
+/// How long a replica that lost the lease race keeps holding its local
+/// refresh claim before re-arming. Without this, every stale hit on a
+/// non-holder replica would spawn a task and pay a shared-backend probe for
+/// the whole duration of the holder's refresh; with it, a stale burst costs
+/// at most one probe per package per replica per window.
+const REFRESH_LEASE_DENIED_CLAIM_HOLD: Duration = Duration::from_secs(1);
+
+/// Delay before the single release retry. Slightly above
+/// [`REDIS_UNAVAILABLE_COOLDOWN`] so the retry is not swallowed by the gate
+/// the failed first attempt armed; a release that fails twice is abandoned
+/// to TTL expiry (bounded, best-effort).
+const REFRESH_LEASE_RELEASE_RETRY_DELAY: Duration = Duration::from_secs(6);
 
 /// Bound on each Redis connection attempt, so a request never stalls behind
 /// an unreachable Redis host (the in-process layer answers instead).
@@ -263,6 +278,15 @@ fn key_invalidation_prefix(key: &str) -> String {
 /// process-local [`RefreshClaim`]: the claim dedups a stale burst within one
 /// process, this lease dedups the same burst across replicas that share a
 /// cache backend.
+///
+/// Deliberately NOT the [`crate::services::cluster_lock::ClusterLock`]
+/// advisory-lock seam: refreshes are frequent, short and fire-and-forget, so
+/// a single `SET NX` on the already-configured shared cache backend beats
+/// holding a Postgres session lock (detached connection per lease) for each
+/// one — and when no shared backend is configured there is nothing to
+/// coordinate at all. The trade-off is TTL-expiry (not session-death) as the
+/// crash-recovery mechanism, which is exactly the bounded best-effort
+/// behavior a background refresh wants.
 #[derive(Debug)]
 pub enum RefreshLease {
     /// No shared lease is held: either no shared backend is configured, or it
@@ -758,17 +782,25 @@ impl SharedCacheBackend for RedisPackumentCache {
         token: &str,
     ) -> Result<(), SharedCacheUnavailable> {
         let mut conn = self.connection().await?;
-        // Plain EVAL (the `script` cargo feature is not enabled): the release
-        // runs once per completed refresh, so re-sending the short script
-        // body costs nothing worth an EVALSHA cache.
-        let _: i64 = redis::cmd("EVAL")
-            .arg(REFRESH_LEASE_RELEASE_SCRIPT)
-            .arg(1)
-            .arg(Self::lease_key(flight_key))
-            .arg(token)
+        // GET-then-DEL rather than a Lua compare-and-delete: EVAL is refused
+        // on scripting-restricted deployments (ACLs without @scripting), and
+        // a systemically failing release would arm the cooldown gate after
+        // every refresh. The non-atomic window (lease expires and a successor
+        // acquires between the GET and the DEL) is sub-millisecond and its
+        // worst case is one duplicate refresh — strictly better than that.
+        let lease_key = Self::lease_key(flight_key);
+        let holder: Option<String> = redis::cmd("GET")
+            .arg(&lease_key)
             .query_async(&mut conn)
             .await
             .map_err(|e| self.command_error("refresh-lease-release", &e))?;
+        if holder.as_deref() == Some(token) {
+            let _: i64 = redis::cmd("DEL")
+                .arg(&lease_key)
+                .query_async(&mut conn)
+                .await
+                .map_err(|e| self.command_error("refresh-lease-release", &e))?;
+        }
         self.note_success();
         Ok(())
     }
@@ -838,6 +870,18 @@ impl PackumentCacheBackend for LayeredPackumentCache {
 
     async fn release_refresh_lease(&self, lease: RefreshLease) {
         if let RefreshLease::Shared { flight_key, token } = lease {
+            if self
+                .shared
+                .try_release_refresh_lease(&flight_key, &token)
+                .await
+                .is_ok()
+            {
+                return;
+            }
+            // One retry after the cooldown window: a release lost to a Redis
+            // blip would otherwise orphan the lease and block every
+            // replica's refresh of this packument until TTL expiry.
+            tokio::time::sleep(REFRESH_LEASE_RELEASE_RETRY_DELAY).await;
             let _ = self
                 .shared
                 .try_release_refresh_lease(&flight_key, &token)
@@ -856,6 +900,14 @@ impl PackumentCacheBackend for LayeredPackumentCache {
 pub struct RefreshClaim {
     flights: Arc<Mutex<HashSet<String>>>,
     key: String,
+}
+
+impl RefreshClaim {
+    /// The flight key this claim covers; the cross-replica lease is keyed on
+    /// it too, so the pair can never diverge.
+    pub fn flight_key(&self) -> &str {
+        &self.key
+    }
 }
 
 impl Drop for RefreshClaim {
@@ -1034,37 +1086,56 @@ impl NpmPackumentCache {
 
     /// Run one background refresh under both dedup layers (#2248): `claim` is
     /// the process-local guard (held for the task's lifetime), and the
-    /// backend's cross-replica lease gates the actual work. When another
-    /// replica already holds the lease the refresh is skipped — that
-    /// replica's result reaches everyone through the shared cache anyway.
-    /// Returns `None` when skipped, `Some(refresh result)` otherwise.
+    /// backend's cross-replica lease — keyed on the claim's flight key —
+    /// gates the actual work. When another replica already holds the lease
+    /// the refresh is skipped (that replica's result reaches everyone through
+    /// the shared cache) and the claim is parked briefly so a stale burst
+    /// costs one shared-backend probe per window, not one per request.
+    ///
+    /// The refresh is bounded by [`REFRESH_LEASE_COMPUTE_TIMEOUT`], so a
+    /// holder can never outlive its lease and race a successor's newer
+    /// entry. A failed refresh still releases the lease, so any replica
+    /// (including a healthy one, when the holder's upstream path is broken)
+    /// can retry on the next stale hit. Only a crash mid-refresh leaves the
+    /// lease to TTL expiry — bounded, and the stale window keeps serving.
+    ///
+    /// Returns `None` when skipped or timed out, `Some(refresh result)`
+    /// otherwise.
     pub async fn refresh_under_lease<T, E, F, Fut>(
         &self,
         claim: RefreshClaim,
-        flight_key: &str,
         refresh: F,
     ) -> Option<Result<T, E>>
     where
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<T, E>>,
     {
-        let _claim = claim;
         let Some(lease) = self
             .backend
-            .try_acquire_refresh_lease(flight_key, REFRESH_LEASE_TTL)
+            .try_acquire_refresh_lease(claim.flight_key(), REFRESH_LEASE_TTL)
             .await
         else {
             tracing::debug!(
-                flight_key,
+                flight_key = claim.flight_key(),
                 "npm packument refresh skipped; another replica holds the refresh lease"
             );
+            tokio::time::sleep(REFRESH_LEASE_DENIED_CLAIM_HOLD).await;
             return None;
         };
-        let result = refresh().await;
-        // Free the lease on completion (success or failure) so the next
-        // stale hit can refresh; an abandoned lease expires via its TTL.
+        let result = tokio::time::timeout(REFRESH_LEASE_COMPUTE_TIMEOUT, refresh()).await;
+        // Free the lease on completion (success, failure, or timeout) so the
+        // next stale hit can refresh; an abandoned lease expires via TTL.
         self.backend.release_refresh_lease(lease).await;
-        Some(result)
+        match result {
+            Ok(result) => Some(result),
+            Err(_elapsed) => {
+                tracing::debug!(
+                    flight_key = claim.flight_key(),
+                    "npm packument refresh abandoned; compute exceeded the lease-bounded timeout"
+                );
+                None
+            }
+        }
     }
 
     /// Serve one packument request through the cache.
@@ -1624,8 +1695,10 @@ mod tests {
         store: InProcessPackumentCache,
         lease_grants: AtomicUsize,
         lease_acquires: std::sync::Mutex<Vec<String>>,
+        /// Every release ATTEMPT (including injected failures).
         lease_releases: std::sync::Mutex<Vec<(String, String)>>,
         granted_tokens: std::sync::Mutex<Vec<String>>,
+        release_failures_remaining: AtomicUsize,
     }
 
     impl ScriptableSharedCache {
@@ -1637,6 +1710,7 @@ mod tests {
                 lease_acquires: std::sync::Mutex::new(Vec::new()),
                 lease_releases: std::sync::Mutex::new(Vec::new()),
                 granted_tokens: std::sync::Mutex::new(Vec::new()),
+                release_failures_remaining: AtomicUsize::new(0),
             }
         }
 
@@ -1646,6 +1720,11 @@ mod tests {
 
         fn set_lease_grants(&self, remaining: usize) {
             self.lease_grants.store(remaining, Ordering::SeqCst);
+        }
+
+        fn fail_next_releases(&self, count: usize) {
+            self.release_failures_remaining
+                .store(count, Ordering::SeqCst);
         }
 
         fn lease_acquires(&self) -> Vec<String> {
@@ -1722,6 +1801,13 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((flight_key.to_string(), token.to_string()));
+            let failed = self
+                .release_failures_remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+                .is_ok();
+            if failed {
+                return Err(SharedCacheUnavailable);
+            }
             Ok(())
         }
     }
@@ -1815,7 +1901,7 @@ mod tests {
         let claim = cache.try_claim_refresh("flight").expect("claim");
         let ran = AtomicUsize::new(0);
         let result = cache
-            .refresh_under_lease(claim, "flight", || async {
+            .refresh_under_lease(claim, || async {
                 ran.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, &str>(())
             })
@@ -1837,7 +1923,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn refresh_under_lease_skips_when_another_replica_holds_the_lease() {
         let shared = Arc::new(ScriptableSharedCache::new(true));
         shared.set_lease_grants(0);
@@ -1845,7 +1931,7 @@ mod tests {
         let claim = cache.try_claim_refresh("flight").expect("claim");
         let ran = AtomicUsize::new(0);
         let result = cache
-            .refresh_under_lease(claim, "flight", || async {
+            .refresh_under_lease(claim, || async {
                 ran.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, &str>(())
             })
@@ -1869,7 +1955,7 @@ mod tests {
         let claim = cache.try_claim_refresh("flight").expect("claim");
         let ran = AtomicUsize::new(0);
         let result = cache
-            .refresh_under_lease(claim, "flight", || async {
+            .refresh_under_lease(claim, || async {
                 ran.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, &str>(())
             })
@@ -1892,7 +1978,7 @@ mod tests {
         let cache = lease_facade(shared.clone());
         let claim = cache.try_claim_refresh("flight").expect("claim");
         let result = cache
-            .refresh_under_lease(claim, "flight", || async { Err::<(), _>("boom") })
+            .refresh_under_lease(claim, || async { Err::<(), _>("boom") })
             .await;
         assert_eq!(result, Some(Err("boom")));
         assert_eq!(
@@ -1911,7 +1997,7 @@ mod tests {
         let claim = cache.try_claim_refresh("flight").expect("claim");
         let ran = AtomicUsize::new(0);
         let result = cache
-            .refresh_under_lease(claim, "flight", || async {
+            .refresh_under_lease(claim, || async {
                 ran.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, &str>(())
             })
@@ -1936,11 +2022,11 @@ mod tests {
         let claim_b = replica_b.try_claim_refresh("flight").expect("claim b");
         let ran = AtomicUsize::new(0);
         let (a, b) = tokio::join!(
-            replica_a.refresh_under_lease(claim_a, "flight", || async {
+            replica_a.refresh_under_lease(claim_a, || async {
                 ran.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, &str>(())
             }),
-            replica_b.refresh_under_lease(claim_b, "flight", || async {
+            replica_b.refresh_under_lease(claim_b, || async {
                 ran.fetch_add(1, Ordering::SeqCst);
                 Ok::<_, &str>(())
             }),
@@ -1957,6 +2043,81 @@ mod tests {
                 .count(),
             1,
             "exactly one replica runs the refresh, the other skips"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refresh_under_lease_denial_parks_the_claim_before_rearming() {
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        shared.set_lease_grants(0);
+        let cache = Arc::new(lease_facade(shared.clone()));
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let task = tokio::spawn({
+            let cache = cache.clone();
+            async move {
+                cache
+                    .refresh_under_lease(claim, || async { Ok::<_, &str>(()) })
+                    .await
+            }
+        });
+        // Mid-hold: the claim must still be parked, so a stale burst cannot
+        // spawn a second shared-backend probe inside the window.
+        tokio::time::advance(Duration::from_millis(500)).await;
+        assert!(
+            cache.try_claim_refresh("flight").is_none(),
+            "the claim must stay held during the denial hold"
+        );
+        assert_eq!(task.await.expect("join"), None);
+        assert!(
+            cache.try_claim_refresh("flight").is_some(),
+            "the claim re-arms once the hold elapses"
+        );
+        assert_eq!(
+            shared.lease_acquires().len(),
+            1,
+            "one denied probe, not one per stale hit"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refresh_under_lease_abandons_computes_that_outlive_the_lease_bound() {
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        let cache = lease_facade(shared.clone());
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let result = cache
+            .refresh_under_lease(claim, || async {
+                std::future::pending::<Result<(), &str>>().await
+            })
+            .await;
+        assert!(
+            result.is_none(),
+            "a compute that outlives the lease bound must be abandoned, not              allowed to finish after a successor and overwrite its entry"
+        );
+        assert_eq!(
+            shared.lease_releases().len(),
+            1,
+            "the lease is released even when the compute is abandoned"
+        );
+        assert!(
+            cache.try_claim_refresh("flight").is_some(),
+            "the claim re-arms after the abandoned refresh"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn refresh_under_lease_retries_a_failed_release_once() {
+        let shared = Arc::new(ScriptableSharedCache::new(true));
+        shared.fail_next_releases(1);
+        let cache = lease_facade(shared.clone());
+        let claim = cache.try_claim_refresh("flight").expect("claim");
+        let result = cache
+            .refresh_under_lease(claim, || async { Ok::<_, &str>(()) })
+            .await;
+        assert_eq!(result, Some(Ok(())));
+        assert_eq!(
+            shared.lease_releases().len(),
+            2,
+            "a release lost to a shared-store blip must be retried once so              the lease is not orphaned until TTL expiry"
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #2248. Follow-up to #2166.

The stale-while-revalidate background refresh dedups within a single process only (the in-process claim set). With the Redis backend on a multi-replica deployment, a traffic burst on the same stale packument spread across N replicas triggers up to N concurrent upstream refreshes for the same key — bounded and best-effort, so pure waste rather than incorrectness, but it multiplies upstream load for zero benefit.

This gates the background refresh behind a **cross-replica lease** on the shared backend:

- On a stale hit, the spawned refresh task first attempts `SET ak:npm-packument:refresh-lease:{flight_key} {token} NX EX 90` — only the winner refreshes; everyone else skips, and the winner's entry reaches all replicas through the shared cache. (The issue sketched acquiring *before* spawning; acquiring *inside* the spawned task has the same dedup effect with zero added latency on the stale-serving request path.)
- **Release is conditional on a per-acquisition token** (GET-then-DEL; deliberately not Lua `EVAL`, which scripting-restricted Redis deployments refuse — the sub-millisecond non-atomic window's worst case is one duplicate refresh), so a holder that outlived its TTL can never free a successor replica's lease. A release lost to a Redis blip is retried once after the cooldown window, so a transient outage cannot orphan the lease until TTL expiry.
- **Lease TTL (90 s) can never be outlived**: the leased compute is bounded at 80 s, so a slow refresh is abandoned rather than allowed to finish after a successor and overwrite its newer entry. A crashed holder delays the next cross-replica refresh until expiry, never blocks it permanently.
- **A denied replica parks its local claim briefly** before re-arming, so a stale burst on a non-holder costs one shared-backend probe per window, not one spawned task per request.
- **Failure posture matches the rest of the shared backend**: Redis unreachable or in cooldown degrades to a local lease — per-process dedup still applies and refreshes are never lost to a cache outage. The in-process backend (no shared state) is unaffected: the default trait impl grants a local lease unconditionally.

The lease/claim split: the existing `RefreshClaim` dedups a stale burst within one process (no Redis round-trip for followers); the lease dedups across replicas (one `SET NX` per spawned refresh attempt, off the request path).

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated (lease acquire/skip/degrade/release-on-failure semantics, claim always freed, two-facades-one-shared-store race collapses to exactly one refresh, in-process backend unaffected, denial parks the claim, over-long computes abandoned with the lease released, failed release retried once)
- [x] Integration tests added/updated (env-gated real-Redis test via `NPM_PACKUMENT_CACHE_TEST_REDIS_URL`: NX denial while held, PTTL bound, wrong-token release is a no-op, release/reacquire cycle with unique tokens; DB-backed handler test: a stale hit with the lease held elsewhere serves the cached body and provably issues **no** upstream refresh request)
- [ ] E2E tests added/updated (if applicable) — N/A, no client-visible protocol change
- [x] Manually tested locally (`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` against Postgres 16 + a live Redis 7)
- [x] No regressions in existing tests (the only failures in a full parallel run are pre-existing large-object-streaming/timeout flakes that reproduce identically on `main` and pass in isolation on both)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
