### PR TITLE
test(maven): pin metadata checksum recompute for hosted SNAPSHOT deploy

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -4282,6 +4282,214 @@ mod tests {
         );
     }
 
+    /// Drive the real `upload` (PUT) handler for `<repo_key>/<path>`, asserting
+    /// a 201. Mirrors what a Maven client does when it deploys an object
+    /// (metadata body or a `.sha1`/`.md5` sidecar) to a hosted repo.
+    async fn put_object(
+        state: &SharedState,
+        auth: &AuthExtension,
+        repo_key: &str,
+        path: &str,
+        body: &[u8],
+    ) {
+        use axum::extract::{Path, State};
+        use axum::Extension;
+
+        let resp = upload(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Path((repo_key.to_string(), path.to_string())),
+            axum::http::HeaderMap::new(),
+            bytes::Bytes::copy_from_slice(body),
+        )
+        .await
+        .expect("upload must succeed");
+        assert_eq!(
+            resp.status(),
+            axum::http::StatusCode::CREATED,
+            "PUT {} must be 201",
+            path
+        );
+    }
+
+    /// HOSTED repo, reporter's exact shape (#2183): a Maven client `mvn deploy`
+    /// PUTs a SNAPSHOT `maven-metadata.xml` AND a `maven-metadata.xml.sha1`
+    /// (and `.md5`) sidecar whose stored bytes DELIBERATELY DO NOT MATCH the
+    /// XML. On 1.2.0 the read path served the stored sidecar verbatim while the
+    /// body could be (re)generated, so `.sha1` diverged from the served
+    /// `maven-metadata.xml` and stayed wrong across re-deploys. #1922 made the
+    /// checksum a single source of truth: the download handler recomputes it
+    /// from the exact bytes the sibling `maven-metadata.xml` URL serves and
+    /// never reads the stored sidecar for a metadata checksum. This pins that
+    /// the planted-wrong sidecar is IGNORED and the served `.sha1`/`.md5` equal
+    /// the checksum of the served metadata body — the one case #1922's tests
+    /// (local-dynamic / virtual-merged / remote-bogus-upstream) did not cover.
+    #[tokio::test]
+    async fn test_resolver_hosted_snapshot_ignores_mismatched_sidecar_2183() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (repo_id, repo_key, dir) = tdh::create_repo(&pool, "local", "maven").await;
+        let (user_id, username) = tdh::create_user(&pool).await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+
+        let state = tdh::build_state(pool.clone(), dir.to_str().unwrap());
+        let auth = tdh::make_auth(user_id, &username);
+
+        let meta_path = "com/example/foo/1.0.0-SNAPSHOT/maven-metadata.xml";
+        // A realistic SNAPSHOT metadata body, exactly as a Maven client renders
+        // and uploads it to a hosted repo.
+        let meta_v1 = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<metadata>\n",
+            "  <groupId>com.example</groupId>\n",
+            "  <artifactId>foo</artifactId>\n",
+            "  <version>1.0.0-SNAPSHOT</version>\n",
+            "  <versioning>\n",
+            "    <snapshot>\n",
+            "      <timestamp>20240101.000000</timestamp>\n",
+            "      <buildNumber>1</buildNumber>\n",
+            "    </snapshot>\n",
+            "    <lastUpdated>20240101000000</lastUpdated>\n",
+            "    <snapshotVersions>\n",
+            "      <snapshotVersion>\n",
+            "        <extension>jar</extension>\n",
+            "        <value>1.0.0-20240101.000000-1</value>\n",
+            "        <updated>20240101000000</updated>\n",
+            "      </snapshotVersion>\n",
+            "    </snapshotVersions>\n",
+            "  </versioning>\n",
+            "</metadata>\n",
+        )
+        .as_bytes();
+
+        // The client uploads the metadata AND deliberately-WRONG sidecars.
+        // (A real client uploads the correct digest, but 1.2.0's bug was that
+        // AK served the STORED sidecar; planting a wrong one makes any
+        // regression to that behavior unmistakable.)
+        let bogus_sha1 = "0000bogussha1value000000000000000000000000";
+        let bogus_md5 = "ffffbogusmd5value00000000000000f";
+        put_object(&state, &auth, &repo_key, meta_path, meta_v1).await;
+        put_object(
+            &state,
+            &auth,
+            &repo_key,
+            &format!("{}.sha1", meta_path),
+            bogus_sha1.as_bytes(),
+        )
+        .await;
+        put_object(
+            &state,
+            &auth,
+            &repo_key,
+            &format!("{}.md5", meta_path),
+            bogus_md5.as_bytes(),
+        )
+        .await;
+
+        // GET the metadata + its checksum siblings via the real download handler.
+        let (sha1_body, sha1) =
+            served_metadata_and_checksum(&state, &auth, &repo_key, meta_path, "sha1").await;
+        let (md5_body, md5) =
+            served_metadata_and_checksum(&state, &auth, &repo_key, meta_path, "md5").await;
+
+        // The served metadata body must be the stored SNAPSHOT document.
+        assert_eq!(
+            sha1_body.as_ref(),
+            meta_v1,
+            "hosted repo must serve the stored maven-metadata.xml verbatim"
+        );
+        assert_eq!(sha1_body, md5_body, "both GETs must serve identical bytes");
+
+        // The checksum must be recomputed from the SERVED bytes — never the
+        // planted-wrong stored sidecar (this is the exact #2183 assertion).
+        assert_eq!(
+            sha1,
+            compute_checksum(&sha1_body, ChecksumType::Sha1),
+            "served .sha1 must equal sha1 of the served metadata body (#2183)"
+        );
+        assert_ne!(
+            sha1, bogus_sha1,
+            "served .sha1 must NOT be the planted mismatched sidecar (#2183)"
+        );
+        assert_eq!(
+            md5,
+            compute_checksum(&md5_body, ChecksumType::Md5),
+            "served .md5 must equal md5 of the served metadata body (#2183)"
+        );
+        assert_ne!(
+            md5, bogus_md5,
+            "served .md5 must NOT be the planted mismatched sidecar (#2183)"
+        );
+
+        // Re-deploy: PUT an UPDATED metadata body (new buildNumber/timestamp)
+        // plus, again, a stale wrong sidecar. The served `.sha1`/`.md5` must
+        // stay in lockstep with the NEW served XML — proving the checksum
+        // tracks the body across re-deploy (the reporter observed the mismatch
+        // persisting across re-deploys on 1.2.0).
+        let meta_v2 = concat!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n",
+            "<metadata>\n",
+            "  <groupId>com.example</groupId>\n",
+            "  <artifactId>foo</artifactId>\n",
+            "  <version>1.0.0-SNAPSHOT</version>\n",
+            "  <versioning>\n",
+            "    <snapshot>\n",
+            "      <timestamp>20240202.020202</timestamp>\n",
+            "      <buildNumber>2</buildNumber>\n",
+            "    </snapshot>\n",
+            "    <lastUpdated>20240202020202</lastUpdated>\n",
+            "    <snapshotVersions>\n",
+            "      <snapshotVersion>\n",
+            "        <extension>jar</extension>\n",
+            "        <value>1.0.0-20240202.020202-2</value>\n",
+            "        <updated>20240202020202</updated>\n",
+            "      </snapshotVersion>\n",
+            "    </snapshotVersions>\n",
+            "  </versioning>\n",
+            "</metadata>\n",
+        )
+        .as_bytes();
+        put_object(&state, &auth, &repo_key, meta_path, meta_v2).await;
+        // Sidecar is still stale/wrong after re-deploy.
+        put_object(
+            &state,
+            &auth,
+            &repo_key,
+            &format!("{}.sha1", meta_path),
+            bogus_sha1.as_bytes(),
+        )
+        .await;
+
+        let (sha1_body2, sha1_2) =
+            served_metadata_and_checksum(&state, &auth, &repo_key, meta_path, "sha1").await;
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+
+        assert_eq!(
+            sha1_body2.as_ref(),
+            meta_v2,
+            "re-deploy must serve the UPDATED stored metadata body"
+        );
+        assert_ne!(
+            sha1_body2, sha1_body,
+            "the re-deployed body must actually differ from the first deploy"
+        );
+        assert_eq!(
+            sha1_2,
+            compute_checksum(&sha1_body2, ChecksumType::Sha1),
+            "after re-deploy the served .sha1 must track the NEW served body (#2183)"
+        );
+        assert_ne!(
+            sha1_2, bogus_sha1,
+            "re-deployed .sha1 must still ignore the planted mismatched sidecar (#2183)"
+        );
+    }
+
     /// VIRTUAL maven repo merging a LOCAL member's versions with a REMOTE
     /// member's versions proxied from upstream — exercises the CONCURRENT
     /// metadata-merge fan-out (#2069): `fetch_remote_member_metadata` plus the


