### PR TITLE
fix(api): resolve 5 OpenAPI schema-name collisions and empty the ratchet

### DIFF
--- a/backend/src/api/handlers/curation.rs
+++ b/backend/src/api/handlers/curation.rs
@@ -36,7 +36,7 @@ use crate::services::curation_service::CurationService;
         CreateRuleRequest,
         UpdateRuleRequest,
         RuleResponse,
-        PackageResponse,
+        CurationPackageResponse,
         BulkStatusRequest,
         PackageListQuery,
         ReEvaluateRequest,
@@ -135,7 +135,7 @@ pub struct RuleResponse {
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-pub struct PackageResponse {
+pub struct CurationPackageResponse {
     pub id: Uuid,
     pub staging_repo_id: Uuid,
     pub remote_repo_id: Uuid,
@@ -327,13 +327,13 @@ async fn delete_rule(
     path = "/api/v1/curation/packages",
     operation_id = "list_curation_packages",
     params(PackageListQuery),
-    responses((status = 200, body = Vec<PackageResponse>)),
+    responses((status = 200, body = Vec<CurationPackageResponse>)),
     tag = "Curation"
 )]
 async fn list_packages(
     State(state): State<SharedState>,
     Query(query): Query<PackageListQuery>,
-) -> Result<Json<Vec<PackageResponse>>, AppError> {
+) -> Result<Json<Vec<CurationPackageResponse>>, AppError> {
     let svc = CurationService::new(state.db.clone());
     let packages = svc
         .list_packages(
@@ -351,13 +351,13 @@ async fn list_packages(
     path = "/api/v1/curation/packages/{id}",
     operation_id = "get_curation_package",
     params(("id" = Uuid, Path, description = "Package ID")),
-    responses((status = 200, body = PackageResponse)),
+    responses((status = 200, body = CurationPackageResponse)),
     tag = "Curation"
 )]
 async fn get_package(
     State(state): State<SharedState>,
     Path(id): Path<Uuid>,
-) -> Result<Json<PackageResponse>, AppError> {
+) -> Result<Json<CurationPackageResponse>, AppError> {
     let svc = CurationService::new(state.db.clone());
     let pkg = svc.get_package(id).await?;
     Ok(Json(pkg_to_response(pkg)))
@@ -367,14 +367,14 @@ async fn get_package(
     post,
     path = "/api/v1/curation/packages/{id}/approve",
     params(("id" = Uuid, Path, description = "Package ID")),
-    responses((status = 200, body = PackageResponse)),
+    responses((status = 200, body = CurationPackageResponse)),
     tag = "Curation"
 )]
 async fn approve_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
-) -> Result<Json<PackageResponse>, AppError> {
+) -> Result<Json<CurationPackageResponse>, AppError> {
     auth.require_admin()?;
     let svc = CurationService::new(state.db.clone());
     let pkg = svc
@@ -393,14 +393,14 @@ async fn approve_package(
     post,
     path = "/api/v1/curation/packages/{id}/block",
     params(("id" = Uuid, Path, description = "Package ID")),
-    responses((status = 200, body = PackageResponse)),
+    responses((status = 200, body = CurationPackageResponse)),
     tag = "Curation"
 )]
 async fn block_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
-) -> Result<Json<PackageResponse>, AppError> {
+) -> Result<Json<CurationPackageResponse>, AppError> {
     auth.require_admin()?;
     let svc = CurationService::new(state.db.clone());
     let pkg = svc
@@ -512,8 +512,8 @@ fn rule_to_response(rule: crate::models::curation::CurationRule) -> RuleResponse
     }
 }
 
