### PR TITLE
ci: serialize sync_worker claim-recovery tests in nextest db-serial group

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,16 @@
 #     — the `test_run_gc_*` tests run a cluster-wide GC reap and assert on the
 #     exact set of keys collected. A concurrent GC test reaps another's fixtures
 #     first, failing e.g. "GC result should include the upload temp and part keys".
+#   * `sync_worker.rs` `recover_expired_sync_task_claims` — the
+#     `expired_sync_task_claims_recover_and_fence_stale_owner` and
+#     `legacy_in_progress_sync_task_without_claim_metadata_recovers` tests seed an
+#     expired / legacy `in_progress` `sync_tasks` row, then call the recovery
+#     sweep, which UPDATEs *every* stale claim in the DB (no peer scope) and assert
+#     on the exact global count (`recovered == 1`). A sibling test's stale row is
+#     swept in the same pass, failing the count/fence assertions. (The peer-scoped
+#     `claim_pending_sync_tasks` concurrency tests only touch their own unique
+#     peer's rows via `WHERE peer_instance_id = $1` and hold live-TTL claims the
+#     sweep cannot match, so they stay parallel.)
 #
 # Under nextest's process-per-test model those in-process mutexes do NOT
 # serialize across the suite, so the tests interfere nondeterministically, fail,
@@ -24,11 +34,13 @@
 # Pin every test that mutates this shared DB state to a single-threaded test
 # group so nextest never runs two of them at once, restoring the serialization
 # the in-process mutexes provide under `cargo test`. Add new tests that take
-# STUCK_SCAN_LOCK_ID or `storage_gc_test_guard()` to the matching filter below.
+# STUCK_SCAN_LOCK_ID or `storage_gc_test_guard()`, or that call
+# `recover_expired_sync_task_claims` and assert on its global result, to the
+# matching filter below.
 
 [test-groups]
 db-serial = { max-threads = 1 }
 
 [[profile.default.overrides]]
-filter = 'test(cleanup_stuck_scans) | test(storage_gc_service::tests)'
+filter = 'test(cleanup_stuck_scans) | test(storage_gc_service::tests) | test(sync_worker::tests::expired_sync_task_claims_recover_and_fence_stale_owner) | test(sync_worker::tests::legacy_in_progress_sync_task_without_claim_metadata_recovers)'
 test-group = 'db-serial'


### PR DESCRIPTION
## Summary

Two `sync_worker` claim-recovery tests fail nondeterministically under the parallel
`nextest` runner, turning the `🧪 Backend Unit Tests` job red and blocking `CI Complete`
on every open PR:

- `services::sync_worker::tests::expired_sync_task_claims_recover_and_fence_stale_owner`
- `services::sync_worker::tests::legacy_in_progress_sync_task_without_claim_metadata_recovers`

Both tests seed an expired / legacy `in_progress` `sync_tasks` row and then call
`recover_expired_sync_task_claims`, which `UPDATE`s **every** stale claim in the database
(the recovery `WHERE` clause has no peer scope) and assert on the exact global result
(`recovered == 1`). Under nextest's process-per-test model these two run concurrently
against the shared test DB, so each recovery sweep also reaps the sibling's stale row and
the count / fence assertions fail. They pass in isolation and under single-process
`cargo test` (where they never overlap).

This is the same class of global-DB-state contention already handled by the `db-serial`
single-threaded test group (`cleanup_stuck_scans_*` on `STUCK_SCAN_LOCK_ID`, and the
`storage_gc_service` cluster-wide GC reap tests). These two recovery tests were simply
never added to that group.

### Change (config only — no product code, no test-logic change)

- Extend the `db-serial` group `filter` in `.config/nextest.toml` to also match the two
  flaky recovery tests, so nextest never runs them at the same time as each other or as
  the other global-DB-state tests.
- Update the explanatory comment block to document the
  `recover_expired_sync_task_claims` case alongside the existing
  `STUCK_SCAN_LOCK_ID` / `storage_gc` notes, so future additions follow the pattern.

The original `test(cleanup_stuck_scans)` and `test(storage_gc_service::tests)` entries are
kept intact.

### Scope: the other `sync_worker` claim tests stay parallel

`sync_policy_reevaluation_preserves_live_claim_and_finalizes`,
`claim_pending_sync_tasks_exactly_once_under_concurrency`, and
`claim_pending_sync_tasks_caps_peer_under_concurrency` were reviewed and deliberately left
parallel: each operates only on its own fixture's unique `peer_id` via
`claim_pending_sync_tasks` (peer-scoped `WHERE peer_instance_id = $1` for both the
candidate select and the live-claim `COUNT`), holds live-TTL claims that the recovery
sweep's `claim_expires_at <= NOW()` predicate cannot match, asserts only on its own
task/peer rows, and never calls the un-scoped `recover_expired_sync_task_claims`. A
codebase-wide check confirms the two serialized tests are the only ones that assert on the
global recovery result, so there is no remaining latent flake in this class.

### Verification

Against a throwaway Postgres, the DB-backed `sync_worker` tests at `-j8`
(process-per-test):

- **Before** (unpatched `.config/nextest.toml`): 12 runs → **1 failure** reproducing the
  race — both recovery tests panicked at `sync_worker.rs:4289` on
  `assert_eq!(recovered, 1, "expired claim must be recovered")` (each sweep counted the
  sibling's stale row).
- **After** (patched config): 15 consecutive runs → **0 failures**.

`cargo build --lib --tests` clean; `cargo fmt --check` clean. No migration, no sqlx change,
no clippy impact expected (TOML-only diff).

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

<!-- This is a test-execution-isolation config change only (no product code). The
recovery tests themselves are the regression coverage; the before/after flake
reproduction above (fails without this change, passes with it) is the evidence. -->

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2282
