### PR TITLE
test(scan): add end-to-end Grype/Dependency-Track/OpenSCAP scan+SBOM coverage (#1706)

### DIFF
--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -12494,4 +12494,850 @@ mod tests {
 
         fx.teardown().await;
     }
+
+    // =======================================================================
+    // #1706: end-to-end scan -> SBOM orchestration matrix.
+    //
+    // Covers the full `ScannerService::scan_artifact_*` pipeline
+    // (scan_target -> create_findings/create_packages -> complete_scan /
+    // fail_scan -> recalculate_score -> optional Dependency-Track submit)
+    // across the 3x4 matrix of {Grype, OpenSCAP, Dependency-Track} x
+    // {happy, egress-restricted, zero-finding, wrong-format}.
+    //
+    // The Grype/OpenSCAP cells inject a `FakeScanner` (an `Arc<dyn Scanner>`)
+    // via direct `ScannerService { .. }` construction, reusing the exact
+    // seam the `NeverApplicableScanner` tests use above. The Dependency-Track
+    // cells point a real `DependencyTrackService` at a `wiremock` server.
+    // No cell shells out to a live scanner, so all 12 run deterministically
+    // in the CI unit + coverage jobs (Postgres + wiremock only).
+    //
+    // SECURITY-CRITICAL ASYMMETRY (do NOT "fix" it): a Grype/OpenSCAP scan
+    // error must FAIL CLOSED (scan_results.status = 'failed'), because an
+    // unreachable vuln DB must never present as a clean row. Dependency-Track
+    // submission is best-effort/fire-and-forget (see
+    // `submit_sbom_to_dependency_track`): a DT outage must NOT fail the scan.
+    // =======================================================================
+    mod e2e_scan_sbom_matrix {
+        use super::*;
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::models::sbom::SbomFormat;
+        use crate::services::dependency_track_service::{
+            DependencyTrackConfig, DependencyTrackService,
+        };
+        use crate::services::sbom_service::SbomService;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        // ---- Fake scanner (Grype / OpenSCAP shape) ------------------------
+
+        /// What a [`FakeScanner`] emits when the orchestrator invokes it.
+        enum FakeOutcome {
+            /// Scanner ran successfully and returned this finding + package set.
+            Complete {
+                findings: Vec<RawFinding>,
+                packages: Vec<RawPackage>,
+            },
+            /// Scanner errored (e.g. could not reach its vuln DB, or produced
+            /// an unparseable report). Drives the fail-closed orchestration
+            /// path (`fail_scan` -> status='failed').
+            Fail(String),
+        }
+
+        /// An in-process `Arc<dyn Scanner>` that drives the real orchestration
+        /// with zero external processes. `scan_type` is set to `"grype"` or
+        /// `"openscap"` so the persisted `scan_results.scan_type` matches the
+        /// production branching. Applicability defaults to `true`.
+        struct FakeScanner {
+            scanner_name: String,
+            scan_type: &'static str,
+            outcome: FakeOutcome,
+        }
+
+        impl FakeScanner {
+            fn completed(
+                scan_type: &'static str,
+                findings: Vec<RawFinding>,
+                packages: Vec<RawPackage>,
+            ) -> Arc<dyn Scanner> {
+                Arc::new(FakeScanner {
+                    scanner_name: format!("fake-{scan_type}"),
+                    scan_type,
+                    outcome: FakeOutcome::Complete { findings, packages },
+                })
+            }
+
+            fn failing(scan_type: &'static str, reason: &str) -> Arc<dyn Scanner> {
+                Arc::new(FakeScanner {
+                    scanner_name: format!("fake-{scan_type}"),
+                    scan_type,
+                    outcome: FakeOutcome::Fail(reason.to_string()),
+                })
+            }
+        }
+
+        #[async_trait]
+        impl Scanner for FakeScanner {
+            fn name(&self) -> &str {
+                &self.scanner_name
+            }
+
+            fn scan_type(&self) -> &str {
+                self.scan_type
+            }
+
+            async fn scan(
+                &self,
+                _artifact: &Artifact,
+                _metadata: Option<&ArtifactMetadata>,
+                _content: &Bytes,
+            ) -> Result<ScanOutput> {
+                match &self.outcome {
+                    FakeOutcome::Complete { findings, packages } => Ok(ScanOutput {
+                        findings: findings.clone(),
+                        packages: packages.clone(),
+                        scan_completeness: ScanCompleteness::Complete,
+                    }),
+                    // Displays as "Internal error: <reason>" so the reason is
+                    // preserved in scan_results.error_message via fail_scan.
+                    FakeOutcome::Fail(reason) => Err(AppError::Internal(reason.clone())),
+                }
+            }
+        }
+
+        // ---- Builders (shared to keep jscpd duplication low) --------------
+
+        fn cve_finding(severity: Severity, cve: &str, component: &str) -> RawFinding {
+            RawFinding {
+                severity,
+                title: format!("{cve} in {component}"),
+                description: Some("injected by #1706 matrix e2e test".to_string()),
+                cve_id: Some(cve.to_string()),
+                affected_component: Some(component.to_string()),
+                affected_version: Some("1.0.0".to_string()),
+                fixed_version: Some("1.0.1".to_string()),
+                source: Some("test".to_string()),
+                source_url: None,
+            }
+        }
+
+        fn raw_package(name: &str, version: &str) -> RawPackage {
+            RawPackage {
+                name: name.to_string(),
+                version: Some(version.to_string()),
+                purl: Some(format!("pkg:generic/{name}@{version}")),
+                license: Some("MIT".to_string()),
+                source_target: Some("package-lock.json".to_string()),
+            }
+        }
+
+        /// One Critical + one High CVE — the standard "vulnerable artifact"
+        /// finding set shared by the happy-path cells.
+        fn two_cve_findings() -> Vec<RawFinding> {
+            vec![
+                cve_finding(Severity::Critical, "CVE-2024-0001", "body-parser"),
+                cve_finding(Severity::High, "CVE-2024-0002", "lodash"),
+            ]
+        }
+
+        /// Two inventory packages — drives scan_packages persistence and a
+        /// non-empty SBOM component list.
+        fn two_packages() -> Vec<RawPackage> {
+            vec![
+                raw_package("body-parser", "1.19.0"),
+                raw_package("lodash", "4.17.19"),
+            ]
+        }
+
+        /// A `grype`-shaped fake scanner that completes with the standard
+        /// finding+package set — the common driver for the DT / SBOM cells.
+        fn grype_completed() -> Arc<dyn Scanner> {
+            FakeScanner::completed("grype", two_cve_findings(), two_packages())
+        }
+
+        // ---- Service + artifact construction ------------------------------
+
+        /// Build a `ScannerService` wired to the fixture's DB/storage with the
+        /// supplied fake scanners and optional Dependency-Track service.
+        /// Wrapped as a helper so the private struct literal is written once
+        /// rather than copy-pasted across every matrix cell (jscpd <3%).
+        fn make_scanner_service_with(
+            fx: &tdh::Fixture,
+            scanners: Vec<Arc<dyn Scanner>>,
+            dependency_track: Option<Arc<DependencyTrackService>>,
+        ) -> ScannerService {
+            ScannerService {
+                db: fx.pool.clone(),
+                scanners,
+                scan_result_service: Arc::new(ScanResultService::new(fx.pool.clone())),
+                scan_config_service: Arc::new(ScanConfigService::new(fx.pool.clone())),
+                storage: fx.state.storage.clone(),
+                storage_registry: fx.state.storage_registry.clone(),
+                storage_base_path: fx.storage_dir.to_string_lossy().into_owned(),
+                scan_workspace_path: fx
+                    .storage_dir
+                    .join("scan-workspace")
+                    .to_string_lossy()
+                    .into_owned(),
+                dependency_track,
+            }
+        }
+
+        /// Insert a non-deleted artifact AND store its bytes so the
+        /// orchestrator's `fetch_artifact_content_from_storage` read succeeds
+        /// before the (fake) scanner runs. Returns the artifact id.
+        async fn seed_scannable_artifact(fx: &tdh::Fixture, prefix: &str) -> Uuid {
+            let artifact_id = Uuid::new_v4();
+            let checksum = fresh_checksum();
+            let storage_key = format!("{prefix}/{artifact_id}.bin");
+            fx.state
+                .storage
+                .put(&storage_key, Bytes::from_static(b"scan-me"))
+                .await
+                .expect("store artifact bytes");
+            sqlx::query(
+                r#"
+                INSERT INTO artifacts (
+                    id, repository_id, name, path, size_bytes, checksum_sha256,
+                    content_type, storage_key, is_deleted
+                )
+                VALUES ($1, $2, 'pkg.bin', 'pkg.bin', 7, $3,
+                        'application/octet-stream', $4, false)
+                "#,
+            )
+            .bind(artifact_id)
+            .bind(fx.repo_id)
+            .bind(&checksum)
+            .bind(&storage_key)
+            .execute(&fx.pool)
+            .await
+            .expect("insert scannable artifact");
+            artifact_id
+        }
+
+        /// One-shot matrix-cell setup: fixture + seeded artifact + a scan run
+        /// with the given fakes/DT. Returns `None` (skip the test) when
+        /// `DATABASE_URL` is unset. The orchestration always returns `Ok(())` —
+        /// scanner failures are recorded on the row, not propagated — so the
+        /// `expect` here is valid for the fail-closed cells too. Factored out
+        /// so the ~6-line preamble is not copy-pasted across 15 cells (jscpd).
+        async fn setup_and_scan(
+            prefix: &str,
+            scanners: Vec<Arc<dyn Scanner>>,
+            dependency_track: Option<Arc<DependencyTrackService>>,
+        ) -> Option<(tdh::Fixture, Uuid)> {
+            let fx = tdh::Fixture::setup("local", "generic").await?;
+            let artifact_id = seed_scannable_artifact(&fx, prefix).await;
+            let scanner = make_scanner_service_with(&fx, scanners, dependency_track);
+            scanner
+                .scan_artifact_with_options(artifact_id, true, true)
+                .await
+                .expect("scan orchestration must return Ok (failures land on the row)");
+            Some((fx, artifact_id))
+        }
+
+        /// Cascade-clean the scan state and drop the fixture. Shared postamble.
+        async fn finish(fx: tdh::Fixture) {
+            cleanup_scan_state(&fx.pool, fx.repo_id).await;
+            fx.teardown().await;
+        }
+
+        // ---- Read-back helpers --------------------------------------------
+
+        #[derive(Debug)]
+        struct ScanRow {
+            status: String,
+            findings_count: i32,
+            critical_count: i32,
+            high_count: i32,
+            inventory_status: String,
+            error_message: Option<String>,
+        }
+
+        /// Read the latest `scan_results` row for an (artifact, scan_type).
+        async fn latest_scan_row(pool: &PgPool, artifact_id: Uuid, scan_type: &str) -> ScanRow {
+            let row: (String, i32, i32, i32, String, Option<String>) = sqlx::query_as(
+                r#"
+                SELECT status, findings_count, critical_count, high_count,
+                       inventory_status, error_message
+                FROM scan_results
+                WHERE artifact_id = $1 AND scan_type = $2
+                ORDER BY created_at DESC
+                LIMIT 1
+                "#,
+            )
+            .bind(artifact_id)
+            .bind(scan_type)
+            .fetch_one(pool)
+            .await
+            .expect("scan_results row must exist for this scan_type");
+            ScanRow {
+                status: row.0,
+                findings_count: row.1,
+                critical_count: row.2,
+                high_count: row.3,
+                inventory_status: row.4,
+                error_message: row.5,
+            }
+        }
+
+        async fn latest_scan_id(pool: &PgPool, artifact_id: Uuid, scan_type: &str) -> Uuid {
+            sqlx::query_scalar(
+                "SELECT id FROM scan_results WHERE artifact_id = $1 AND scan_type = $2 \
+                 ORDER BY created_at DESC LIMIT 1",
+            )
+            .bind(artifact_id)
+            .bind(scan_type)
+            .fetch_one(pool)
+            .await
+            .expect("scan id")
+        }
+
+        async fn scan_package_count(pool: &PgPool, scan_id: Uuid) -> i64 {
+            sqlx::query_scalar("SELECT COUNT(*) FROM scan_packages WHERE scan_result_id = $1")
+                .bind(scan_id)
+                .fetch_one(pool)
+                .await
+                .expect("count packages")
+        }
+
+        /// Assert the row carries a fail-closed error whose message preserves
+        /// `reason`. Shared by every egress/wrong-format cell.
+        fn assert_failed_closed(row: &ScanRow, reason: &str) {
+            assert_eq!(
+                row.status, "failed",
+                "scanner error must FAIL CLOSED, never present as clean/completed"
+            );
+            assert_ne!(row.status, "completed");
+            assert_ne!(row.status, "not_applicable");
+            assert_eq!(row.inventory_status, "failed");
+            assert!(
+                row.error_message
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains(reason),
+                "error_message must preserve the failure reason ({reason}), got: {:?}",
+                row.error_message
+            );
+        }
+
+        /// Generate a CycloneDX SBOM from the packages the scan persisted into
+        /// `scan_packages`, exercising the same inventory-derived path the DT
+        /// submit uses. Returns the persisted SBOM document.
+        async fn sbom_from_persisted_inventory(
+            fx: &tdh::Fixture,
+            artifact_id: Uuid,
+        ) -> crate::models::sbom::SbomDocument {
+            #[allow(clippy::type_complexity)]
+            let rows: Vec<(String, Option<String>, Option<String>, Option<String>)> =
+                sqlx::query_as(
+                    r#"
+                    SELECT sp.name, sp.version, sp.purl, sp.license
+                    FROM scan_packages sp
+                    JOIN scan_results sr ON sr.id = sp.scan_result_id
+                    WHERE sr.artifact_id = $1
+                    "#,
+                )
+                .bind(artifact_id)
+                .fetch_all(&fx.pool)
+                .await
+                .expect("read persisted scan_packages");
+            let deps = build_dependency_info_from_packages(rows, "generic");
+            SbomService::new(fx.pool.clone())
+                .generate_sbom(artifact_id, fx.repo_id, SbomFormat::CycloneDX, deps)
+                .await
+                .expect("SBOM generation must succeed")
+        }
+
+        fn dt_service_at(base_url: &str) -> Arc<DependencyTrackService> {
+            let dt = DependencyTrackService::new(DependencyTrackConfig {
+                base_url: base_url.to_string(),
+                api_key: "matrix-test-key".to_string(),
+                enabled: true,
+            })
+            .expect("construct DT service");
+            Arc::new(dt)
+        }
+
+        // ===================================================================
+        // Grype-shape cells (findings + package inventory)
+        // ===================================================================
+
+        /// happy: scanner runs, findings + packages persist, status=completed,
+        /// counts correct, findings retrievable via the read path.
+        #[tokio::test]
+        async fn test_grype_happy_path_completes_and_persists() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "grype-happy",
+                vec![FakeScanner::completed(
+                    "grype",
+                    two_cve_findings(),
+                    two_packages(),
+                )],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(row.status, "completed", "happy scan must complete");
+            assert_eq!(row.findings_count, 2);
+            assert_eq!(row.critical_count, 1);
+            assert_eq!(row.high_count, 1);
+            assert_eq!(
+                row.inventory_status, "complete",
+                "package inventory persisted -> inventory_status=complete"
+            );
+
+            // scan_packages persisted.
+            let scan_id = latest_scan_id(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(
+                scan_package_count(&fx.pool, scan_id).await,
+                2,
+                "both inventory packages must be persisted"
+            );
+
+            // Findings retrievable via the same read path the API uses.
+            let (findings, total) = ScanResultService::new(fx.pool.clone())
+                .list_findings(scan_id, 0, 50)
+                .await
+                .expect("list findings");
+            assert_eq!(total, 2);
+            let cves: Vec<String> = findings.iter().filter_map(|f| f.cve_id.clone()).collect();
+            assert!(cves.contains(&"CVE-2024-0001".to_string()));
+            assert!(cves.contains(&"CVE-2024-0002".to_string()));
+
+            finish(fx).await;
+        }
+
+        /// egress-restricted (SECURITY-CRITICAL): scanner cannot reach its vuln
+        /// DB -> Err -> the row must FAIL CLOSED (status='failed',
+        /// inventory_status='failed', error preserved). It must NEVER land as a
+        /// clean/completed zero-findings row. The repo score also fails closed
+        /// (has_failed_scan=true, #2167).
+        #[tokio::test]
+        async fn test_grype_egress_restricted_fails_closed() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "grype-egress",
+                vec![FakeScanner::failing("grype", "grype vuln DB unreachable")],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_failed_closed(&row, "grype vuln DB unreachable");
+
+            // Repo-level gate also fails closed.
+            let score = ScanResultService::new(fx.pool.clone())
+                .get_score(fx.repo_id)
+                .await
+                .expect("score query")
+                .expect("score row must exist after a scan");
+            assert!(
+                score.has_failed_scan,
+                "a failed scan must flag the repo has_failed_scan=true (fail-closed gate)"
+            );
+
+            finish(fx).await;
+        }
+
+        /// zero-finding: scanner RAN and found nothing (0 findings, packages
+        /// present). Must land as status='completed' with findings_count=0 —
+        /// distinct from not_applicable (scanner did not run, #1693) and from
+        /// failed. SBOM stays non-empty because the inventory persisted.
+        #[tokio::test]
+        async fn test_grype_zero_finding_completes_not_not_applicable() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "grype-zero",
+                vec![FakeScanner::completed("grype", vec![], two_packages())],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(
+                row.status, "completed",
+                "a clean scan that RAN must be completed, not not_applicable/failed"
+            );
+            assert_eq!(row.findings_count, 0);
+            assert_eq!(row.critical_count, 0);
+            assert_eq!(row.high_count, 0);
+
+            // Inventory still persisted -> SBOM non-empty even with zero CVEs.
+            let sbom = sbom_from_persisted_inventory(&fx, artifact_id).await;
+            assert!(
+                sbom.component_count >= 2,
+                "zero-CVE scan must still yield a non-empty SBOM (components={})",
+                sbom.component_count
+            );
+
+            finish(fx).await;
+        }
+
+        /// wrong-format: scanner produced an unparseable report -> Err. The
+        /// orchestration must gracefully mark the row failed and return Ok(())
+        /// (no panic, no 5xx propagation).
+        #[tokio::test]
+        async fn test_grype_wrong_format_fails_gracefully() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "grype-badfmt",
+                vec![FakeScanner::failing(
+                    "grype",
+                    "grype failed: malformed report (unexpected end of JSON)",
+                )],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_failed_closed(&row, "malformed report");
+
+            finish(fx).await;
+        }
+
+        // ===================================================================
+        // OpenSCAP-shape cells (policy findings only, no package inventory)
+        // ===================================================================
+
+        /// happy: OpenSCAP-shape scanner returns findings-only (no inventory).
+        /// status=completed, findings persisted; SBOM falls back to
+        /// scan_findings for the component list.
+        #[tokio::test]
+        async fn test_openscap_happy_path_findings_only_completes() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "openscap-happy",
+                vec![FakeScanner::completed(
+                    "openscap",
+                    vec![cve_finding(Severity::High, "CVE-2024-9001", "openssl")],
+                    vec![],
+                )],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "openscap").await;
+            assert_eq!(row.status, "completed");
+            assert_eq!(row.findings_count, 1);
+            assert_eq!(row.high_count, 1);
+
+            // No package inventory was emitted -> no scan_packages rows.
+            let scan_id = latest_scan_id(&fx.pool, artifact_id, "openscap").await;
+            assert_eq!(
+                scan_package_count(&fx.pool, scan_id).await,
+                0,
+                "findings_only shape persists no inventory"
+            );
+
+            finish(fx).await;
+        }
+
+        /// egress-restricted (SECURITY-CRITICAL): OpenSCAP sidecar unreachable
+        /// -> Err -> fail closed at the orchestration level.
+        #[tokio::test]
+        async fn test_openscap_egress_restricted_fails_closed() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "openscap-egress",
+                vec![FakeScanner::failing(
+                    "openscap",
+                    "openscap sidecar unreachable",
+                )],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "openscap").await;
+            assert_failed_closed(&row, "openscap sidecar unreachable");
+
+            finish(fx).await;
+        }
+
+        /// zero-finding: OpenSCAP ran and found no policy violations ->
+        /// completed with findings_count=0 (not not_applicable/failed).
+        #[tokio::test]
+        async fn test_openscap_zero_finding_completes() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "openscap-zero",
+                vec![FakeScanner::completed("openscap", vec![], vec![])],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "openscap").await;
+            assert_eq!(row.status, "completed");
+            assert_ne!(row.status, "not_applicable");
+            assert_eq!(row.findings_count, 0);
+
+            finish(fx).await;
+        }
+
+        /// wrong-format: OpenSCAP returned an unparseable document -> Err ->
+        /// graceful failure (status=failed, no panic).
+        #[tokio::test]
+        async fn test_openscap_wrong_format_fails_gracefully() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "openscap-badfmt",
+                vec![FakeScanner::failing(
+                    "openscap",
+                    "openscap failed: could not parse ARF result",
+                )],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "openscap").await;
+            assert_failed_closed(&row, "could not parse ARF result");
+
+            finish(fx).await;
+        }
+
+        // ===================================================================
+        // Dependency-Track cells (best-effort SBOM submit via wiremock)
+        //
+        // A grype-shape fake drives the scan to `completed` so the post-scan
+        // DT submit path has an inventory to forward. The assertions focus on
+        // the DT-specific behavior: a submit happens on happy/zero-finding,
+        // and a DT outage/garbage response is SWALLOWED (scan still completes).
+        // ===================================================================
+
+        /// Mount the DT project-lookup + BOM-upload endpoints for a healthy DT.
+        async fn mount_healthy_dt(server: &MockServer) {
+            // Lookup returns an existing project (skips the create PUT).
+            Mock::given(method("GET"))
+                .and(path("/api/v1/project/lookup"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "uuid": "11111111-1111-1111-1111-111111111111",
+                    "name": "pkg.bin",
+                    "version": null
+                })))
+                .mount(server)
+                .await;
+            // DT's BOM ingest endpoint is a PUT (see `upload_sbom`).
+            Mock::given(method("PUT"))
+                .and(path("/api/v1/bom"))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_json(serde_json::json!({"token": "bom-token-1706"})),
+                )
+                .mount(server)
+                .await;
+        }
+
+        async fn dt_received_bom_upload(server: &MockServer) -> bool {
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .any(|r| r.method == wiremock::http::Method::PUT && r.url.path() == "/api/v1/bom")
+        }
+
+        /// happy: after a completed scan with inventory, the orchestrator PUTs
+        /// the generated CycloneDX SBOM to DT's /api/v1/bom.
+        #[tokio::test]
+        async fn test_dt_happy_path_submits_sbom_after_completed_scan() {
+            let server = MockServer::start().await;
+            mount_healthy_dt(&server).await;
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "dt-happy",
+                vec![grype_completed()],
+                Some(dt_service_at(&server.uri())),
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(row.status, "completed");
+            assert!(
+                dt_received_bom_upload(&server).await,
+                "DT must receive the SBOM upload after a completed scan"
+            );
+
+            finish(fx).await;
+        }
+
+        /// zero-finding: a clean scan (0 CVEs, packages present) must STILL
+        /// submit its SBOM to DT so DT can run independent correlation (#965).
+        #[tokio::test]
+        async fn test_dt_zero_finding_still_submits_sbom() {
+            let server = MockServer::start().await;
+            mount_healthy_dt(&server).await;
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "dt-zero",
+                vec![FakeScanner::completed("grype", vec![], two_packages())],
+                Some(dt_service_at(&server.uri())),
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(row.status, "completed");
+            assert_eq!(row.findings_count, 0);
+            assert!(
+                dt_received_bom_upload(&server).await,
+                "even a zero-CVE scan must forward its inventory SBOM to DT"
+            );
+
+            finish(fx).await;
+        }
+
+        /// egress-restricted (DT is DIFFERENT — best-effort): DT unreachable
+        /// must NOT fail the scan. Point DT at a dead port; the scan still
+        /// completes and the orchestrator swallows the transport error.
+        /// This asymmetry vs Grype/OpenSCAP is correct behavior, not a bug.
+        #[tokio::test]
+        async fn test_dt_egress_restricted_scan_still_completes() {
+            // 127.0.0.1:0 is a private, always-refused address.
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "dt-egress",
+                vec![grype_completed()],
+                Some(dt_service_at("http://127.0.0.1:0")),
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(
+                row.status, "completed",
+                "DT is best-effort: an unreachable DT must not flip the scan to failed"
+            );
+            assert_eq!(row.findings_count, 2);
+
+            finish(fx).await;
+        }
+
+        /// wrong-format: DT returns a malformed JSON body. The parse error is
+        /// swallowed (best-effort) and the scan still completes.
+        #[tokio::test]
+        async fn test_dt_wrong_format_response_swallowed() {
+            let server = MockServer::start().await;
+            // Lookup returns 200 but with an unparseable body -> DT service
+            // maps it to a parse error, which the orchestrator swallows.
+            Mock::given(method("GET"))
+                .and(path("/api/v1/project/lookup"))
+                .respond_with(ResponseTemplate::new(200).set_body_string("{ not-json"))
+                .mount(&server)
+                .await;
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "dt-badfmt",
+                vec![grype_completed()],
+                Some(dt_service_at(&server.uri())),
+            )
+            .await
+            else {
+                return;
+            };
+
+            let row = latest_scan_row(&fx.pool, artifact_id, "grype").await;
+            assert_eq!(
+                row.status, "completed",
+                "a garbage DT response must be swallowed; scan still completes"
+            );
+
+            finish(fx).await;
+        }
+
+        // ===================================================================
+        // SBOM-generation cross-checks + gate contrast
+        // ===================================================================
+
+        /// SBOM contains the scanned components on a happy (with-CVE) scan.
+        #[tokio::test]
+        async fn test_sbom_components_present_for_happy_scan() {
+            let Some((fx, artifact_id)) =
+                setup_and_scan("sbom-happy", vec![grype_completed()], None).await
+            else {
+                return;
+            };
+
+            let sbom = sbom_from_persisted_inventory(&fx, artifact_id).await;
+            assert_eq!(sbom.format, "cyclonedx");
+            assert!(
+                sbom.component_count >= 2,
+                "SBOM must include the scanned components (got {})",
+                sbom.component_count
+            );
+
+            finish(fx).await;
+        }
+
+        /// SBOM is still non-empty when the scan found zero CVEs (inventory
+        /// drives the component list, not the finding list).
+        #[tokio::test]
+        async fn test_sbom_components_present_for_zero_finding_scan() {
+            let Some((fx, artifact_id)) = setup_and_scan(
+                "sbom-zero",
+                vec![FakeScanner::completed("grype", vec![], two_packages())],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let sbom = sbom_from_persisted_inventory(&fx, artifact_id).await;
+            assert!(
+                sbom.component_count >= 2,
+                "a zero-CVE SBOM must still enumerate the dependency tree (got {})",
+                sbom.component_count
+            );
+
+            finish(fx).await;
+        }
+
+        /// gate contrast: a COMPLETED scan must NOT flag the repo failed-closed
+        /// (has_failed_scan=false), i.e. a scanned-clean artifact is not
+        /// blocked — the positive counterpart to the egress fail-closed cells.
+        #[tokio::test]
+        async fn test_completed_scan_does_not_flag_repo_failed() {
+            let Some((fx, _artifact_id)) = setup_and_scan(
+                "gate-clean",
+                vec![FakeScanner::completed("grype", vec![], two_packages())],
+                None,
+            )
+            .await
+            else {
+                return;
+            };
+
+            let score = ScanResultService::new(fx.pool.clone())
+                .get_score(fx.repo_id)
+                .await
+                .expect("score query")
+                .expect("score row exists");
+            assert!(
+                !score.has_failed_scan,
+                "a completed scan must NOT flag the repo has_failed_scan (not blocked)"
+            );
+
+            finish(fx).await;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Adds the missing **end-to-end scan → SBOM orchestration coverage** for the
scanner matrix (issue #1706). Prior tests exercised each scanner boundary in
isolation (the Grype parser, the OpenSCAP and Dependency-Track wiremock HTTP
boundaries) plus only the `not_applicable` orchestration branch. Nothing drove
the full `ScannerService::scan_artifact_*` pipeline —
`scan_target → create_findings/create_packages → complete_scan/fail_scan →
recalculate_score → SBOM generation → best-effort Dependency-Track submit` —
per scanner shape across the four operational scenarios.

The new tests inject fake `Arc<dyn Scanner>` implementations at the existing
`Scanner`-trait seam (the same direct `ScannerService { .. }` construction the
`NeverApplicableScanner` tests already use) and point a real
`DependencyTrackService` at a `wiremock` server. This drives the real
orchestration with **zero external processes**, so every cell runs
deterministically in ephemeral CI (Postgres + wiremock only — no live grype /
OpenSCAP sidecar / Dependency-Track).

**Placement:** all tests are in-module `#[cfg(test)]` lib tests inside
`backend/src/services/scanner_service.rs` (new `mod e2e_scan_sbom_matrix`).
This is deliberate: the fake-injection seam uses the module-private
`ScannerService` fields, and the CI unit job and the coverage gate both run
`--lib` only — `backend/tests/*.rs` integration files do not count toward
coverage. No file was added under `backend/tests/`.

### Matrix covered — {Grype, OpenSCAP, Dependency-Track} × {happy, egress-restricted, zero-finding, wrong-format}

- **happy:** scan runs → findings + package inventory persisted and retrievable
  (`list_findings`), `status='completed'`, counts correct, SBOM non-empty.
- **egress-restricted — Grype/OpenSCAP (SECURITY-CRITICAL, fail closed):**
  scanner returns `Err` (unreachable vuln DB) → row must be `status='failed'` /
  `inventory_status='failed'` with the reason preserved, and the repo score
  fails closed (`has_failed_scan=true`, #2167). An unreachable vuln DB can
  never present as a clean/completed row.
- **egress-restricted — Dependency-Track (intentionally different):** DT
  submission is best-effort / fire-and-forget, so an unreachable DT
  (dead port) must **not** fail the scan — `status` stays `'completed'` and the
  transport error is swallowed. This asymmetry is documented in the test so a
  future reader does not "fix" DT into fail-closed.
- **zero-finding:** scanner ran and found nothing (0 findings, packages
  present) → `status='completed'`, `findings_count=0` — distinct from
  `not_applicable` (#1693) — and the SBOM is still non-empty because the
  inventory persisted.
- **wrong-format:** malformed/unparseable scanner or DT output → graceful
  failure (`status='failed'` for the primary scanners; swallowed for DT); the
  orchestration returns `Ok(())` and never panics or propagates a 5xx.

Shared `FakeScanner` + `ScanOutput`/finding/package builders + a
`setup_and_scan` helper keep the repetitive matrix free of copy-paste
(duplication stays under the 3% gate).

This is **test-only**; there is no product-code change.

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix (it adds hardening test coverage for the scanner matrix)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #1706
