### PR TITLE
fix(oci): populate the packages catalog on manifest push

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -6676,6 +6676,44 @@ async fn handle_get_manifest(
     )
 }
 
+/// True when a manifest reference is a tag rather than a digest
+/// (`sha256:...`). Same filter as the tags/list handler and the
+/// `docker_tag` grouping query (`POSITION(':' IN tag) = 0`): OCI tag
+/// grammar (`[a-zA-Z0-9_][a-zA-Z0-9._-]*`) can never contain `:`.
+pub(crate) fn oci_reference_is_tag(reference: &str) -> bool {
+    !reference.contains(':')
+}
+
+/// Sum of the artifact sizes recorded for an index manifest's child
+/// manifests, used to size the packages-catalog row for a multi-arch tag.
+///
+/// An image index carries no `config`/`layers` of its own, so the size
+/// computed from its body is ~0; the meaningful number is the sum over the
+/// child image manifests it references (`docker push` uploads those first,
+/// so their `artifacts` rows exist by the time the index is tagged). Same
+/// join the `docker_tag` grouping endpoint uses (`fetch_index_child_sizes`
+/// in repositories.rs). Best-effort: sizing must not fail the push.
+async fn index_child_artifact_size_sum(db: &PgPool, repo_id: Uuid, parent_digest: &str) -> i64 {
+    sqlx::query_scalar::<_, i64>(
+        r#"SELECT COALESCE(SUM(a.size_bytes), 0)::BIGINT
+           FROM oci_manifest_refs r
+           JOIN artifacts a
+             ON a.repository_id = r.repository_id
+            AND a.checksum_sha256 = REPLACE(r.child_digest, 'sha256:', '')
+            AND a.is_deleted = false
+           WHERE r.repository_id = $1
+             AND r.parent_digest = $2"#,
+    )
+    .bind(repo_id)
+    .bind(parent_digest)
+    .fetch_one(db)
+    .await
+    .unwrap_or_else(|e| {
+        warn!("Failed to sum child manifest sizes for {parent_digest}: {e}");
+        0
+    })
+}
+
 async fn handle_put_manifest(
     state: &SharedState,
     headers: &HeaderMap,
@@ -6883,6 +6921,36 @@ async fn handle_put_manifest(
         Err(e) => {
             tracing::error!("Failed to upsert artifact record for {}: {}", artifact_path, e);
         }
+    }
+
+    // Surface the pushed image in the packages catalog. The web UI's
+    // Packages tab reads `packages`/`package_versions` (via
+    // /api/v1/packages), NOT `artifacts` — every other format handler
+    // (composer, debian, incus, maven, npm, nuget, pypi, generic upload)
+    // populates the catalog on upload, but the OCI path never did, so a
+    // pushed image was pullable yet invisible in the Packages tab.
+    // Digest-only pushes are skipped: the child manifests of a multi-arch
+    // index are not user-facing versions (mirrors the tags/list filter).
+    // Best-effort — a catalog failure must not fail the push docker just
+    // committed (the fire-and-forget wrapper logs it).
+    if oci_reference_is_tag(reference) {
+        let child_size = match class {
+            ManifestClass::Index => {
+                index_child_artifact_size_sum(&state.db, repo_id, &digest).await
+            }
+            _ => 0,
+        };
+        crate::services::package_service::PackageService::new(state.db.clone())
+            .try_create_or_update_from_artifact(
+                repo_id,
+                &image,
+                reference,
+                total_size.saturating_add(child_size),
+                checksum,
+                None,
+                Some(serde_json::json!({ "format": "docker" })),
+            )
+            .await;
     }
 
     info!("Manifest pushed: {}:{} ({})", image_name, reference, digest);
@@ -12894,6 +12962,25 @@ mod oci_manifest_refs_tests {
             classify_manifest(br#"{"manifests":[],"config":{"digest":"sha256:x"}}"#),
             ManifestClass::Index
         ));
+    }
+
+    /// Packages-catalog gate: only tag references may create catalog rows.
+    /// A digest push (multi-arch index children, `docker push <name>@sha256:...`)
+    /// is not a user-facing version. Matches the OCI tag grammar
+    /// (`[a-zA-Z0-9_][a-zA-Z0-9._-]*` — no `:` possible) and the
+    /// `POSITION(':' IN tag) = 0` filter in tags/list and docker_tag grouping.
+    #[test]
+    fn oci_reference_is_tag_accepts_tags_rejects_digests() {
+        assert!(oci_reference_is_tag("latest"));
+        assert!(oci_reference_is_tag("1.2.3"));
+        assert!(oci_reference_is_tag("v1.0.0-rc.1_hotfix"));
+        assert!(!oci_reference_is_tag(
+            "sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1"
+        ));
+        assert!(!oci_reference_is_tag("sha512:00aa"));
+        // Defensive: a bare colon-containing string is still not a tag.
+        assert!(!oci_reference_is_tag("a:b"));
+        assert!(!oci_reference_is_tag(":"));
     }
 
     /// #1409 C1: the STORED media type is derived from content, so the gate

