### PR TITLE
refactor(auth): fold token issued-at into AuthExtension and extract invalidate-other-sessions helper

### DIFF
--- a/backend/src/api/handlers/approval.rs
+++ b/backend/src/api/handlers/approval.rs
@@ -2164,6 +2164,7 @@ mod tests {
                 is_service_account: false,
                 scopes: None,
                 allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+                iat_ms: None,
             }
         }
 

--- a/backend/src/api/handlers/artifact_labels.rs
+++ b/backend/src/api/handlers/artifact_labels.rs
@@ -475,6 +475,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         let result = require_auth(Some(auth.clone()));
         assert!(result.is_ok());
@@ -497,6 +498,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/builds.rs
+++ b/backend/src/api/handlers/builds.rs
@@ -604,6 +604,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         let result = require_auth(Some(auth));
         assert!(result.is_ok());
@@ -659,6 +660,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/ci_auth_admin.rs
+++ b/backend/src/api/handlers/ci_auth_admin.rs
@@ -443,6 +443,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3502,6 +3502,7 @@ mod tests {
                 is_service_account: false,
                 scopes: None,
                 allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+                iat_ms: None,
             }
         }
 

--- a/backend/src/api/handlers/curation.rs
+++ b/backend/src/api/handlers/curation.rs
@@ -548,6 +548,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -561,6 +562,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/groups.rs
+++ b/backend/src/api/handlers/groups.rs
@@ -1337,6 +1337,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -2668,6 +2668,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/packages.rs
+++ b/backend/src/api/handlers/packages.rs
@@ -484,6 +484,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::from(allowed),
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -1334,6 +1334,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_ok());
     }
@@ -1349,6 +1350,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         let err = auth.require_admin().unwrap_err();
         assert!(
@@ -1369,6 +1371,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_err());
     }
@@ -1384,6 +1387,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["admin".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_ok());
     }
@@ -1399,6 +1403,7 @@ mod tests {
             is_service_account: true,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_err());
     }
@@ -1418,6 +1423,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(!auth.is_admin);
         // Exercises the real guard used by `get_identity` (auth.require_admin()).
@@ -1442,6 +1448,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.is_admin);
         // Exercises the real guard used by `get_identity` (auth.require_admin()).
