### PR TITLE
feat(audit): record TOTP, password-change and session-invalidation auth events

### DIFF
--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -30,6 +30,7 @@ use uuid::Uuid;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::{AppState, SharedState};
 use crate::config::Config;
+use crate::models::user::User;
 
 /// Connect to the test database. Returns `None` when `DATABASE_URL` is
 /// unset or unreachable so suites no-op gracefully.
@@ -477,6 +478,114 @@ pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
         .bind(user_id)
         .execute(pool)
         .await;
+}
+
+/// Count `audit_log` rows for a given resource id + action string.
+///
+/// Shared by the auth-event audit trail tests (#386 / #1617 Phase 1) across
+/// the `profile`, `totp`, and `users` handler modules so the identical
+/// count-query is defined once rather than copy-pasted into each DB-backed
+/// test module (keeps the jscpd duplication gate green).
+pub async fn audit_count(pool: &PgPool, resource_id: Uuid, action: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM audit_log WHERE resource_id = $1 AND action = $2",
+    )
+    .bind(resource_id)
+    .bind(action)
+    .fetch_one(pool)
+    .await
+    .expect("audit_log count query")
+}
+
+/// Delete a test user plus the auth-related rows the audit/2FA test modules
+/// create for it (audit_log, refresh/pending jti, password history). Shared
+/// teardown so the identical cleanup block isn't copy-pasted across the #386
+/// audit test modules (jscpd dedup).
+pub async fn cleanup_user(pool: &PgPool, user_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+    for table in ["refresh_token_jti", "totp_pending_jti", "password_history"] {
+        let _ = sqlx::query(&format!("DELETE FROM {table} WHERE user_id = $1"))
+            .bind(user_id)
+            .execute(pool)
+            .await;
+    }
+    let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await;
+}
+
+/// A TOTP-enrolled test user plus everything the enable/disable/verify handler
+/// tests need: the loaded [`User`] model, the raw secret bytes for generating
+/// live codes, the base32 secret, and the storage-backed [`SharedState`].
+pub struct TotpUserFixture {
+    pub user: User,
+    pub secret_bytes: Vec<u8>,
+    pub secret_b32: String,
+    pub state: SharedState,
+    pub storage_dir: PathBuf,
+}
+
+/// Seed a fresh `totp_enabled` user with the given backup-code hashes and
+/// return a [`TotpUserFixture`]. Centralizes the seed + `User` literal so the
+/// TOTP handler test modules (verify-hardening #1819/#1820/#1822 and the #386
+/// audit-trail tests) share one definition instead of copy-pasting it (jscpd
+/// dedup). `password_hash` is seeded to the sentinel `"unused"`; tests that
+/// exercise the password-verify path (e.g. `disable_totp`) overwrite it with a
+/// real bcrypt hash.
+pub async fn create_totp_user(pool: &PgPool, backup_hashes: &[String]) -> TotpUserFixture {
+    let (user_id, username) = create_user(pool).await;
+    let secret = totp_rs::Secret::generate_secret();
+    let secret_b32 = secret.to_encoded().to_string();
+    let secret_bytes = secret.to_bytes().expect("secret bytes");
+    let backup_json = serde_json::to_string(backup_hashes).expect("serialize backup");
+    sqlx::query(
+        "UPDATE users SET totp_secret = $1, totp_enabled = true, totp_backup_codes = $2 \
+         WHERE id = $3",
+    )
+    .bind(&secret_b32)
+    .bind(&backup_json)
+    .bind(user_id)
+    .execute(pool)
+    .await
+    .expect("enable totp");
+    let storage_dir = std::env::temp_dir().join(format!("totp-fixture-{}", Uuid::new_v4()));
+    std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+    let state = build_state(pool.clone(), storage_dir.to_str().unwrap());
+    let user = User {
+        id: user_id,
+        username,
+        email: format!("{user_id}@test.local"),
+        password_hash: Some("unused".to_string()),
+        display_name: None,
+        auth_provider: crate::models::user::AuthProvider::Local,
+        external_id: None,
+        is_admin: false,
+        is_active: true,
+        is_service_account: false,
+        must_change_password: false,
+        totp_secret: Some(secret_b32.clone()),
+        totp_enabled: true,
+        totp_backup_codes: Some(backup_json),
+        totp_verified_at: None,
+        failed_login_attempts: 0,
+        locked_until: None,
+        last_failed_login_at: None,
+        password_changed_at: chrono::Utc::now(),
+        last_login_at: None,
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+    };
+    TotpUserFixture {
+        user,
+        secret_bytes,
+        secret_b32,
+        state,
+        storage_dir,
+    }
 }
 
 /// Build a `Basic <base64(user:pass)>` header value.

