### PR TITLE
refactor(auth): make AuthExtension.allowed_repo_ids an explicit AccessScope (#2206)

### DIFF
--- a/backend/src/api/handlers/approval.rs
+++ b/backend/src/api/handlers/approval.rs
@@ -2163,7 +2163,7 @@ mod tests {
                 is_api_token: false,
                 is_service_account: false,
                 scopes: None,
-                allowed_repo_ids: None,
+                allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             }
         }
 

--- a/backend/src/api/handlers/artifact_labels.rs
+++ b/backend/src/api/handlers/artifact_labels.rs
@@ -474,7 +474,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         let result = require_auth(Some(auth.clone()));
         assert!(result.is_ok());
@@ -496,7 +496,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/builds.rs
+++ b/backend/src/api/handlers/builds.rs
@@ -603,7 +603,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         let result = require_auth(Some(auth));
         assert!(result.is_ok());
@@ -658,7 +658,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/ci_auth_admin.rs
+++ b/backend/src/api/handlers/ci_auth_admin.rs
@@ -442,7 +442,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3501,7 +3501,7 @@ mod tests {
                 is_api_token: false,
                 is_service_account: false,
                 scopes: None,
-                allowed_repo_ids: None,
+                allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             }
         }
 

--- a/backend/src/api/handlers/curation.rs
+++ b/backend/src/api/handlers/curation.rs
@@ -547,7 +547,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -560,7 +560,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/groups.rs
+++ b/backend/src/api/handlers/groups.rs
@@ -1336,7 +1336,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -2667,7 +2667,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/packages.rs
+++ b/backend/src/api/handlers/packages.rs
@@ -14,6 +14,7 @@ use crate::api::dto::Pagination;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::models::access_scope::AccessScope;
 use crate::services::curation_service::version_compare;
 use crate::services::repository_service::{
     build_visibility_clause_for, RepoVisibility, VisibilityBind,
@@ -29,9 +30,12 @@ fn repo_visibility_for(auth: Option<&AuthExtension>) -> RepoVisibility {
         None => RepoVisibility::PublicOnly,
         Some(a) if a.is_admin => RepoVisibility::All,
         // Repo-scoped token: restrict strictly to the token's allowed set.
-        Some(a) if a.allowed_repo_ids.is_some() => {
-            RepoVisibility::Ids(a.allowed_repo_ids.clone().unwrap_or_default())
-        }
+        Some(a) if matches!(a.allowed_repo_ids, AccessScope::Restricted(_)) => RepoVisibility::Ids(
+            a.allowed_repo_ids
+                .as_allowed_repo_ids()
+                .unwrap_or_default()
+                .to_vec(),
+        ),
         Some(a) => RepoVisibility::User(a.user_id),
     }
 }
@@ -479,7 +483,7 @@ mod tests {
             is_api_token: allowed.is_some(),
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: allowed,
+            allowed_repo_ids: AccessScope::from(allowed),
         }
     }
 

--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -1333,7 +1333,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_ok());
     }
@@ -1348,7 +1348,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         let err = auth.require_admin().unwrap_err();
         assert!(
@@ -1368,7 +1368,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_err());
     }
@@ -1383,7 +1383,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(vec!["admin".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_ok());
     }
@@ -1398,7 +1398,7 @@ mod tests {
             is_api_token: false,
             is_service_account: true,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_err());
     }
@@ -1417,7 +1417,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(!auth.is_admin);
         // Exercises the real guard used by `get_identity` (auth.require_admin()).
@@ -1441,7 +1441,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.is_admin);
         // Exercises the real guard used by `get_identity` (auth.require_admin()).
