### PR TITLE
refactor(auth): make ApiTokenValidation.allowed_repo_ids an explicit AccessScope (#2206)

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -730,7 +730,7 @@ async fn validate_api_token_with_scopes(
         is_api_token: true,
         is_service_account: validation.user.is_service_account,
         scopes: Some(validation.scopes),
-        allowed_repo_ids: AccessScope::from(validation.allowed_repo_ids),
+        allowed_repo_ids: validation.allowed_repo_ids,
     })
 }
 

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -20,6 +20,7 @@ use uuid::Uuid;
 
 use crate::config::Config;
 use crate::error::{AppError, Result};
+use crate::models::access_scope::AccessScope;
 use crate::models::user::{AuthProvider, User};
 
 /// Federated authentication credentials
@@ -85,8 +86,9 @@ pub struct ApiTokenValidation {
     pub user: User,
     /// Token scopes (e.g. "read:artifacts", "write:artifacts", "*")
     pub scopes: Vec<String>,
-    /// Repository IDs the token is restricted to (None = unrestricted)
-    pub allowed_repo_ids: Option<Vec<Uuid>>,
+    /// Repository-scope authorization decision for this token.
+    /// `Admin` = unrestricted; `Restricted(v)` = allowlist; `Restricted(vec![])` = deny-all.
+    pub allowed_repo_ids: AccessScope,
 }
 
 /// JWT claims structure.
@@ -1830,7 +1832,7 @@ impl AuthService {
         let validation = ApiTokenValidation {
             user,
             scopes: stored_token.scopes,
-            allowed_repo_ids,
+            allowed_repo_ids: AccessScope::from(allowed_repo_ids),
         };
 
         // Populate cache; evict stale entries on write to keep memory bounded.
@@ -3241,6 +3243,53 @@ mod tests {
         }
     }
 
+    /// Pins the `ApiTokenValidation.allowed_repo_ids` ctor boundary
+    /// (`AccessScope::from` on the resolved `Option<Vec<Uuid>>` local in
+    /// `validate_api_token`) to today's authorization semantics: unscoped
+    /// tokens reach every repo, allowlisted tokens reach only their repos, and
+    /// an empty allowlist denies everything (never falls open).
+    #[test]
+    fn test_api_token_validation_scope_ctor_preserves_semantics() {
+        let repo_a = Uuid::new_v4();
+        let repo_b = Uuid::new_v4();
+
+        // 1. Unrestricted (no join rows / empty selector -> None -> Admin):
+        //    reaches all repos.
+        let unrestricted = ApiTokenValidation {
+            user: make_test_user(),
+            scopes: vec!["*".to_string()],
+            allowed_repo_ids: AccessScope::from(None::<Vec<Uuid>>),
+        };
+        assert_eq!(unrestricted.allowed_repo_ids, AccessScope::Admin);
+        assert!(unrestricted.allowed_repo_ids.grants(repo_a));
+        assert!(unrestricted.allowed_repo_ids.grants(repo_b));
+
+        // 2. Allowlist (N join rows -> Some(ids) -> Restricted(ids)): reaches
+        //    only its repos.
+        let restricted = ApiTokenValidation {
+            user: make_test_user(),
+            scopes: vec!["read:artifacts".to_string()],
+            allowed_repo_ids: AccessScope::from(Some(vec![repo_a])),
+        };
+        assert_eq!(
+            restricted.allowed_repo_ids,
+            AccessScope::Restricted(vec![repo_a])
+        );
+        assert!(restricted.allowed_repo_ids.grants(repo_a));
+        assert!(!restricted.allowed_repo_ids.grants(repo_b));
+
+        // 3. Empty scope (selector resolves to zero ids -> Some(vec![]) ->
+        //    Restricted(vec![])): deny-by-default, reaches nothing.
+        let empty = ApiTokenValidation {
+            user: make_test_user(),
+            scopes: vec!["read:artifacts".to_string()],
+            allowed_repo_ids: AccessScope::from(Some(Vec::<Uuid>::new())),
+        };
+        assert_eq!(empty.allowed_repo_ids, AccessScope::Restricted(vec![]));
+        assert!(!empty.allowed_repo_ids.grants(repo_a));
+        assert!(!empty.allowed_repo_ids.grants(repo_b));
+    }
+
     // We cannot create a PgPool without a real database, so for unit tests that
     // need JWT encoding/decoding, we directly use jsonwebtoken's encode/decode
     // with the same keys the AuthService would use.
