### PR TITLE
fix(oci): stream virtual-repo blob cache-fill instead of buffering at the 8 MiB metadata cap

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2472,6 +2472,16 @@ pub enum VirtualBlobResolution {
         content: Bytes,
         content_type: Option<String>,
     },
+    /// A remote member served the blob and it is being STREAMED through
+    /// (teed into the proxy cache), rather than buffered in heap (#2274).
+    /// This is the fallback used for image layers that legitimately exceed
+    /// the buffered metadata cap: `resolve_virtual_blob` routes the member
+    /// blob fetch through the digest-gated streaming helper, so a
+    /// multi-GiB layer pulled through a virtual repo returns `200` (streamed)
+    /// instead of `502`, with the cache commit gated on the requested digest.
+    RemoteStream {
+        result: crate::services::proxy_service::StreamingFetchResult,
+    },
 }
 
 /// Pure constructor for the `Local` arm of [`VirtualBlobResolution`].
@@ -2506,30 +2516,6 @@ fn should_attempt_remote_member(
     has_upstream_url: bool,
 ) -> bool {
     member.repo_type == RepositoryType::Remote && has_proxy_service && has_upstream_url
-}
-
-/// Pure post-processing of a successful upstream blob fetch.
-///
-/// Returns `Some(VirtualBlobResolution::Remote { .. })` when the
-/// upstream bytes match the requested content-addressable digest, and
-/// `None` when they do not (the caller must "fall through" to the next
-/// virtual-repo member). For blobs the requested reference is always a
-/// digest, so the verification is unconditional.
-///
-/// Extracted out of [`resolve_virtual_blob`] so the security-critical
-/// verify-then-wrap step can be unit-tested without a wiremock upstream.
-fn finalize_upstream_blob(
-    digest: &str,
-    content: Bytes,
-    content_type: Option<String>,
-) -> Option<VirtualBlobResolution> {
-    if !verify_digest_or_fall_through(&content, digest) {
-        return None;
-    }
-    Some(VirtualBlobResolution::Remote {
-        content,
-        content_type,
-    })
 }
 
 /// Pure post-processing of a successful upstream manifest fetch.
@@ -2748,40 +2734,39 @@ pub async fn resolve_virtual_blob(
             if let (Some(proxy), Some(upstream_url)) =
                 (&state.proxy_service, member.upstream_url.as_deref())
             {
+                // #2274: STREAM the virtual-member blob (parity with the
+                // already-streaming plain-Remote blob download) instead of
+                // buffering it at the 8 MiB metadata cap, which 502'd any
+                // layer larger than the cap. The streaming tee keeps heap
+                // bounded (~4 MiB) regardless of layer size.
+                //
+                // Cache-poisoning protection: for blobs the requested
+                // `digest` is always content-addressable, so the cache
+                // commit is gated on the streamed body's SHA-256 matching
+                // it (the bare-hex form is passed to the streaming helper).
+                // A member that answers `200` with wrong bytes streams to
+                // the client — which independently verifies the digest and
+                // rejects them — but never poisons the proxy cache. This is
+                // the same serve posture the plain-Remote path already ships.
+                let expected_checksum = digest.strip_prefix("sha256:").map(str::to_string);
                 for image in candidate_upstream_images(image_name, upstream_url) {
                     let upstream_path = upstream_blob_path(&image, digest);
-                    // #2192 / #1608 Phase 4c: this virtual-member blob fallback
-                    // stays BUFFERED (unlike the plain-Remote blob download,
-                    // which now streams). `finalize_upstream_blob` below
-                    // content-address-verifies the whole body against the
-                    // requested digest before serving — a security-critical
-                    // check that requires the complete payload in memory, so it
-                    // cannot be streamed without sacrificing verification.
-                    if let Ok((content, content_type)) = proxy_helpers::proxy_fetch_capped(
+                    // A member without the blob (404) or any upstream error
+                    // maps to `Err`; skip it and try the next candidate /
+                    // member, preserving the existing member-selection walk.
+                    match proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
                         proxy,
                         member.id,
                         &member.key,
                         upstream_url,
                         &upstream_path,
-                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                        &upstream_path,
+                        expected_checksum.clone(),
                     )
                     .await
                     {
-                        // #1348 round 1, concern #3 (digest verification):
-                        // for blobs the requested `digest` is always a
-                        // content-addressable digest. The verify-and-wrap
-                        // step lives in `finalize_upstream_blob` so it
-                        // can be unit-tested without a wiremock upstream.
-                        match finalize_upstream_blob(digest, content, content_type) {
-                            Some(resolution) => return Some(resolution),
-                            None => {
-                                warn!(
-                                    "Virtual blob digest mismatch from upstream {} for {}: refusing to serve",
-                                    upstream_url, digest
-                                );
-                                continue;
-                            }
-                        }
+                        Ok(result) => return Some(VirtualBlobResolution::RemoteStream { result }),
+                        Err(_) => continue,
                     }
                 }
             }
@@ -4207,6 +4192,23 @@ async fn handle_head_blob(
                     "application/octet-stream",
                     false,
                 ),
+                VirtualBlobResolution::RemoteStream { result } => {
+                    // HEAD: headers only. Drop the body stream (its upstream
+                    // read is lazy, so no layer bytes are transferred) and
+                    // report the upstream-advertised length when known.
+                    let ct = result
+                        .content_type
+                        .clone()
+                        .unwrap_or_else(|| "application/octet-stream".to_string());
+                    let mut builder = Response::builder()
+                        .status(StatusCode::OK)
+                        .header("Docker-Content-Digest", digest)
+                        .header(CONTENT_TYPE, ct);
+                    if let Some(len) = result.content_length {
+                        builder = builder.header(CONTENT_LENGTH, len.to_string());
+                    }
+                    builder.body(Body::empty()).unwrap()
+                }
             };
         }
     }
