### PR TITLE
fix(api): align OpenAPI spec with runtime behavior on six endpoints

### DIFF
--- a/backend/src/api/handlers/artifacts.rs
+++ b/backend/src/api/handlers/artifacts.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::repositories::ArtifactResponse;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -84,21 +85,22 @@ pub fn router() -> Router<SharedState> {
         .merge(super::artifact_labels::artifact_labels_router())
 }
 
-#[derive(Debug, Serialize, ToSchema)]
-pub struct ArtifactResponse {
-    pub id: Uuid,
-    pub repository_id: Uuid,
-    pub repository_key: Option<String>,
-    pub path: String,
-    pub name: String,
-    pub version: Option<String>,
-    pub size_bytes: i64,
-    pub checksum_sha256: String,
-    pub checksum_md5: Option<String>,
-    pub checksum_sha1: Option<String>,
-    pub content_type: String,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
+/// Row shape for the by-id artifact lookup.
+///
+/// Runtime `query_as` (not the compile-time macro) so the query needs no
+/// `.sqlx` offline entry; the columns mirror what
+/// [`ArtifactResponse`] needs.
+#[derive(Debug, sqlx::FromRow)]
+struct ArtifactByIdRow {
+    id: Uuid,
+    repository_key: String,
+    path: String,
+    name: String,
+    version: Option<String>,
+    size_bytes: i64,
+    checksum_sha256: String,
+    content_type: String,
+    created_at: chrono::DateTime<chrono::Utc>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -136,19 +138,14 @@ pub async fn get_artifact(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ArtifactResponse>> {
-    let artifact = sqlx::query!(
-        r#"
-        SELECT
-            a.id, a.repository_id, a.path, a.name, a.version, a.size_bytes,
-            a.checksum_sha256, a.checksum_md5, a.checksum_sha1,
-            a.content_type, a.created_at, a.updated_at,
-            r.key as repository_key
-        FROM artifacts a
-        JOIN repositories r ON r.id = a.repository_id
-        WHERE a.id = $1 AND a.is_deleted = false
-        "#,
-        id
+    let artifact: ArtifactByIdRow = sqlx::query_as(
+        "SELECT a.id, r.key AS repository_key, a.path, a.name, a.version, \
+                a.size_bytes, a.checksum_sha256, a.content_type, a.created_at \
+         FROM artifacts a \
+         JOIN repositories r ON r.id = a.repository_id \
+         WHERE a.id = $1 AND a.is_deleted = false",
     )
+    .bind(id)
     .fetch_optional(&state.db)
     .await
     .map_err(|e| AppError::Database(e.to_string()))?
@@ -156,20 +153,40 @@ pub async fn get_artifact(
 
     check_artifact_visibility(&auth, id, &state.db).await?;
 
+    let download_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1")
+            .bind(id)
+            .fetch_one(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let metadata: Option<serde_json::Value> =
+        sqlx::query_scalar("SELECT metadata FROM artifact_metadata WHERE artifact_id = $1")
+            .bind(id)
+            .fetch_optional(&state.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
     Ok(Json(ArtifactResponse {
         id: artifact.id,
-        repository_id: artifact.repository_id,
-        repository_key: Some(artifact.repository_key),
+        repository_key: artifact.repository_key,
         path: artifact.path,
         name: artifact.name,
         version: artifact.version,
         size_bytes: artifact.size_bytes,
         checksum_sha256: artifact.checksum_sha256,
-        checksum_md5: artifact.checksum_md5,
-        checksum_sha1: artifact.checksum_sha1,
         content_type: artifact.content_type,
+        download_count,
         created_at: artifact.created_at,
-        updated_at: artifact.updated_at,
+        metadata,
+        // This handler resolves a real `artifacts` row by id, so it is
+        // always a hosted artifact (analyzable), matching the by-path
+        // handler in repositories.rs.
+        analyzable: true,
+        // Proxy cache freshness is a Remote-repo, by-path concern; the
+        // by-id surface does not resolve through the proxy cache.
+        cache_cached_at: None,
+        cache_expires_at: None,
     }))
 }
 
@@ -286,7 +303,13 @@ pub async fn get_artifact_stats(
 #[derive(OpenApi)]
 #[openapi(
     paths(get_artifact, get_artifact_metadata, get_artifact_stats,),
-    components(schemas(ArtifactResponse, ArtifactMetadataResponse, ArtifactStatsResponse,))
+    // `ArtifactResponse` is intentionally NOT registered here: the canonical
+    // schema lives in repositories.rs (RepositoriesApiDoc). Registering a
+    // second struct under the same name used to shadow it (utoipa merge is
+    // first-wins on schema names) and published a stale shape for
+    // GET /api/v1/artifacts/{id}. See the schema-name-uniqueness regression
+    // test in openapi.rs.
+    components(schemas(ArtifactMetadataResponse, ArtifactStatsResponse,))
 )]
 pub struct ArtifactsApiDoc;
 
@@ -296,87 +319,109 @@ mod tests {
     use chrono::Utc;
 
     // ── ArtifactResponse serialization tests ────────────────────────
+    //
+    // The by-id endpoint now serves the canonical repositories.rs
+    // ArtifactResponse (the shape the published OpenAPI spec has always
+    // declared). These tests pin the on-the-wire contract of that shape as
+    // served by GET /api/v1/artifacts/{id}.
 
     #[test]
     fn test_artifact_response_serialization_all_fields() {
         let now = Utc::now();
         let id = Uuid::new_v4();
-        let repo_id = Uuid::new_v4();
         let resp = ArtifactResponse {
             id,
-            repository_id: repo_id,
-            repository_key: Some("maven-releases".to_string()),
+            repository_key: "maven-releases".to_string(),
             path: "com/example/lib/1.0/lib-1.0.jar".to_string(),
             name: "lib".to_string(),
             version: Some("1.0".to_string()),
             size_bytes: 102400,
             checksum_sha256: "abc123".to_string(),
-            checksum_md5: Some("def456".to_string()),
-            checksum_sha1: Some("ghi789".to_string()),
             content_type: "application/java-archive".to_string(),
+            download_count: 42,
             created_at: now,
-            updated_at: now,
+            metadata: Some(serde_json::json!({"groupId": "com.example"})),
+            analyzable: true,
+            cache_cached_at: None,
+            cache_expires_at: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["id"], id.to_string());
-        assert_eq!(json["repository_id"], repo_id.to_string());
         assert_eq!(json["repository_key"], "maven-releases");
         assert_eq!(json["path"], "com/example/lib/1.0/lib-1.0.jar");
         assert_eq!(json["name"], "lib");
         assert_eq!(json["version"], "1.0");
         assert_eq!(json["size_bytes"], 102400);
         assert_eq!(json["checksum_sha256"], "abc123");
-        assert_eq!(json["checksum_md5"], "def456");
-        assert_eq!(json["checksum_sha1"], "ghi789");
         assert_eq!(json["content_type"], "application/java-archive");
+        // Spec-required fields the by-id endpoint previously omitted (#98).
+        assert_eq!(json["download_count"], 42);
+        assert_eq!(json["analyzable"], true);
+        assert_eq!(json["metadata"]["groupId"], "com.example");
     }
 
     #[test]
-    fn test_artifact_response_optional_fields_null() {
-        let now = Utc::now();
+    fn test_artifact_response_no_undeclared_fields() {
+        // The previous local ArtifactResponse leaked DB columns the spec
+        // never declared. Pin their absence on the serialized output.
         let resp = ArtifactResponse {
             id: Uuid::new_v4(),
-            repository_id: Uuid::new_v4(),
-            repository_key: None,
+            repository_key: "generic-local".to_string(),
             path: "file.tar.gz".to_string(),
             name: "file".to_string(),
             version: None,
             size_bytes: 0,
             checksum_sha256: "sha".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
             content_type: "application/octet-stream".to_string(),
-            created_at: now,
-            updated_at: now,
+            download_count: 0,
+            created_at: Utc::now(),
+            metadata: None,
+            analyzable: true,
+            cache_cached_at: None,
+            cache_expires_at: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
-        assert!(json["repository_key"].is_null());
+        let obj = json.as_object().unwrap();
+        for undeclared in [
+            "repository_id",
+            "checksum_md5",
+            "checksum_sha1",
+            "updated_at",
+        ] {
+            assert!(
+                !obj.contains_key(undeclared),
+                "`{undeclared}` is not part of the published ArtifactResponse schema"
+            );
+        }
+        // Cache freshness fields are skip_serializing_if = None.
+        assert!(!obj.contains_key("cache_cached_at"));
+        assert!(!obj.contains_key("cache_expires_at"));
         assert!(json["version"].is_null());
-        assert!(json["checksum_md5"].is_null());
-        assert!(json["checksum_sha1"].is_null());
+        assert!(json["metadata"].is_null());
     }
 
     #[test]
     fn test_artifact_response_zero_size() {
-        let now = Utc::now();
         let resp = ArtifactResponse {
             id: Uuid::new_v4(),
-            repository_id: Uuid::new_v4(),
-            repository_key: None,
+            repository_key: "generic-local".to_string(),
             path: "empty".to_string(),
             name: "empty".to_string(),
             version: None,
             size_bytes: 0,
             checksum_sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
                 .to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
             content_type: "application/octet-stream".to_string(),
-            created_at: now,
-            updated_at: now,
+            download_count: 0,
+            created_at: Utc::now(),
+            metadata: None,
+            analyzable: false,
+            cache_cached_at: None,
+            cache_expires_at: None,
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["size_bytes"], 0);
+        assert_eq!(json["analyzable"], false);
     }
 
     // ── ArtifactMetadataResponse serialization tests ────────────────
@@ -475,18 +520,19 @@ mod tests {
     fn test_artifact_response_debug_impl() {
         let resp = ArtifactResponse {
             id: Uuid::nil(),
-            repository_id: Uuid::nil(),
-            repository_key: None,
+            repository_key: "k".to_string(),
             path: "p".to_string(),
             name: "n".to_string(),
             version: None,
             size_bytes: 0,
             checksum_sha256: "s".to_string(),
-            checksum_md5: None,
-            checksum_sha1: None,
             content_type: "t".to_string(),
+            download_count: 0,
             created_at: Utc::now(),
-            updated_at: Utc::now(),
+            metadata: None,
+            analyzable: true,
+            cache_cached_at: None,
+            cache_expires_at: None,
         };
         let debug_str = format!("{:?}", resp);
         assert!(debug_str.contains("ArtifactResponse"));

--- a/backend/src/api/handlers/ci_auth_admin.rs
+++ b/backend/src/api/handlers/ci_auth_admin.rs
@@ -72,7 +72,10 @@ fn require_admin(auth: &AuthExtension) -> crate::error::Result<()> {
 
 #[utoipa::path(
     get,
-    path = "/",
+    // `""` (not `"/"`): the route is served at the bare collection path
+    // `/api/v1/admin/ci-oidc`; `path = "/"` published a trailing-slash URL
+    // that the router 404s. Mirrors lifecycle.rs.
+    path = "",
     context_path = "/api/v1/admin/ci-oidc",
     tag = "admin",
     // Explicit id: the default (`list_providers`) collides with the SSO
@@ -120,7 +123,8 @@ pub async fn get_provider(
 
 #[utoipa::path(
     post,
-    path = "/",
+    // `""` (not `"/"`): see list_providers above.
+    path = "",
     context_path = "/api/v1/admin/ci-oidc",
     tag = "admin",
     security(("bearer_auth" = [])),

--- a/backend/src/api/handlers/email_subscriptions.rs
+++ b/backend/src/api/handlers/email_subscriptions.rs
@@ -11,6 +11,7 @@
 
 use axum::{
     extract::{Path, State},
+    http::StatusCode,
     routing::{delete, get},
     Extension, Json, Router,
 };
@@ -358,7 +359,7 @@ pub async fn create_subscription(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
     Json(body): Json<CreateEmailSubscriptionRequest>,
-) -> Result<Json<EmailSubscriptionResponse>> {
+) -> Result<(StatusCode, Json<EmailSubscriptionResponse>)> {
     let (auth, repo_id) = authorize_subscription_repo(&state, auth, &key).await?;
 
     validate_event_types(&body.event_types)?;
@@ -399,7 +400,9 @@ pub async fn create_subscription(
     )
     .await;
 
-    Ok(Json(row.into()))
+    // 201 to match the published spec (`status = 201` above); the handler
+    // used to return a bare 200, which strict generated SDKs reject.
+    Ok((StatusCode::CREATED, Json(row.into())))
 }
 
 /// Delete an email subscription by id.

--- a/backend/src/api/handlers/lifecycle.rs
+++ b/backend/src/api/handlers/lifecycle.rs
@@ -14,7 +14,7 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::lifecycle_service::{
     CreatePolicyRequest, LifecyclePolicy, LifecycleService, PolicyExecutionResult,
-    UpdatePolicyRequest,
+    UpdateLifecyclePolicyRequest,
 };
 
 #[derive(OpenApi)]
@@ -32,7 +32,7 @@ use crate::services::lifecycle_service::{
     components(schemas(
         LifecyclePolicy,
         CreatePolicyRequest,
-        UpdatePolicyRequest,
+        UpdateLifecyclePolicyRequest,
         PolicyExecutionResult,
     ))
 )]
@@ -134,7 +134,7 @@ pub async fn get_policy(
     params(
         ("id" = Uuid, Path, description = "Policy ID"),
     ),
-    request_body = UpdatePolicyRequest,
+    request_body = UpdateLifecyclePolicyRequest,
     responses(
         (status = 200, description = "Policy updated successfully", body = LifecyclePolicy),
     ),
@@ -144,7 +144,7 @@ pub async fn update_policy(
     State(state): State<SharedState>,
     Extension(_auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
-    Json(payload): Json<UpdatePolicyRequest>,
+    Json(payload): Json<UpdateLifecyclePolicyRequest>,
 ) -> Result<Json<LifecyclePolicy>> {
     let service = LifecycleService::new(state.db.clone());
     let policy = service.update_policy(id, payload).await?;
@@ -338,7 +338,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ── UpdatePolicyRequest deserialization tests ────────────────────
+    // ── UpdateLifecyclePolicyRequest deserialization tests ────────────────────
 
     #[test]
     fn test_update_policy_request_all_fields() {
@@ -349,7 +349,7 @@ mod tests {
             "config": {"max_versions": 10},
             "priority": 5
         }"#;
-        let req: UpdatePolicyRequest = serde_json::from_str(json).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name, Some("renamed".to_string()));
         assert_eq!(req.description, Some("updated desc".to_string()));
         assert_eq!(req.enabled, Some(false));
@@ -360,7 +360,7 @@ mod tests {
     #[test]
     fn test_update_policy_request_empty_body() {
         let json = r#"{}"#;
-        let req: UpdatePolicyRequest = serde_json::from_str(json).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_str(json).unwrap();
         assert!(req.name.is_none());
         assert!(req.description.is_none());
         assert!(req.enabled.is_none());
@@ -371,7 +371,7 @@ mod tests {
     #[test]
     fn test_update_policy_request_partial() {
         let json = r#"{"enabled": true}"#;
-        let req: UpdatePolicyRequest = serde_json::from_str(json).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.enabled, Some(true));
         assert!(req.name.is_none());
     }

--- a/backend/src/api/handlers/quality_gates.rs
+++ b/backend/src/api/handlers/quality_gates.rs
@@ -608,9 +608,17 @@ async fn trigger_checks(
     path = "/checks",
     context_path = "/api/v1/quality",
     tag = "quality",
-    params(ListChecksQuery),
+    // Explicit params instead of `params(ListChecksQuery)`: the handler
+    // 400s without `artifact_id`, so the spec must declare it required
+    // (the struct field is `Option` only so the handler can return a clean
+    // validation error instead of an axum 422). `repository_id` is accepted
+    // but ignored, so it is intentionally not published.
+    params(
+        ("artifact_id" = Uuid, Query, description = "Artifact ID to list quality check results for"),
+    ),
     responses(
         (status = 200, description = "List of quality check results", body = Vec<CheckResponse>),
+        (status = 400, description = "Missing or invalid artifact_id", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
 )]

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3713,7 +3713,10 @@ pub async fn get_artifact_metadata(
     request_body(content = Vec<u8>, content_type = "application/octet-stream"),
     security(("bearer_auth" = [])),
     responses(
-        (status = 200, description = "Artifact uploaded", body = ArtifactResponse),
+        // 201, not 200: the handler has always returned StatusCode::CREATED
+        // (package-manager clients depend on it); the spec must say so or
+        // strict generated SDKs treat every successful upload as an error.
+        (status = 201, description = "Artifact uploaded", body = ArtifactResponse),
         (status = 401, description = "Authentication required"),
         (status = 404, description = "Repository not found"),
     )

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -123,62 +123,133 @@ impl Modify for SecurityAddon {
     }
 }
 
+/// Per-module OpenAPI documents, in merge order.
+///
+/// Kept as a named list (rather than inline `doc.merge(...)` calls) so tests
+/// can inspect each module's contribution BEFORE the first-wins merge
+/// collapses schema-name collisions -- see
+/// `test_openapi_schema_names_are_unique_across_modules`.
+pub(crate) fn module_docs() -> Vec<(&'static str, utoipa::openapi::OpenApi)> {
+    use super::handlers;
+    vec![
+        ("auth", handlers::auth::AuthApiDoc::openapi()),
+        (
+            "repositories",
+            handlers::repositories::RepositoriesApiDoc::openapi(),
+        ),
+        ("artifacts", handlers::artifacts::ArtifactsApiDoc::openapi()),
+        ("users", handlers::users::UsersApiDoc::openapi()),
+        ("groups", handlers::groups::GroupsApiDoc::openapi()),
+        ("packages", handlers::packages::PackagesApiDoc::openapi()),
+        ("search", handlers::search::SearchApiDoc::openapi()),
+        ("builds", handlers::builds::BuildsApiDoc::openapi()),
+        ("promotion", handlers::promotion::PromotionApiDoc::openapi()),
+        ("health", handlers::health::HealthApiDoc::openapi()),
+        ("plugins", handlers::plugins::PluginsApiDoc::openapi()),
+        ("webhooks", handlers::webhooks::WebhooksApiDoc::openapi()),
+        (
+            "email_subscriptions",
+            handlers::email_subscriptions::EmailSubscriptionsApiDoc::openapi(),
+        ),
+        ("signing", handlers::signing::SigningApiDoc::openapi()),
+        ("security", handlers::security::SecurityApiDoc::openapi()),
+        ("sbom", handlers::sbom::SbomApiDoc::openapi()),
+        ("admin", handlers::admin::AdminApiDoc::openapi()),
+        ("analytics", handlers::analytics::AnalyticsApiDoc::openapi()),
+        ("lifecycle", handlers::lifecycle::LifecycleApiDoc::openapi()),
+        (
+            "storage_gc",
+            handlers::storage_gc::StorageGcApiDoc::openapi(),
+        ),
+        (
+            "monitoring",
+            handlers::monitoring::MonitoringApiDoc::openapi(),
+        ),
+        ("telemetry", handlers::telemetry::TelemetryApiDoc::openapi()),
+        ("peers", handlers::peers::PeersApiDoc::openapi()),
+        (
+            "permissions",
+            handlers::permissions::PermissionsApiDoc::openapi(),
+        ),
+        ("migration", handlers::migration::MigrationApiDoc::openapi()),
+        ("sso", handlers::sso::SsoApiDoc::openapi()),
+        ("sso_admin", handlers::sso_admin::SsoAdminApiDoc::openapi()),
+        ("totp", handlers::totp::TotpApiDoc::openapi()),
+        (
+            "remote_instances",
+            handlers::remote_instances::RemoteInstancesApiDoc::openapi(),
+        ),
+        (
+            "dependency_track",
+            handlers::dependency_track::DependencyTrackApiDoc::openapi(),
+        ),
+        ("peer", handlers::peer::PeerApiDoc::openapi()),
+        ("transfer", handlers::transfer::TransferApiDoc::openapi()),
+        ("tree", handlers::tree::TreeApiDoc::openapi()),
+        (
+            "repository_labels",
+            handlers::repository_labels::RepositoryLabelsApiDoc::openapi(),
+        ),
+        (
+            "sync_policies",
+            handlers::sync_policies::SyncPoliciesApiDoc::openapi(),
+        ),
+        (
+            "peer_instance_labels",
+            handlers::peer_instance_labels::PeerInstanceLabelsApiDoc::openapi(),
+        ),
+        (
+            "quality_gates",
+            handlers::quality_gates::QualityGatesApiDoc::openapi(),
+        ),
+        ("approval", handlers::approval::ApprovalApiDoc::openapi()),
+        ("age_gate", handlers::age_gate::AgeGateApi::openapi()),
+        (
+            "promotion_rules",
+            handlers::promotion_rules::PromotionRulesApiDoc::openapi(),
+        ),
+        (
+            "service_accounts",
+            handlers::service_accounts::ServiceAccountsApiDoc::openapi(),
+        ),
+        (
+            "artifact_labels",
+            handlers::artifact_labels::ArtifactLabelsApiDoc::openapi(),
+        ),
+        ("curation", handlers::curation::CurationApiDoc::openapi()),
+        (
+            "quarantine",
+            handlers::quarantine::QuarantineApiDoc::openapi(),
+        ),
+        ("upload", handlers::upload::UploadApiDoc::openapi()),
+        (
+            "system_config",
+            handlers::system_config::SystemConfigApiDoc::openapi(),
+        ),
+        (
+            "repo_tokens",
+            handlers::repo_tokens::RepoTokensApiDoc::openapi(),
+        ),
+        ("smtp", handlers::smtp::SmtpApiDoc::openapi()),
+        ("ci_auth", handlers::ci_auth::CiAuthApiDoc::openapi()),
+        (
+            "ci_auth_admin",
+            handlers::ci_auth_admin::CiAuthAdminApiDoc::openapi(),
+        ),
+    ]
+}
+
 /// Build the merged OpenAPI document from all handler modules.
 pub fn build_openapi() -> utoipa::openapi::OpenApi {
     let mut doc = ApiDoc::openapi();
 
-    // Merge per-module OpenAPI structs as they are annotated.
-    // Each module defines its own XxxApiDoc that lists its paths and schemas.
-    doc.merge(super::handlers::auth::AuthApiDoc::openapi());
-    doc.merge(super::handlers::repositories::RepositoriesApiDoc::openapi());
-    doc.merge(super::handlers::artifacts::ArtifactsApiDoc::openapi());
-    doc.merge(super::handlers::users::UsersApiDoc::openapi());
-    doc.merge(super::handlers::groups::GroupsApiDoc::openapi());
-    doc.merge(super::handlers::packages::PackagesApiDoc::openapi());
-    doc.merge(super::handlers::search::SearchApiDoc::openapi());
-    doc.merge(super::handlers::builds::BuildsApiDoc::openapi());
-    doc.merge(super::handlers::promotion::PromotionApiDoc::openapi());
-    doc.merge(super::handlers::health::HealthApiDoc::openapi());
-    doc.merge(super::handlers::plugins::PluginsApiDoc::openapi());
-    doc.merge(super::handlers::webhooks::WebhooksApiDoc::openapi());
-    doc.merge(super::handlers::email_subscriptions::EmailSubscriptionsApiDoc::openapi());
-    doc.merge(super::handlers::signing::SigningApiDoc::openapi());
-    doc.merge(super::handlers::security::SecurityApiDoc::openapi());
-    doc.merge(super::handlers::sbom::SbomApiDoc::openapi());
-    doc.merge(super::handlers::admin::AdminApiDoc::openapi());
-    doc.merge(super::handlers::analytics::AnalyticsApiDoc::openapi());
-    doc.merge(super::handlers::lifecycle::LifecycleApiDoc::openapi());
-    doc.merge(super::handlers::storage_gc::StorageGcApiDoc::openapi());
-    doc.merge(super::handlers::monitoring::MonitoringApiDoc::openapi());
-    doc.merge(super::handlers::telemetry::TelemetryApiDoc::openapi());
-    doc.merge(super::handlers::peers::PeersApiDoc::openapi());
-    doc.merge(super::handlers::permissions::PermissionsApiDoc::openapi());
-    doc.merge(super::handlers::migration::MigrationApiDoc::openapi());
-    doc.merge(super::handlers::sso::SsoApiDoc::openapi());
-    doc.merge(super::handlers::sso_admin::SsoAdminApiDoc::openapi());
-    doc.merge(super::handlers::totp::TotpApiDoc::openapi());
-    doc.merge(super::handlers::remote_instances::RemoteInstancesApiDoc::openapi());
-    doc.merge(super::handlers::dependency_track::DependencyTrackApiDoc::openapi());
-    doc.merge(super::handlers::peer::PeerApiDoc::openapi());
-    doc.merge(super::handlers::transfer::TransferApiDoc::openapi());
-    doc.merge(super::handlers::tree::TreeApiDoc::openapi());
-    doc.merge(super::handlers::repository_labels::RepositoryLabelsApiDoc::openapi());
-    doc.merge(super::handlers::sync_policies::SyncPoliciesApiDoc::openapi());
-    doc.merge(super::handlers::peer_instance_labels::PeerInstanceLabelsApiDoc::openapi());
-    doc.merge(super::handlers::quality_gates::QualityGatesApiDoc::openapi());
-    doc.merge(super::handlers::approval::ApprovalApiDoc::openapi());
-    doc.merge(super::handlers::age_gate::AgeGateApi::openapi());
-    doc.merge(super::handlers::promotion_rules::PromotionRulesApiDoc::openapi());
-    doc.merge(super::handlers::service_accounts::ServiceAccountsApiDoc::openapi());
-    doc.merge(super::handlers::artifact_labels::ArtifactLabelsApiDoc::openapi());
-    doc.merge(super::handlers::curation::CurationApiDoc::openapi());
-    doc.merge(super::handlers::quarantine::QuarantineApiDoc::openapi());
-    doc.merge(super::handlers::upload::UploadApiDoc::openapi());
-    doc.merge(super::handlers::system_config::SystemConfigApiDoc::openapi());
-    doc.merge(super::handlers::repo_tokens::RepoTokensApiDoc::openapi());
-    doc.merge(super::handlers::smtp::SmtpApiDoc::openapi());
-    doc.merge(super::handlers::ci_auth::CiAuthApiDoc::openapi());
-    doc.merge(super::handlers::ci_auth_admin::CiAuthAdminApiDoc::openapi());
+    // Merge per-module OpenAPI structs as they are annotated. NOTE: the merge
+    // is FIRST-WINS on schema names -- a name collision between two modules
+    // silently publishes only the earlier module's shape. The schema-name
+    // uniqueness test below guards against that.
+    for (_module, module_doc) in module_docs() {
+        doc.merge(module_doc);
+    }
 
     doc
 }
@@ -341,6 +412,97 @@ mod tests {
              and block SDK generation/publishing. Give one handler an explicit \
              `operation_id = \"...\"` in its #[utoipa::path]:\n{}",
             dups.join("\n")
+        );
+    }
+
+    /// Regression: utoipa's `merge` is FIRST-WINS on schema NAMES. Two
+    /// different structs that share a name across handler modules mean the
+    /// later module's operations silently publish the earlier module's
+    /// shape — a spec-fidelity drift no per-operation check can see. This
+    /// is exactly how GET /api/v1/artifacts/{id} published the wrong
+    /// `ArtifactResponse` and PATCH /admin/lifecycle/{id} published the
+    /// quality-gate `UpdatePolicyRequest` (CLI repo #98). Registering the
+    /// SAME struct from several modules is fine (identical definition);
+    /// two different definitions under one name is not.
+    #[test]
+    fn test_openapi_schema_names_are_unique_across_modules() {
+        use std::collections::{HashMap, HashSet};
+
+        // Ratchet: pre-existing collisions grandfathered until each is
+        // renamed (same fix as `ArtifactResponse`/`UpdatePolicyRequest`).
+        // For every name below, the FIRST-listed module's definition is the
+        // one the published spec currently carries; the other module's
+        // operations publish the wrong shape. This list may only SHRINK —
+        // the assertions below fail both on a NEW collision and on a stale
+        // entry (so a fixed collision must be removed here).
+        const KNOWN_COLLISIONS: &[&str] = &[
+            "CreateApiTokenRequest", // auth vs users
+            "CreatePolicyRequest",   // security (quality-gate) vs lifecycle
+            "PackageResponse",       // packages vs curation
+            "PaginationInfo",        // search vs migration
+            "ReindexResponse",       // search vs admin
+        ];
+
+        // name -> (first module that registered it, serialized schema)
+        let mut seen: HashMap<String, (String, String)> = HashMap::new();
+        let mut conflicts: HashSet<String> = HashSet::new();
+        let mut conflict_details: Vec<String> = Vec::new();
+
+        let mut docs = module_docs();
+        // Include the base doc's own components too.
+        docs.insert(0, ("(base ApiDoc)", ApiDoc::openapi()));
+
+        for (module, doc) in docs {
+            let Some(components) = doc.components else {
+                continue;
+            };
+            for (name, schema) in components.schemas {
+                let json = serde_json::to_string(&schema).expect("schema must serialize");
+                match seen.get(&name) {
+                    Some((first_module, first_json)) => {
+                        if *first_json != json && conflicts.insert(name.clone()) {
+                            conflict_details.push(format!(
+                                "  {name}: `{first_module}` and `{module}` register \
+                                 different definitions under the same schema name"
+                            ));
+                        }
+                    }
+                    None => {
+                        seen.insert(name, (module.to_string(), json));
+                    }
+                }
+            }
+        }
+
+        let mut new_conflicts: Vec<String> = conflict_details
+            .iter()
+            .filter(|d| {
+                !KNOWN_COLLISIONS
+                    .iter()
+                    .any(|k| d.contains(&format!("  {k}:")))
+            })
+            .cloned()
+            .collect();
+        new_conflicts.sort();
+        assert!(
+            new_conflicts.is_empty(),
+            "Duplicate OpenAPI schema name(s) with divergent definitions — \
+             utoipa keeps only the FIRST definition, so every other module's \
+             operations publish the wrong shape in the spec. Rename the \
+             colliding struct(s) or share one canonical type:\n{}",
+            new_conflicts.join("\n")
+        );
+
+        // Ratchet enforcement: a grandfathered entry that no longer collides
+        // must be deleted from KNOWN_COLLISIONS so the list only shrinks.
+        let stale: Vec<&&str> = KNOWN_COLLISIONS
+            .iter()
+            .filter(|k| !conflicts.contains(**k))
+            .collect();
+        assert!(
+            stale.is_empty(),
+            "KNOWN_COLLISIONS entries no longer collide — remove them so the \
+             grandfather list only shrinks: {stale:?}"
         );
     }
 

--- a/backend/src/services/lifecycle_service.rs
+++ b/backend/src/services/lifecycle_service.rs
@@ -347,7 +347,7 @@ pub struct CreatePolicyRequest {
 
 /// Request to update a lifecycle policy.
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct UpdatePolicyRequest {
+pub struct UpdateLifecyclePolicyRequest {
     pub name: Option<String>,
     pub description: Option<String>,
     pub enabled: Option<bool>,
@@ -505,7 +505,7 @@ impl LifecycleService {
     pub async fn update_policy(
         &self,
         id: Uuid,
-        req: UpdatePolicyRequest,
+        req: UpdateLifecyclePolicyRequest,
     ) -> Result<LifecyclePolicy> {
         let existing = self.get_policy(id).await?;
 
@@ -1767,7 +1767,7 @@ mod tests {
     #[test]
     fn test_update_policy_request_empty() {
         let json_str = "{}";
-        let req: UpdatePolicyRequest = serde_json::from_str(json_str).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_str(json_str).unwrap();
         assert!(req.name.is_none());
         assert!(req.description.is_none());
         assert!(req.enabled.is_none());
@@ -2389,7 +2389,7 @@ mod tests {
             "enabled": false,
             "priority": 99
         });
-        let req: UpdatePolicyRequest = serde_json::from_value(json_val).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_value(json_val).unwrap();
         assert!(req.name.is_none());
         assert!(req.description.is_none());
         assert_eq!(req.enabled, Some(false));
@@ -2407,7 +2407,7 @@ mod tests {
             "priority": 5,
             "cron_schedule": "0 0 3 * * *"
         });
-        let req: UpdatePolicyRequest = serde_json::from_value(json_val).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_value(json_val).unwrap();
         assert_eq!(req.name, Some("Updated Name".to_string()));
         assert_eq!(req.description, Some("Updated Description".to_string()));
         assert_eq!(req.enabled, Some(true));
@@ -2449,7 +2449,7 @@ mod tests {
         let json_val = json!({
             "enabled": true
         });
-        let req: UpdatePolicyRequest = serde_json::from_value(json_val).unwrap();
+        let req: UpdateLifecyclePolicyRequest = serde_json::from_value(json_val).unwrap();
         assert!(req.cron_schedule.is_none());
     }
 


### PR DESCRIPTION
Closes #2334

Six endpoints where the published OpenAPI spec disagrees with what the backend serves; each mismatch breaks strict generated SDK clients (tracker: artifact-keeper/artifact-keeper-cli#98). Every drift was reproduced against a live v1.4.0 instance before fixing, and every fix verified in the re-exported `openapi.json`.

## Changes

| # | Endpoint | Drift | Fix |
|---|----------|-------|-----|
| 1 | `GET /api/v1/artifacts/{id}` | Served a raw-DB shape (`repository_id`, `checksum_md5`, `checksum_sha1`, `updated_at`; no `download_count`/`analyzable`/`metadata`) while the spec promises the canonical `ArtifactResponse` — a duplicate local struct lost the first-wins schema-name merge | Handler now builds the canonical `repositories.rs::ArtifactResponse` (fetches download count + metadata; `analyzable: true` — it resolves a real `artifacts` row, matching the by-path handler); duplicate struct deleted (`artifacts.rs`) |
| 2 | `POST /api/v1/repositories/{key}/email-subscriptions` | Returned 200; spec declares 201 | Returns `201 Created` (`email_subscriptions.rs`) |
| 3 | `PATCH /api/v1/admin/lifecycle/{id}` | Request schema slot stolen by the quality-gate `UpdatePolicyRequest` in `security.rs` (same name, first-wins), so the spec told clients to send fields the handler drops | Lifecycle struct renamed `UpdateLifecyclePolicyRequest` (`lifecycle_service.rs`, `lifecycle.rs`) |
| 4 | `GET/POST /api/v1/admin/ci-oidc` | Annotated `path = "/"` → spec URL has trailing slash, which the router 404s | `path = ""`, mirroring `lifecycle.rs` (`ci_auth_admin.rs`) |
| 5 | `GET /api/v1/quality/checks` | `artifact_id` optional in spec but the handler 400s without it; ignored `repository_id` also advertised | Explicit required `artifact_id` query param; `repository_id` no longer published; 400 documented (`quality_gates.rs`) |
| 6 | `PUT /api/v1/repositories/{key}/artifacts/{path}` | Handler has always returned 201; spec declared only 200 | Spec-side fix: declare 201 (package-manager clients depend on the 201, so the handler is intentionally untouched) (`repositories.rs`) |

## Regression guard

`build_openapi()`'s merge list is now a named `module_docs()` table, and a new test (`test_openapi_schema_names_are_unique_across_modules`) fails when two modules register **different** definitions under one schema name — the exact failure mode behind drifts 1 and 3, invisible to any per-operation check because utoipa's merge silently keeps the first definition.

The guard immediately surfaced **five more pre-existing collisions**, grandfathered in a shrink-only ratchet list (the test fails on any new collision AND on a stale grandfathered entry): `CreateApiTokenRequest` (auth vs users), `CreatePolicyRequest` (security vs lifecycle — the create-side sibling of drift 3), `PackageResponse` (packages vs curation), `PaginationInfo` (search vs migration), `ReindexResponse` (search vs admin). Renaming those changes more published schemas than this PR should carry; proposed as follow-up work on #2334.

## Review gate: by-id response shape change (drift 1)

The by-id JSON drops `repository_id`, `checksum_md5`, `checksum_sha1`, `updated_at` (it now serves exactly what the published spec has always promised). Consumer audit:

- **web UI** (`artifact-keeper-web@main`): does **not** call `/api/v1/artifacts/{id}` — `src/lib/api/artifacts.ts` explicitly routes artifact detail through the by-path endpoint ("the SDK's getArtifact uses /api/v1/artifacts/{id} which is a different endpoint, so we fetch directly"), and its `Artifact` type/`adaptArtifact` already model the canonical shape (`repository_key`, `download_count`, `analyzable`, cache fields).
- **backend repo scripts/tests**: `scripts/test-private-repo-visibility.sh` asserts only status codes on the by-id endpoint; `tests/search_checksum_sha1_md5_tests.rs` exercises DB columns via search, not this endpoint.
- Clients needing MD5/SHA1 checksums still get them from the search surface; `updated_at`/`repository_id` were never in the published schema.

External API consumers outside these repos cannot be audited from here — flagging for reviewer judgment.

## Explicitly deferred

Drift 6 from the triage (sso `PUT` vs `PATCH` verb mismatch) is intentionally **not** touched: fixing it is a breaking route change and it causes no SDK breakage today.

## Verification

- `cargo check --workspace --all-targets` and `cargo test --lib` clean (12,550 passed; the 3 clippy `useless_borrows_in_formatting` warnings in `repositories.rs` test code pre-date this branch and come from a newer local clippy).
- Re-exported spec confirms: by-id `ArtifactResponse` has `analyzable`+`download_count` and none of the dropped DB fields; lifecycle PATCH references `UpdateLifecyclePolicyRequest` with lifecycle fields; ci-oidc paths have no trailing slash; subscription create and upload declare 201; `artifact_id` is required on `/quality/checks`.
- Live v1.4.0 instance: reproduced all six drifts pre-fix (by-id raw shape; ci-oidc slash 404 / no-slash 200; `/quality/checks` 400 without `artifact_id`; subscription create 200; upload 201).

## Post-merge propagation

1. Re-export the spec (`EXPORT_OPENAPI_SPEC=1 cargo test --lib export_openapi_spec -- --ignored`) / let `sync-openapi-spec.yml` push it to the api repo.
2. Sync `openapi.json` into `artifact-keeper-api`.
3. Regenerate the Progenitor CLI SDK (and the TS SDK) from the updated spec; the CLI can then drop any workarounds for artifact-keeper-cli#98.