### PR TITLE
fix(pypi): make virtual repo dependency-confusion isolation priority-aware

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -2982,17 +2982,27 @@ fn shadowing_guard_db_err(virtual_repo_id: Uuid, format: &str, e: sqlx::Error) -
     (StatusCode::INTERNAL_SERVER_ERROR, "Database error").into_response()
 }
 
-/// PEP 708 dependency-confusion decision for a PyPI virtual repository (#1600).
+/// PEP 708 dependency-confusion decision for a PyPI virtual repository (#1600,
+/// made priority-aware by #2311).
 ///
-/// Returns `true` when the virtual must ISOLATE this project name to its local
-/// owner: a local/staging member owns the PEP 503 normalized `normalized_name`
-/// AND no `pypi_project_tracks` declaration exists on an owning member for it.
-/// When `true`, the caller MUST serve only the owning member's distributions in
-/// both the simple index and the file download (no cross-member union, no
-/// proxy fallthrough), which is PEP 708's "refuse to implicitly assume merging
-/// is safe" default and keeps the index and download consistent.
+/// Returns `Some(min_priority)` when a local/staging member owns the PEP 503
+/// normalized `normalized_name` AND no `pypi_project_tracks` declaration
+/// exists on an owning member for it. `min_priority` is the smallest
+/// `virtual_repo_members.priority` value among the owning local members
+/// (lower value = higher priority, matching the `ORDER BY vrm.priority`
+/// member ordering).
 ///
-/// Returns `false` when the name is not locally owned (proxy normally) or when
+/// The caller must then decide isolation PER REMOTE MEMBER: a Remote member
+/// `R` is suppressed only when the owning local member outranks it
+/// (`min_priority < R.priority`). A Remote member configured at equal or
+/// higher priority than every owning local (`R.priority <= min_priority`)
+/// still surfaces — the operator explicitly ranked the upstream above the
+/// local owner, so hiding it would invert their priority intent (#2311).
+/// Suppression when the local owner outranks the remote is PEP 708's "refuse
+/// to implicitly assume merging is safe" default and must be applied
+/// consistently in both the simple index and the file download.
+///
+/// Returns `None` when the name is not locally owned (proxy normally) or when
 /// an operator `tracks` declaration permits merging the same project across
 /// members (the #1267 union / #1584 version fallthrough then apply).
 ///
