### PR TITLE
fix(auth): return 503 not 401 from guest_access_guard on AuthOutcome::Overloaded

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -747,30 +747,6 @@ async fn validate_api_token_with_scopes(
     })
 }
 
-/// Try to resolve an optional authentication token into an [`AuthExtension`].
-///
-/// Returns `Some(ext)` when a valid Bearer JWT, Bearer API token, or ApiKey
-/// token is present, and `None` otherwise (missing, invalid, or expired).
-/// This is the shared logic used by [`optional_auth_middleware`] and
-/// [`repo_visibility_middleware`].
-///
-/// Note: this helper conflates "no credential" with "invalid credential" —
-/// callers that need to distinguish those two outcomes (e.g. to honour an
-/// off-boarding deactivation immediately on optional-auth routes, see
-/// [`try_resolve_auth_outcome`] and issue #1371) should use the outcome
-/// variant instead.
-pub(crate) async fn try_resolve_auth(
-    auth_service: &AuthService,
-    extracted: ExtractedToken<'_>,
-) -> Option<AuthExtension> {
-    match try_resolve_auth_outcome(auth_service, extracted).await {
-        AuthOutcome::Resolved(ext) => Some(ext),
-        AuthOutcome::NoCredential | AuthOutcome::InvalidCredential | AuthOutcome::Overloaded => {
-            None
-        }
-    }
-}
-
 /// Outcome of resolving an authentication credential.
 ///
 /// Distinguishes three states an optional-auth path needs to handle