@@ -1636,7 +1636,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -1650,7 +1650,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/permissions.rs
+++ b/backend/src/api/handlers/permissions.rs
@@ -842,7 +842,7 @@ mod tests {
             is_api_token: true,
             is_service_account: true,
             scopes: Some(vec!["read".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -855,7 +855,7 @@ mod tests {
             is_api_token: true,
             is_service_account: true,
             scopes: Some(vec!["write".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -931,7 +931,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         // JWT sessions pass the scope check (they are not scope-restricted),
         // so the next gate, require_admin, must catch them.
@@ -955,7 +955,7 @@ mod tests {
             is_api_token: true,
             is_service_account: true,
             scopes: Some(vec!["read".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(
             ext.require_scope("write").is_err(),

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -243,7 +243,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.is_admin);
         assert!(!auth.is_api_token);
@@ -259,7 +259,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(vec!["read".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(!auth.is_admin);
         assert!(auth.is_api_token);

--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -3207,7 +3207,7 @@ mod tests {
                 is_api_token: false,
                 is_service_account: false,
                 scopes: None,
-                allowed_repo_ids: None,
+                allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             }
         }
 
@@ -3224,7 +3224,7 @@ mod tests {
                 is_api_token: true,
                 is_service_account: true,
                 scopes: Some(scopes.iter().map(|s| s.to_string()).collect()),
-                allowed_repo_ids: None,
+                allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             }
         }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -8581,7 +8581,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -611,7 +611,7 @@ mod tests {
             is_api_token: scopes.is_some(),
             is_service_account: false,
             scopes,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -28,6 +28,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::formats::maven::MavenHandler;
+use crate::models::access_scope::AccessScope;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::artifact_service::ArtifactService;
 use crate::services::cache_classifier;
@@ -1227,9 +1228,12 @@ pub async fn list_repositories(
         // allowed repositories, not every repo the owning user can reach.
         // Checked before the general `User` arm. Admin tokens are handled
         // above and bypass scope restrictions.
-        Some(a) if a.allowed_repo_ids.is_some() => {
-            RepoVisibility::Ids(a.allowed_repo_ids.clone().unwrap_or_default())
-        }
+        Some(a) if matches!(a.allowed_repo_ids, AccessScope::Restricted(_)) => RepoVisibility::Ids(
+            a.allowed_repo_ids
+                .as_allowed_repo_ids()
+                .unwrap_or_default()
+                .to_vec(),
+        ),
         Some(a) => RepoVisibility::User(a.user_id),
     };
     let service = RepositoryService::new(state.db.clone());
@@ -6614,7 +6618,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(require_auth(Some(auth)).is_ok());
     }
@@ -8128,7 +8132,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: repo_ids,
+            allowed_repo_ids: AccessScope::from(repo_ids),
         }
     }
 
@@ -10086,7 +10090,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         }
     }
 
@@ -12319,7 +12323,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         }
     }
 
@@ -12526,7 +12530,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::models::access_scope::AccessScope;
 use crate::models::sbom::{
     CveStatus, CveTrends, LicensePolicy, PolicyAction, SbomComponent, SbomDocument, SbomFormat,
 };
@@ -453,7 +454,7 @@ async fn list_sboms(
         // narrow by repository or artifact. Listing all SBOMs would let
         // a token scoped to repo A enumerate dep trees of every other
         // repo. Force the caller to be explicit about the repo scope.
-        if auth.is_api_token && auth.allowed_repo_ids.is_some() {
+        if auth.is_api_token && matches!(auth.allowed_repo_ids, AccessScope::Restricted(_)) {
             return Err(AppError::Validation(
                 "Scope-restricted tokens must filter by repository_id or artifact_id".into(),
             ));
@@ -2218,7 +2219,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         }
     }
 
@@ -2329,7 +2330,7 @@ mod tests {
             is_api_token,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: allowed,
+            allowed_repo_ids: AccessScope::from(allowed),
         }
     }
 
@@ -3190,7 +3191,7 @@ mod tests {
         // Build an auth extension whose allowed_repo_ids does NOT include
         // the fixture's repo. Mirror tdh::make_auth then tighten scopes.
         let mut auth = tdh::make_auth(fx.user_id, &fx.username);
-        auth.allowed_repo_ids = Some(vec![Uuid::new_v4()]);
+        auth.allowed_repo_ids = AccessScope::Restricted(vec![Uuid::new_v4()]);
 
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),

--- a/backend/src/api/handlers/search.rs
+++ b/backend/src/api/handlers/search.rs
@@ -1323,7 +1323,7 @@ mod tests {
             is_api_token: false,
             is_service_account,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -1455,7 +1455,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(vec!["read".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         });
         match classify_repo_access(&auth) {
             RepoAccessMode::UserScoped(uid) => assert_eq!(uid, specific_id),

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -1958,7 +1958,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
 
         // ---- Case 1: non-admin + bypass_dedup=true -> 403 Authorization

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -741,7 +741,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -754,7 +754,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -469,7 +469,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -482,7 +482,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -632,7 +632,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_ok());
     }
@@ -647,7 +647,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         let err = auth.require_admin().unwrap_err();
         assert!(
@@ -667,7 +667,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_err());
     }
@@ -682,7 +682,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(vec!["admin".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
         assert!(auth.require_admin().is_ok());
     }

--- a/backend/src/api/handlers/sync_policies.rs
+++ b/backend/src/api/handlers/sync_policies.rs
@@ -1105,7 +1105,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -332,7 +332,7 @@ pub fn make_auth(user_id: Uuid, username: &str) -> AuthExtension {
         is_api_token: false,
         is_service_account: false,
         scopes: None,
-        allowed_repo_ids: None,
+        allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
     }
 }
 

--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -975,7 +975,7 @@ mod totp_token_invalidation_regression_tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
 
         // Token issued one minute before the change (millisecond issued-at,
@@ -1056,7 +1056,7 @@ mod totp_token_invalidation_regression_tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
 
         // The caller's token was issued "now" (millisecond `iat_ms`, as the
@@ -1144,7 +1144,7 @@ mod totp_token_invalidation_regression_tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
 
         let pre_change_iat = Utc::now().timestamp_millis() - 60_000;
@@ -1228,7 +1228,7 @@ mod totp_token_invalidation_regression_tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         };
 
         let caller_iat_ms = Utc::now().timestamp_millis();

--- a/backend/src/api/handlers/tree.rs
+++ b/backend/src/api/handlers/tree.rs
@@ -901,7 +901,8 @@ mod tests {
         // Token scoped to some OTHER repo id only.
         let mut auth = tdh::make_auth(user_id, &username);
         auth.is_api_token = true;
-        auth.allowed_repo_ids = Some(vec![Uuid::new_v4()]);
+        auth.allowed_repo_ids =
+            crate::models::access_scope::AccessScope::Restricted(vec![Uuid::new_v4()]);
         let state = tdh::build_state(pool.clone(), "/tmp");
         let app = tdh::router_with_auth(router(), state, auth);
 

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -1177,7 +1177,7 @@ mod tests {
             is_api_token: allowed.is_some(),
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: allowed,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::from(allowed),
         }
     }
 

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -3135,7 +3135,7 @@ mod tests {
                 is_api_token: false,
                 is_service_account: false,
                 scopes: None,
-                allowed_repo_ids: None,
+                allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
             }
         }
 

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -46,8 +46,8 @@ pub struct AuthExtension {
     pub is_service_account: bool,
     /// Token scopes if authenticated via API token
     pub scopes: Option<Vec<String>>,
-    /// Repository IDs this token is restricted to (None = unrestricted)
-    pub allowed_repo_ids: Option<Vec<Uuid>>,
+    /// Repository-scope authorization decision for this principal.
+    pub allowed_repo_ids: AccessScope,
 }
 
 /// Marker request extension inserted alongside [`AuthExtension`] when the
