### PR TITLE
fix(migration): persist storage_backend for auto-provisioned repos (#2336)

### DIFF
--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -1248,6 +1248,40 @@ mod tests {
     }
 
     #[test]
+    fn test_build_storage_path_contract() {
+        // Only "filesystem" gets the absolute staging prefix; every other
+        // backend name — including unknown ones — is treated as object storage
+        // and addressed by the bare repo key. This mirrors the create-repo
+        // handler and guards against a newly added cloud backend silently
+        // inheriting the filesystem path convention (#2336).
+        let base = "/srv/ak/storage";
+
+        // Filesystem: absolute prefix, and nested keys are preserved verbatim.
+        assert_eq!(
+            MigrationService::build_storage_path("filesystem", base, "libs-release"),
+            "/srv/ak/storage/libs-release"
+        );
+        assert_eq!(
+            MigrationService::build_storage_path("filesystem", base, "team/libs"),
+            "/srv/ak/storage/team/libs"
+        );
+
+        // Object stores ignore the base entirely and use the bare key, even a
+        // backend name the helper has never seen before.
+        assert_eq!(
+            MigrationService::build_storage_path("minio", base, "libs-release"),
+            "libs-release"
+        );
+
+        // Backend matching is exact and case-sensitive: "Filesystem" is NOT the
+        // filesystem backend, so it must not receive the staging prefix.
+        assert_eq!(
+            MigrationService::build_storage_path("Filesystem", base, "libs-release"),
+            "libs-release"
+        );
+    }
+
+    #[test]
     fn test_permission_mapping() {
         assert_eq!(MigrationService::map_permission("read"), Some("read"));
         assert_eq!(MigrationService::map_permission("deploy"), Some("write"));

--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -383,11 +383,32 @@ impl MigrationService {
         }
     }
 
-    /// Create a repository in Artifact Keeper from Artifactory config
+    /// Compute the persisted `storage_path` for an auto-provisioned repository.
+    ///
+    /// Filesystem-backed repos store an ABSOLUTE path under the staging/storage
+    /// base so writes land on the mounted volume (#2025). Cloud backends (s3,
+    /// gcs, azure) address objects by the bare repo key, matching the HTTP
+    /// create-repo handler in `api::handlers::repositories`.
+    fn build_storage_path(storage_backend: &str, storage_base: &str, target_key: &str) -> String {
+        if storage_backend == "filesystem" {
+            format!("{}/{}", storage_base, target_key)
+        } else {
+            target_key.to_string()
+        }
+    }
+
+    /// Create a repository in Artifact Keeper from Artifactory config.
+    ///
+    /// `storage_backend` is the resolved backend name the migrated repo should
+    /// use (typically the server's default backend). Without it every
+    /// auto-provisioned repo fell back to the column default `filesystem`,
+    /// silently stranding S3/GCS/Azure deployments' migrated artifacts on local
+    /// disk (#2336).
     pub async fn create_repository(
         &self,
         config: &RepositoryMigrationConfig,
         storage_base: &str,
+        storage_backend: &str,
     ) -> Result<Uuid, MigrationError> {
         // Check compatibility
         if config.format_compatibility == FormatCompatibility::Unsupported {
@@ -409,13 +430,14 @@ impl MigrationService {
         // The repositories table schema has no `metadata`, `display_name`, or
         // `repository_type` columns. The corresponding columns are `name` and
         // `repo_type`, and `storage_path` is NOT NULL — so the INSERT must
-        // supply it. storage_path is stored absolute (under STORAGE_PATH),
-        // matching the HTTP create-repo handler.
-        let storage_path = format!("{}/{}", storage_base, config.target_key);
+        // supply it. `storage_backend` must also be supplied explicitly;
+        // otherwise it falls back to the column default `filesystem` (#2336).
+        let storage_path =
+            Self::build_storage_path(storage_backend, storage_base, &config.target_key);
         let repo_id: (Uuid,) = sqlx::query_as(
             r#"
-            INSERT INTO repositories (key, name, description, format, repo_type, storage_path)
-            VALUES ($1, $2, $3, $4::repository_format, $5::repository_type, $6)
+            INSERT INTO repositories (key, name, description, format, repo_type, storage_path, storage_backend)
+            VALUES ($1, $2, $3, $4::repository_format, $5::repository_type, $6, $7)
             RETURNING id
             "#,
         )
@@ -425,6 +447,7 @@ impl MigrationService {
         .bind(&format)
         .bind(repo_type)
         .bind(&storage_path)
+        .bind(storage_backend)
         .fetch_one(&self.db)
         .await?;
 
@@ -1194,6 +1217,34 @@ mod tests {
             MigrationService::get_format_compatibility("unknown"),
             FormatCompatibility::Unsupported
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // storage_path convention for auto-provisioned repos (#2336, #2025)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_storage_path_filesystem_is_absolute() {
+        // Filesystem repos must root under the staging base so writes land on
+        // the mounted volume (regression for #2025).
+        assert_eq!(
+            MigrationService::build_storage_path("filesystem", "/data/storage", "libs-local"),
+            "/data/storage/libs-local"
+        );
+    }
+
+    #[test]
+    fn test_build_storage_path_cloud_uses_bare_key() {
+        // Cloud backends address objects by the bare repo key, matching the
+        // HTTP create-repo handler. Prefixing a local staging path would be
+        // wrong for object storage (#2336).
+        for backend in ["s3", "gcs", "azure"] {
+            assert_eq!(
+                MigrationService::build_storage_path(backend, "/data/storage", "libs-local"),
+                "libs-local",
+                "backend {backend} should use the bare key"
+            );
+        }
     }
 
     #[test]

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -348,13 +348,13 @@ impl MigrationWorker {
                     }
                 }
             } else {
+                // Auto-provisioned repos inherit the server's default storage
+                // backend; without this they fall back to the column default
+                // `filesystem`, stranding cloud deployments' artifacts (#2336).
+                let backend = self.storage_registry.default_backend();
                 match self
                     .migration_service
-                    .create_repository(
-                        &migration_config,
-                        &self.config.staging_path,
-                        self.storage_registry.default_backend(),
-                    )
+                    .create_repository(&migration_config, &self.config.staging_path, backend)
                     .await
                 {
                     Ok(_) => {

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -350,7 +350,11 @@ impl MigrationWorker {
             } else {
                 match self
                     .migration_service
-                    .create_repository(&migration_config, &self.config.staging_path)
+                    .create_repository(
+                        &migration_config,
+                        &self.config.staging_path,
+                        self.storage_registry.default_backend(),
+                    )
                     .await
                 {
                     Ok(_) => {

--- a/backend/tests/migration_storage_path_tests.rs
+++ b/backend/tests/migration_storage_path_tests.rs
@@ -1,10 +1,15 @@
-//! Regression for #2025: `MigrationService::create_repository` must persist an
-//! ABSOLUTE `storage_path` under STORAGE_PATH.
+//! Regression for #2025 and #2336: `MigrationService::create_repository` must
+//! persist a `storage_path` and `storage_backend` consistent with the resolved
+//! default backend.
 //!
-//! Pre-fix it stored the bare repo key (a relative path). `FilesystemStorage`
-//! then rooted that at the process cwd (`/app`), which is read-only on hardened
-//! containers (`readOnlyRootFilesystem`), so every migrated artifact write
-//! failed with `Read-only file system (os error 30)`.
+//! #2025: filesystem repos stored the bare repo key (a relative path).
+//! `FilesystemStorage` then rooted that at the process cwd (`/app`), which is
+//! read-only on hardened containers (`readOnlyRootFilesystem`), so every
+//! migrated artifact write failed with `Read-only file system (os error 30)`.
+//!
+//! #2336: `storage_backend` was never bound on the INSERT, so every migrated
+//! repo fell back to the column default `filesystem` — silently stranding
+//! S3/GCS/Azure deployments' migrated artifacts on local disk.
 
 use artifact_keeper_backend::services::migration_service::{
     FormatCompatibility, MigrationService, RepositoryMigrationConfig, RepositoryType,
@@ -12,45 +17,51 @@ use artifact_keeper_backend::services::migration_service::{
 use sqlx::PgPool;
 use uuid::Uuid;
 
-#[tokio::test]
-#[ignore] // requires Postgres (Tier 2): cargo test --workspace -- --ignored
-async fn create_repository_persists_absolute_storage_path() {
-    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
-        .await
-        .unwrap();
-
-    let key = format!("mig-store-{}", &Uuid::new_v4().to_string()[..8]);
-    let storage_base = "/data/storage";
-
-    let config = RepositoryMigrationConfig {
-        source_key: key.clone(),
-        target_key: key.clone(),
+fn config_for(key: &str) -> RepositoryMigrationConfig {
+    RepositoryMigrationConfig {
+        source_key: key.to_string(),
+        target_key: key.to_string(),
         repo_type: RepositoryType::Local,
         package_type: "maven".to_string(),
         description: None,
         format_compatibility: FormatCompatibility::Full,
         upstream_url: None,
         members: vec![],
-    };
+    }
+}
 
-    let repo_id = MigrationService::new(pool.clone())
-        .create_repository(&config, storage_base)
-        .await
-        .expect("create_repository should succeed");
-
-    let storage_path: String =
-        sqlx::query_scalar("SELECT storage_path FROM repositories WHERE id = $1")
+async fn read_storage(pool: &PgPool, repo_id: Uuid) -> (String, String) {
+    let row: (String, String) =
+        sqlx::query_as("SELECT storage_path, storage_backend FROM repositories WHERE id = $1")
             .bind(repo_id)
-            .fetch_one(&pool)
+            .fetch_one(pool)
             .await
             .unwrap();
-
     // cleanup before asserting so a failure does not leak the row
     sqlx::query("DELETE FROM repositories WHERE id = $1")
         .bind(repo_id)
-        .execute(&pool)
+        .execute(pool)
         .await
         .ok();
+    row
+}
+
+#[tokio::test]
+#[ignore] // requires Postgres (Tier 2): cargo test --workspace -- --ignored
+async fn create_repository_persists_absolute_storage_path_for_filesystem() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+
+    let key = format!("mig-store-fs-{}", &Uuid::new_v4().to_string()[..8]);
+    let storage_base = "/data/storage";
+
+    let repo_id = MigrationService::new(pool.clone())
+        .create_repository(&config_for(&key), storage_base, "filesystem")
+        .await
+        .expect("create_repository should succeed");
+
+    let (storage_path, storage_backend) = read_storage(&pool, repo_id).await;
 
     // The bug stored `key` (relative). The fix stores `{storage_base}/{key}`.
     assert_eq!(storage_path, format!("{storage_base}/{key}"));
@@ -58,4 +69,29 @@ async fn create_repository_persists_absolute_storage_path() {
         storage_path.starts_with('/'),
         "storage_path must be absolute, got {storage_path:?}"
     );
+    assert_eq!(storage_backend, "filesystem");
+}
+
+#[tokio::test]
+#[ignore] // requires Postgres (Tier 2): cargo test --workspace -- --ignored
+async fn create_repository_inherits_default_cloud_backend() {
+    // Regression for #2336: when the server default backend is s3, a migrated
+    // repo must record storage_backend=s3 and a bare-key storage_path — not
+    // silently fall back to filesystem under the staging path.
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .unwrap();
+
+    let key = format!("mig-store-s3-{}", &Uuid::new_v4().to_string()[..8]);
+
+    let repo_id = MigrationService::new(pool.clone())
+        .create_repository(&config_for(&key), "/data/storage", "s3")
+        .await
+        .expect("create_repository should succeed");
+
+    let (storage_path, storage_backend) = read_storage(&pool, repo_id).await;
+
+    assert_eq!(storage_backend, "s3");
+    // Cloud backends address objects by the bare repo key.
+    assert_eq!(storage_path, key);
 }


### PR DESCRIPTION
## Summary

Fixes #2336. Repositories auto-provisioned by the migration worker never had `storage_backend` bound on the `INSERT` in `MigrationService::create_repository`, so every migrated repo silently fell back to the column default `filesystem` (`migrations/003_repositories.sql`).
Also resolves #2317.

On S3/GCS/Azure deployments, `MigrationWorker::storage_for_repo` reads that per-repo column to pick a backend — so all migrated artifacts landed on local/EFS disk instead of object storage, with no error surfaced. This was the silent half left behind by #2029, which only addressed the loud filesystem `storage_path` crash.

Changes:
- `create_repository` now takes the resolved backend name; the worker passes `storage_registry.default_backend()` at the call site.
- `storage_backend` is bound explicitly on the INSERT.
- `storage_path` now branches like the HTTP create-repo handler: absolute `{staging}/{key}` for `filesystem`, bare `{key}` for cloud backends (object storage keys should not be prefixed with a local staging path).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added unit tests for the `build_storage_path` helper (filesystem vs cloud) and extended `migration_storage_path_tests.rs` with a case asserting a migrated repo inherits an `s3` default backend with a bare-key path — this fails on `main` (where `storage_backend` is never bound).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes