### PR TITLE
feat(sso): map SAML assertion groups to local group memberships

### DIFF
--- a/backend/migrations/149_saml_map_groups_to_groups.sql
+++ b/backend/migrations/149_saml_map_groups_to_groups.sql
@@ -1,0 +1,13 @@
+-- SAML group-to-group mapping (parity with OIDC #1094).
+--
+-- Add map_groups_to_groups column to saml_configs. When true, the group
+-- values carried in the SAML assertion (via the `groups` attribute mapping)
+-- are reflected as Artifact Keeper group memberships, with groups auto-created
+-- on first sight and tagged external_source = 'saml'. When false, only the
+-- existing admin_group -> is_admin behavior applies.
+--
+-- Reuses the groups.external_source / external_provider_id columns and the
+-- idx_groups_external index already added in migration 100.
+
+ALTER TABLE saml_configs
+    ADD COLUMN map_groups_to_groups BOOLEAN NOT NULL DEFAULT false;

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -10669,12 +10669,12 @@ mod tests {
             assert!(
                 validate_virtual_repo_member_count("my-repo", &rt, None).is_ok(),
                 "{:?} with no members must be Ok",
-                &rt
+                rt
             );
             assert!(
                 validate_virtual_repo_member_count("my-repo", &rt, Some(&[])).is_ok(),
                 "{:?} with empty members must be Ok",
-                &rt
+                rt
             );
         }
     }
@@ -11597,7 +11597,7 @@ mod tests {
                      VALUES ($1, $2, $3, $4, $5, $6, $7)",
                 )
                 .bind(repo_id)
-                .bind(format!("app/{}", &key))
+                .bind(format!("app/{}", key))
                 .bind("manifest")
                 .bind(16_i64)
                 .bind("f".repeat(64))

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -897,6 +897,10 @@ pub async fn saml_acs(
         }
     };
 
+    // Captured before the move into FederatedCredentials for group-to-group
+    // mapping below.
+    let saml_groups = saml_user.groups.clone();
+
     // Sync user and generate tokens
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let (user, tokens) = auth_service
@@ -924,6 +928,24 @@ pub async fn saml_acs(
         serde_json::json!({ "username": user.username }),
     )
     .await;
