### PR TITLE
fix(signing): normalize key_type so RSA algorithm variants no longer 500 at key creation

### DIFF
--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -14,7 +14,7 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::signing_key::{RepositorySigningConfig, SigningKeyPublic};
 use crate::services::repository_service::RepositoryService;
-use crate::services::signing_service::{CreateKeyRequest, SigningService};
+use crate::services::signing_service::{normalize_key_type, CreateKeyRequest, SigningService};
 
 /// Create signing key management routes.
 pub fn router() -> Router<SharedState> {
@@ -137,19 +137,54 @@ async fn create_key(
             .await?;
     }
 
+    // Normalize the key family / algorithm pair before handing off to the
+    // signing service. Clients commonly send the algorithm variant
+    // ("rsa2048"/"rsa4096") as the key_type; without normalization that value
+    // hits the signing_keys_key_type_check CHECK constraint at INSERT and
+    // surfaces as an opaque 500 DATABASE_ERROR. An unsupported key_type now
+    // returns a clean Validation (400) instead.
+    let (key_type, algorithm) =
+        resolve_key_type_and_algorithm(payload.key_type, payload.algorithm)?;
+
     let svc = signing_service(&state);
     let key = svc
         .create_key(CreateKeyRequest {
             repository_id: payload.repository_id,
             name: payload.name,
-            key_type: payload.key_type.unwrap_or_else(|| "rsa".to_string()),
-            algorithm: payload.algorithm.unwrap_or_else(|| "rsa4096".to_string()),
+            key_type,
+            algorithm,
             uid_name: payload.uid_name,
             uid_email: payload.uid_email,
             created_by: Some(auth.user_id),
         })
         .await?;
     Ok(Json(key))
+}
+
+/// Resolve the `(key_type, algorithm)` pair from the optional payload fields.
+///
+/// - `key_type` is normalized to the DB-accepted family (`gpg`/`rsa`/`ed25519`);
+///   RSA algorithm variants sent as key_type are coerced to `rsa`.
+/// - When the client sent an RSA variant as `key_type` without an explicit
+///   `algorithm`, the variant is used as the algorithm so the requested key
+///   size is honored.
+/// - Defaults (`rsa` / `rsa4096`) are preserved when fields are omitted.
+fn resolve_key_type_and_algorithm(
+    key_type: Option<String>,
+    algorithm: Option<String>,
+) -> Result<(String, String)> {
+    let raw_key_type = key_type.unwrap_or_else(|| "rsa".to_string());
+    let family = normalize_key_type(&raw_key_type)
+        .map_err(AppError::Validation)?
+        .to_string();
+    let algorithm = algorithm.unwrap_or_else(|| {
+        if matches!(raw_key_type.as_str(), "rsa2048" | "rsa4096") {
+            raw_key_type.clone()
+        } else {
+            "rsa4096".to_string()
+        }
+    });
+    Ok((family, algorithm))
 }
 
 /// Get a signing key by ID.
