### PR TITLE
fix(npm): raise packument cache buffer cap

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -128,9 +128,9 @@ fn npm_metadata_compression_layer() -> CompressionLayer<impl Predicate> {
 // ---------------------------------------------------------------------------
 
 /// Buffering cap when caching a computed packument body. Packuments are
-/// bounded JSON; this matches the cap `dist_tags_get` already uses when it
-/// buffers the same responses.
-const NPM_PACKUMENT_BUFFER_CAP: usize = 32 * 1024 * 1024;
+/// bounded JSON; keep this aligned with the upstream npm metadata cap so
+/// large public packuments (for example `prisma`) can still be cached.
+const NPM_PACKUMENT_BUFFER_CAP: usize = proxy_helpers::LARGE_METADATA_MAX_BYTES;
 
 /// True when the client advertises `gzip` (or `*`) in `Accept-Encoding`, i.e.
 /// the metadata compression layer would have gzipped the response. Only gzip
@@ -431,7 +431,7 @@ async fn compute_and_store_packument(
         return Err(response);
     }
 
-    // STREAMING-EXEMPT: capped metadata read (a computed npm packument JSON, not an artifact blob); bounded to <=32 MiB via NPM_PACKUMENT_BUFFER_CAP so a hostile/broken upstream cannot OOM us; over-cap is surfaced as an error and left uncached; tracked under #1608
+    // STREAMING-EXEMPT: capped metadata read (a computed npm packument JSON, not an artifact blob); bounded to <=128 MiB via NPM_PACKUMENT_BUFFER_CAP so a hostile/broken upstream cannot OOM us; over-cap is surfaced as an error and left uncached; tracked under #1608
     let body_bytes = axum::body::to_bytes(response.into_body(), NPM_PACKUMENT_BUFFER_CAP)
         .await
         .map_err(|e| {


### PR DESCRIPTION
## Summary

- Raise the npm computed packument cache buffering cap from 32 MiB to `LARGE_METADATA_MAX_BYTES` (128 MiB).
- Align npm packument caching with the existing large metadata cap used elsewhere in npm metadata handling.
- Fix caching for real-world npm packuments that are larger than the old 32 MiB cap:
  - `prisma`: 43,294,110 bytes (~41.29 MiB)
  - `vite`: 38,896,984 bytes (~37.10 MiB)

These package metadata responses exceed the previous 33,554,432-byte cap, so computed packument caching could fail and leave them uncached.

## Test Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test npm --lib`
- [ ] `cargo test --workspace --lib`

`cargo test --workspace --lib` was attempted locally but did not complete green in this environment: URL/SSRF validation tests fail because `upstream.example.com` resolves to private IP `10.19.190.233`, which is rejected by the SSRF guard. The failure is unrelated to the npm packument buffer change.

## API Changes

None.