+
+    // When map_groups_to_groups is enabled, reflect the SAML assertion group
+    // values as Artifact Keeper group memberships (parity with OIDC #1094).
+    // Auto-create groups tagged external_source = 'saml' and reconcile so
+    // removed groups drop their members. Failure never blocks login.
+    if row.map_groups_to_groups {
+        if let Err(e) =
+            sync_federated_groups_to_local_groups(&state.db, user.id, id, "saml", &saml_groups)
+                .await
+        {
+            tracing::warn!(
+                error = %e,
+                user_id = %user.id,
+                provider_id = %id,
+                "Failed to sync SAML groups to local groups; user login still succeeds"
+            );
+        }
+    }
 
     // Create a short-lived exchange code instead of passing raw tokens in the URL
     let exchange_code = AuthConfigService::create_exchange_code(
@@ -1119,32 +1141,46 @@ pub(crate) fn extract_oidc_groups(claims: &serde_json::Value, groups_claim: &str
 }
 
 /// Reconcile an OIDC user's group memberships against the `groups` table.
-///
-/// For each group name in `oidc_groups`:
-/// - Find the group by name; if missing, auto-create it tagged with
-///   `external_source = 'oidc'` and `external_provider_id = provider_id`.
-/// - Ensure a `user_group_members` row exists.
-///
-/// Then remove the user from any group that:
-/// - is tagged with this same `external_source` + `external_provider_id`, AND
-/// - is not present in `oidc_groups`.
-///
-/// Operator-managed groups (NULL `external_source`) are never modified by
-/// this sync. (Issue #1094.)
+/// Thin wrapper over [`sync_federated_groups_to_local_groups`] with the
+/// `oidc` source tag. (Issue #1094.)
 pub(crate) async fn sync_oidc_groups_to_local_groups(
     pool: &sqlx::PgPool,
     user_id: Uuid,
     provider_id: Uuid,
     oidc_groups: &[String],
 ) -> Result<()> {
+    sync_federated_groups_to_local_groups(pool, user_id, provider_id, "oidc", oidc_groups).await
+}
+
+/// Reconcile a federated user's group memberships against the `groups` table.
+///
+/// For each group name in `idp_groups`:
+/// - Find the group by name; if missing, auto-create it tagged with
+///   `external_source = source` and `external_provider_id = provider_id`.
+/// - Ensure a `user_group_members` row exists.
+///
+/// Then remove the user from any group that:
+/// - is tagged with this same `external_source` + `external_provider_id`, AND
+/// - is not present in `idp_groups`.
+///
+/// Operator-managed groups (NULL `external_source`) and groups owned by other
+/// providers/sources are never modified by this sync. `source` scopes the
+/// reconcile to one IdP kind (e.g. "oidc", "saml"). (Issues #1094, SAML parity.)
+pub(crate) async fn sync_federated_groups_to_local_groups(
+    pool: &sqlx::PgPool,
+    user_id: Uuid,
+    provider_id: Uuid,
+    source: &str,
+    idp_groups: &[String],
+) -> Result<()> {
     let mut tx = pool
         .begin()
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-    // Upsert each OIDC group: find-or-create, then ensure membership.
-    let mut current_group_ids: Vec<Uuid> = Vec::with_capacity(oidc_groups.len());
-    for name in oidc_groups {
+    // Upsert each group: find-or-create, then ensure membership.
+    let mut current_group_ids: Vec<Uuid> = Vec::with_capacity(idp_groups.len());
+    for name in idp_groups {
         if name.trim().is_empty() {
             continue;
         }
@@ -1164,13 +1200,14 @@ pub(crate) async fn sync_oidc_groups_to_local_groups(
         let (group_id,): (Uuid,) = sqlx::query_as(
             r#"
             INSERT INTO groups (name, description, external_source, external_provider_id)
-            VALUES ($1, $2, 'oidc', $3)
+            VALUES ($1, $2, $3, $4)
             ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
             RETURNING id
             "#,
         )
         .bind(name)
-        .bind(format!("Auto-created from OIDC group claim: {name}"))
+        .bind(format!("Auto-created from {source} group claim: {name}"))
+        .bind(source)
         .bind(provider_id)
         .fetch_one(&mut *tx)
         .await
@@ -1192,24 +1229,25 @@ pub(crate) async fn sync_oidc_groups_to_local_groups(
         current_group_ids.push(group_id);
     }
 
-    // Remove the user from any OIDC-managed group (same provider) that they
-    // are no longer a member of according to the latest claims. We deliberately
-    // limit the scope to groups marked external_source = 'oidc' AND
-    // external_provider_id = provider_id so we never strip membership in
-    // operator-managed groups or groups owned by other IdPs.
+    // Remove the user from any group managed by this same source+provider that
+    // they are no longer a member of according to the latest assertion/claims.
+    // We deliberately limit the scope to groups marked external_source = source
+    // AND external_provider_id = provider_id so we never strip membership in
+    // operator-managed groups or groups owned by other IdPs/sources.
     sqlx::query(
         r#"
         DELETE FROM user_group_members
         WHERE user_id = $1
           AND group_id IN (
               SELECT id FROM groups
-              WHERE external_source = 'oidc'
-                AND external_provider_id = $2
-                AND NOT (id = ANY($3))
+              WHERE external_source = $2
+                AND external_provider_id = $3
+                AND NOT (id = ANY($4))
           )
         "#,
     )
     .bind(user_id)
+    .bind(source)
     .bind(provider_id)
     .bind(&current_group_ids)
     .execute(&mut *tx)
@@ -2591,7 +2629,7 @@ mod tests {
     // =======================================================================
 
     mod sync_db {
-        use super::super::sync_oidc_groups_to_local_groups;
+        use super::super::{sync_federated_groups_to_local_groups, sync_oidc_groups_to_local_groups};
         use crate::api::handlers::test_db_helpers as db_helpers;
         use sqlx::PgPool;
         use uuid::Uuid;
@@ -2743,6 +2781,45 @@ mod tests {
             assert!(group_id_by_name(&pool, "   ").await.is_none());
 
             cleanup_groups(&pool, &[real_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        #[tokio::test]
+        async fn test_sync_saml_tags_source_and_isolates_from_oidc() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            // Same provider_id on purpose: isolation must come from `source`,
+            // not just a differing provider id.
+            let provider_id = Uuid::new_v4();
+            let sg = rand_group_name("saml-team");
+
+            sync_federated_groups_to_local_groups(&pool, user_id, provider_id, "saml", &[sg.clone()])
+                .await
+                .expect("saml sync");
+
+            let sg_id = group_id_by_name(&pool, &sg).await.expect("saml group");
+            assert!(user_is_in_group(&pool, user_id, sg_id).await);
+            assert_eq!(
+                group_external_source(&pool, sg_id).await.as_deref(),
+                Some("saml")
+            );
+
+            // An OIDC reconcile for the same provider with no groups must NOT
+            // strip the SAML-sourced membership — the DELETE is scoped by source.
+            sync_oidc_groups_to_local_groups(&pool, user_id, provider_id, &[])
+                .await
+                .expect("oidc empty sync");
+            assert!(user_is_in_group(&pool, user_id, sg_id).await);
+
+            // A SAML reconcile with no groups, however, does drop the membership.
+            sync_federated_groups_to_local_groups(&pool, user_id, provider_id, "saml", &[])
+                .await
+                .expect("saml empty sync");
+            assert!(!user_is_in_group(&pool, user_id, sg_id).await);
+
+            cleanup_groups(&pool, &[sg_id]).await;
             cleanup_user(&pool, user_id).await;
         }
 

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -2629,7 +2629,9 @@ mod tests {
     // =======================================================================
 
     mod sync_db {
-        use super::super::{sync_federated_groups_to_local_groups, sync_oidc_groups_to_local_groups};
+        use super::super::{
+            sync_federated_groups_to_local_groups, sync_oidc_groups_to_local_groups,
+        };
         use crate::api::handlers::test_db_helpers as db_helpers;
         use sqlx::PgPool;
         use uuid::Uuid;
@@ -2795,9 +2797,15 @@ mod tests {
             let provider_id = Uuid::new_v4();
             let sg = rand_group_name("saml-team");
 
-            sync_federated_groups_to_local_groups(&pool, user_id, provider_id, "saml", &[sg.clone()])
-                .await
-                .expect("saml sync");
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "saml",
+                &[sg.clone()],
+            )
+            .await
+            .expect("saml sync");
 
             let sg_id = group_id_by_name(&pool, &sg).await.expect("saml group");
             assert!(user_is_in_group(&pool, user_id, sg_id).await);

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -2802,7 +2802,7 @@ mod tests {
                 user_id,
                 provider_id,
                 "saml",
-                &[sg.clone()],
+                std::slice::from_ref(&sg),
             )
             .await
             .expect("saml sync");

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -1126,6 +1126,7 @@ mod tests {
             admin_group: Some("admin-group".to_string()),
             is_enabled: false,
             use_absolute_acs_url: false,
+            map_groups_to_groups: false,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -112,6 +112,7 @@ pub struct SamlConfigRow {
     /// historical relative path. Defaults to false so existing
     /// configurations keep their pre-138 wire format.
     pub use_absolute_acs_url: bool,
+    pub map_groups_to_groups: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -211,6 +212,10 @@ pub struct SamlConfigResponse {
     /// emits an absolute ACS URL. Defaults to false so existing providers
     /// keep their pre-138 wire format.
     pub use_absolute_acs_url: bool,
+    /// Opt-in flag (see migration 149): when true, group values from the SAML
+    /// assertion are reflected as Artifact Keeper group memberships. Defaults
+    /// to false so existing providers keep admin_group-only behavior.
+    pub map_groups_to_groups: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -327,6 +332,9 @@ pub struct CreateSamlConfigRequest {
     /// emits an absolute ACS URL for stricter IdPs that reject the
     /// historical relative path. Defaults to false.
     pub use_absolute_acs_url: Option<bool>,
+    /// Opt-in flag (see migration 149): reflect SAML assertion group values as
+    /// Artifact Keeper group memberships. Defaults to false.
+    pub map_groups_to_groups: Option<bool>,
 }
 
 #[derive(Debug, Clone, Deserialize, ToSchema)]
@@ -345,6 +353,7 @@ pub struct UpdateSamlConfigRequest {
     pub admin_group: Option<String>,
     pub is_enabled: Option<bool>,
     pub use_absolute_acs_url: Option<bool>,
+    pub map_groups_to_groups: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, ToSchema)]
@@ -1156,7 +1165,8 @@ impl AuthConfigService {
             SELECT id, name, entity_id, sso_url, slo_url, certificate,
                    name_id_format, attribute_mapping, sp_entity_id,
                    sign_requests, require_signed_assertions, admin_group,
-                   is_enabled, use_absolute_acs_url, created_at, updated_at
+                   is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                   created_at, updated_at
             FROM saml_configs
             ORDER BY name
             "#,
@@ -1174,7 +1184,8 @@ impl AuthConfigService {
             SELECT id, name, entity_id, sso_url, slo_url, certificate,
                    name_id_format, attribute_mapping, sp_entity_id,
                    sign_requests, require_signed_assertions, admin_group,
-                   is_enabled, use_absolute_acs_url, created_at, updated_at
+                   is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                   created_at, updated_at
             FROM saml_configs
             WHERE id = $1
             "#,
@@ -1194,7 +1205,8 @@ impl AuthConfigService {
             SELECT id, name, entity_id, sso_url, slo_url, certificate,
                    name_id_format, attribute_mapping, sp_entity_id,
                    sign_requests, require_signed_assertions, admin_group,
-                   is_enabled, use_absolute_acs_url, created_at, updated_at
+                   is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                   created_at, updated_at
             FROM saml_configs
             WHERE id = $1
             "#,
@@ -1222,18 +1234,20 @@ impl AuthConfigService {
         let require_signed_assertions = req.require_signed_assertions.unwrap_or(true);
         let is_enabled = req.is_enabled.unwrap_or(true);
         let use_absolute_acs_url = req.use_absolute_acs_url.unwrap_or(false);
+        let map_groups_to_groups = req.map_groups_to_groups.unwrap_or(false);
 
         let row = sqlx::query_as::<_, SamlConfigRow>(
             r#"
             INSERT INTO saml_configs (id, name, entity_id, sso_url, slo_url, certificate,
                                       name_id_format, attribute_mapping, sp_entity_id,
                                       sign_requests, require_signed_assertions, admin_group,
-                                      is_enabled, use_absolute_acs_url)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                                      is_enabled, use_absolute_acs_url, map_groups_to_groups)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
             RETURNING id, name, entity_id, sso_url, slo_url, certificate,
                       name_id_format, attribute_mapping, sp_entity_id,
                       sign_requests, require_signed_assertions, admin_group,
-                      is_enabled, use_absolute_acs_url, created_at, updated_at
+                      is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                      created_at, updated_at
             "#,
         )
         .bind(id)
@@ -1250,6 +1264,7 @@ impl AuthConfigService {
         .bind(&req.admin_group)
         .bind(is_enabled)
         .bind(use_absolute_acs_url)
+        .bind(map_groups_to_groups)
         .fetch_one(pool)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to create SAML config: {e}")))?;
@@ -1267,7 +1282,8 @@ impl AuthConfigService {
             SELECT id, name, entity_id, sso_url, slo_url, certificate,
                    name_id_format, attribute_mapping, sp_entity_id,
                    sign_requests, require_signed_assertions, admin_group,
-                   is_enabled, use_absolute_acs_url, created_at, updated_at
+                   is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                   created_at, updated_at
             FROM saml_configs
             WHERE id = $1
             "#,
@@ -1295,6 +1311,9 @@ impl AuthConfigService {
         let use_absolute_acs_url = req
             .use_absolute_acs_url
             .unwrap_or(existing.use_absolute_acs_url);
+        let map_groups_to_groups = req
+            .map_groups_to_groups
+            .unwrap_or(existing.map_groups_to_groups);
 
         let row = sqlx::query_as::<_, SamlConfigRow>(
             r#"
@@ -1303,12 +1322,13 @@ impl AuthConfigService {
                 certificate = $5, name_id_format = $6, attribute_mapping = $7,
                 sp_entity_id = $8, sign_requests = $9, require_signed_assertions = $10,
                 admin_group = $11, is_enabled = $12, use_absolute_acs_url = $13,
-                updated_at = NOW()
-            WHERE id = $14
+                map_groups_to_groups = $14, updated_at = NOW()
+            WHERE id = $15
             RETURNING id, name, entity_id, sso_url, slo_url, certificate,
                       name_id_format, attribute_mapping, sp_entity_id,
                       sign_requests, require_signed_assertions, admin_group,
-                      is_enabled, use_absolute_acs_url, created_at, updated_at
+                      is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                      created_at, updated_at
             "#,
         )
         .bind(&name)
@@ -1324,6 +1344,7 @@ impl AuthConfigService {
         .bind(&admin_group)
         .bind(is_enabled)
         .bind(use_absolute_acs_url)
+        .bind(map_groups_to_groups)
         .bind(id)
         .fetch_one(pool)
         .await
@@ -1357,7 +1378,8 @@ impl AuthConfigService {
             RETURNING id, name, entity_id, sso_url, slo_url, certificate,
                       name_id_format, attribute_mapping, sp_entity_id,
                       sign_requests, require_signed_assertions, admin_group,
-                      is_enabled, use_absolute_acs_url, created_at, updated_at
+                      is_enabled, use_absolute_acs_url, map_groups_to_groups,
+                      created_at, updated_at
             "#,
         )
         .bind(toggle.enabled)
@@ -1386,6 +1408,7 @@ impl AuthConfigService {
             admin_group: row.admin_group,
             is_enabled: row.is_enabled,
             use_absolute_acs_url: row.use_absolute_acs_url,
+            map_groups_to_groups: row.map_groups_to_groups,
             created_at: row.created_at,
             updated_at: row.updated_at,
         }
@@ -1966,6 +1989,7 @@ mod tests {
             admin_group: Some("admins".to_string()),
             is_enabled: true,
             use_absolute_acs_url: false,
+            map_groups_to_groups: false,
             created_at: now,
             updated_at: now,
         }
@@ -2334,6 +2358,7 @@ mod tests {
             admin_group: None,
             is_enabled: true,
             use_absolute_acs_url: false,
+            map_groups_to_groups: false,
             created_at: now,
             updated_at: now,
         };
@@ -2429,6 +2454,7 @@ mod tests {
             admin_group: None,
             is_enabled: true,
             use_absolute_acs_url: false,
+            map_groups_to_groups: false,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -3077,6 +3103,7 @@ mod tests {
                 admin_group: None,
                 is_enabled: Some(true),
                 use_absolute_acs_url: None,
+                map_groups_to_groups: None,
             }
         }
 
@@ -3177,6 +3204,7 @@ mod tests {
                 admin_group: None,
                 is_enabled: None,
                 use_absolute_acs_url: None,
+                map_groups_to_groups: None,
             };
             let updated = AuthConfigService::update_saml(&pool, created.id, update)
                 .await
@@ -3212,6 +3240,7 @@ mod tests {
                 admin_group: None,
                 is_enabled: None,
                 use_absolute_acs_url: Some(false),
+                map_groups_to_groups: None,
             };
             let updated = AuthConfigService::update_saml(&pool, created.id, update)
                 .await

--- a/backend/tests/sso_saml_acs_e2e_tests.rs
+++ b/backend/tests/sso_saml_acs_e2e_tests.rs
@@ -120,6 +120,7 @@ async fn create_saml_provider(pool: &PgPool, opts: SamlProviderOpts) -> Uuid {
             admin_group: opts.admin_group,
             is_enabled: Some(true),
             use_absolute_acs_url: Some(opts.use_absolute_acs_url),
+            map_groups_to_groups: None,
         },
     )
     .await


### PR DESCRIPTION
Closes #2333

## What

Adds a per-provider `map_groups_to_groups` flag to SAML configs (migration 149),
mirroring the OIDC group-to-group mapping from #1094. When enabled, group values
carried in the SAML assertion (`groups` attribute mapping) are reflected as
Artifact Keeper group memberships: groups are auto-created tagged
`external_source = 'saml'` and reconciled on every login. When disabled (default),
only the existing `admin_group -> is_admin` behavior applies.

## Why

SAML currently maps assertion groups only to `is_admin` via `admin_group`; there
is no way to grant non-admin permissions from group membership. OIDC already
supports this (#1094), but IdPs like Google Workspace only emit group membership
over SAML, not in the OIDC id_token — so SAML users could not receive
group-based permissions at all.

## How

- The OIDC group-sync core is generalized into `sync_federated_groups_to_local_groups`
  taking a `source` tag; `sync_oidc_groups_to_local_groups` becomes a thin wrapper,
  so all existing OIDC callers/tests are untouched.
- `saml_acs` invokes it with `source = "saml"` when the provider has
  `map_groups_to_groups` enabled. Sync failure is logged and never blocks login.
- The reconcile DELETE is scoped by `(external_source, external_provider_id)`, so
  SAML and OIDC providers never strip each other's memberships, and operator-managed
  groups (NULL `external_source`) are never touched.

## Tests

Adds `test_sync_saml_tags_source_and_isolates_from_oidc`: verifies SAML groups are
tagged `'saml'` and that an OIDC reconcile with the same provider id does not strip
SAML-sourced memberships. Existing OIDC sync tests unchanged.

## Also fixed (unrelated, CI-blocking)

`clippy` 1.97 (released 2026-07-07) promoted `useless_borrows_in_formatting`,
which now fires on pre-existing code in `backend/src/api/handlers/repositories.rs`
(two `assert!` format args and one `format!()` call). This fails
`cargo clippy --workspace --all-targets -- -D warnings` for **any** PR against the
repo, not just this one. Removed the three redundant `&` references so CI can go
green. This is orthogonal to the SAML change — happy to split it into a standalone
PR if preferred.