@@ -788,9 +764,7 @@ pub(crate) async fn try_resolve_auth(
 ///     instead of being unambiguously rejected, which masks the
 ///     deactivation and weakens the security posture.
 ///
-/// Use [`try_resolve_auth_outcome`] to obtain this tri-state result; the
-/// boolean [`try_resolve_auth`] helper continues to flatten Invalid into
-/// None for callers that don't need to distinguish.
+/// Use [`try_resolve_auth_outcome`] to obtain this tri-state result.
 #[derive(Debug)]
 pub(crate) enum AuthOutcome {
     Resolved(AuthExtension),
@@ -810,11 +784,10 @@ pub(crate) enum AuthOutcome {
 
 /// Resolve a possibly-missing credential into an [`AuthOutcome`].
 ///
-/// This is the strict variant of [`try_resolve_auth`]: it preserves the
-/// distinction between "no credential presented" and "credential presented
-/// but invalid" so optional-auth middleware can return 401 on the latter
-/// rather than silently dropping to anonymous. The original
-/// [`try_resolve_auth`] delegates to this function and flattens the result.
+/// Preserves the distinction between "no credential presented", "credential
+/// presented but invalid", and "transiently overloaded" so callers can return
+/// 401 on invalid, 503 on overload, and continue as anonymous only on the
+/// no-credential case — rather than silently collapsing all three.
 ///
 /// Decision tree:
 ///   * `ExtractedToken::None` -> `NoCredential` (anonymous request)
@@ -1302,7 +1275,10 @@ fn unauthorized_response() -> Response {
 /// `unauthorized_response` is the load-bearing fix for the twine-upload
 /// gate failure: a saturated auth cap is "retry shortly", not "wrong
 /// password".
-fn service_unavailable_response() -> Response {
+///
+/// `pub(super)` so the sibling `guest_access_guard` can return the same 503 for
+/// an `AuthOutcome::Overloaded` shed instead of collapsing it into a 401.
+pub(super) fn service_unavailable_response() -> Response {
     Response::builder()
         .status(StatusCode::SERVICE_UNAVAILABLE)
         .header(axum::http::header::RETRY_AFTER, "1")
@@ -3497,7 +3473,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_try_resolve_auth_basic_falls_back_to_jwt_password() {
+    async fn test_try_resolve_auth_outcome_basic_falls_back_to_jwt_password() {
         use crate::api::handlers::test_db_helpers as tdh;
 
         let Some(pool) = tdh::try_pool().await else {
@@ -3518,7 +3494,7 @@ mod tests {
         let jwt = mint_access_jwt(secret, user_id, "ci-user");
         let basic = base64::engine::general_purpose::STANDARD.encode(format!("ci-user:{}", jwt));
 
-        let resolved = try_resolve_auth(&auth_service, ExtractedToken::Basic(&basic)).await;
+        let resolved = try_resolve_auth_outcome(&auth_service, ExtractedToken::Basic(&basic)).await;
 
         sqlx::query("DELETE FROM users WHERE id = $1")
             .bind(user_id)
@@ -3526,10 +3502,14 @@ mod tests {
             .await
             .expect("cleanup test user");
 
-        let ext = resolved.expect("expected jwt fallback to authenticate basic password");
-        assert_eq!(ext.username, "ci-user");
-        assert!(!ext.is_admin);
-        assert!(!ext.is_api_token);
+        match resolved {
+            AuthOutcome::Resolved(ext) => {
+                assert_eq!(ext.username, "ci-user");
+                assert!(!ext.is_admin);
+                assert!(!ext.is_api_token);
+            }
+            other => panic!("expected jwt fallback to authenticate basic password, got {other:?}"),
+        }
     }
 
     async fn run_through_auth_middleware(
@@ -3910,8 +3890,8 @@ mod tests {
     // try_resolve_auth_outcome: tri-state behaviour pinned for #1371.
     // The outcome enum is what lets `optional_auth_middleware` distinguish
     // "no credential" (continue anonymously) from "credential presented but
-    // invalid" (401). The legacy `try_resolve_auth` helper delegates to this
-    // function and collapses Invalid into None for back-compat.
+    // invalid" (401), and `guest_access_guard` distinguish an `Overloaded`
+    // shed (503) from an unauthenticated request (401).
     // -----------------------------------------------------------------------
 
     #[tokio::test]

--- a/backend/src/api/middleware/guest_access.rs
+++ b/backend/src/api/middleware/guest_access.rs
@@ -21,11 +21,19 @@
 //! The guard is registered as an outer (global) layer in `routes::create_router`,
 //! which means it runs **before** the inner `auth_middleware` /
 //! `optional_auth_middleware` / `repo_visibility_middleware` layers populate
-//! request extensions. To make the gating decision we therefore call
-//! `try_resolve_auth` directly (the same helper the optional and visibility
-//! middlewares use) and short-circuit with 401 if no principal is found and
-//! the path is not allowlisted. Inner middlewares run again on requests that
-//! pass the guard and populate the extensions used by handlers.
+//! request extensions. To make the gating decision we therefore resolve auth
+//! directly (the same path the optional and visibility middlewares use) and
+//! short-circuit if the path is not allowlisted. Inner middlewares run again on
+//! requests that pass the guard and populate the extensions used by handlers.
+//!
+//! We resolve via [`try_resolve_auth_outcome`] and match on the full
+//! [`AuthOutcome`] rather than a boolean "is there a principal?" check, so a
+//! transient [`AuthOutcome::Overloaded`] shed (the bcrypt-capacity cap
+//! saturating) becomes a retryable **503**, not a 401. Flattening `Overloaded`
+//! into an "unauthenticated" 401 would fail requests carrying valid credentials
+//! under load — the exact regression `AuthOutcome::Overloaded` exists to prevent
+//! (a saturated auth cap is retryable; non-retrying clients such as twine abort
+//! on 401). The guard therefore returns the same 503 the inner middlewares do.
 
 use std::sync::Arc;
 
@@ -38,7 +46,9 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::api::middleware::auth::{extract_token, try_resolve_auth};
+use crate::api::middleware::auth::{
+    extract_token, service_unavailable_response, try_resolve_auth_outcome, AuthOutcome,
+};
 use crate::services::auth_service::AuthService;
 
 /// Shared state for the guest-access guard.
@@ -112,6 +122,25 @@ fn unauthorized_response() -> Response {
     response
 }
 
+/// Map a resolved [`AuthOutcome`] to the guard's short-circuit response, or
+/// `None` when the request should be allowed through to the inner layers.
+///
+/// This is the load-bearing distinction: an `Overloaded` shed must yield a
+/// retryable **503**, NOT a 401. Collapsing it into the "unauthenticated" 401
+/// would make valid credentials fail under transient auth-cap saturation. Kept
+/// as a pure function so the mapping is unit-testable without a live auth backend.
+fn guard_short_circuit(outcome: &AuthOutcome) -> Option<Response> {
+    match outcome {
+        // A principal resolved — let the request through; inner middlewares
+        // re-resolve and populate request extensions for handlers.
+        AuthOutcome::Resolved(_) => None,
+        // Transient bcrypt-capacity shed: retryable 503, never a 401.
+        AuthOutcome::Overloaded => Some(service_unavailable_response()),
+        // No/invalid credential presented: guest access is disabled → 401.
+        AuthOutcome::NoCredential | AuthOutcome::InvalidCredential => Some(unauthorized_response()),
+    }
+}
+
 /// Middleware that blocks unauthenticated requests when guest access is
 /// disabled server-wide. See module docs for behaviour and allowlist.
 pub async fn guest_access_guard(
@@ -128,19 +157,17 @@ pub async fn guest_access_guard(
         return next.run(request).await;
     }
 
-    // Resolve auth from the request headers. We only need to know whether
-    // some valid principal exists; the inner auth middleware will populate
-    // the request extensions for handlers if the guard lets the request
-    // through.
+    // Resolve auth from the request headers via `try_resolve_auth_outcome` and
+    // match the full outcome so a transient `AuthOutcome::Overloaded` shed
+    // becomes a retryable 503 rather than a spurious 401 — see module docs.
+    // Inner middlewares re-resolve and populate request extensions for handlers
+    // on requests that pass the guard.
     let extracted = extract_token(&request);
-    if try_resolve_auth(&state.auth_service, extracted)
-        .await
-        .is_some()
-    {
-        return next.run(request).await;
+    let outcome = try_resolve_auth_outcome(&state.auth_service, extracted).await;
+    match guard_short_circuit(&outcome) {
+        Some(response) => response,
+        None => next.run(request).await,
     }
-
-    unauthorized_response()
 }
 
 #[cfg(test)]
@@ -207,6 +234,37 @@ mod tests {
         assert!(!is_allowlisted("/foo/api/v1/auth"));
         assert!(!is_allowlisted("/proxy/v2/library"));
         assert!(!is_allowlisted("/api/v1/authentication"));
+    }
+
+    // -- guard_short_circuit (Overloaded must be 503, never 401) --
+
+    #[test]
+    fn short_circuit_overloaded_is_503_not_401() {
+        // Regression: a transient bcrypt-capacity shed must surface as a
+        // retryable 503 through the guard. Collapsing it into the
+        // GUEST_ACCESS_DISABLED 401 is what broke preemptive-auth clients
+        // (twine, uv/pip token-in-url, CI X-API-Key) under concurrent load.
+        let resp =
+            guard_short_circuit(&AuthOutcome::Overloaded).expect("Overloaded must short-circuit");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            resp.headers().contains_key(axum::http::header::RETRY_AFTER),
+            "503 shed should carry a Retry-After hint"
+        );
+    }
+
+    #[test]
+    fn short_circuit_no_credential_is_401() {
+        let resp = guard_short_circuit(&AuthOutcome::NoCredential)
+            .expect("NoCredential must short-circuit");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn short_circuit_invalid_credential_is_401() {
+        let resp = guard_short_circuit(&AuthOutcome::InvalidCredential)
+            .expect("InvalidCredential must short-circuit");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     // -- unauthorized_response --


### PR DESCRIPTION
## Summary

When `guest_access_enabled = false`, `guest_access_guard` (the outer global layer) resolved credentials via the `Option`-returning `try_resolve_auth`, which collapses `AuthOutcome::Overloaded` into `None`, then mapped `None` to a `401 GUEST_ACCESS_DISABLED`.

A transient bcrypt-capacity shed — which the codebase deliberately models as a **retryable 503, never a 401** — was therefore returned as `401 Unauthorized` on requests carrying **valid credentials**. This reintroduces, for guest-access-disabled deployments, the exact failure `AuthOutcome::Overloaded` was introduced to fix (#1437/#1442, twine/`cargo publish`): non-retrying clients (twine, `uv`/pip with token-in-URL, goproxy, CI sending `X-API-Key` preemptively) abort on the 401.

Every primary resolver (`auth_middleware`, optional-auth, repo-visibility) already short-circuits `Overloaded` to `service_unavailable_response()` before flattening; only the outer guard didn't. See #2314 for the full analysis and a live reproduction.

This PR routes the guard through `try_resolve_auth_outcome`, extracts the mapping into a pure `guard_short_circuit` helper, and returns the same 503 (with `Retry-After: 1`) the inner layers return for `Overloaded`. `service_unavailable_response()` is made `pub(crate)` so the guard reuses the identical response.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`guard_short_circuit` unit tests assert `Overloaded -> 503` (with `Retry-After`) and `NoCredential`/`InvalidCredential -> 401`. The pre-existing 503-vs-401 gap would have failed `short_circuit_overloaded_is_503_not_401`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests (existing guard e2e cases — valid JWT → 200, invalid bearer → 401, no cred → 401 — are unchanged)

## API Changes
- [x] N/A — no new endpoints or schemas. Behavioral: guest-guard now returns `503 Retry-After: 1` (instead of `401`) for the transient auth-capacity shed, matching the inner middlewares.

Fixes #2314