--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -19,6 +19,10 @@ use crate::api::handlers::auth::set_auth_cookies;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::services::audit_service::{
+    audit_fire_and_forget, sessions_invalidated_audit_entry, totp_audit_entry, AuditAction,
+    AuditEntry, ResourceType,
+};
 use crate::services::auth_service::{invalidate_other_sessions, AuthService};
 
 /// Build a TOTP instance from raw secret bytes and a username label.
@@ -300,6 +304,20 @@ pub async fn enable_totp(
         );
     }
 
+    // Audit the credential-posture change and the mass session invalidation
+    // it triggered (#386). Fire-and-forget and placed AFTER the state change
+    // has committed so an audit-table outage can never fail the enable.
+    audit_fire_and_forget(
+        state.db.clone(),
+        totp_audit_entry(AuditAction::TotpEnabled, auth.user_id),
+    )
+    .await;
+    audit_fire_and_forget(
+        state.db.clone(),
+        sessions_invalidated_audit_entry(auth.user_id, auth.user_id, "totp_enable"),
+    )
+    .await;
+
     Ok(Json(TotpEnableResponse { backup_codes }))
 }
 
@@ -349,6 +367,16 @@ pub async fn verify_totp(
     .ok_or_else(|| AppError::Authentication("User not found".to_string()))?;
 
     if !user_row.totp_enabled {
+        // A 2FA login attempt against a user without TOTP enabled is a failed
+        // login; record it (#386). Fire-and-forget, non-gating.
+        audit_fire_and_forget(
+            state.db.clone(),
+            AuditEntry::new(AuditAction::LoginFailed, ResourceType::User)
+                .user(claims.sub)
+                .resource(claims.sub)
+                .details(serde_json::json!({ "reason": "totp_not_enabled" })),
+        )
+        .await;
         return Err(AppError::Authentication(
             "TOTP not enabled for this user".to_string(),
         ));
@@ -363,6 +391,10 @@ pub async fn verify_totp(
     let code_valid = totp
         .check_current(&payload.code)
         .map_err(|e| AppError::Internal(format!("TOTP check error: {}", e)))?;
+
+    // Track which factor authenticated so the success audit event can label
+    // the login method (#386): a primary TOTP code vs a one-time backup code.
+    let mut used_backup_code = false;
 
     if !code_valid {
         // Try backup codes. Consumption must be atomic: a previous read of
@@ -415,8 +447,23 @@ pub async fn verify_totp(
             .map_err(|e| AppError::Database(e.to_string()))?;
 
         if !backup_used {
+            // Neither the primary TOTP code nor a backup code matched: this is
+            // a failed 2FA login and MUST be audited (#386). Fire-and-forget,
+            // non-gating, emitted before returning the error.
+            audit_fire_and_forget(
+                state.db.clone(),
+                AuditEntry::new(AuditAction::LoginFailed, ResourceType::User)
+                    .user(claims.sub)
+                    .resource(claims.sub)
+                    .details(serde_json::json!({
+                        "reason": "invalid_totp_code",
+                        "method": "totp",
+                    })),
+            )
+            .await;
             return Err(AppError::Authentication("Invalid TOTP code".to_string()));
         }
+        used_backup_code = true;
     }
 
     // TOTP verified -- now fetch full user and generate real tokens
@@ -462,6 +509,26 @@ pub async fn verify_totp(
     auth_service
         .persist_refresh_jti_from_pair(&tokens, user.id)
         .await?;
+
+    // A completed TOTP verify IS a login: record it so 2FA users' logins are
+    // no longer invisible in the audit trail (#386). Fire-and-forget,
+    // non-gating, placed after the refresh jti is durably persisted.
+    let method_label = if used_backup_code {
+        "totp_backup_code"
+    } else {
+        "totp"
+    };
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::Login, ResourceType::User)
+            .user(user.id)
+            .resource(user.id)
+            .details(serde_json::json!({
+                "username": user.username,
+                "method": method_label,
+            })),
+    )
+    .await;
 
     let body = super::auth::LoginResponse {
         access_token: tokens.access_token.clone(),
@@ -582,6 +649,19 @@ pub async fn disable_totp(
             "Failed to revoke refresh-token families after TOTP disable",
         );
     }
+
+    // Audit the credential-posture change and the mass session invalidation
+    // it triggered (#386). Fire-and-forget, POST-commit, non-gating.
+    audit_fire_and_forget(
+        state.db.clone(),
+        totp_audit_entry(AuditAction::TotpDisabled, auth.user_id),
+    )
+    .await;
+    audit_fire_and_forget(
+        state.db.clone(),
+        sessions_invalidated_audit_entry(auth.user_id, auth.user_id, "totp_disable"),
+    )
+    .await;
 
     Ok(())
 }
@@ -1291,8 +1371,7 @@ mod totp_verify_hardening_tests {
     //!    authenticate concurrent sessions.
     use super::*;
     use crate::api::handlers::test_db_helpers as tdh;
-    use crate::models::user::{AuthProvider, User};
-    use chrono::Utc;
+    use crate::models::user::User;
     use uuid::Uuid;
 
     /// Enrol a fresh user in TOTP with the given backup-code hashes and return
@@ -1303,55 +1382,12 @@ mod totp_verify_hardening_tests {
         pool: &sqlx::PgPool,
         backup_hashes: &[String],
     ) -> (User, SharedState, Vec<u8>, String, std::path::PathBuf) {
-        let (user_id, username) = tdh::create_user(pool).await;
-        let secret = totp_rs::Secret::generate_secret();
-        let secret_b32 = secret.to_encoded().to_string();
-        let secret_bytes = secret.to_bytes().expect("secret bytes");
-        let backup_json = serde_json::to_string(backup_hashes).expect("serialize backup");
-        sqlx::query(
-            "UPDATE users SET totp_secret = $1, totp_enabled = true, totp_backup_codes = $2 \
-             WHERE id = $3",
-        )
-        .bind(&secret_b32)
-        .bind(&backup_json)
-        .bind(user_id)
-        .execute(pool)
-        .await
-        .expect("enable totp");
-
-        let storage_dir = std::env::temp_dir().join(format!("totp-verify-{}", Uuid::new_v4()));
-        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
-        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
-
-        let user = User {
-            id: user_id,
-            username,
-            email: format!("{user_id}@test.local"),
-            password_hash: Some("unused".to_string()),
-            display_name: None,
-            auth_provider: AuthProvider::Local,
-            external_id: None,
-            is_admin: false,
-            is_active: true,
-            is_service_account: false,
-            must_change_password: false,
-            totp_secret: Some(secret_b32),
-            totp_enabled: true,
-            totp_backup_codes: Some(backup_json),
-            totp_verified_at: None,
-            failed_login_attempts: 0,
-            locked_until: None,
-            last_failed_login_at: None,
-            password_changed_at: Utc::now(),
-            last_login_at: None,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        };
-        let auth_service = AuthService::new(pool.clone(), Arc::new(state.config.clone()));
+        let fx = tdh::create_totp_user(pool, backup_hashes).await;
+        let auth_service = AuthService::new(pool.clone(), Arc::new(fx.state.config.clone()));
         let pending = auth_service
-            .generate_totp_pending_token(&user)
+            .generate_totp_pending_token(&fx.user)
             .expect("pending token");
-        (user, state, secret_bytes, pending, storage_dir)
+        (fx.user, fx.state, fx.secret_bytes, pending, fx.storage_dir)
     }
 
     async fn cleanup(pool: &sqlx::PgPool, user_id: Uuid, dir: &std::path::Path) {
@@ -1492,6 +1528,193 @@ mod totp_verify_hardening_tests {
         assert!(
             codes.iter().all(|c| c.is_empty()),
             "the consumed backup-code slot must be cleared"
+        );
+    }
+}
+
+/// DB-backed tests for the auth-event audit trail added in #386 (#1617
+/// Phase 1): TOTP enable, disable and login-verify must each emit the right
+/// audit rows, while a failed 2FA verify emits `LOGIN_FAILED`. Each test
+/// no-ops when `DATABASE_URL` is unset (`tdh::try_pool`).
+#[cfg(test)]
+mod totp_audit_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    /// Pick a 6-digit code guaranteed to differ from the live TOTP code so the
+    /// verify path takes the failure branch deterministically.
+    fn wrong_code(current: &str) -> String {
+        if current == "000000" {
+            "111111".to_string()
+        } else {
+            "000000".to_string()
+        }
+    }
+
+    #[tokio::test]
+    async fn enable_totp_emits_totp_enabled_and_sessions_invalidated() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = tdh::create_totp_user(&pool, &[]).await;
+        let user_id = fx.user.id;
+        let auth = tdh::make_auth(user_id, &fx.user.username);
+        let totp = build_totp(fx.secret_bytes.clone(), fx.user.username.clone()).expect("totp");
+        let code = totp.generate_current().expect("code");
+
+        let res = enable_totp(
+            State(fx.state.clone()),
+            Extension(auth),
+            Json(TotpCodeRequest { code }),
+        )
+        .await;
+
+        let enabled = tdh::audit_count(&pool, user_id, "TOTP_ENABLED").await;
+        let invalidated = tdh::audit_count(&pool, user_id, "SESSIONS_INVALIDATED").await;
+        tdh::cleanup_user(&pool, user_id).await;
+        let _ = std::fs::remove_dir_all(&fx.storage_dir);
+
+        assert!(res.is_ok(), "enable_totp failed: {:?}", res.err());
+        assert_eq!(enabled, 1, "enable_totp MUST write one TOTP_ENABLED row");
+        assert_eq!(
+            invalidated, 1,
+            "enable_totp MUST write one SESSIONS_INVALIDATED row"
+        );
+    }
+
+    #[tokio::test]
+    async fn disable_totp_emits_totp_disabled_and_sessions_invalidated() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = tdh::create_totp_user(&pool, &[]).await;
+        let user_id = fx.user.id;
+        let password = "Disable!2026pw";
+        let hash = bcrypt::hash(password, 4).expect("hash password");
+        sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
+            .bind(&hash)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("seed password hash");
+        let auth = tdh::make_auth(user_id, &fx.user.username);
+        let totp = build_totp(fx.secret_bytes.clone(), fx.user.username.clone()).expect("totp");
+        let code = totp.generate_current().expect("code");
+
+        let res = disable_totp(
+            State(fx.state.clone()),
+            Extension(auth),
+            Json(TotpDisableRequest {
+                password: password.to_string(),
+                code,
+            }),
+        )
+        .await;
+
+        let disabled = tdh::audit_count(&pool, user_id, "TOTP_DISABLED").await;
+        let invalidated = tdh::audit_count(&pool, user_id, "SESSIONS_INVALIDATED").await;
+        tdh::cleanup_user(&pool, user_id).await;
+        let _ = std::fs::remove_dir_all(&fx.storage_dir);
+
+        assert!(res.is_ok(), "disable_totp failed: {:?}", res.err());
+        assert_eq!(disabled, 1, "disable_totp MUST write one TOTP_DISABLED row");
+        assert_eq!(
+            invalidated, 1,
+            "disable_totp MUST write one SESSIONS_INVALIDATED row"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_totp_success_emits_login_and_wrong_code_emits_login_failed() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = tdh::create_totp_user(&pool, &[]).await;
+        let user_id = fx.user.id;
+        let svc = AuthService::new(pool.clone(), Arc::new(fx.state.config.clone()));
+        let totp = build_totp(fx.secret_bytes.clone(), fx.user.username.clone()).expect("totp");
+
+        // Wrong-code attempt -> LOGIN_FAILED (fresh single-use pending token).
+        let bad_pending = svc.generate_totp_pending_token(&fx.user).expect("pending");
+        let current = totp.generate_current().expect("code");
+        let bad = verify_totp(
+            State(fx.state.clone()),
+            HeaderMap::new(),
+            Json(TotpVerifyRequest {
+                totp_token: bad_pending,
+                code: wrong_code(&current),
+            }),
+        )
+        .await;
+
+        // Successful verify -> LOGIN (a second fresh pending token + live code).
+        let ok_pending = svc.generate_totp_pending_token(&fx.user).expect("pending");
+        let code = totp.generate_current().expect("code");
+        let ok = verify_totp(
+            State(fx.state.clone()),
+            HeaderMap::new(),
+            Json(TotpVerifyRequest {
+                totp_token: ok_pending,
+                code,
+            }),
+        )
+        .await;
+
+        let logins = tdh::audit_count(&pool, user_id, "LOGIN").await;
+        let failed = tdh::audit_count(&pool, user_id, "LOGIN_FAILED").await;
+        tdh::cleanup_user(&pool, user_id).await;
+        let _ = std::fs::remove_dir_all(&fx.storage_dir);
+
+        assert!(bad.is_err(), "wrong TOTP code must be rejected");
+        assert!(
+            ok.is_ok(),
+            "verify with live code must succeed: {:?}",
+            ok.err()
+        );
+        assert_eq!(logins, 1, "successful TOTP verify MUST write one LOGIN row");
+        assert_eq!(
+            failed, 1,
+            "a wrong-code TOTP verify MUST write one LOGIN_FAILED row"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_totp_on_non_2fa_user_emits_login_failed() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let fx = tdh::create_totp_user(&pool, &[]).await;
+        let user_id = fx.user.id;
+        // Flip the DB row so the handler takes the "TOTP not enabled" branch.
+        sqlx::query("UPDATE users SET totp_enabled = false WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("clear totp_enabled");
+        let svc = AuthService::new(pool.clone(), Arc::new(fx.state.config.clone()));
+        let pending = svc.generate_totp_pending_token(&fx.user).expect("pending");
+
+        let res = verify_totp(
+            State(fx.state.clone()),
+            HeaderMap::new(),
+            Json(TotpVerifyRequest {
+                totp_token: pending,
+                code: "000000".to_string(),
+            }),
+        )
+        .await;
+
+        let failed = tdh::audit_count(&pool, user_id, "LOGIN_FAILED").await;
+        tdh::cleanup_user(&pool, user_id).await;
+        let _ = std::fs::remove_dir_all(&fx.storage_dir);
+
+        assert!(
+            res.is_err(),
+            "verify against a non-2FA user must be rejected"
+        );
+        assert_eq!(
+            failed, 1,
+            "a TOTP verify against a user without 2FA MUST write one LOGIN_FAILED row"
         );
     }
 }

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -15,7 +15,10 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
-use crate::services::audit_service::{api_token_audit_entry, audit_fire_and_forget, AuditAction};
+use crate::services::audit_service::{
+    api_token_audit_entry, audit_fire_and_forget, password_change_audit_entry,
+    sessions_invalidated_audit_entry, AuditAction,
+};
 use crate::services::auth_service::{
     invalidate_user_token_cache_entries, invalidate_user_tokens, AuthService,
 };
@@ -1062,6 +1065,22 @@ pub async fn change_password(
         tracing::warn!(user_id = %id, error = %e, "Failed to revoke refresh-token families after password change");
     }
 
+    // Audit the password change and the session invalidation it triggered
+    // (#386). Fire-and-forget and placed AFTER the transaction has committed
+    // so an audit-table outage can never fail the password change. `by_admin`
+    // is true only when an admin changes a DIFFERENT user's password.
+    let by_admin = auth.is_admin && auth.user_id != id;
+    audit_fire_and_forget(
+        state.db.clone(),
+        password_change_audit_entry(id, auth.user_id, by_admin),
+    )
+    .await;
+    audit_fire_and_forget(
+        state.db.clone(),
+        sessions_invalidated_audit_entry(id, auth.user_id, "password_change"),
+    )
+    .await;
+
     // If this user had must_change_password, check if setup mode should be unlocked
     if had_must_change && state.setup_required.load(Ordering::Relaxed) {
         state.setup_required.store(false, Ordering::Relaxed);
@@ -1190,6 +1209,20 @@ pub async fn reset_password(
     if let Err(e) = auth_service.revoke_all_refresh_token_families(id).await {
         tracing::warn!(user_id = %id, error = %e, "Failed to revoke refresh-token families after password reset");
     }
+
+    // Audit the admin-initiated password reset and the session invalidation it
+    // triggered (#386). Subject = target user, actor = acting admin; an admin
+    // reset is by definition `by_admin = true`. Fire-and-forget, POST-commit.
+    audit_fire_and_forget(
+        state.db.clone(),
+        password_change_audit_entry(id, auth.user_id, true),
+    )
+    .await;
+    audit_fire_and_forget(
+        state.db.clone(),
+        sessions_invalidated_audit_entry(id, auth.user_id, "password_reset"),
+    )
+    .await;
 
     Ok(Json(ResetPasswordResponse {
         temporary_password: temp_password,
@@ -1369,6 +1402,15 @@ pub async fn force_password_change(
         id,
         Some(auth.username.clone()),
     );
+
+    // Forcing a password change does NOT itself change the password (it only
+    // flags `must_change_password`), so only the mass session invalidation is
+    // audited here — emitting PASSWORD_CHANGED would be misleading (#386).
+    audit_fire_and_forget(
+        state.db.clone(),
+        sessions_invalidated_audit_entry(id, auth.user_id, "force_password_change"),
+    )
+    .await;
 
     Ok(Json(ForcePasswordChangeResponse {
         message: "User will be required to change password on next login".to_string(),
@@ -3072,5 +3114,139 @@ mod admin_scope_policy_tests {
         );
 
         cleanup(&pool, user_id).await;
+    }
+}
+
+/// DB-backed tests for the auth-event audit trail added in #386 (#1617
+/// Phase 1): a self-service password change and an admin password reset must
+/// emit `PASSWORD_CHANGED` (plus `SESSIONS_INVALIDATED` for the self change),
+/// with `details.by_admin` reflecting who performed it. Each test no-ops when
+/// `DATABASE_URL` is unset (`tdh::try_pool`).
+#[cfg(test)]
+mod password_audit_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    /// Read `details.by_admin` off the single PASSWORD_CHANGED audit row for a
+    /// subject, if present.
+    async fn by_admin_flag(pool: &sqlx::PgPool, subject: Uuid) -> Option<bool> {
+        sqlx::query_scalar::<_, bool>(
+            "SELECT (details->>'by_admin')::bool FROM audit_log \
+             WHERE resource_id = $1 AND action = 'PASSWORD_CHANGED' LIMIT 1",
+        )
+        .bind(subject)
+        .fetch_optional(pool)
+        .await
+        .expect("by_admin query")
+    }
+
+    #[tokio::test]
+    async fn self_change_password_emits_password_changed_and_sessions_invalidated() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let current = "OldPass!2026";
+        let hash = bcrypt::hash(current, 4).expect("hash password");
+        sqlx::query("UPDATE users SET password_hash = $1 WHERE id = $2")
+            .bind(&hash)
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("seed password hash");
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        let auth = tdh::make_auth(user_id, &username);
+
+        let res = change_password(
+            State(state.clone()),
+            Extension(auth),
+            Path(user_id),
+            Json(ChangePasswordRequest {
+                current_password: Some(current.to_string()),
+                new_password: "NewPass!2026".to_string(),
+            }),
+        )
+        .await;
+
+        let changed = tdh::audit_count(&pool, user_id, "PASSWORD_CHANGED").await;
+        let invalidated = tdh::audit_count(&pool, user_id, "SESSIONS_INVALIDATED").await;
+        let by_admin = by_admin_flag(&pool, user_id).await;
+        tdh::cleanup_user(&pool, user_id).await;
+
+        assert!(res.is_ok(), "change_password failed: {:?}", res.err());
+        assert_eq!(
+            changed, 1,
+            "self change_password MUST write one PASSWORD_CHANGED row"
+        );
+        assert_eq!(
+            invalidated, 1,
+            "self change_password MUST write one SESSIONS_INVALIDATED row"
+        );
+        assert_eq!(
+            by_admin,
+            Some(false),
+            "a self change must record details.by_admin = false"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_reset_password_emits_password_changed_by_admin_on_target() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (target_id, _target_name) = tdh::create_user(&pool).await;
+        let (admin_id, admin_name) = tdh::create_user(&pool).await;
+        let mut auth = tdh::make_auth(admin_id, &admin_name);
+        auth.is_admin = true;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+
+        let res = reset_password(State(state.clone()), Extension(auth), Path(target_id)).await;
+
+        let changed = tdh::audit_count(&pool, target_id, "PASSWORD_CHANGED").await;
+        let by_admin = by_admin_flag(&pool, target_id).await;
+        tdh::cleanup_user(&pool, target_id).await;
+        tdh::cleanup_user(&pool, admin_id).await;
+
+        assert!(res.is_ok(), "reset_password failed: {:?}", res.err());
+        assert_eq!(
+            changed, 1,
+            "admin reset MUST write one PASSWORD_CHANGED row on the target user"
+        );
+        assert_eq!(
+            by_admin,
+            Some(true),
+            "an admin reset must record details.by_admin = true"
+        );
+    }
+
+    #[tokio::test]
+    async fn admin_force_password_change_emits_sessions_invalidated_only() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (target_id, _target_name) = tdh::create_user(&pool).await;
+        let (admin_id, admin_name) = tdh::create_user(&pool).await;
+        let mut auth = tdh::make_auth(admin_id, &admin_name);
+        auth.is_admin = true;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+
+        let res =
+            force_password_change(State(state.clone()), Extension(auth), Path(target_id)).await;
+
+        let invalidated = tdh::audit_count(&pool, target_id, "SESSIONS_INVALIDATED").await;
+        // No password actually changed, so PASSWORD_CHANGED must NOT be emitted.
+        let changed = tdh::audit_count(&pool, target_id, "PASSWORD_CHANGED").await;
+        tdh::cleanup_user(&pool, target_id).await;
+        tdh::cleanup_user(&pool, admin_id).await;
+
+        assert!(res.is_ok(), "force_password_change failed: {:?}", res.err());
+        assert_eq!(
+            invalidated, 1,
+            "force_password_change MUST write one SESSIONS_INVALIDATED row"
+        );
+        assert_eq!(
+            changed, 0,
+            "force_password_change must NOT emit PASSWORD_CHANGED (no password changed)"
+        );
     }
 }

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -73,6 +73,14 @@ pub enum AuditAction {
 
     // Scanning / janitors
     ScanReaped,
+
+    // Auth-event audit completeness (#386 / #1617 Phase 1). Appended at the
+    // END of the enum so the additive change has no effect on the ordering of
+    // existing variants and minimizes merge-conflict surface with other
+    // in-flight audit-taxonomy work.
+    TotpEnabled,
+    TotpDisabled,
+    SessionsInvalidated,
 }
 
 impl AuditAction {
@@ -118,6 +126,9 @@ impl AuditAction {
             AuditAction::SbomGenerated => "SBOM_GENERATED",
             AuditAction::SbomRead => "SBOM_READ",
             AuditAction::ScanReaped => "SCAN_REAPED",
+            AuditAction::TotpEnabled => "TOTP_ENABLED",
+            AuditAction::TotpDisabled => "TOTP_DISABLED",
+            AuditAction::SessionsInvalidated => "SESSIONS_INVALIDATED",
         }
     }
 }
@@ -519,6 +530,54 @@ pub fn api_token_audit_entry(
             "token_id": token_id.to_string(),
             "token_name": token_name,
             "surface": surface,
+        }))
+}
+
+/// Build an audit entry for a self-service or admin password change (#386 /
+/// #1617 Phase 1).
+///
+/// `subject` is the user whose password changed (recorded as `user_id` and the
+/// resource). `actor` is the principal that performed the change; it equals
+/// `subject` on a self-change and is the acting admin on an admin reset. The
+/// plaintext password and any hash are NEVER included. The acting principal is
+/// recorded under `actor_id` (not the reserved `actor` key, which
+/// [`AuditEntry::details`] strips as an anti-spoof measure). Pure builder —
+/// unit-testable without a database.
+pub fn password_change_audit_entry(subject: Uuid, actor: Uuid, by_admin: bool) -> AuditEntry {
+    AuditEntry::new(AuditAction::PasswordChanged, ResourceType::User)
+        .user(subject)
+        .resource(subject)
+        .details(serde_json::json!({
+            "actor_id": actor.to_string(),
+            "by_admin": by_admin,
+        }))
+}
+
+/// Build an audit entry for a TOTP enable/disable — a self-service
+/// credential-posture change (#386). `action` is [`AuditAction::TotpEnabled`]
+/// or [`AuditAction::TotpDisabled`]; `subject` is the user whose 2FA changed.
+/// Pure builder — unit-testable without a database.
+pub fn totp_audit_entry(action: AuditAction, subject: Uuid) -> AuditEntry {
+    AuditEntry::new(action, ResourceType::User)
+        .user(subject)
+        .resource(subject)
+}
+
+/// Build an audit entry for a mass session / refresh-token invalidation (#386).
+///
+/// `subject` is the user whose sessions were invalidated; `actor` is the
+/// principal that triggered it (equals `subject` on a self-service change,
+/// the acting admin otherwise). `trigger` is a stable static label
+/// (`"totp_enable"` | `"totp_disable"` | `"password_change"` |
+/// `"password_reset"` | `"force_password_change"`). Recorded under `actor_id`
+/// (not the reserved `actor` key). Pure builder — unit-testable.
+pub fn sessions_invalidated_audit_entry(subject: Uuid, actor: Uuid, trigger: &str) -> AuditEntry {
+    AuditEntry::new(AuditAction::SessionsInvalidated, ResourceType::User)
+        .user(subject)
+        .resource(subject)
+        .details(serde_json::json!({
+            "actor_id": actor.to_string(),
+            "trigger": trigger,
         }))
 }
 
@@ -1064,5 +1123,86 @@ mod tests {
         let obj = details.as_object().expect("details is object");
         assert!(!obj.contains_key("token"));
         assert!(!obj.contains_key("secret"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #386 (#1617 Phase 1): auth-event audit completeness — new action
+    // variants + pure builder helpers.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_audit_action_as_str_auth_event_completeness() {
+        assert_eq!(AuditAction::TotpEnabled.as_str(), "TOTP_ENABLED");
+        assert_eq!(AuditAction::TotpDisabled.as_str(), "TOTP_DISABLED");
+        assert_eq!(
+            AuditAction::SessionsInvalidated.as_str(),
+            "SESSIONS_INVALIDATED"
+        );
+    }
+
+    #[test]
+    fn test_password_change_audit_entry_self_shape() {
+        let subject = Uuid::new_v4();
+        let entry = password_change_audit_entry(subject, subject, false);
+        assert_eq!(entry.user_id(), Some(subject));
+        assert_eq!(entry.resource_id(), Some(subject));
+        assert_eq!(entry.action().as_str(), "PASSWORD_CHANGED");
+        assert_eq!(entry.resource_type().as_str(), "user");
+        let details = entry.details_ref().expect("details present");
+        assert_eq!(details["actor_id"], subject.to_string());
+        assert_eq!(details["by_admin"], false);
+        let obj = details.as_object().expect("details is object");
+        // The audit entry must never carry the password, a hash, or the
+        // reserved (stripped) `actor` key.
+        assert!(!obj.contains_key("password"));
+        assert!(!obj.contains_key("hash"));
+        assert!(!obj.contains_key("password_hash"));
+        assert!(!obj.contains_key("actor"));
+    }
+
+    #[test]
+    fn test_password_change_audit_entry_admin_records_distinct_actor() {
+        let subject = Uuid::new_v4();
+        let actor = Uuid::new_v4();
+        let entry = password_change_audit_entry(subject, actor, true);
+        assert_eq!(entry.user_id(), Some(subject));
+        let details = entry.details_ref().expect("details present");
+        assert_eq!(details["actor_id"], actor.to_string());
+        assert_eq!(details["by_admin"], true);
+    }
+
+    #[test]
+    fn test_totp_audit_entry_enable_shape() {
+        let subject = Uuid::new_v4();
+        let entry = totp_audit_entry(AuditAction::TotpEnabled, subject);
+        assert_eq!(entry.action().as_str(), "TOTP_ENABLED");
+        assert_eq!(entry.resource_type().as_str(), "user");
+        assert_eq!(entry.user_id(), Some(subject));
+        assert_eq!(entry.resource_id(), Some(subject));
+    }
+
+    #[test]
+    fn test_totp_audit_entry_disable_shape() {
+        let subject = Uuid::new_v4();
+        let entry = totp_audit_entry(AuditAction::TotpDisabled, subject);
+        assert_eq!(entry.action().as_str(), "TOTP_DISABLED");
+        assert_eq!(entry.user_id(), Some(subject));
+        assert_eq!(entry.resource_id(), Some(subject));
+    }
+
+    #[test]
+    fn test_sessions_invalidated_audit_entry_shape_and_trigger_roundtrip() {
+        let subject = Uuid::new_v4();
+        let actor = Uuid::new_v4();
+        let entry = sessions_invalidated_audit_entry(subject, actor, "password_change");
+        assert_eq!(entry.action().as_str(), "SESSIONS_INVALIDATED");
+        assert_eq!(entry.resource_type().as_str(), "user");
+        assert_eq!(entry.user_id(), Some(subject));
+        assert_eq!(entry.resource_id(), Some(subject));
+        let details = entry.details_ref().expect("details present");
+        assert_eq!(details["actor_id"], actor.to_string());
+        assert_eq!(details["trigger"], "password_change");
+        // Reserved key must not survive into the stored payload.
+        assert!(!details.as_object().expect("object").contains_key("actor"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #386

Completes the auth-event audit coverage for the #1617 Phase 1 taxonomy. The
login/logout/refresh, API-token mint/revoke and SSO paths already emit
`AuditService` events; this PR fills the remaining gap where several
auth-state-changing handlers made no audit record at all:

- **TOTP login (`verify_totp`)** — a completed 2FA verify now records a `LOGIN`
  (with `method: "totp"` / `"totp_backup_code"`), and the failure paths record
  `LOGIN_FAILED` (`invalid_totp_code`, `totp_not_enabled`). Previously a 2FA
  user's logins were invisible in the trail (`totp.rs` did not import the audit
  service).
- **TOTP enable / disable** — new `TOTP_ENABLED` / `TOTP_DISABLED` events.
- **Password change / reset** — `change_password` and admin `reset_password`
  now emit the previously-defined-but-unused `PASSWORD_CHANGED` action, with
  `details.by_admin` distinguishing a self-change from an admin reset.
- **Mass session invalidation** — the credential-change handlers already revoke
  other sessions / refresh-token families; that security-relevant event now
  emits a new `SESSIONS_INVALIDATED` action (with a `trigger` label) from
  `enable_totp`, `disable_totp`, `change_password`, `reset_password` and
  `force_password_change`.

Design notes:

- **Additive taxonomy, no migration.** Three new `AuditAction` variants
  (`TOTP_ENABLED`, `TOTP_DISABLED`, `SESSIONS_INVALIDATED`) are appended to the
  existing flat `UPPER_SNAKE` enum, and `PASSWORD_CHANGED` / `LOGIN` /
  `LOGIN_FAILED` are reused. This keeps the stored `audit_log.action` column and
  every existing query/UI/SIEM filter working unchanged. `audit_log` is an
  established table (migration 005); no schema change.
- **Non-gating, fire-and-forget, post-commit.** Every emit uses the existing
  `audit_fire_and_forget` helper and is placed after the state change has
  committed, so an audit-table outage can never fail a login, enable/disable, or
  password change. The existing session-invalidation / refresh-family revocation
  calls are not reordered or gated.
- **Three pure builder helpers** (`password_change_audit_entry`,
  `totp_audit_entry`, `sessions_invalidated_audit_entry`) mirror the existing
  `api_token_audit_entry` pattern so the changed logic is DB-free unit-testable.
  The acting principal is recorded under `actor_id` (the reserved `actor` key is
  stripped by `AuditEntry::details`); no password or hash is ever included.
- **Scope.** `auth.rs` / `auth_service.rs` are intentionally untouched.
- **Follow-up (out of scope):** these handlers have no `ConnectInfo` /
  trusted-client-IP extractor wired, so `ip` is omitted for consistency with the
  existing `audit_auth` emitter. Threading a real client IP into auth audit is a
  separate change.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added pure `--lib` unit tests for the three new builders + `as_str` values, and
DB-backed handler tests asserting the audit rows that were previously absent:
`enable_totp` → `TOTP_ENABLED` + `SESSIONS_INVALIDATED`; `disable_totp` →
`TOTP_DISABLED` + `SESSIONS_INVALIDATED`; self `change_password` →
`PASSWORD_CHANGED` (`by_admin=false`) + `SESSIONS_INVALIDATED`; admin
`reset_password` → `PASSWORD_CHANGED` (`by_admin=true`) on the target;
`verify_totp` success → `LOGIN`, wrong code → `LOGIN_FAILED`. The shared
`audit_count` / `cleanup_user` / `create_totp_user` scaffolding is hoisted into
`test_db_helpers` (the existing verify-hardening module was migrated onto it) so
the new test modules add no copy-pasted boilerplate.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (no new endpoints, request/response shapes, or schema;
  additive audit-log rows only)
