### PR TITLE
fix(security): validate scan-policy max_severity and repository_id before insert

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,6 +786,7 @@ jobs:
             --test sso_saml_acs_e2e_tests \
             --test cache_invalidation_fanout_tests \
             --test age_gate_tests \
+            --test scan_policy_validation_tests \
             -- --ignored --test-threads=1
 
       # `incus_upload_tests::test_chunked_upload_cross_repo_session_rejected`

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -907,6 +907,8 @@ async fn list_policies(
     request_body = CreatePolicyRequest,
     responses(
         (status = 200, description = "Policy created", body = PolicyResponse),
+        (status = 400, description = "Invalid max_severity (must be one of critical, high, medium, low; case-insensitive)", body = crate::api::openapi::ErrorResponse),
+        (status = 404, description = "repository_id does not reference an existing repository", body = crate::api::openapi::ErrorResponse),
         (status = 422, description = "Validation error", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))

--- a/backend/src/services/policy_service.rs
+++ b/backend/src/services/policy_service.rs
@@ -48,6 +48,21 @@ fn normalize_max_severity(raw: &str) -> Result<String> {
     }
 }
 
+/// Decision half of [`PolicyService::ensure_repository_exists`] (#2320): map
+/// the `EXISTS` query result onto Ok / 404-NotFound. Split out from the DB
+/// query so the contract — a missing FK target must surface as `NotFound`
+/// naming the repository id, never a raw FK-violation 500 — is pure and
+/// unit-testable.
+fn repository_exists_or_not_found(exists: bool, repository_id: Uuid) -> Result<()> {
+    if exists {
+        Ok(())
+    } else {
+        Err(AppError::NotFound(format!(
+            "Repository {repository_id} not found"
+        )))
+    }
+}
+
 pub struct PolicyService {
     db: PgPool,
 }
@@ -216,13 +231,7 @@ impl PolicyService {
                 .await
                 .map_err(|e| AppError::Database(e.to_string()))?;
 
-        if exists {
-            Ok(())
-        } else {
-            Err(AppError::NotFound(format!(
-                "Repository {repository_id} not found"
-            )))
-        }
+        repository_exists_or_not_found(exists, repository_id)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -489,6 +498,120 @@ mod tests {
             normalize_max_severity("info"),
             Err(AppError::Validation(_))
         ));