@@ -4092,7 +4141,7 @@ mod tests {
                     updated_at: Utc::now(),
                 },
                 scopes,
-                allowed_repo_ids: None,
+                allowed_repo_ids: AccessScope::Admin,
             },
             token_id: Uuid::nil(),
             expires_at: None,
@@ -4222,7 +4271,7 @@ mod tests {
                     updated_at: Utc::now(),
                 },
                 scopes: vec![],
-                allowed_repo_ids: None,
+                allowed_repo_ids: AccessScope::Admin,
             },
             token_id: Uuid::new_v4(),
             expires_at: Some(past),
@@ -4260,7 +4309,7 @@ mod tests {
                     updated_at: Utc::now(),
                 },
                 scopes: vec![],
-                allowed_repo_ids: None,
+                allowed_repo_ids: AccessScope::Admin,
             },
             token_id: Uuid::new_v4(),
             expires_at: Some(future),
@@ -4925,7 +4974,7 @@ mod tests {
                         updated_at: Utc::now(),
                     },
                     scopes: vec![],
-                    allowed_repo_ids: None,
+                    allowed_repo_ids: AccessScope::Admin,
                 },
                 token_id: Uuid::new_v4(),
                 expires_at: None,
@@ -5024,7 +5073,7 @@ mod tests {
                         updated_at: Utc::now(),
                     },
                     scopes: vec![],
-                    allowed_repo_ids: None,
+                    allowed_repo_ids: AccessScope::Admin,
                 },
                 token_id: Uuid::new_v4(),
                 expires_at: None,


### PR DESCRIPTION
## Summary

Completes the `#2206` field migration begun in PR-a (#2257). PR-a swapped
`AuthExtension.allowed_repo_ids` from the footgun `Option<Vec<Uuid>>` (where
`None` silently means "no repository restriction") to the explicit
[`AccessScope`] enum, and bridged the still-`Option` `ApiTokenValidation`
sibling with `AccessScope::from(...)`. This PR (PR-b) finishes the swap by
changing `ApiTokenValidation.allowed_repo_ids` to `AccessScope` and collapsing
that temporary bridge to a direct move, so the whole api-token authorization
path speaks the same deny-by-default type end to end.

Scope is small and behavior-preserving:

- **`services/auth_service.rs`** — change the `ApiTokenValidation` field type;
  in the sole production construction (`validate_api_token`) wrap the resolved
  `Option<Vec<Uuid>>` local at the struct literal via `AccessScope::from(...)`,
  leaving the producer's `None`-vs-empty branching (empty selector / no join
  rows -> unrestricted; selector resolves to zero ids -> deny-all) untouched;
  five cache-fixture test constructions go `None` -> `AccessScope::Admin`.
- **`api/middleware/auth.rs`** — the `From<ApiTokenValidation>` bridge PR-a
  wrote as `AccessScope::from(validation.allowed_repo_ids)` becomes a direct
  move now that the field is already `AccessScope`.

The conversion is exactly today's semantics: `None <-> Admin`,
`Some(v) <-> Restricted(v)`, `Some(vec![]) <-> Restricted(vec![])` (deny-all,
never falls open). `Claims.allowed_repo_ids` (the JWT wire type) is deliberately
left as `Option<Vec<Uuid>>` — only the internal validation/extension types
migrate. No serialized type changes, so no OpenAPI or migration impact.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

This is a type-safety refactor (`refactor/`), not a bug fix; there is no
behavior change to regress. A new unit test pins the conversion invariant.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added `test_api_token_validation_scope_ctor_preserves_semantics`, pinning the
three cardinal cases at the `ApiTokenValidation` ctor boundary: unscoped token
(`None -> Admin`) grants every repo; allowlist (`Some([r]) -> Restricted([r])`)
grants only `r`; empty scope (`Some(vec![]) -> Restricted(vec![])`) grants
nothing. The existing cache-fixture and `Claims` repo-scope tests pass verbatim.

Manually verified on an isolated stack with real DB-provisioned users/tokens: a
repo-scoped api token (`api_token_repositories` join row) reaches only its own
repository (`404` on its repo, `403` on a foreign repo via the
`can_access_repo` gate), while an unscoped api token reaches every repository —
identical to pre-PR behavior.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

`ApiTokenValidation` is an internal-only type (`#[derive(Debug, Clone)]`, not
`Serialize`/`Deserialize`); it is on no API schema. No DB column changes (the
`api_token_repositories` table and `api_tokens.repo_selector` JSONB are read
exactly as before), so no migration and no `cargo sqlx prepare`.

Closes #2206
