### PR TITLE
fix(sbom): don't offer SBOM/scan for proxy-cached remote artifacts

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2062,6 +2062,17 @@ pub struct ArtifactResponse {
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[schema(value_type = Option<Object>)]
     pub metadata: Option<serde_json::Value>,
+    /// Whether this artifact can have an SBOM generated or a security scan
+    /// run against it. `false` for proxy-cached (Remote) objects: those are
+    /// listed with a synthetic, SHA-256-derived id (see
+    /// [`cached_artifact_id`]) and have no row in the `artifacts` table
+    /// (#1280/#1278), so SBOM/scan lookups by `artifacts.id` cannot resolve
+    /// them and `sbom_documents`/`scan_results` cannot reference them.
+    /// `true` for hosted artifacts, which carry a real DB id. The web UI
+    /// uses this to hide/disable the "Generate SBOM" / "Scan" actions where
+    /// they cannot work; clients that predate the field should treat an
+    /// absent value as `true` so hosted artifacts are never hidden. (#2227)
+    pub analyzable: bool,
     /// When the proxy cache entry for this artifact was last written.
     /// Only populated for Remote (proxy) repositories whose proxy service is
     /// configured AND that have a cache-metadata blob for this path. None
@@ -2535,6 +2546,9 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
+        // Proxy-cached objects have no `artifacts` row (#1280/#1278) and a
+        // synthetic id, so SBOM/scan cannot resolve them: not analyzable.
+        analyzable: false,
         // This is a proxy-cache entry, so surface the cache timestamp.
         // CachedArtifactEntry carries no expiry, so cache_expires_at is None.
         cache_cached_at: Some(entry.cached_at),
@@ -2711,6 +2725,8 @@ fn build_artifact_response(
         download_count,
         created_at: artifact.created_at,
         metadata: None,
+        // Hosted artifact backed by a real `artifacts` row: SBOM/scan resolve.
+        analyzable: true,
         // Cache metadata is surfaced only by the per-artifact metadata
         // endpoint to avoid fanning out a storage GET per artifact in
         // listings (#1541). Helpers used by listings leave these as None;
@@ -2762,6 +2778,9 @@ fn expand_maven_secondary_files(
             download_count: 0,
             created_at: artifact.created_at,
             metadata: None,
+            // Secondary Maven files are recorded under a real primary
+            // artifact row (its id), so they are analyzable like the primary.
+            analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
         });
@@ -3601,6 +3620,9 @@ pub async fn get_artifact_metadata(
             download_count: downloads,
             created_at: artifact.created_at,
             metadata: metadata.map(|m| m.metadata),
+            // This handler resolves a real `artifacts` row by id, so it is
+            // always a hosted artifact (analyzable), even inside a Remote repo.
+            analyzable: true,
             cache_cached_at: cache_meta.as_ref().map(|m| m.cached_at),
             cache_expires_at: cache_meta.as_ref().map(|m| m.expires_at),
         })
@@ -3847,6 +3869,8 @@ pub async fn upload_artifact(
             download_count: downloads,
             created_at: artifact.created_at,
             metadata: metadata_json,
+            // Freshly-uploaded hosted artifact with a real DB id: analyzable.
+            analyzable: true,
             // Just-uploaded artifacts have no proxy cache state yet -- the
             // cache is populated lazily on the first proxy fetch.
             cache_cached_at: None,
@@ -5967,6 +5991,10 @@ mod tests {
         assert_eq!(resp.checksum_sha256, "deadbeef");
         assert_eq!(resp.download_count, 0);
         assert!(resp.version.is_none());
+        // Proxy-cached objects have no `artifacts` row and a synthetic id,
+        // so they cannot be SBOM'd or scanned: the listing marks them
+        // non-analyzable so the UI hides those actions (#2227).
+        assert!(!resp.analyzable);
         // A cached-listing entry is a live proxy-cache object, so its
         // freshness timestamp is exactly when it was cached; the sidecar
         // projection carries no expiry. (Asserting these guards the
@@ -6020,6 +6048,8 @@ mod tests {
         assert_eq!(resp.size_bytes, 500);
         assert_eq!(resp.checksum_sha256, "primary-sha");
         assert_eq!(resp.download_count, 42);
+        // Hosted artifacts have a real DB id, so SBOM/scan resolve: analyzable.
+        assert!(resp.analyzable);
     }
 
     // -----------------------------------------------------------------------
@@ -7386,12 +7416,16 @@ mod tests {
             download_count: 42,
             created_at: chrono::Utc::now(),
             metadata: None,
+            analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
         };
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"download_count\":42"));
         assert!(json.contains("\"size_bytes\":1024"));
