### PR TITLE
fix: harden repository and admin authorization

### DIFF
--- a/backend/src/api/handlers/dependency_track.rs
+++ b/backend/src/api/handlers/dependency_track.rs
@@ -132,7 +132,12 @@ fn get_dt_service(
     ),
     security(("bearer_auth" = []))
 )]
-async fn dt_status(State(state): State<SharedState>) -> Result<Json<DtStatusResponse>> {
+async fn dt_status(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+) -> Result<Json<DtStatusResponse>> {
+    auth.require_admin()?;
+
     match &state.dependency_track {
         Some(dt) => {
             let (healthy, error_status, error_message) = match dt.health_status().await {
@@ -170,8 +175,10 @@ async fn dt_status(State(state): State<SharedState>) -> Result<Json<DtStatusResp
 )]
 async fn list_projects(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<DtProject>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let projects = dt.list_projects().await?;
     Ok(Json(projects))
@@ -193,9 +200,11 @@ async fn list_projects(
 )]
 async fn get_project(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(project_uuid): Path<String>,
 ) -> Result<Json<Vec<DtFinding>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let findings = dt.get_findings(&project_uuid).await?;
     Ok(Json(findings))
@@ -217,9 +226,11 @@ async fn get_project(
 )]
 async fn get_project_findings(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(project_uuid): Path<String>,
 ) -> Result<Json<Vec<DtFinding>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let findings = dt.get_findings(&project_uuid).await?;
     Ok(Json(findings))
@@ -241,9 +252,11 @@ async fn get_project_findings(
 )]
 async fn get_project_components(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(project_uuid): Path<String>,
 ) -> Result<Json<Vec<DtComponentFull>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let components = dt.get_components(&project_uuid).await?;
     Ok(Json(components))
@@ -265,9 +278,11 @@ async fn get_project_components(
 )]
 async fn get_project_metrics(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(project_uuid): Path<String>,
 ) -> Result<Json<DtProjectMetrics>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let metrics = dt.get_project_metrics(&project_uuid).await?;
     Ok(Json(metrics))
@@ -290,10 +305,12 @@ async fn get_project_metrics(
 )]
 async fn get_project_metrics_history(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(project_uuid): Path<String>,
     Query(query): Query<MetricsHistoryQuery>,
 ) -> Result<Json<Vec<DtProjectMetrics>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let history = dt
         .get_project_metrics_history(&project_uuid, query.days)
@@ -314,8 +331,10 @@ async fn get_project_metrics_history(
 )]
 async fn get_portfolio_metrics(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<DtPortfolioMetrics>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let metrics = dt.get_portfolio_metrics().await?;
     Ok(Json(metrics))
@@ -337,9 +356,11 @@ async fn get_portfolio_metrics(
 )]
 async fn get_project_violations(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(project_uuid): Path<String>,
 ) -> Result<Json<Vec<DtPolicyViolation>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let violations = dt.get_policy_violations(&project_uuid).await?;
     Ok(Json(violations))