@@ -641,6 +676,75 @@ mod tests {
         let payload: CreateKeyPayload = serde_json::from_str(r#"{"name": "k"}"#).unwrap();
         let algorithm = payload.algorithm.unwrap_or_else(|| "rsa4096".to_string());
         assert_eq!(algorithm, "rsa4096");
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_key_type_and_algorithm (#2319 regression)
+    //
+    // POST /signing/keys with key_type "rsa2048"/"rsa4096" used to pass the
+    // algorithm variant straight into the key_type column and blow up on the
+    // signing_keys_key_type_check constraint (500 DATABASE_ERROR). The
+    // resolver must coerce variants to the "rsa" family, honor the variant as
+    // the algorithm when none is given, and reject unknown values with a
+    // Validation error (400).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_resolve_rsa2048_as_key_type_creates_valid_pair() {
+        let (key_type, algorithm) =
+            resolve_key_type_and_algorithm(Some("rsa2048".to_string()), None).unwrap();
+        // "rsa" satisfies the signing_keys_key_type_check DB constraint.
+        assert_eq!(key_type, "rsa");
+        // The requested key size is preserved via the algorithm.
+        assert_eq!(algorithm, "rsa2048");
+    }
+
+    #[test]
+    fn test_resolve_rsa4096_as_key_type_creates_valid_pair() {
+        let (key_type, algorithm) =
+            resolve_key_type_and_algorithm(Some("rsa4096".to_string()), None).unwrap();
+        assert_eq!(key_type, "rsa");
+        assert_eq!(algorithm, "rsa4096");
+    }
+
+    #[test]
+    fn test_resolve_explicit_algorithm_takes_precedence() {
+        let (key_type, algorithm) = resolve_key_type_and_algorithm(
+            Some("rsa4096".to_string()),
+            Some("rsa2048".to_string()),
+        )
+        .unwrap();
+        assert_eq!(key_type, "rsa");
+        assert_eq!(algorithm, "rsa2048");
+    }
+
+    #[test]
+    fn test_resolve_defaults_when_both_omitted() {
+        let (key_type, algorithm) = resolve_key_type_and_algorithm(None, None).unwrap();
+        assert_eq!(key_type, "rsa");
+        assert_eq!(algorithm, "rsa4096");
+    }
+
+    #[test]
+    fn test_resolve_gpg_key_type_preserved() {
+        let (key_type, algorithm) =
+            resolve_key_type_and_algorithm(Some("gpg".to_string()), Some("rsa2048".to_string()))
+                .unwrap();
+        assert_eq!(key_type, "gpg");
+        assert_eq!(algorithm, "rsa2048");
+    }
+
+    #[test]
+    fn test_resolve_ed25519_key_type_preserved() {
+        let (key_type, _) =
+            resolve_key_type_and_algorithm(Some("ed25519".to_string()), None).unwrap();
+        assert_eq!(key_type, "ed25519");
+    }
+
+    #[test]
+    fn test_resolve_unknown_key_type_is_validation_error() {
+        let err = resolve_key_type_and_algorithm(Some("dsa".to_string()), None).unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/signing_service.rs
+++ b/backend/src/services/signing_service.rs
@@ -41,6 +41,25 @@ pub(crate) fn algorithm_to_bits(algorithm: &str) -> std::result::Result<usize, S
     }
 }
 
+/// Normalize a key-type string to one of the families accepted by the
+/// `signing_keys_key_type_check` DB constraint (`gpg`, `rsa`, `ed25519`).
+///
+/// Clients commonly send the RSA algorithm variant ("rsa2048"/"rsa4096") in
+/// the `key_type` field; those are coerced to the `rsa` family. Anything else
+/// is rejected with a message suitable for a 400 response, instead of letting
+/// the value trip the CHECK constraint at INSERT time (opaque 500).
+pub(crate) fn normalize_key_type(key_type: &str) -> std::result::Result<&'static str, String> {
+    match key_type {
+        "rsa" | "rsa2048" | "rsa4096" => Ok("rsa"),
+        "gpg" => Ok("gpg"),
+        "ed25519" => Ok("ed25519"),
+        other => Err(format!(
+            "Unsupported key_type: {}. Use gpg, rsa, or ed25519.",
+            other
+        )),
+    }
+}
+
 fn algorithm_to_bits_u32(algorithm: &str) -> std::result::Result<u32, String> {
     algorithm_to_bits(algorithm).and_then(|bits| {
         u32::try_from(bits).map_err(|_| format!("Unsupported RSA key size: {}", bits))
@@ -219,7 +238,14 @@ impl SigningService {
 
     /// Generate a new signing key pair and store it.
     pub async fn create_key(&self, req: CreateKeyRequest) -> Result<SigningKeyPublic> {
-        let (public_key_out, private_key_material, fingerprint, key_id) = if req.key_type == "gpg" {
+        // Normalize the key family before generation so an unsupported value
+        // surfaces as a clean 400 Validation error instead of tripping the
+        // signing_keys_key_type_check DB constraint (opaque 500). (#2319)
+        let key_type = normalize_key_type(&req.key_type)
+            .map_err(AppError::Validation)?
+            .to_string();
+
+        let (public_key_out, private_key_material, fingerprint, key_id) = if key_type == "gpg" {
             self.generate_openpgp_key(&req).await?
         } else {
             self.generate_rsa_key(&req.algorithm).await?
@@ -244,7 +270,7 @@ impl SigningService {
             id,
             req.repository_id,
             req.name,
-            req.key_type,
+            key_type,
             fingerprint,
             key_id,
             public_key_out,
@@ -266,7 +292,7 @@ impl SigningService {
             id,
             repository_id: req.repository_id,
             name: req.name,
-            key_type: req.key_type,
+            key_type,
             fingerprint: Some(fingerprint),
             key_id: Some(key_id),
             public_key_pem: public_key_out,
@@ -984,6 +1010,54 @@ mod tests {
     #[test]
     fn test_algorithm_to_bits_empty() {
         assert!(algorithm_to_bits("").is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // normalize_key_type (#2319 regression: algorithm variant sent as
+    // key_type must coerce to the DB-accepted family, not 500 at INSERT)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_normalize_key_type_rsa2048_coerced_to_rsa_family() {
+        assert_eq!(normalize_key_type("rsa2048").unwrap(), "rsa");
+    }
+
+    #[test]
+    fn test_normalize_key_type_rsa4096_coerced_to_rsa_family() {
+        assert_eq!(normalize_key_type("rsa4096").unwrap(), "rsa");
+    }
+
+    #[test]
+    fn test_normalize_key_type_rsa_passthrough() {
+        assert_eq!(normalize_key_type("rsa").unwrap(), "rsa");
+    }
+
+    #[test]
+    fn test_normalize_key_type_gpg_passthrough() {
+        assert_eq!(normalize_key_type("gpg").unwrap(), "gpg");
+    }
+
+    #[test]
+    fn test_normalize_key_type_ed25519_passthrough() {
+        assert_eq!(normalize_key_type("ed25519").unwrap(), "ed25519");
+    }
+
+    #[test]
+    fn test_normalize_key_type_unsupported_rejected() {
+        let result = normalize_key_type("dsa");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unsupported key_type"));
+    }
+
+    #[test]
+    fn test_normalize_key_type_empty_rejected() {
+        assert!(normalize_key_type("").is_err());
+    }
+
+    #[test]
+    fn test_normalize_key_type_case_sensitive() {
+        // The DB CHECK constraint is case-sensitive; so is normalization.
+        assert!(normalize_key_type("RSA2048").is_err());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`POST /api/v1/signing/keys` with `key_type` `rsa2048` or `rsa4096` returned **500 DATABASE_ERROR**: the handler passed the payload's `key_type` straight into the INSERT, where the `signing_keys_key_type_check` constraint (migration `027_signing_keys.sql`) only accepts the key families `gpg`/`rsa`/`ed25519`. Clients commonly put the algorithm variant into `key_type`, so a valid-looking create blew up server-side and blocked the sign-key workflow.

## Changes

- **`services/signing_service.rs`** — new `normalize_key_type` helper (mirrors the existing `algorithm_to_bits` validation): coerces `rsa`/`rsa2048`/`rsa4096` to the `rsa` family, keeps `gpg`/`ed25519`, rejects anything else with `AppError::Validation` (400). Enforced inside `create_key` so every caller (including key rotation) is validated before the INSERT.
- **`api/handlers/signing.rs`** — new `resolve_key_type_and_algorithm`: normalizes the family at the API edge and, when a client sends an RSA variant as `key_type` without an explicit `algorithm`, uses the variant as the algorithm so the requested key size is honored. Defaults (`rsa`/`rsa4096`) unchanged.

## Behavior

| Request | Before | After |
|---|---|---|
| `key_type: rsa2048` | 500 DATABASE_ERROR | 200, `rsa` family key with a 2048-bit RSA key |
| `key_type: rsa4096` | 500 DATABASE_ERROR | 200, `rsa` family key with a 4096-bit RSA key |
| `key_type: gpg` / `ed25519` / `rsa` | 200 | 200 (unchanged) |
| `key_type: dsa` (unknown) | 500 DATABASE_ERROR | 400 Validation |

## Testing

- 15 new unit tests: `normalize_key_type` coverage in the service module and `resolve_key_type_and_algorithm` regression coverage in the handler module (variant coercion, algorithm derivation, explicit-algorithm precedence, defaults, gpg/ed25519 passthrough, unknown rejection).
- `cargo test --lib signing`: 127 passed, 0 failed.
- `cargo build` green; no sqlx query text changed (bind-arg rename only), so offline metadata is untouched.

Closes #2319