### PR TITLE
fix(auth): dedicated strict rate limit for the login endpoint

### DIFF
--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -3654,6 +3654,8 @@ mod tests {
                 rate_limit_presign_per_window: 30,
 
                 rate_limit_login_global_per_window: 8192,
+                rate_limit_login_per_window: 10,
+                rate_limit_login_window_secs: 900,
                 rate_limit_password_change_per_window: 5,
                 rate_limit_password_change_window_secs: 900,
                 rate_limit_window_secs: 60,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -6717,6 +6717,8 @@ mod tests {
                 rate_limit_presign_per_window: 30,
 
                 rate_limit_login_global_per_window: 8192,
+                rate_limit_login_per_window: 10,
+                rate_limit_login_window_secs: 900,
                 rate_limit_password_change_per_window: 5,
                 rate_limit_password_change_window_secs: 900,
                 rate_limit_window_secs: 60,

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -228,6 +228,8 @@ fn cfg(storage_path: &str) -> Config {
         rate_limit_presign_per_window: 30,
 
         rate_limit_login_global_per_window: 8192,
+        rate_limit_login_per_window: 10,
+        rate_limit_login_window_secs: 900,
         rate_limit_password_change_per_window: 5,
         rate_limit_password_change_window_secs: 900,
         rate_limit_window_secs: 60,

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -318,6 +318,16 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         state.config.rate_limit_login_global_per_window,
         state.config.rate_limit_window_secs,
     ));
+    // Dedicated tight per-(username, IP) bucket for the login endpoint. The
+    // login handler bcrypt-verifies the submitted password (and does so even
+    // for locked accounts), so borrowing the loose general-auth budget lets a
+    // single client drive a burst of verifies that saturates CPU. This budget
+    // sheds excess login attempts as 429 in the middleware layer, before the
+    // verifier runs. Default: 10 attempts / 15 minutes per (username, IP).
+    let login_rate_limiter = Arc::new(RateLimiter::new(
+        state.config.rate_limit_login_per_window,
+        state.config.rate_limit_login_window_secs,
+    ));
     // Stricter per-user bucket for self-password-change attempts. The
     // handler bcrypt-verifies the current password, so an attacker who
     // already holds the victim's JWT can otherwise drive ~`api/min`
@@ -343,12 +353,12 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         enabled: rate_limit_enabled,
         trusted_proxies: Arc::clone(&trusted_proxies),
     };
-    // Login-only state: keys the shared auth limiter per-(username, IP) and
-    // gates it behind the global shedding backstop. Applied only to /login so
-    // /logout and /refresh keep the plain IP-keyed limiter.
+    // Login-only state: keys the dedicated tight login limiter per-(username,
+    // IP) and gates it behind the global shedding backstop. Applied only to
+    // /login so /logout and /refresh keep the looser auth limiter.
     let login_rate_limit_state = LoginRateLimitState {
         inner: RateLimitState {
-            limiter: Arc::clone(&auth_rate_limiter),
+            limiter: Arc::clone(&login_rate_limiter),
             exemptions: Arc::clone(&exemptions),
             enabled: rate_limit_enabled,
             trusted_proxies: Arc::clone(&trusted_proxies),
@@ -397,6 +407,7 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
         let search_cleanup = Arc::clone(&search_rate_limiter);
         let presign_cleanup = Arc::clone(&presign_rate_limiter);
         let login_global_cleanup = Arc::clone(&login_global_rate_limiter);
+        let login_cleanup = Arc::clone(&login_rate_limiter);
         let password_change_cleanup = Arc::clone(&password_change_rate_limiter);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
@@ -407,6 +418,7 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 search_cleanup.cleanup_expired().await;
                 presign_cleanup.cleanup_expired().await;
                 login_global_cleanup.cleanup_expired().await;
+                login_cleanup.cleanup_expired().await;
                 password_change_cleanup.cleanup_expired().await;
             }
         });