@@ -100,13 +100,12 @@ impl AuthExtension {
     /// Repo-scope authorization decision for this principal, as an explicit
     /// [`AccessScope`].
     ///
-    /// Bridges the legacy `allowed_repo_ids` field to the enum: a `None`
-    /// restriction maps to [`AccessScope::Admin`] (grants all repositories),
-    /// and `Some(v)` maps to [`AccessScope::Restricted`] (deny-by-default
-    /// allowlist). This is the single place the `Option<Vec<Uuid>>` shape is
-    /// interpreted for repo-scope decisions (#1617, Phase 4).
+    /// Returns the principal's repository scope: [`AccessScope::Admin`] grants
+    /// all repositories, [`AccessScope::Restricted`] is a deny-by-default
+    /// allowlist. This is the single accessor callers use to reason about
+    /// repo-scope decisions (#1617, Phase 4).
     pub fn access_scope(&self) -> AccessScope {
-        AccessScope::from(&self.allowed_repo_ids)
+        self.allowed_repo_ids.clone()
     }
 
     /// Check whether this auth context has access to a specific repository.
@@ -170,7 +169,7 @@ impl From<Claims> for AuthExtension {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: claims.allowed_repo_ids,
+            allowed_repo_ids: AccessScope::from(claims.allowed_repo_ids),
         }
     }
 }