@@ -3004,7 +3014,7 @@ pub async fn pypi_virtual_isolates_name(
     db: &PgPool,
     virtual_repo_id: Uuid,
     normalized_name: &str,
-) -> Result<bool, Response> {
+) -> Result<Option<i32>, Response> {
     let members = fetch_virtual_members(db, virtual_repo_id).await?;
     let local_ids: Vec<Uuid> = members
         .iter()
@@ -3012,28 +3022,34 @@ pub async fn pypi_virtual_isolates_name(
         .map(|m| m.id)
         .collect();
     if local_ids.is_empty() {
-        return Ok(false);
+        return Ok(None);
     }
 
-    // Which local/staging members actually own (hold artifacts for) this name?
-    // Uses the same PEP 503 normalization as simple_project so isolation agrees
-    // with what the index lists.
-    let owning_ids: Vec<Uuid> = sqlx::query_scalar(
-        "SELECT DISTINCT repository_id FROM artifacts \
-         WHERE repository_id = ANY($1) \
-           AND is_deleted = false \
-           AND LOWER(REPLACE(REPLACE(REPLACE(name, '_', '-'), '.', '-'), '--', '-')) = $2",
+    // Which local/staging members actually own (hold artifacts for) this name,
+    // and at what member priority? Uses the same PEP 503 normalization as
+    // simple_project so isolation agrees with what the index lists.
+    let owning: Vec<(Uuid, i32)> = sqlx::query_as(
+        "SELECT DISTINCT a.repository_id, vrm.priority \
+         FROM artifacts a \
+         INNER JOIN virtual_repo_members vrm \
+                 ON vrm.member_repo_id = a.repository_id \
+                AND vrm.virtual_repo_id = $3 \
+         WHERE a.repository_id = ANY($1) \
+           AND a.is_deleted = false \
+           AND LOWER(REPLACE(REPLACE(REPLACE(a.name, '_', '-'), '.', '-'), '--', '-')) = $2",
     )
     .bind(&local_ids)
     .bind(normalized_name)
+    .bind(virtual_repo_id)
     .fetch_all(db)
     .await
     .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "cross-format", e))?;
 
-    if owning_ids.is_empty() {
+    if owning.is_empty() {
         // Name is not owned by any local member: no confusion risk, proxy normally.
-        return Ok(false);
+        return Ok(None);
     }
+    let owning_ids: Vec<Uuid> = owning.iter().map(|(id, _)| *id).collect();
 
     // A `tracks` declaration on any owning member means the operator has
     // asserted the local project is the same project as upstream, so merging is
@@ -3048,7 +3064,31 @@ pub async fn pypi_virtual_isolates_name(
     .await
     .map_err(|e| shadowing_guard_db_err(virtual_repo_id, "cross-format", e))?;
 
-    Ok(tracked == 0)
+    if tracked > 0 {
+        return Ok(None);
+    }
+    Ok(owning.iter().map(|(_, priority)| *priority).min())
+}
+
+/// Fetches the `virtual_repo_members.priority` value for every member of
+/// `virtual_repo_id`, keyed by member repository id (lower value = higher
+/// priority). Used by the PyPI virtual paths to make the PEP 708 isolation
+/// decision per remote member relative to the owning local member's priority
+/// (#2311). Fails closed (Err) on DB error, matching
+/// [`pypi_virtual_isolates_name`].
+#[allow(clippy::result_large_err)]
+pub async fn fetch_virtual_member_priorities(
+    db: &PgPool,
+    virtual_repo_id: Uuid,
+) -> Result<std::collections::HashMap<Uuid, i32>, Response> {
+    let rows: Vec<(Uuid, i32)> = sqlx::query_as(
+        "SELECT member_repo_id, priority FROM virtual_repo_members WHERE virtual_repo_id = $1",
+    )
+    .bind(virtual_repo_id)
+    .fetch_all(db)
+    .await
+    .map_err(map_db_err)?;
+    Ok(rows.into_iter().collect())
 }
 
 /// Returns true if any non-Remote member of `virtual_repo_id` owns an

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -739,13 +739,22 @@ async fn simple_project(
                 );
             }
 
-            // PEP 708 (#1600): when a local member owns this name and no
-            // operator `tracks` declaration permits merging, isolate the name to
-            // its local owner. We then skip every Remote member below, so the
-            // index lists only the local distributions (and the download path
-            // makes the same decision, keeping index and download consistent).
-            let isolate =
+            // PEP 708 (#1600, priority-aware per #2311): when a local member
+            // owns this name and no operator `tracks` declaration permits
+            // merging, isolate the name to its local owner — but only against
+            // Remote members the owning local outranks. A Remote member the
+            // operator configured at equal or higher priority than the owning
+            // local still surfaces below, so a lower-priority local owner
+            // cannot hide a higher-priority upstream's versions from pip.
+            // The download path makes the same per-member decision, keeping
+            // index and download consistent.
+            let owning_local_min_priority =
                 proxy_helpers::pypi_virtual_isolates_name(&state.db, repo.id, &normalized).await?;
+            let member_priorities = if owning_local_min_priority.is_some() {
+                proxy_helpers::fetch_virtual_member_priorities(&state.db, repo.id).await?
+            } else {
+                Default::default()
+            };
 
             let mut local_artifacts: Vec<SimpleProjectArtifact> = Vec::new();
             let mut remote_response: Option<(Bytes, Option<String>)> = None;
@@ -792,23 +801,38 @@ async fn simple_project(
             // Ownership / dependency-confusion guard (#1600), superseding the
             // name-only suppression from #1738. When a local member owns this
             // PEP 503 name and no operator `tracks` declaration permits merging,
-            // `isolate` is true and the virtual serves ONLY that member's
-            // distributions for the name — in both the simple index and the
-            // download — rather than unioning the remote's versions for it.
-            // Unioning an unrelated public package that merely shares the name
-            // is a supply-chain hole (`pip` prefers the higher public version)
-            // AND makes the index inconsistent with the download path, which is
-            // also tracks-aware and 404s for any version only the remote has.
-            // Local precedence is the PEP 708-aligned default for a locally-
-            // owned name; a `tracks` declaration re-enables the union (#1582).
-            // Second pass: fetch a remote index only when the name is not
-            // isolated.
+            // the virtual serves ONLY that member's distributions for the name
+            // — in both the simple index and the download — rather than
+            // unioning the remote's versions for it. Unioning an unrelated
+            // public package that merely shares the name is a supply-chain hole
+            // (`pip` prefers the higher public version) AND makes the index
+            // inconsistent with the download path, which is also tracks-aware
+            // and 404s for any version only the remote has. Local precedence is
+            // the PEP 708-aligned default for a locally-owned name; a `tracks`
+            // declaration re-enables the union (#1582).
+            //
+            // #2311: the guard is applied PER REMOTE MEMBER relative to member
+            // priority. It only suppresses a Remote member the owning local
+            // outranks (owning priority value strictly lower). A Remote member
+            // at equal or higher priority than the owning local was explicitly
+            // ranked above the internal package by the operator, so its
+            // versions still surface.
+            // Second pass: fetch a remote index only from non-suppressed
+            // remote members.
             for member in &members {
-                if isolate {
-                    break;
-                }
                 if member.repo_type != RepositoryType::Remote {
                     continue;
+                }
+                if let Some(local_min) = owning_local_min_priority {
+                    // A member missing from the priority map cannot outrank the
+                    // owning local: treat it as lowest priority (fail closed).
+                    let member_priority = member_priorities
+                        .get(&member.id)
+                        .copied()
+                        .unwrap_or(i32::MAX);
+                    if local_min < member_priority {
+                        continue;
+                    }
                 }
                 // Only take the first remote response; multiple remote
                 // members in one virtual is rare, and merging two upstream
@@ -1575,21 +1599,33 @@ async fn serve_file(
                 // version-aware shadowing guard (#1217, #1582) and the
                 // name-only local-precedence suppression (#1738). Isolate to the
                 // local owner when a local member owns the name and no operator
-                // `tracks` declaration permits merging with upstream. When
-                // isolated, every Remote member is skipped so an unrelated
-                // public package of the same name is never served through the
-                // virtual; the download then 404s for a version the local owner
-                // lacks, which matches what the simple index lists (consistent).
-                // When a `tracks` declaration exists (same project, split version
-                // ranges, #1582) this returns false and the proxy fallthrough
+                // `tracks` declaration permits merging with upstream. A
+                // suppressed Remote member is skipped so an unrelated public
+                // package of the same name is never served through the virtual;
+                // the download then 404s for a version the local owner lacks,
+                // which matches what the simple index lists (consistent). When
+                // a `tracks` declaration exists (same project, split version
+                // ranges, #1582) this returns None and the proxy fallthrough
                 // below applies.
+                //
+                // #2311: the guard is priority-aware and applied PER REMOTE
+                // MEMBER — it only suppresses a Remote member the owning local
+                // outranks (owning priority value strictly lower). A Remote
+                // member at equal or higher priority than the owning local
+                // still serves, mirroring the simple-index decision above so
+                // every version the index lists is downloadable.
                 let normalized_project = normalize_pep503(project);
-                let suppress_remote_members = proxy_helpers::pypi_virtual_isolates_name(
+                let owning_local_min_priority = proxy_helpers::pypi_virtual_isolates_name(
                     &state.db,
                     repo.id,
                     &normalized_project,
                 )
                 .await?;
+                let member_priorities = if owning_local_min_priority.is_some() {
+                    proxy_helpers::fetch_virtual_member_priorities(&state.db, repo.id).await?
+                } else {
+                    Default::default()
+                };
 
                 for member in &members {
                     // #2066: enforce THIS member's download age gate before any
@@ -1642,14 +1678,24 @@ async fn serve_file(
                     // a stable key, then fall back to the format-specific fetch
                     // that resolves the real download URL via the simple index.
                     //
-                    // Shadowing guard (#1217 follow-up, ak-hv3s): when
-                    // `suppress_remote_members` is set, skip every Remote
-                    // member so an upstream cannot serve a project whose
-                    // normalized PEP 503 name a local member already
-                    // owns. Pair with `order_members_local_first`-style
-                    // ordering at the top of this loop: locals run
-                    // first so they win even when the guard doesn't fire.
-                    if member.repo_type == RepositoryType::Remote && !suppress_remote_members {
+                    // Shadowing guard (#1217 follow-up, ak-hv3s; priority-aware
+                    // per #2311): skip this Remote member when a local member
+                    // that owns the normalized PEP 503 name outranks it, so an
+                    // upstream cannot serve a project a higher-priority local
+                    // member already owns. A member missing from the priority
+                    // map cannot outrank the owning local: it is treated as
+                    // lowest priority (fail closed, suppressed).
+                    let remote_suppressed = match owning_local_min_priority {
+                        Some(local_min) => {
+                            local_min
+                                < member_priorities
+                                    .get(&member.id)
+                                    .copied()
+                                    .unwrap_or(i32::MAX)
+                        }
+                        None => false,
+                    };
+                    if member.repo_type == RepositoryType::Remote && !remote_suppressed {
                         if let (Some(ref upstream_url), Some(ref proxy)) =
                             (&member.upstream_url, &state.proxy_service)
                         {

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -10672,12 +10672,12 @@ mod tests {
             assert!(
                 validate_virtual_repo_member_count("my-repo", &rt, None).is_ok(),
                 "{:?} with no members must be Ok",
-                &rt
+                rt
             );
             assert!(
                 validate_virtual_repo_member_count("my-repo", &rt, Some(&[])).is_ok(),
                 "{:?} with empty members must be Ok",
-                &rt
+                rt
             );
         }
     }
@@ -11600,7 +11600,7 @@ mod tests {
                      VALUES ($1, $2, $3, $4, $5, $6, $7)",
                 )
                 .bind(repo_id)
-                .bind(format!("app/{}", &key))
+                .bind(format!("app/{}", key))
                 .bind("manifest")
                 .bind(16_i64)
                 .bind("f".repeat(64))
@@ -13011,10 +13011,12 @@ mod tests {
         );
     }
 
-    /// PEP 708 (#1600): a PyPI virtual isolates a locally-owned project name by
-    /// default (so an unrelated public package of the same name is never served
-    /// through the virtual), and only unblocks the cross-member union when an
-    /// operator `tracks` declaration exists on the owning member.
+    /// PEP 708 (#1600, priority-aware per #2311): a PyPI virtual isolates a
+    /// locally-owned project name by default (so an unrelated public package
+    /// of the same name is never served through the virtual), reporting the
+    /// owning local member's priority so callers suppress only the remote
+    /// members the owner outranks, and only unblocks the cross-member union
+    /// when an operator `tracks` declaration exists on the owning member.
     #[tokio::test]
     async fn pypi_virtual_isolates_locally_owned_name_until_tracks_declared() {
         use crate::api::handlers::test_db_helpers as tdh;
@@ -13056,20 +13058,24 @@ mod tests {
         .await
         .expect("seed local artifact");
 
-        // Default: owned locally, no tracks -> ISOLATE (do not merge upstream).
+        // Default: owned locally, no tracks -> ISOLATE (do not merge upstream),
+        // reporting the owning local member's priority (1) so the caller can
+        // suppress exactly the remote members the owner outranks — here the
+        // priority-2 remote (the genuine dependency-confusion case).
         assert!(
             matches!(
                 proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "acme-sdk").await,
-                Ok(true)
+                Ok(Some(1))
             ),
-            "a locally-owned name with no tracks declaration must be isolated"
+            "a locally-owned name with no tracks declaration must be isolated \
+             at the owning member's priority"
         );
 
         // A name the local member does not own -> proxy normally (no isolation).
         assert!(
             matches!(
                 proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "six").await,
-                Ok(false)
+                Ok(None)
             ),
             "a name no local member owns must not be isolated"
         );
@@ -13089,7 +13095,7 @@ mod tests {
         assert!(
             matches!(
                 proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "acme-sdk").await,
-                Ok(false)
+                Ok(None)
             ),
             "a tracks declaration must re-enable the cross-member union"
         );
@@ -13101,6 +13107,101 @@ mod tests {
             .ok();
         let _ = std::fs::remove_dir_all(&local_dir);
         let _ = std::fs::remove_dir_all(&remote_dir);
+        let _ = std::fs::remove_dir_all(&virtual_dir);
+    }
+
+    /// #2311: the PEP 708 isolation decision must respect member priority. A
+    /// local member that owns a name but sits at LOWER priority (higher
+    /// `priority` value) than a remote member must not hide that remote: the
+    /// guard reports the owning member's priority and the priority map lets
+    /// callers serve every remote at equal or higher priority, while a remote
+    /// the local owner outranks stays suppressed (the genuine
+    /// dependency-confusion case).
+    #[tokio::test]
+    async fn pypi_virtual_isolation_respects_member_priority() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let (local_id, _lk, local_dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let (remote_hi_id, _rhk, remote_hi_dir) = tdh::create_repo(&pool, "remote", "pypi").await;
+        let (remote_lo_id, _rlk, remote_lo_dir) = tdh::create_repo(&pool, "remote", "pypi").await;
+        let (virtual_id, _vk, virtual_dir) = tdh::create_repo(&pool, "virtual", "pypi").await;
+
+        // Priority inversion: the remote at priority 1 outranks the owning
+        // local at priority 2; a second remote at priority 3 is outranked.
+        for (member, priority) in [
+            (remote_hi_id, 1_i32),
+            (local_id, 2_i32),
+            (remote_lo_id, 3_i32),
+        ] {
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(virtual_id)
+            .bind(member)
+            .bind(priority)
+            .execute(&pool)
+            .await
+            .expect("insert virtual member");
+        }
+
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(local_id)
+        .bind("mypackage/1.0.0/mypackage-1.0.0-py3-none-any.whl")
+        .bind("mypackage")
+        .bind(1_i64)
+        .bind("0".repeat(64))
+        .bind("application/octet-stream")
+        .bind("pypi/mypackage/1")
+        .execute(&pool)
+        .await
+        .expect("seed local artifact");
+
+        // The guard reports the owning local member's priority (2), NOT a
+        // blanket "suppress all remotes".
+        let owning = proxy_helpers::pypi_virtual_isolates_name(&pool, virtual_id, "mypackage")
+            .await
+            .expect("isolation query");
+        assert_eq!(
+            owning,
+            Some(2),
+            "the guard must report the owning local member's priority"
+        );
+
+        // The per-member decision the handlers apply: a remote is suppressed
+        // only when the owning local strictly outranks it.
+        let priorities = proxy_helpers::fetch_virtual_member_priorities(&pool, virtual_id)
+            .await
+            .expect("fetch member priorities");
+        let local_min = owning.expect("owned");
+        let hi_suppressed = local_min < priorities[&remote_hi_id];
+        let lo_suppressed = local_min < priorities[&remote_lo_id];
+        assert!(
+            !hi_suppressed,
+            "a remote member at HIGHER priority (1) than the owning local (2) \
+             must survive isolation so its versions stay visible to pip (#2311)"
+        );
+        assert!(
+            lo_suppressed,
+            "a remote member at LOWER priority (3) than the owning local (2) \
+             must stay suppressed (dependency-confusion protection)"
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+            .bind(vec![local_id, remote_hi_id, remote_lo_id, virtual_id])
+            .execute(&pool)
+            .await
+            .ok();
+        let _ = std::fs::remove_dir_all(&local_dir);
+        let _ = std::fs::remove_dir_all(&remote_hi_dir);
+        let _ = std::fs::remove_dir_all(&remote_lo_dir);
         let _ = std::fs::remove_dir_all(&virtual_dir);
     }
 


### PR DESCRIPTION
## Summary

Makes the PyPI virtual-repository dependency-confusion isolation guard (#1600) priority-aware, fixing the case where a **lower-priority** local member that owns a package name hid a **higher-priority** remote member's versions from the simple index and download path (#2311).

- `pypi_virtual_isolates_name` now returns the **minimum `virtual_repo_members.priority` among owning local/staging members** (`Option<i32>`, `None` = not owned or `tracks` declared) instead of a bare bool, and a new `fetch_virtual_member_priorities` helper exposes the per-member priority map.
- Both call sites (simple index `simple_project` and the virtual download path) now decide isolation **per remote member**: a remote is skipped only when the owning local member strictly outranks it (lower priority value). A remote at equal or higher priority than the owning local surfaces as the operator configured.
- The genuine dependency-confusion protection is unchanged: a higher-priority local owner still suppresses lower-priority remotes in both the index and download (consistent 404 for remote-only versions). The `tracks` declaration escape hatch is unchanged.
- Also fixes three pre-existing `clippy::useless_borrows_in_formatting` lints in `repositories.rs` tests that fail `cargo clippy -D warnings` on current stable (1.97).

Verified live against a patched deployment: a virtual with `pypi.org` remote at priority 1 and a local owner of `six` at priority 2 now serves the full union (local wheel + all upstream versions, remote-only version downloads 200); the inverted ordering (local at priority 1) still serves only the local wheel and 404s remote-only versions; declaring/removing a `tracks` row toggles the union as before.

Closes #2311

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`pypi_virtual_isolates_locally_owned_name_until_tracks_declared` updated for the new return type; new `pypi_virtual_isolation_respects_member_priority` covers the priority inversion (higher-priority remote survives, lower-priority remote stays suppressed). `cargo test --lib pypi` (282) and `--lib proxy` (693) green against a live DB.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