+    }
+
+    // -----------------------------------------------------------------------
+    // repository existence pre-check (#2320)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_repository_exists_or_not_found_accepts_existing_repository() {
+        let repo_id = Uuid::new_v4();
+        assert!(
+            repository_exists_or_not_found(true, repo_id).is_ok(),
+            "an existing repository must pass the pre-check"
+        );
+    }
+
+    #[test]
+    fn test_repository_exists_or_not_found_maps_missing_repo_to_not_found() {
+        // #2320 regression: a stale/mistyped repository_id used to fall
+        // through to the scan_policies_repository_id_fkey violation on
+        // INSERT and surface as an opaque 500. The pre-check must turn it
+        // into a NotFound (404) that names the offending id.
+        let repo_id = Uuid::new_v4();
+        match repository_exists_or_not_found(false, repo_id) {
+            Err(AppError::NotFound(msg)) => {
+                assert!(
+                    msg.contains(&repo_id.to_string()),
+                    "NotFound message should name the repository id, got: {msg}"
+                );
+            }
+            other => panic!("expected AppError::NotFound for a missing repository, got: {other:?}"),
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // create/update entry-point validation ordering (#2320)
+    // -----------------------------------------------------------------------
+
+    /// A pool that never opens a connection (and gives up acquiring almost
+    /// immediately). Calling a service method with it proves where the DB
+    /// boundary sits: anything that returns `Validation` did so BEFORE any
+    /// DB round-trip, and anything that returns `Database` got past
+    /// validation and genuinely tried to reach the pool.
+    fn disconnected_service() -> PolicyService {
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_millis(50))
+            .connect_lazy("postgres://unused:unused@127.0.0.1:1/unused")
+            .expect("connect_lazy should not fail");
+        PolicyService::new(pool)
+    }
+
+    #[tokio::test]
+    async fn test_create_policy_rejects_invalid_max_severity_before_touching_db() {
+        let svc = disconnected_service();
+        let err = svc
+            .create_policy("p", None, "bogus", false, false, None, None, false)
+            .await
+            .unwrap_err();
+        // Validation (not Database/PoolTimedOut) proves the reject happened
+        // before any DB round-trip — the pool cannot serve a connection.
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_create_policy_with_valid_severity_proceeds_to_repository_check() {
+        let svc = disconnected_service();
+        let err = svc
+            .create_policy(
+                "p",
+                Some(Uuid::new_v4()),
+                "Critical",
+                false,
+                false,
+                None,
+                None,
+                false,
+            )
+            .await
+            .unwrap_err();
+        // The mis-cased-but-known severity normalizes fine, so create must
+        // move on to the repository existence pre-check, whose EXISTS query
+        // is the first DB touch — surfacing here as a Database error.
+        assert!(matches!(err, AppError::Database(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_create_policy_unscoped_valid_input_reaches_insert() {
+        let svc = disconnected_service();
+        let err = svc
+            .create_policy("p", None, "high", true, true, Some(1), Some(30), true)
+            .await
+            .unwrap_err();
+        // No repository scope: nothing to pre-check, so the INSERT itself is
+        // the first DB touch.
+        assert!(matches!(err, AppError::Database(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_update_policy_rejects_invalid_max_severity_before_touching_db() {
+        let svc = disconnected_service();
+        let err = svc
+            .update_policy(
+                Uuid::new_v4(),
+                None,
+                Some("bogus"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)), "got: {err:?}");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/policy_service.rs
+++ b/backend/src/services/policy_service.rs
@@ -20,6 +20,34 @@ fn block_unscanned_violated(block_unscanned: bool, scan_state: ScanState) -> boo
     block_unscanned && scan_state.is_unscanned()
 }
 
+/// Allowed values for `scan_policies.max_severity`, mirroring the DB CHECK
+/// constraint in `migrations/022_security_scanning.sql`.
+///
+/// Note the set deliberately excludes `info` even though the scanner-side
+/// [`Severity`] enum has an `Info` variant: `max_severity` is a blocking
+/// threshold, and gating downloads on purely informational findings is never
+/// a meaningful policy, so the schema never allowed it.
+pub const ALLOWED_MAX_SEVERITIES: [&str; 4] = ["critical", "high", "medium", "low"];
+
+/// Normalize and validate a client-supplied `max_severity` value (#2320).
+///
+/// Case-insensitive: `"Critical"` / `"HIGH"` are accepted and canonicalized
+/// to lowercase so they satisfy the DB CHECK constraint. Anything outside the
+/// allowed set returns [`AppError::Validation`] (400) with an actionable
+/// message. Before this existed the raw string went straight into the
+/// INSERT/UPDATE and a mis-cased or unknown value surfaced as a
+/// CHECK-constraint violation, i.e. an opaque 500 `DATABASE_ERROR`.
+fn normalize_max_severity(raw: &str) -> Result<String> {
+    let normalized = raw.trim().to_ascii_lowercase();
+    if ALLOWED_MAX_SEVERITIES.contains(&normalized.as_str()) {
+        Ok(normalized)
+    } else {
+        Err(AppError::Validation(format!(
+            "invalid max_severity '{raw}': must be one of critical, high, medium, low"
+        )))
+    }
+}
+
 pub struct PolicyService {
     db: PgPool,
 }
@@ -174,6 +202,29 @@ impl PolicyService {
     // CRUD
     // -----------------------------------------------------------------------
 
+    /// Verify a repository id points at an existing repository (#2320).
+    ///
+    /// Scan policies can be scoped to a repository; a stale or mistyped id
+    /// used to fall through to the `scan_policies_repository_id_fkey` FK
+    /// violation on INSERT and surface as a 500. Checking first lets us
+    /// return a proper 404.
+    async fn ensure_repository_exists(&self, repository_id: Uuid) -> Result<()> {
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM repositories WHERE id = $1)")
+                .bind(repository_id)
+                .fetch_one(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if exists {
+            Ok(())
+        } else {
+            Err(AppError::NotFound(format!(
+                "Repository {repository_id} not found"
+            )))
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub async fn create_policy(
         &self,
@@ -186,6 +237,14 @@ impl PolicyService {
         max_artifact_age_days: Option<i32>,
         require_signature: bool,
     ) -> Result<ScanPolicy> {
+        // #2320: validate inputs up front so a bad request comes back as a
+        // 4xx instead of tripping the DB CHECK / FK constraint and surfacing
+        // as an opaque 500 DATABASE_ERROR.
+        let max_severity = normalize_max_severity(max_severity)?;
+        if let Some(repo_id) = repository_id {
+            self.ensure_repository_exists(repo_id).await?;
+        }
+
         let policy: ScanPolicy = sqlx::query_as(
             r#"
             INSERT INTO scan_policies (name, repository_id, max_severity, block_unscanned, block_on_fail,
@@ -198,7 +257,7 @@ impl PolicyService {
         )
         .bind(name)
         .bind(repository_id)
-        .bind(max_severity)
+        .bind(&max_severity)
         .bind(block_unscanned)
         .bind(block_on_fail)
         .bind(min_staging_hours)
@@ -267,6 +326,10 @@ impl PolicyService {
         max_artifact_age_days: Option<i32>,
         require_signature: Option<bool>,
     ) -> Result<ScanPolicy> {
+        // #2320: same normalization as create_policy — a mis-cased or unknown
+        // max_severity on update used to trip the DB CHECK constraint (500).
+        let max_severity = max_severity.map(normalize_max_severity).transpose()?;
+
         let policy: ScanPolicy = sqlx::query_as(
             r#"
             UPDATE scan_policies
@@ -370,6 +433,62 @@ mod tests {
                 "gate disabled -> never a violation regardless of scan state"
             );
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // max_severity normalization (#2320)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_normalize_max_severity_accepts_canonical_values() {
+        for value in ALLOWED_MAX_SEVERITIES {
+            assert_eq!(
+                normalize_max_severity(value).unwrap(),
+                value,
+                "canonical lowercase value '{value}' must pass through unchanged"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_max_severity_canonicalizes_case_and_whitespace() {
+        // #2320 regression: "Critical" used to be forwarded verbatim to the
+        // INSERT, violate the lowercase CHECK constraint, and surface as a
+        // 500 DATABASE_ERROR. It must now normalize cleanly.
+        assert_eq!(normalize_max_severity("Critical").unwrap(), "critical");
+        assert_eq!(normalize_max_severity("HIGH").unwrap(), "high");
+        assert_eq!(normalize_max_severity("  Medium ").unwrap(), "medium");
+        assert_eq!(normalize_max_severity("LoW").unwrap(), "low");
+    }
+
+    #[test]
+    fn test_normalize_max_severity_rejects_unknown_values() {
+        // Unknown values must be a Validation error (400), never reach the DB.
+        for bad in ["severe", "none", "", "critical; DROP TABLE", "🔥"] {
+            match normalize_max_severity(bad) {
+                Err(AppError::Validation(msg)) => {
+                    assert!(
+                        msg.contains("max_severity"),
+                        "validation message should name the offending field, got: {msg}"
+                    );
+                }
+                other => {
+                    panic!("expected AppError::Validation for max_severity '{bad}', got: {other:?}")
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_normalize_max_severity_rejects_info() {
+        // The Severity enum has an Info variant but the scan_policies CHECK
+        // constraint deliberately excludes it — a blocking threshold of
+        // "info" would gate on purely informational findings. Keep rejecting
+        // it here so the API contract matches the schema.
+        assert!(matches!(
+            normalize_max_severity("info"),
+            Err(AppError::Validation(_))
+        ));
     }
 
     // -----------------------------------------------------------------------

--- a/backend/tests/scan_policy_validation_tests.rs
+++ b/backend/tests/scan_policy_validation_tests.rs
@@ -1,0 +1,248 @@
+//! Integration tests for scan-policy create/update input validation (#2320).
+//!
+//! `POST /api/v1/security/policies` used to forward `max_severity` and
+//! `repository_id` straight into the INSERT, so a mis-cased severity
+//! ("Critical") or an unknown repository id tripped the DB CHECK / FK
+//! constraint and surfaced as an opaque `500 DATABASE_ERROR`. These tests pin
+//! the fixed contract: bad input is a 4xx (400 validation / 404 not-found),
+//! mis-cased-but-known severities are canonicalized, and valid requests keep
+//! succeeding.
+//!
+//! Requires PostgreSQL:
+//!   DATABASE_URL=postgresql://registry:registry@localhost:5432/artifact_registry \
+//!     cargo test --test scan_policy_validation_tests -- --ignored
+
+use artifact_keeper_backend::error::AppError;
+use artifact_keeper_backend::services::policy_service::PolicyService;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn connect_db() -> PgPool {
+    let url = std::env::var("DATABASE_URL")
+        .expect("DATABASE_URL must be set; see module docstring for setup");
+    PgPool::connect(&url)
+        .await
+        .expect("failed to connect to test database")
+}
+
+/// Insert a minimal repository row so repo-scoped policies have a real FK
+/// target. The random id keeps the unique `repositories.key` constraint from
+/// colliding with rows left behind by a previous (uncleaned) test run.
+async fn create_repo(pool: &PgPool) -> Uuid {
+    let id = Uuid::new_v4();
+    let key = format!("scan-policy-val-{id}");
+    sqlx::query(
+        "INSERT INTO repositories (id, key, name, storage_path, repo_type, format)
+         VALUES ($1, $2, $2, $3, 'local', 'npm')",
+    )
+    .bind(id)
+    .bind(&key)
+    .bind(format!("/tmp/test-artifacts/{id}"))
+    .execute(pool)
+    .await
+    .expect("insert repo");
+    id
+}
+
+async fn delete_repo(pool: &PgPool, id: Uuid) {
+    // scan_policies.repository_id is ON DELETE CASCADE, so this also removes
+    // any policies the test created against the repo.
+    sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("delete repo");
+}
+
+async fn delete_policy(pool: &PgPool, id: Uuid) {
+    sqlx::query("DELETE FROM scan_policies WHERE id = $1")
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("delete policy");
+}
+
+/// The HTTP status the error maps to via the real `IntoResponse` conversion —
+/// what a client of `POST /api/v1/security/policies` actually observes.
+fn status_of(err: AppError) -> StatusCode {
+    err.into_response().status()
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL
+async fn test_create_policy_invalid_max_severity_is_400_not_500() {
+    let pool = connect_db().await;
+    let svc = PolicyService::new(pool);
+
+    let err = svc
+        .create_policy(
+            &format!("bad-severity-{}", Uuid::new_v4()),
+            None,
+            "severe", // not in {critical, high, medium, low}
+            true,
+            false,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect_err("unknown max_severity must be rejected");
+
+    assert!(
+        matches!(err, AppError::Validation(_)),
+        "expected AppError::Validation, got: {err:?}"
+    );
+    assert_eq!(
+        status_of(err),
+        StatusCode::BAD_REQUEST,
+        "#2320: invalid max_severity must surface as 400, not 500 DATABASE_ERROR"
+    );
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL
+async fn test_create_policy_miscased_max_severity_is_canonicalized() {
+    let pool = connect_db().await;
+    let svc = PolicyService::new(pool.clone());
+
+    // #2320 regression: "Critical" used to violate the lowercase CHECK
+    // constraint and return 500. It must now succeed and store canonical
+    // lowercase.
+    let policy = svc
+        .create_policy(
+            &format!("miscased-severity-{}", Uuid::new_v4()),
+            None,
+            "Critical",
+            true,
+            false,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("mis-cased but known max_severity must be accepted");
+
+    assert_eq!(policy.max_severity, "critical");
+    delete_policy(&pool, policy.id).await;
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL
+async fn test_create_policy_unknown_repository_is_404_not_500() {
+    let pool = connect_db().await;
+    let svc = PolicyService::new(pool);
+
+    let err = svc
+        .create_policy(
+            &format!("bad-repo-{}", Uuid::new_v4()),
+            Some(Uuid::new_v4()), // no such repository
+            "high",
+            true,
+            false,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect_err("nonexistent repository_id must be rejected");
+
+    assert!(
+        matches!(err, AppError::NotFound(_)),
+        "expected AppError::NotFound, got: {err:?}"
+    );
+    assert_eq!(
+        status_of(err),
+        StatusCode::NOT_FOUND,
+        "#2320: unknown repository_id must surface as 404, not 500 (FK violation)"
+    );
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL
+async fn test_create_policy_valid_request_still_succeeds() {
+    let pool = connect_db().await;
+    let svc = PolicyService::new(pool.clone());
+    let repo_id = create_repo(&pool).await;
+
+    let policy = svc
+        .create_policy(
+            &format!("valid-policy-{}", Uuid::new_v4()),
+            Some(repo_id),
+            "medium",
+            true,
+            true,
+            Some(24),
+            Some(365),
+            false,
+        )
+        .await
+        .expect("a fully valid create must keep working unchanged");
+
+    assert_eq!(policy.repository_id, Some(repo_id));
+    assert_eq!(policy.max_severity, "medium");
+    assert!(policy.block_unscanned);
+    assert!(policy.block_on_fail);
+    assert_eq!(policy.min_staging_hours, Some(24));
+    assert_eq!(policy.max_artifact_age_days, Some(365));
+
+    delete_repo(&pool, repo_id).await;
+}
+
+#[tokio::test]
+#[ignore] // requires DATABASE_URL
+async fn test_update_policy_miscased_max_severity_is_canonicalized() {
+    let pool = connect_db().await;
+    let svc = PolicyService::new(pool.clone());
+
+    let policy = svc
+        .create_policy(
+            &format!("update-severity-{}", Uuid::new_v4()),
+            None,
+            "low",
+            true,
+            false,
+            None,
+            None,
+            false,
+        )
+        .await
+        .expect("create baseline policy");
+
+    // Same normalization on the update path: "HIGH" used to trip the CHECK
+    // constraint (500); it must now canonicalize and persist.
+    let updated = svc
+        .update_policy(
+            policy.id,
+            None,
+            Some("HIGH"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("mis-cased but known max_severity must be accepted on update");
+    assert_eq!(updated.max_severity, "high");
+
+    let err = svc
+        .update_policy(
+            policy.id,
+            None,
+            Some("bogus"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("unknown max_severity must be rejected on update");
+    assert_eq!(status_of(err), StatusCode::BAD_REQUEST);
+
+    delete_policy(&pool, policy.id).await;
+}


### PR DESCRIPTION
## Summary

`POST /api/v1/security/policies` forwarded client input straight into the INSERT, so:

- a mis-cased `max_severity` (e.g. `"Critical"`) violated the lowercase DB CHECK constraint (`migrations/022_security_scanning.sql`), and
- a `repository_id` that references no existing repository tripped `scan_policies_repository_id_fkey`,

both surfacing as an opaque **500 DATABASE_ERROR** instead of an actionable client error.

## Changes

- **`normalize_max_severity()`** (`backend/src/services/policy_service.rs`): trims + lowercases the input and validates it against the CHECK-constraint set `{critical, high, medium, low}`; unknown values return `AppError::Validation` (400). Applied on both `create_policy` and `update_policy` (the update path had the same 500).
- **`ensure_repository_exists()`**: repo-scoped policy creation verifies the FK target first and returns 404 `NotFound` instead of an FK-violation 500.
- **Behavior preserved**: fully valid requests are unchanged; mis-cased-but-known severities now succeed and persist canonical lowercase.
- **`info` severity**: the DB CHECK deliberately excludes `info` (a blocking threshold on informational findings is never meaningful), so the validator rejects it too — API contract now matches the schema, documented on the constant.
- **OpenAPI**: 400/404 responses documented on `create_policy`.

## Tests

- Unit tests for the normalizer (canonical pass-through, case/whitespace canonicalization, unknown-value rejection incl. `info`).
- New DB-gated regression suite `backend/tests/scan_policy_validation_tests.rs` pinning the fixed contract via the real `IntoResponse` mapping: invalid severity → **400 not 500**, unknown `repository_id` → **404 not 500**, valid create/update still succeed. Wired into the CI integration-test allowlist (needs only Postgres).
- Verified locally: `cargo build`, `cargo test --lib services::policy_service` (21 passed), and the 5 DB-backed tests green against a live migrated Postgres.

Closes #2320