### PR DESCRIPTION
## Summary

Adds a DB-backed regression test pinning the exact shape reported in #2183: a
**hosted** Maven repo where a client `mvn deploy` PUTs a SNAPSHOT
`maven-metadata.xml` **and** a `maven-metadata.xml.sha1`/`.md5` sidecar whose
stored bytes do **not** match the metadata XML.

The underlying defect was real on 1.2.0 — the read path served the stored
checksum sidecar verbatim while the metadata body could be (re)generated, so the
served `.sha1` diverged from the served `maven-metadata.xml` and the mismatch
persisted across re-deploys. It was **already fixed on `main` by #1922**, which
made the metadata checksum a single source of truth: the download handler
recomputes the digest from the exact bytes the sibling `maven-metadata.xml` URL
serves (`backend/src/api/handlers/maven.rs`) and never reads the stored sidecar
for a metadata checksum.

#1922 shipped tests for the local-dynamic, virtual-merged, and
remote-with-bogus-upstream-sidecar cases, but not the reporter's precise
hosted-with-mismatched-stored-sidecar shape. This PR pins that last case shut. No
product code changes; test-only.

Reporters still on 1.2.0 should upgrade past the release that shipped #1922
(1.2.1+) — the served checksum has tracked the served metadata body since then.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

The new `test_resolver_hosted_snapshot_ignores_mismatched_sidecar_2183`:
1. Creates a hosted Maven repo; via the real `upload` (PUT) handler deploys a
   SNAPSHOT `maven-metadata.xml`, then a `maven-metadata.xml.sha1` and `.md5`
   whose contents are deliberately wrong.
2. GETs the checksum siblings through the real `download` handler and asserts
   each equals the checksum of the **served** metadata bytes (fetched through the
   same handler the metadata URL uses) and is **not** the planted wrong value.
3. Re-deploys with an updated body + a still-stale sidecar and asserts the served
   `.sha1` tracks the new served XML (stays in lockstep across re-deploy).

The test would fail against pre-#1922 behavior (served-stored-sidecar) and passes
on current `main`, confirming #1922 closed the issue.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2183