@@ -359,9 +380,11 @@ async fn get_project_violations(
 )]
 async fn update_analysis(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Json(body): Json<UpdateAnalysisBody>,
 ) -> Result<Json<DtAnalysisResponse>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let result = dt
         .update_analysis(
@@ -391,8 +414,10 @@ async fn update_analysis(
 )]
 async fn list_policies(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<DtPolicyFull>>> {
+    auth.require_admin()?;
+
     let dt = get_dt_service(&state)?;
     let policies = dt.get_policies().await?;
     Ok(Json(policies))

--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -462,14 +462,14 @@ pub struct RepositoryAssessment {
 
 // ============ Ownership Scoping ============
 //
-// The migration router is mounted under `auth_middleware`, so every request
-// here is authenticated, but until now the handlers queried
-// `source_connections` / `migration_jobs` by primary key only — any
-// authenticated user could read or mutate any other user's (or tenant's) rows
-// (BOLA). We scope every access to the calling user via the `created_by`
-// columns that already exist on both tables (migration `020_migration_tables`),
-// mirroring the per-user ownership model used by `repo_tokens.rs` (#1974) and
-// `service_accounts.rs`: admins retain full cross-user visibility/control.
+// The migration router is mounted under `admin_middleware` in production
+// because source connections can contain external registry credentials and jobs
+// can bulk-create/update repository content. The owner scoping below remains as
+// defense in depth and for direct router tests: every access is constrained to
+// the caller via the `created_by` columns that already exist on both tables
+// (migration `020_migration_tables`), mirroring the per-user ownership model
+// used by `repo_tokens.rs` (#1974) and `service_accounts.rs`. Admins retain
+// full cross-user visibility/control.
 //
 // Pre-fix rows have `created_by = NULL` (creation never stamped it); those are
 // owned by nobody and therefore invisible/untouchable to non-admins

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -459,9 +459,9 @@ fn oci_forbidden_scope(required: &str) -> Response {
 }
 
 /// Build a 403 Forbidden response when a caller is authenticated but lacks
-/// write/delete access to the target repository (private-repo members-only
-/// gate). Uses the OCI `DENIED` error code, the registry-standard code for an
-/// authorization failure on an authenticated request.
+/// write/delete access to the target repository. Uses the OCI `DENIED` error
+/// code, the registry-standard code for an authorization failure on an
+/// authenticated request.
 fn oci_denied_repo_access() -> Response {
     oci_error(
         StatusCode::FORBIDDEN,
@@ -492,23 +492,11 @@ fn enforce_scan_pull_scope(
     }
 }
 
-/// OCI v2 write/delete authorization — parity with the REST artifact-write gate.
+/// OCI v2 write/delete authorization — parity with the REST artifact gates.
 ///
-/// The REST artifact path enforces a private-repository members-only gate
-/// (`require_repo_write_access` in `handlers/repositories.rs`, the #1764
-/// lineage): admins bypass, public repositories are writable by any
-/// authenticated caller, and every other caller must hold a role assignment
-/// scoped to the repository (direct or global) — exactly
-/// `RepositoryService::user_can_access_repo`. The /v2 write/delete handlers
-/// authenticate the caller and check the OCI token scope, but never consulted
-/// this per-repo membership gate, so a non-admin non-member could push to /
-/// delete from a PRIVATE repository that the REST path denies with 403. Apply
-/// the same decision here.
-///
-/// This is intentionally the per-repo membership check, NOT the fine-grained
-/// permission-rule check (`check_permission`/`has_any_rules_for_target`): the
-/// latter defaults to "no rules => allow", which would leave a freshly-created
-/// private repo with no rules wide open — the gap that the REST gate closes.
+/// Public visibility is read-only: pushes/deletes require the requested
+/// repository action (or `admin`) once fine-grained rules exist, with legacy
+/// role assignments as the fallback for rule-less repositories.
 ///
 /// Public-pull / anonymous-read paths never reach this helper (it is only
 /// invoked on write/delete handlers after authentication). Proxy/mirror flows
@@ -519,14 +507,14 @@ async fn require_oci_repo_write_access(
     state: &SharedState,
     claims: &crate::services::auth_service::Claims,
     repo_id: Uuid,
-    repo_is_public: bool,
+    action: &str,
 ) -> Result<(), Response> {
-    if claims.is_admin || repo_is_public {
+    if claims.is_admin {
         return Ok(());
     }
     match state
         .create_repository_service()
-        .user_can_access_repo(repo_id, claims.sub)
+        .user_can_perform_repo_action(repo_id, claims.sub, action)
         .await
     {
         Ok(true) => Ok(()),
@@ -4418,11 +4406,8 @@ async fn handle_start_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate, parity
-    // with the REST artifact-write path). Without this a non-admin non-member
-    // could open a blob upload against a PRIVATE repo it has no grant on.
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization, parity with the REST artifact-write path.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     // #1776: only repositories that store their own manifests (Local/Staging)
@@ -4758,9 +4743,8 @@ async fn handle_patch_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
 
@@ -5004,9 +4988,8 @@ async fn handle_cancel_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     let storage = match state.storage_for_repo(&repo.location) {
@@ -5246,9 +5229,8 @@ async fn handle_complete_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
 
@@ -6699,9 +6681,8 @@ async fn handle_put_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     // #1776: only repositories that store their own manifests (Local/Staging)
@@ -7715,9 +7696,8 @@ async fn handle_delete_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write/delete authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository delete authorization.
+    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, "delete").await {
         return resp;
     }
 
@@ -13651,6 +13631,13 @@ mod manifest_digest_db_tests {
         let fx = tdh::Fixture::setup("local", "docker")
             .await
             .expect("fixture setup");
+        tdh::grant_repo_actions(
+            &fx.pool,
+            fx.repo_id,
+            fx.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let auth = bearer(&fx).await;
         let name = format!("{}/image", fx.repo_key);
         let ct = "application/vnd.oci.image.manifest.v1+json";
@@ -13800,6 +13787,13 @@ mod manifest_digest_db_tests {
         let fx = tdh::Fixture::setup("local", "docker")
             .await
             .expect("fixture setup");
+        tdh::grant_repo_actions(
+            &fx.pool,
+            fx.repo_id,
+            fx.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let auth = bearer(&fx).await;
         let ct = "application/vnd.oci.image.manifest.v1+json";
 
@@ -13951,6 +13945,13 @@ mod manifest_digest_db_tests {
         let fx = tdh::Fixture::setup("local", "docker")
             .await
             .expect("fixture setup");
+        tdh::grant_repo_actions(
+            &fx.pool,
+            fx.repo_id,
+            fx.user_id,
+            &["read", "write", "delete"],
+        )
+        .await;
         let auth = bearer(&fx).await;
         let digest = format!("sha256:{}", "c".repeat(64));
 
@@ -14111,6 +14112,13 @@ mod oci_blob_upload_streaming_tests {
                 tokio::time::sleep(std::time::Duration::from_millis(250)).await;
             }
             let inner = inner.expect("OCI streaming upload fixture setup failed");
+            tdh::grant_repo_actions(
+                &inner.pool,
+                inner.repo_id,
+                inner.user_id,
+                &["read", "write", "delete"],
+            )
+            .await;
             let auth_service =
                 AuthService::new(inner.state.db.clone(), Arc::new(inner.state.config.clone()));
             let user = sqlx::query_as::<_, crate::models::user::User>(
@@ -21690,10 +21698,9 @@ mod cross_repo_session_regression_tests {
 // OCI v2 write authorization + body-size cap.
 //
 // Authorization: the /v2 blob-upload and manifest write/delete paths must
-// enforce the SAME private-repo members-only gate the REST artifact path
-// enforces (`require_repo_write_access` -> `user_can_access_repo`, the #1764
-// lineage). A non-admin non-member is denied on a PRIVATE repo; admins and
-// granted members are allowed; public repos and anonymous reads are unaffected.
+// enforce the same action-aware repository gate as the REST artifact path.
+// Public visibility is read-only: write/delete requires an explicit action
+// grant (or admin). Anonymous reads are unaffected.
 //
 // Size cap: an over-limit body must yield 413 Payload Too Large (declared
 // Content-Length / Content-Range rejection, or the streaming cumulative cap),

--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -242,8 +242,11 @@ fn parse_status(s: &str) -> Option<InstanceStatus> {
 )]
 pub async fn list_peers(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListPeersQuery>,
 ) -> Result<Json<PeerInstanceListResponse>> {
+    auth.require_admin()?;
+
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
     let offset = ((page - 1) * per_page) as i64;
@@ -374,8 +377,11 @@ pub async fn register_peer(
 )]
 pub async fn get_peer(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<PeerInstanceResponse>> {
+    auth.require_admin()?;
+
     let service = PeerInstanceService::new(state.db.clone());
     let instance = service.get_by_id(id).await?;
 
@@ -508,9 +514,12 @@ pub async fn trigger_sync(
 )]
 pub async fn get_sync_tasks(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Query(query): Query<ListPeersQuery>,
 ) -> Result<Json<Vec<SyncTaskResponse>>> {
+    auth.require_admin()?;
+
     let limit = query.per_page.unwrap_or(50) as i64;
     let service = PeerInstanceService::new(state.db.clone());
     let tasks = service.get_pending_sync_tasks(id, limit).await?;
@@ -551,8 +560,11 @@ pub async fn get_sync_tasks(
 )]
 pub async fn get_assigned_repos(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<Uuid>>> {
+    auth.require_admin()?;
+
     let service = PeerInstanceService::new(state.db.clone());
     let repos = service.get_assigned_repositories(id).await?;
     Ok(Json(repos))
@@ -635,8 +647,11 @@ pub async fn assign_repo(
 )]
 pub async fn get_subscription(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((id, repo_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<SubscriptionResponse>> {
+    auth.require_admin()?;
+
     let service = PeerInstanceService::new(state.db.clone());
     let sub = service.get_subscription(id, repo_id).await?;
     Ok(Json(SubscriptionResponse {

--- a/backend/src/api/handlers/remote_instances.rs
+++ b/backend/src/api/handlers/remote_instances.rs
@@ -56,6 +56,8 @@ async fn list_instances(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<RemoteInstanceResponse>>> {
+    auth.require_admin()?;
+
     let instances = RemoteInstanceService::list(&state.db, auth.user_id).await?;
     Ok(Json(instances))
 }
@@ -84,6 +86,8 @@ async fn create_instance(
     Extension(auth): Extension<AuthExtension>,
     Json(req): Json<CreateInstanceRequest>,
 ) -> Result<Json<RemoteInstanceResponse>> {
+    auth.require_admin()?;
+
     // Validate URL to prevent SSRF via the proxy endpoints
     validate_outbound_url(&req.url, "Remote instance URL")?;
 
@@ -112,6 +116,8 @@ async fn delete_instance(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<()> {
+    auth.require_admin()?;
+
     RemoteInstanceService::delete(&state.db, id, auth.user_id).await
 }
 
@@ -195,6 +201,8 @@ async fn proxy_get(
     Extension(auth): Extension<AuthExtension>,
     Path((id, path)): Path<(Uuid, String)>,
 ) -> Result<Response> {
+    auth.require_admin()?;
+
     validate_proxy_path(&path)?;
     let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
@@ -231,6 +239,8 @@ async fn proxy_post(
     Path((id, path)): Path<(Uuid, String)>,
     body: axum::body::Bytes,
 ) -> Result<Response> {
+    auth.require_admin()?;
+
     validate_proxy_path(&path)?;
     let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
@@ -269,6 +279,8 @@ async fn proxy_put(
     Path((id, path)): Path<(Uuid, String)>,
     body: axum::body::Bytes,
 ) -> Result<Response> {
+    auth.require_admin()?;
+
     validate_proxy_path(&path)?;
     let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);
@@ -305,6 +317,8 @@ async fn proxy_delete(
     Extension(auth): Extension<AuthExtension>,
     Path((id, path)): Path<(Uuid, String)>,
 ) -> Result<Response> {
+    auth.require_admin()?;
+
     validate_proxy_path(&path)?;
     let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, &path);

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -1,7 +1,7 @@
 //! Repository-scoped access token management.
 //!
-//! Allows repository administrators (users with write scope or global admins)
-//! to create, list, and revoke API tokens scoped to a specific repository.
+//! Allows repository administrators to create, list, and revoke API tokens
+//! scoped to a specific repository.
 //! Tokens created through these endpoints are automatically restricted to the
 //! repository they were created on via the `api_token_repositories` join table.
 
@@ -116,7 +116,8 @@ fn caller_owns_token(auth: &AuthExtension, created_by_user_id: Option<Uuid>) -> 
 }
 
 /// Require that the caller is authenticated and has write scope on repos
-/// (or is a global admin).
+/// (or is a global admin). The repository-admin permission check happens after
+/// the target repository is resolved.
 fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     let auth =
         auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
@@ -152,23 +153,18 @@ async fn authorize_repo_for_tokens(
         )));
     }
 
-    // Per-repo authorization (mirrors `require_visible` in the repositories
-    // handler). The `can_access_repo` check above only enforces the *token's*
-    // repo scope — a broad `write:repositories` token (`allowed_repo_ids =
-    // None`) passes it for ANY repo. Without this DB-level check, any
-    // authenticated user with the write scope could mint repo-scoped tokens on
-    // a PRIVATE repository they cannot see (#1783). A private repo is visible
-    // only to an admin or a user with a role assignment scoped to it.
-    if !repo.is_public
-        && !auth.is_admin
-        && !repo_service
-            .user_can_access_repo(repo.id, auth.user_id)
-            .await?
-    {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
+    // Repo-scoped tokens are delegation credentials. Visibility/write access is
+    // not enough: a public repository must not let any authenticated principal
+    // mint a token for it, and a writer must not escalate into token issuance.
+    if !auth.is_admin {
+        let allowed = repo_service
+            .user_can_perform_repo_action(repo.id, auth.user_id, "admin")
+            .await?;
+        if !allowed {
+            return Err(AppError::Authorization(
+                "Insufficient permissions to manage repository tokens".to_string(),
+            ));
+        }
     }
 
     Ok((auth, repo))
@@ -1002,7 +998,8 @@ mod admin_scope_policy_tests {
     /// (token `allowed_repo_ids = None`, so `can_access_repo` passes for ANY
     /// repo) must NOT be able to mint a repo token on a PRIVATE repository it
     /// has no role on. Before the fix the endpoint returned 200/created; it
-    /// must now 404 (existence-hiding), exactly like `require_visible`.
+    /// must now 403 because repo-scoped token issuance requires repository
+    /// admin permission even when the repository is public/readable.
     #[tokio::test]
     async fn non_admin_without_role_cannot_mint_token_on_private_repo() {
         let Some((pool, state, user_id, username, repo_key)) = setup().await else {
@@ -1028,8 +1025,8 @@ mod admin_scope_policy_tests {
 
         assert_eq!(
             status,
-            StatusCode::NOT_FOUND,
-            "non-admin without a role must not mint tokens on a private repo (existence-hiding); got {} body: {}",
+            StatusCode::FORBIDDEN,
+            "non-admin without repo-admin must not mint tokens on a private repo; got {} body: {}",
             status,
             String::from_utf8_lossy(&body_bytes),
         );
@@ -1179,10 +1176,8 @@ mod ownership_gate_tests {
         row.0
     }
 
-    /// Full public-repo setup with two members (victor=creator, sam=peer) and a
-    /// token seeded on the repo by victor. The repo is public so the #1783
-    /// private-repo gate is satisfied and the gate under test is purely
-    /// per-token, not visibility.
+    /// Full public-repo setup with two users (victor=repo admin/creator,
+    /// sam=peer) and a token seeded on the repo by victor.
     struct Fixture {
         pool: sqlx::PgPool,
         state: SharedState,
@@ -1203,6 +1198,16 @@ mod ownership_gate_tests {
             .expect("make repo public");
         let (victor, victor_name) = tdh::create_user(&pool).await;
         let (sam, _sam_name) = tdh::create_user(&pool).await;
+        sqlx::query(
+            "INSERT INTO permissions \
+               (principal_type, principal_id, target_type, target_id, actions) \
+             VALUES ('user', $1, 'repository', $2, ARRAY['admin'])",
+        )
+        .bind(victor)
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("grant victor repo-admin permission");
         let state = tdh::build_state(pool.clone(), "/tmp");
         let token_id = create_token_as(&state, member_auth(victor, &victor_name), &repo_key).await;
         Some(Fixture {
@@ -1225,6 +1230,12 @@ mod ownership_gate_tests {
             .bind(f.victor)
             .execute(&f.pool)
             .await;
+        let _ = sqlx::query(
+            "DELETE FROM permissions WHERE target_type = 'repository' AND target_id = $1",
+        )
+        .bind(f.repo_id)
+        .execute(&f.pool)
+        .await;
         let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
             .bind(f.repo_id)
             .execute(&f.pool)
@@ -1237,23 +1248,23 @@ mod ownership_gate_tests {
         }
     }
 
-    /// (1) A peer GET of another member's token returns 404 (was 200).
+    /// (1) A peer GET of another member's token returns 403 at the repo-admin gate.
     #[tokio::test]
-    async fn peer_get_token_is_404() {
+    async fn peer_get_token_is_403() {
         let Some(f) = fixture().await else { return };
         let app = app_as(f.state.clone(), member_auth(f.sam, "sam"));
         let (status, _) = tdh::send(app, get_token_req(&f.repo_key, f.token_id)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND, "peer GET must 404");
+        assert_eq!(status, StatusCode::FORBIDDEN, "peer GET must 403");
         teardown(&f).await;
     }
 
-    /// (2) A peer DELETE returns 404 and the token is NOT revoked.
+    /// (2) A peer DELETE returns 403 and the token is NOT revoked.
     #[tokio::test]
-    async fn peer_delete_token_is_404_and_not_revoked() {
+    async fn peer_delete_token_is_403_and_not_revoked() {
         let Some(f) = fixture().await else { return };
         let app = app_as(f.state.clone(), member_auth(f.sam, "sam"));
         let (status, _) = tdh::send(app, delete_token_req(&f.repo_key, f.token_id)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND, "peer DELETE must 404");
+        assert_eq!(status, StatusCode::FORBIDDEN, "peer DELETE must 403");
         assert!(
             revoked_at(&f.pool, f.token_id).await.is_none(),
             "peer DELETE must NOT revoke the token"
@@ -1321,20 +1332,14 @@ mod ownership_gate_tests {
     async fn list_scopes_to_owner_for_non_admin_and_all_for_admin() {
         let Some(f) = fixture().await else { return };
 
-        // Peer sees no items (victor's token is filtered out).
+        // Peer cannot list repository-scoped tokens without repo-admin.
         let app = app_as(f.state.clone(), member_auth(f.sam, "sam"));
         let (status, bytes) = tdh::send(app, list_tokens_req(&f.repo_key)).await;
-        assert_eq!(status, StatusCode::OK);
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let peer_ids: Vec<&str> = v["items"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|i| i["id"].as_str().unwrap())
-            .collect();
         assert!(
-            !peer_ids.contains(&f.token_id.to_string().as_str()),
-            "peer list must not contain victor's token"
+            status == StatusCode::FORBIDDEN,
+            "peer list must 403, got {} body: {}",
+            status,
+            String::from_utf8_lossy(&bytes),
         );
 
         // Creator sees their own token.

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -88,12 +88,11 @@ fn require_repo_access(auth: &AuthExtension, repo_id: Uuid) -> Result<()> {
     }
 }
 
-/// Authorize a write/delete operation against a repository.
+/// Authorize a mutating/admin operation against a repository.
 ///
-/// Enforces both the token-scope check (`require_repo_access`) and, for private
-/// repositories, per-repo authorization: admins bypass; every other caller must
-/// hold a role assignment scoped to the repo (direct or global). Public repos
-/// keep their existing behavior (token-scope only).
+/// Enforces both the token-scope check (`require_repo_access`) and per-repo
+/// authorization. Public visibility is deliberately read-only: a public repo
+/// does not grant write/delete/admin rights to every authenticated caller.
 ///
 /// Exposed as `pub(crate)` so the repository sub-resource handlers that live in
 /// sibling modules (labels, security, email subscriptions) and the chunked
@@ -101,25 +100,50 @@ fn require_repo_access(auth: &AuthExtension, repo_id: Uuid) -> Result<()> {
 /// rather than re-deriving (or forgetting) it. The `/api/v1/repositories` nest
 /// runs under `optional_auth_middleware` only, NOT `repo_visibility_middleware`,
 /// so each sub-handler must enforce this itself.
-pub(crate) async fn require_repo_write_access(
+async fn require_repo_action_access(
     auth: &AuthExtension,
     repo: &crate::models::repository::Repository,
     repo_service: &RepositoryService,
+    action: &str,
 ) -> Result<()> {
     require_repo_access(auth, repo.id)?;
-    if repo.is_public || auth.is_admin {
+    if auth.is_admin {
         return Ok(());
     }
     if repo_service
-        .user_can_access_repo(repo.id, auth.user_id)
+        .user_can_perform_repo_action(repo.id, auth.user_id, action)
         .await?
     {
         Ok(())
     } else {
         Err(AppError::Authorization(
-            "You do not have access to this repository".to_string(),
+            "You do not have permission to perform this action on this repository".to_string(),
         ))
     }
+}
+
+pub(crate) async fn require_repo_write_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_action_access(auth, repo, repo_service, "write").await
+}
+
+pub(crate) async fn require_repo_delete_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_action_access(auth, repo, repo_service, "delete").await
+}
+
+pub(crate) async fn require_repo_admin_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_action_access(auth, repo, repo_service, "admin").await
 }
 
 /// Ensure a repository is visible to the current user.
@@ -745,7 +769,7 @@ pub async fn set_cache_ttl(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
 
     // Fine-grained permission check: non-admins need "admin" on the target
     // repository. Cache TTL is a pull-through proxy supply-chain control on the
@@ -895,7 +919,7 @@ pub async fn invalidate_cache(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
 
     // Cache invalidation is meaningless on Local / Virtual / Staging repos --
     // only Remote (proxy) repos own a cache. Reject up front before touching
@@ -1031,15 +1055,17 @@ pub async fn put_pypi_track(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, project)): Path<(String, String)>,
-    Json(payload): Json<PypiTrackRequest>,
+    body: Bytes,
 ) -> Result<Json<PypiTrackResponse>> {
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
     require_pypi_tracks_repo(&repo)?;
 
+    let payload: PypiTrackRequest = serde_json::from_slice(&body)
+        .map_err(|e| AppError::Validation(format!("Invalid JSON: {}", e)))?;
     let tracks_url = payload.tracks_url.trim().to_string();
     if !(tracks_url.starts_with("http://") || tracks_url.starts_with("https://")) {
         return Err(AppError::Validation(
@@ -1099,7 +1125,7 @@ pub async fn delete_pypi_track(
     auth.require_scope("write")?;
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
 
     let normalized = crate::api::handlers::pypi::normalize_pep503(&project);
     sqlx::query(
@@ -4621,7 +4647,7 @@ pub async fn delete_artifact(
     auth.require_scope("delete")?;
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    require_repo_delete_access(&auth, &repo, &repo_service).await?;
 
     // Resolve the npm canonical `/-/` URL shape the Web UI emits to the
     // version-segmented path the tarball is actually stored under (#2269),
@@ -5200,7 +5226,7 @@ pub async fn set_upstream_auth(
     auth.require_scope("write")?;
     let repo = load_remote_repo(&state, &auth, &key).await?;
     let repo_service = RepositoryService::new(state.db.clone());
-    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    require_repo_admin_access(&auth, &repo, &repo_service).await?;
 
     if payload.auth_type == "none" {
         crate::services::upstream_auth::remove_upstream_auth(&state.db, repo.id).await?;
@@ -5386,6 +5412,10 @@ pub async fn set_routing_rules(
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
 
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
+
     // Validate every rule before persisting
     for (i, rule) in payload.rules.iter().enumerate() {
         if let Err(msg) = routing_rules::validate_routing_rule(rule) {
@@ -5395,10 +5425,6 @@ pub async fn set_routing_rules(
             )));
         }
     }
-
-    let service = RepositoryService::new(state.db.clone());
-    let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
 
     let value = serde_json::to_string(&payload.rules)
         .map_err(|e| AppError::Internal(format!("Failed to serialize routing rules: {}", e)))?;
@@ -5449,7 +5475,7 @@ pub async fn delete_routing_rules(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
 
     sqlx::query(
         r#"
@@ -8450,14 +8476,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_require_repo_write_access_public_allowed_no_db() {
-        let repo = make_repo(true); // is_public = true
-        let res =
-            require_repo_write_access(&make_auth_ext(None), &repo, &no_db_repo_service()).await;
+    async fn test_require_repo_write_access_public_requires_grant_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let mut repo = make_repo_with_id(repo_id, &key);
+        repo.is_public = true;
+        let ext = tdh::make_auth(user_id, &username);
+        let svc = RepositoryService::new(pool.clone());
+
+        let denied = require_repo_write_access(&ext, &repo, &svc).await;
         assert!(
-            res.is_ok(),
-            "a public repo is writable past the gate, no DB: {res:?}"
+            matches!(denied, Err(AppError::Authorization(_))),
+            "public visibility must not grant write without an explicit repo grant: {denied:?}"
         );
+
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let allowed = require_repo_write_access(&ext, &repo, &svc).await;
+        assert!(
+            allowed.is_ok(),
+            "legacy repo membership remains a write grant when no fine-grained rules exist: {allowed:?}"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
     }
 
     #[tokio::test]
@@ -8567,6 +8611,7 @@ mod tests {
         let (user_id, username) = tdh::create_user(&pool).await;
         let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
         let auth = Some(tdh::make_auth(user_id, &username));
         // {package}/{version}/{filename} -> a versioned release coordinate.
@@ -8583,8 +8628,8 @@ mod tests {
         .await;
         assert!(up.is_ok(), "initial publish must succeed: {up:?}");
 
-        // 2) DELETE (soft-delete -> tombstone). Generic classifies mutable, so
-        // the delete guard permits this even for a non-admin.
+        // 2) DELETE (soft-delete -> tombstone). The fixture has an explicit
+        // delete grant so this test reaches the release-immutability backstop.
         let del = delete_artifact(
             State(state.clone()),
             Extension(auth.clone()),
@@ -8643,6 +8688,7 @@ mod tests {
         let (user_id, username) = tdh::create_user(&pool).await;
         let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
         let auth = Some(tdh::make_auth(user_id, &username));
         let mut admin_ext = tdh::make_auth(user_id, &username);
@@ -8963,12 +9009,7 @@ mod tests {
         )
         .await;
         match denied {
-            Err(AppError::Authorization(msg)) => {
-                assert!(
-                    msg.contains("Insufficient permissions"),
-                    "unexpected message: {msg}"
-                );
-            }
+            Err(AppError::Authorization(_)) => {}
             other => {
                 panic!("expected Authorization denial without repository:admin, got: {other:?}")
             }
@@ -9146,29 +9187,28 @@ mod tests {
         );
     }
 
-    /// Cross-tenant write authz (xtenant-write-authz-systemic):
+    /// Cross-tenant mutation authz (xtenant-write-authz-systemic):
     ///
     /// The `/api/v1/repositories` REST nest runs under `optional_auth_middleware`
     /// only, NOT `repo_visibility_middleware`, so each sub-resource mutation
-    /// handler must enforce the tenant write gate itself. Assert every such
-    /// handler references `require_repo_write_access` (the canonical
-    /// `is_public + role_assignments` gate) so a future handler cannot silently
-    /// fall open to a non-member, non-admin caller on a private repo. String-grep
-    /// because the handlers need a full `SharedState` to run.
+    /// handler must enforce the action-specific tenant gate itself. Assert each
+    /// handler references the helper that matches its mutation class so a future
+    /// handler cannot silently fall open to a non-member, non-admin caller.
+    /// String-grep because the handlers need a full `SharedState` to run.
     #[test]
-    fn test_repo_mutation_handlers_call_write_gate() {
+    fn test_repo_mutation_handlers_call_action_gate() {
         let source = include_str!("repositories.rs");
 
-        for handler in [
-            "set_cache_ttl",
-            "invalidate_cache",
-            "put_pypi_track",
-            "delete_pypi_track",
-            "set_routing_rules",
-            "delete_routing_rules",
-            "set_upstream_auth",
-            "upload_artifact",
-            "delete_artifact",
+        for (handler, helper) in [
+            ("set_cache_ttl", "require_repo_admin_access("),
+            ("invalidate_cache", "require_repo_admin_access("),
+            ("put_pypi_track", "require_repo_admin_access("),
+            ("delete_pypi_track", "require_repo_admin_access("),
+            ("set_routing_rules", "require_repo_admin_access("),
+            ("delete_routing_rules", "require_repo_admin_access("),
+            ("set_upstream_auth", "require_repo_admin_access("),
+            ("upload_artifact", "require_repo_write_access("),
+            ("delete_artifact", "require_repo_delete_access("),
         ] {
             let marker = format!("pub async fn {}(", handler);
             let start = source
@@ -9182,14 +9222,32 @@ mod tests {
             let body = &rest[..end];
 
             assert!(
-                body.contains("require_repo_write_access("),
-                "handler `{}` does not call `require_repo_write_access` \
-                 (xtenant-write-authz-systemic). The /repositories nest is not \
-                 covered by repo_visibility_middleware, so each mutation handler \
-                 must enforce the tenant write gate itself. If you intentionally \
-                 restructured the authz model, update this test to match.",
-                handler
+                body.contains(helper),
+                "handler `{}` does not call `{}` (xtenant-write-authz-systemic). \
+                 The /repositories nest is not covered by repo_visibility_middleware, \
+                 so each mutation handler must enforce its action gate itself.",
+                handler,
+                helper
             );
+
+            if handler == "put_pypi_track" {
+                let gate_pos = body
+                    .find("require_repo_admin_access(")
+                    .expect("put_pypi_track must call require_repo_admin_access");
+                let parse_pos = body
+                    .find("serde_json::from_slice")
+                    .expect("put_pypi_track must parse JSON explicitly");
+                assert!(
+                    body.contains("body: Bytes"),
+                    "put_pypi_track must take raw Bytes so non-admin callers \
+                     are denied before request-body schema validation"
+                );
+                assert!(
+                    gate_pos < parse_pos,
+                    "put_pypi_track must authorize repo-admin access before \
+                     parsing/validating the tracks payload"
+                );
+            }
         }
     }
 
@@ -9232,8 +9290,8 @@ mod tests {
     // model (role_assignments) for private repositories, so the cases that
     // exercise the DB grant lookup (private + authenticated non-admin) are
     // covered by integration/live verification rather than these pure tests.
-    // The cases below short-circuit BEFORE any DB access (public repos, the
-    // anonymous-on-private denial, and the token-scope mismatch denial) and so
+    // The cases below short-circuit BEFORE any DB access (public visibility,
+    // the anonymous-on-private denial, and the token-scope mismatch denial) and so
     // remain DB-free; we drive them with an unused pool handle.
 
     #[tokio::test]
@@ -9310,14 +9368,25 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[tokio::test]
-    async fn test_require_repo_write_access_public_ok() {
-        let repo = make_repo(true);
-        let auth = make_auth_ext(None);
-        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
+    async fn test_require_repo_write_access_public_without_grant_denied_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let mut repo = make_repo_with_id(repo_id, &key);
+        repo.is_public = true;
+        let auth = tdh::make_auth(user_id, &username);
+        let svc = RepositoryService::new(pool.clone());
+
+        let result = require_repo_write_access(&auth, &repo, &svc).await;
         assert!(
-            require_repo_write_access(&auth, &repo, &svc).await.is_ok(),
-            "any authenticated caller may write to a public repo"
+            matches!(result, Err(AppError::Authorization(_))),
+            "public repo visibility must not grant write"
         );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
     }
 
     #[tokio::test]
@@ -9671,6 +9740,7 @@ mod tests {
         let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
             return;
         };
+        tdh::grant_repo_actions(&fx.pool, fx.repo_id, fx.user_id, &["admin"]).await;
 
         let proxy =
             tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
@@ -9727,6 +9797,7 @@ mod tests {
         let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
             return;
         };
+        tdh::grant_repo_actions(&fx.pool, fx.repo_id, fx.user_id, &["admin"]).await;
 
         let proxy =
             tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
@@ -9768,6 +9839,7 @@ mod tests {
         let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
             return;
         };
+        tdh::grant_repo_actions(&fx.pool, fx.repo_id, fx.user_id, &["admin"]).await;
 
         // Plain `build_state` does NOT install a proxy_service, so the
         // handler hits the `state.proxy_service.as_ref().ok_or_else(...)`
@@ -13182,6 +13254,7 @@ mod tests {
         let (user_id, username) = tdh::create_user(&pool).await;
         let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "npm").await;
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
         let auth = Some(tdh::make_auth(user_id, &username));
 

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -351,6 +351,8 @@ async fn generate_sbom(
     Extension(auth): Extension<AuthExtension>,
     Json(body): Json<GenerateSbomRequest>,
 ) -> Result<Json<SbomResponse>> {
+    auth.require_admin()?;
+
     let service = SbomService::new(state.db.clone());
     let format = SbomFormat::parse(&body.format)
         .ok_or_else(|| AppError::Validation(format!("Unknown format: {}", body.format)))?;
@@ -619,6 +621,8 @@ async fn delete_sbom(
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<serde_json::Value>> {
+    auth.require_admin()?;
+
     ensure_sbom_repo_access(&state.db, &auth, id).await?;
     let service = SbomService::new(state.db.clone());
     service.delete_sbom(id).await?;
@@ -685,10 +689,12 @@ async fn get_sbom_components(
 )]
 async fn convert_sbom(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(body): Json<ConvertSbomRequest>,
 ) -> Result<Json<SbomContentResponse>> {
+    auth.require_admin()?;
+
     let service = SbomService::new(state.db.clone());
     let target_format = SbomFormat::parse(&body.target_format)
         .ok_or_else(|| AppError::Validation(format!("Unknown format: {}", body.target_format)))?;
@@ -1009,6 +1015,8 @@ async fn update_cve_status(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateCveStatusRequest>,
 ) -> Result<Json<crate::models::sbom::CveHistoryEntry>> {
+    auth.require_admin()?;
+
     let service = SbomService::new(state.db.clone());
     let status = CveStatus::parse(&body.status)
         .ok_or_else(|| AppError::Validation(format!("Unknown status: {}", body.status)))?;
@@ -1083,6 +1091,8 @@ async fn update_cve_status_by_artifact_cve(
     Path((artifact_id, cve_id)): Path<(Uuid, String)>,
     Json(body): Json<UpdateCveStatusRequest>,
 ) -> Result<Json<crate::models::sbom::CveHistoryEntry>> {
+    auth.require_admin()?;
+
     if !is_valid_vuln_id(&cve_id) {
         return Err(AppError::Validation(invalid_cve_id_route_message(&cve_id)));
     }
@@ -1119,9 +1129,11 @@ async fn update_cve_status_by_artifact_cve(
 )]
 async fn get_cve_trends(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<GetCveTrendsQuery>,
 ) -> Result<Json<CveTrends>> {
+    auth.require_admin()?;
+
     let service = SbomService::new(state.db.clone());
     let trends = service.get_cve_trends(query.repository_id).await?;
     Ok(Json(trends))
@@ -1142,8 +1154,10 @@ async fn get_cve_trends(
 )]
 async fn list_license_policies(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<LicensePolicyResponse>>> {
+    auth.require_admin()?;
+
     let policies: Vec<LicensePolicy> =
         sqlx::query_as("SELECT * FROM license_policies ORDER BY name")
             .fetch_all(&state.db)
@@ -1173,9 +1187,11 @@ async fn list_license_policies(
 )]
 async fn get_license_policy(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<LicensePolicyResponse>> {
+    auth.require_admin()?;
+
     let policy: LicensePolicy = sqlx::query_as("SELECT * FROM license_policies WHERE id = $1")
         .bind(id)
         .fetch_optional(&state.db)
@@ -1285,9 +1301,11 @@ async fn delete_license_policy(
 )]
 async fn check_license_compliance(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Json(body): Json<CheckLicenseComplianceRequest>,
 ) -> Result<Json<LicenseCheckResult>> {
+    auth.require_admin()?;
+
     let service = SbomService::new(state.db.clone());
     let policy = service
         .get_license_policy(body.repository_id)
@@ -2958,6 +2976,12 @@ mod tests {
             .await;
     }
 
+    fn make_admin_auth(user_id: Uuid, username: &str) -> AuthExtension {
+        let mut auth = crate::api::handlers::test_db_helpers::make_auth(user_id, username);
+        auth.is_admin = true;
+        auth
+    }
+
     #[tokio::test]
     async fn test_handler_rejects_malformed_cve_id_before_db_lookup() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -2966,7 +2990,7 @@ mod tests {
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -2997,7 +3021,7 @@ mod tests {
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         // `CveStatus::parse` returns None for any string outside the four
         // known variants. Handler must surface that as 400 with the
         // original status text echoed so the client can debug.
@@ -3032,7 +3056,7 @@ mod tests {
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-1010", "high").await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3072,7 +3096,7 @@ mod tests {
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-2020", "low").await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3106,7 +3130,7 @@ mod tests {
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3142,7 +3166,7 @@ mod tests {
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-4040", "medium")
             .await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         // Send the CVE id lower-cased: handler must still match.
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
@@ -3179,7 +3203,7 @@ mod tests {
         )
         .await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = make_admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3222,7 +3246,7 @@ mod tests {
 
         // Build an auth extension whose allowed_repo_ids does NOT include
         // the fixture's repo. Mirror tdh::make_auth then tighten scopes.
-        let mut auth = tdh::make_auth(fx.user_id, &fx.username);
+        let mut auth = make_admin_auth(fx.user_id, &fx.username);
         auth.allowed_repo_ids = AccessScope::Restricted(vec![Uuid::new_v4()]);
 
         let result = super::update_cve_status_by_artifact_cve(

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -10,7 +10,7 @@ use sqlx::PgPool;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
-use crate::api::handlers::repositories::{require_repo_write_access, require_visible};
+use crate::api::handlers::repositories::{require_repo_admin_access, require_visible};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -556,8 +556,10 @@ async fn get_all_scores(
 )]
 async fn list_scan_configs(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<ScanConfigResponse>>> {
+    auth.require_admin()?;
+
     let svc = ScanConfigService::new(state.db.clone());
     let configs = svc.list_configs().await?;
     let response: Vec<ScanConfigResponse> =
@@ -588,6 +590,8 @@ async fn trigger_scan(
     Extension(auth): Extension<AuthExtension>,
     Json(body): Json<TriggerScanRequest>,
 ) -> Result<Json<TriggerScanResponse>> {
+    auth.require_admin()?;
+
     // 503 (not 500) because "scanner not configured" is a normal operational
     // state on minimal stacks (no Trivy / OpenSCAP service), not a server
     // bug. 500 alerts on operator dashboards; 503 does not.
@@ -607,12 +611,6 @@ async fn trigger_scan(
     // result; `bypass_dedup` removes that safety. Gating on admin scope
     // matches the inventory-backfill path in admin.rs which also touches
     // every artifact in a repository (see issue #1469 review feedback).
-    if bypass_dedup && !auth.is_admin {
-        return Err(AppError::Authorization(
-            "bypass_dedup requires admin privileges".to_string(),
-        ));
-    }
-
     if let Some(artifact_id) = body.artifact_id {
         // Honest not-found up front (#2227): without this, an id with no
         // `artifacts` row -- e.g. the synthetic, SHA-256-derived id a Remote
@@ -713,9 +711,11 @@ async fn trigger_scan(
 )]
 async fn list_scans(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListScansQuery>,
 ) -> Result<Json<ScanListResponse>> {
+    auth.require_admin()?;
+
     let svc = ScanResultService::new(state.db.clone());
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
@@ -751,9 +751,11 @@ async fn list_scans(
 )]
 async fn get_scan(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ScanResponse>> {
+    auth.require_admin()?;
+
     let svc = ScanResultService::new(state.db.clone());
     let s = svc.get_scan(id).await?;
 
@@ -782,10 +784,12 @@ async fn get_scan(
 )]
 async fn list_findings(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(scan_id): Path<Uuid>,
     Query(query): Query<ListFindingsQuery>,
 ) -> Result<Json<FindingListResponse>> {
+    auth.require_admin()?;
+
     let svc = ScanResultService::new(state.db.clone());
 
     // Verify the scan exists. Without this check, an unknown scan_id falls
@@ -891,8 +895,10 @@ async fn revoke_acknowledgment(
 )]
 async fn list_policies(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<PolicyResponse>>> {
+    auth.require_admin()?;
+
     let svc = PolicyService::new(state.db.clone());
     let policies = svc.list_policies().await?;
     let response: Vec<PolicyResponse> = policies.into_iter().map(PolicyResponse::from).collect();
@@ -950,9 +956,11 @@ async fn create_policy(
 )]
 async fn get_policy(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<PolicyResponse>> {
+    auth.require_admin()?;
+
     let svc = PolicyService::new(state.db.clone());
     let p = svc.get_policy(id).await?;
 
@@ -1099,7 +1107,7 @@ async fn update_repo_security(
     // so enforce is_public + per-repo role-assignment membership here.
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    require_repo_admin_access(&auth, &repo, &repo_service).await?;
     let repo = repo.id;
 
     let svc = ScanConfigService::new(state.db.clone());
@@ -1126,10 +1134,12 @@ async fn update_repo_security(
 )]
 async fn list_artifact_scans(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(artifact_id): Path<Uuid>,
     Query(query): Query<ListScansQuery>,
 ) -> Result<Json<ScanListResponse>> {
+    auth.require_admin()?;
+
     let svc = ScanResultService::new(state.db.clone());
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
@@ -1241,7 +1251,7 @@ mod tests {
     /// Cross-tenant authz guard (xtenant-write-authz-systemic). The repo-scoped
     /// security endpoints live under the /repositories nest (not gated by
     /// repo_visibility_middleware), so each must enforce the tenant gate itself.
-    /// Assert the write handler calls `require_repo_write_access` and the read
+    /// Assert the write handler calls `require_repo_admin_access` and the read
     /// handlers call `require_visible`. String-grep because the handlers need a
     /// full DB-backed `SharedState` to run.
     #[test]
@@ -1257,8 +1267,8 @@ mod tests {
             &rest[..end]
         };
         assert!(
-            body_of("update_repo_security").contains("require_repo_write_access("),
-            "update_repo_security must call require_repo_write_access (xtenant)"
+            body_of("update_repo_security").contains("require_repo_admin_access("),
+            "update_repo_security must call require_repo_admin_access (xtenant)"
         );
         for reader in ["get_repo_security", "list_repo_scans"] {
             assert!(
@@ -1891,15 +1901,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Regression: bypass_dedup must be admin-gated in trigger_scan.
+    // Regression: trigger_scan must be admin-gated.
     //
-    // PR #1514 review feedback: `bypass_dedup` skips the hash-based scan
-    // dedup short-circuit and fans out unbounded tokio::spawn workers across
-    // an entire repository's artifacts. The pre-existing `force = true` path
-    // was naturally rate-limited because dedup collapsed repeated calls
-    // against the same checksum into a single cached result; `bypass_dedup`
-    // removes that safety, so a non-admin caller setting it to true would be
-    // a DoS amplifier.
+    // Security hardening made scan trigger an administrative operation for
+    // all callers. `bypass_dedup` remains especially expensive, but even the
+    // normal trigger path can schedule scanner work and expose operational
+    // surfaces that should not be available to non-admin users.
     //
     // This test invokes the `trigger_scan` handler directly (not via the
     // router) so it covers the actual 403 branch under `cargo llvm-cov`.
@@ -1907,17 +1914,17 @@ mod tests {
     // no-ops cleanly otherwise, matching the `tdh::Fixture` pattern used
     // by sibling handler tests.
     //
-    // Coverage strategy: three call shapes prove the gate's behaviour
+    // Coverage strategy: call shapes prove the gate's behaviour
     // without spinning up a real scan run:
     //
-    //   1. non-admin + bypass_dedup=true  -> 403 Authorization (the gate)
+    //   1. non-admin + bypass_dedup=true -> 403 Authorization
     //   2. admin + bypass_dedup=true + no ids -> 400 Validation
     //      (the gate is bypassed for admins; we land on the next check)
-    //   3. non-admin + bypass_dedup omitted + no ids -> 400 Validation
-    //      (the gate does not fire for the normal trigger path)
+    //   3. non-admin + bypass_dedup omitted + no ids -> 403 Authorization
+    //   4. non-admin + bypass_dedup=false + no ids -> 403 Authorization
     // -----------------------------------------------------------------------
     #[tokio::test]
-    async fn test_trigger_scan_handler_admin_gates_bypass_dedup() {
+    async fn test_trigger_scan_handler_requires_admin() {
         use crate::api::handlers::test_db_helpers as tdh;
         use std::sync::Arc;
 
@@ -1995,13 +2002,13 @@ mod tests {
         match result {
             Err(AppError::Authorization(msg)) => {
                 assert!(
-                    msg.contains("bypass_dedup"),
-                    "403 message should mention bypass_dedup, got: {}",
+                    msg.contains("Admin access required"),
+                    "unexpected 403 message: {}",
                     msg
                 );
             }
             other => panic!(
-                "expected AppError::Authorization for non-admin bypass_dedup, got: {:?}",
+                "expected AppError::Authorization for non-admin trigger_scan, got: {:?}",
                 other.as_ref().err()
             ),
         }
@@ -2035,9 +2042,7 @@ mod tests {
             ),
         }
 
-        // ---- Case 3: non-admin + bypass_dedup omitted + no ids -> 400 Validation
-        // The gate must not fire on the normal trigger path; non-admins
-        // should still be able to call trigger_scan without bypass_dedup.
+        // ---- Case 3: non-admin + bypass_dedup omitted + no ids -> 403 Authorization
         let result = trigger_scan(
             State(state.clone()),
             Extension(make_auth(false)),
@@ -2049,17 +2054,14 @@ mod tests {
         )
         .await;
         match result {
-            Err(AppError::Validation(_)) => {} // expected
+            Err(AppError::Authorization(_)) => {} // expected
             other => panic!(
-                "non-admin without bypass_dedup must not be 403'd; expected \
-                 AppError::Validation for the missing-ids case, got: {:?}",
+                "non-admin without bypass_dedup must be stopped by the admin gate; got: {:?}",
                 other.as_ref().err()
             ),
         }
 
-        // ---- Case 4: non-admin + bypass_dedup=false -> 400 Validation
-        // Explicit `false` must behave the same as omitted (gate condition
-        // is `bypass_dedup && !auth.is_admin`, so false short-circuits).
+        // ---- Case 4: non-admin + bypass_dedup=false -> 403 Authorization
         let result = trigger_scan(
             State(state.clone()),
             Extension(make_auth(false)),
@@ -2071,11 +2073,9 @@ mod tests {
         )
         .await;
         match result {
-            Err(AppError::Validation(_)) => {} // expected
+            Err(AppError::Authorization(_)) => {} // expected
             other => panic!(
-                "non-admin with bypass_dedup=false must not be 403'd; \
-                 expected AppError::Validation for the missing-ids case, \
-                 got: {:?}",
+                "non-admin with bypass_dedup=false must be stopped by the admin gate; got: {:?}",
                 other.as_ref().err()
             ),
         }

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -96,9 +96,11 @@ pub struct SigningConfigResponse {
 )]
 async fn list_keys(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListKeysQuery>,
 ) -> Result<Json<KeyListResponse>> {
+    require_signing_admin(&auth)?;
+
     let svc = signing_service(&state);
     let keys = svc.list_keys(query.repository_id).await?;
     let total = keys.len();
@@ -170,9 +172,11 @@ async fn create_key(
 )]
 async fn get_key(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<SigningKeyPublic>> {
+    require_signing_admin(&auth)?;
+
     let svc = signing_service(&state);
     let key = svc.get_key(key_id).await?;
     Ok(Json(key))
@@ -253,6 +257,8 @@ async fn rotate_key(
     Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<SigningKeyPublic>> {
+    require_signing_admin(&auth)?;
+
     let svc = signing_service(&state);
     let new_key = svc.rotate_key(key_id, Some(auth.user_id)).await?;
     Ok(Json(new_key))
@@ -300,9 +306,11 @@ async fn get_public_key(
 )]
 async fn get_repo_signing_config(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(repo_id): Path<Uuid>,
 ) -> Result<Json<SigningConfigResponse>> {
+    require_signing_admin(&auth)?;
+
     let svc = signing_service(&state);
     let config = svc.get_signing_config(repo_id).await?;
 

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -428,6 +428,28 @@ pub async fn grant_repo_access(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     .expect("grant developer role");
 }
 
+/// Grant explicit fine-grained repository actions to the fixture user.
+///
+/// Use this in tests that intentionally exercise action-specific behavior
+/// beyond the legacy developer/write grant, such as successful destructive
+/// operations after repository delete hardening.
+pub async fn grant_repo_actions(pool: &PgPool, repo_id: Uuid, user_id: Uuid, actions: &[&str]) {
+    let actions: Vec<String> = actions.iter().map(|action| (*action).to_string()).collect();
+    sqlx::query(
+        "INSERT INTO permissions \
+         (principal_type, principal_id, target_type, target_id, actions) \
+         VALUES ('user', $1, 'repository', $2, $3) \
+         ON CONFLICT (principal_type, principal_id, target_type, target_id) \
+         DO UPDATE SET actions = EXCLUDED.actions, updated_at = NOW()",
+    )
+    .bind(user_id)
+    .bind(repo_id)
+    .bind(&actions)
+    .execute(pool)
+    .await
+    .expect("grant repository actions");
+}
+
 /// Recursively find the largest file (in bytes) under `dir`, or 0 if none.
 fn dir_max_file_size(dir: &std::path::Path) -> u64 {
     let mut max = 0u64;
@@ -522,6 +544,15 @@ pub async fn wait_for_cache_commit(dir: &std::path::Path, min_size: u64) {
 }
 
 pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    let _ = sqlx::query(
+        "DELETE FROM permissions \
+         WHERE (target_type = 'repository' AND target_id = $1) \
+            OR (principal_type = 'user' AND principal_id = $2)",
+    )
+    .bind(repo_id)
+    .bind(user_id)
+    .execute(pool)
+    .await;
     let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
         .bind(repo_id)
         .execute(pool)

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -219,13 +219,10 @@ async fn create_session(
     // repo_visibility_middleware), and the target repo is named in the JSON body,
     // so the tenant-membership gate that protects the URL-addressed artifact PUT
     // never sees this request. The fine-grained RBAC checks below fall OPEN when
-    // a repo has no permission rules (`has_rules == false`), so derive the tenant
-    // boundary from `is_public` + role_assignments membership
-    // (`require_repo_write_access`): a non-member, non-admin can never open a
-    // session against another tenant's private repo regardless of whether any
-    // permission rule exists. Admins, public-repo writers, same-org members and
-    // write/admin-holding peer-replication identities all pass unchanged. Mirrors
-    // `repositories::upload_artifact`.
+    // a repo has no permission rules (`has_rules == false`), so enforce the
+    // same action-aware gate as the URL-addressed artifact PUT. Public
+    // visibility is read-only: opening an upload session still requires an
+    // explicit repository write grant (or admin).
     let repo_service = RepositoryService::new(state.db.clone());
     let repo_record = repo_service
         .get_by_key(&req.repository_key)
@@ -1145,7 +1142,7 @@ mod tests {
     /// (and `upload_write_decision`) fall OPEN when the target repo has no
     /// fine-grained permission rules (`!has_rules`), so `create_session` must
     /// ALSO enforce the rule-independent tenant gate `require_repo_write_access`
-    /// (is_public + role_assignments membership). String-grep because the handler
+    /// (action-aware write grant). String-grep because the handler
     /// needs a real DB to run.
     #[test]
     fn test_create_session_enforces_tenant_gate() {

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -406,6 +406,8 @@ pub async fn create_webhook(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateWebhookRequest>,
 ) -> Result<Json<WebhookSecretCreatedResponse>> {
+    auth.require_admin()?;
+
     // Validate URL (SSRF prevention)
     validate_webhook_url(&payload.url)?;
 
@@ -3760,12 +3762,12 @@ mod tests {
             let Some(pool) = tdh::try_pool().await else {
                 return;
             };
-            let creator = create_user(&pool, false).await;
+            let creator = create_user(&pool, true).await;
             let state = tdh::build_state(pool.clone(), "/tmp");
 
             let resp = create_webhook(
                 axum::extract::State(state.clone()),
-                axum::Extension(auth_for(creator, false)),
+                axum::Extension(auth_for(creator, true)),
                 axum::Json(CreateWebhookRequest {
                     name: format!("created-by-{}", &creator.to_string()[..8]),
                     url: "http://198.51.100.9/hook".to_string(),

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1247,12 +1247,32 @@ pub struct RepoVisibilityState {
 
 /// Extract the repository key from a format handler request path.
 ///
-/// Format routes are nested as `/{format}/{repo_key}/...`, so the repo key
-/// is the second path segment (e.g. `/pypi/my-repo/simple/` -> `"my-repo"`).
+/// Format routes are nested as `/{format}/{repo_key}/...`, but middleware can
+/// observe either the nest-stripped form or the full `/api/v1/...` URI. In both
+/// cases the repo key is the segment immediately after the format prefix.
 pub(crate) fn extract_repo_key(path: &str) -> &str {
-    let trimmed = path.trim_start_matches('/');
-    let mut segments = trimmed.split('/');
-    segments.next(); // skip format prefix (pypi, npm, maven, etc.)
+    let mut segments = path.split('/').filter(|segment| !segment.is_empty());
+    let first = match segments.next() {
+        Some(segment) => segment,
+        None => return "",
+    };
+
+    let format = if first == "api" {
+        let Some(version) = segments.next() else {
+            return "";
+        };
+        if !version.starts_with('v') {
+            return "";
+        }
+        segments.next()
+    } else {
+        Some(first)
+    };
+
+    if format.is_none() {
+        return "";
+    }
+
     segments.next().unwrap_or("")
 }
 
@@ -1623,36 +1643,48 @@ pub async fn repo_visibility_middleware(
                 if !allowed {
                     return forbidden_permission_response();
                 }
-            } else if !is_public {
-                // A private repo with NO fine-grained permission rules must
-                // still not be readable by every authenticated user. Mirror
-                // the REST `require_visible` model: a non-admin needs a role
-                // assignment scoped to this repo (or a global assignment).
+            } else if is_write || !is_public {
+                // A repo with NO fine-grained permission rules falls back to
+                // legacy role assignments. Private repos need that legacy
+                // membership for reads and writes; public repos need it for
+                // writes because public visibility is read-only.
                 //
-                // Without this branch the native-protocol path default-ALLOWED
-                // rule-less private repos to any authenticated principal, while
-                // the REST download path denied the same caller (404) — a
-                // cross-tenant private-artifact leak (red-team round 2).
+                // Without this branch the native-protocol path default-allowed
+                // writes to rule-less public repos for any authenticated
+                // principal, while the REST path now requires an explicit
+                // repository write grant.
                 //
                 // Uses sqlx::query_scalar (not the macro) so no new entry in
                 // the sqlx offline-query cache is required, matching the rest
-                // of this middleware. Same predicate as
-                // RepositoryService::user_can_access_repo.
+                // of this middleware. Same legacy action mapping as
+                // RepositoryService::user_can_perform_repo_action.
+                let action = action_for_method(request.method());
                 let granted = sqlx::query_scalar::<_, bool>(
                     "SELECT EXISTS ( \
                          SELECT 1 FROM role_assignments ra \
+                         INNER JOIN roles r ON r.id = ra.role_id \
                          WHERE ra.user_id = $1 \
                            AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
+                           AND ( \
+                               r.name = 'admin' \
+                               OR $3 = ANY(r.permissions) \
+                               OR 'admin' = ANY(r.permissions) \
+                               OR ($3 = 'read') \
+                               OR ($3 = 'write' AND r.name = 'developer') \
+                           ) \
                      )",
                 )
                 .bind(ext.user_id)
                 .bind(repo.id)
+                .bind(action)
                 .fetch_one(&vis_state.db)
                 .await;
 
                 match granted {
                     Ok(true) => {}
-                    // Existence-hiding 404, matching REST `require_visible`.
+                    // Public write denials can be honest 403; private denials
+                    // keep existence-hiding 404, matching REST `require_visible`.
+                    Ok(false) if is_write => return forbidden_permission_response(),
                     Ok(false) => return not_found_response(),
                     Err(_) => {
                         // DB error on access check: fail closed.
@@ -2301,6 +2333,20 @@ mod tests {
     #[test]
     fn test_extract_repo_key_no_leading_slash() {
         assert_eq!(extract_repo_key("pypi/my-repo/simple"), "my-repo");
+    }
+
+    #[test]
+    fn test_extract_repo_key_full_api_path() {
+        assert_eq!(extract_repo_key("/api/v1/pypi/my-repo/simple/"), "my-repo");
+        assert_eq!(
+            extract_repo_key("/api/v1/maven/my-repo/com/example/artifact"),
+            "my-repo"
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_key_full_api_path_without_repo() {
+        assert_eq!(extract_repo_key("/api/v1/pypi"), "");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -880,12 +880,13 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
-        // Migration routes with auth middleware
+        // Migration routes are administrative: they store external source
+        // credentials and can drive bulk repository mutations.
         .nest(
             "/migrations",
             handlers::migration::router().layer(middleware::from_fn_with_state(
                 auth_service.clone(),
-                auth_middleware,
+                admin_middleware,
             )),
         )
         // Chunked/resumable upload routes with auth middleware
@@ -991,6 +992,27 @@ mod tests {
         assert!(
             next_middleware.contains("admin_middleware"),
             "plugin install + lifecycle routes must be gated by admin_middleware"
+        );
+    }
+
+    #[test]
+    fn migrations_require_admin_middleware() {
+        // Migration source connections can contain credentials for external
+        // registries, and migration jobs can bulk-create/update repository
+        // content. Keep the whole nest behind admin_middleware so non-admins
+        // are stopped before request-body validation or connection/job lookup.
+        let migrations_nest = ROUTES_RS_SRC
+            .split("handlers::migration::router()")
+            .nth(1)
+            .expect("migration router must be nested under /migrations");
+        let next_middleware = migrations_nest
+            .split("from_fn_with_state")
+            .nth(1)
+            .expect("migration router nest must attach a middleware layer");
+        assert!(
+            next_middleware.contains("admin_middleware"),
+            "migration routes must be gated by admin_middleware before handler \
+             extractors can validate bodies or look up source connections"
         );
     }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -739,6 +739,90 @@ impl RepositoryService {
         Ok(granted)
     }
 
+    /// Check whether a user may perform a specific mutating/admin action on a repository.
+    ///
+    /// Fine-grained repository permissions are authoritative once any rules exist
+    /// for the repository: callers need the requested action or `admin`. Repos
+    /// without fine-grained rules fall back to the legacy `role_assignments`
+    /// membership model so older installations do not become deny-all overnight.
+    pub async fn user_can_perform_repo_action(
+        &self,
+        repo_id: Uuid,
+        user_id: Uuid,
+        action: &str,
+    ) -> Result<bool> {
+        let has_rules: bool = sqlx::query_scalar(
+            "SELECT EXISTS( \
+                 SELECT 1 FROM permissions \
+                 WHERE target_type = 'repository' AND target_id = $1 \
+             )",
+        )
+        .bind(repo_id)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if !has_rules {
+            return self
+                .user_can_perform_legacy_repo_action(repo_id, user_id, action)
+                .await;
+        }
+
+        let allowed: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM permissions p \
+                 WHERE p.target_type = 'repository' \
+                   AND p.target_id = $2 \
+                   AND ($3 = ANY(p.actions) OR 'admin' = ANY(p.actions)) \
+                   AND ( \
+                       (p.principal_type = 'user' AND p.principal_id = $1) \
+                       OR (p.principal_type = 'group' AND p.principal_id IN ( \
+                           SELECT group_id FROM user_group_members WHERE user_id = $1 \
+                       )) \
+                   ) \
+             )",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .bind(action)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(allowed)
+    }
+
+    async fn user_can_perform_legacy_repo_action(
+        &self,
+        repo_id: Uuid,
+        user_id: Uuid,
+        action: &str,
+    ) -> Result<bool> {
+        let allowed: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM role_assignments ra \
+                 INNER JOIN roles r ON r.id = ra.role_id \
+                 WHERE ra.user_id = $1 \
+                   AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
+                   AND ( \
+                       r.name = 'admin' \
+                       OR $3 = ANY(r.permissions) \
+                       OR 'admin' = ANY(r.permissions) \
+                       OR ($3 = 'read') \
+                       OR ($3 = 'write' AND r.name = 'developer') \
+                   ) \
+             )",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .bind(action)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(allowed)
+    }
+
     /// Get a repository by ID
     pub async fn get_by_id(&self, id: Uuid) -> Result<Repository> {
         let repo = sqlx::query_as!(
@@ -2951,6 +3035,110 @@ mod tests {
                     .await
                     .expect("permissions-grant access check"),
                 "user with a non-empty permissions grant must have access"
+            );
+
+            cleanup_repo(&pool, repo.id).await;
+            for uid in [owner_id, grantee_id] {
+                let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                    .bind(uid)
+                    .execute(&pool)
+                    .await;
+            }
+        }
+
+        /// Action-specific RBAC: visibility/read grants must not authorize
+        /// repository writes or deletes, and `admin` implies all repo actions.
+        #[tokio::test]
+        async fn test_user_can_perform_repo_action_honors_specific_actions() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+
+            let (owner_id, _) = tdh::create_user(&pool).await;
+            let (grantee_id, _) = tdh::create_user(&pool).await;
+
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let mut req = make_create_req(&suffix, RepositoryFormat::Generic);
+            req.created_by = Some(owner_id);
+            let repo = service.create(req).await.expect("create private repo");
+
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
+            )
+            .bind(grantee_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("insert read permission");
+
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "write")
+                    .await
+                    .expect("write check"),
+                "read permission must not grant write"
+            );
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("delete check"),
+                "read permission must not grant delete"
+            );
+
+            sqlx::query(
+                "UPDATE permissions SET actions = ARRAY['write'] \
+                 WHERE principal_type = 'user' AND principal_id = $1 \
+                   AND target_type = 'repository' AND target_id = $2",
+            )
+            .bind(grantee_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("update to write permission");
+
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "write")
+                    .await
+                    .expect("write check"),
+                "write permission must grant write"
+            );
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("delete check"),
+                "write permission must not grant delete"
+            );
+
+            sqlx::query(
+                "UPDATE permissions SET actions = ARRAY['admin'] \
+                 WHERE principal_type = 'user' AND principal_id = $1 \
+                   AND target_type = 'repository' AND target_id = $2",
+            )
+            .bind(grantee_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("update to admin permission");
+
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("delete check"),
+                "admin permission must grant delete"
+            );
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "admin")
+                    .await
+                    .expect("admin check"),
+                "admin permission must grant admin"
             );
 
             cleanup_repo(&pool, repo.id).await;


### PR DESCRIPTION
## Summary

closes #2321 

This PR hardens authorization checks across repository mutation paths and administrative/security surfaces.

The main changes are:

- introduce action-specific repository authorization for `read`, `write`, `delete`, and `admin`;
- treat public repository visibility as read-only visibility, not write/delete permission;
- require explicit repository write/delete/admin authority on generic artifact APIs, resumable uploads, native publish paths, repository-admin subresources, and repository-scoped token delegation;
- require global admin for sensitive administrative/security/integration/migration surfaces unless they already have a narrower documented model;
- make protected routes stop unauthorized callers before request validation or resource lookup where practical;
- add focused regression tests and source-level guard tests to keep these checks from drifting.

I am intentionally keeping the PR description at the policy/implementation level. I can share the private authorization verification matrix with maintainers out of band if needed.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Validation run:

```text
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test --workspace --lib --quiet
```

Full lib-suite result:

```text
12553 passed; 0 failed; 5 ignored
```

Manual/private validation:

```text
Authorization regression protocol against a private deployment:
214 PASS, 0 FAIL

Confirmed mutation findings: 0
Confirmed data exposure findings: 0
Authz-order indicators: 0
Unexpected authz results: 0
Persistent mutation caveats: 0
```

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Notes for reviewers

No new public endpoints or migrations are introduced. The patch tightens authorization behavior on existing routes and aligns REST, resumable upload, native package publish, and API-token paths around the same repository action model.

### CI Notes / Test Fixture Updates

These test updates align fixtures with the stricter RBAC model introduced by this PR. They do not relax the new authorization behavior: tests that exercise successful destructive/admin paths now grant the exact permission needed, while denial tests still assert authorization failure.

Changed cases:

- `test_db_helpers.rs`
  - Added `grant_repo_actions(...)` and cleanup for matching `permissions` rows.
  - Reason: legacy `developer` fixtures no longer imply `delete` or admin-like repo actions.

- OCI delete fixtures:
  - `digest_pull_and_delete_survive_tag_overwrite`
  - `delete_manifest_cleanup_failure_rolls_back_tag_delete`
  - `untagged_digest_is_repo_scoped_on_shared_backend`
  - shared `OciUploadFixture::setup()`
  - Reason: these tests validate OCI delete/cleanup semantics, so they now grant explicit `read/write/delete`.

- Repository delete tests:
  - `delete_then_reupload_different_bytes_blocked_db`
  - `delete_artifact_gated_on_promotion_only_repo_db`
  - `npm_generic_download_delete_resolve_canonical_url_db`
  - Reason: each test expects a successful delete path before validating immutability, promotion-only behavior, or canonical path handling. Fixtures now grant explicit `read/write/delete`.

- Cache invalidation tests:
  - `invalidate_cache_handler_returns_200_for_remote_repo`
  - `invalidate_cache_handler_returns_400_for_non_remote_repo`
  - `invalidate_cache_handler_returns_503_when_proxy_service_missing`
  - Reason: `invalidate_cache` is now repo-admin gated before remote/local/proxy validation. Fixtures now grant explicit `admin` so the tests still cover cache behavior.

- Cache TTL authz test:
  - `set_cache_ttl_requires_repo_admin_grant_db`
  - Reason: denial behavior is still correct, but the hardened path returns the shared repository authorization message instead of the old `PermissionService` wording. The test now asserts `AppError::Authorization` rather than a specific string.

- SBOM CVE status handler tests:
  - `test_handler_rejects_malformed_cve_id_before_db_lookup`
  - `test_handler_rejects_unknown_status_string`
  - `test_handler_acknowledge_happy_path_returns_synth_entry`
  - `test_handler_fixed_status_returns_validation_error`
  - `test_handler_no_matching_scan_findings_returns_not_found`
  - `test_handler_normalizes_lowercase_cve_id_input`
  - `test_handler_accepts_ghsa_id`
  - `test_handler_rejects_caller_without_repo_access`
  - Reason: `update_cve_status_by_artifact_cve` is now admin-only. Tests that need to reach validation/update/not-found logic use admin auth; the repo-access negative case still uses restricted `allowed_repo_ids`.

- Security scan trigger test:
  - `test_trigger_scan_handler_requires_admin`
  - Reason: `trigger_scan` is now admin-only for all request shapes, not only `bypass_dedup=true`. The test now checks non-admin denial for omitted/false/true `bypass_dedup`, and verifies admin reaches post-auth validation.

- Webhook ownership test:
  - `create_webhook_records_created_by`
  - Reason: webhook creation is now admin-only. The test creates the webhook as admin, then still verifies non-admin owner read behavior for the same user id.