-fn pkg_to_response(pkg: crate::models::curation::CurationPackage) -> PackageResponse {
-    PackageResponse {
+fn pkg_to_response(pkg: crate::models::curation::CurationPackage) -> CurationPackageResponse {
+    CurationPackageResponse {
         id: pkg.id,
         staging_repo_id: pkg.staging_repo_id,
         remote_repo_id: pkg.remote_repo_id,

--- a/backend/src/api/handlers/lifecycle.rs
+++ b/backend/src/api/handlers/lifecycle.rs
@@ -13,7 +13,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::services::lifecycle_service::{
-    CreatePolicyRequest, LifecyclePolicy, LifecycleService, PolicyExecutionResult,
+    CreateLifecyclePolicyRequest, LifecyclePolicy, LifecycleService, PolicyExecutionResult,
     UpdateLifecyclePolicyRequest,
 };
 
@@ -31,7 +31,7 @@ use crate::services::lifecycle_service::{
     ),
     components(schemas(
         LifecyclePolicy,
-        CreatePolicyRequest,
+        CreateLifecyclePolicyRequest,
         UpdateLifecyclePolicyRequest,
         PolicyExecutionResult,
     ))
@@ -84,7 +84,7 @@ pub async fn list_policies(
     context_path = "/api/v1/admin/lifecycle",
     tag = "lifecycle",
     operation_id = "create_lifecycle_policy",
-    request_body = CreatePolicyRequest,
+    request_body = CreateLifecyclePolicyRequest,
     responses(
         (status = 200, description = "Policy created successfully", body = LifecyclePolicy),
     ),
@@ -93,7 +93,7 @@ pub async fn list_policies(
 pub async fn create_policy(
     State(state): State<SharedState>,
     Extension(_auth): Extension<AuthExtension>,
-    Json(payload): Json<CreatePolicyRequest>,
+    Json(payload): Json<CreateLifecyclePolicyRequest>,
 ) -> Result<Json<LifecyclePolicy>> {
     let service = LifecycleService::new(state.db.clone());
     let policy = service.create_policy(payload).await?;
@@ -283,7 +283,7 @@ mod tests {
         assert!(q.repository_id.is_none());
     }
 
-    // ── CreatePolicyRequest deserialization tests ────────────────────
+    // ── CreateLifecyclePolicyRequest deserialization tests ────────────────────
 
     #[test]
     fn test_create_policy_request_full() {
@@ -295,7 +295,7 @@ mod tests {
             "config": {"max_age_days": 90},
             "priority": 10
         }"#;
-        let req: CreatePolicyRequest = serde_json::from_str(json).unwrap();
+        let req: CreateLifecyclePolicyRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name, "cleanup-old");
         assert_eq!(req.policy_type, "max_age_days");
         assert_eq!(req.priority, Some(10));
@@ -310,7 +310,7 @@ mod tests {
             "policy_type": "max_versions",
             "config": {"max_versions": 5}
         }"#;
-        let req: CreatePolicyRequest = serde_json::from_str(json).unwrap();
+        let req: CreateLifecyclePolicyRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name, "global-policy");
         assert!(req.repository_id.is_none());
         assert!(req.description.is_none());
@@ -320,21 +320,24 @@ mod tests {
     #[test]
     fn test_create_policy_request_missing_name_fails() {
         let json = r#"{"policy_type": "max_age_days", "config": {}}"#;
-        let result: std::result::Result<CreatePolicyRequest, _> = serde_json::from_str(json);
+        let result: std::result::Result<CreateLifecyclePolicyRequest, _> =
+            serde_json::from_str(json);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_create_policy_request_missing_policy_type_fails() {
         let json = r#"{"name": "test", "config": {}}"#;
-        let result: std::result::Result<CreatePolicyRequest, _> = serde_json::from_str(json);
+        let result: std::result::Result<CreateLifecyclePolicyRequest, _> =
+            serde_json::from_str(json);
         assert!(result.is_err());
     }
 
     #[test]
     fn test_create_policy_request_missing_config_fails() {
         let json = r#"{"name": "test", "policy_type": "max_age_days"}"#;
-        let result: std::result::Result<CreatePolicyRequest, _> = serde_json::from_str(json);
+        let result: std::result::Result<CreateLifecyclePolicyRequest, _> =
+            serde_json::from_str(json);
         assert!(result.is_err());
     }
 

--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -302,11 +302,11 @@ pub struct ReportQuery {
 #[derive(Debug, Serialize)]
 pub struct ListResponse<T> {
     pub items: Vec<T>,
-    pub pagination: Option<PaginationInfo>,
+    pub pagination: Option<MigrationPaginationInfo>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
-pub struct PaginationInfo {
+pub struct MigrationPaginationInfo {
     pub page: i64,
     pub per_page: i64,
     pub total: i64,
@@ -1026,7 +1026,7 @@ async fn list_migrations(
     if !table_exists {
         return Ok(Json(ListResponse {
             items: vec![],
-            pagination: Some(PaginationInfo {
+            pagination: Some(MigrationPaginationInfo {
                 page: 1,
                 per_page: 20,
                 total: 0,
@@ -1079,7 +1079,7 @@ async fn list_migrations(
 
     Ok(Json(ListResponse {
         items: jobs.into_iter().map(Into::into).collect(),
-        pagination: Some(PaginationInfo {
+        pagination: Some(MigrationPaginationInfo {
             page,
             per_page,
             total: total.0,
@@ -1592,7 +1592,7 @@ async fn list_migration_items(
 
     Ok(Json(ListResponse {
         items: items.into_iter().map(Into::into).collect(),
-        pagination: Some(PaginationInfo {
+        pagination: Some(MigrationPaginationInfo {
             page,
             per_page,
             total: total.0,
@@ -2151,12 +2151,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // PaginationInfo
+    // MigrationPaginationInfo
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_pagination_info() {
-        let page_info = PaginationInfo {
+        let page_info = MigrationPaginationInfo {
             page: 2,
             per_page: 20,
             total: 100,
@@ -3284,7 +3284,7 @@ mod tests {
         ConnectionTestResult,
         SourceRepository,
         CreateMigrationRequest,
-        PaginationInfo,
+        MigrationPaginationInfo,
         MigrationJobResponse,
         MigrationItemResponse,
         MigrationReportResponse,

--- a/backend/src/api/handlers/search.rs
+++ b/backend/src/api/handlers/search.rs
@@ -795,7 +795,7 @@ pub async fn recent(
 
 /// Response returned when a reindex is triggered.
 #[derive(Debug, Serialize, ToSchema)]
-pub struct ReindexResponse {
+pub struct SearchReindexResponse {
     pub status: String,
     pub message: String,
 }
@@ -811,11 +811,13 @@ pub struct ReindexResponse {
     tag = "admin",
     operation_id = "trigger_search_reindex",
     responses(
-        (status = 200, description = "Reindex started in background", body = ReindexResponse),
+        (status = 200, description = "Reindex started in background", body = SearchReindexResponse),
         (status = 500, description = "Search engine is not configured"),
     ),
 )]
-pub async fn trigger_reindex(State(state): State<SharedState>) -> Result<Json<ReindexResponse>> {
+pub async fn trigger_reindex(
+    State(state): State<SharedState>,
+) -> Result<Json<SearchReindexResponse>> {
     let search = state
         .search_service
         .as_ref()
@@ -836,7 +838,7 @@ pub async fn trigger_reindex(State(state): State<SharedState>) -> Result<Json<Re
         }
     });
 
-    Ok(Json(ReindexResponse {
+    Ok(Json(SearchReindexResponse {
         status: "started".to_string(),
         message: "Full reindex of artifacts and repositories triggered in background".to_string(),
     }))
@@ -863,7 +865,7 @@ pub async fn trigger_reindex(State(state): State<SharedState>) -> Result<Json<Re
         ChecksumArtifact,
         ChecksumSearchResponse,
         SuggestResponse,
-        ReindexResponse,
+        SearchReindexResponse,
     ))
 )]
 pub struct SearchApiDoc;
@@ -1296,12 +1298,12 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // ReindexResponse serialization
+    // SearchReindexResponse serialization
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_reindex_response_serialization() {
-        let resp = ReindexResponse {
+        let resp = SearchReindexResponse {
             status: "started".to_string(),
             message: "Full reindex triggered".to_string(),
         };

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -782,7 +782,7 @@ pub async fn revoke_role(
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CreateApiTokenRequest {
+pub struct CreateUserApiTokenRequest {
     pub name: String,
     pub scopes: Vec<String>,
     pub expires_in_days: Option<i64>,
@@ -882,7 +882,7 @@ async fn list_user_tokens_inner(
     params(
         ("id" = Uuid, Path, description = "User ID"),
     ),
-    request_body = CreateApiTokenRequest,
+    request_body = CreateUserApiTokenRequest,
     responses(
         (status = 200, description = "API token created successfully", body = ApiTokenCreatedResponse),
         (status = 403, description = "Cannot create tokens for other users"),
@@ -893,7 +893,7 @@ pub async fn create_api_token(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
-    Json(payload): Json<CreateApiTokenRequest>,
+    Json(payload): Json<CreateUserApiTokenRequest>,
 ) -> Result<Json<ApiTokenCreatedResponse>> {
     // Users can only create tokens for themselves unless admin
     auth.require_self_or_admin(id, "Cannot create tokens for other users")?;
@@ -908,7 +908,7 @@ async fn create_api_token_inner(
     state: &SharedState,
     auth: &AuthExtension,
     id: Uuid,
-    payload: CreateApiTokenRequest,
+    payload: CreateUserApiTokenRequest,
 ) -> Result<Json<ApiTokenCreatedResponse>> {
     // Refuse admin-class scopes from non-admin callers. See
     // `token_service::ADMIN_ONLY_SCOPES` for the policy rationale —
@@ -1561,7 +1561,7 @@ pub async fn list_current_user_tokens(
     context_path = "/api/v1/users",
     tag = "users",
     operation_id = "create_current_user_api_token",
-    request_body = CreateApiTokenRequest,
+    request_body = CreateUserApiTokenRequest,
     responses(
         (status = 200, description = "API token created successfully", body = ApiTokenCreatedResponse),
         (status = 403, description = "Requested scopes require administrator privileges"),
@@ -1571,7 +1571,7 @@ pub async fn list_current_user_tokens(
 pub async fn create_current_user_api_token(
     State(state): State<SharedState>,
     Extension(auth): Extension<AuthExtension>,
-    Json(payload): Json<CreateApiTokenRequest>,
+    Json(payload): Json<CreateUserApiTokenRequest>,
 ) -> Result<Json<ApiTokenCreatedResponse>> {
     create_api_token_inner(&state, &auth, auth.user_id, payload).await
 }
@@ -1661,7 +1661,7 @@ pub async fn change_current_user_password(
         RoleResponse,
         RoleListResponse,
         AssignRoleRequest,
-        CreateApiTokenRequest,
+        CreateUserApiTokenRequest,
         ApiTokenResponse,
         ApiTokenCreatedResponse,
         ApiTokenListResponse,
@@ -2025,7 +2025,7 @@ mod tests {
     #[test]
     fn test_create_api_token_request_deserialize() {
         let json = r#"{"name":"CI token","scopes":["read","deploy"],"expires_in_days":90}"#;
-        let req: CreateApiTokenRequest = serde_json::from_str(json).unwrap();
+        let req: CreateUserApiTokenRequest = serde_json::from_str(json).unwrap();
         assert_eq!(req.name, "CI token");
         assert_eq!(req.scopes, vec!["read", "deploy"]);
         assert_eq!(req.expires_in_days, Some(90));
@@ -2034,7 +2034,7 @@ mod tests {
     #[test]
     fn test_create_api_token_request_no_expiry() {
         let json = r#"{"name":"permanent","scopes":["*"]}"#;
-        let req: CreateApiTokenRequest = serde_json::from_str(json).unwrap();
+        let req: CreateUserApiTokenRequest = serde_json::from_str(json).unwrap();
         assert!(req.expires_in_days.is_none());
     }
 

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -435,13 +435,11 @@ mod tests {
         // operations publish the wrong shape. This list may only SHRINK —
         // the assertions below fail both on a NEW collision and on a stale
         // entry (so a fixed collision must be removed here).
-        const KNOWN_COLLISIONS: &[&str] = &[
-            "CreateApiTokenRequest", // auth vs users
-            "CreatePolicyRequest",   // security (quality-gate) vs lifecycle
-            "PackageResponse",       // packages vs curation
-            "PaginationInfo",        // search vs migration
-            "ReindexResponse",       // search vs admin
-        ];
+        // All previously grandfathered collisions have been resolved by
+        // renaming the less-canonical struct in each pair (see #2334 for the
+        // ArtifactResponse/UpdatePolicyRequest precedent). The ratchet is now
+        // empty: any new divergent same-name schema fails this test outright.
+        const KNOWN_COLLISIONS: &[&str] = &[];
 
         // name -> (first module that registered it, serialized schema)
         let mut seen: HashMap<String, (String, String)> = HashMap::new();

--- a/backend/src/services/lifecycle_service.rs
+++ b/backend/src/services/lifecycle_service.rs
@@ -334,7 +334,7 @@ pub struct LifecyclePolicy {
 
 /// Request to create a lifecycle policy.
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct CreatePolicyRequest {
+pub struct CreateLifecyclePolicyRequest {
     pub repository_id: Option<Uuid>,
     pub name: String,
     pub description: Option<String>,
@@ -399,7 +399,10 @@ impl LifecycleService {
     }
 
     /// Create a new lifecycle policy.
-    pub async fn create_policy(&self, req: CreatePolicyRequest) -> Result<LifecyclePolicy> {
+    pub async fn create_policy(
+        &self,
+        req: CreateLifecyclePolicyRequest,
+    ) -> Result<LifecyclePolicy> {
         // Validate policy_type
         let valid_types = [
             "max_age_days",
@@ -1620,7 +1623,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_max_versions_without_repository_id_rejected() {
         let svc = make_service_for_validation();
-        let req = CreatePolicyRequest {
+        let req = CreateLifecyclePolicyRequest {
             repository_id: None,
             name: "global-max-versions".to_string(),
             description: None,
@@ -1637,7 +1640,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_size_quota_without_repository_id_rejected() {
         let svc = make_service_for_validation();
-        let req = CreatePolicyRequest {
+        let req = CreateLifecyclePolicyRequest {
             repository_id: None,
             name: "global-size-quota".to_string(),
             description: None,
@@ -1659,7 +1662,7 @@ mod tests {
         // would fail here is the INSERT (no live DB), which surfaces as a
         // Database error, never a Validation error about repository_id.
         let svc = make_service_for_validation();
-        let req = CreatePolicyRequest {
+        let req = CreateLifecyclePolicyRequest {
             repository_id: None,
             name: "global-max-age".to_string(),
             description: None,
@@ -1739,7 +1742,7 @@ mod tests {
             "policy_type": "max_age_days",
             "config": {"days": 30}
         }"#;
-        let req: CreatePolicyRequest = serde_json::from_str(json_str).unwrap();
+        let req: CreateLifecyclePolicyRequest = serde_json::from_str(json_str).unwrap();
         assert_eq!(req.name, "My Policy");
         assert_eq!(req.policy_type, "max_age_days");
         assert!(req.repository_id.is_none());
@@ -1758,7 +1761,7 @@ mod tests {
             "config": {"quota_bytes": 1000000},
             "priority": 5
         });
-        let req: CreatePolicyRequest = serde_json::from_value(json_val).unwrap();
+        let req: CreateLifecyclePolicyRequest = serde_json::from_value(json_val).unwrap();
         assert_eq!(req.repository_id, Some(repo_id));
         assert_eq!(req.description, Some("With all fields".to_string()));
         assert_eq!(req.priority, Some(5));
@@ -2364,14 +2367,15 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // CreatePolicyRequest: deserialization edge cases
+    // CreateLifecyclePolicyRequest: deserialization edge cases
     // -----------------------------------------------------------------------
 
     #[test]
     fn test_create_policy_request_missing_required_field() {
         // Missing "name" field
         let json_str = r#"{"policy_type": "max_age_days", "config": {"days": 30}}"#;
-        let result: std::result::Result<CreatePolicyRequest, _> = serde_json::from_str(json_str);
+        let result: std::result::Result<CreateLifecyclePolicyRequest, _> =
+            serde_json::from_str(json_str);
         assert!(result.is_err());
     }
 
@@ -2379,7 +2383,8 @@ mod tests {
     fn test_create_policy_request_missing_config() {
         // Missing "config" field
         let json_str = r#"{"name": "Test", "policy_type": "max_age_days"}"#;
-        let result: std::result::Result<CreatePolicyRequest, _> = serde_json::from_str(json_str);
+        let result: std::result::Result<CreateLifecyclePolicyRequest, _> =
+            serde_json::from_str(json_str);
         assert!(result.is_err());
     }
 
@@ -2429,7 +2434,7 @@ mod tests {
             "config": {"days": 7},
             "cron_schedule": "0 0 2 * * *"
         });
-        let req: CreatePolicyRequest = serde_json::from_value(json_val).unwrap();
+        let req: CreateLifecyclePolicyRequest = serde_json::from_value(json_val).unwrap();
         assert_eq!(req.cron_schedule, Some("0 0 2 * * *".to_string()));
     }
 
@@ -2440,7 +2445,7 @@ mod tests {
             "policy_type": "max_age_days",
             "config": {"days": 7}
         });
-        let req: CreatePolicyRequest = serde_json::from_value(json_val).unwrap();
+        let req: CreateLifecyclePolicyRequest = serde_json::from_value(json_val).unwrap();
         assert!(req.cron_schedule.is_none());
     }
 

--- a/backend/tests/lifecycle_policy_tests.rs
+++ b/backend/tests/lifecycle_policy_tests.rs
@@ -11,7 +11,9 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use artifact_keeper_backend::services::lifecycle_service::{CreatePolicyRequest, LifecycleService};
+use artifact_keeper_backend::services::lifecycle_service::{
+    CreateLifecyclePolicyRequest, LifecycleService,
+};
 
 /// Create a test repository and return its ID.
 async fn create_test_repo(pool: &PgPool, name: &str) -> Uuid {
@@ -106,7 +108,7 @@ async fn test_tag_pattern_keep_deletes_non_matching_artifacts() {
 
     // Create a tag_pattern_keep policy: keep release-* and v*
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Keep releases".to_string(),
             description: Some("Keep release and version tags".to_string()),
@@ -187,7 +189,7 @@ async fn test_tag_pattern_keep_all_match_deletes_nothing() {
     let a2 = insert_artifact(&pool, repo_id, "release-2.0", 200).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Keep all releases".to_string(),
             description: None,
@@ -226,7 +228,7 @@ async fn test_tag_pattern_keep_none_match_deletes_all() {
     let a2 = insert_artifact(&pool, repo_id, "dev-build-2", 200).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Keep only releases".to_string(),
             description: None,
@@ -266,7 +268,7 @@ async fn test_tag_pattern_delete_still_works() {
     let a_snapshot = insert_artifact(&pool, repo_id, "snapshot-nightly", 200).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Delete snapshots".to_string(),
             description: None,
@@ -368,7 +370,7 @@ async fn test_size_quota_lru_evicts_never_downloaded_first() {
 
     // Set quota to 200 bytes — need to evict 200 bytes (2 artifacts)
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "LRU quota".to_string(),
             description: None,
@@ -436,7 +438,7 @@ async fn test_size_quota_lru_frequently_downloaded_survives() {
 
     // Set quota to 100 bytes — need to evict 200 bytes (2 artifacts)
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "LRU frequent test".to_string(),
             description: None,
@@ -649,7 +651,7 @@ async fn test_tag_pattern_delete_cascades_oci_tags_for_soft_deleted_manifest() {
     insert_oci_tag(&pool, repo_id, "myimg", "release-alias", ephemeral_digest).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Delete snapshot-images".to_string(),
             description: None,
@@ -742,7 +744,7 @@ async fn test_max_age_days_cascades_oci_tags() {
         .expect("backdate failed");
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Drop > 7 days".to_string(),
             description: None,
@@ -807,7 +809,7 @@ async fn test_cascade_respects_repo_scope() {
         .unwrap();
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_a),
             name: "Drop snapshots in A".to_string(),
             description: None,
@@ -866,7 +868,7 @@ async fn test_cascade_handles_port_in_image_name() {
     insert_oci_tag(&pool, repo_id, image, "alias", digest).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Drop snapshot-keep-me".to_string(),
             description: None,
@@ -943,7 +945,7 @@ async fn test_cascade_handles_digest_reference() {
         .expect("backdate failed");
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Drop > 7 days".to_string(),
             description: None,
@@ -1033,7 +1035,7 @@ async fn test_execute_policy_reclaims_orphan_oci_tags() {
     .await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Drop ^stale$ (no match)".to_string(),
             description: None,
@@ -1152,7 +1154,7 @@ async fn test_cascade_picks_up_orphans_from_prior_run() {
     insert_oci_tag(&pool, repo_id, "imgC", "live", live_digest).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Recovery sweep".to_string(),
             description: None,
@@ -1220,7 +1222,7 @@ async fn test_size_quota_under_limit_evicts_nothing() {
     let a2 = insert_artifact(&pool, repo_id, "small-2", 100).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Generous quota".to_string(),
             description: None,
@@ -1327,7 +1329,7 @@ async fn test_max_versions_cascades_oci_tags() {
     .unwrap();
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Keep latest".to_string(),
             description: None,
@@ -1423,7 +1425,7 @@ async fn test_no_downloads_days_cascades_oci_tags() {
     record_download_days_ago(&pool, cold_alias_id, 1).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Drop cold".to_string(),
             description: None,
@@ -1489,7 +1491,7 @@ async fn test_tag_pattern_keep_cascades_oci_tags() {
     insert_oci_tag(&pool, repo_id, "img", "v0.0.0-snap", snapshot_digest).await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Keep semver".to_string(),
             description: None,
@@ -1564,7 +1566,7 @@ async fn test_size_quota_bytes_cascades_oci_tags() {
     record_download(&pool, evict_alias_id, "2026-05-29T00:00:00Z").await;
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Tight quota".to_string(),
             description: None,
@@ -1657,7 +1659,7 @@ async fn test_lifecycle_cascade_unblocks_storage_gc_orphan_detection() {
     );
 
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Drop > 7 days".to_string(),
             description: None,
@@ -1722,7 +1724,7 @@ async fn cascade_retains_sole_protecting_oci_tag() {
     // A retention rule whose regex matches the manifest artifact's name
     // ("app:prod"): tx1 soft-deletes the manifest row, tx2 runs the cascade.
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Prune prod".to_string(),
             description: None,
@@ -1780,7 +1782,7 @@ async fn cascade_prunes_redundant_tag_when_sibling_survives() {
     // A prune rule matching only "stale": tx1 soft-deletes the `stale`
     // manifest row (the `keep` row stays live), tx2 runs the cascade.
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Prune stale".to_string(),
             description: None,
@@ -1843,7 +1845,7 @@ async fn cascade_retains_all_when_every_protecting_tag_pruned() {
     // ("app:prod", "app:prod-old"): tx1 soft-deletes both manifest rows,
     // tx2 runs the cascade.
     let policy = svc
-        .create_policy(CreatePolicyRequest {
+        .create_policy(CreateLifecyclePolicyRequest {
             repository_id: Some(repo_id),
             name: "Prune all prod".to_string(),
             description: None,


### PR DESCRIPTION
## Summary

`build_openapi()` merges every module's utoipa `components(schemas(...))` into one document. utoipa keeps the **first** definition registered under a given schema name, so when two modules define **different** structs under the **same** name, every later endpoint silently publishes the earlier module's shape. #2334 added `test_openapi_schema_names_are_unique_across_modules` and grandfathered five pre-existing collisions in the shrink-only `KNOWN_COLLISIONS` ratchet. This PR resolves all five and empties the ratchet.

The headline case is a real spec bug: `POST /api/v1/admin/lifecycle` published the **quality-gate** `CreatePolicyRequest` fields instead of the lifecycle create fields — the create-side sibling of the `UpdatePolicyRequest` drift already fixed in #2334.

Each collision is resolved by renaming the **less-canonical** struct in the pair (definition + imports + utoipa `components(schemas)`/`request_body`/`responses` annotations + tests):

| Schema | Renamed side | New name | Canonical side kept |
|---|---|---|---|
| `CreatePolicyRequest` | lifecycle | `CreateLifecyclePolicyRequest` | security/quality-gate |
| `CreateApiTokenRequest` | users | `CreateUserApiTokenRequest` | auth (`/auth/tokens`) |
| `PackageResponse` | curation | `CurationPackageResponse` | packages |
| `PaginationInfo` | migration | `MigrationPaginationInfo` | search |
| `ReindexResponse` | search (`/admin/search/reindex`) | `SearchReindexResponse` | admin (`/admin/reindex`) |

`KNOWN_COLLISIONS` is now empty. The guard fails on both new collisions and stale ratchet entries, so emptying it is required once fixed.

### POST /api/v1/admin/lifecycle — before / after
- **Before:** body → `CreatePolicyRequest` (`block_on_fail`, `block_unscanned`, `max_artifact_age_days`, `max_severity`, `min_staging_hours`, `name`, `repository_id`, `require_signature`) — wrong (quality-gate shape).
- **After:** body → `CreateLifecyclePolicyRequest` (`name`, `description`, `policy_type`, `config`, `priority`, `cron_schedule`, `repository_id`) — correct lifecycle shape.

These are schema-**name** changes; the generated SDK regen picks them up (expected).

## Test Checklist
- [x] `cargo fmt --all --check` clean
- [x] `cargo build --lib` clean (SQLX_OFFLINE)
- [x] `test_openapi_schema_names_are_unique_across_modules` passes with **empty** `KNOWN_COLLISIONS`
- [x] `export_openapi_spec` regenerated — all five names now publish distinctly; `POST /admin/lifecycle` shows lifecycle fields
- [x] 525 affected-module unit tests pass (lifecycle/users/curation/search/admin/security/auth/openapi/lifecycle_service), 0 failed
- [x] `tests/lifecycle_policy_tests.rs` compiles against the renamed type

## API Changes
Five response/request schema **names** renamed (shapes unchanged). Endpoint paths unchanged. `POST /api/v1/admin/lifecycle` request body now correctly documents lifecycle fields instead of quality-gate fields.

Closes #2339
