### PR TITLE
fix(proxy): preserve format for split proxy cache TTLs

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -30,7 +30,7 @@ use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
 use crate::formats::composer::ComposerHandler;
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 
 // ---------------------------------------------------------------------------
 // Router
@@ -1032,6 +1032,7 @@ async fn download_archive(
                         &target.fetch_path,
                         &target.cache_path,
                         "application/zip",
+                        RepositoryFormat::Composer,
                     )
                     .await;
                 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -565,15 +565,25 @@ impl<'a> DebianProxy<'a> {
         // treats it as a cache miss and re-fetches from upstream.
         maybe_invalidate_by_epoch(proxy, self.repo_key, self.distribution, &upstream_path).await;
 
-        let (content, upstream_ct) = proxy_helpers::proxy_fetch_capped(
-            proxy,
+        // Use a Debian-format repo so the cache TTL classifier sees the
+        // real format: by-hash paths classify as Immutable (10-year TTL),
+        // while ordinary dists/ index files stay Mutable (5-min TTL).
+        // The generic proxy_fetch_capped helper defaults to Generic,
+        // which treats every path as mutable.
+        let proxy_repo = proxy_helpers::build_remote_repo_with_format(
             repo.id,
             self.repo_key,
             upstream_url,
-            &upstream_path,
-            proxy_helpers::LARGE_METADATA_MAX_BYTES,
-        )
-        .await?;
+            RepositoryFormat::Debian,
+        );
+        let (content, upstream_ct) = proxy
+            .fetch_artifact_capped(
+                &proxy_repo,
+                &upstream_path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await
+            .map_err(map_proxy_err)?;
         Err(build_dists_response(content, upstream_ct, content_type))
     }
 
@@ -830,15 +840,22 @@ async fn try_virtual_dists(
         // Epoch-based lazy invalidation for this member's cache entry
         maybe_invalidate_by_epoch(proxy, &member.key, distribution, upstream_path).await;
 
-        match proxy_helpers::proxy_fetch_capped(
-            proxy,
+        // Use a Debian-format repo so the cache TTL classifier sees the
+        // real format: by-hash paths classify as Immutable (10-year TTL),
+        // while ordinary dists/ index files stay Mutable (5-min TTL).
+        let proxy_repo = proxy_helpers::build_remote_repo_with_format(
             member.id,
             &member.key,
             upstream_url,
-            upstream_path,
-            proxy_helpers::LARGE_METADATA_MAX_BYTES,
-        )
-        .await
+            RepositoryFormat::Debian,
+        );
+        match proxy
+            .fetch_artifact_capped(
+                &proxy_repo,
+                upstream_path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await
         {
             Ok((content, upstream_ct)) => {
                 return Ok(Some(build_dists_response(
@@ -847,11 +864,11 @@ async fn try_virtual_dists(
                     default_content_type,
                 )));
             }
-            Err(resp) => {
-                if resp.status() == StatusCode::NOT_FOUND {
+            Err(e) => {
+                if matches!(e, crate::error::AppError::NotFound(_)) {
                     continue;
                 }
-                first_err.get_or_insert(resp);
+                first_err.get_or_insert(map_proxy_err(e));
             }
         }
     }
@@ -1371,15 +1388,24 @@ async fn dists_proxy_catchall(
     // Immutable paths (by-hash) are skipped by maybe_invalidate_by_epoch.
     maybe_invalidate_by_epoch(proxy, &repo_key, &distribution, &upstream_path).await;
 
-    let (content, upstream_ct) = proxy_helpers::proxy_fetch_capped(
-        proxy,
+    // Use a Debian-format repo so the cache TTL classifier sees the real
+    // format: by-hash paths under dists/ classify as Immutable (10-year
+    // TTL), while ordinary dists/ index files (Packages, Sources,
+    // Translation, etc.) stay Mutable (5-min TTL).
+    let proxy_repo = proxy_helpers::build_remote_repo_with_format(
         repo.id,
         &repo_key,
         upstream_url,
-        &upstream_path,
-        proxy_helpers::LARGE_METADATA_MAX_BYTES,
-    )
-    .await?;
+        RepositoryFormat::Debian,
+    );
+    let (content, upstream_ct) = proxy
+        .fetch_artifact_capped(
+            &proxy_repo,
+            &upstream_path,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        )
+        .await
+        .map_err(map_proxy_err)?;
 
     let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
 

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -24,7 +24,7 @@ use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
 use crate::formats::helm::{generate_index_yaml, ChartYaml, HelmHandler, HelmIndex};
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::proxy_service::ProxyService;
 
 // ---------------------------------------------------------------------------
@@ -294,6 +294,7 @@ async fn fetch_chart_via_index(
         upstream_url,
         &fetch_url,
         &cache_path,
+        RepositoryFormat::Helm,
     )
     .await?;
     proxy_helpers::stream_fetch_result(result, "application/gzip", Some(filename))

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -36,7 +36,7 @@ use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::AppError;
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::age_gate_service::{AgeGateDecision, AgeGateService};
 use crate::services::npm_packument_cache::{
     self as packument_cache, CachedPackument, NpmPackumentCache,
@@ -1972,6 +1972,7 @@ async fn serve_tarball(
                 upstream_url,
                 &fetch_path,
                 &fetch_path,
+                RepositoryFormat::Npm,
             )
             .await?;
 
@@ -2067,6 +2068,7 @@ async fn serve_tarball(
                             member_upstream,
                             &lkg_path,
                             &lkg_path,
+                            member.format.clone(),
                         )
                         .await?;
                         correct_cached_tarball_content_type(&state.db, member.id, &lkg_path).await;

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -34,7 +34,7 @@ use crate::api::extractors::RequestBaseUrl;
 use crate::api::handlers::proxy_helpers;
 use crate::api::SharedState;
 use crate::error::AppError;
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::models::user::User;
 use crate::services::auth_service::AuthService;
 use crate::storage::keys::OCI_MANIFEST_STORAGE_PREFIX;
@@ -2762,6 +2762,7 @@ pub async fn resolve_virtual_blob(
                         &upstream_path,
                         &upstream_path,
                         expected_checksum.clone(),
+                        member.format.clone(),
                     )
                     .await
                     {
@@ -3396,6 +3397,7 @@ async fn try_upstream_fetch_streaming_blob(
         upstream_url,
         &upstream_path,
         &upstream_path,
+        RepositoryFormat::Docker,
     )
     .await
     .ok()?;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1182,6 +1182,7 @@ pub async fn proxy_fetch_streaming_with_cache_key(
     upstream_url: &str,
     fetch_path: &str,
     cache_path: &str,
+    format: RepositoryFormat,
 ) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
     proxy_fetch_streaming_with_cache_key_verified(
         proxy_service,
@@ -1191,6 +1192,7 @@ pub async fn proxy_fetch_streaming_with_cache_key(
         fetch_path,
         cache_path,
         None,
+        format,
     )
     .await
 }
@@ -1201,6 +1203,7 @@ pub async fn proxy_fetch_streaming_with_cache_key(
 /// is served to the client but NOT persisted, so a digest-addressed upstream
 /// answering with wrong bytes cannot poison the cache. The OCI virtual-repo
 /// blob fallback passes the requested blob digest here.
+#[allow(clippy::too_many_arguments)]
 pub async fn proxy_fetch_streaming_with_cache_key_verified(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -1209,24 +1212,18 @@ pub async fn proxy_fetch_streaming_with_cache_key_verified(
     fetch_path: &str,
     cache_path: &str,
     expected_checksum: Option<String>,
+    format: RepositoryFormat,
 ) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
-    with_proxy_repo(
-        repo_id,
-        repo_key,
-        upstream_url,
-        fetch_path,
-        |repo| async move {
-            proxy_service
-                .fetch_artifact_streaming_with_cache_path_gated(
-                    &repo,
-                    fetch_path,
-                    cache_path,
-                    expected_checksum,
-                )
-                .await
-        },
-    )
-    .await
+    let repo = build_remote_repo_with_format(repo_id, repo_key, upstream_url, format);
+    proxy_service
+        .fetch_artifact_streaming_with_cache_path_gated(
+            &repo,
+            fetch_path,
+            cache_path,
+            expected_checksum,
+        )
+        .await
+        .map_err(|e| map_proxy_error(repo_key, fetch_path, e))
 }
 
 /// Response-producing sibling of [`proxy_fetch_streaming_with_cache_key`]:
@@ -1237,6 +1234,7 @@ pub async fn proxy_fetch_streaming_with_cache_key_verified(
 /// OpenTofu network-mirror archive downloads, where the registry-provided
 /// `download_url` is an absolute URL and `https://` trips the cache path's
 /// empty-segment guard — use this instead of `proxy_fetch_streaming` (#1998).
+#[allow(clippy::too_many_arguments)]
 pub async fn proxy_fetch_streaming_response_with_cache_key(
     proxy_service: &ProxyService,
     repo_id: Uuid,
@@ -1245,6 +1243,7 @@ pub async fn proxy_fetch_streaming_response_with_cache_key(
     fetch_path: &str,
     cache_path: &str,
     default_content_type: &str,
+    format: RepositoryFormat,
 ) -> Result<Response, Response> {
     let result = proxy_fetch_streaming_with_cache_key(
         proxy_service,
@@ -1253,6 +1252,7 @@ pub async fn proxy_fetch_streaming_response_with_cache_key(
         upstream_url,
         fetch_path,
         cache_path,
+        format,
     )
     .await?;
 
@@ -1271,8 +1271,9 @@ pub async fn proxy_check_cache_streaming(
     repo_key: &str,
     upstream_url: &str,
     cache_path: &str,
+    format: RepositoryFormat,
 ) -> Option<crate::services::proxy_service::StreamingFetchResult> {
-    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
+    let repo = build_remote_repo_with_format(repo_id, repo_key, upstream_url, format);
     match proxy_service
         .streaming_cached_artifact_by_path(&repo, cache_path)
         .await
@@ -4117,13 +4118,34 @@ pub fn age_gate_blocked_response(
 /// `Repository` value for `ProxyService` calls that need more than just
 /// the fields carried on the thin `RepoInfo` struct, e.g.
 /// `ProxyService::fetch_dists_with_revalidation` in the Debian handler.
+///
+/// Defaults to [`RepositoryFormat::Generic`]. Format-aware callers (e.g.
+/// Debian dists proxying) should use [`build_remote_repo_with_format`] so
+/// the proxy cache TTL classifier sees the real format and applies the
+/// correct immutable-vs-mutable rules (#1611).
 pub(crate) fn build_remote_repo(id: Uuid, key: &str, upstream_url: &str) -> Repository {
+    build_remote_repo_with_format(id, key, upstream_url, RepositoryFormat::Generic)
+}
+
+/// Same as [`build_remote_repo`] but lets the caller specify the format.
+///
+/// The proxy cache TTL classifier (`cache_classifier::classify`) keys off
+/// `repo.format` to decide immutable (10-year TTL) vs mutable (5-min TTL).
+/// A handler that proxies a format with immutable paths (e.g. Debian
+/// `by-hash` indices) MUST pass its real format here; otherwise the
+/// classifier sees `Generic` and treats every path as mutable.
+pub(crate) fn build_remote_repo_with_format(
+    id: Uuid,
+    key: &str,
+    upstream_url: &str,
+    format: RepositoryFormat,
+) -> Repository {
     Repository {
         id,
         key: key.to_string(),
         name: key.to_string(),
         description: None,
-        format: RepositoryFormat::Generic,
+        format,
         repo_type: RepositoryType::Remote,
         storage_backend: "filesystem".to_string(),
         storage_path: String::new(),
@@ -5187,6 +5209,72 @@ mod tests {
         let after = Utc::now();
         assert!(repo.created_at >= before && repo.created_at <= after);
         assert!(repo.updated_at >= before && repo.updated_at <= after);
+    }
+
+    // ── build_remote_repo_with_format tests ─────────────────────────
+
+    #[test]
+    fn test_build_remote_repo_with_format_sets_format() {
+        let repo = build_remote_repo_with_format(
+            Uuid::new_v4(),
+            "debian-proxy",
+            "https://deb.debian.org/debian",
+            RepositoryFormat::Debian,
+        );
+        assert_eq!(repo.format, RepositoryFormat::Debian);
+    }
+
+    #[test]
+    fn test_build_remote_repo_with_format_generic_matches_default() {
+        // Passing Generic must produce the same result as build_remote_repo.
+        let id = Uuid::new_v4();
+        let a = build_remote_repo_with_format(id, "k", "https://u.com", RepositoryFormat::Generic);
+        let b = build_remote_repo(id, "k", "https://u.com");
+        assert_eq!(a.format, b.format);
+        assert_eq!(a.key, b.key);
+        assert_eq!(a.upstream_url, b.upstream_url);
+    }
+
+    /// Regression: a Debian by-hash path proxied through a repo built with
+    /// `build_remote_repo_with_format(_, _, _, Debian)` MUST classify as
+    /// Immutable so `cache_ttl_for_path` stamps a 10-year TTL — not the
+    /// 5-minute mutable default that a Generic-format repo would produce.
+    #[test]
+    fn test_build_remote_repo_with_format_debian_by_hash_classifies_immutable() {
+        use crate::services::cache_classifier;
+
+        let repo = build_remote_repo_with_format(
+            Uuid::new_v4(),
+            "debian-huaweicloud",
+            "https://mirrors.huaweicloud.com/debian",
+            RepositoryFormat::Debian,
+        );
+        let by_hash_path =
+            "dists/trixie/main/binary-amd64/by-hash/SHA256/0f343b0931126a20f133d67c2b018a3b";
+        assert!(
+            cache_classifier::classify(&repo.format, by_hash_path).is_immutable(),
+            "Debian by-hash path must classify as Immutable when repo format is Debian"
+        );
+    }
+
+    /// Negative regression: an ordinary mutable dists/ index file proxied
+    /// through a Debian-format repo must still classify as Mutable so the
+    /// 5-minute TTL (revalidation window) is preserved.
+    #[test]
+    fn test_build_remote_repo_with_format_debian_dists_index_classifies_mutable() {
+        use crate::services::cache_classifier;
+
+        let repo = build_remote_repo_with_format(
+            Uuid::new_v4(),
+            "debian-huaweicloud",
+            "https://mirrors.huaweicloud.com/debian",
+            RepositoryFormat::Debian,
+        );
+        let mutable_path = "dists/trixie/main/binary-amd64/Packages.xz";
+        assert!(
+            !cache_classifier::classify(&repo.format, mutable_path).is_immutable(),
+            "Debian dists/ index must classify as Mutable when repo format is Debian"
+        );
     }
 
     // ── with_proxy_repo tests ────────────────────────────────────────
@@ -7948,6 +8036,7 @@ mod tests {
             &fetch_path,
             cache_path,
             "application/zip",
+            RepositoryFormat::Terraform,
         )
         .await
         .expect("streaming response must succeed for a split fetch/cache path");

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -34,7 +34,7 @@ use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
 use crate::error::AppError;
 use crate::formats::pypi::PypiHandler;
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::age_gate_service::{AgeGateDecision, AgeGateService};
 use crate::services::upstream_metadata::metadata_http_client;
 use chrono::Utc;
@@ -1430,6 +1430,7 @@ async fn enforce_pypi_download_age_gate(
         repo_key,
         upstream_url,
         &lkg_cache_path,
+        RepositoryFormat::Pypi,
     )
     .await
     {
@@ -1444,6 +1445,7 @@ async fn enforce_pypi_download_age_gate(
         project,
         &lkg_filename,
         &index_path,
+        RepositoryFormat::Pypi,
     )
     .await?;
     Ok(Some(build_streaming_file_response(&lkg_filename, result)))
@@ -1516,6 +1518,7 @@ async fn serve_file(
                         repo_key,
                         upstream_url,
                         &local_cache_path,
+                        RepositoryFormat::Pypi,
                     )
                     .await
                     {
@@ -1533,6 +1536,7 @@ async fn serve_file(
                         project,
                         filename,
                         &index_path,
+                        RepositoryFormat::Pypi,
                     )
                     .await?;
 
@@ -1680,6 +1684,7 @@ async fn serve_file(
                                 &member.key,
                                 upstream_url,
                                 &local_cache_path,
+                                member.format.clone(),
                             )
                             .await
                             {
@@ -1696,6 +1701,7 @@ async fn serve_file(
                                 project,
                                 filename,
                                 &member_index_path,
+                                member.format.clone(),
                             )
                             .await
                             {
@@ -1767,6 +1773,7 @@ async fn serve_file(
                         project,
                         filename,
                         &index_path,
+                        RepositoryFormat::Pypi,
                     )
                     .await
                 },
@@ -2112,6 +2119,7 @@ async fn pypi_proxy_cache_redirect(
 /// (CUDA / ML packages routinely exceed 400 MiB) previously OOM-killed
 /// memory-constrained pods when several `pip install` runs downloaded
 /// concurrently through the buffered path.
+#[allow(clippy::too_many_arguments)]
 async fn fetch_from_pypi_remote_streaming(
     proxy: &crate::services::proxy_service::ProxyService,
     repo_id: uuid::Uuid,
@@ -2120,6 +2128,7 @@ async fn fetch_from_pypi_remote_streaming(
     project: &str,
     filename: &str,
     index_path: &str,
+    format: RepositoryFormat,
 ) -> Result<crate::services::proxy_service::StreamingFetchResult, Response> {
     let target = resolve_pypi_remote_fetch_target(
         proxy,
@@ -2139,6 +2148,7 @@ async fn fetch_from_pypi_remote_streaming(
         &target.fetch_base,
         &target.fetch_path,
         &target.cache_path,
+        format,
     )
     .await
 }
@@ -6891,6 +6901,7 @@ mod tests {
             "numpy",
             "numpy-2.0.0-py3-none-any.whl",
             "simple",
+            RepositoryFormat::Pypi,
         )
         .await
         .expect("streaming fetch via fallback path must succeed");
@@ -6900,8 +6911,27 @@ mod tests {
         while let Some(chunk) = body.next().await {
             body_bytes.extend_from_slice(&chunk.expect("stream chunk must be Ok"));
         }
-        let _ = std::fs::remove_dir_all(&tmp);
         assert_eq!(body_bytes, wheel_body);
+
+        tdh::wait_for_cache_commit(&tmp, wheel_body.len() as u64).await;
+        let cache_path = "simple/numpy/numpy-2.0.0-py3-none-any.whl";
+        let metadata_key = crate::services::proxy_service::ProxyService::cache_metadata_key(
+            "pypi-remote",
+            cache_path,
+        )
+        .expect("metadata key");
+        let metadata = proxy
+            .load_cache_metadata_pub(&metadata_key)
+            .await
+            .expect("streaming fetch must write cache metadata");
+        let ttl_secs = (metadata.expires_at - metadata.cached_at).num_seconds();
+        assert_eq!(
+            ttl_secs,
+            crate::services::cache_classifier::Mutability::Immutable.write_ttl_secs(),
+            "PyPI wheel cache entries must use the immutable 10-year TTL"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]
@@ -7123,6 +7153,7 @@ mod tests {
             "pypi-remote",
             "https://pypi.org/simple",
             "simple/numpy/numpy-2.0.0-py3-none-any.whl",
+            RepositoryFormat::Pypi,
         )
         .await;
 

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -37,7 +37,7 @@ use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::validation::validate_outbound_url;
 use crate::api::SharedState;
-use crate::models::repository::RepositoryType;
+use crate::models::repository::{RepositoryFormat, RepositoryType};
 
 // ---------------------------------------------------------------------------
 // Router
@@ -1465,6 +1465,7 @@ async fn mirror_download(
         archive_url,
         &cache_path,
         "application/zip",
+        RepositoryFormat::Terraform,
     )
     .await
 }


### PR DESCRIPTION
## Summary
Fix proxy cache TTL classification for split fetch/cache-path flows by preserving the repository format when building the temporary remote repository used by proxy fetch helpers.

Previously, helpers built these repos as `Generic`, so format-aware immutable paths could be treated as mutable and receive the short 5-minute TTL. This affected paths like Debian `by-hash` indices and package artifacts fetched through split cache-key helpers.

Changes:
- Add `build_remote_repo_with_format` and thread `RepositoryFormat` through split proxy streaming helpers.
- Update Composer, Helm, npm, OCI, PyPI, Terraform, and Debian proxy paths to pass the real repository format.
- Update Debian capped dists fetches to use a Debian-format proxy repo so `by-hash` entries keep immutable TTLs.
- Preserve virtual repository member formats when fetching from member remotes.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [ ] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes