### PR TITLE
fix(swift): aggregate release versions across all virtual repo members

### DIFF
--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -276,27 +276,32 @@ async fn query_release_versions(
 }
 
 /// Fan out a `list_releases` lookup across the members of a virtual repo,
-/// returning the versions from the first member that owns the package
-/// (members are returned in priority order). Remote members are not consulted
-/// for listing because their upstream listing shape is format-specific; the
-/// `.zip`/metadata endpoints proxy them on demand.
+/// aggregating the versions from ALL Local/Staging members that own the
+/// package. Members are visited in priority order and the result is
+/// deduplicated by version string, so when the same version exists in more
+/// than one member the highest-priority member's entry wins. Remote members
+/// are not consulted for listing because their upstream listing shape is
+/// format-specific; the `.zip`/metadata endpoints proxy them on demand.
 pub async fn query_release_versions_virtual(
     db: &PgPool,
     virtual_repo_id: uuid::Uuid,
     package_id: &str,
 ) -> Result<Vec<String>, Response> {
     let members = proxy_helpers::fetch_virtual_members(db, virtual_repo_id).await?;
+    let mut aggregated: Vec<String> = Vec::new();
+    let mut seen_versions: std::collections::HashSet<String> = std::collections::HashSet::new();
     for member in &members {
         if member.repo_type != RepositoryType::Local && member.repo_type != RepositoryType::Staging
         {
             continue;
         }
-        let versions = query_release_versions(db, member.id, package_id).await?;
-        if !versions.is_empty() {
-            return Ok(versions);
+        for version in query_release_versions(db, member.id, package_id).await? {
+            if seen_versions.insert(version.clone()) {
+                aggregated.push(version);
+            }
         }
     }
-    Ok(Vec::new())
+    Ok(aggregated)
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/tests/swift_virtual_lookup_tests.rs
+++ b/backend/tests/swift_virtual_lookup_tests.rs
@@ -5,8 +5,10 @@
 //! `get_release_metadata`, and `fetch_manifest` previously queried the
 //! `artifacts` table using the *virtual* repo's own id. Virtual repos own no
 //! artifacts, so every lookup returned 404 even when a member served the
-//! package. The fix fans out across Local/Staging members in priority order
-//! and returns the first hit.
+//! package. The fix fans out across Local/Staging members in priority order:
+//! single-version lookups return the first hit, while `list_releases`
+//! aggregates versions across all members, deduplicated with the
+//! highest-priority member winning on conflict (#2307).
 //!
 //! Requires a PostgreSQL database with migrations applied. Run with:
 //!
@@ -177,30 +179,83 @@ async fn swift_virtual_resolves_release_from_local_member() {
     cleanup(&pool, virtual_id, &[local_id]).await;
 }
 
-/// Priority ordering: the first member (by priority) that owns the package wins.
+/// Aggregation (#2307): `list_releases` must union versions across ALL
+/// Local/Staging members, not just the first member that owns the package.
 #[tokio::test]
 #[ignore]
-async fn swift_virtual_returns_first_member_hit_by_priority() {
+async fn swift_virtual_aggregates_versions_across_members() {
     let pool = pool().await;
     let suffix = Uuid::new_v4();
-    let virtual_id = insert_repo(&pool, &format!("sw-virt-prio-{}", suffix), "virtual").await;
+    let virtual_id = insert_repo(&pool, &format!("sw-virt-agg-{}", suffix), "virtual").await;
     let local_a = insert_repo(&pool, &format!("sw-a-{}", suffix), "local").await;
     let local_b = insert_repo(&pool, &format!("sw-b-{}", suffix), "local").await;
-    // local_b has higher priority value but later position; local_a is first.
     add_virtual_member(&pool, virtual_id, local_a, 1).await;
     add_virtual_member(&pool, virtual_id, local_b, 2).await;
 
     let package_id = "apple.swift-log";
     insert_swift_artifact(&pool, local_a, package_id, "1.0.0", None).await;
-    insert_swift_artifact(&pool, local_b, package_id, "9.9.9", None).await;
+    insert_swift_artifact(&pool, local_b, package_id, "2.0.0", None).await;
+
+    let versions = query_release_versions_virtual(&pool, virtual_id, package_id)
+        .await
+        .expect("lookup must succeed");
+    assert!(
+        versions.contains(&"1.0.0".to_string()),
+        "member A's version must appear in the aggregated list, got {:?}",
+        versions
+    );
+    assert!(
+        versions.contains(&"2.0.0".to_string()),
+        "member B's version must appear in the aggregated list, got {:?}",
+        versions
+    );
+    assert_eq!(
+        versions.len(),
+        2,
+        "no duplicates or extras, got {:?}",
+        versions
+    );
+
+    cleanup(&pool, virtual_id, &[local_a, local_b]).await;
+}
+
+/// Deduplication (#2307): when the same version exists in multiple members it
+/// must appear exactly once (the highest-priority member's entry wins).
+#[tokio::test]
+#[ignore]
+async fn swift_virtual_dedupes_versions_across_members() {
+    let pool = pool().await;
+    let suffix = Uuid::new_v4();
+    let virtual_id = insert_repo(&pool, &format!("sw-virt-dedup-{}", suffix), "virtual").await;
+    let local_a = insert_repo(&pool, &format!("sw-da-{}", suffix), "local").await;
+    let local_b = insert_repo(&pool, &format!("sw-db-{}", suffix), "local").await;
+    add_virtual_member(&pool, virtual_id, local_a, 1).await;
+    add_virtual_member(&pool, virtual_id, local_b, 2).await;
+
+    let package_id = "apple.swift-nio";
+    insert_swift_artifact(&pool, local_a, package_id, "3.1.0", None).await;
+    insert_swift_artifact(&pool, local_b, package_id, "3.1.0", None).await;
+    insert_swift_artifact(&pool, local_b, package_id, "3.2.0", None).await;
 
     let versions = query_release_versions_virtual(&pool, virtual_id, package_id)
         .await
         .expect("lookup must succeed");
     assert_eq!(
-        versions,
-        vec!["1.0.0".to_string()],
-        "the highest-priority member that owns the package must win"
+        versions.iter().filter(|v| v.as_str() == "3.1.0").count(),
+        1,
+        "a version present in both members must appear exactly once, got {:?}",
+        versions
+    );
+    assert!(
+        versions.contains(&"3.2.0".to_string()),
+        "the second member's unique version must still appear, got {:?}",
+        versions
+    );
+    assert_eq!(
+        versions.len(),
+        2,
+        "expected exactly two versions, got {:?}",
+        versions
     );
 
     cleanup(&pool, virtual_id, &[local_a, local_b]).await;


### PR DESCRIPTION
## Summary

`query_release_versions_virtual` (`backend/src/api/handlers/swift.rs`) short-circuited on the first non-empty Local/Staging member, so a virtual Swift repository whose members held different versions of the same package returned only the highest-priority member's versions from `GET /swift/:repo_key/:scope/:name`. Every other aggregate-able format (Cargo, PyPI, RubyGems, Maven, NuGet, Helm, Conda, CRAN) already unions versions across members; Swift was the sole exception.

## Changes

- `query_release_versions_virtual` now iterates all Local/Staging members in priority order, accumulating versions into a `Vec` deduplicated by a `HashSet` — the highest-priority member's entry wins on conflict (same pattern as the Cargo virtual index aggregation).
- Remote members remain skipped for listing, per the existing design (upstream listing shape is format-specific; `.zip`/metadata endpoints proxy on demand).
- Single-version lookup paths (`query_release_metadata_virtual`, manifest owner resolution) are unchanged — first-hit short-circuit is correct there.
- Updated the doc comments to describe the aggregation semantics.

## Tests

- New `swift_virtual_aggregates_versions_across_members`: two local members with `1.0.0` / `2.0.0` of one package — both versions must appear in the union.
- New `swift_virtual_dedupes_versions_across_members`: the same version in two members appears exactly once; the second member's unique version still appears.
- Replaces the previous `swift_virtual_returns_first_member_hit_by_priority` test, which asserted the old short-circuit behavior.
- All 4 tests in `swift_virtual_lookup_tests` pass against a live migrated database; `cargo test --lib swift` (45 tests) and `cargo clippy` green.

Closes #2307