--- a/backend/tests/oci_packages_index_tests.rs
+++ b/backend/tests/oci_packages_index_tests.rs
@@ -1,0 +1,408 @@
+//! Integration tests: Docker/OCI pushes must appear in the WebUI Packages tab.
+//!
+//! The WebUI Packages tab is backed by the `/api/v1/packages` list endpoint,
+//! which reads the `packages` table (NOT `artifacts`). Before the fix, the
+//! OCI v2 manifest-PUT handler inserted `oci_tags` + `artifacts` rows but
+//! never called `PackageService`, so a successfully pushed image was pullable
+//! over the registry protocol yet never showed up in the WebUI. composer /
+//! debian / incus / maven / npm / nuget / pypi and the generic upload path
+//! all call `PackageService` after their artifact insert; OCI did not.
+//!
+//! These tests push manifests over the real /v2 wire protocol, then query the
+//! same `list_packages` handler the WebUI uses and assert on the catalog rows.
+//!
+//! Requires a PostgreSQL database with migrations applied:
+//!
+//! ```sh
+//! DATABASE_URL="postgresql://registry:registry@localhost:30432/artifact_registry" \
+//!   cargo test --test oci_packages_index_tests -- --ignored
+//! ```
+
+#![allow(clippy::unwrap_used)]
+#![allow(clippy::disallowed_methods)] // streaming-invariant: test file exempt — buffering response bodies in test assertions is not an artifact path (#1608)
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use sqlx::{PgPool, Row};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+use artifact_keeper_backend::api::handlers::{oci_v2, packages};
+use artifact_keeper_backend::api::middleware::auth::optional_auth_middleware;
+use artifact_keeper_backend::api::{AppState, SharedState};
+use artifact_keeper_backend::config::Config;
+use artifact_keeper_backend::services::auth_service::AuthService;
+
+// ===========================================================================
+// Test helpers
+// ===========================================================================
+
+fn test_config(storage_path: &str) -> Config {
+    Config {
+        database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
+        storage_path: storage_path.into(),
+        jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+        ..Default::default()
+    }
+}
+
+fn basic_auth_header(username: &str, password: &str) -> String {
+    use base64::Engine;
+    let encoded =
+        base64::engine::general_purpose::STANDARD.encode(format!("{}:{}", username, password));
+    format!("Basic {}", encoded)
+}
+
+async fn create_test_user(pool: &PgPool, username: &str, password: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    let hash = bcrypt::hash(password, 4).expect("bcrypt hash failed");
+    sqlx::query(
+        r#"
+        INSERT INTO users (id, username, email, password_hash, auth_provider, is_admin, is_active)
+        VALUES ($1, $2, $3, $4, 'local', true, true)
+        "#,
+    )
+    .bind(id)
+    .bind(username)
+    .bind(format!("{}@test.local", username))
+    .bind(&hash)
+    .execute(pool)
+    .await
+    .expect("failed to create test user");
+    id
+}
+
+/// Create a public docker-format local repo. Returns (repo_id, key, storage_path).
+async fn create_docker_repo(pool: &PgPool) -> (Uuid, String, PathBuf) {
+    let id = Uuid::new_v4();
+    let key = format!("ocipkg-{}", &id.to_string()[..8]);
+    let storage_path = std::env::temp_dir().join(format!("ocipkg-{}", id));
+    std::fs::create_dir_all(&storage_path).expect("create storage dir");
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+         VALUES ($1, $2, $2, $3, 'local', 'docker'::repository_format, true)",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(storage_path.to_string_lossy().as_ref())
+    .execute(pool)
+    .await
+    .expect("insert docker repo");
+    (id, key, storage_path)
+}
+
+fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+    let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = Arc::new(
+        artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(storage_path),
+    );
+    let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+        HashMap::new(),
+        "filesystem".to_string(),
+    ));
+    Arc::new(AppState::new(
+        test_config(storage_path),
+        pool,
+        storage,
+        registry,
+    ))
+}
+
+fn auth_service(state: &SharedState, storage_path: &str) -> Arc<AuthService> {
+    Arc::new(AuthService::new(
+        state.db.clone(),
+        Arc::new(test_config(storage_path)),
+    ))
+}
+
+async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    sqlx::query("DELETE FROM package_versions WHERE package_id IN (SELECT id FROM packages WHERE repository_id = $1)")
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .ok();
+    for table in [
+        "packages",
+        "manifest_blob_refs",
+        "oci_manifest_refs",
+        "oci_tags",
+        "artifacts",
+        "repositories",
+    ] {
+        let (sql, bind_id) = if table == "repositories" {
+            (format!("DELETE FROM {} WHERE id = $1", table), repo_id)
+        } else {
+            (
+                format!("DELETE FROM {} WHERE repository_id = $1", table),
+                repo_id,
+            )
+        };
+        sqlx::query(&sql).bind(bind_id).execute(pool).await.ok();
+    }
+    sqlx::query("DELETE FROM users WHERE id = $1")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .ok();
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    format!("{:x}", hasher.finalize())
+}
+
+/// PUT a manifest over the /v2 wire protocol. Returns the response status.
+async fn put_manifest(
+    state: &SharedState,
+    auth: &str,
+    repo_key: &str,
+    image: &str,
+    reference: &str,
+    content_type: &str,
+    body: &[u8],
+) -> StatusCode {
+    let app = oci_v2::router().with_state(state.clone());
+    let req = Request::builder()
+        .method("PUT")
+        .uri(format!("/{}/{}/manifests/{}", repo_key, image, reference))
+        .header("Authorization", auth)
+        .header("Content-Type", content_type)
+        .body(Body::from(body.to_vec()))
+        .unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+/// Fetch (name, version, size_bytes) for every catalog row in the repo.
+async fn fetch_catalog_rows(pool: &PgPool, repo_id: Uuid) -> Vec<(String, String, i64)> {
+    sqlx::query(
+        "SELECT p.name, v.version, v.size_bytes \
+         FROM packages p JOIN package_versions v ON v.package_id = p.id \
+         WHERE p.repository_id = $1 ORDER BY p.name, v.version",
+    )
+    .bind(repo_id)
+    .fetch_all(pool)
+    .await
+    .expect("failed to query packages catalog")
+    .into_iter()
+    .map(|r| (r.get("name"), r.get("version"), r.get("size_bytes")))
+    .collect()
+}
+
+const IMAGE_MANIFEST_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+const INDEX_MANIFEST_TYPE: &str = "application/vnd.oci.image.index.v1+json";
+
+/// Minimal image manifest: config 1000 bytes + layers 2000/3000 = 6000 total.
+const IMAGE_MANIFEST_BODY: &[u8] = br#"{
+    "schemaVersion": 2,
+    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+    "config": {"mediaType": "application/vnd.oci.image.config.v1+json", "size": 1000, "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+    "layers": [
+        {"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "size": 2000, "digest": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+        {"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "size": 3000, "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"}
+    ]
+}"#;
+
+// ===========================================================================
+// Regression: pushed image appears in the WebUI Packages list
+// ===========================================================================
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointed at a Postgres with migrations applied"]
+async fn test_docker_push_appears_in_packages_list() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("ocipkg-u1-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "pushpass").await;
+    let (repo_id, repo_key, storage_path) = create_docker_repo(&pool).await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+    let auth = basic_auth_header(&username, "pushpass");
+
+    let status = put_manifest(
+        &state,
+        &auth,
+        &repo_key,
+        "acme/app",
+        "1.0.0",
+        IMAGE_MANIFEST_TYPE,
+        IMAGE_MANIFEST_BODY,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "manifest PUT should 201");
+
+    // The catalog rows behind the WebUI Packages tab must exist.
+    let rows = fetch_catalog_rows(&pool, repo_id).await;
+    assert_eq!(
+        rows,
+        vec![("acme/app".to_string(), "1.0.0".to_string(), 6000)],
+        "docker push must create exactly one packages/package_versions pair \
+         (name = image, version = tag, size = config + layers)"
+    );
+
+    // And the same `list_packages` handler the WebUI calls must list it.
+    // Anonymous request on a public repo, resolved by the same optional-auth
+    // middleware production mounts.
+    let svc = auth_service(&state, storage_path.to_str().unwrap());
+    let app = packages::router()
+        .layer(axum::middleware::from_fn_with_state(
+            svc,
+            optional_auth_middleware,
+        ))
+        .with_state(state.clone());
+    let req = Request::builder()
+        .method("GET")
+        .uri(format!("/?repository_key={}", repo_key))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let items = json["items"].as_array().expect("items array");
+    assert_eq!(
+        items.len(),
+        1,
+        "WebUI Packages tab should list the pushed image; empty list is the \
+         pre-fix regression. Body: {}",
+        json
+    );
+    assert_eq!(items[0]["name"].as_str().unwrap(), "acme/app");
+    assert_eq!(items[0]["version"].as_str().unwrap(), "1.0.0");
+
+    // Re-push of the same tag must not duplicate catalog rows (UPSERT).
+    let status = put_manifest(
+        &state,
+        &auth,
+        &repo_key,
+        "acme/app",
+        "1.0.0",
+        IMAGE_MANIFEST_TYPE,
+        IMAGE_MANIFEST_BODY,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let rows = fetch_catalog_rows(&pool, repo_id).await;
+    assert_eq!(rows.len(), 1, "re-push must UPSERT, not duplicate");
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}
+
+// ===========================================================================
+// Digest-only pushes (multi-arch index children, push-by-digest) must NOT
+// create catalog rows — they are not user-facing versions.
+// ===========================================================================
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointed at a Postgres with migrations applied"]
+async fn test_digest_push_creates_no_catalog_row() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("ocipkg-u2-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "pushpass").await;
+    let (repo_id, repo_key, storage_path) = create_docker_repo(&pool).await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+    let auth = basic_auth_header(&username, "pushpass");
+
+    let digest_ref = format!("sha256:{}", sha256_hex(IMAGE_MANIFEST_BODY));
+    let status = put_manifest(
+        &state,
+        &auth,
+        &repo_key,
+        "acme/app",
+        &digest_ref,
+        IMAGE_MANIFEST_TYPE,
+        IMAGE_MANIFEST_BODY,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "digest PUT should 201");
+
+    let rows = fetch_catalog_rows(&pool, repo_id).await;
+    assert!(
+        rows.is_empty(),
+        "a digest-only push must not create catalog rows, got: {:?}",
+        rows
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}
+
+// ===========================================================================
+// Multi-arch: a tagged image index folds in its child manifests' sizes
+// (an index body itself has no config/layers), mirroring the docker_tag
+// grouping endpoint's size semantics.
+// ===========================================================================
+
+#[tokio::test]
+#[ignore = "requires DATABASE_URL pointed at a Postgres with migrations applied"]
+async fn test_index_push_folds_child_manifest_sizes() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+    let username = format!("ocipkg-u3-{}", &Uuid::new_v4().to_string()[..8]);
+    let user_id = create_test_user(&pool, &username, "pushpass").await;
+    let (repo_id, repo_key, storage_path) = create_docker_repo(&pool).await;
+    let state = build_state(pool.clone(), storage_path.to_str().unwrap());
+    let auth = basic_auth_header(&username, "pushpass");
+
+    // Child image manifest pushed by digest first (docker push order).
+    let child_digest = format!("sha256:{}", sha256_hex(IMAGE_MANIFEST_BODY));
+    let status = put_manifest(
+        &state,
+        &auth,
+        &repo_key,
+        "acme/multi",
+        &child_digest,
+        IMAGE_MANIFEST_TYPE,
+        IMAGE_MANIFEST_BODY,
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "child digest PUT should 201");
+
+    // Then the tagged index referencing the child.
+    let index_body = format!(
+        r#"{{
+            "schemaVersion": 2,
+            "mediaType": "{}",
+            "manifests": [
+                {{"mediaType": "{}", "size": {}, "digest": "{}",
+                  "platform": {{"architecture": "amd64", "os": "linux"}}}}
+            ]
+        }}"#,
+        INDEX_MANIFEST_TYPE,
+        IMAGE_MANIFEST_TYPE,
+        IMAGE_MANIFEST_BODY.len(),
+        child_digest,
+    );
+    let status = put_manifest(
+        &state,
+        &auth,
+        &repo_key,
+        "acme/multi",
+        "2.0.0",
+        INDEX_MANIFEST_TYPE,
+        index_body.as_bytes(),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED, "index PUT should 201");
+
+    // Only the tagged index creates a catalog row; its size is the child
+    // image's config+layers total (6000), not the ~0 of the index body.
+    let rows = fetch_catalog_rows(&pool, repo_id).await;
+    assert_eq!(
+        rows,
+        vec![("acme/multi".to_string(), "2.0.0".to_string(), 6000)],
+        "tagged index must create one catalog row sized from its children"
+    );
+
+    let _ = std::fs::remove_dir_all(&storage_path);
+    cleanup(&pool, repo_id, user_id).await;
+}