@@ -4356,6 +4358,12 @@ async fn handle_get_blob(
                     "application/octet-stream",
                     true,
                 ),
+                VirtualBlobResolution::RemoteStream { result } => {
+                    // #2274: stream the resolved member layer straight to the
+                    // client (teed into the proxy cache) with the mandatory
+                    // Docker-Content-Digest header, never buffering it in heap.
+                    build_oci_streaming_proxy_response(result, digest, "application/octet-stream")
+                }
             };
         }
     }
@@ -11510,8 +11518,8 @@ mod tests {
                 assert_eq!(content.as_ref(), b"layer-bytes");
                 assert_eq!(content_type.as_deref(), Some("application/octet-stream"));
             }
-            VirtualBlobResolution::Local { .. } => {
-                panic!("Remote variant constructed but Local matched");
+            VirtualBlobResolution::Local { .. } | VirtualBlobResolution::RemoteStream { .. } => {
+                panic!("Remote variant constructed but a different variant matched");
             }
         }
     }
@@ -11536,7 +11544,7 @@ mod tests {
     // -----------------------------------------------------------------------
     //
     // `negative_cache_evict_and_has_room`, `local_blob_resolution`,
-    // `should_attempt_remote_member`, `finalize_upstream_blob`, and
+    // `should_attempt_remote_member`, and
     // `finalize_upstream_manifest` were carved out of the async resolver
     // hot path so the decision logic that previously lived inline could
     // be covered by unit tests without standing up a Postgres + wiremock
@@ -11703,7 +11711,7 @@ mod tests {
                 assert_eq!(storage_key, "oci-blobs/sha256:abc");
                 assert_eq!(member.id, member_id);
             }
-            VirtualBlobResolution::Remote { .. } => {
+            VirtualBlobResolution::Remote { .. } | VirtualBlobResolution::RemoteStream { .. } => {
                 panic!("expected Local variant from local_blob_resolution");
             }
         }
@@ -11756,51 +11764,13 @@ mod tests {
         assert!(!super::should_attempt_remote_member(&m, true, true));
     }
 
-    // finalize_upstream_blob: verify-then-wrap step for the resolver.
-
-    #[test]
-    fn test_finalize_upstream_blob_matching_digest_returns_remote() {
-        let bytes = Bytes::from_static(b"hello world");
-        let digest = "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9";
-        let result =
-            super::finalize_upstream_blob(digest, bytes.clone(), Some("application/json".into()))
-                .expect("matching digest must produce a Remote resolution");
-        match result {
-            VirtualBlobResolution::Remote {
-                content,
-                content_type,
-            } => {
-                assert_eq!(content, bytes);
-                assert_eq!(content_type.as_deref(), Some("application/json"));
-            }
-            VirtualBlobResolution::Local { .. } => {
-                panic!("finalize_upstream_blob must never construct a Local variant");
-            }
-        }
-    }
-
-    #[test]
-    fn test_finalize_upstream_blob_mismatched_digest_falls_through() {
-        // The exact bytes-substitution attack vector PR #1348 closes:
-        // upstream serves "hello world" under a non-matching digest.
-        // finalize_upstream_blob must refuse the response so the resolver
-        // can `continue` to the next virtual-repo member.
-        let bytes = Bytes::from_static(b"hello world");
-        let wrong = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
-        assert!(super::finalize_upstream_blob(wrong, bytes, None).is_none());
-    }
-
-    #[test]
-    fn test_finalize_upstream_blob_empty_body_with_canonical_digest_accepts() {
-        let canonical = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
-        let result = super::finalize_upstream_blob(canonical, Bytes::new(), None)
-            .expect("canonical empty-string digest must verify against empty content");
-        if let VirtualBlobResolution::Remote { content, .. } = result {
-            assert!(content.is_empty());
-        } else {
-            panic!("expected Remote variant");
-        }
-    }
+    // Digest verification for the virtual-repo blob fallback moved to the
+    // streaming cache-commit gate (#2274): `resolve_virtual_blob` now streams
+    // the member blob and commits it to the proxy cache ONLY when the streamed
+    // SHA-256 matches the requested digest (see `CacheMetadataTemplate::
+    // expected_checksum` in `proxy_service`). The end-to-end streaming +
+    // poisoning-guard behaviour is covered by the DB-backed wiremock tests in
+    // `virtual_blob_streaming_fallback_tests` below.
 
     // finalize_upstream_manifest: verify-then-compute step for manifest
     // resolution.
@@ -12167,6 +12137,423 @@ mod remote_blob_streaming_fallback_tests {
              proving manifests are NOT streamed"
         );
 
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// #2274: the VIRTUAL-repo member blob fallback STREAMS (digest-gated) instead
+// of buffering at the 8 MiB metadata cap. A layer larger than the cap pulled
+// through a virtual docker repo must return 200 (streamed) + the correct
+// Docker-Content-Digest, warm the cache, and — critically — a member serving
+// WRONG bytes for a digest-addressed URL must NOT poison the proxy cache.
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::disallowed_methods)]
+// streaming-invariant: test module exempt — buffering response bodies in test
+// assertions is not an artifact path (#1608)
+#[cfg(test)]
+mod virtual_blob_streaming_fallback_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use wiremock::matchers::{method, path as wm_path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn sha256_hex(data: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(data);
+        format!("{:x}", hasher.finalize())
+    }
+
+    async fn insert_remote_repo(pool: &sqlx::PgPool, upstream_url: &str) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("oci-strm-rem-{}", &id.to_string()[..8]);
+        let storage_path = format!("/tmp/oci-strm-{}", id);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, upstream_url, is_public) \
+             VALUES ($1, $2, $2, $3, 'remote', 'docker'::repository_format, $4, true)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(&storage_path)
+        .bind(upstream_url)
+        .execute(pool)
+        .await
+        .expect("insert remote repo");
+        (id, key)
+    }
+
+    async fn insert_virtual_repo(pool: &sqlx::PgPool) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("oci-strm-virt-{}", &id.to_string()[..8]);
+        let storage_path = format!("/tmp/oci-strm-virt-{}", id);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'virtual', 'docker'::repository_format, true)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(&storage_path)
+        .execute(pool)
+        .await
+        .expect("insert virtual repo");
+        (id, key)
+    }
+
+    async fn link_member(pool: &sqlx::PgPool, virtual_id: Uuid, member_id: Uuid, priority: i32) {
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, $3)",
+        )
+        .bind(virtual_id)
+        .bind(member_id)
+        .bind(priority)
+        .execute(pool)
+        .await
+        .expect("link virtual member");
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, ids: &[Uuid]) {
+        for id in ids {
+            let _ = sqlx::query(
+                "DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1 OR member_repo_id = $1",
+            )
+            .bind(id)
+            .execute(pool)
+            .await;
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(pool)
+                .await;
+        }
+    }
+
+    /// Render the resolver output through the real handler helper and collect
+    /// the streamed body, returning (status, Docker-Content-Digest, body).
+    async fn render_and_collect(
+        resolution: VirtualBlobResolution,
+        digest: &str,
+    ) -> (StatusCode, Option<String>, Vec<u8>) {
+        let result = match resolution {
+            VirtualBlobResolution::RemoteStream { result } => result,
+            _ => panic!("expected RemoteStream resolution"),
+        };
+        let resp =
+            super::build_oci_streaming_proxy_response(result, digest, "application/octet-stream");
+        let status = resp.status();
+        let dcd = resp
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect streamed body")
+            .to_vec();
+        (status, dcd, body)
+    }
+
+    /// A 9 MiB layer (> 8 MiB DEFAULT_METADATA_MAX_BYTES) served by a Remote
+    /// MEMBER of a Virtual repo must STREAM with 200 + the correct
+    /// Docker-Content-Digest (was 502/500 on the buffered fallback), warm the
+    /// cache, and be served from cache on the second pull (member fetched once).
+    #[tokio::test]
+    async fn virtual_blob_streams_large_layer_from_member() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let layer = vec![0x5au8; 9 * 1024 * 1024];
+        let digest = format!("sha256:{}", sha256_hex(&layer));
+
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(layer.clone()),
+            )
+            // Warm-cache proof: the member is fetched from upstream at most once.
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-vblob-stream-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+
+        let (member_id, _) = insert_remote_repo(&pool, &server.uri()).await;
+        let (virt_id, _) = insert_virtual_repo(&pool).await;
+        link_member(&pool, virt_id, member_id, 1).await;
+
+        for i in 0..2 {
+            if i == 1 {
+                tdh::wait_for_cache_commit(&tmp, layer.len() as u64).await;
+            }
+            let resolution = super::resolve_virtual_blob(&state, virt_id, "myimage", &digest)
+                .await
+                .expect("large virtual-member layer must stream (200), not 502");
+            let (status, dcd, body) = render_and_collect(resolution, &digest).await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(dcd.as_deref(), Some(digest.as_str()));
+            assert_eq!(body.len(), layer.len(), "full layer must stream through");
+        }
+
+        drop(server);
+        cleanup(&pool, &[virt_id, member_id]).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Member selection preserved: a member that 404s for the digest is skipped
+    /// and the next member's blob is streamed.
+    #[tokio::test]
+    async fn virtual_blob_skips_404_member_and_streams_next() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let body = b"second-member-layer-bytes".to_vec();
+        let digest = format!("sha256:{}", sha256_hex(&body));
+
+        let server_a = MockServer::start().await;
+        let server_b = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(ResponseTemplate::new(404))
+            .expect(1)
+            .mount(&server_a)
+            .await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(body.clone()),
+            )
+            .expect(1)
+            .mount(&server_b)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-vblob-404-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+
+        let (member_a, _) = insert_remote_repo(&pool, &server_a.uri()).await;
+        let (member_b, _) = insert_remote_repo(&pool, &server_b.uri()).await;
+        let (virt_id, _) = insert_virtual_repo(&pool).await;
+        link_member(&pool, virt_id, member_a, 1).await;
+        link_member(&pool, virt_id, member_b, 2).await;
+
+        let resolution = super::resolve_virtual_blob(&state, virt_id, "myimage", &digest)
+            .await
+            .expect("must fall through the 404 member to the one that serves the blob");
+        let (status, dcd, got) = render_and_collect(resolution, &digest).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dcd.as_deref(), Some(digest.as_str()));
+        assert_eq!(got, body);
+
+        drop(server_a);
+        drop(server_b);
+        cleanup(&pool, &[virt_id, member_a, member_b]).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Cache-poisoning guard: a member returning 200 with WRONG bytes (sha256
+    /// != requested digest) must NOT be committed to the proxy cache. Proven by
+    /// a second resolve fetching from upstream AGAIN (the mismatched body was
+    /// never cached, so it is never served warm as that digest).
+    #[tokio::test]
+    async fn virtual_blob_wrong_bytes_are_not_cached() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // Digest addresses the CORRECT bytes; the member serves different bytes
+        // of the same length so the truncation guard passes and only the digest
+        // gate can reject the cache commit.
+        let correct = b"the-authentic-layer-bytes!".to_vec();
+        let wrong = b"tampered-substitute-bytes!".to_vec();
+        assert_eq!(correct.len(), wrong.len());
+        let digest = format!("sha256:{}", sha256_hex(&correct));
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(wrong.clone()),
+            )
+            // Not-poisoned proof: because the mismatched body is never cached,
+            // the second resolve must hit upstream again -> exactly 2 fetches.
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-vblob-poison-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+
+        let (member_id, _) = insert_remote_repo(&pool, &server.uri()).await;
+        let (virt_id, _) = insert_virtual_repo(&pool).await;
+        link_member(&pool, virt_id, member_id, 1).await;
+
+        for _ in 0..2 {
+            let resolution = super::resolve_virtual_blob(&state, virt_id, "myimage", &digest)
+                .await
+                .expect("a 200 member still resolves (bytes served, client verifies digest)");
+            // Fully drain so the tee's background writer runs its digest gate
+            // (mismatch -> delete object, no metadata sidecar).
+            let (_status, _dcd, drained) = render_and_collect(resolution, &digest).await;
+            assert_eq!(drained, wrong, "the streamed body is forwarded verbatim");
+            // Give the background writer a moment to finish its reject/delete.
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        }
+
+        // The mismatched body must never have been committed as a cache hit.
+        assert!(
+            !tdh::committed_cache_entry_exists(&tmp, wrong.len() as u64),
+            "digest-mismatched bytes must not be committed to the proxy cache"
+        );
+
+        drop(server);
+        cleanup(&pool, &[virt_id, member_id]).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    fn anon_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            format!("Bearer {ANONYMOUS_TOKEN}").parse().unwrap(),
+        );
+        headers
+    }
+
+    /// End-to-end through the real `handle_get_blob` handler: a `docker pull`
+    /// of a >8 MiB layer via a VIRTUAL repo returns 200 with the streamed body
+    /// and the mandatory Docker-Content-Digest (the exact #2274 repro that
+    /// previously 502'd on the buffered fallback).
+    #[tokio::test]
+    async fn handle_get_blob_streams_virtual_member_layer() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let layer = vec![0x33u8; 9 * 1024 * 1024];
+        let digest = format!("sha256:{}", sha256_hex(&layer));
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(layer.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-vget-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+
+        let (member_id, _) = insert_remote_repo(&pool, &server.uri()).await;
+        let (virt_id, virt_key) = insert_virtual_repo(&pool).await;
+        link_member(&pool, virt_id, member_id, 1).await;
+
+        let image_name = format!("{virt_key}/myimage");
+        let resp = super::handle_get_blob(
+            &state,
+            &anon_headers(),
+            "http://localhost",
+            &image_name,
+            &digest,
+        )
+        .await;
+        let status = resp.status();
+        let dcd = resp
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect streamed body")
+            .to_vec();
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "virtual pull-through must stream 200"
+        );
+        assert_eq!(dcd.as_deref(), Some(digest.as_str()));
+        assert_eq!(body.len(), layer.len());
+
+        drop(server);
+        cleanup(&pool, &[virt_id, member_id]).await;
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// `handle_head_blob` for the same virtual member returns 200 + headers
+    /// only (Content-Length forwarded, empty body) — the streaming HEAD arm.
+    #[tokio::test]
+    async fn handle_head_blob_reports_virtual_member_layer_headers() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let layer = vec![0x44u8; 9 * 1024 * 1024];
+        let digest = format!("sha256:{}", sha256_hex(&layer));
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/v2/myimage/blobs/{digest}")))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(layer.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("oci-vhead-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), tmp.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), tmp.to_str().unwrap(), proxy);
+
+        let (member_id, _) = insert_remote_repo(&pool, &server.uri()).await;
+        let (virt_id, virt_key) = insert_virtual_repo(&pool).await;
+        link_member(&pool, virt_id, member_id, 1).await;
+
+        let image_name = format!("{virt_key}/myimage");
+        let resp = super::handle_head_blob(
+            &state,
+            &anon_headers(),
+            "http://localhost",
+            &image_name,
+            &digest,
+        )
+        .await;
+        let status = resp.status();
+        let dcd = resp
+            .headers()
+            .get("Docker-Content-Digest")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let clen = resp
+            .headers()
+            .get(CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("collect body")
+            .to_vec();
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dcd.as_deref(), Some(digest.as_str()));
+        assert_eq!(clen.as_deref(), Some(layer.len().to_string().as_str()));
+        assert!(body.is_empty(), "HEAD must not return a body");
+
+        drop(server);
+        cleanup(&pool, &[virt_id, member_id]).await;
         let _ = std::fs::remove_dir_all(&tmp);
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1183,6 +1183,33 @@ pub async fn proxy_fetch_streaming_with_cache_key(
     fetch_path: &str,
     cache_path: &str,
 ) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