+        // `analyzable` is always serialized (no serde skip) so clients can
+        // gate the SBOM/Scan actions on it (#2227).
+        assert!(json.contains("\"analyzable\":true"));
         // Cache fields are omitted when None so the wire shape stays the
         // same for non-Remote repos and for Remote repos without cache
         // metadata (#1541).
@@ -7425,6 +7459,7 @@ mod tests {
             download_count: 0,
             created_at: cached,
             metadata: None,
+            analyzable: false,
             cache_cached_at: Some(cached),
             cache_expires_at: Some(expires),
         };

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -19,6 +19,15 @@ use crate::models::sbom::{
 use crate::services::audit_service::{AuditAction, AuditEntry, AuditService, ResourceType};
 use crate::services::sbom_service::{DependencyInfo, LicenseCheckResult, SbomService};
 
+/// Not-found message for artifact-scoped analysis endpoints (SBOM generate,
+/// CVE history). A bare "Artifact not found" was confusing for proxy-cached
+/// (Remote) objects: those are listed with a synthetic, SHA-256-derived id and
+/// have no row in the `artifacts` table (#1280/#1278), so SBOM/scan lookups by
+/// `artifacts.id` can never resolve them even though the object is visible in
+/// the listing. This message distinguishes that expected case from a genuine
+/// missing id and tells the caller what actually works. (#2227)
+pub(crate) const ARTIFACT_NOT_ANALYZABLE_MSG: &str = "Artifact not found or not eligible for analysis: SBOM generation and security scanning are available only for artifacts hosted in this registry, not proxy-cached remote artifacts.";
+
 /// Emit an audit log entry for an SBOM action against an artifact. Failures
 /// are logged but never propagated: the mutation/read is already complete and
 /// breaking the response over a best-effort audit write would do callers no
@@ -353,7 +362,7 @@ async fn generate_sbom(
             .fetch_optional(&state.db)
             .await
             .map_err(|e: sqlx::Error| AppError::Database(e.to_string()))?
-            .ok_or_else(|| AppError::NotFound("Artifact not found".into()))?;
+            .ok_or_else(|| AppError::NotFound(ARTIFACT_NOT_ANALYZABLE_MSG.into()))?;
 
     // If force_regenerate, delete existing SBOM first
     if body.force_regenerate {
@@ -1601,7 +1610,7 @@ async fn ensure_artifact_repo_access(
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
 
-    require_repo_access(auth, repo_id, "Artifact not found")
+    require_repo_access(auth, repo_id, ARTIFACT_NOT_ANALYZABLE_MSG)
 }
 
 /// Like [`ensure_artifact_repo_access`] but resolves through `sbom_documents`
@@ -2344,6 +2353,27 @@ mod tests {
         let auth = make_auth(None, false);
         let err = require_repo_access(&auth, None, "SBOM not found").unwrap_err();
         assert!(matches!(err, AppError::NotFound(_)));
+    }
+
+    #[test]
+    fn test_artifact_analysis_missing_uses_honest_not_analyzable_message() {
+        // #2227: the artifact-scoped analysis endpoints (SBOM generate, CVE
+        // history) no longer return a bare "Artifact not found". When the id
+        // has no `artifacts` row -- e.g. the synthetic id a Remote repo lists
+        // for a proxy-cached object -- the caller must learn that analysis is
+        // only available for hosted artifacts. Pin the exact wording that
+        // `ensure_artifact_repo_access` (and `generate_sbom`) surface.
+        let auth = make_auth(None, false);
+        let err = require_repo_access(&auth, None, ARTIFACT_NOT_ANALYZABLE_MSG).unwrap_err();
+        match err {
+            AppError::NotFound(msg) => {
+                assert_eq!(msg, ARTIFACT_NOT_ANALYZABLE_MSG);
+                assert!(msg.contains("hosted in this registry"));
+                assert!(msg.contains("proxy-cached remote artifacts"));
+                assert_ne!(msg, "Artifact not found");
+            }
+            other => panic!("expected NotFound with the honest message, got {:?}", other),
+        }
     }
 
     #[test]

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -614,6 +614,25 @@ async fn trigger_scan(
     }
 
     if let Some(artifact_id) = body.artifact_id {
+        // Honest not-found up front (#2227): without this, an id with no
+        // `artifacts` row -- e.g. the synthetic, SHA-256-derived id a Remote
+        // repo lists for a proxy-cached object (#1280/#1278) -- returned a
+        // fire-and-forget 200 and then failed only in the worker's logs
+        // ("Scan failed for artifact ...: Artifact not found"). Resolve the
+        // row first and return a clear 404 so the caller learns that scans
+        // are only available for artifacts hosted in this registry.
+        let exists: Option<Uuid> =
+            sqlx::query_scalar("SELECT id FROM artifacts WHERE id = $1 AND is_deleted = false")
+                .bind(artifact_id)
+                .fetch_optional(&state.db)
+                .await
+                .map_err(|e: sqlx::Error| AppError::Database(e.to_string()))?;
+        if exists.is_none() {
+            return Err(AppError::NotFound(
+                crate::api::handlers::sbom::ARTIFACT_NOT_ANALYZABLE_MSG.into(),
+            ));
+        }
+
         // Pre-allocate one scan_result row per configured scanner so the IDs
         // can be returned in this response. The actual scan work is still
         // fire-and-forget (tokio::spawn) but uses these pre-committed IDs

--- a/backend/tests/sbom_cached_artifact_not_analyzable_tests.rs
+++ b/backend/tests/sbom_cached_artifact_not_analyzable_tests.rs
@@ -1,0 +1,184 @@
+//! DB-gated invariant tests for #2227: SBOM/scan resolution of proxy-cached
+//! (Remote) objects.
+//!
+//! Root cause of #2227: a Remote (proxy) repository lists a proxy-cached
+//! object with a *synthetic* id derived from `SHA-256("proxy-cache/<key>/<path>")`
+//! (see `cached_artifact_id` in `api::handlers::repositories`). That object has
+//! **no row** in the `artifacts` table by design (#1280/#1278), so every
+//! artifact-scoped analysis handler — SBOM generate (`generate_sbom`), CVE
+//! history (`ensure_artifact_repo_access`) and the scan trigger
+//! (`trigger_scan`) — resolves the id strictly against `artifacts.id` and
+//! finds nothing, returning 404. Hosted (Local) npm/Docker artifacts have real
+//! v4 ids and continue to resolve.
+//!
+//! These tests pin that invariant at the DB layer the three handlers share:
+//! a hosted npm artifact and a hosted Docker manifest artifact both resolve,
+//! while the synthetic cached id resolves to nothing.
+//!
+//! Requires a PostgreSQL database with migrations applied. Run:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test sbom_cached_artifact_not_analyzable_tests -- --ignored
+//! ```
+
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Recompute the synthetic proxy-cache id exactly as
+/// `api::handlers::repositories::cached_artifact_id` does: the first 16 bytes
+/// of `SHA-256("proxy-cache/<repo_key>/<path>")`. Kept in sync manually because
+/// the source helper is private to the handler module. If this drifts, the
+/// listing and these tests disagree, which is itself the bug to catch.
+fn synthetic_cached_id(repo_key: &str, path: &str) -> Uuid {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("proxy-cache/{}/{}", repo_key, path).as_bytes());
+    let digest = hasher.finalize();
+    let mut bytes = [0u8; 16];
+    bytes.copy_from_slice(&digest[..16]);
+    Uuid::from_bytes(bytes)
+}
+
+async fn create_repo(pool: &PgPool, format: &str) -> (Uuid, String) {
+    let id = Uuid::new_v4();
+    let key = format!("test-2227-{}-{}", format, id);
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+         VALUES ($1, $2, $3, $4, 'local', $5::repository_format)",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(format!("2227-{}", id))
+    .bind(format!("/tmp/test-artifacts/{}", id))
+    .bind(format)
+    .execute(pool)
+    .await
+    .expect("failed to create test repository");
+    (id, key)
+}
+
+async fn insert_hosted_artifact(
+    pool: &PgPool,
+    repo_id: Uuid,
+    name: &str,
+    path: &str,
+    content_type: &str,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO artifacts (id, repository_id, name, path, size_bytes, checksum_sha256,
+                               content_type, storage_key, is_deleted)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $4, false)
+        "#,
+    )
+    .bind(id)
+    .bind(repo_id)
+    .bind(name)
+    .bind(path)
+    .bind(2048_i64)
+    .bind(format!("{:x}", Sha256::digest(path.as_bytes())))
+    .bind(content_type)
+    .execute(pool)
+    .await
+    .expect("failed to insert hosted artifact");
+    id
+}
+
+/// The resolution the three analysis handlers share: `generate_sbom` selects
+/// `(id, repository_id)`, `ensure_artifact_repo_access` selects
+/// `repository_id ... AND NOT is_deleted`, and the `trigger_scan` pre-check
+/// selects `id ... AND is_deleted = false`. All agree for these fixtures, so a
+/// single existence probe models the honest-404-vs-resolves decision.
+async fn artifact_resolves(pool: &PgPool, artifact_id: Uuid) -> bool {
+    let row: Option<Uuid> =
+        sqlx::query_scalar("SELECT id FROM artifacts WHERE id = $1 AND is_deleted = false")
+            .bind(artifact_id)
+            .fetch_optional(pool)
+            .await
+            .expect("resolution query failed");
+    row.is_some()
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid) {
+    sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+#[tokio::test]
+#[ignore] // Requires database
+async fn hosted_npm_and_docker_artifacts_resolve_but_synthetic_cached_id_does_not() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").expect("DATABASE_URL"))
+        .await
+        .expect("failed to connect to database");
+
+    // Hosted npm artifact (real v4 id) -> analysis resolves. (Regression guard:
+    // the fix must not break SBOM/scan for hosted artifacts.)
+    let (npm_repo, npm_key) = create_repo(&pool, "npm").await;
+    let npm_id = insert_hosted_artifact(
+        &pool,
+        npm_repo,
+        "left-pad-1.3.0.tgz",
+        "left-pad/1.3.0/left-pad-1.3.0.tgz",
+        "application/octet-stream",
+    )
+    .await;
+    assert!(
+        artifact_resolves(&pool, npm_id).await,
+        "hosted npm artifact must resolve so SBOM/scan still works"
+    );
+
+    // Hosted Docker/OCI manifest artifact (real v4 id) -> analysis resolves.
+    let (docker_repo, docker_key) = create_repo(&pool, "docker").await;
+    let docker_id = insert_hosted_artifact(
+        &pool,
+        docker_repo,
+        "sha256:manifest",
+        "library/postgres/manifests/16-alpine",
+        "application/vnd.oci.image.manifest.v1+json",
+    )
+    .await;
+    assert!(
+        artifact_resolves(&pool, docker_id).await,
+        "hosted Docker manifest artifact must resolve so SBOM/scan still works"
+    );
+
+    // Synthetic proxy-cache ids for a Remote npm and a Remote docker object:
+    // no `artifacts` row exists, so resolution misses and the handlers return
+    // the honest not-analyzable 404 instead of a silent success.
+    let synth_npm = synthetic_cached_id("npm-remote", "left-pad/-/left-pad-1.3.0.tgz");
+    let synth_docker = synthetic_cached_id("docker-remote", "library/postgres/manifests/16-alpine");
+    assert!(
+        !artifact_resolves(&pool, synth_npm).await,
+        "synthetic proxy-cache npm id must not resolve (#1280/#1278 invariant)"
+    );
+    assert!(
+        !artifact_resolves(&pool, synth_docker).await,
+        "synthetic proxy-cache docker id must not resolve (#1280/#1278 invariant)"
+    );
+
+    // The synthetic id is deterministic and distinct from the hosted ids.
+    assert_eq!(
+        synth_npm,
+        synthetic_cached_id("npm-remote", "left-pad/-/left-pad-1.3.0.tgz"),
+        "synthetic id must be stable for the same repo_key + path"
+    );
+    assert_ne!(synth_npm, npm_id);
+    assert_ne!(synth_docker, docker_id);
+
+    // Silence unused-key warnings; keys document the Remote repos the synthetic
+    // ids would have been listed under.
+    let _ = (npm_key, docker_key);
+
+    cleanup(&pool, npm_repo).await;
+    cleanup(&pool, docker_repo).await;
+}


### PR DESCRIPTION
## Summary

Requesting an SBOM (or a security scan) for an artifact shown under a **Remote
(proxy) repository** failed with a confusing `404 "Artifact not found"` for both
npm and Docker packages (#2227).

Root cause: proxy-cached (Remote) objects are listed with a **synthetic,
SHA-256-derived id** (`cached_artifact_id`, `repositories.rs`) and, by design,
have **no row in the `artifacts` table** (#1280/#1278). Every artifact-scoped
analysis handler resolves strictly by `artifacts.id`:

- SBOM create (`generate_sbom`, `sbom.rs`)
- SBOM CVE history (`ensure_artifact_repo_access`, `sbom.rs`)
- security scan (`trigger_scan`, `security.rs`)

so the row is never found and the request fails — even though the item is
visible in the listing. Hosted (Local) npm/Docker artifacts carry real v4 ids
and were never affected.

This is a correctness/UX hardening, not a feature: SBOM/scan of proxy-cached
remote artifacts was never supported (and cannot be, given the
`NOT NULL REFERENCES artifacts(id)` FKs on `sbom_documents`/`scan_results` and
the "cache is not an artifact row" invariant). The change makes the failure
honest and gives the UI an authoritative signal so the doomed action is no
longer offered.

What changed (backend only, no migration):

1. `ArtifactResponse` gains an `analyzable: bool` field. It is `false` for
   proxy-cached (Remote) listing entries (`build_cached_artifact_response`) and
   `true` for hosted artifacts (`build_artifact_response`, the per-artifact
   metadata handler, the generic upload response, and Maven secondary files).
   Clients that predate the field should treat an absent value as `true`.
2. The analysis endpoints return an actionable message instead of a bare
   "Artifact not found": *"Artifact not found or not eligible for analysis: SBOM
   generation and security scanning are available only for artifacts hosted in
   this registry, not proxy-cached remote artifacts."* This now covers SBOM
   create, CVE history, and the scan trigger (which previously accepted the
   request and failed only in worker logs).

The synthetic id computation is unchanged (clients dedupe listings by it) and no
proxy-cached object is inserted into `artifacts` (preserves the #1280/#1278
invariant and its pinned tests).

**Follow-up (separate web PR, ships after this backend change):** gate the
"Generate SBOM" / "Scan" actions on `artifact.analyzable === true` (hide/disable
for cached remote entries), defaulting to *shown* when the flag is absent so
hosted artifacts are never accidentally hidden. The backend flag added here is
the signal that web change needs.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Unit tests (`--lib`, no DB):
- `build_cached_artifact_response` sets `analyzable == false`;
  `build_artifact_response` sets `analyzable == true`; `ArtifactResponse`
  serializes `analyzable`.
- `sbom.rs`: the analysis not-found path surfaces the honest, non-"Artifact not
  found" message.

DB-gated integration test (`sbom_cached_artifact_not_analyzable_tests`,
`-- --ignored`): a hosted npm artifact and a hosted Docker manifest artifact
resolve, while a synthetic proxy-cache id (recomputed via the same
`SHA-256("proxy-cache/<key>/<path>")` scheme) does not — the exact invariant the
three handlers rely on.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance: a Remote npm repo lists cached
items with synthetic ids and `analyzable:false`; POST `/api/v1/sbom`, POST
`/api/v1/security/scan`, and GET `/api/v1/sbom/cve/history/{id}` with that
synthetic id all return `404` with the new message. A Local npm repo lists the
published package with `analyzable:true`, and SBOM create returns a generated
SBOM (scan queues) — hosted resolution unchanged.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

`ArtifactResponse` gains one additive, always-serialized field (`analyzable`);
no endpoints added or removed; no migration.

Closes #2227