--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -483,6 +483,22 @@ pub struct Config {
     /// sheds rather than starves. Env var:
     /// `RATE_LIMIT_LOGIN_GLOBAL_PER_WINDOW`. Default: 8192.
     pub rate_limit_login_global_per_window: u32,
+    /// Maximum login attempts per `(username, source-IP)` per
+    /// `rate_limit_login_window_secs`. The login handler bcrypt-verifies the
+    /// submitted password (cost-12, ~187ms) and does so even for locked
+    /// accounts, so borrowing the loose general-auth budget lets a single
+    /// client drive a burst of verifies that saturates CPU. This dedicated,
+    /// tight per-key budget sheds the excess as 429 in the middleware layer,
+    /// before the verifier runs. Sized for humans (automation uses tokens or
+    /// `rate_limit_exempt_usernames`); logout/refresh/totp keep the looser
+    /// `rate_limit_auth_per_window` budget. Env var:
+    /// `RATE_LIMIT_LOGIN_PER_WINDOW`. Default: 10.
+    pub rate_limit_login_per_window: u32,
+    /// Window length for the login limiter, in seconds. Decoupled from
+    /// `rate_limit_window_secs` (typically 60) so the login bucket can use a
+    /// longer, lockout-style window (default 15 minutes). Env var:
+    /// `RATE_LIMIT_LOGIN_WINDOW_SECS`. Default: 900.
+    pub rate_limit_login_window_secs: u64,
     /// Maximum self-password-change attempts per user per
     /// `rate_limit_password_change_window_secs`. Tighter than the global API
     /// bucket because `POST /users/:id/password` verifies the current
@@ -729,6 +745,8 @@ redacted_debug!(Config {
     show rate_limit_api_per_window,
     show rate_limit_search_per_window,
     show rate_limit_login_global_per_window,
+    show rate_limit_login_per_window,
+    show rate_limit_login_window_secs,
     show rate_limit_password_change_per_window,
     show rate_limit_password_change_window_secs,
     show rate_limit_window_secs,
@@ -835,6 +853,8 @@ impl Default for Config {
             rate_limit_search_per_window: 300,
             rate_limit_presign_per_window: 30,
             rate_limit_login_global_per_window: 8192,
+            rate_limit_login_per_window: 10,
+            rate_limit_login_window_secs: 900,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,
@@ -1061,6 +1081,8 @@ impl Config {
                 "RATE_LIMIT_LOGIN_GLOBAL_PER_WINDOW",
                 8192,
             ),
+            rate_limit_login_per_window: env_parse("RATE_LIMIT_LOGIN_PER_WINDOW", 10),
+            rate_limit_login_window_secs: env_parse("RATE_LIMIT_LOGIN_WINDOW_SECS", 900),
             rate_limit_password_change_per_window: env_parse(
                 "RATE_LIMIT_PASSWORD_CHANGE_PER_WINDOW",
                 5,
@@ -1510,6 +1532,26 @@ mod tests {
     }
 
     #[test]
+    fn test_config_login_rate_limit_env_override() {
+        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        env::set_var("DATABASE_URL", "postgresql://localhost/testdb");
+        env::set_var("JWT_SECRET", STRONG_SECRET);
+        env::set_var("RATE_LIMIT_LOGIN_PER_WINDOW", "3");
+        env::set_var("RATE_LIMIT_LOGIN_WINDOW_SECS", "600");
+        let config = Config::from_env().expect("config should load");
+        env::remove_var("RATE_LIMIT_LOGIN_PER_WINDOW");
+        env::remove_var("RATE_LIMIT_LOGIN_WINDOW_SECS");
+        assert_eq!(
+            config.rate_limit_login_per_window, 3,
+            "RATE_LIMIT_LOGIN_PER_WINDOW must override the per-key login budget"
+        );
+        assert_eq!(
+            config.rate_limit_login_window_secs, 600,
+            "RATE_LIMIT_LOGIN_WINDOW_SECS must override the login window length"
+        );
+    }
+
+    #[test]
     fn test_config_blob_gc_disabled_by_default() {
         let _lock = ENV_MUTEX.lock().unwrap();
         let saved_db = env::var("DATABASE_URL").ok();
@@ -1574,6 +1616,15 @@ mod tests {
         // 100+ password guesses per minute through the bcrypt verifier.
         assert_eq!(config.rate_limit_password_change_per_window, 5);
         assert_eq!(config.rate_limit_password_change_window_secs, 900);
+        // The login endpoint gets its own tight per-(username, IP) budget so a
+        // failed-login burst sheds before the bcrypt verifier runs, rather than
+        // borrowing the loose general-auth budget.
+        assert_eq!(config.rate_limit_login_per_window, 10);
+        assert_eq!(config.rate_limit_login_window_secs, 900);
+        assert!(
+            config.rate_limit_login_per_window < config.rate_limit_auth_per_window,
+            "login budget must be strictly tighter than the general-auth budget"
+        );
         assert!(
             (config.rate_limit_password_change_per_window as u64) * config.rate_limit_window_secs
                 < (config.rate_limit_api_per_window as u64)

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -3197,6 +3197,8 @@ mod tests {
             rate_limit_presign_per_window: 30,
 
             rate_limit_login_global_per_window: 8192,
+            rate_limit_login_per_window: 10,
+            rate_limit_login_window_secs: 900,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -805,6 +805,8 @@ mod tests {
             rate_limit_presign_per_window: 30,
 
             rate_limit_login_global_per_window: 8192,
+            rate_limit_login_per_window: 10,
+            rate_limit_login_window_secs: 900,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,

--- a/backend/src/services/oidc_service.rs
+++ b/backend/src/services/oidc_service.rs
@@ -910,6 +910,8 @@ mod tests {
             rate_limit_presign_per_window: 30,
 
             rate_limit_login_global_per_window: 8192,
+            rate_limit_login_per_window: 10,
+            rate_limit_login_window_secs: 900,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,
@@ -1025,6 +1027,8 @@ mod tests {
             rate_limit_presign_per_window: 30,
 
             rate_limit_login_global_per_window: 8192,
+            rate_limit_login_per_window: 10,
+            rate_limit_login_window_secs: 900,
             rate_limit_password_change_per_window: 5,
             rate_limit_password_change_window_secs: 900,
             rate_limit_window_secs: 60,

--- a/backend/tests/composer_packages_index_tests.rs
+++ b/backend/tests/composer_packages_index_tests.rs
@@ -110,6 +110,8 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_password_change_per_window: 5,
         rate_limit_password_change_window_secs: 900,
         rate_limit_login_global_per_window: 8192,
+        rate_limit_login_per_window: 10,
+        rate_limit_login_window_secs: 900,
         rate_limit_window_secs: 60,
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,

--- a/backend/tests/incus_upload_tests.rs
+++ b/backend/tests/incus_upload_tests.rs
@@ -98,6 +98,8 @@ fn test_config(storage_path: &str) -> Config {
         rate_limit_password_change_per_window: 5,
         rate_limit_password_change_window_secs: 900,
         rate_limit_login_global_per_window: 8192,
+        rate_limit_login_per_window: 10,
+        rate_limit_login_window_secs: 900,
         rate_limit_window_secs: 60,
         rate_limit_exempt_usernames: Vec::new(),
         rate_limit_exempt_service_accounts: false,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,6 +222,20 @@ services:
       RUST_LOG: ${RUST_LOG:-info,artifact_keeper=debug}
       ENVIRONMENT: ${ENVIRONMENT:-development}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost,https://localhost}
+      # Trusted reverse-proxy CIDRs (#2298 / #2023). Caddy terminates all
+      # external traffic and forwards the real client IP in `X-Forwarded-For`
+      # (Caddy overwrites any client-supplied XFF with the real TCP peer, so
+      # the value cannot be spoofed). The backend believes that header ONLY
+      # when the immediate TCP peer falls inside one of these ranges; the
+      # default is empty (secure) and would make the backend key every request
+      # on Caddy's container IP. That collapse is dangerous for the login
+      # limiter: every source of a given account would share ONE bucket, so a
+      # single flooding client could lock a specific victim — including owner
+      # break-glass — out of login. Setting this to the compose network subnet
+      # (pinned to 172.30.0.0/24 under `networks:` below) restores per-client
+      # keying on the real client IP. Override for bare-metal / custom bridge
+      # subnets; keep it in sync with the actual proxy network.
+      RATE_LIMIT_TRUSTED_PROXY_CIDRS: ${RATE_LIMIT_TRUSTED_PROXY_CIDRS:-172.30.0.0/24}
       TRIVY_URL: http://trivy:8090
       OPENSCAP_URL: http://openscap:8091
       SCAN_WORKSPACE_PATH: /scan-workspace
@@ -500,6 +514,16 @@ volumes:
 # A single bridge network for all services. All inter-container communication
 # stays on this network; only Caddy (and optionally Postgres/OpenSearch for
 # debugging) expose ports to the host.
+#
+# The subnet is PINNED so it is deterministic: the backend's
+# RATE_LIMIT_TRUSTED_PROXY_CIDRS (see the backend service) must match the
+# network Caddy lives on for per-client login rate-limit keying to work.
+# Without a pinned subnet Docker would pick one from its default pool at
+# random, and the trusted-proxy CIDR could drift out of range. Change both in
+# lockstep if this subnet collides with an existing network on your host.
 networks:
   default:
     name: artifact-keeper-network
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24


### PR DESCRIPTION
## Summary

Hardens the login endpoint by giving it its own dedicated, tight per-`(username, source-IP)` rate-limit budget instead of borrowing the loose general-auth budget (`rate_limit_auth_per_window`, 120/60s).

The login handler bcrypt-verifies the submitted password (cost-12, ~187ms per attempt) and, by design, runs that verification even for locked accounts to preserve owner break-glass. Sharing the general-auth budget meant a repeated stream of failed logins from a single client reached the verifier on nearly every request, so a bounded burst could drive a lot of concurrent CPU-bound verifies. Logout/refresh/TOTP genuinely need the looser budget for legitimate session-maintenance traffic behind NAT, so lowering the shared limiter is not the right lever.

This change adds a separate login limiter with its own config knobs and repoints only the login rate-limit state at it. Excess login attempts for a given `(username, IP)` now shed as `429` in the middleware layer, before the password verifier runs. Every other auth path (`/auth/logout`, `/auth/refresh`, `/auth/totp/verify`) is untouched and keeps the 120/60s budget. No account-lockout / break-glass semantics change; `auth_service.rs` is not modified. No DB migration.

New configuration (both env-overridable, sensible defaults):
- `RATE_LIMIT_LOGIN_PER_WINDOW` — max login attempts per `(username, IP)` per window. Default: `10`.
- `RATE_LIMIT_LOGIN_WINDOW_SECS` — login limiter window length. Default: `900` (15 min).

Keyed per-`(username, IP)`, so it never bars the real owner from their own address, and distinct users behind a shared NAT get distinct keys. Service accounts continue to use tokens or `rate_limit_exempt_usernames`; the `RATE_LIMIT_ENABLED` master switch and CIDR/username exemptions are still honored ahead of keying.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added/covered tests (`backend/src`):
- `config::tests` — assert the new defaults (`rate_limit_login_per_window == 10`, `rate_limit_login_window_secs == 900`), that the login budget is strictly tighter than the general-auth budget, and env-override parsing (`RATE_LIMIT_LOGIN_PER_WINDOW` / `RATE_LIMIT_LOGIN_WINDOW_SECS`).
- `api::middleware::rate_limit::tests::test_login_flood_on_one_identity_does_not_lock_out_others` — existing harness (`login_app(per_key=3, …)`) proves the first 3 attempts for one `(username, IP)` pass and the 4th sheds `429`, while a different IP for the same username and a different username on the same IP keep independent buckets.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated instance:
- 15 sequential failed logins for one `(username, IP)`: first 10 → `401`, remaining 5 → `429` (previously every attempt reached the handler).
- 25 concurrent failed logins for one `(username, IP)`: all shed `429` before the verifier; a concurrent `GET /health` stayed at baseline latency (~0.001s) with no spike.
- Legitimate correct-password login for a fresh `(username, IP)` → `200`; `POST /auth/refresh` and `POST /auth/logout` continue to succeed with no new `429`.
- Full workspace `--lib` suite: 12545 passed. `cargo fmt --check`, `cargo clippy -D warnings`, and duplication check all clean.

## API Changes
- [x] N/A - no API changes

Closes #2298