+    proxy_fetch_streaming_with_cache_key_verified(
+        proxy_service,
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        cache_path,
+        None,
+    )
+    .await
+}
+
+/// Digest-gated sibling of [`proxy_fetch_streaming_with_cache_key`] (#2274).
+/// Identical, except the proxy-cache commit is gated on `expected_checksum`
+/// (bare lowercase SHA-256 hex): a streamed body whose SHA-256 does not match
+/// is served to the client but NOT persisted, so a digest-addressed upstream
+/// answering with wrong bytes cannot poison the cache. The OCI virtual-repo
+/// blob fallback passes the requested blob digest here.
+pub async fn proxy_fetch_streaming_with_cache_key_verified(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    expected_checksum: Option<String>,
+) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
     with_proxy_repo(
         repo_id,
         repo_key,
@@ -1190,7 +1217,12 @@ pub async fn proxy_fetch_streaming_with_cache_key(
         fetch_path,
         |repo| async move {
             proxy_service
-                .fetch_artifact_streaming_with_cache_path(&repo, fetch_path, cache_path)
+                .fetch_artifact_streaming_with_cache_path_gated(
+                    &repo,
+                    fetch_path,
+                    cache_path,
+                    expected_checksum,
+                )
                 .await
         },
     )

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -460,7 +460,7 @@ pub async fn wait_for_cached_blob(dir: &std::path::Path, min_size: u64) {
 /// True when `dir` holds a committed proxy-cache entry of at least
 /// `min_size` bytes: a `{base}__content__` object of that size whose
 /// matching `{base}__cache_meta__.json` sidecar exists.
-fn committed_cache_entry_exists(dir: &std::path::Path, min_size: u64) -> bool {
+pub fn committed_cache_entry_exists(dir: &std::path::Path, min_size: u64) -> bool {
     let Ok(entries) = std::fs::read_dir(dir) else {
         return false;
     };

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -143,6 +143,16 @@ struct CacheMetadataTemplate {
     /// which does not currently surface the header into the tee template.
     last_modified: Option<String>,
     ttl_secs: i64,
+    /// Optional content-addressable checksum the cache commit is gated on
+    /// (#2274). Bare lowercase SHA-256 hex (no `sha256:` prefix). When
+    /// `Some`, [`CachePersister::tee_stream`] persists the cached object
+    /// ONLY if the streamed body's SHA-256 equals this value; a mismatch is
+    /// treated like a rejected write (object deleted, no metadata sidecar)
+    /// so a digest-addressed fetch that returns wrong bytes cannot poison
+    /// the proxy cache. `None` preserves the pre-existing behaviour for every
+    /// other streaming caller (deb/pypi/plain-Remote), which gate only on the
+    /// upstream Content-Length.
+    expected_checksum: Option<String>,
 }
 
 /// Bound on the in-flight chunk queue between the upstream-reader task
@@ -1210,6 +1220,37 @@ impl CachePersister {
             match put_result {
                 Ok(result) => match classify_stream_write(result.bytes_written, expected_len) {
                     StreamWriteOutcome::Commit => {
+                        // #2274 digest-gated commit: when the caller pinned an
+                        // expected content-addressable checksum (the OCI
+                        // virtual-repo blob fallback passes the requested blob
+                        // digest), refuse to persist a body whose streamed
+                        // SHA-256 does not match it. The bytes were already
+                        // forwarded to the client — which independently verifies
+                        // the digest — but the proxy cache must never be poisoned
+                        // with mismatched content addressed by that digest. Treat
+                        // a mismatch exactly like the truncated/empty reject path:
+                        // delete the object and skip the metadata sidecar so the
+                        // next request refetches upstream (self-heal).
+                        if let Some(expected) = template.expected_checksum.as_deref() {
+                            if result.checksum_sha256 != expected {
+                                tracing::warn!(
+                                    cache_key = %cache_key_for_writer,
+                                    "streamed body checksum does not match the requested digest; \
+                                     not caching (no metadata sidecar) so the cache entry cannot \
+                                     be poisoned"
+                                );
+                                if let Err(e) = storage_clone.delete(&cache_key_for_writer).await {
+                                    tracing::debug!(
+                                        cache_key = %cache_key_for_writer,
+                                        error = %e,
+                                        "best-effort delete of digest-mismatched proxy-cache \
+                                         object failed; the missing metadata sidecar still forces \
+                                         a refetch"
+                                    );
+                                }
+                                return;
+                            }
+                        }
                         let now = Utc::now();
                         // #1618 S9 / #1051: pin the storage backend's ETag at
                         // write time so the fast path can re-HEAD on each hit
@@ -2538,6 +2579,26 @@ impl ProxyService {
         fetch_path: &str,
         cache_path: &str,
     ) -> Result<StreamingFetchResult> {
+        self.fetch_artifact_streaming_with_cache_path_gated(repo, fetch_path, cache_path, None)
+            .await
+    }
+
+    /// Digest-gated sibling of [`Self::fetch_artifact_streaming_with_cache_path`]
+    /// (#2274). Behaves identically except that, when `expected_checksum` is
+    /// `Some` (bare lowercase SHA-256 hex), the background cache writer commits
+    /// the teed object ONLY if the streamed body's SHA-256 matches — otherwise
+    /// the object is dropped without a metadata sidecar (self-healing refetch).
+    /// Used by the OCI virtual-repo blob fallback so a member answering `200`
+    /// with wrong bytes for a digest-addressed URL cannot poison the cache. The
+    /// client still receives the streamed bytes and independently verifies the
+    /// digest, matching the plain-Remote blob path's serve posture.
+    pub async fn fetch_artifact_streaming_with_cache_path_gated(
+        &self,
+        repo: &Repository,
+        fetch_path: &str,
+        cache_path: &str,
+        expected_checksum: Option<String>,
+    ) -> Result<StreamingFetchResult> {
         // #1631 layer 2 (#1694): single-flight the cold-cache streaming path so
         // N concurrent requests for the same uncached object open upstream ONCE.
         // The streaming coordinator's followers subscribe to the leader's
@@ -2550,7 +2611,12 @@ impl ProxyService {
         const STREAM_REENTER_BUDGET: usize = 8;
         for _ in 0..STREAM_REENTER_BUDGET {
             if let Some(result) = self
-                .try_fetch_artifact_streaming_once(repo, fetch_path, cache_path)
+                .try_fetch_artifact_streaming_once(
+                    repo,
+                    fetch_path,
+                    cache_path,
+                    expected_checksum.clone(),
+                )
                 .await?
             {
                 return Ok(result);
@@ -2558,7 +2624,7 @@ impl ProxyService {
         }
         // Exhausted re-enters (pathological contention): do one final
         // uncoordinated attempt so the request never spuriously fails.
-        self.fetch_artifact_streaming_uncoordinated(repo, fetch_path, cache_path)
+        self.fetch_artifact_streaming_uncoordinated(repo, fetch_path, cache_path, expected_checksum)
             .await
     }
 
@@ -2597,6 +2663,7 @@ impl ProxyService {
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
+        expected_checksum: Option<String>,
     ) -> Result<Option<StreamingFetchResult>> {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
@@ -2628,6 +2695,7 @@ impl ProxyService {
                     cache_path,
                     cache_key.clone(),
                     metadata_key.clone(),
+                    expected_checksum.clone(),
                 )
             })
             .await?;
@@ -2774,6 +2842,7 @@ impl ProxyService {
         cache_path: &str,
         cache_key: String,
         metadata_key: String,
+        expected_checksum: Option<String>,
     ) -> Result<StreamHandle> {
         // Package Age Policy (#1770): the streaming path has no buffered
         // upstream `Last-Modified` to base a release-date hold on (#1771), so
@@ -2846,6 +2915,7 @@ impl ProxyService {
                 etag: upstream.etag,
                 last_modified: None,
                 ttl_secs: cache_ttl,
+                expected_checksum,
             },
             upstream.content_length,
         );
@@ -2906,6 +2976,7 @@ impl ProxyService {
         repo: &Repository,
         fetch_path: &str,
         cache_path: &str,
+        expected_checksum: Option<String>,
     ) -> Result<StreamingFetchResult> {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
@@ -2918,7 +2989,14 @@ impl ProxyService {
         }
 
         let handle = self
-            .open_streaming_leader(repo, fetch_path, cache_path, cache_key, metadata_key)
+            .open_streaming_leader(
+                repo,
+                fetch_path,
+                cache_path,
+                cache_key,
+                metadata_key,
+                expected_checksum,
+            )
             .await?;
         Ok(StreamingFetchResult::from(handle))
     }
@@ -7625,6 +7703,7 @@ mod tests {
             etag: None,
             last_modified: None,
             ttl_secs: 60,
+            expected_checksum: None,
         }
     }
 
@@ -7957,6 +8036,7 @@ mod tests {
             etag: Some("\"abc123\"".to_string()),
             last_modified: None,
             ttl_secs: 7200,
+            expected_checksum: None,
         };
         let mut client = tee_upstream_to_cache(
             upstream,

--- a/backend/tests/oci_virtual_resolution_tests.rs
+++ b/backend/tests/oci_virtual_resolution_tests.rs
@@ -209,12 +209,21 @@ async fn resolve_virtual_blob_walks_to_third_member_when_first_two_404() {
     let res = resolve_virtual_blob(&state, virt_id, "myimage", &blob_digest).await;
 
     match res {
-        Some(VirtualBlobResolution::Remote { content, .. }) => {
-            assert_eq!(content.as_ref(), blob_body.as_slice());
+        // #2274: the remote member blob is now STREAMED (teed into the proxy
+        // cache) rather than buffered. Collect the streamed body and assert it
+        // round-trips server_c's bytes.
+        Some(VirtualBlobResolution::RemoteStream { result }) => {
+            use futures::StreamExt;
+            let mut body = result.body;
+            let mut collected = Vec::new();
+            while let Some(chunk) = body.next().await {
+                collected.extend_from_slice(&chunk.expect("stream chunk"));
+            }
+            assert_eq!(collected.as_slice(), blob_body.as_slice());
         }
         other => panic!(
-            "expected Remote resolution from server_c, got {:?}",
-            other.map(|_| "Local")
+            "expected RemoteStream resolution from server_c, got {:?}",
+            other.map(|_| "non-stream")
         ),
     }
 


### PR DESCRIPTION
## Summary

Pulling a Docker/OCI image through a **virtual** repository failed with a 502/500
for any layer larger than 8 MiB on a cache miss. The plain-`Remote` docker blob
download already streams (since ≥1.3.0, `try_upstream_fetch_streaming_blob`), but
the **virtual-repo member blob fallback** in `resolve_virtual_blob` still fetched
the upstream blob through the *buffered* `proxy_fetch_capped(DEFAULT_METADATA_MAX_BYTES
= 8 MiB)` path and aborted (`BadGateway`) for any layer over the cap. That is the
`docker-public` (virtual) repro in the linked issue.

This change brings the virtual-member blob path to parity with the already-streaming
plain-`Remote` path:

- `resolve_virtual_blob` now streams the successful member's blob through the
  streaming proxy helper (teed into the proxy cache) instead of buffering it, via a
  new `VirtualBlobResolution::RemoteStream` variant rendered with the existing
  `build_oci_streaming_proxy_response`. Heap stays bounded by the ~4 MiB tee cap
  regardless of layer size (multi-GiB layers no longer risk OOM).
- **Digest-gated cache commit (cache-poisoning protection):** because a streamed
  blob cannot be verified before the first byte reaches the client, the proxy-cache
  *commit* is now gated on the streamed body's SHA-256 matching the requested
  content-addressable digest. A member that answers `200` with wrong bytes streams
  to the client (which independently verifies and rejects the digest) but is
  **never** persisted to the cache. Implemented as an optional `expected_checksum`
  on the streaming cache-commit path (`CacheMetadataTemplate` → `tee_stream`); all
  existing streaming callers (deb/pypi/plain-Remote) pass `None` and are unchanged.
- **Member selection preserved:** a member that 404s for the digest is still
  skipped and the next member is tried; only the first successful member's blob is
  streamed.
- The plain-`Remote` blob download path (`try_upstream_fetch_streaming_blob`) and
  the buffered manifest fallback are **not** touched.

Small config blobs and manifest resolution continue to work unchanged.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New DB-backed wiremock tests (model on the existing
`remote_blob_streams_large_layer_and_warms_cache`), in
`virtual_blob_streaming_fallback_tests`:

- `virtual_blob_streams_large_layer_from_member` — a 9 MiB (> 8 MiB) layer served
  by a Remote member of a Virtual repo resolves `200` with the correct
  `Docker-Content-Digest` and full body (was 502), and is served warm on the second
  pull (upstream fetched once).
- `virtual_blob_skips_404_member_and_streams_next` — a member that 404s for the
  digest is skipped to the next member.
- `virtual_blob_wrong_bytes_are_not_cached` — a member returning `200` with wrong
  bytes (sha ≠ requested digest) is streamed but **not** committed to the proxy
  cache (a second resolve refetches upstream; no committed cache entry exists).
- `handle_get_blob_streams_virtual_member_layer` / `handle_head_blob_reports_virtual_member_layer_headers`
  — end-to-end through the real OCI handlers.
- Updated `resolve_virtual_blob_walks_to_third_member_when_first_two_404`
  integration test to consume the streamed body.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manually verified on an isolated instance: created a Remote `docker-hub`
(`https://registry-1.docker.io`) wrapped in a Virtual `docker-public`, then pulled
`memcached:trixie` whose largest layer is ~28.4 MiB (> 8 MiB). The blob GET through
the virtual repo returned `200` with the full body and a matching
`Docker-Content-Digest` (previously 502), the second pull was served warm, and a
small config blob still resolved.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No migration. No new `sqlx::query!` macros (only runtime `sqlx::query`), so no
`.sqlx` prepare changes.

Closes #2274