@@ -185,7 +184,7 @@ impl From<User> for AuthExtension {
             is_api_token: false,
             is_service_account: user.is_service_account,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         }
     }
 }
@@ -731,7 +730,7 @@ async fn validate_api_token_with_scopes(
         is_api_token: true,
         is_service_account: validation.user.is_service_account,
         scopes: Some(validation.scopes),
-        allowed_repo_ids: validation.allowed_repo_ids,
+        allowed_repo_ids: AccessScope::from(validation.allowed_repo_ids),
     })
 }
 
@@ -1888,7 +1887,7 @@ mod tests {
             is_api_token: true,
             is_service_account: false,
             scopes: Some(scopes),
-            allowed_repo_ids: repo_ids,
+            allowed_repo_ids: AccessScope::from(repo_ids),
         }
     }
 
@@ -1952,7 +1951,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(ext.has_scope("anything"));
     }
@@ -2007,7 +2006,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         let result = require_auth_basic_scope(Some(ext), "maven", "write");
         assert!(result.is_ok(), "JWT sessions must not be scope-gated");
@@ -2090,7 +2089,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(require_scope_response(Some(&ext), "write").is_ok());
         assert!(require_scope_response(Some(&ext), "delete").is_ok());
@@ -2124,7 +2123,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
 
         let cloned = ext.clone();
@@ -2188,7 +2187,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         let result = require_auth_basic(Some(ext), "maven");
         assert!(result.is_ok());
@@ -2502,6 +2501,43 @@ mod tests {
         );
     }
 
+    // Authorization invariants stated directly against the `AccessScope` field
+    // (the point of the type swap): the enum makes "no restriction" and
+    // "restricted to nothing" impossible to confuse.
+    #[test]
+    fn test_access_scope_field_admin_grants_all() {
+        let ext = make_api_token_ext(vec!["*".to_string()], None);
+        assert_eq!(ext.allowed_repo_ids, AccessScope::Admin);
+        assert_eq!(ext.access_scope(), AccessScope::Admin);
+        assert!(
+            ext.can_access_repo(Uuid::new_v4()),
+            "AccessScope::Admin must reach every repository"
+        );
+    }
+
+    #[test]
+    fn test_access_scope_field_empty_scope_denies_all() {
+        // Some(vec![]) through the helper yields Restricted([]).
+        let ext = make_api_token_ext(vec!["*".to_string()], Some(vec![]));
+        assert_eq!(ext.allowed_repo_ids, AccessScope::Restricted(vec![]));
+        assert!(
+            !ext.can_access_repo(Uuid::new_v4()),
+            "empty scope (Restricted([])) must grant nothing, never fall open"
+        );
+    }
+
+    #[test]
+    fn test_access_scope_field_restricted_grants_only_listed() {
+        let target = Uuid::new_v4();
+        let ext = make_api_token_ext(vec!["*".to_string()], Some(vec![target]));
+        assert_eq!(ext.allowed_repo_ids, AccessScope::Restricted(vec![target]));
+        assert!(ext.can_access_repo(target), "listed repo must be reachable");
+        assert!(
+            !ext.can_access_repo(Uuid::new_v4()),
+            "a repo outside the allowlist must be denied"
+        );
+    }
+
     #[test]
     fn test_can_access_repo_jwt_always_unrestricted() {
         let ext = AuthExtension {
@@ -2512,7 +2548,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         // JWT sessions have no repo restrictions (allowed_repo_ids is None).
         assert!(ext.can_access_repo(Uuid::new_v4()));
@@ -2530,7 +2566,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(ext.require_admin().is_ok());
     }
@@ -2545,7 +2581,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         let err = ext.require_admin().unwrap_err();
         assert!(err.to_string().contains("Admin access required"));
@@ -2561,7 +2597,7 @@ mod tests {
             is_api_token: true,
             is_service_account: true,
             scopes: Some(vec!["admin".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(ext.require_admin().is_ok());
     }
@@ -2576,7 +2612,7 @@ mod tests {
             is_api_token: true,
             is_service_account: true,
             scopes: Some(vec!["read".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(ext.require_admin().is_err());
     }
@@ -2595,7 +2631,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         }
     }
 
@@ -2829,7 +2865,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         // The middleware skips permission checks when is_admin is true.
         // Verify the flag is correctly detected.
@@ -2935,7 +2971,7 @@ mod tests {
             is_api_token: true,
             is_service_account: true,
             scopes: Some(vec!["admin".to_string()]),
-            allowed_repo_ids: None,
+            allowed_repo_ids: AccessScope::Admin,
         };
         assert!(
             ext.is_admin,
@@ -3754,7 +3790,7 @@ mod tests {
                 is_api_token: true,
                 is_service_account: true,
                 scopes: Some(vec!["read".to_string()]),
-                allowed_repo_ids: None,
+                allowed_repo_ids: AccessScope::Admin,
             }
         }
 

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -1025,7 +1025,7 @@ mod tests {
             is_api_token: false,
             is_service_account,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         }
     }
 
@@ -1380,7 +1380,7 @@ mod tests {
             is_api_token: false,
             is_service_account: false,
             scopes: None,
-            allowed_repo_ids: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
         });
         next.run(request).await
     }
