### PR TITLE
test(auth): gate invalid-bearer guard test on DATABASE_URL

### DIFF
--- a/backend/src/api/middleware/guest_access.rs
+++ b/backend/src/api/middleware/guest_access.rs
@@ -613,7 +613,35 @@ mod tests {
 
     #[tokio::test]
     async fn guard_rejects_request_with_invalid_bearer_when_disabled() {
-        let app = make_app(make_state(false));
+        // An unknown bearer falls through JWT validation to the API-token
+        // lookup, which hits Postgres. With the guard now surfacing
+        // `AuthOutcome::Overloaded` as 503, an *unreachable* pool is
+        // (correctly) classified as a transient pool-timeout shed rather
+        // than an invalid credential — so this test needs a real DB to
+        // deterministically observe the 401. Skip when `DATABASE_URL` is
+        // unset, mirroring `guard_allows_request_with_valid_jwt_when_disabled`;
+        // CI runs it against the real postgres service. The DB-free mapping
+        // (`InvalidCredential` -> 401, `Overloaded` -> 503) is pinned by the
+        // `guard_short_circuit` unit tests above.
+        //
+        // Reuse the shared `test_db_helpers::try_pool()` scaffold (same skip
+        // semantics) instead of open-coding the DATABASE_URL/connect dance —
+        // that copy keeps the guard/DB setup a single source of truth and
+        // avoids a jscpd clone of the sibling test's connect block.
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let mut config = Config::test_config();
+        config.guest_access_enabled = false;
+        let auth_service = Arc::new(AuthService::new(pool, Arc::new(config)));
+        let state = GuestAccessState {
+            guest_access_enabled: false,
+            auth_service,
+        };
+
+        let app = make_app(state);
         let resp = app
             .oneshot(
                 Request::builder()


### PR DESCRIPTION
## Summary

Follow-up to #2315: `guard_rejects_request_with_invalid_bearer_when_disabled` builds on the intentionally-unreachable `lazy_pool()`, and an unknown bearer inherently falls through to the API-token **DB lookup**. Now that the guard correctly surfaces `AuthOutcome::Overloaded` as a 503, a DB-free machine sees the pool-acquire timeout classified as `Overloaded` (per #2125) and the test fails 503-vs-401, while CI (live postgres) passes.

Gate the test on `DATABASE_URL` exactly like the sibling `guard_allows_request_with_valid_jwt_when_disabled`: with a real DB the unknown token deterministically resolves `InvalidCredential` → 401. The DB-free short-circuit mapping (`InvalidCredential`/`NoCredential` → 401, `Overloaded` → 503) remains pinned by the pure `guard_short_circuit` unit tests from #2315, which run everywhere.

Test-only change; no runtime behavior touched.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (DB-free host: guest_access suite 29/29 green; previously 1 failed)
- [x] No regressions in existing tests

## API Changes
- [x] N/A — test-only

Closes #2341