@@ -1637,6 +1644,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -1651,6 +1659,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/permissions.rs
+++ b/backend/src/api/handlers/permissions.rs
@@ -843,6 +843,7 @@ mod tests {
             is_service_account: true,
             scopes: Some(vec!["read".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -856,6 +857,7 @@ mod tests {
             is_service_account: true,
             scopes: Some(vec!["write".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -932,6 +934,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         // JWT sessions pass the scope check (they are not scope-restricted),
         // so the next gate, require_admin, must catch them.
@@ -956,6 +959,7 @@ mod tests {
             is_service_account: true,
             scopes: Some(vec!["read".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(
             ext.require_scope("write").is_err(),

--- a/backend/src/api/handlers/profile.rs
+++ b/backend/src/api/handlers/profile.rs
@@ -244,6 +244,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.is_admin);
         assert!(!auth.is_api_token);
@@ -260,6 +261,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["read".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(!auth.is_admin);
         assert!(auth.is_api_token);

--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -3208,6 +3208,7 @@ mod tests {
                 is_service_account: false,
                 scopes: None,
                 allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+                iat_ms: None,
             }
         }
 
@@ -3225,6 +3226,7 @@ mod tests {
                 is_service_account: true,
                 scopes: Some(scopes.iter().map(|s| s.to_string()).collect()),
                 allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+                iat_ms: None,
             }
         }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -8582,6 +8582,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -612,6 +612,7 @@ mod tests {
             is_service_account: false,
             scopes,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -6619,6 +6619,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(require_auth(Some(auth)).is_ok());
     }
@@ -8133,6 +8134,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::from(repo_ids),
+            iat_ms: None,
         }
     }
 
@@ -10091,6 +10093,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -12324,6 +12327,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -12531,6 +12535,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -2220,6 +2220,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -2331,6 +2332,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::from(allowed),
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/search.rs
+++ b/backend/src/api/handlers/search.rs
@@ -1324,6 +1324,7 @@ mod tests {
             is_service_account,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -1456,6 +1457,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["read".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         });
         match classify_repo_access(&auth) {
             RepoAccessMode::UserScoped(uid) => assert_eq!(uid, specific_id),

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -1959,6 +1959,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
 
         // ---- Case 1: non-admin + bypass_dedup=true -> 403 Authorization

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -742,6 +742,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -755,6 +756,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -470,6 +470,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -483,6 +484,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -633,6 +633,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_ok());
     }
@@ -648,6 +649,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         let err = auth.require_admin().unwrap_err();
         assert!(
@@ -668,6 +670,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_err());
     }
@@ -683,6 +686,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["admin".to_string()]),
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(auth.require_admin().is_ok());
     }

--- a/backend/src/api/handlers/sync_policies.rs
+++ b/backend/src/api/handlers/sync_policies.rs
@@ -1106,6 +1106,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -333,6 +333,7 @@ pub fn make_auth(user_id: Uuid, username: &str) -> AuthExtension {
         is_service_account: false,
         scopes: None,
         allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+        iat_ms: None,
     }
 }
 

--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -16,12 +16,10 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::api::extractors::request_scheme_is_https;
 use crate::api::handlers::auth::set_auth_cookies;
-use crate::api::middleware::auth::{AuthExtension, TokenIat};
+use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
-use crate::services::auth_service::{
-    invalidate_user_tokens, invalidate_user_tokens_except_caller, AuthService,
-};
+use crate::services::auth_service::{invalidate_other_sessions, AuthService};
 
 /// Build a TOTP instance from raw secret bytes and a username label.
 fn build_totp(secret_bytes: Vec<u8>, username: String) -> Result<TOTP> {
@@ -181,7 +179,6 @@ pub struct TotpEnableResponse {
 pub async fn enable_totp(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
-    token_iat: Option<Extension<TokenIat>>,
     Json(payload): Json<TotpCodeRequest>,
 ) -> Result<Json<TotpEnableResponse>> {
     // Fetch stored secret
@@ -253,7 +250,7 @@ pub async fn enable_totp(
     // When the caller didn't use a JWT (no `iat`), fall back to `NOW()` so
     // the original #1146 semantic still holds for any other JWT sessions
     // this user has.
-    let caller_iat_ms = token_iat.as_ref().map(|Extension(TokenIat(iat))| *iat);
+    let caller_iat_ms = auth.caller_iat_ms();
     let verified_ts: DateTime<Utc> = match caller_iat_ms {
         Some(iat_ms) => DateTime::<Utc>::from_timestamp_millis(iat_ms).ok_or_else(|| {
             AppError::Internal(format!(
@@ -281,10 +278,7 @@ pub async fn enable_totp(
     // Refresh tokens are revoked via the DB on every replica below so the
     // OAuth refresh-grant cannot mint a fresh access token from a stale
     // refresh JWT — that's the original #1146 threat.
-    match caller_iat_ms {
-        Some(iat_ms) => invalidate_user_tokens_except_caller(auth.user_id, iat_ms),
-        None => invalidate_user_tokens(auth.user_id),
-    }
+    invalidate_other_sessions(auth.user_id, caller_iat_ms);
 
     // Refresh-token family revocation (#1146 / #1370): a refresh JWT issued
     // before TOTP was enabled stays valid until natural expiry. Mark every
@@ -514,7 +508,6 @@ pub struct TotpDisableRequest {
 pub async fn disable_totp(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
-    token_iat: Option<Extension<TokenIat>>,
     Json(payload): Json<TotpDisableRequest>,
 ) -> Result<()> {
     // Verify password
@@ -572,11 +565,7 @@ pub async fn disable_totp(
     // Invalidate prior tokens issued under the stricter (TOTP-required)
     // policy while exempting the calling session so the user is not signed
     // out by their own disable action (#1370).
-    let caller_iat_ms = token_iat.as_ref().map(|Extension(TokenIat(iat))| *iat);
-    match caller_iat_ms {
-        Some(iat_ms) => invalidate_user_tokens_except_caller(auth.user_id, iat_ms),
-        None => invalidate_user_tokens(auth.user_id),
-    }
+    invalidate_other_sessions(auth.user_id, auth.caller_iat_ms());
 
     // Refresh-token family revocation (#1146 / #1370): kill every refresh
     // JWT for this user across replicas so the OAuth refresh-grant cannot
@@ -976,6 +965,8 @@ mod totp_token_invalidation_regression_tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            // Non-JWT caller (API-token / basic-auth): no `iat` to exempt.
+            iat_ms: None,
         };
 
         // Token issued one minute before the change (millisecond issued-at,
@@ -993,7 +984,6 @@ mod totp_token_invalidation_regression_tests {
         let result = enable_totp(
             State(state),
             Extension(auth),
-            None,
             Json(TotpCodeRequest { code }),
         )
         .await;
@@ -1048,17 +1038,6 @@ mod totp_token_invalidation_regression_tests {
         let totp = build_totp(secret_bytes, format!("test-{user_id}")).expect("build totp");
         let code = totp.generate_current().expect("generate code");
 
-        let auth = AuthExtension {
-            user_id,
-            username: format!("test-{user_id}"),
-            email: format!("test-{user_id}@example.test"),
-            is_admin: false,
-            is_api_token: false,
-            is_service_account: false,
-            scopes: None,
-            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
-        };
-
         // The caller's token was issued "now" (millisecond `iat_ms`, as the
         // middleware now supplies via `Claims::effective_iat_ms`); tokens
         // issued before now must be killed; the caller's own token must
@@ -1068,10 +1047,23 @@ mod totp_token_invalidation_regression_tests {
         let pre_caller_iat_ms = caller_iat_ms - 60_000;
         let older_same_second_ms = caller_iat_ms - 1;
 
+        // The calling JWT's issued-at now travels on `AuthExtension::iat_ms`
+        // (folded from the former separate `TokenIat` extension, #1394).
+        let auth = AuthExtension {
+            user_id,
+            username: format!("test-{user_id}"),
+            email: format!("test-{user_id}@example.test"),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: Some(caller_iat_ms),
+        };
+
         let result = enable_totp(
             State(state),
             Extension(auth),
-            Some(Extension(TokenIat(caller_iat_ms))),
             Json(TotpCodeRequest { code }),
         )
         .await;
@@ -1145,6 +1137,7 @@ mod totp_token_invalidation_regression_tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         };
 
         let pre_change_iat = Utc::now().timestamp_millis() - 60_000;
@@ -1158,7 +1151,6 @@ mod totp_token_invalidation_regression_tests {
         let result = disable_totp(
             State(state),
             Extension(auth),
-            None,
             Json(TotpDisableRequest {
                 password: "real-test-password".to_string(),
                 code,
@@ -1220,6 +1212,12 @@ mod totp_token_invalidation_regression_tests {
         let totp = build_totp(secret_bytes, format!("test-{user_id}")).expect("build totp");
         let code = totp.generate_current().expect("generate code");
 
+        let caller_iat_ms = Utc::now().timestamp_millis();
+        let pre_caller_iat_ms = caller_iat_ms - 60_000;
+        let older_same_second_ms = caller_iat_ms - 1;
+
+        // The calling JWT's issued-at now travels on `AuthExtension::iat_ms`
+        // (folded from the former separate `TokenIat` extension, #1394).
         let auth = AuthExtension {
             user_id,
             username: format!("test-{user_id}"),
@@ -1229,16 +1227,12 @@ mod totp_token_invalidation_regression_tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: Some(caller_iat_ms),
         };
-
-        let caller_iat_ms = Utc::now().timestamp_millis();
-        let pre_caller_iat_ms = caller_iat_ms - 60_000;
-        let older_same_second_ms = caller_iat_ms - 1;
 
         let result = disable_totp(
             State(state),
             Extension(auth),
-            Some(Extension(TokenIat(caller_iat_ms))),
             Json(TotpDisableRequest {
                 password: "real-test-password".to_string(),
                 code,

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -1178,6 +1178,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::from(allowed),
+            iat_ms: None,
         }
     }
 

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -3136,6 +3136,7 @@ mod tests {
                 is_service_account: false,
                 scopes: None,
                 allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+                iat_ms: None,
             }
         }
 

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -34,7 +34,15 @@ use crate::services::permission_service::PermissionService;
 static X_API_KEY: HeaderName = HeaderName::from_static("x-api-key");
 
 /// Extension that holds authenticated user information
-#[derive(Debug, Clone)]
+///
+/// `Default` derives a deny-by-default principal (anonymous, non-admin,
+/// `allowed_repo_ids = AccessScope::default()` = `Restricted(vec![])`, and no
+/// `iat_ms`). It exists so the ~130 test fixtures and the two non-JWT
+/// production literals can spell only the fields they care about via
+/// `..Default::default()`; the JWT source of truth (`impl From<Claims>`) always
+/// sets every field explicitly. The default MUST fail CLOSED — see
+/// `AccessScope::default`.
+#[derive(Debug, Clone, Default)]
 pub struct AuthExtension {
     pub user_id: Uuid,
     pub username: String,
@@ -48,6 +56,17 @@ pub struct AuthExtension {
     pub scopes: Option<Vec<String>>,
     /// Repository-scope authorization decision for this principal.
     pub allowed_repo_ids: AccessScope,
+    /// Calling token's **millisecond** issued-at (`Claims::effective_iat_ms`).
+    ///
+    /// `Some` only on the JWT path (Bearer, cookie, or a JWT presented as a
+    /// Basic-auth password). `None` for API-key, X-API-Key, Basic
+    /// username/password, ticket, and service-account auth (there is no JWT
+    /// `iat`). Used by credential-change handlers (TOTP enable/disable) to
+    /// exempt the calling session's own token from the invalidation it just
+    /// triggered (#1370). Folded onto `AuthExtension` (from the former separate
+    /// `TokenIat` extension) so the single `From<Claims>` source stamps it
+    /// uniformly alongside the live re-derived `is_admin` (#1166, #1394).
+    pub iat_ms: Option<i64>,
 }
 
 /// Marker request extension inserted alongside [`AuthExtension`] when the
@@ -61,25 +80,16 @@ pub struct AuthExtension {
 #[derive(Debug, Clone, Copy)]
 pub struct DownloadTicketAuth;
 
-/// Calling token's `iat` (issued-at) Unix-timestamp in seconds.
-///
-/// Inserted alongside [`AuthExtension`] by [`auth_middleware`] only when the
-/// caller authenticated with a JWT (Bearer or cookie). Absent for API-key,
-/// Basic, ticket, and service-account auth (where there is no JWT iat).
-///
-/// Used by handlers that perform credential-change invalidation
-/// (TOTP enable/disable, password change) to exempt the calling session's
-/// own token from being killed by the same operation it just performed.
-/// Issue #1370.
-///
-/// Carries the calling token's **millisecond** issued-at
-/// (`Claims::effective_iat_ms`) so the exempt-caller watermark can be set with
-/// millisecond precision (`caller_iat_ms - 1`), exempting only the caller and
-/// catching every strictly-older token — including one from the same second.
-#[derive(Debug, Clone, Copy)]
-pub struct TokenIat(pub i64);
-
 impl AuthExtension {
+    /// Calling token's **millisecond** issued-at, or `None` for non-JWT
+    /// principals. See [`AuthExtension::iat_ms`]. Handlers performing a
+    /// credential-change invalidation (TOTP enable/disable) use this to exempt
+    /// the calling session's own token from the invalidation it just triggered
+    /// (#1370).
+    pub fn caller_iat_ms(&self) -> Option<i64> {
+        self.iat_ms
+    }
+
     /// Check whether this auth context has a required scope.
     /// JWT sessions (non-API-token auth) always pass since they have no scope
     /// restrictions. API tokens must explicitly include the scope (or `*`/`admin`).
@@ -161,6 +171,11 @@ impl AuthExtension {
 
 impl From<Claims> for AuthExtension {
     fn from(claims: Claims) -> Self {
+        // Single source of truth for the calling JWT's issued-at. Folded here
+        // (from the former separate `TokenIat` extension) so every JWT
+        // principal carries `iat_ms` uniformly (#1394). Computed before the
+        // partial move of `claims.allowed_repo_ids` below.
+        let iat_ms = Some(claims.effective_iat_ms());
         Self {
             user_id: claims.sub,
             username: claims.username,
@@ -170,6 +185,7 @@ impl From<Claims> for AuthExtension {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::from(claims.allowed_repo_ids),
+            iat_ms,
         }
     }
 }
@@ -185,6 +201,8 @@ impl From<User> for AuthExtension {
             is_service_account: user.is_service_account,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            // Basic username/password auth carries no JWT `iat`.
+            iat_ms: None,
         }
     }
 }
@@ -494,10 +512,11 @@ pub async fn auth_middleware(
     // 401 message stays informative when only a ?ticket= was supplied.
     let had_header_credentials = !matches!(extracted, ExtractedToken::None);
 
-    // Carry the JWT `iat` alongside the resolved AuthExtension so handlers
-    // performing credential-change invalidation (TOTP, password) can exempt
-    // the calling session's own token. Only populated on the JWT path.
-    let header_result: Result<(AuthExtension, Option<TokenIat>), &'static str> = match extracted {
+    // The resolved principal. The JWT `iat` used by credential-change
+    // invalidation (TOTP, password) to exempt the calling session's own token
+    // now travels as `AuthExtension::iat_ms`, stamped at the single
+    // `From<Claims>` source; it is `None` for non-JWT principals (#1394).
+    let header_result: Result<AuthExtension, &'static str> = match extracted {
         // Replica-safe access-token validation. The async variant consults the
         // DB credential-change watermark (#1173) so a password reset, TOTP
         // change, or deactivation on a peer replica is honoured here on the
@@ -507,12 +526,9 @@ pub async fn auth_middleware(
         // PR #1190 was supposed to close.
         ExtractedToken::Bearer(token) => {
             match auth_service.validate_access_token_async(token).await {
-                Ok(claims) => {
-                    let iat = TokenIat(claims.effective_iat_ms());
-                    Ok((AuthExtension::from(claims), Some(iat)))
-                }
+                Ok(claims) => Ok(AuthExtension::from(claims)),
                 Err(_) => match validate_api_token_with_scopes(&auth_service, token).await {
-                    Ok(ext) => Ok((ext, None)),
+                    Ok(ext) => Ok(ext),
                     // Same transient bcrypt-capacity shed as the Basic branch
                     // below: a saturated cap is "retry shortly", not "wrong
                     // token". See `TokenAuthError::Overloaded`.
@@ -523,7 +539,7 @@ pub async fn auth_middleware(
         }
         ExtractedToken::ApiKey(token) => {
             match validate_api_token_with_scopes(&auth_service, token).await {
-                Ok(ext) => Ok((ext, None)),
+                Ok(ext) => Ok(ext),
                 Err(TokenAuthError::Overloaded) => return service_unavailable_response(),
                 Err(TokenAuthError::Invalid) => Err("Invalid or expired API token"),
             }
@@ -532,7 +548,7 @@ pub async fn auth_middleware(
             None => Err("Invalid Basic auth credentials"),
             Some((username, password)) => {
                 match auth_service.authenticate(&username, &password).await {
-                    Ok((user, _token_pair)) => Ok((AuthExtension::from(user), None)),
+                    Ok((user, _token_pair)) => Ok(AuthExtension::from(user)),
                     // A transient bcrypt-capacity shed must NOT be collapsed
                     // into a 401. `authenticate()` runs bcrypt(cost=12) under a
                     // process-wide concurrency cap (see
@@ -567,13 +583,11 @@ pub async fn auth_middleware(
                         // token. This enables CI/CD keyless flows (e.g. OIDC
                         // token exchange) where package managers like Maven,
                         // pip/twine, and Helm send the AK access token as the
-                        // Basic-auth password. Carry the `iat` so credential
-                        // change invalidation can exempt the calling session.
+                        // Basic-auth password. `From<Claims>` stamps `iat_ms` so
+                        // credential-change invalidation can exempt the calling
+                        // session.
                         match auth_service.validate_access_token_async(&password).await {
-                            Ok(claims) => {
-                                let iat = TokenIat(claims.effective_iat_ms());
-                                Ok((AuthExtension::from(claims), Some(iat)))
-                            }
+                            Ok(claims) => Ok(AuthExtension::from(claims)),
                             Err(_) => Err("Invalid credentials"),
                         }
                     }
@@ -585,7 +599,7 @@ pub async fn auth_middleware(
     };
 
     let header_error = match header_result {
-        Ok((ext, token_iat)) => {
+        Ok(ext) => {
             // Enforce a forced password rotation (`must_change_password`).
             //
             // The flag is advisory in the token/claims, so we read the live DB
@@ -630,9 +644,6 @@ pub async fn auth_middleware(
             // See #1438 (B10).
             request.extensions_mut().insert(Some(ext.clone()));
             request.extensions_mut().insert(ext);
-            if let Some(iat) = token_iat {
-                request.extensions_mut().insert(iat);
-            }
             return next.run(request).await;
         }
         Err(msg) => msg,
@@ -731,6 +742,8 @@ async fn validate_api_token_with_scopes(
         is_service_account: validation.user.is_service_account,
         scopes: Some(validation.scopes),
         allowed_repo_ids: validation.allowed_repo_ids,
+        // API tokens are not JWTs and carry no `iat`.
+        iat_ms: None,
     })
 }
 
@@ -1843,6 +1856,7 @@ mod tests {
             scan_pull_repo: None,
         };
 
+        let effective = claims.effective_iat_ms();
         let ext = AuthExtension::from(claims);
         assert_eq!(ext.user_id, user_id);
         assert_eq!(ext.username, "testuser");
@@ -1850,6 +1864,47 @@ mod tests {
         assert!(ext.is_admin);
         assert!(!ext.is_api_token);
         assert!(ext.scopes.is_none());
+        // #1394: the folded `iat_ms` is stamped from the single `From<Claims>`
+        // source and equals the calling token's `effective_iat_ms`.
+        assert_eq!(ext.iat_ms, Some(effective));
+        assert_eq!(ext.caller_iat_ms(), Some(effective));
+    }
+
+    /// #1394: a Basic username/password principal (`From<User>`) carries no JWT
+    /// `iat`, so its folded `iat_ms` is `None` and it falls back to the
+    /// "invalidate everything" branch of `invalidate_other_sessions`.
+    #[test]
+    fn test_auth_extension_from_user_has_no_iat_ms() {
+        use crate::models::user::{AuthProvider, User};
+        let now = chrono::Utc::now();
+        let user = User {
+            id: Uuid::new_v4(),
+            username: "basic".to_string(),
+            email: "basic@example.com".to_string(),
+            password_hash: None,
+            auth_provider: AuthProvider::Local,
+            external_id: None,
+            display_name: None,
+            is_active: true,
+            is_admin: false,
+            is_service_account: false,
+            must_change_password: false,
+            totp_secret: None,
+            totp_enabled: false,
+            totp_backup_codes: None,
+            totp_verified_at: None,
+            failed_login_attempts: 0,
+            locked_until: None,
+            last_failed_login_at: None,
+            password_changed_at: now,
+            last_login_at: Some(now),
+            created_at: now,
+            updated_at: now,
+        };
+
+        let ext = AuthExtension::from(user);
+        assert_eq!(ext.iat_ms, None);
+        assert_eq!(ext.caller_iat_ms(), None);
     }
 
     #[test]
@@ -1888,6 +1943,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(scopes),
             allowed_repo_ids: AccessScope::from(repo_ids),
+            iat_ms: None,
         }
     }
 
@@ -1952,6 +2008,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(ext.has_scope("anything"));
     }
@@ -2007,6 +2064,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         let result = require_auth_basic_scope(Some(ext), "maven", "write");
         assert!(result.is_ok(), "JWT sessions must not be scope-gated");
@@ -2090,6 +2148,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(require_scope_response(Some(&ext), "write").is_ok());
         assert!(require_scope_response(Some(&ext), "delete").is_ok());
@@ -2124,6 +2183,7 @@ mod tests {
             is_service_account: false,
             scopes: Some(vec!["read".to_string(), "write".to_string()]),
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
 
         let cloned = ext.clone();
@@ -2188,6 +2248,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         let result = require_auth_basic(Some(ext), "maven");
         assert!(result.is_ok());
@@ -2549,6 +2610,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         // JWT sessions have no repo restrictions (allowed_repo_ids is None).
         assert!(ext.can_access_repo(Uuid::new_v4()));
@@ -2567,6 +2629,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(ext.require_admin().is_ok());
     }
@@ -2582,6 +2645,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         let err = ext.require_admin().unwrap_err();
         assert!(err.to_string().contains("Admin access required"));
@@ -2598,6 +2662,7 @@ mod tests {
             is_service_account: true,
             scopes: Some(vec!["admin".to_string()]),
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(ext.require_admin().is_ok());
     }
@@ -2613,6 +2678,7 @@ mod tests {
             is_service_account: true,
             scopes: Some(vec!["read".to_string()]),
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(ext.require_admin().is_err());
     }
@@ -2632,6 +2698,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -2866,6 +2933,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         // The middleware skips permission checks when is_admin is true.
         // Verify the flag is correctly detected.
@@ -2972,6 +3040,7 @@ mod tests {
             is_service_account: true,
             scopes: Some(vec!["admin".to_string()]),
             allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
         };
         assert!(
             ext.is_admin,
@@ -3791,6 +3860,7 @@ mod tests {
                 is_service_account: true,
                 scopes: Some(vec!["read".to_string()]),
                 allowed_repo_ids: AccessScope::Admin,
+                iat_ms: None,
             }
         }
 

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -1026,6 +1026,7 @@ mod tests {
             is_service_account,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         }
     }
 
@@ -1381,6 +1382,7 @@ mod tests {
             is_service_account: false,
             scopes: None,
             allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+            iat_ms: None,
         });
         next.run(request).await
     }
@@ -1733,6 +1735,7 @@ mod tests {
                         is_service_account: false,
                         scopes: None,
                         allowed_repo_ids: crate::models::access_scope::AccessScope::Admin,
+                        iat_ms: None,
                     });
                     next.run(request).await
                 },

--- a/backend/src/models/access_scope.rs
+++ b/backend/src/models/access_scope.rs
@@ -69,6 +69,18 @@ impl AccessScope {
     }
 }
 
+impl Default for AccessScope {
+    /// Deny-by-default: the default scope grants access to **nothing**
+    /// (`Restricted(vec![])`), never `Admin`. This is what `..Default::default()`
+    /// resolves to when an `AuthExtension` literal omits `allowed_repo_ids`
+    /// (e.g. test fixtures). If any production path ever constructs an
+    /// `AuthExtension` via `..Default::default()`, it MUST fail CLOSED — an
+    /// accidental omission can never silently grant cross-repo access.
+    fn default() -> Self {
+        AccessScope::Restricted(Vec::new())
+    }
+}
+
 impl From<Option<Vec<Uuid>>> for AccessScope {
     fn from(value: Option<Vec<Uuid>>) -> Self {
         match value {
@@ -119,6 +131,18 @@ mod tests {
         assert!(scope.grants(repo(1)));
         assert!(scope.grants(repo(2)));
         assert!(scope.grants(Uuid::nil()));
+    }
+
+    /// SECURITY-CRITICAL (#1394): the derived `Default` — reached whenever an
+    /// `AuthExtension` is built via `..Default::default()` — must fail CLOSED.
+    /// It is `Restricted(vec![])` (grants nothing), never `Admin`.
+    #[test]
+    fn default_is_deny_by_default_never_admin() {
+        let scope = AccessScope::default();
+        assert_eq!(scope, AccessScope::Restricted(Vec::new()));
+        assert_ne!(scope, AccessScope::Admin);
+        assert!(!scope.grants(repo(1)));
+        assert!(!scope.grants(Uuid::nil()));
     }
 
     #[test]

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -298,6 +298,28 @@ pub fn invalidate_user_tokens_except_caller(user_id: Uuid, caller_iat_ms: i64) {
     invalidate_user_tokens_at(user_id, watermark_ms);
 }
 
+/// Invalidate every OTHER session for `user_id` on a **self-service**
+/// credential change (TOTP enable/disable), exempting the calling session's own
+/// JWT so the user is not signed out by their own action (#1370).
+///
+/// `caller_iat_ms` is the calling token's millisecond issued-at
+/// ([`Claims::effective_iat_ms`], surfaced as [`AuthExtension::iat_ms`]).
+/// `None` — a non-JWT caller (API key, Basic username/password, service
+/// account) that has no `iat` to exempt — falls back to killing ALL of the
+/// user's sessions, preserving the original #1146 semantic.
+///
+/// This is the single home for the previously-duplicated "invalidate others,
+/// keep caller" branch that lived verbatim in both `enable_totp` and
+/// `disable_totp` (#1394). It is deliberately distinct from the plain
+/// [`invalidate_user_tokens`] used by the admin-acting-on-another-user sites
+/// (deactivate / reset / SSO demotion), which have no caller session to keep.
+pub fn invalidate_other_sessions(user_id: Uuid, caller_iat_ms: Option<i64>) {
+    match caller_iat_ms {
+        Some(ms) => invalidate_user_tokens_except_caller(user_id, ms),
+        None => invalidate_user_tokens(user_id),
+    }
+}
+
 /// Set the in-memory watermark to a specific epoch **millisecond**. Shared by
 /// the "invalidate everything", "floor second" and "exempt caller" variants
 /// above.
@@ -4860,6 +4882,50 @@ mod tests {
         assert!(
             is_token_invalidated(user_id, caller_iat_ms - 5000),
             "a strictly older token must be invalidated"
+        );
+    }
+
+    /// `invalidate_other_sessions` (the extracted #1394 helper) must exempt the
+    /// calling session when a JWT `iat` is supplied and fall back to killing
+    /// ALL sessions for a non-JWT caller (`None`).
+    #[test]
+    fn test_invalidate_other_sessions_exempts_caller_with_iat() {
+        let user_id = Uuid::new_v4();
+        let caller_iat_ms = Utc::now().timestamp().saturating_mul(1000) + 421;
+
+        invalidate_other_sessions(user_id, Some(caller_iat_ms));
+
+        // Caller's own token survives; strictly-older tokens (incl. same-second)
+        // are invalidated — identical to `invalidate_user_tokens_except_caller`.
+        assert!(
+            !is_token_invalidated(user_id, caller_iat_ms),
+            "the calling session must be exempt when its iat is supplied"
+        );
+        assert!(
+            is_token_invalidated(user_id, caller_iat_ms - 1),
+            "an older same-second session must be invalidated"
+        );
+        assert!(
+            is_token_invalidated(user_id, caller_iat_ms - 5000),
+            "a strictly older session must be invalidated"
+        );
+    }
+
+    /// A non-JWT caller (`None`) has no session to exempt, so every session —
+    /// including one minted at the current instant — is invalidated (the legacy
+    /// #1146 "invalidate everything" semantic).
+    #[test]
+    fn test_invalidate_other_sessions_none_kills_all() {
+        let user_id = Uuid::new_v4();
+        // A token minted "now" (its iat is <= the NOW() watermark this helper
+        // writes for the None case).
+        let now_token_iat_ms = Utc::now().timestamp_millis();
+
+        invalidate_other_sessions(user_id, None);
+
+        assert!(
+            is_token_invalidated(user_id, now_token_iat_ms),
+            "a None (non-JWT) caller must invalidate all sessions, keeping none"
         );
     }
 


### PR DESCRIPTION
## Summary

Unifies the credential-change session model (#1394) with two internal,
behavior-preserving changes:

1. **Fold `TokenIat` into `AuthExtension`.** The calling token's millisecond
   issued-at previously travelled as a *separate* request extension (`TokenIat`),
   populated only on the JWT branches of `auth_middleware` and threaded into the
   TOTP handlers as an extra `Option<Extension<TokenIat>>` argument. It is now a
   field `iat_ms: Option<i64>` on `AuthExtension`, stamped at the single source of
   truth — `impl From<Claims>` — so every JWT principal carries it uniformly
   alongside the live re-derived `is_admin` (#1166). `From<User>` (Basic
   username/password) and the API-token path set `iat_ms: None` (no JWT `iat`).
   The now-redundant `TokenIat` struct, its two `let iat = TokenIat(...)` sites,
   the `header_result` tuple shape, and the extra `insert(iat)` are removed.

2. **Extract the "invalidate others, keep caller" helper.** The identical
   exempt-caller block was duplicated verbatim in `totp::enable_totp` and
   `totp::disable_totp`. It is extracted to a single free fn
   `auth_service::invalidate_other_sessions(user_id, caller_iat_ms: Option<i64>)`
   and both handlers now call it, reading `auth.caller_iat_ms()`. The
   admin-acting-on-another-user "invalidate ALL" sites
   (`users.rs` / `service_accounts.rs` / `auth_interceptor.rs` / SSO apply) are a
   different semantic and are intentionally left untouched.

Folding a field onto the non-`Default` `AuthExtension` struct touches every
`AuthExtension { .. }` literal. To keep the churn minimal and future-proof, the
struct now derives `Default` and `AccessScope` gains a `Default` impl.

**SECURITY-CRITICAL:** `AccessScope::default()` is **deny-by-default** —
`AccessScope::Restricted(vec![])`, which grants nothing, never `Admin`. Any code
path that ever constructs an `AuthExtension` via `..Default::default()` therefore
fails **closed**. This is asserted by a dedicated unit test
(`default_is_deny_by_default_never_admin`).

No behavior change: the derived-GREATEST credential watermark
(`fetch_credential_change_watermark` over `password_changed_at` /
`totp_verified_at` / `privileges_changed_at`) and the strict-`<`
`is_token_invalidated_replica_safe` check are unchanged. No new
`credential_watermark_at` column, no `change_password` self-logout change (that
would be a separate, explicit behavior change).

**No migration and no `cargo sqlx prepare`** — the change is pure Rust (a struct
field, a `Default` impl, and a free fn); no new column and no new
`query!`/`query_as!` macro.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a behavior-preserving refactor (no bug fix). Tests were still
  added/updated to pin the invariants (see below).

## Test Checklist
- [x] Unit tests added/updated
  - `invalidate_other_sessions`: `Some(ms)` exempts the caller; `None` (non-JWT)
    invalidates all sessions.
  - `From<Claims>` now asserts `iat_ms == Some(effective_iat_ms())`;
    new `From<User>` test asserts `iat_ms == None`.
  - `AccessScope::default()` deny-by-default guard.
  - Existing TOTP causation tests updated to set `iat_ms` on the folded field
    (dropping the `TokenIat` extension arg); assertions unchanged — caller keeps
    its session, strictly-older sessions (incl. same-second) are invalidated,
    non-JWT caller invalidates all.
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo build --lib --tests` clean; `fmt` +
  `clippy --all-targets -D warnings` clean; auth / auth_service / totp / access_scope
  test modules pass against a throwaway Postgres, including
  `enable_totp_exempts_caller_iat_from_invalidation`. Live-verified on an isolated
  stack: enrolling TOTP with one session invalidates an older-iat second session
  for that user while the enrolling session keeps working.
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes (`AuthExtension` is an internal request extension, not
  a serialized schema; no route/DTO/OpenAPI impact).

Closes #1394