@@ -1732,7 +1732,7 @@ mod tests {
                         is_api_token: false,
                         is_service_account: false,
                         scopes: None,
-                        allowed_repo_ids: None,
+                        allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
                     });
                     next.run(request).await
                 },


### PR DESCRIPTION
## Summary

Replaces the footgun-prone `Option<Vec<Uuid>>` shape of
`AuthExtension.allowed_repo_ids` with the explicit `AccessScope` enum
(`backend/src/models/access_scope.rs`, shipped in #2205). The old shape invites
the "`None` falls open" bug class: a reader or refactor can confuse "no
restriction / admin" (`None`) with "restricted to nothing" (`Some(vec![])`), and
an accidental `None` silently grants full cross-repo access. `AccessScope` makes
the decision exhaustively matched — `Admin` (grants every repo) can never be
confused with `Restricted(vec![])` (deny-by-default, grants nothing).

This is a behavior-preserving internal type change. The mapping is exactly
today's semantics, already proven by the `AccessScope` unit tests:

- `None` ≡ `AccessScope::Admin` — grants all repositories.
- `Some(v)` ≡ `AccessScope::Restricted(v)` — deny-by-default allowlist;
  `Restricted(vec![])` grants nothing (never falls open).

Scope of the change (`AuthExtension` only):

- Struct field `AuthExtension.allowed_repo_ids: Option<Vec<Uuid>>` → `AccessScope`.
- 71 mechanical field-inits `None` → `AccessScope::Admin`.
- 2 production conversions bridge from types that stay `Option<Vec<Uuid>>`
  (`Claims` — JWT wire format; `ApiTokenValidation`) via `AccessScope::from(...)`.
- 5 test-helper builders keep their `Option` param and wrap only the field-init.
- 3 read sites (`packages`/`repositories` listing visibility, SBOM scope guard)
  rewritten from `.is_some()`/`unwrap_or_default()` to an `AccessScope` match,
  preserving behavior exactly.
- `AuthExtension::access_scope()` becomes an identity accessor (kept — 5 callers
  depend on it).

`Claims.allowed_repo_ids` (JWT wire), `ApiTokenValidation.allowed_repo_ids`, the
CI-OIDC DTO fields, and the `SearchQuery` SQL sinks are intentionally untouched;
they stay `Option<Vec<Uuid>>` and are bridged at the `AuthExtension` boundary.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is a `refactor/` type-safety hardening, not a bug fix. It preserves current
authorization behavior; the added tests lock the invariants against future drift.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added three explicit invariant tests stated directly against the new
`AccessScope` field (in `api::middleware::auth::tests`):
- `test_access_scope_field_admin_grants_all` — unscoped/admin reaches every repo.
- `test_access_scope_field_restricted_grants_only_listed` — a repo-scoped token
  reaches only its listed repo, never others.
- `test_access_scope_field_empty_scope_denies_all` — an empty scope
  (`Restricted([])`) grants nothing and never falls open.

The existing `can_access_repo` invariants and the `repo_visibility_for`
listing-scope tests pass verbatim. `cargo build --lib --tests`, `cargo clippy
--lib -D warnings`, and `cargo fmt --check` are clean; the full `cargo test
--lib` suite passes (unrelated wiremock streaming tests flake under sandbox
resource contention only).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

`AccessScope` is an internal-only type: it changes no DB column and no
serialized wire representation. No migration, no OpenAPI change.

Closes #2206