### PR DESCRIPTION
## Summary

Closes #2331

Docker/OCI pushes wrote `oci_tags` + `artifacts` rows but never called `PackageService`, so a pushed image was tagged and pullable yet permanently invisible in the WebUI **Packages** tab (which reads `packages`/`package_versions` via `/api/v1/packages`). Every other format handler already populates the catalog on upload — nuget (#1289), incus (#1477), composer (#1487), maven (#1909), plus npm/pypi/debian/generic — OCI was the remaining gap.

The manifest-PUT handler now upserts the catalog after the tag commit, mirroring those precedents:

- **name** = image, **version** = tag, **checksum** = manifest digest, metadata `{"format": "docker"}`.
- **size** = config + layers from the manifest body; for a **multi-arch index** (whose body has no config/layers) the summed child-manifest sizes recorded for the previously pushed children are folded in — same join and semantics as the `docker_tag` grouping endpoint (`fetch_index_child_sizes`).
- **Digest-only pushes are skipped** (`oci_reference_is_tag`, the same `:`-based filter `tags/list` and the `docker_tag` grouping use): the child manifests of a multi-arch index and push-by-digest are not user-facing versions.
- **Best-effort**: the fire-and-forget `try_create_or_update_from_artifact` wrapper is used, so a catalog failure logs a warning and never fails the push docker just committed. Re-pushes collapse via the service's existing UPSERT semantics.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`backend/tests/oci_packages_index_tests.rs` (modeled on `composer_packages_index_tests.rs` from #1487) pushes manifests over the real `/v2` wire protocol and fails on `main`:

1. `test_docker_push_appears_in_packages_list` — a tagged image push creates exactly one `packages`/`package_versions` pair (size = config + layers) AND is returned by the same `list_packages` handler the WebUI calls; a re-push UPSERTs instead of duplicating.
2. `test_digest_push_creates_no_catalog_row` — push-by-digest leaves the catalog untouched.
3. `test_index_push_folds_child_manifest_sizes` — a tagged index creates one row sized from its children, not the ~0-byte index body.

Plus a unit test for the tag/digest gate (`oci_reference_is_tag_accepts_tags_rejects_digests`).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib`, and the three new integration tests against Postgres with all migrations applied
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
