### PR TITLE
chore: bump version to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.3.0",
+        version = "1.4.0",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
## Summary
Bump the application version from 1.3.0 to 1.4.0 for the v1.4.0 release cut.

- `Cargo.toml` `[workspace.package] version` 1.3.0 -> 1.4.0 (drives `/health`, telemetry, and SBOM via `env!("CARGO_PKG_VERSION")`; `backend/Cargo.toml` inherits through `version.workspace = true`).
- `backend/src/api/openapi.rs` OpenAPI `info.version` 1.3.0 -> 1.4.0 (hardcoded literal, not env-driven — keeps the Swagger UI in sync with the rest of the app).
- `Cargo.lock` `artifact-keeper-backend` package version 1.3.0 -> 1.4.0.

No dependency versions changed. `cargo build --lib` compiles cleanly.

Closes #2299

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes
