### PR TITLE
feat(rpm): Phase-1 proxy hardening — SSRF connect-time IP check, RPM cache classification, content integrity, mirrorlist rejection

### DIFF
--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -215,6 +215,12 @@ pub fn classify(format: &RepositoryFormat, path: &str) -> Mutability {
         // rewritten in place by upstream.
         RepositoryFormat::Debian => classify_debian(&lower),
 
+        // -- RPM / YUM ------------------------------------------------------
+        // repomd.xml(+.asc) is the single mutable entry point; every other
+        // repodata file is content-addressed (checksum-prefixed filename) and
+        // packages are version-pinned — both immutable.
+        RepositoryFormat::Rpm => classify_rpm(&lower),
+
         // Everything else: conservative default. Revalidate rather than risk
         // serving a stale index forever.
         _ => Mutability::mutable_default(),
@@ -261,7 +267,8 @@ pub fn is_explicitly_mutable_index(format: &RepositoryFormat, path: &str) -> boo
         | RepositoryFormat::WasmOci
         | RepositoryFormat::HelmOci
         | RepositoryFormat::Cargo
-        | RepositoryFormat::Debian => !classify(format, &lower).is_immutable(),
+        | RepositoryFormat::Debian
+        | RepositoryFormat::Rpm => !classify(format, &lower).is_immutable(),
 
         // Conan revision-file coordinates
         // (`.../revisions/{rev}/files/{file}`) are legitimately rewritten in
@@ -273,7 +280,7 @@ pub fn is_explicitly_mutable_index(format: &RepositoryFormat, path: &str) -> boo
         // is a no-op for conan (matching the conan upload handlers' intent).
         RepositoryFormat::Conan => true,
 
-        // Default-format families (Generic, Nuget, Composer, Go, Rpm,
+        // Default-format families (Generic, Nuget, Composer, Go,
         // Helm, ...) have no in-place index files at artifact coordinates:
         // every stored path is a release coordinate.
         _ => false,
@@ -395,6 +402,34 @@ fn classify_debian(lower: &str) -> Mutability {
     Mutability::mutable_default()
 }
 
+/// RPM: `repodata/repomd.xml`(+`.asc`) is the mutable index; all other
+/// `repodata/<checksum>-*` files are content-addressed and packages
+/// (`.rpm`/`.drpm`) are version-pinned — both immutable.
+fn classify_rpm(lower: &str) -> Mutability {
+    let leaf = leaf(lower);
+    // The mutable pointer and its detached signature.
+    if leaf == "repomd.xml" || leaf == "repomd.xml.asc" {
+        return Mutability::mutable_default();
+    }
+    // Packages are immutable.
+    if leaf.ends_with(".rpm") || leaf.ends_with(".drpm") {
+        return Mutability::Immutable;
+    }
+    // Content-addressed metadata under repodata/: a checksum-prefixed name such
+    // as `<hex>-primary.xml.gz` / `.zck`. Require a hex prefix before the first
+    // '-' so a bare `primary.xml.gz` (no unique-filename) stays conservative.
+    if lower.starts_with("repodata/") {
+        if let Some((prefix, _rest)) = leaf.split_once('-') {
+            let looks_hashed = prefix.len() >= 8 && prefix.chars().all(|c| c.is_ascii_hexdigit());
+            if looks_hashed {
+                return Mutability::Immutable;
+            }
+        }
+    }
+    // Unknown path: revalidate.
+    Mutability::mutable_default()
+}
+
 /// The final path segment (after the last `/`), or the whole string.
 fn leaf(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
@@ -475,7 +510,7 @@ mod tests {
         ));
         // Default-format families have NO in-place index at a coordinate; every
         // stored path is a release coordinate -> always false (protected).
-        for f in [Generic, Nuget, Composer, Go, Rpm, Helm] {
+        for f in [Generic, Nuget, Composer, Go, Helm] {
             assert!(
                 !is_explicitly_mutable_index(&f, "anything/1.0.0/file.bin"),
                 "{f:?} coordinates must be treated as release coordinates"
@@ -697,5 +732,53 @@ mod tests {
     #[test]
     fn negative_ttl_constant_is_short() {
         assert!((30..=60).contains(&NEGATIVE_CACHE_TTL_SECS));
+    }
+
+    #[test]
+    fn test_classify_rpm() {
+        use RepositoryFormat::Rpm;
+        // repomd.xml and its signature are the mutable entry point.
+        assert_eq!(
+            classify(&Rpm, "repodata/repomd.xml"),
+            Mutability::mutable_default()
+        );
+        assert_eq!(
+            classify(&Rpm, "repodata/repomd.xml.asc"),
+            Mutability::mutable_default()
+        );
+        // Content-addressed metadata (checksum-prefixed) is immutable.
+        assert_eq!(
+            classify(&Rpm, "repodata/1a2b3c4d-primary.xml.gz"),
+            Mutability::Immutable
+        );
+        assert_eq!(
+            classify(&Rpm, "repodata/deadbeef-primary.xml.zck"),
+            Mutability::Immutable
+        );
+        // Packages are immutable.
+        assert_eq!(
+            classify(&Rpm, "Packages/foo-1.2-3.x86_64.rpm"),
+            Mutability::Immutable
+        );
+        assert_eq!(
+            classify(&Rpm, "getPackage/bar-2.0-1.noarch.drpm"),
+            Mutability::Immutable
+        );
+        // Unknown / directory-ish paths stay conservative.
+        assert_eq!(classify(&Rpm, "repodata/"), Mutability::mutable_default());
+    }
+
+    #[test]
+    fn test_rpm_explicit_mutable_index() {
+        use RepositoryFormat::Rpm;
+        assert!(is_explicitly_mutable_index(&Rpm, "repodata/repomd.xml"));
+        assert!(!is_explicitly_mutable_index(
+            &Rpm,
+            "Packages/foo-1.2-3.x86_64.rpm"
+        ));
+        assert!(!is_explicitly_mutable_index(
+            &Rpm,
+            "repodata/deadbeef-primary.xml.gz"
+        ));
     }
 }

--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -435,6 +435,53 @@ fn leaf(path: &str) -> &str {
     path.rsplit('/').next().unwrap_or(path)
 }
 
+/// If `path` is a createrepo unique-filename (`repodata/<sha256>-<name>`),
+/// return the 64-hex-char checksum prefix. Used to verify a content-addressed
+/// body's integrity before caching it as immutable (design S3): the RPM
+/// `createrepo --unique-md-filenames` convention embeds the SHA-256 of the
+/// file's own content in its name (e.g.
+/// `repodata/1a2b...-primary.xml.gz`), so the path itself is an assertion
+/// about the body that a proxy can verify before trusting it forever.
+///
+/// Returns `None` for any path whose leaf does not have a 64-hex-char prefix
+/// before the first `-` (e.g. `repomd.xml`, a package file, or a
+/// non-checksum-prefixed metadata file) — those paths are not
+/// content-addressed and this check does not apply to them.
+pub fn expected_sha256_from_path(path: &str) -> Option<&str> {
+    let lower = path.to_ascii_lowercase();
+    let leaf = leaf(&lower);
+    let (prefix, _) = leaf.split_once('-')?;
+    if prefix.len() == 64 && prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        // Return the slice from the ORIGINAL path (case-insensitive hex).
+        let start = path.len() - leaf.len();
+        Some(&path[start..start + 64])
+    } else {
+        None
+    }
+}
+
+/// Phase-1 interim over-quota guard for a single object about to be cached
+/// (bug artifact-keeper-x70). Returns `true` when `quota_bytes` is set and
+/// `object_len` exceeds it, in which case the caller must skip the cache
+/// write for this object (still serving the body to the client).
+///
+/// This is deliberately NOT full per-repo usage accounting: the proxy cache
+/// is not recorded in the `artifacts` table (#1278), so there is no running
+/// per-repo proxy-cache total to check a request against yet. Full quota
+/// enforcement (usage tracking + eviction) is deferred to P4; this is only a
+/// cheap guard against a single object that is, by itself, already larger
+/// than the whole configured quota.
+///
+/// `quota_bytes = None` (no quota configured) never exceeds. An object
+/// exactly equal to the quota does NOT exceed (the quota is an inclusive
+/// ceiling, not an exclusive bound).
+pub fn exceeds_single_object_quota(quota_bytes: Option<i64>, object_len: i64) -> bool {
+    match quota_bytes {
+        Some(quota) => object_len > quota,
+        None => false,
+    }
+}
+
 /// Concrete versioned Maven artifact extensions (immutable). Checksums and
 /// signatures of these are immutable too.
 fn has_artifact_extension(leaf: &str) -> bool {
@@ -795,5 +842,90 @@ mod tests {
             &Rpm,
             "repodata/deadbeef-primary.xml.gz"
         ));
+    }
+
+    // ----- expected_sha256_from_path(): content-addressed integrity (S3) ----
+
+    #[test]
+    fn test_expected_sha256_from_path() {
+        // Full SHA-256 (64 hex) prefix is returned.
+        let p = "repodata/9f".to_string() + &"a".repeat(62) + "-primary.xml.gz";
+        assert!(expected_sha256_from_path(&p).is_some());
+        // repomd.xml and packages have no embedded checksum.
+        assert_eq!(expected_sha256_from_path("repodata/repomd.xml"), None);
+        assert_eq!(
+            expected_sha256_from_path("Packages/foo-1.2-3.x86_64.rpm"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_expected_sha256_from_path_returns_exact_slice_of_original_path() {
+        let hex = "9f".to_string() + &"a".repeat(62);
+        let p = format!("repodata/{hex}-primary.xml.gz");
+        assert_eq!(expected_sha256_from_path(&p), Some(hex.as_str()));
+    }
+
+    #[test]
+    fn test_expected_sha256_from_path_case_insensitive_hex() {
+        // Uppercase hex in the path is still recognized as a checksum
+        // prefix, and the returned slice is the ORIGINAL (uppercase) bytes so
+        // the caller can compare byte-for-byte with a lowercase hex digest
+        // using an ascii-case-insensitive comparison.
+        let hex_upper = "9F".to_string() + &"A".repeat(62);
+        let p = format!("repodata/{hex_upper}-primary.xml.gz");
+        assert_eq!(expected_sha256_from_path(&p), Some(hex_upper.as_str()));
+    }
+
+    #[test]
+    fn test_expected_sha256_from_path_rejects_short_prefix() {
+        // A prefix shorter than 64 hex chars is not a full SHA-256 and must
+        // not be treated as content-addressed.
+        let p = "repodata/deadbeef-primary.xml.gz";
+        assert_eq!(expected_sha256_from_path(p), None);
+    }
+
+    #[test]
+    fn test_expected_sha256_from_path_rejects_non_hex_prefix() {
+        // 64 characters but not all hex digits.
+        let p = "repodata/".to_string() + &"z".repeat(64) + "-primary.xml.gz";
+        assert_eq!(expected_sha256_from_path(&p), None);
+    }
+
+    #[test]
+    fn test_expected_sha256_from_path_no_dash_in_leaf() {
+        // No '-' separator at all -> no checksum prefix to extract.
+        assert_eq!(
+            expected_sha256_from_path("repodata/primarynodash.xml"),
+            None
+        );
+    }
+
+    // ----- exceeds_single_object_quota(): Phase-1 interim guard (x70) -------
+
+    #[test]
+    fn test_exceeds_single_object_quota_table() {
+        // (quota_bytes, object_len, expected)
+        let cases: Vec<(Option<i64>, i64, bool)> = vec![
+            // No quota configured -> never exceeds.
+            (None, 0, false),
+            (None, i64::MAX, false),
+            // Object strictly larger than quota -> exceeds.
+            (Some(100), 101, true),
+            // Object exactly at quota -> does NOT exceed (quota is a ceiling,
+            // not an exclusive bound).
+            (Some(100), 100, false),
+            // Object smaller than quota -> does not exceed.
+            (Some(100), 99, false),
+            // Zero-byte object never exceeds any positive quota.
+            (Some(100), 0, false),
+        ];
+        for (quota_bytes, object_len, expected) in cases {
+            assert_eq!(
+                exceeds_single_object_quota(quota_bytes, object_len),
+                expected,
+                "exceeds_single_object_quota({quota_bytes:?}, {object_len}) expected {expected}"
+            );
+        }
     }
 }

--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -418,7 +418,7 @@ fn classify_rpm(lower: &str) -> Mutability {
     // Content-addressed metadata under repodata/: a checksum-prefixed name such
     // as `<hex>-primary.xml.gz` / `.zck`. Require a hex prefix before the first
     // '-' so a bare `primary.xml.gz` (no unique-filename) stays conservative.
-    if lower.starts_with("repodata/") {
+    if lower.contains("repodata/") {
         if let Some((prefix, _rest)) = leaf.split_once('-') {
             let looks_hashed = prefix.len() >= 8 && prefix.chars().all(|c| c.is_ascii_hexdigit());
             if looks_hashed {
@@ -766,6 +766,21 @@ mod tests {
         );
         // Unknown / directory-ish paths stay conservative.
         assert_eq!(classify(&Rpm, "repodata/"), Mutability::mutable_default());
+        // A bare, non-checksum-prefixed metadata file stays conservative (mutable).
+        assert_eq!(
+            classify(&Rpm, "repodata/primary.xml.gz"),
+            Mutability::mutable_default()
+        );
+        // A prefix shorter than 8 hex chars is NOT treated as content-addressed.
+        assert_eq!(
+            classify(&Rpm, "repodata/1234567-primary.xml.gz"),
+            Mutability::mutable_default()
+        );
+        // Content-addressed metadata nested under a subpath is still immutable.
+        assert_eq!(
+            classify(&Rpm, "centos/9/repodata/deadbeef12-primary.xml.gz"),
+            Mutability::Immutable
+        );
     }
 
     #[test]

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -59,7 +59,9 @@ fn log_proxy_env() {
 pub fn base_client_builder() -> ClientBuilder {
     log_proxy_env();
 
-    let mut builder = reqwest::Client::builder().redirect(ssrf_redirect_policy());
+    let mut builder = reqwest::Client::builder()
+        .redirect(ssrf_redirect_policy())
+        .dns_resolver(crate::services::ssrf_dns::ssrf_guard_resolver());
 
     if let Ok(ca_path) = std::env::var("CUSTOM_CA_CERT_PATH") {
         match std::fs::read(&ca_path) {
@@ -269,6 +271,26 @@ mod tests {
         assert!(
             err.to_string().contains("SSRF") || err.is_redirect(),
             "expected redirect-rejection error, got: {err}"
+        );
+    }
+
+    /// A hostname resolving to a blocked IP must be refused at DNS time, not
+    /// connected to. `localhost` resolves to 127.0.0.1/::1 (blocked).
+    #[tokio::test]
+    async fn test_client_refuses_host_resolving_to_blocked_ip() {
+        let client = base_client_builder().build().unwrap();
+        let err = client
+            .get("http://localhost/")
+            .send()
+            .await
+            .expect_err("host resolving to a blocked IP must be refused");
+        // A DNS/connect-layer rejection (not a live HTTP response).
+        assert!(
+            err.is_connect()
+                || err.is_request()
+                || err.to_string().to_lowercase().contains("ssrf")
+                || err.to_string().to_lowercase().contains("block"),
+            "expected resolver rejection, got: {err}"
         );
     }
 

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -276,11 +276,41 @@ mod tests {
 
     /// A hostname resolving to a blocked IP must be refused at DNS time, not
     /// connected to. `localhost` resolves to 127.0.0.1/::1 (blocked).
+    ///
+    /// This test is deliberately discriminating: a plain "connection
+    /// refused" (e.g. nothing listening on the port) also satisfies
+    /// `err.is_connect()`, so an assertion on the error alone would pass
+    /// even if `.dns_resolver(...)` were removed from `base_client_builder`
+    /// entirely (a false negative). To rule that out, we bind a *real*
+    /// listener on `127.0.0.1` and target it via `localhost:{port}` — an
+    /// unprotected client WOULD successfully connect to this listener, so
+    /// asserting the listener never receives a connection is what actually
+    /// proves the resolver blocked the request rather than merely finding
+    /// nothing to talk to.
     #[tokio::test]
     async fn test_client_refuses_host_resolving_to_blocked_ip() {
-        let client = base_client_builder().build().unwrap();
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let port = listener.local_addr().expect("local addr").port();
+
+        // Bound the request with a short timeout: `base_client_builder`
+        // itself sets no total request timeout, and this test's listener
+        // never writes an HTTP response. If the resolver regressed and the
+        // client actually connected, `.send().await` would otherwise hang
+        // forever waiting on a response that never arrives, hanging the
+        // test (and CI) instead of failing it. With the resolver correctly
+        // in place, rejection happens at the DNS stage well within this
+        // bound, so the timeout never fires on the passing path.
+        let client = base_client_builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let url = format!("http://localhost:{port}/");
         let err = client
-            .get("http://localhost/")
+            .get(&url)
             .send()
             .await
             .expect_err("host resolving to a blocked IP must be refused");
@@ -291,6 +321,20 @@ mod tests {
                 || err.to_string().to_lowercase().contains("ssrf")
                 || err.to_string().to_lowercase().contains("block"),
             "expected resolver rejection, got: {err}"
+        );
+
+        // Discriminating check: the listener must never have accepted a
+        // connection. If the resolver were not wired in (or removed), the
+        // client would successfully connect to 127.0.0.1:{port} via
+        // `localhost`, and this would find a pending connection instead of
+        // timing out.
+        let accept_result =
+            tokio::time::timeout(Duration::from_millis(200), listener.accept()).await;
+        assert!(
+            accept_result.is_err(),
+            "listener must never accept a connection; the SSRF resolver should have \
+             blocked the request before any TCP connection was attempted, but a \
+             connection was accepted: {accept_result:?}"
         );
     }
 

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -273,6 +273,36 @@ pub fn record_email_dispatch_attempted(event_type: &str) {
     .increment(1);
 }
 
+/// Record a proxy-cache write refused because the fetched body's SHA-256
+/// did not match the checksum embedded in a content-addressed path (e.g. an
+/// RPM createrepo unique-filename `repodata/<sha256>-primary.xml.gz`).
+///
+/// This is a `target: "security"`-adjacent signal: a mismatch here means
+/// either transport corruption or a dishonest/compromised upstream handed us
+/// bytes that do not match the identity the path itself promises. The body
+/// is still served to the client; only the cache write is skipped so a bad
+/// body is never pinned as "immutable forever".
+pub fn record_proxy_cache_checksum_mismatch(repo_key: &str) {
+    counter!(
+        "ak_proxy_cache_checksum_mismatch_total",
+        "repository" => repo_key.to_string()
+    )
+    .increment(1);
+}
+
+/// Record a proxy-cache write skipped because the fetched object exceeded
+/// the repository's `quota_bytes` (Phase-1 interim single-object guard for
+/// bug artifact-keeper-x70; full per-repo usage accounting is deferred to
+/// P4). The body is still served to the client; only the cache write is
+/// skipped.
+pub fn record_proxy_cache_quota_exceeded(repo_key: &str) {
+    counter!(
+        "ak_proxy_cache_quota_exceeded_total",
+        "repository" => repo_key.to_string()
+    )
+    .increment(1);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -389,6 +419,16 @@ mod tests {
     #[test]
     fn test_record_email_dispatch_attempted_does_not_panic() {
         record_email_dispatch_attempted("artifact.uploaded");
+    }
+
+    #[test]
+    fn test_record_proxy_cache_checksum_mismatch_does_not_panic() {
+        record_proxy_cache_checksum_mismatch("my-rpm-repo");
+    }
+
+    #[test]
+    fn test_record_proxy_cache_quota_exceeded_does_not_panic() {
+        record_proxy_cache_quota_exceeded("my-rpm-repo");
     }
 
     #[test]

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -70,6 +70,7 @@ pub mod signing_service;
 pub mod smtp_service;
 pub mod source_registry;
 pub mod spdx_licenses;
+pub mod ssrf_dns;
 pub mod storage_gc_service;
 pub mod storage_service;
 pub mod sync_policy_service;

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2427,6 +2427,79 @@ impl ProxyService {
                         let quarantine_until = self
                             .quarantine_until_for_new_entry(repo.id, resp.last_modified.as_deref())
                             .await;
+
+                        // S3: content-addressed integrity. When `cache_path`
+                        // embeds a hex checksum (createrepo unique-filename,
+                        // e.g. `repodata/<sha256>-primary.xml.gz`), the path
+                        // itself asserts the body's identity. Verify it BEFORE
+                        // caching as immutable -- an immutable entry is cached
+                        // forever and never revalidated, so a dishonest or
+                        // compromised upstream handing us a mismatched body
+                        // here would be pinned permanently. On mismatch: serve
+                        // the body to the client (it already asked for this
+                        // path and upstream returned 200) but refuse to cache
+                        // it, so the next request re-fetches from upstream
+                        // instead of hitting a poisoned cache entry. This check
+                        // is a no-op (`None`) for every non-content-addressed
+                        // path and every other format.
+                        let checksum_ok = match cache_classifier::expected_sha256_from_path(
+                            cache_path,
+                        ) {
+                            Some(expected) => {
+                                let actual = StorageService::calculate_hash(&resp.content);
+                                if actual.eq_ignore_ascii_case(expected) {
+                                    true
+                                } else {
+                                    tracing::warn!(
+                                        target: "security",
+                                        repository = %repo.key,
+                                        cache_key = %cache_key,
+                                        path = %cache_path,
+                                        expected_sha256 = %expected,
+                                        actual_sha256 = %actual,
+                                        "content-addressed proxy body does not match the checksum \
+                                         embedded in its path; refusing to cache (serving body to \
+                                         client, treating as a cache miss)"
+                                    );
+                                    crate::services::metrics_service::record_proxy_cache_checksum_mismatch(
+                                        &repo.key,
+                                    );
+                                    false
+                                }
+                            }
+                            None => true,
+                        };
+
+                        // Phase-1 interim over-quota guard (bug
+                        // artifact-keeper-x70): full per-repo proxy-cache usage
+                        // accounting is deferred to P4 (proxy-cached content is
+                        // deliberately absent from the `artifacts` table, #1278,
+                        // so there is no running per-repo total to check yet).
+                        // This is only a cheap single-object guard: an object
+                        // larger than the repository's configured quota on its
+                        // own is never cached, even though nothing tracks
+                        // cumulative usage below that ceiling yet.
+                        let quota_ok = !cache_classifier::exceeds_single_object_quota(
+                            repo.quota_bytes,
+                            resp.content.len() as i64,
+                        );
+                        if !quota_ok {
+                            tracing::warn!(
+                                target: "security",
+                                repository = %repo.key,
+                                cache_key = %cache_key,
+                                path = %cache_path,
+                                object_len = resp.content.len(),
+                                quota_bytes = ?repo.quota_bytes,
+                                "proxy-fetched object exceeds repository quota_bytes; skipping \
+                                 cache write (Phase-1 interim single-object guard, serving body \
+                                 to client)"
+                            );
+                            crate::services::metrics_service::record_proxy_cache_quota_exceeded(
+                                &repo.key,
+                            );
+                        }
+
                         // B6 (coalescing 502 leak, remaining path): the upstream fetch
                         // already SUCCEEDED -- `resp.content` is in hand. A failure to
                         // persist the cache entry must NOT fail the client request.
@@ -2441,7 +2514,11 @@ impl ProxyService {
                         // write as best-effort: log at warn and still serve the bytes
                         // we fetched. The cache self-heals on the next request (the
                         // streaming path already documents this self-healing).
-                        if let Err(cache_err) = self
+                        if !checksum_ok || !quota_ok {
+                            // Guard tripped above: skip the cache write entirely
+                            // (do not index into the package catalog either --
+                            // nothing was actually cached).
+                        } else if let Err(cache_err) = self
                             .cache_artifact(
                                 &cache_key,
                                 &metadata_key,
@@ -10017,6 +10094,188 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    /// S3: a content-addressed RPM repodata body (createrepo unique
+    /// filename `repodata/<sha256>-primary.xml.gz`) whose SHA-256 does NOT
+    /// match the checksum embedded in the path must still be served to the
+    /// client (upstream returned 200; the client asked for this path) but
+    /// must NOT be cached -- caching it would pin a mismatched body as
+    /// "immutable forever" under the RPM classifier. This drives the real
+    /// buffered fetch path (`fetch_artifact_capped`, the same one RPM
+    /// repodata handlers use) against a wiremock upstream so both the S3
+    /// guard and its call site are exercised end-to-end.
+    #[tokio::test]
+    async fn test_content_addressed_checksum_mismatch_is_served_but_not_cached() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let server = MockServer::start().await;
+
+        // The path promises this SHA-256; the body served below hashes to
+        // something else entirely, so this is a deliberate mismatch.
+        let claimed_sha256 = "0".repeat(64);
+        let cache_path = format!("repodata/{claimed_sha256}-primary.xml.gz");
+        let body = b"this body does not hash to the claimed checksum";
+        assert_ne!(
+            StorageService::calculate_hash(body.as_ref()),
+            claimed_sha256,
+            "test fixture sanity: body must NOT hash to the claimed checksum"
+        );
+
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{cache_path}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.as_ref()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("ak-x70-s3-mismatch-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("create tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+
+        let mut repo = remote_repo_for("rpm-remote", &server.uri(), tmp.to_str().unwrap());
+        repo.format = RepositoryFormat::Rpm;
+
+        let result = proxy
+            .fetch_artifact_capped(&repo, &cache_path, DEFAULT_METADATA_MAX_BYTES)
+            .await;
+
+        let (content, _ct) = result.expect(
+            "a checksum mismatch must still serve the fetched body to the \
+             client, not fail the request",
+        );
+        assert_eq!(&content[..], body.as_ref());
+
+        // The whole point of the guard: this must NOT have been cached.
+        let cached = proxy
+            .get_cached_artifact_by_path(&repo.key, &cache_path)
+            .await
+            .expect("cache lookup must not error");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            cached.is_none(),
+            "a content-addressed body whose SHA-256 does not match its path \
+             must be refused from the cache (treated as a miss), not pinned \
+             as an immutable entry"
+        );
+    }
+
+    /// Companion to the mismatch test above: a content-addressed RPM
+    /// repodata body whose SHA-256 DOES match the path's embedded checksum
+    /// must be cached normally. Pins that the S3 guard is gated on
+    /// `expected_sha256_from_path` returning `Some` AND a genuine mismatch --
+    /// it must not accidentally block every content-addressed write.
+    #[tokio::test]
+    async fn test_content_addressed_checksum_match_is_cached() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let server = MockServer::start().await;
+
+        let body = b"primary.xml.gz body that DOES match its own checksum";
+        let real_sha256 = StorageService::calculate_hash(body.as_ref());
+        let cache_path = format!("repodata/{real_sha256}-primary.xml.gz");
+
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{cache_path}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.as_ref()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("ak-x70-s3-match-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("create tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+
+        let mut repo = remote_repo_for("rpm-remote", &server.uri(), tmp.to_str().unwrap());
+        repo.format = RepositoryFormat::Rpm;
+
+        let result = proxy
+            .fetch_artifact_capped(&repo, &cache_path, DEFAULT_METADATA_MAX_BYTES)
+            .await;
+        let (content, _ct) = result.expect("matching checksum must fetch successfully");
+        assert_eq!(&content[..], body.as_ref());
+
+        let cached = proxy
+            .get_cached_artifact_by_path(&repo.key, &cache_path)
+            .await
+            .expect("cache lookup must not error");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        let (cached_content, _) = cached.expect("a matching content-addressed body MUST be cached");
+        assert_eq!(&cached_content[..], body.as_ref());
+    }
+
+    /// Phase-1 interim over-quota guard (bug artifact-keeper-x70): an
+    /// object larger than the repository's configured `quota_bytes` must be
+    /// served to the client but never written to the cache.
+    #[tokio::test]
+    async fn test_object_exceeding_quota_is_served_but_not_cached() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path as wm_path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let server = MockServer::start().await;
+
+        let cache_path = "repodata/repomd.xml";
+        let body = b"this object is bigger than the tiny configured quota";
+        assert!(
+            body.len() > 10,
+            "test fixture sanity: body must exceed the quota configured below"
+        );
+
+        Mock::given(method("GET"))
+            .and(wm_path(format!("/{cache_path}")))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(body.as_ref()))
+            .mount(&server)
+            .await;
+
+        let tmp = std::env::temp_dir().join(format!("ak-x70-quota-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&tmp).expect("create tmp");
+        let proxy = tdh::build_proxy_service_with_fs(pool, tmp.to_str().unwrap());
+
+        let mut repo = remote_repo_for("rpm-remote-quota", &server.uri(), tmp.to_str().unwrap());
+        repo.format = RepositoryFormat::Rpm;
+        // Quota smaller than the served body -- must trip the guard.
+        repo.quota_bytes = Some(10);
+
+        let result = proxy
+            .fetch_artifact_capped(&repo, cache_path, DEFAULT_METADATA_MAX_BYTES)
+            .await;
+
+        let (content, _ct) =
+            result.expect("an over-quota object must still be served to the client");
+        assert_eq!(&content[..], body.as_ref());
+
+        let cached = proxy
+            .get_cached_artifact_by_path(&repo.key, cache_path)
+            .await
+            .expect("cache lookup must not error");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        assert!(
+            cached.is_none(),
+            "an object larger than the repository's quota_bytes must be \
+             refused from the cache (Phase-1 interim single-object guard, \
+             bug artifact-keeper-x70), not silently cached over quota"
+        );
     }
 
     #[test]

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -92,20 +92,36 @@ pub(crate) enum VisibilityBind {
 pub(crate) fn validate_remote_upstream(
     repo_type: &RepositoryType,
     upstream_url: &Option<String>,
+    format: &RepositoryFormat,
 ) -> Result<()> {
     if *repo_type == RepositoryType::Remote {
         match upstream_url {
             None => {
                 return Err(AppError::Validation(
                     "Remote repository must have an upstream URL".to_string(),
-                ))
+                ));
             }
-            Some(url) => validate_outbound_url(url, "Upstream URL")?,
+            Some(url) => {
+                validate_outbound_url(url, "Upstream URL")?;
+                if *format == RepositoryFormat::Rpm && is_mirrorlist_or_metalink(url) {
+                    return Err(AppError::Validation(
+                        "RPM remote upstream must be a concrete baseurl, not a mirrorlist/metalink \
+                         URL. Point it at a resolved repo root (e.g. .../BaseOS/x86_64/os/)."
+                            .to_string(),
+                    ));
+                }
+            }
         }
     } else if let Some(url) = upstream_url {
         validate_outbound_url(url, "Upstream URL")?;
     }
     Ok(())
+}
+
+/// Heuristic: a URL whose path or query names a mirrorlist/metalink endpoint.
+fn is_mirrorlist_or_metalink(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.contains("mirrorlist") || lower.contains("metalink")
 }
 
 /// Derive a format key string from a RepositoryFormat enum.
@@ -539,7 +555,7 @@ impl RepositoryService {
     /// Create a new repository
     pub async fn create(&self, req: CreateRepositoryRequest) -> Result<Repository> {
         // Validate remote repository has upstream URL and it is safe to contact
-        validate_remote_upstream(&req.repo_type, &req.upstream_url)?;
+        validate_remote_upstream(&req.repo_type, &req.upstream_url, &req.format)?;
 
         // Check if format handler is enabled (T044).
         //
@@ -893,9 +909,13 @@ impl RepositoryService {
 
     /// Update a repository
     pub async fn update(&self, id: Uuid, req: UpdateRepositoryRequest) -> Result<Repository> {
-        // Validate upstream_url is safe to contact if it is being updated
-        if let Some(ref url) = req.upstream_url {
-            validate_outbound_url(url, "Upstream URL")?;
+        // Validate upstream_url is safe to contact if it is being updated.
+        // `UpdateRepositoryRequest` carries neither `repo_type` nor `format`
+        // (both are immutable after creation), so load the existing row to
+        // source them for the mirrorlist/metalink check on RPM remotes.
+        if req.upstream_url.is_some() {
+            let existing = self.get_by_id(id).await?;
+            validate_remote_upstream(&existing.repo_type, &req.upstream_url, &existing.format)?;
         }
 
         let repo = sqlx::query_as!(
@@ -1672,7 +1692,8 @@ mod tests {
 
     #[test]
     fn test_validate_remote_upstream_remote_without_url_fails() {
-        let result = validate_remote_upstream(&RepositoryType::Remote, &None);
+        let result =
+            validate_remote_upstream(&RepositoryType::Remote, &None, &RepositoryFormat::Generic);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("upstream URL"));
     }
@@ -1682,25 +1703,29 @@ mod tests {
         let result = validate_remote_upstream(
             &RepositoryType::Remote,
             &Some("https://upstream.example.com".to_string()),
+            &RepositoryFormat::Generic,
         );
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_remote_upstream_local_without_url_passes() {
-        let result = validate_remote_upstream(&RepositoryType::Local, &None);
+        let result =
+            validate_remote_upstream(&RepositoryType::Local, &None, &RepositoryFormat::Generic);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_remote_upstream_virtual_without_url_passes() {
-        let result = validate_remote_upstream(&RepositoryType::Virtual, &None);
+        let result =
+            validate_remote_upstream(&RepositoryType::Virtual, &None, &RepositoryFormat::Generic);
         assert!(result.is_ok());
     }
 
     #[test]
     fn test_validate_remote_upstream_staging_without_url_passes() {
-        let result = validate_remote_upstream(&RepositoryType::Staging, &None);
+        let result =
+            validate_remote_upstream(&RepositoryType::Staging, &None, &RepositoryFormat::Generic);
         assert!(result.is_ok());
     }
 
@@ -1709,6 +1734,7 @@ mod tests {
         let result = validate_remote_upstream(
             &RepositoryType::Remote,
             &Some("http://127.0.0.1:8080/".to_string()),
+            &RepositoryFormat::Generic,
         );
         assert!(result.is_err());
     }
@@ -1718,6 +1744,7 @@ mod tests {
         let result = validate_remote_upstream(
             &RepositoryType::Remote,
             &Some("http://169.254.169.254/latest/meta-data/".to_string()),
+            &RepositoryFormat::Generic,
         );
         assert!(result.is_err());
     }
@@ -1728,8 +1755,26 @@ mod tests {
         let result = validate_remote_upstream(
             &RepositoryType::Local,
             &Some("http://10.0.0.1/internal".to_string()),
+            &RepositoryFormat::Generic,
         );
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_rpm_remote_rejects_mirrorlist_and_metalink() {
+        let ml = Some("https://mirrors.example.org/mirrorlist?repo=epel-9&arch=x86_64".to_string());
+        let mt = Some("https://mirrors.example.org/metalink?repo=epel-9".to_string());
+        let base = Some("https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/".to_string());
+        assert!(
+            validate_remote_upstream(&RepositoryType::Remote, &ml, &RepositoryFormat::Rpm).is_err()
+        );
+        assert!(
+            validate_remote_upstream(&RepositoryType::Remote, &mt, &RepositoryFormat::Rpm).is_err()
+        );
+        assert!(
+            validate_remote_upstream(&RepositoryType::Remote, &base, &RepositoryFormat::Rpm)
+                .is_ok()
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/ssrf_dns.rs
+++ b/backend/src/services/ssrf_dns.rs
@@ -19,15 +19,25 @@ pub fn ssrf_guard_resolver() -> Arc<dyn Resolve> {
     Arc::new(SsrfGuardResolver)
 }
 
+/// Pure filter: keep only addresses not rejected by
+/// [`crate::api::validation::is_blocked_resolved_ip`]. Extracted from
+/// [`SsrfGuardResolver::resolve`] so the security-critical mixed-address
+/// case (some resolved addresses blocked, some not) can be unit tested
+/// without any DNS/network I/O.
+fn filter_allowed(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketAddr> {
+    addrs
+        .into_iter()
+        .filter(|sa| !crate::api::validation::is_blocked_resolved_ip(sa.ip()))
+        .collect()
+}
+
 impl Resolve for SsrfGuardResolver {
     fn resolve(&self, name: Name) -> Resolving {
         Box::pin(async move {
             let host = name.as_str().to_string();
             // Port 0 is a placeholder; reqwest substitutes the real port.
             let resolved = tokio::net::lookup_host((host.as_str(), 0)).await?;
-            let allowed: Vec<SocketAddr> = resolved
-                .filter(|sa| !crate::api::validation::is_blocked_resolved_ip(sa.ip()))
-                .collect();
+            let allowed: Vec<SocketAddr> = filter_allowed(resolved);
             if allowed.is_empty() {
                 let err: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
@@ -44,6 +54,54 @@ impl Resolve for SsrfGuardResolver {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The security-critical case: given a mix of blocked and allowed
+    /// addresses (as a rebinding attacker might produce by returning both
+    /// a public IP and a loopback/link-local IP for one hostname), the
+    /// filter must drop only the blocked ones and keep the allowed one(s)
+    /// intact — proving this is per-address filtering, not an
+    /// all-or-nothing decision keyed off the first address.
+    #[test]
+    fn filter_allowed_drops_only_blocked_from_mixed_input() {
+        let blocked_loopback: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let blocked_metadata: SocketAddr = "169.254.169.254:0".parse().unwrap();
+        let allowed: SocketAddr = "93.184.216.34:0".parse().unwrap();
+
+        let result = filter_allowed([blocked_loopback, allowed, blocked_metadata]);
+
+        assert_eq!(
+            result,
+            vec![allowed],
+            "expected only the non-blocked address to survive, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_allowed_all_blocked_returns_empty() {
+        let blocked_loopback: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let blocked_metadata: SocketAddr = "169.254.169.254:0".parse().unwrap();
+
+        let result = filter_allowed([blocked_loopback, blocked_metadata]);
+
+        assert!(
+            result.is_empty(),
+            "expected all-blocked input to yield an empty result, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn filter_allowed_all_allowed_unchanged() {
+        let a: SocketAddr = "93.184.216.34:0".parse().unwrap();
+        let b: SocketAddr = "8.8.8.8:0".parse().unwrap();
+
+        let result = filter_allowed([a, b]);
+
+        assert_eq!(
+            result,
+            vec![a, b],
+            "expected all-allowed input to pass through unchanged, got {result:?}"
+        );
+    }
 
     #[tokio::test]
     async fn resolver_rejects_localhost() {

--- a/backend/src/services/ssrf_dns.rs
+++ b/backend/src/services/ssrf_dns.rs
@@ -1,0 +1,75 @@
+//! SSRF-validating DNS resolver: rejects hostnames that resolve to blocked
+//! (loopback / link-local / private / cloud-metadata) IPs at connect time,
+//! closing the DNS-rebinding gap that URL-string validation cannot catch.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+/// A `reqwest` DNS resolver that resolves via the OS resolver and then drops
+/// any address rejected by [`crate::api::validation::is_blocked_resolved_ip`].
+/// If every resolved address is blocked, resolution fails (the request never
+/// connects), defeating DNS-rebinding attacks that pass the URL-string check.
+#[derive(Debug, Default, Clone)]
+pub struct SsrfGuardResolver;
+
+/// Convenience: an `Arc<dyn Resolve>` for `ClientBuilder::dns_resolver`.
+pub fn ssrf_guard_resolver() -> Arc<dyn Resolve> {
+    Arc::new(SsrfGuardResolver)
+}
+
+impl Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        Box::pin(async move {
+            let host = name.as_str().to_string();
+            // Port 0 is a placeholder; reqwest substitutes the real port.
+            let resolved = tokio::net::lookup_host((host.as_str(), 0)).await?;
+            let allowed: Vec<SocketAddr> = resolved
+                .filter(|sa| !crate::api::validation::is_blocked_resolved_ip(sa.ip()))
+                .collect();
+            if allowed.is_empty() {
+                let err: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "all resolved addresses blocked by SSRF policy",
+                ));
+                return Err(err);
+            }
+            let addrs: Addrs = Box::new(allowed.into_iter());
+            Ok(addrs)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolver_rejects_localhost() {
+        // `localhost` resolves to 127.0.0.1 / ::1, both blocked.
+        let name: Name = "localhost".parse().expect("valid dns name");
+        let result = SsrfGuardResolver.resolve(name).await;
+        assert!(
+            result.is_err(),
+            "localhost must be refused by the SSRF resolver"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolver_allows_non_blocked_ip_literal() {
+        // An IP literal resolves synchronously (no real DNS/network I/O,
+        // per std's `ToSocketAddrs` fast path) and 1.1.1.1 is a public
+        // address, so the allow-path (not just the reject-path) must let it
+        // through with at least one address.
+        let name: Name = "1.1.1.1".parse().expect("valid dns name");
+        let mut addrs = SsrfGuardResolver
+            .resolve(name)
+            .await
+            .expect("a non-blocked IP literal must resolve successfully");
+        assert!(
+            addrs.next().is_some(),
+            "expected at least one allowed address"
+        );
+    }
+}

--- a/docs/plans/2026-07-09-rpm-phase1-proxy-hardening-plan.md
+++ b/docs/plans/2026-07-09-rpm-phase1-proxy-hardening-plan.md
@@ -367,13 +367,23 @@ At the immutable-write site found in Step 1, before persisting, when `expected_s
 
 Model it on the existing proxy_service cache tests (search `#[tokio::test]` in that file). Assert: fetch a `repodata/<64hex>-primary.xml.gz` whose body hashes differently → body returned to caller, no cache sidecar written.
 
-- [ ] **Step 8: Run tests + fmt/clippy, then commit**
+- [ ] **Step 8: Interim one-object-over-quota guard (S2 interim; full quota → P4)**
+
+At the SAME buffered cache-write decision point, add a cheap guard: if `repo.quota_bytes` is
+`Some(q)` and the object being cached is larger than `q`, skip the cache write (still stream/return
+to the client) and log a `target: "security"` warning + metric. This is the Phase-1 interim for
+bug `artifact-keeper-x70`; true per-repo usage accounting + eviction is deferred to P4 (proxy cache
+is NOT recorded in the `artifacts` table, so there is no per-repo proxy-cache usage figure to check
+a running total against yet). Add a pure helper + unit test for the decision, e.g.
+`fn exceeds_single_object_quota(quota_bytes: Option<i64>, object_len: i64) -> bool`.
+
+- [ ] **Step 9: Run tests + fmt/clippy, then commit**
 
 ```bash
 cargo test -p artifact-keeper-backend --lib cache_classifier:: proxy_service::
 cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings
 git add backend/src/services/cache_classifier.rs backend/src/services/proxy_service.rs
-git commit -m "fix(security): verify content-addressed body hash before immutable caching"
+git commit -m "fix(security): verify content-addressed hash + reject over-quota single objects before caching"
 ```
 
 ---
@@ -478,13 +488,12 @@ without that read would mean guessing — against this skill's "no placeholders"
 ~15-minute read of the named functions first, after which its task is written to the same standard
 as Tasks 1–4.
 
-- **Task 5 — Cache quota enforcement (`artifact-keeper-x70`, S2).** Read the cache-write sites
-  (`proxy_service.rs` ~1085 buffered `storage.put`, ~1268–1290 streaming writer) and how a Remote
-  repo's cached bytes are accounted (are proxied blobs recorded in `artifacts`, i.e. counted by the
-  `SUM(size_bytes)` usage query at `repository_service.rs:1307`, or only under `proxy-cache/` keys?).
-  Then: before an immutable cache write, if `repo.quota_bytes` is `Some(q)` and
-  `current_usage + object_size > q`, skip the cache write (still stream to client) + warn/metric.
-  Reuse `exceeds_quota_warning_threshold` / the `artifact_service.rs:662` quota pattern.
+- **Task 5 — Full cache quota enforcement — MOVED TO P4 (bug `artifact-keeper-x70`).** Confirmed:
+  proxy-cache blobs are NOT recorded in the `artifacts` table (test
+  `proxy_service.rs:10266 test_cache_artifact_does_not_insert_into_artifacts_table`), so there is no
+  per-repo proxy-cache usage figure to enforce a running total against. True enforcement needs a
+  usage-accounting mechanism (per-repo counter + eviction) that belongs with P4's GC. **Phase-1
+  interim** (reject caching a single object larger than `quota_bytes`) is folded into Task 3 Step 8.
 - **Task 6 — Range/`206` passthrough (§8.2.2).** Read `fetch_artifact_streaming_uncoordinated`
   (`proxy_service.rs:2974`) and the upstream request builder it calls, to see where request headers
   are set. Then: forward the client `Range` header, relay `206`/`Content-Range`/`Accept-Ranges`, and

--- a/docs/plans/2026-07-09-rpm-phase1-proxy-hardening-plan.md
+++ b/docs/plans/2026-07-09-rpm-phase1-proxy-hardening-plan.md
@@ -1,0 +1,508 @@
+# RPM Proxy Hardening (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Harden Artifact Keeper's already-shipping Remote proxy for RPM: fix the DNS-rebinding SSRF gap, enforce cache quota, classify RPM cache freshness correctly, verify content-addressed integrity, and reject mirrorlist/metalink upstreams.
+
+**Architecture:** Small, surgical changes to existing modules — a new SSRF-validating DNS resolver wired into the shared `base_client_builder`; an `Rpm` arm added to the central `cache_classifier`; validation and cache-write guards. No new tables. Reuses `is_blocked_resolved_ip`, `cache_classifier`, `validate_remote_upstream`, and existing quota helpers.
+
+**Tech Stack:** Rust, Axum, reqwest (workspace dep), sqlx/PostgreSQL, tokio.
+
+**Tracking:** beads epic `artifact-keeper-1gx`; this plan implements task `1gx.1` and bugs `artifact-keeper-3to` (SSRF) and `artifact-keeper-x70` (quota). Design: `docs/plans/2026-07-09-rpm-remote-proxy-design.md` (§6 S1/S2/S3/S9, §8).
+
+## Global Constraints
+
+- Branch `feat/rpm-remote-proxy`; never push to main; PR + squash-merge after CI.
+- CI gates (all must pass): `cargo fmt --check`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test --workspace --lib`; **≥70% coverage on changed lines**; **≤3% jscpd duplication on changed files**.
+- Keep new logic in **pure, table-testable functions** (coverage + duplication gates).
+- Streaming invariant (#1608): never buffer a full artifact body on an artifact path.
+- Do NOT construct a new `reqwest::Client`; all outbound HTTP goes through `http_client::base_client_builder()`.
+- No `Co-Authored-By` / AI-attribution in commits.
+
+---
+
+### Task 1: SSRF-validating DNS resolver (fixes `artifact-keeper-3to`, design S1)
+
+Closes the DNS-rebinding gap: URL strings are validated at config time and every redirect hop, but the *resolved IP* of the initial request is never checked. Wire a custom `reqwest::dns::Resolve` into `base_client_builder` that rejects any resolved IP failing `is_blocked_resolved_ip`.
+
+**Files:**
+- Create: `backend/src/services/ssrf_dns.rs`
+- Modify: `backend/src/services/mod.rs` (add `pub mod ssrf_dns;`)
+- Modify: `backend/src/services/http_client.rs:59-97` (`base_client_builder`) — attach the resolver
+- Test: in `backend/src/services/ssrf_dns.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `crate::api::validation::is_blocked_resolved_ip(std::net::IpAddr) -> bool` (validation.rs:265).
+- Produces: `pub struct SsrfGuardResolver;` implementing `reqwest::dns::Resolve`; `base_client_builder()` returns a `ClientBuilder` whose DNS resolution rejects blocked IPs.
+
+- [ ] **Step 1: Write the failing test** (create `backend/src/services/ssrf_dns.rs` with just the test + an empty resolver stub referenced by it)
+
+```rust
+//! SSRF-validating DNS resolver: rejects hostnames that resolve to blocked
+//! (loopback / link-local / private / cloud-metadata) IPs at connect time,
+//! closing the DNS-rebinding gap that URL-string validation cannot catch.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
+
+/// A `reqwest` DNS resolver that resolves via the OS resolver and then drops
+/// any address rejected by [`crate::api::validation::is_blocked_resolved_ip`].
+/// If every resolved address is blocked, resolution fails (the request never
+/// connects), defeating DNS-rebinding attacks that pass the URL-string check.
+#[derive(Debug, Default, Clone)]
+pub struct SsrfGuardResolver;
+
+/// Convenience: an `Arc<dyn Resolve>` for `ClientBuilder::dns_resolver`.
+pub fn ssrf_guard_resolver() -> Arc<dyn Resolve> {
+    Arc::new(SsrfGuardResolver)
+}
+
+impl Resolve for SsrfGuardResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        Box::pin(async move {
+            let host = name.as_str().to_string();
+            // Port 0 is a placeholder; reqwest substitutes the real port.
+            let resolved = tokio::net::lookup_host((host.as_str(), 0)).await?;
+            let allowed: Vec<SocketAddr> = resolved
+                .filter(|sa| !crate::api::validation::is_blocked_resolved_ip(sa.ip()))
+                .collect();
+            if allowed.is_empty() {
+                let err: Box<dyn std::error::Error + Send + Sync> = Box::new(
+                    std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "all resolved addresses blocked by SSRF policy",
+                    ),
+                );
+                return Err(err);
+            }
+            let addrs: Addrs = Box::new(allowed.into_iter());
+            Ok(addrs)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolver_rejects_localhost() {
+        // `localhost` resolves to 127.0.0.1 / ::1, both blocked.
+        let name: Name = "localhost".parse().expect("valid dns name");
+        let result = SsrfGuardResolver.resolve(name).await;
+        assert!(result.is_err(), "localhost must be refused by the SSRF resolver");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p artifact-keeper-backend --lib ssrf_dns::tests::resolver_rejects_localhost -- --nocapture`
+Expected: FAIL to compile until `pub mod ssrf_dns;` is added, then the test passes once the module compiles. (If `Name: FromStr` is unavailable in the pinned reqwest, see Step 3 note.)
+
+- [ ] **Step 3: Register the module and confirm the resolver compiles**
+
+Add to `backend/src/services/mod.rs` (alphabetical with the other `pub mod` lines):
+
+```rust
+pub mod ssrf_dns;
+```
+
+Note: if `Name` does not implement `FromStr` in the pinned reqwest version, change the test to build a client with the resolver and assert `client.get("http://localhost/").send().await` errors (an integration-level assertion). Verify the API with `cargo doc -p reqwest --open` or `grep "impl FromStr for Name" ~/.cargo`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cargo test -p artifact-keeper-backend --lib ssrf_dns::tests::resolver_rejects_localhost`
+Expected: PASS.
+
+- [ ] **Step 5: Wire the resolver into `base_client_builder`**
+
+In `backend/src/services/http_client.rs`, change the builder construction (currently line 62):
+
+```rust
+    let mut builder = reqwest::Client::builder()
+        .redirect(ssrf_redirect_policy())
+        .dns_resolver(crate::services::ssrf_dns::ssrf_guard_resolver());
+```
+
+- [ ] **Step 6: Add a client-level regression test** (in `http_client.rs` tests module, mirroring `test_redirect_to_blocked_ip_is_refused`)
+
+```rust
+    /// A hostname resolving to a blocked IP must be refused at DNS time, not
+    /// connected to. `localhost` resolves to 127.0.0.1/::1 (blocked).
+    #[tokio::test]
+    async fn test_client_refuses_host_resolving_to_blocked_ip() {
+        let client = base_client_builder().build().unwrap();
+        let err = client
+            .get("http://localhost/")
+            .send()
+            .await
+            .expect_err("host resolving to a blocked IP must be refused");
+        // A DNS/connect-layer rejection (not a live HTTP response).
+        assert!(
+            err.is_connect() || err.is_request() || err.to_string().to_lowercase().contains("ssrf") || err.to_string().to_lowercase().contains("block"),
+            "expected resolver rejection, got: {err}"
+        );
+    }
+```
+
+- [ ] **Step 7: Run the focused + regression tests, then fmt/clippy**
+
+Run: `cargo test -p artifact-keeper-backend --lib ssrf_dns:: http_client::tests::test_client_refuses_host_resolving_to_blocked_ip`
+Then: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings`
+Expected: PASS; no clippy warnings.
+
+- [ ] **Step 8: Run the existing http_client SSRF tests to confirm no regression**
+
+Run: `cargo test -p artifact-keeper-backend --lib http_client::tests`
+Expected: PASS (including `test_redirect_to_blocked_ip_is_refused`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/src/services/ssrf_dns.rs backend/src/services/mod.rs backend/src/services/http_client.rs
+git commit -m "fix(security): validate resolved IP at connect time (DNS-rebinding SSRF)"
+```
+
+---
+
+### Task 2: RPM cache-freshness classifier arm (implements `artifact-keeper-1gx.1` core, design S9/§8.2.1)
+
+RPM currently falls into `cache_classifier::classify`'s conservative `_ => mutable_default()` (300s), so content-addressed `repodata/<sha256>-*.xml.gz`, `.rpm`, `.drpm`, `.zck` are needlessly revalidated every 5 min. Add an `Rpm` arm: content-addressed metadata + packages → `Immutable`; `repomd.xml`(+`.asc`) → mutable default.
+
+**Files:**
+- Modify: `backend/src/services/cache_classifier.rs` (add `classify_rpm`; add `Rpm` arm at the match near line 216–220; add `Rpm` to `is_explicitly_mutable_index`'s real-classifier arm at line 247–264 and remove it from the `_` comment at 276)
+- Test: same file (`#[cfg(test)]` table test)
+
+**Interfaces:**
+- Consumes: `Mutability`, `Mutability::Immutable`, `Mutability::mutable_default()`, `leaf(&str)` (existing helper used by `classify_maven`).
+- Produces: `fn classify_rpm(lower: &str) -> Mutability`; `classify(&RepositoryFormat::Rpm, path)` returns correct mutability.
+
+- [ ] **Step 1: Write the failing table test**
+
+```rust
+    #[test]
+    fn test_classify_rpm() {
+        use RepositoryFormat::Rpm;
+        // repomd.xml and its signature are the mutable entry point.
+        assert_eq!(classify(&Rpm, "repodata/repomd.xml"), Mutability::mutable_default());
+        assert_eq!(classify(&Rpm, "repodata/repomd.xml.asc"), Mutability::mutable_default());
+        // Content-addressed metadata (checksum-prefixed) is immutable.
+        assert_eq!(
+            classify(&Rpm, "repodata/1a2b3c4d-primary.xml.gz"),
+            Mutability::Immutable
+        );
+        assert_eq!(
+            classify(&Rpm, "repodata/deadbeef-primary.xml.zck"),
+            Mutability::Immutable
+        );
+        // Packages are immutable.
+        assert_eq!(classify(&Rpm, "Packages/foo-1.2-3.x86_64.rpm"), Mutability::Immutable);
+        assert_eq!(classify(&Rpm, "getPackage/bar-2.0-1.noarch.drpm"), Mutability::Immutable);
+        // Unknown / directory-ish paths stay conservative.
+        assert_eq!(classify(&Rpm, "repodata/"), Mutability::mutable_default());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p artifact-keeper-backend --lib cache_classifier::tests::test_classify_rpm`
+Expected: FAIL (RPM currently returns `mutable_default()` for the content-addressed/package cases).
+
+- [ ] **Step 3: Add the `Rpm` arm and `classify_rpm`**
+
+In `classify` (near line 216, before the `_ =>` arm) add:
+
+```rust
+        // -- RPM / YUM ------------------------------------------------------
+        // repomd.xml(+.asc) is the single mutable entry point; every other
+        // repodata file is content-addressed (checksum-prefixed filename) and
+        // packages are version-pinned — both immutable.
+        RepositoryFormat::Rpm => classify_rpm(&lower),
+```
+
+Add the helper (next to `classify_maven`):
+
+```rust
+/// RPM: `repodata/repomd.xml`(+`.asc`) is the mutable index; all other
+/// `repodata/<checksum>-*` files are content-addressed and packages
+/// (`.rpm`/`.drpm`) are version-pinned — both immutable.
+fn classify_rpm(lower: &str) -> Mutability {
+    let leaf = leaf(lower);
+    // The mutable pointer and its detached signature.
+    if leaf == "repomd.xml" || leaf == "repomd.xml.asc" {
+        return Mutability::mutable_default();
+    }
+    // Packages are immutable.
+    if leaf.ends_with(".rpm") || leaf.ends_with(".drpm") {
+        return Mutability::Immutable;
+    }
+    // Content-addressed metadata under repodata/: a checksum-prefixed name such
+    // as `<hex>-primary.xml.gz` / `.zck`. Require a hex prefix before the first
+    // '-' so a bare `primary.xml.gz` (no unique-filename) stays conservative.
+    if lower.starts_with("repodata/") {
+        if let Some((prefix, _rest)) = leaf.split_once('-') {
+            let looks_hashed = prefix.len() >= 8 && prefix.chars().all(|c| c.is_ascii_hexdigit());
+            if looks_hashed {
+                return Mutability::Immutable;
+            }
+        }
+    }
+    // Unknown path: revalidate.
+    Mutability::mutable_default()
+}
+```
+
+- [ ] **Step 4: Add `Rpm` to `is_explicitly_mutable_index` for consistency**
+
+In `is_explicitly_mutable_index` (line 247), add `| RepositoryFormat::Rpm` to the real-classifier arm so `repomd.xml` reports as a mutable index and content-addressed/package paths report as release coordinates:
+
+```rust
+        | RepositoryFormat::Cargo
+        | RepositoryFormat::Debian
+        | RepositoryFormat::Rpm => !classify(format, &lower).is_immutable(),
+```
+
+Update the `_ =>` comment at line 276 to drop `Rpm` from the "Default-format families" list.
+
+- [ ] **Step 5: Add a test pinning `is_explicitly_mutable_index` for RPM**
+
+```rust
+    #[test]
+    fn test_rpm_explicit_mutable_index() {
+        use RepositoryFormat::Rpm;
+        assert!(is_explicitly_mutable_index(&Rpm, "repodata/repomd.xml"));
+        assert!(!is_explicitly_mutable_index(&Rpm, "Packages/foo-1.2-3.x86_64.rpm"));
+        assert!(!is_explicitly_mutable_index(&Rpm, "repodata/deadbeef-primary.xml.gz"));
+    }
+```
+
+- [ ] **Step 6: Run tests + fmt/clippy**
+
+Run: `cargo test -p artifact-keeper-backend --lib cache_classifier::`
+Then: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 7: Regression — the hosted RPM release-immutability guard**
+
+Run the RPM handler + release-guard tests to confirm hosted RPM behavior is unchanged:
+Run: `cargo test -p artifact-keeper-backend --lib rpm`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/src/services/cache_classifier.rs
+git commit -m "feat(rpm): classify RPM proxy cache freshness (immutable pkgs/metadata, mutable repomd)"
+```
+
+---
+
+### Task 3: Verify content-addressed integrity before caching (design S3)
+
+When a fetched path embeds a hex checksum (createrepo unique-filename convention), verify the body's SHA-256 matches before caching it as immutable; on mismatch, serve the body but refuse to cache (treat as miss). This makes the "cache forever" decision safe against a dishonest/compromised upstream.
+
+**Files:**
+- Modify: `backend/src/services/cache_classifier.rs` (add a pure `expected_sha256_from_path`)
+- Modify: `backend/src/services/proxy_service.rs` (call the check at the immutable-cache-write site; exact site read in Step 1)
+- Test: `cache_classifier.rs` for the pure extractor; `proxy_service.rs` for the write guard
+
+**Interfaces:**
+- Produces: `pub fn expected_sha256_from_path(path: &str) -> Option<&str>` — returns the hex checksum prefix of a content-addressed repodata filename, if present.
+
+- [ ] **Step 1: Read the immutable cache-write site**
+
+Read `backend/src/services/proxy_service.rs` around the streaming cache writer (lines ~1268–1290 and ~2895–2965, where `size_bytes`/`bytes_written` and `storage_clone.put(...)` appear). Identify where a freshly-fetched *immutable* body is persisted; that is where the S3 guard hooks in.
+
+- [ ] **Step 2: Write the failing test for the pure extractor**
+
+```rust
+    #[test]
+    fn test_expected_sha256_from_path() {
+        // Full SHA-256 (64 hex) prefix is returned.
+        let p = "repodata/9f".to_string() + &"a".repeat(62) + "-primary.xml.gz";
+        assert!(expected_sha256_from_path(&p).is_some());
+        // repomd.xml and packages have no embedded checksum.
+        assert_eq!(expected_sha256_from_path("repodata/repomd.xml"), None);
+        assert_eq!(expected_sha256_from_path("Packages/foo-1.2-3.x86_64.rpm"), None);
+    }
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `cargo test -p artifact-keeper-backend --lib cache_classifier::tests::test_expected_sha256_from_path`
+Expected: FAIL (function not defined).
+
+- [ ] **Step 4: Implement the extractor**
+
+```rust
+/// If `path` is a createrepo unique-filename (`repodata/<sha256>-<name>`),
+/// return the 64-hex-char checksum prefix. Used to verify a content-addressed
+/// body's integrity before caching it as immutable.
+pub fn expected_sha256_from_path(path: &str) -> Option<&str> {
+    let leaf = leaf(&path.to_ascii_lowercase());
+    let (prefix, _) = leaf.split_once('-')?;
+    if prefix.len() == 64 && prefix.chars().all(|c| c.is_ascii_hexdigit()) {
+        // Return the slice from the ORIGINAL path (case-insensitive hex).
+        let start = path.len() - leaf.len();
+        Some(&path[start..start + 64])
+    } else {
+        None
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `cargo test -p artifact-keeper-backend --lib cache_classifier::tests::test_expected_sha256_from_path`
+Expected: PASS.
+
+- [ ] **Step 6: Guard the immutable cache write in `proxy_service.rs`**
+
+At the immutable-write site found in Step 1, before persisting, when `expected_sha256_from_path(cache_path)` is `Some(expected)`, compute the SHA-256 of the fetched bytes and skip the cache write (log a `target: "security"` warning + `metrics_service` counter) if it differs. Reuse the existing hashing helper used for `checksum_sha256` (see `proxy_service.rs:835-852`). Write the exact code against the real function once Step 1 identifies it.
+
+- [ ] **Step 7: Add a proxy_service test asserting a mismatched content-addressed body is not cached**
+
+Model it on the existing proxy_service cache tests (search `#[tokio::test]` in that file). Assert: fetch a `repodata/<64hex>-primary.xml.gz` whose body hashes differently → body returned to caller, no cache sidecar written.
+
+- [ ] **Step 8: Run tests + fmt/clippy, then commit**
+
+```bash
+cargo test -p artifact-keeper-backend --lib cache_classifier:: proxy_service::
+cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings
+git add backend/src/services/cache_classifier.rs backend/src/services/proxy_service.rs
+git commit -m "fix(security): verify content-addressed body hash before immutable caching"
+```
+
+---
+
+### Task 4: Reject mirrorlist/metalink upstreams for Remote RPM repos (design §8.2.6)
+
+A Remote RPM repo must point at one concrete baseurl; a mirrorlist/metalink URL would cache a rotating mirror list. Reject it at repo create/update.
+
+**Files:**
+- Modify: `backend/src/services/repository_service.rs:92-108` (`validate_remote_upstream`)
+- Test: `repository_service.rs` (`#[cfg(test)]`)
+
+**Interfaces:**
+- Consumes: `RepositoryType`, `RepositoryFormat`, existing `AppError::Validation`.
+- Produces: `validate_remote_upstream(repo_type, upstream_url, format)` now also rejects mirrorlist/metalink for RPM. (Add a `format: &RepositoryFormat` parameter; update the two call sites at :542 and near :897.)
+
+- [ ] **Step 1: Write the failing test**
+
+```rust
+    #[test]
+    fn test_rpm_remote_rejects_mirrorlist_and_metalink() {
+        let ml = Some("https://mirrors.example.org/mirrorlist?repo=epel-9&arch=x86_64".to_string());
+        let mt = Some("https://mirrors.example.org/metalink?repo=epel-9".to_string());
+        let base = Some("https://dl.rockylinux.org/pub/rocky/9/BaseOS/x86_64/os/".to_string());
+        assert!(validate_remote_upstream(&RepositoryType::Remote, &ml, &RepositoryFormat::Rpm).is_err());
+        assert!(validate_remote_upstream(&RepositoryType::Remote, &mt, &RepositoryFormat::Rpm).is_err());
+        assert!(validate_remote_upstream(&RepositoryType::Remote, &base, &RepositoryFormat::Rpm).is_ok());
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cargo test -p artifact-keeper-backend --lib repository_service::tests::test_rpm_remote_rejects_mirrorlist_and_metalink`
+Expected: FAIL (signature mismatch — function has no `format` param yet).
+
+- [ ] **Step 3: Add the `format` param + rejection logic**
+
+Update `validate_remote_upstream`:
+
+```rust
+pub(crate) fn validate_remote_upstream(
+    repo_type: &RepositoryType,
+    upstream_url: &Option<String>,
+    format: &RepositoryFormat,
+) -> Result<()> {
+    if *repo_type == RepositoryType::Remote {
+        match upstream_url {
+            None => {
+                return Err(AppError::Validation(
+                    "Remote repository must have an upstream URL".to_string(),
+                ));
+            }
+            Some(url) => {
+                validate_outbound_url(url, "Upstream URL")?;
+                if *format == RepositoryFormat::Rpm && is_mirrorlist_or_metalink(url) {
+                    return Err(AppError::Validation(
+                        "RPM remote upstream must be a concrete baseurl, not a mirrorlist/metalink \
+                         URL. Point it at a resolved repo root (e.g. .../BaseOS/x86_64/os/)."
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+    } else if let Some(url) = upstream_url {
+        validate_outbound_url(url, "Upstream URL")?;
+    }
+    Ok(())
+}
+
+/// Heuristic: a URL whose path or query names a mirrorlist/metalink endpoint.
+fn is_mirrorlist_or_metalink(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.contains("mirrorlist") || lower.contains("metalink")
+}
+```
+
+- [ ] **Step 4: Update the two call sites**
+
+At `repository_service.rs:542`: `validate_remote_upstream(&req.repo_type, &req.upstream_url, &req.format)?;`
+Near `:897` (update path): pass the repository's format (fetch from the existing loaded row / `req.format`). Confirm the field name by reading the surrounding update function.
+
+- [ ] **Step 5: Run tests + fmt/clippy**
+
+Run: `cargo test -p artifact-keeper-backend --lib repository_service::`
+Then: `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/repository_service.rs
+git commit -m "feat(rpm): reject mirrorlist/metalink upstreams for remote RPM repos"
+```
+
+---
+
+## Remaining P1 tasks — need one short code-read before exact steps
+
+These two items are **in Phase-1 scope** (design S2 + §8.2.2) but sit inside `proxy_service`'s
+streaming path, whose exact function bodies I have not yet read. Writing bite-sized code for them
+without that read would mean guessing — against this skill's "no placeholders" rule. Each needs a
+~15-minute read of the named functions first, after which its task is written to the same standard
+as Tasks 1–4.
+
+- **Task 5 — Cache quota enforcement (`artifact-keeper-x70`, S2).** Read the cache-write sites
+  (`proxy_service.rs` ~1085 buffered `storage.put`, ~1268–1290 streaming writer) and how a Remote
+  repo's cached bytes are accounted (are proxied blobs recorded in `artifacts`, i.e. counted by the
+  `SUM(size_bytes)` usage query at `repository_service.rs:1307`, or only under `proxy-cache/` keys?).
+  Then: before an immutable cache write, if `repo.quota_bytes` is `Some(q)` and
+  `current_usage + object_size > q`, skip the cache write (still stream to client) + warn/metric.
+  Reuse `exceeds_quota_warning_threshold` / the `artifact_service.rs:662` quota pattern.
+- **Task 6 — Range/`206` passthrough (§8.2.2).** Read `fetch_artifact_streaming_uncoordinated`
+  (`proxy_service.rs:2974`) and the upstream request builder it calls, to see where request headers
+  are set. Then: forward the client `Range` header, relay `206`/`Content-Range`/`Accept-Ranges`, and
+  do **not** cache partial responses. Integration test: `curl -r 0-1023` through the proxy returns
+  `206`. E2E: `dnf` zchunk delta path works.
+
+---
+
+## Final integration (after Tasks 1–6)
+
+- [ ] **E2E:** add a script under `scripts/native-tests/` that creates a Remote RPM repo pointing at
+  Rocky 9 BaseOS, runs `dnf --disablerepo=* --enablerepo=<ak> install <small-pkg>` with
+  `repo_gpgcheck=1`, then a second install served from cache (assert no upstream hit via proxy
+  metrics/logs). Wire it into the existing native-test runner.
+- [ ] **Full gate run:** `cargo fmt --check && cargo clippy --workspace --all-targets -- -D warnings && cargo test --workspace --lib`; confirm ≥70% changed-line coverage and ≤3% jscpd locally before pushing.
+- [ ] **Update beads:** mark `artifact-keeper-3to`, `artifact-keeper-x70` resolved when their tasks land; note progress on `artifact-keeper-1gx.1`.
+
+## Self-review notes
+- Spec coverage: S1 (Task 1), S3 (Task 3), classifier/S9 (Task 2), mirrorlist (Task 4), S2 (Task 5), Range (Task 6). All §8.2 items mapped.
+- Type consistency: `SsrfGuardResolver`/`ssrf_guard_resolver`, `classify_rpm`, `expected_sha256_from_path`, `is_mirrorlist_or_metalink`, `validate_remote_upstream(_, _, format)` used consistently across tasks.
+- Tasks 1–4 are independently shippable (Task 1 alone is a security fix worth merging).

--- a/docs/plans/2026-07-09-rpm-remote-proxy-design.md
+++ b/docs/plans/2026-07-09-rpm-remote-proxy-design.md
@@ -104,6 +104,39 @@ metadata-only.
   `release_repository_id`, reusing `ensure_promotion_authorized`/tenant checks **and the existing
   scan gates** (mirrored content must not bypass Grype/Dependency-Track).
 
+### 4a. Confirmed target workflow — Rocky 10, curate + AK-sign
+
+Operator confirmed (2026-07-09): mirror **BaseOS / AppStream / CRB / Extras / EPEL** — all
+**public** EL10 rebuild repos, so **no entitlement certs and P6 is not required for this
+deployment**. Workflow: **mirror → scan/approve (may hold back individual packages) → promote →
+serve internally, DNF-valid.**
+
+Decisions this locks in:
+
+- **Curate + AK-sign metadata.** Because approval can hold back individual packages, a promoted repo
+  may differ from upstream, so AK **regenerates** repomd/primary/filelists/other from the approved
+  set and signs with **AK's** key (served at the existing `/rpm/{repo}/repodata/repomd.xml.key`).
+  `repo_gpgcheck` then trusts AK's key; **package-level `gpgcheck` still validates each RPM against
+  Rocky's key** (unchanged). Clients import AK's repo key once.
+- **This overrides §5's "opaque carry-through" YAGNI for package-enumerating metadata.** Curation
+  *is* package filtering, which is incompatible with carrying `filelists`/`other` opaquely (dnf
+  cross-checks filelists against primary by pkgid). P2/P3 must **regenerate primary + filelists +
+  other** from the package set. `comps` (groups) and `updateinfo` (advisories) may still be carried
+  opaquely — an advisory referencing a held-back package simply won't resolve, which is acceptable.
+- **`immediate` (full) mirror is this track's default mode.** "Serve internally" must not depend on
+  reaching upstream at request time, and a full local mirror lets AK regenerate filelists/other
+  **from the stored RPM headers by reusing the existing hosted-repo metadata generation**
+  (`formats/rpm.rs` + the `filelists_xml_gz`/`primary_xml_gz` handlers) instead of writing a
+  from-scratch filelists parser. This **pulls P4's `immediate` mode forward** in this track and
+  makes P3 publish reuse hosted generation rather than opaque carry-through.
+- **Scale note.** A full EL10 BaseOS+AppStream+CRB+Extras+EPEL mirror is large (many GB, tens of
+  thousands of packages); the scan/approve step is a correspondingly large Grype/Dependency-Track
+  workload. Budget disk + scan time; prefer scanning at sync time so promotion gates read cached
+  results.
+
+Net effect on phases: this workflow completes at **P3 + P5**, with **P4 `immediate` mode brought in
+early**; **P1 remains the substrate**; **P6 is dropped** for this deployment.
+
 ---
 
 ## 5. Reuse-vs-rebuild & deliberate divergences
@@ -113,10 +146,13 @@ SSRF-aware client (no bespoke client permitted), `encryption.rs` for certs, prom
 `release_repository_id`/authz/scan-gates, `cluster_work` leases. **Rebuild:** none of the proxy
 stack. **Rename:** mirror sync table → `rpm_remote_sync_tasks`.
 
-**YAGNI v1 (skip):** `streamed` policy; bit-for-bit republish; parsing filelists/other/updateinfo/
-modules (opaque carry-through only → **no package filtering/sub-repos v1**); sqlite `_db`, drpm,
-zchunk *generation*; mirrorlist/metalink serving; shared Remotes; hosted-repo versioning;
-Distribution as a separate entity (use `active_publication_id`).
+**YAGNI v1 (skip):** `streamed` policy; bit-for-bit republish; sqlite `_db`, drpm, zchunk
+*generation*; mirrorlist/metalink serving; shared Remotes; hosted-repo versioning; Distribution as a
+separate entity (use `active_publication_id`). `comps`/`updateinfo`/`modules` carried opaquely.
+
+**Overridden by §4a (curate track):** primary/filelists/other are **regenerated** (not opaque),
+because curation requires package filtering; reuse the existing hosted-repo generation from local
+RPM headers under `immediate` mode.
 
 ---
 

--- a/docs/plans/2026-07-09-rpm-remote-proxy-design.md
+++ b/docs/plans/2026-07-09-rpm-remote-proxy-design.md
@@ -1,0 +1,295 @@
+# Design: RPM/YUM Remote Mirroring & Promotion
+
+**Date:** 2026-07-09
+**Status:** Approved (design) — Phase 1 ready for implementation planning
+**Author:** Brandon Geraci (with Claude Code)
+**Scope:** Add Pulp-grade RPM/YUM mirroring and promotion to Artifact Keeper, delivered as a
+sequenced set of independently-shippable phases. This document specifies the **target
+architecture**, the **6-phase roadmap**, and **Phase 1** in implementation-ready detail.
+Phases 2–6 are specified at roadmap altitude and will each get their own design doc.
+
+---
+
+## 1. Motivation
+
+Artifact Keeper today serves RPMs only as a **hosted** (`Local`) repository: upload, download,
+on-demand `repodata` generation (repomd.xml / primary.xml / filelists.xml), and detached GPG
+signing. It cannot mirror an upstream OS/vendor repository (Rocky, Alma, EPEL, Fedora, RHEL),
+which is the capability Pulp and Artifactory/Nexus provide.
+
+The goal is to let a `Remote` RPM repository **pull-through and/or fully sync** an upstream, make
+the mirrored content **searchable and versioned**, support **point-in-time snapshots**, run
+**scheduled syncs**, and **promote** mirrored content through staging→release stages.
+
+### Non-goals (this effort)
+- Mirroring non-RPM formats via this machinery (RPM-only tables in v1; generalize later if a
+  second synced format demands it).
+- Being a drop-in Pulp replacement. We deliberately diverge from Pulp where the cost is not
+  justified (see §5).
+
+---
+
+## 2. Existing building blocks (reuse inventory)
+
+Verified against the codebase; these are the assets Phase 1+ build on.
+
+| Asset | Location | Role in this design |
+|---|---|---|
+| `ProxyService` | `backend/src/services/proxy_service.rs` | Generic pull-through: TTL, ETag revalidation, SHA-256 verification, storage-backed cache (`proxy-cache/{repo_key}/{path}` + `.__metadata__.json`), conditional HEAD. **Currently has zero callers.** Reuse + extend. |
+| `RepositoryType` enum | `backend/src/models/repository.rs` | `Local`, `Remote` (scaffolded/unwired), `Virtual`, `Staging`. `Remote` + `upstream_url` are the entry point. |
+| `Repository` fields | same | Already has `upstream_url`, `promotion_target_id`, `promotion_policy_id`, `quota_bytes`, `storage_backend`, `storage_path`. |
+| RPM handlers | `backend/src/api/handlers/rpm.rs` | Routes at `/rpm/{repo_key}/...`. **`download_package` reads the local `artifacts` table + `FilesystemStorage::new(...)` directly (lines ~536, ~678) — a storage-abstraction bypass that Phase 1 must fix.** |
+| RPM metadata structs | `backend/src/formats/rpm.rs` | repomd.xml / primary.xml generation structs. Reused by publish (P3). |
+| `SigningService` | `backend/src/services/signing_service.rs` | Detached `.asc` signing already shipped for hosted repos. Reused for publish (P3). |
+| `StorageService` | `backend/src/services/storage_service.rs` | fs/S3/GCS/Azure abstraction; `ProxyService` writes here. Content-addressed keys give free dedup. |
+| Promotion | `backend/src/api/handlers/promotion.rs`, `PromotionPolicyService` | `Staging`→`Local` copy-based promotion with policy gates + history. Extended (not rebuilt) in P5. |
+| Scheduler / job worker | `scheduler_service`, `migration_worker.rs` | In-process tick + job-table+worker pattern reused for sync (P2/P4). |
+
+---
+
+## 3. Target architecture (end state)
+
+### 3.1 Modes
+
+A `Remote` RPM repository operates in one of three escalating modes (stored in `remote_configs`,
+introduced P2):
+
+| Mode | Metadata | Packages | Introduced |
+|---|---|---|---|
+| **passthrough** | not stored in DB; byte-exact cache | cached on GET | P1 |
+| **on_demand** | synced into DB (searchable) | fetched lazily on first GET, then persisted | P2 |
+| **immediate** | synced into DB | all downloaded at sync time | P4 |
+
+Versioning, snapshots, and promotion sit **above** the on_demand/immediate tier. All mirrored
+blobs are **content-addressed** in storage (`content/rpm/{sha256[0..2]}/{sha256}.rpm`), so
+snapshots and promotion are metadata-only operations (no blob copies).
+
+### 3.2 New data model (target)
+
+Introduced across phases; listed here for the whole picture. Migrations start at `049`.
+
+| Table | Purpose | Phase |
+|---|---|---|
+| `remote_configs` | 1:1 typed remote config: `mode`, `metadata_ttl_secs`, `negative_ttl_secs`, `sync_schedule`, encrypted `client_cert`/`client_key`/`ca_cert`, `proxy_url`, `last_synced_at`. Not the k/v `repository_config` — certs need encryption. | P2 (cert cols P6) |
+| `rpm_packages` | Global, deduped content units: NEVRA, `checksum_sha256` (UNIQUE), `size_bytes`, `location_href`, `summary`, raw `<package>` primary.xml snippet, `storage_key` (NULL = not yet fetched). | P2 |
+| `repository_versions` | Monotonic point-in-time membership set per repo. | P3 |
+| `repository_version_packages` | `(version_id, package_id)` membership rows. | P3 |
+| `repo_metadata_files` | Opaque carry-through of non-primary repomd `<data>` entries (filelists/other/updateinfo/modules/comps): `data_type`, `checksum`, `open_checksum`, `storage_key`, `repomd_attrs` jsonb. | P3 |
+| `publications` | Self-consistent locally generated + signed metadata for one version: `repomd_xml`, `repomd_asc`. | P3 |
+| `sync_tasks` | Sync job rows (follows `migration_worker` pattern): `state`, timings, `error`, `stats` jsonb. | P2 |
+| `repositories.active_publication_id` (ALTER) | The "distribution pointer". Repointing it = atomic promote/rollback. | P3 |
+
+### 3.3 New/changed services (target)
+
+| Service | Status | Role |
+|---|---|---|
+| `ProxyService` | Extend | Streaming tee (upstream→client + cache), HTTP Range passthrough, negative cache, per-path TTL classes, single-flight dedup. |
+| `RpmSyncService` | New (P2) | Fetch repomd → stream-parse primary.xml → upsert `rpm_packages` → create `repository_version`; retry if repomd checksum changes mid-sync. |
+| `RpmPublishService` | New (P3) | Generate primary.xml from stored snippets, carry opaque metadata refs, build + sign repomd.xml. |
+| `PromotionService` / `PromotionPolicyService` | Extend (P5) | Promote a `repository_version` by reference into a target repo; reuse policy gates + history. |
+| `scheduler_service` | Extend (P4) | Sync tick: scan `sync_schedule`, enqueue `sync_tasks` under per-repo advisory lock. |
+| RPM handlers | Fix + extend (P1+) | Route through `StorageService`; dispatch on `repo_type`. |
+
+### 3.4 Request-path decision tree (Remote RPM repo, end state)
+1. `active_publication_id` set → serve locally generated repomd/primary + our `.asc`; `.rpm` from
+   `storage_key`, lazy-fetch via ProxyService if NULL.
+2. No publication (passthrough) → ProxyService byte-exact passthrough, incl. upstream
+   `repomd.xml.asc` and gpgkey (never rewrite bodies).
+3. Snapshot URL `/rpm/{repo_key}/@{version}/repodata/...` → serve the pinned publication forever.
+
+---
+
+## 4. Reuse-vs-rebuild decisions
+
+| Decision | Call | Rationale |
+|---|---|---|
+| Lazy-fetch path | Reuse + extend `ProxyService` | TTL/ETag/SHA-256/cache logic already correct; only lacks streaming/Range/negative-cache. |
+| Remote config storage | New `remote_configs` (1:1) | Certs/schedules/TTLs are remote-specific and need encryption; keep `Repository` lean. Pulp's shared many-to-many Remote is YAGNI. |
+| Content units | New `rpm_packages` | `artifacts` is per-repo, path-centric, soft-delete — wrong shape for global deduped version-member units. |
+| Blob storage | Reuse `StorageService`, content-addressed keys | Already abstracts fs/S3/GCS/Azure; content addressing = free dedup + immutability. |
+| Metadata generation | Reuse `formats/rpm.rs` structs + raw-snippet republish | Storing raw `<package>` XML avoids lossless re-serialization bugs. |
+| Signing | Reuse `SigningService` | Detached repomd `.asc` already shipped. |
+| Promotion | Extend existing | Policy gates, history, endpoints, `promotion_target_id` exist; add a version-by-reference path. |
+| Scheduling/jobs | Reuse `scheduler_service` + `migration_worker` pattern | Proven in-process pattern; a Pulp-style task+resource-lock system is overkill. |
+| Distribution entity | Rebuild simpler: `active_publication_id` on Repository | Repo key already IS the serving URL in AK; a separate Distribution row adds indirection with no user value. |
+
+---
+
+## 5. Deliberate divergences from Pulp (YAGNI v1)
+
+| Pulp feature | Decision | Why |
+|---|---|---|
+| `streamed` policy | Skip | `on_demand` covers the use case. |
+| `mirror_complete` bit-for-bit | Skip (passthrough approximates) | Byte-exact republish needs upstream signatures we can't re-sign; passthrough already gives byte-exact. |
+| Parse filelists/other/updateinfo/modules/comps | Opaque carry-through only | Parsing primary.xml suffices for search/versioning; opaque blobs keep modularity/comps/errata working with zero parsing. **Consequence: no package filtering / sub-repos in v1** (filtered repos desync opaque filelists). |
+| sqlite `_db`, drpm/delta, zchunk generation | Skip | createrepo_c 1.0 dropped sqlite by default; dnf works without deltas; upstream `.zck` passes through (Range-aware). |
+| Mirrorlist/metalink serving or transparent resolution | Skip | Admin configures one concrete baseurl; validate at config time. |
+| Shared Remotes across repos; generic content-plugin framework | Skip | 1:1 config; RPM-only tables. Generalize when a 2nd synced format demands it. |
+| Versioning for hosted (`Local`) repos | Skip | Mirror versions solve the stated problem; hosted versioning is a separate feature. |
+
+---
+
+## 6. Phased roadmap
+
+Each phase is independently shippable and demoable.
+
+### P1 — Pull-through (thin vertical slice) — *specified in §7*
+Wire `ProxyService` into the Remote RPM path; fix the `StorageService` seam; add streaming tee,
+Range passthrough, negative cache, TTL classes.
+**Done =** `dnf install` works against AK proxying Rocky 9; 2nd install from cache; upstream
+`.asc` byte-exact so `repo_gpgcheck=1` works; hosted RPM repos provably unaffected.
+
+### P2 — Remote config + metadata sync + search (on_demand)
+`remote_configs` (cert cols present, unused), `rpm_packages`, `sync_tasks`, `RpmSyncService`
+(manual `POST /sync`), package search API; lazy downloads record `storage_key`.
+**Done =** sync EPEL → ~20k packages searchable via API in minutes; dnf unaffected.
+Risks: stream-parse ~200MB primary.xml; bulk-upsert throughput; repomd changing mid-sync.
+
+### P3 — Versions, publications, snapshots
+`repository_versions` + membership, `repo_metadata_files` (opaque carry-through), `publications`,
+`RpmPublishService` + GPG signing, `active_publication_id`, snapshot serving at `/@{version}/`.
+**Done =** create version N, publish, point dnf at `/rpm/epel/@N/`, identical resolvable content
+a month later.
+Risks: repomd generation fidelity (dnf is unforgiving about checksum/open-checksum mismatch);
+snapshot URL routing vs hosted routes.
+
+### P4 — Scheduled sync, immediate policy, GC
+Scheduler tick reading `sync_schedule` under per-repo advisory lock; `immediate` bulk-download
+with concurrency + resume; version retention; orphan-blob GC; quota accounting; **offline mode
+toggle** (Nexus-style cache-only serving).
+**Done =** nightly EPEL full mirror; old versions pruned; GC reclaims orphans without racing
+in-flight lazy fetches.
+Risks: GC-vs-lazy-fetch race; disk growth; long syncs vs deploy restarts (resumable tasks).
+
+### P5 — Promotion of mirrored versions
+Extend promote endpoint/policy: source Staging-or-Remote repo version → target gets new version
+with membership copied by reference + auto-publish + re-sign; history records version ids;
+rollback = repoint `active_publication_id`.
+**Done =** `promote {version: 12}` from `rocky-staging` to `rocky-prod`; clients on the prod URL
+atomically see new signed metadata; one-call rollback.
+Risks: current policy gates assume source=Staging/target=Local — needs a mirrored-content variant;
+per-stage GPG key expectations.
+
+### P6 — RHEL CDN & authenticated upstreams
+Wire encrypted `client_cert`/`client_key`/`ca_cert` into ProxyService + sync HTTP client (reqwest
+identity); entitlement-cert upload UX; validation ping.
+**Done =** sync RHEL 9 BaseOS via entitlement certs; certs stored encrypted, never logged.
+Risks: cert/entitlement lifecycle (expiry alerting); Red Hat T&C compliance is the maintainer's
+call, not a technical one.
+
+### The three hardest problems in the whole effort
+1. **Streaming tee through ProxyService** — feed client + cache simultaneously, honor Range,
+   dedupe concurrent misses, without buffering multi-GB rpms. Changes the current `Bytes` return
+   type, touching every caller. (Starts in P1.)
+2. **Sync consistency at scale** — a `repository_version` must be coherent even when upstream
+   republishes `repomd.xml` mid-sync (recheck/retry loop) with transactional bulk membership
+   writes that don't lock the serving path. (P2/P3.)
+3. **GC of shared content-addressed blobs** — refcounts span repos, versions, snapshots, and
+   in-flight lazy fetches; a wrong delete breaks a "permanent" snapshot. (P4.)
+
+---
+
+## 7. Phase 1 — implementation-ready specification
+
+### 7.1 Objective
+A `Remote` RPM repository transparently pull-through caches a **public** upstream over HTTPS.
+Byte-exact passthrough (including GPG artifacts). No DB metadata, no versioning, no auth.
+
+### 7.2 Components & changes
+
+**A. Request-path dispatch — `backend/src/api/handlers/rpm.rs`**
+- In `download_package` (and the `repodata/*` GET handlers), branch on `repo.repo_type`:
+  - `Local` → existing DB + storage path, **unchanged** (must be behaviorally invisible).
+  - `Remote` → `ProxyService`, proxying the same relative path to
+    `{upstream_url}/{path}`.
+- For a `Remote` repo, a single catch-all proxy covers **both** packages and `repodata/*`
+  uniformly (dnf just issues GETs), including `repomd.xml`, `repomd.xml.asc`, and the
+  checksum-named metadata files.
+
+**B. Storage-seam fix**
+- The `Remote` path uses `StorageService` (where `ProxyService` writes its cache), not the direct
+  `FilesystemStorage::new(&repo.storage_path)` bypass at `rpm.rs:~536/~678`. The `Local` path may
+  remain as-is in P1 (scoped change), but the Remote path must not use the bypass.
+
+**C. `ProxyService` extensions — `backend/src/services/proxy_service.rs`**
+1. **Streaming tee** — replace the buffer-whole-body `fetch_artifact -> (Bytes, ...)` with a
+   streaming response that writes to the cache and streams to the client concurrently. Multi-GB
+   rpms must not be fully buffered in memory. (Keep a buffered path only for small metadata if
+   simpler, but packages must stream.)
+2. **HTTP Range passthrough** — forward `Range` and relay `206 Partial Content` (+ `Content-Range`,
+   `Accept-Ranges`). Required for zchunk and interrupted-download resume. Ranged responses are
+   **not** cached in P1 (only full 200s populate the cache).
+3. **Negative cache** — persist upstream `404`s with `negative_ttl_secs` (default 1800s) to avoid
+   hammering upstream on repeated misses.
+4. **Single-flight** — coalesce concurrent cache-miss fetches for the same path (in-process lock
+   keyed by cache key) to prevent thundering-herd on cold cache.
+
+**D. TTL classes** (classify by request path; P1 stores config in `repository_config` k/v):
+
+| Path pattern | Behavior |
+|---|---|
+| `repodata/repomd.xml`, `repodata/repomd.xml.asc` | TTL `metadata_ttl_secs` (default **600s**); always revalidate via existing ETag conditional GET. |
+| `repodata/<anything-else>` (checksum-named `*.xml.gz`/`.zck`) | Immutable — cache indefinitely. |
+| `*.rpm`, `*.drpm` | Immutable — cache indefinitely. |
+| upstream 404 | Negative cache, `negative_ttl_secs` (default **1800s**). |
+
+**E. Repo-creation validation — `repository_service`**
+- `Remote` + RPM already requires `upstream_url`. Add: reject a `upstream_url` that looks like a
+  mirrorlist/metalink endpoint (heuristic: path contains `mirrorlist`/`metalink`, or query has
+  `release=`/`repo=` typical of metalink) with a clear error directing the admin to a concrete
+  baseurl. Resolving mirrorlist/metalink is explicitly out of scope.
+
+### 7.3 Behavior decisions (Phase 1 defaults)
+- **Byte-exact:** never rewrite response bodies. `repomd.xml.asc` and `gpgkey` pass through
+  untouched so `repo_gpgcheck=1` / `gpgcheck=1` work against the **upstream's** key.
+- **Offline mode:** no dedicated toggle in P1. Cached content is served whenever present; on a
+  cache miss with upstream unreachable, return the upstream error. (Toggle arrives P4.)
+- **E2E target:** Rocky Linux 9 BaseOS (public, plain HTTPS, no certs).
+- **Config location:** TTLs in the existing `repository_config` k/v table; typed `remote_configs`
+  arrives in P2.
+
+### 7.4 Error handling
+- Upstream `404` → `404` to client (+ negative cache).
+- Upstream `5xx`/timeout on cache miss → `502 Bad Gateway` with upstream status in the message; do
+  **not** poison the cache.
+- Cache write failure → still stream to client (serving the client takes priority over caching);
+  log a warning.
+- Checksum mismatch on a cached content-addressed file → treat as cache miss, re-fetch.
+
+### 7.5 Testing
+- **Unit:** path→TTL-class classification; mirrorlist/metalink rejection heuristic; negative-cache
+  expiry; single-flight coalescing.
+- **Integration:** `Remote` RPM repo → mock upstream; assert byte-exact passthrough of
+  `repomd.xml.asc`; assert immutable files cached and served from cache on 2nd request; assert
+  Range request relays `206`; assert `Local` RPM repos are unchanged (regression).
+- **E2E** (`scripts/native-tests/`): create a `Remote` repo pointing at Rocky 9 BaseOS; run
+  `dnf --disablerepo=* --enablerepo=<ak> install <small pkg>` with `repo_gpgcheck=1`; assert
+  success; second install served from cache (assert no upstream hit via proxy logs/metrics).
+- Must pass Tier-1 CI: `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace --lib`.
+
+### 7.6 Out of scope for Phase 1 (explicit)
+DB metadata sync, `rpm_packages`, search, versioning, publications, snapshots, scheduled sync,
+`immediate`/`on_demand` modes, promotion, upstream auth / entitlement certs, offline-mode toggle,
+mirrorlist/metalink resolution, non-RPM formats.
+
+### 7.7 Phase 1 risks
+- Streaming refactor changes the `ProxyService` return type — audit for future callers and keep the
+  change self-contained.
+- Memory blowups if streaming is fudged for large rpms (explicit test with a large artifact).
+- Route-precedence between the Remote catch-all and existing hosted RPM routes — verify hosted
+  repos are untouched.
+
+---
+
+## 8. Rollout & workflow notes
+- All work via feature branches + PRs (never push to main); squash-merge after CI.
+- No Docker builds on cloud instances; E2E runs locally or in GitHub Actions.
+- Each phase ships behind its own PR with the "Done =" criterion demonstrably met.
+- **CI merge gates (mandatory, per CLAUDE.md):** `cargo clippy --workspace --all-targets -- -D warnings`,
+  unit tests, **≥70% coverage on new/changed lines**, **≤3% duplication (jscpd) on changed files**,
+  security audit, CodeQL — all green; no `--admin` bypass. Implication for design: extract testable
+  logic (TTL classification, mirrorlist/metalink rejection, negative-cache expiry, single-flight)
+  into **pure helper functions** so handler code is coverable, and factor the cache read/write
+  patterns into shared helpers to stay under the duplication gate.
+- Check migration numbering before adding migrations (`ls backend/migrations/ | tail -5`); target is
+  `049+` (current tip is `048`).

--- a/docs/plans/2026-07-09-rpm-remote-proxy-design.md
+++ b/docs/plans/2026-07-09-rpm-remote-proxy-design.md
@@ -1,295 +1,236 @@
-# Design: RPM/YUM Remote Mirroring & Promotion
+# Design: RPM/YUM Remote Mirroring & Promotion (re-baselined)
 
 **Date:** 2026-07-09
-**Status:** Approved (design) — Phase 1 ready for implementation planning
+**Status:** Approved (design, re-baselined against verified code) — Phase 1 ready for planning
 **Author:** Brandon Geraci (with Claude Code)
-**Scope:** Add Pulp-grade RPM/YUM mirroring and promotion to Artifact Keeper, delivered as a
-sequenced set of independently-shippable phases. This document specifies the **target
-architecture**, the **6-phase roadmap**, and **Phase 1** in implementation-ready detail.
-Phases 2–6 are specified at roadmap altitude and will each get their own design doc.
+
+> **Re-baseline note.** An earlier revision of this doc described a codebase that did not
+> match reality (it claimed `ProxyService` had zero callers, that `rpm.rs` bypassed the storage
+> abstraction via `FilesystemStorage`, that the migration tip was 048, and that a `sync_tasks`
+> table did not exist). A parallel accuracy + security + compliance review caught this. Every
+> "current state" claim below has now been **verified by direct file reads** (citations inline).
+> The headline correction: **Remote RPM pull-through already works** — the substrate this feature
+> was going to "build" is shipped. The real work is (a) a handful of RPM-specific proxy gaps and
+> (b) the genuinely net-new Pulp-grade sync/versioning/promotion layer, built on existing infra.
 
 ---
 
 ## 1. Motivation
 
-Artifact Keeper today serves RPMs only as a **hosted** (`Local`) repository: upload, download,
-on-demand `repodata` generation (repomd.xml / primary.xml / filelists.xml), and detached GPG
-signing. It cannot mirror an upstream OS/vendor repository (Rocky, Alma, EPEL, Fedora, RHEL),
-which is the capability Pulp and Artifactory/Nexus provide.
+Artifact Keeper can already **serve** hosted RPMs and **proxy** Remote RPM repos (pull-through).
+It cannot **mirror at Pulp grade**: sync upstream metadata into the DB for search, version the
+mirror, take point-in-time snapshots, schedule syncs, or promote mirrored content through
+staging→release with the existing scan gates. This effort adds those, reusing what exists.
 
-The goal is to let a `Remote` RPM repository **pull-through and/or fully sync** an upstream, make
-the mirrored content **searchable and versioned**, support **point-in-time snapshots**, run
-**scheduled syncs**, and **promote** mirrored content through staging→release stages.
-
-### Non-goals (this effort)
-- Mirroring non-RPM formats via this machinery (RPM-only tables in v1; generalize later if a
-  second synced format demands it).
-- Being a drop-in Pulp replacement. We deliberately diverge from Pulp where the cost is not
-  justified (see §5).
+Non-goals: mirroring non-RPM formats via this machinery (RPM-only tables in v1); being a Pulp
+drop-in. Deliberate divergences in §5.
 
 ---
 
-## 2. Existing building blocks (reuse inventory)
+## 2. Verified current state (what already works)
 
-Verified against the codebase; these are the assets Phase 1+ build on.
+All citations verified by direct read on branch `feat/rpm-remote-proxy` (migration tip **148**).
 
-| Asset | Location | Role in this design |
+| Capability | Status | Evidence |
 |---|---|---|
-| `ProxyService` | `backend/src/services/proxy_service.rs` | Generic pull-through: TTL, ETag revalidation, SHA-256 verification, storage-backed cache (`proxy-cache/{repo_key}/{path}` + `.__metadata__.json`), conditional HEAD. **Currently has zero callers.** Reuse + extend. |
-| `RepositoryType` enum | `backend/src/models/repository.rs` | `Local`, `Remote` (scaffolded/unwired), `Virtual`, `Staging`. `Remote` + `upstream_url` are the entry point. |
-| `Repository` fields | same | Already has `upstream_url`, `promotion_target_id`, `promotion_policy_id`, `quota_bytes`, `storage_backend`, `storage_path`. |
-| RPM handlers | `backend/src/api/handlers/rpm.rs` | Routes at `/rpm/{repo_key}/...`. **`download_package` reads the local `artifacts` table + `FilesystemStorage::new(...)` directly (lines ~536, ~678) — a storage-abstraction bypass that Phase 1 must fix.** |
-| RPM metadata structs | `backend/src/formats/rpm.rs` | repomd.xml / primary.xml generation structs. Reused by publish (P3). |
-| `SigningService` | `backend/src/services/signing_service.rs` | Detached `.asc` signing already shipped for hosted repos. Reused for publish (P3). |
-| `StorageService` | `backend/src/services/storage_service.rs` | fs/S3/GCS/Azure abstraction; `ProxyService` writes here. Content-addressed keys give free dedup. |
-| Promotion | `backend/src/api/handlers/promotion.rs`, `PromotionPolicyService` | `Staging`→`Local` copy-based promotion with policy gates + history. Extended (not rebuilt) in P5. |
-| Scheduler / job worker | `scheduler_service`, `migration_worker.rs` | In-process tick + job-table+worker pattern reused for sync (P2/P4). |
+| Remote RPM **repodata** pull-through | **Shipped** | `rpm.rs:118` `try_proxy_repodata` → `proxy_helpers::proxy_fetch_capped` (buffered, capped) for Remote repos. |
+| Remote RPM **package** pull-through | **Shipped** | `rpm.rs:747` `download_package` falls back to `proxy_helpers::try_remote_or_virtual_download` on local miss. |
+| **Streaming** (no full-body buffering) | **Shipped** | `proxy_helpers::proxy_fetch_streaming*` (`:538`) → `ProxyService::fetch_artifact_streaming`; `rpm.rs` `build_rpm_package_response` streams via `Body::from_stream(get_stream(...))` (#1608 "Core Invariant ①"). Storage via `state.storage_for_repo(...).get_stream(...)` — **no `FilesystemStorage` bypass exists.** |
+| Central **cache freshness** classifier | **Shipped** | `cache_classifier.rs` (Core Invariant ④, #1611): `classify(format, path) -> Mutability{Immutable\|Mutable{ttl}}`, pure `evaluate()`, `Freshness{Fresh,Stale,NegativeHit}`. Constants: `MUTABLE_DEFAULT_TTL_SECS=300`, `NEGATIVE_CACHE_TTL_SECS=45`, `STALE_IF_ERROR_GRACE_SECS=3600` (RFC 5861 stale-if-error already implemented). |
+| Cache **integrity on read** | **Shipped** | `ProxyService` stores + compares `checksum_sha256` on cache reads (`proxy_service.rs:835-852`) — detects on-disk corruption. |
+| **SSRF** URL validation | **Shipped (partial)** | `validation.rs:147` `validate_outbound_url` / `:319` `is_blocked_url` block loopback/link-local/private/metadata (169.254.169.254); wired into repo create/update (`repository_service.rs:92-109`). `http_client.rs:59` `base_client_builder` + `:129` `ssrf_redirect_policy` re-validate every redirect hop. **Gap: no connect-time resolved-IP check (DNS rebinding) — see §6.** |
+| Secrets **encryption at rest** | **Shipped** | `encryption.rs` (AES-256-GCM `CredentialEncryption`); precedent in `signing_service.rs`, `webhook_secret_crypto.rs`. Reuse for entitlement certs (P6). |
+| **Promotion** (Staging→release) + scan gates | **Shipped** | Release target = `repository_config` key `release_repository_id` (`promotion.rs:337-358`). Authz: `ensure_promotion_authorized` + admin-mintable `promote:artifacts` scope + `require_promotion_tenant_access` (`promotion.rs:432-564`). Scan gates: Grype/Dependency-Track (`grype_scanner.rs`, `dependency_track_service.rs`; migs 054–056 promotion_approvals/gates/rules, 121 block-unscanned, 143 repo_scan_failed). |
+| Cross-replica **singleton job lease** | **Shipped** | `cluster_work.rs:249` `try_acquire_scheduler_lease` + `scheduler_leases` table (mig 147). Reuse for scheduled sync (P4) and cross-replica single-flight. |
+| Background **sync worker** pattern | **Shipped (different domain)** | `sync_worker.rs` + `sync_tasks` table (mig 008) — **peer-mesh/edge replication** (`edge_node_id`/`artifact_id`), 10 callers. Pattern is reusable; **the table name is taken (§6).** |
+| Audit + telemetry infra | **Shipped** | `audit_log` (mig 005: user_id/action/resource_type/ip); `download_statistics` (mig 004: user_id/ip/user_agent). |
+
+**Bottom line:** Remote RPM pull-through, streaming, cache classification, stale-if-error,
+SSRF URL-string validation, secrets encryption, promotion, and cross-replica leasing all exist.
 
 ---
 
-## 3. Target architecture (end state)
+## 3. The real gaps
 
-### 3.1 Modes
+### RPM-proxy gaps (small, mostly Phase 1)
+1. **No `Rpm` arm in `cache_classifier::classify`** — RPM paths hit the conservative 300s mutable
+   default, so content-addressed `repodata/<sha256>-*.xml.gz`, `.rpm`, `.drpm`, `.zck` are
+   revalidated every 5 min instead of cached immutably. Add an arm: content-addressed/package
+   paths → `Immutable`; `repodata/repomd.xml`(+`.asc`) → `Mutable` (300s default is safe).
+2. **No HTTP `Range`/`206` passthrough** — verified absent in `proxy_service.rs` (only a
+   `validate_upstream_status` test references 206). Needed for zchunk chunk-deltas + `.rpm` resume.
+3. **No mirrorlist/metalink rejection** at repo creation — a mirrorlist/metalink `upstream_url`
+   must be rejected (proxy one concrete baseurl only).
+4. **No cache quota enforcement** — `Repository.quota_bytes` exists but is not enforced against
+   proxy-cache writes (unbounded growth risk — §6, security High).
+5. **DNS-rebinding connect-time gap** — see §6 (security High); affects the already-shipped proxy.
 
-A `Remote` RPM repository operates in one of three escalating modes (stored in `remote_configs`,
-introduced P2):
+### Pulp-grade gaps (net-new; build on existing infra)
+6. **Metadata sync into DB** for search/versioning (`RpmSyncService`, parse primary.xml).
+7. **Versions / snapshots / publications** (locally generated + AK-signed metadata).
+8. **Promotion of mirrored content** through the existing `release_repository_id` + scan-gate path.
+9. **GPG-verify-before-ingest/re-sign** — precondition for P2/P3 (§6, security High).
 
-| Mode | Metadata | Packages | Introduced |
-|---|---|---|---|
-| **passthrough** | not stored in DB; byte-exact cache | cached on GET | P1 |
-| **on_demand** | synced into DB (searchable) | fetched lazily on first GET, then persisted | P2 |
-| **immediate** | synced into DB | all downloaded at sync time | P4 |
+---
 
-Versioning, snapshots, and promotion sit **above** the on_demand/immediate tier. All mirrored
-blobs are **content-addressed** in storage (`content/rpm/{sha256[0..2]}/{sha256}.rpm`), so
-snapshots and promotion are metadata-only operations (no blob copies).
+## 4. Target architecture
 
-### 3.2 New data model (target)
+A `Remote` RPM repository gains three escalating modes (config in a new `remote_configs` row):
+**passthrough** (today's behavior, hardened), **on_demand** (metadata in DB, packages lazy),
+**immediate** (full mirror). Versioning/snapshots/promotion sit above on_demand/immediate.
+Mirrored blobs stay content-addressed in `StorageService`, so snapshots/promotion are
+metadata-only.
 
-Introduced across phases; listed here for the whole picture. Migrations start at `049`.
+### New data model (migrations start at **149**; verify with `ls backend/migrations | sort -V | tail`)
 
 | Table | Purpose | Phase |
 |---|---|---|
-| `remote_configs` | 1:1 typed remote config: `mode`, `metadata_ttl_secs`, `negative_ttl_secs`, `sync_schedule`, encrypted `client_cert`/`client_key`/`ca_cert`, `proxy_url`, `last_synced_at`. Not the k/v `repository_config` — certs need encryption. | P2 (cert cols P6) |
-| `rpm_packages` | Global, deduped content units: NEVRA, `checksum_sha256` (UNIQUE), `size_bytes`, `location_href`, `summary`, raw `<package>` primary.xml snippet, `storage_key` (NULL = not yet fetched). | P2 |
-| `repository_versions` | Monotonic point-in-time membership set per repo. | P3 |
-| `repository_version_packages` | `(version_id, package_id)` membership rows. | P3 |
-| `repo_metadata_files` | Opaque carry-through of non-primary repomd `<data>` entries (filelists/other/updateinfo/modules/comps): `data_type`, `checksum`, `open_checksum`, `storage_key`, `repomd_attrs` jsonb. | P3 |
-| `publications` | Self-consistent locally generated + signed metadata for one version: `repomd_xml`, `repomd_asc`. | P3 |
-| `sync_tasks` | Sync job rows (follows `migration_worker` pattern): `state`, timings, `error`, `stats` jsonb. | P2 |
-| `repositories.active_publication_id` (ALTER) | The "distribution pointer". Repointing it = atomic promote/rollback. | P3 |
+| `remote_configs` | 1:1 typed remote config: `mode`, TTL overrides, `sync_schedule`, **encrypted** `client_cert`/`client_key`/`ca_cert` (via `encryption.rs`), `proxy_url`, `trusted_gpg_key`, `last_synced_at`. | P2 (cert cols P6) |
+| `rpm_packages` | Global deduped content units: NEVRA, `checksum_sha256` UNIQUE, `location_href`, raw `<package>` snippet, `storage_key` (NULL=not fetched). | P2 |
+| `repository_versions` (+ `_packages`) | Monotonic point-in-time membership. | P3 |
+| `repo_metadata_files` | Opaque carry-through of non-primary repomd `<data>` (filelists/other/updateinfo/modules/comps). | P3 |
+| `publications` | Locally generated + AK-signed repomd/metadata for one version. | P3 |
+| **`rpm_remote_sync_tasks`** | Mirror sync jobs. **Renamed** to avoid colliding with the existing peer-mesh `sync_tasks` (mig 008). | P2 |
+| `repositories.active_publication_id` (ALTER) | Distribution pointer; repoint = atomic promote/rollback. | P3 |
 
-### 3.3 New/changed services (target)
-
-| Service | Status | Role |
-|---|---|---|
-| `ProxyService` | Extend | Streaming tee (upstream→client + cache), HTTP Range passthrough, negative cache, per-path TTL classes, single-flight dedup. |
-| `RpmSyncService` | New (P2) | Fetch repomd → stream-parse primary.xml → upsert `rpm_packages` → create `repository_version`; retry if repomd checksum changes mid-sync. |
-| `RpmPublishService` | New (P3) | Generate primary.xml from stored snippets, carry opaque metadata refs, build + sign repomd.xml. |
-| `PromotionService` / `PromotionPolicyService` | Extend (P5) | Promote a `repository_version` by reference into a target repo; reuse policy gates + history. |
-| `scheduler_service` | Extend (P4) | Sync tick: scan `sync_schedule`, enqueue `sync_tasks` under per-repo advisory lock. |
-| RPM handlers | Fix + extend (P1+) | Route through `StorageService`; dispatch on `repo_type`. |
-
-### 3.4 Request-path decision tree (Remote RPM repo, end state)
-1. `active_publication_id` set → serve locally generated repomd/primary + our `.asc`; `.rpm` from
-   `storage_key`, lazy-fetch via ProxyService if NULL.
-2. No publication (passthrough) → ProxyService byte-exact passthrough, incl. upstream
-   `repomd.xml.asc` and gpgkey (never rewrite bodies).
-3. Snapshot URL `/rpm/{repo_key}/@{version}/repodata/...` → serve the pinned publication forever.
+### Services (all extend existing, except two new)
+- `cache_classifier::classify` — **add `Rpm` arm** (P1).
+- `ProxyService` / `proxy_helpers` — **add Range/206 passthrough** and quota-aware cache writes (P1); reuse existing streaming + classifier + stale-if-error unchanged.
+- `http_client` — **add connect-time resolved-IP validation** (DNS-rebinding fix) to `base_client_builder` (P1).
+- `RpmSyncService` (**new**, P2) — fetch repomd, **verify `.asc` against `trusted_gpg_key`**, stream-parse primary.xml (with decompression cap), upsert `rpm_packages`, create a version.
+- `RpmPublishService` (**new**, P3) — generate + sign metadata via `SigningService`.
+- Scheduled sync (P4) — reuse `cluster_work::try_acquire_scheduler_lease` (not a new lock).
+- Promotion (P5) — extend `promotion.rs` to promote a **version by reference** into
+  `release_repository_id`, reusing `ensure_promotion_authorized`/tenant checks **and the existing
+  scan gates** (mirrored content must not bypass Grype/Dependency-Track).
 
 ---
 
-## 4. Reuse-vs-rebuild decisions
+## 5. Reuse-vs-rebuild & deliberate divergences
 
-| Decision | Call | Rationale |
-|---|---|---|
-| Lazy-fetch path | Reuse + extend `ProxyService` | TTL/ETag/SHA-256/cache logic already correct; only lacks streaming/Range/negative-cache. |
-| Remote config storage | New `remote_configs` (1:1) | Certs/schedules/TTLs are remote-specific and need encryption; keep `Repository` lean. Pulp's shared many-to-many Remote is YAGNI. |
-| Content units | New `rpm_packages` | `artifacts` is per-repo, path-centric, soft-delete — wrong shape for global deduped version-member units. |
-| Blob storage | Reuse `StorageService`, content-addressed keys | Already abstracts fs/S3/GCS/Azure; content addressing = free dedup + immutability. |
-| Metadata generation | Reuse `formats/rpm.rs` structs + raw-snippet republish | Storing raw `<package>` XML avoids lossless re-serialization bugs. |
-| Signing | Reuse `SigningService` | Detached repomd `.asc` already shipped. |
-| Promotion | Extend existing | Policy gates, history, endpoints, `promotion_target_id` exist; add a version-by-reference path. |
-| Scheduling/jobs | Reuse `scheduler_service` + `migration_worker` pattern | Proven in-process pattern; a Pulp-style task+resource-lock system is overkill. |
-| Distribution entity | Rebuild simpler: `active_publication_id` on Repository | Repo key already IS the serving URL in AK; a separate Distribution row adds indirection with no user value. |
+**Reuse:** `cache_classifier` (add arm, don't parallel it), `proxy_helpers` streaming, `http_client`
+SSRF-aware client (no bespoke client permitted), `encryption.rs` for certs, promotion's
+`release_repository_id`/authz/scan-gates, `cluster_work` leases. **Rebuild:** none of the proxy
+stack. **Rename:** mirror sync table → `rpm_remote_sync_tasks`.
+
+**YAGNI v1 (skip):** `streamed` policy; bit-for-bit republish; parsing filelists/other/updateinfo/
+modules (opaque carry-through only → **no package filtering/sub-repos v1**); sqlite `_db`, drpm,
+zchunk *generation*; mirrorlist/metalink serving; shared Remotes; hosted-repo versioning;
+Distribution as a separate entity (use `active_publication_id`).
 
 ---
 
-## 5. Deliberate divergences from Pulp (YAGNI v1)
+## 6. Security & compliance requirements (from parallel review — binding)
 
-| Pulp feature | Decision | Why |
-|---|---|---|
-| `streamed` policy | Skip | `on_demand` covers the use case. |
-| `mirror_complete` bit-for-bit | Skip (passthrough approximates) | Byte-exact republish needs upstream signatures we can't re-sign; passthrough already gives byte-exact. |
-| Parse filelists/other/updateinfo/modules/comps | Opaque carry-through only | Parsing primary.xml suffices for search/versioning; opaque blobs keep modularity/comps/errata working with zero parsing. **Consequence: no package filtering / sub-repos in v1** (filtered repos desync opaque filelists). |
-| sqlite `_db`, drpm/delta, zchunk generation | Skip | createrepo_c 1.0 dropped sqlite by default; dnf works without deltas; upstream `.zck` passes through (Range-aware). |
-| Mirrorlist/metalink serving or transparent resolution | Skip | Admin configures one concrete baseurl; validate at config time. |
-| Shared Remotes across repos; generic content-plugin framework | Skip | 1:1 config; RPM-only tables. Generalize when a 2nd synced format demands it. |
-| Versioning for hosted (`Local`) repos | Skip | Mirror versions solve the stated problem; hosted versioning is a separate feature. |
+These are design requirements, not optional hardening. Phase assignment noted.
 
----
+| # | Requirement | Severity | Phase |
+|---|---|---|---|
+| S1 | **DNS-rebinding:** validate the *resolved IP* at connect time (custom `reqwest` resolver/connector re-applying `is_blocked_url` logic), for initial request + every redirect. The Range/streaming change must route **only** through `base_client_builder()` — no new client. Add a test asserting connect-time IP checks. | High | **P1** |
+| S2 | **Cache quota:** enforce `Repository.quota_bytes` on proxy-cache writes (at minimum: stop caching + alert past quota, keep serving). Don't defer disk-exhaustion control to P4 GC. | High | **P1** |
+| S3 | **Content-addressed integrity:** when a fetched path embeds a hex checksum (createrepo unique-filename convention), verify SHA-256 of the body before caching it "immutable". | Medium | **P1** |
+| S4 | **GPG-verify-before-ingest:** `RpmSyncService` must verify `repomd.xml.asc` against a configured `trusted_gpg_key` before ingesting/parsing; without it, refuse publishable/re-signed mode or label the publication "unverified upstream". Prevents P3 AK-re-signing from laundering unverified content. | High | P2/P3 |
+| S5 | **Authz:** new `POST /sync`, `remote_configs` writes, and P6 cert upload need a global capability gate (admin or admin-mintable scope, e.g. `manage:remote-config`/`trigger:sync`) **plus** a non-admin-bypassing per-repo tenant check — mirroring `ensure_promotion_authorized` + `require_promotion_tenant_access`. | Medium | P2/P6 |
+| S6 | **Scan gates for mirrored promotion:** mirrored content promoted to a release repo must pass the same Grype/Dependency-Track gates as uploaded artifacts (decide sync-time vs promotion-time scanning; do not silently bypass). | High | P5 |
+| S7 | **Audit logging:** remote create/edit, sync trigger, cert upload, and mirrored-content promotion write `audit_log` entries (actor/action/resource). | Medium | P2/P5/P6 |
+| S8 | **Cert handling:** reuse `encryption.rs` AES-256-GCM (no new scheme); redacting newtype so `{:?}` can't leak key material; test that logs never contain raw cert bytes. | Medium | P6 |
+| S9 | **Negative-cache tuning:** reuse the existing 45s `NEGATIVE_CACHE_TTL_SECS` convention (the earlier draft's 1800s was wrong); exempt `repomd.xml`(+`.asc`) from negative caching (already revalidated). | Medium | P1 |
+| S10 | **Decompression cap:** P2 primary.xml.gz parsing must cap decompressed size / use a bounded decompressor. | Medium | P2 |
+| S11 | **Single-flight across replicas:** in-process coalescing only dedupes per process; for multi-replica, consider the `scheduler_leases`/advisory-lock pattern, or document the bounded N-fetch tradeoff. | Medium | P1 (doc) / P4 |
+| S12 | **Secrets hygiene:** forbid credentials embedded in `upstream_url`/`proxy_url`; size-cap + redact any upstream response data persisted to `rpm_remote_sync_tasks.error`/`stats`. | Medium | P2/P6 |
+| C1 | **RHEL redistribution (P6):** explicit operator-vs-software responsibility statement + on-screen notice at entitlement-cert config; gate P6 on legal-counsel review, not engineering. | Medium | P6 |
+| C2 | **Trust-model doc (P3):** document that once a publication exists, `repo_gpgcheck` validates AK's key (operators must distribute it); package-level signatures remain the vendor's; package integrity enforced via checksum vs upstream primary.xml. | Medium | P3 |
 
-## 6. Phased roadmap
-
-Each phase is independently shippable and demoable.
-
-### P1 — Pull-through (thin vertical slice) — *specified in §7*
-Wire `ProxyService` into the Remote RPM path; fix the `StorageService` seam; add streaming tee,
-Range passthrough, negative cache, TTL classes.
-**Done =** `dnf install` works against AK proxying Rocky 9; 2nd install from cache; upstream
-`.asc` byte-exact so `repo_gpgcheck=1` works; hosted RPM repos provably unaffected.
-
-### P2 — Remote config + metadata sync + search (on_demand)
-`remote_configs` (cert cols present, unused), `rpm_packages`, `sync_tasks`, `RpmSyncService`
-(manual `POST /sync`), package search API; lazy downloads record `storage_key`.
-**Done =** sync EPEL → ~20k packages searchable via API in minutes; dnf unaffected.
-Risks: stream-parse ~200MB primary.xml; bulk-upsert throughput; repomd changing mid-sync.
-
-### P3 — Versions, publications, snapshots
-`repository_versions` + membership, `repo_metadata_files` (opaque carry-through), `publications`,
-`RpmPublishService` + GPG signing, `active_publication_id`, snapshot serving at `/@{version}/`.
-**Done =** create version N, publish, point dnf at `/rpm/epel/@N/`, identical resolvable content
-a month later.
-Risks: repomd generation fidelity (dnf is unforgiving about checksum/open-checksum mismatch);
-snapshot URL routing vs hosted routes.
-
-### P4 — Scheduled sync, immediate policy, GC
-Scheduler tick reading `sync_schedule` under per-repo advisory lock; `immediate` bulk-download
-with concurrency + resume; version retention; orphan-blob GC; quota accounting; **offline mode
-toggle** (Nexus-style cache-only serving).
-**Done =** nightly EPEL full mirror; old versions pruned; GC reclaims orphans without racing
-in-flight lazy fetches.
-Risks: GC-vs-lazy-fetch race; disk growth; long syncs vs deploy restarts (resumable tasks).
-
-### P5 — Promotion of mirrored versions
-Extend promote endpoint/policy: source Staging-or-Remote repo version → target gets new version
-with membership copied by reference + auto-publish + re-sign; history records version ids;
-rollback = repoint `active_publication_id`.
-**Done =** `promote {version: 12}` from `rocky-staging` to `rocky-prod`; clients on the prod URL
-atomically see new signed metadata; one-call rollback.
-Risks: current policy gates assume source=Staging/target=Local — needs a mirrored-content variant;
-per-stage GPG key expectations.
-
-### P6 — RHEL CDN & authenticated upstreams
-Wire encrypted `client_cert`/`client_key`/`ca_cert` into ProxyService + sync HTTP client (reqwest
-identity); entitlement-cert upload UX; validation ping.
-**Done =** sync RHEL 9 BaseOS via entitlement certs; certs stored encrypted, never logged.
-Risks: cert/entitlement lifecycle (expiry alerting); Red Hat T&C compliance is the maintainer's
-call, not a technical one.
-
-### The three hardest problems in the whole effort
-1. **Streaming tee through ProxyService** — feed client + cache simultaneously, honor Range,
-   dedupe concurrent misses, without buffering multi-GB rpms. Changes the current `Bytes` return
-   type, touching every caller. (Starts in P1.)
-2. **Sync consistency at scale** — a `repository_version` must be coherent even when upstream
-   republishes `repomd.xml` mid-sync (recheck/retry loop) with transactional bulk membership
-   writes that don't lock the serving path. (P2/P3.)
-3. **GC of shared content-addressed blobs** — refcounts span repos, versions, snapshots, and
-   in-flight lazy fetches; a wrong delete breaks a "permanent" snapshot. (P4.)
+**P1 verdict from review:** safe to proceed **provided S1, S2, S3, S9 (and S11 as a documented
+note) are in the Phase-1 spec.** S4/S6/C1/C2 are the load-bearing items for later phases.
 
 ---
 
-## 7. Phase 1 — implementation-ready specification
+## 7. Revised phased roadmap
 
-### 7.1 Objective
-A `Remote` RPM repository transparently pull-through caches a **public** upstream over HTTPS.
-Byte-exact passthrough (including GPG artifacts). No DB metadata, no versioning, no auth.
+- **P1 — RPM proxy hardening (thin slice).** `Rpm` arm in `cache_classifier`; Range/206 passthrough
+  through `base_client_builder`; mirrorlist/metalink rejection at repo create; **S1 DNS-rebind
+  connect-time check, S2 quota enforcement, S3 content-addressed checksum verify, S9 negative-cache
+  reuse**. No new tables.
+  **Done =** `dnf install` against a Remote repo mirroring Rocky 9 works with `repo_gpgcheck=1`;
+  content-addressed files served immutably from cache (no needless revalidation); a rebinding test
+  and a quota test pass; existing hosted + other-format proxy behavior unchanged.
+- **P2 — Sync + search (on_demand).** `remote_configs`, `rpm_packages`, `rpm_remote_sync_tasks`,
+  `RpmSyncService` (manual `POST /sync`), package search; **S4 GPG-verify, S5 authz, S7 audit, S10
+  decompression cap, S12 hygiene.** Done = sync EPEL → ~20k searchable packages; dnf unaffected.
+- **P3 — Versions, publications, snapshots.** `repository_versions`(+members), `repo_metadata_files`,
+  `publications`, `RpmPublishService` + signing, `active_publication_id`, `/@{version}/` serving;
+  **C2 trust-model doc.** Done = pin `/rpm/epel/@N/`, identical resolvable content later.
+- **P4 — Scheduled sync, immediate policy, GC.** Reuse `try_acquire_scheduler_lease`; `immediate`
+  bulk download; version retention; orphan-blob GC; offline mode. Done = nightly mirror; GC safe.
+- **P5 — Promote mirrored versions.** Extend promotion to promote a version by reference into
+  `release_repository_id`; **S6 scan gates apply**; rollback = repoint `active_publication_id`.
+- **P6 — RHEL / authed upstreams.** Encrypted certs via `encryption.rs`; **S8 handling, C1 legal
+  gate.** Done = sync RHEL 9 via entitlement certs, encrypted, never logged.
 
-### 7.2 Components & changes
-
-**A. Request-path dispatch — `backend/src/api/handlers/rpm.rs`**
-- In `download_package` (and the `repodata/*` GET handlers), branch on `repo.repo_type`:
-  - `Local` → existing DB + storage path, **unchanged** (must be behaviorally invisible).
-  - `Remote` → `ProxyService`, proxying the same relative path to
-    `{upstream_url}/{path}`.
-- For a `Remote` repo, a single catch-all proxy covers **both** packages and `repodata/*`
-  uniformly (dnf just issues GETs), including `repomd.xml`, `repomd.xml.asc`, and the
-  checksum-named metadata files.
-
-**B. Storage-seam fix**
-- The `Remote` path uses `StorageService` (where `ProxyService` writes its cache), not the direct
-  `FilesystemStorage::new(&repo.storage_path)` bypass at `rpm.rs:~536/~678`. The `Local` path may
-  remain as-is in P1 (scoped change), but the Remote path must not use the bypass.
-
-**C. `ProxyService` extensions — `backend/src/services/proxy_service.rs`**
-1. **Streaming tee** — replace the buffer-whole-body `fetch_artifact -> (Bytes, ...)` with a
-   streaming response that writes to the cache and streams to the client concurrently. Multi-GB
-   rpms must not be fully buffered in memory. (Keep a buffered path only for small metadata if
-   simpler, but packages must stream.)
-2. **HTTP Range passthrough** — forward `Range` and relay `206 Partial Content` (+ `Content-Range`,
-   `Accept-Ranges`). Required for zchunk and interrupted-download resume. Ranged responses are
-   **not** cached in P1 (only full 200s populate the cache).
-3. **Negative cache** — persist upstream `404`s with `negative_ttl_secs` (default 1800s) to avoid
-   hammering upstream on repeated misses.
-4. **Single-flight** — coalesce concurrent cache-miss fetches for the same path (in-process lock
-   keyed by cache key) to prevent thundering-herd on cold cache.
-
-**D. TTL classes** (classify by request path; P1 stores config in `repository_config` k/v):
-
-| Path pattern | Behavior |
-|---|---|
-| `repodata/repomd.xml`, `repodata/repomd.xml.asc` | TTL `metadata_ttl_secs` (default **600s**); always revalidate via existing ETag conditional GET. |
-| `repodata/<anything-else>` (checksum-named `*.xml.gz`/`.zck`) | Immutable — cache indefinitely. |
-| `*.rpm`, `*.drpm` | Immutable — cache indefinitely. |
-| upstream 404 | Negative cache, `negative_ttl_secs` (default **1800s**). |
-
-**E. Repo-creation validation — `repository_service`**
-- `Remote` + RPM already requires `upstream_url`. Add: reject a `upstream_url` that looks like a
-  mirrorlist/metalink endpoint (heuristic: path contains `mirrorlist`/`metalink`, or query has
-  `release=`/`repo=` typical of metalink) with a clear error directing the admin to a concrete
-  baseurl. Resolving mirrorlist/metalink is explicitly out of scope.
-
-### 7.3 Behavior decisions (Phase 1 defaults)
-- **Byte-exact:** never rewrite response bodies. `repomd.xml.asc` and `gpgkey` pass through
-  untouched so `repo_gpgcheck=1` / `gpgcheck=1` work against the **upstream's** key.
-- **Offline mode:** no dedicated toggle in P1. Cached content is served whenever present; on a
-  cache miss with upstream unreachable, return the upstream error. (Toggle arrives P4.)
-- **E2E target:** Rocky Linux 9 BaseOS (public, plain HTTPS, no certs).
-- **Config location:** TTLs in the existing `repository_config` k/v table; typed `remote_configs`
-  arrives in P2.
-
-### 7.4 Error handling
-- Upstream `404` → `404` to client (+ negative cache).
-- Upstream `5xx`/timeout on cache miss → `502 Bad Gateway` with upstream status in the message; do
-  **not** poison the cache.
-- Cache write failure → still stream to client (serving the client takes priority over caching);
-  log a warning.
-- Checksum mismatch on a cached content-addressed file → treat as cache miss, re-fetch.
-
-### 7.5 Testing
-- **Unit:** path→TTL-class classification; mirrorlist/metalink rejection heuristic; negative-cache
-  expiry; single-flight coalescing.
-- **Integration:** `Remote` RPM repo → mock upstream; assert byte-exact passthrough of
-  `repomd.xml.asc`; assert immutable files cached and served from cache on 2nd request; assert
-  Range request relays `206`; assert `Local` RPM repos are unchanged (regression).
-- **E2E** (`scripts/native-tests/`): create a `Remote` repo pointing at Rocky 9 BaseOS; run
-  `dnf --disablerepo=* --enablerepo=<ak> install <small pkg>` with `repo_gpgcheck=1`; assert
-  success; second install served from cache (assert no upstream hit via proxy logs/metrics).
-- Must pass Tier-1 CI: `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace --lib`.
-
-### 7.6 Out of scope for Phase 1 (explicit)
-DB metadata sync, `rpm_packages`, search, versioning, publications, snapshots, scheduled sync,
-`immediate`/`on_demand` modes, promotion, upstream auth / entitlement certs, offline-mode toggle,
-mirrorlist/metalink resolution, non-RPM formats.
-
-### 7.7 Phase 1 risks
-- Streaming refactor changes the `ProxyService` return type — audit for future callers and keep the
-  change self-contained.
-- Memory blowups if streaming is fudged for large rpms (explicit test with a large artifact).
-- Route-precedence between the Remote catch-all and existing hosted RPM routes — verify hosted
-  repos are untouched.
+**Three hardest problems (revised):** (1) DNS-rebind-safe streaming client without regressing the
+shipped SSRF controls; (2) sync consistency when upstream republishes repomd mid-sync + GPG-verify;
+(3) GC of shared content-addressed blobs vs in-flight lazy fetches and pinned snapshots.
 
 ---
 
-## 8. Rollout & workflow notes
-- All work via feature branches + PRs (never push to main); squash-merge after CI.
-- No Docker builds on cloud instances; E2E runs locally or in GitHub Actions.
-- Each phase ships behind its own PR with the "Done =" criterion demonstrably met.
-- **CI merge gates (mandatory, per CLAUDE.md):** `cargo clippy --workspace --all-targets -- -D warnings`,
-  unit tests, **≥70% coverage on new/changed lines**, **≤3% duplication (jscpd) on changed files**,
-  security audit, CodeQL — all green; no `--admin` bypass. Implication for design: extract testable
-  logic (TTL classification, mirrorlist/metalink rejection, negative-cache expiry, single-flight)
-  into **pure helper functions** so handler code is coverable, and factor the cache read/write
-  patterns into shared helpers to stay under the duplication gate.
-- Check migration numbering before adding migrations (`ls backend/migrations/ | tail -5`); target is
-  `049+` (current tip is `048`).
+## 8. Phase 1 — implementation-ready specification
+
+### 8.1 Objective
+Harden the **existing** Remote RPM passthrough: correct cache classification, add Range support,
+reject non-baseurl upstreams, and close the S1/S2/S3/S9 review findings. Public HTTPS upstreams
+only; no auth, no DB metadata, no versioning.
+
+### 8.2 Work items
+1. **`cache_classifier::classify` — add `Rpm` arm** (pure fn; table-tested for jscpd/coverage):
+   - `repodata/repomd.xml`, `repodata/repomd.xml.asc` → `Mutable{300}` (safe default; revalidated).
+   - `repodata/<hex>-*` (content-addressed) and `*.rpm`/`*.drpm`/`*.zck` → `Immutable`.
+   - Everything else under the repo → conservative `Mutable` default.
+2. **Range/206 passthrough** in the proxy fetch path: forward `Range`, relay `206`/`Content-Range`/
+   `Accept-Ranges`; do **not** cache partial responses (only full 200s populate cache). Must use
+   `base_client_builder()` (S1).
+3. **DNS-rebinding connect-time check (S1):** add a custom resolver/connector to
+   `base_client_builder` that re-applies `is_blocked_url`-equivalent logic to the **resolved IP**,
+   for initial + redirect hops. Test: hostname resolving to 169.254.169.254 is refused at connect.
+4. **Quota enforcement (S2):** before a proxy-cache write, check `Repository.quota_bytes`; past
+   quota, skip the cache write (still stream to client) and emit a warning/metric.
+5. **Content-addressed integrity (S3):** when the path embeds a hex checksum, verify body SHA-256
+   before caching immutable; mismatch → serve but refuse to cache (treat as miss).
+6. **Mirrorlist/metalink rejection:** in `repository_service` repo create/update validation for
+   Remote+RPM, reject an `upstream_url` whose path/query indicates mirrorlist/metalink, with a
+   clear error pointing to a concrete baseurl.
+7. **Negative-cache (S9):** confirm RPM uses the shared 45s `NEGATIVE_CACHE_TTL_SECS`; exempt
+   `repomd.xml`(+`.asc`) from negative caching.
+
+### 8.3 Error handling
+Upstream 404 → 404 (+ short negative cache, except repomd). Upstream 5xx/timeout on miss → 502;
+existing `STALE_IF_ERROR_GRACE_SECS` stale-if-error path continues to serve a still-held mutable
+body. Cache-write failure → still stream to client (existing self-healing). Checksum mismatch → S3.
+
+### 8.4 Testing
+- **Unit (pure fns):** `Rpm` classify arm (table test: repomd vs content-addressed vs pkg);
+  mirrorlist/metalink rejection; S3 checksum-in-path verification; S2 quota decision.
+- **Integration:** Remote RPM repo vs mock upstream — immutable file served from cache without
+  revalidation; repomd revalidated; Range → 206 relayed; **S1 rebinding refused at connect**;
+  hosted + other-format proxy paths unchanged (regression).
+- **E2E** (`scripts/native-tests/`): Remote repo → Rocky 9 BaseOS; `dnf install` with
+  `repo_gpgcheck=1`; 2nd install from cache (assert no upstream hit).
+- **CI gates (must pass):** `cargo fmt --check`; `cargo clippy --workspace --all-targets -- -D
+  warnings`; `cargo test --workspace --lib`; ≥70% coverage on changed lines; ≤3% jscpd duplication.
+
+### 8.5 Out of scope for P1
+DB metadata sync, `rpm_packages`, search, versions, publications, snapshots, scheduled sync,
+on_demand/immediate modes, promotion, upstream auth/certs, offline-mode toggle, mirrorlist
+resolution, non-RPM formats.
+
+### 8.6 Phase 1 risks
+Touching `base_client_builder`/the shared fetch path affects **all** formats — regression tests for
+maven/pypi/etc. proxy paths are mandatory. The DNS-rebind resolver must not break normal resolution
+or add latency. Keep the classifier arm a pure function to satisfy coverage/duplication gates.
+
+---
+
+## 9. Rollout & workflow
+- Feature branches + PRs (never push to main); squash-merge after CI; each phase = its own PR with
+  its "Done =" met. No Docker builds on cloud. Verify migration numbering before adding (tip 148).
+- Before P2/P5/P6 sub-design-docs are written, resolve their binding review items (S4/S6/C1/C2).


### PR DESCRIPTION
Closes #2353. Phase 1 of RPM/YUM remote mirroring (beads `artifact-keeper-1gx.1`).

## What this does
Hardens the already-shipping outbound proxy, focused on Remote RPM repos. Four scoped changes:

1. **SSRF DNS-rebinding fix** (`ssrf_dns.rs`, `http_client.rs`) — a custom `reqwest` DNS resolver filters resolved IPs through the existing `is_blocked_resolved_ip` before connect, for the initial request and every redirect. Closes bug `artifact-keeper-3to`; applies to **all** proxied formats. Pure `filter_allowed` helper is table-tested (mixed block/allow), and the client-level regression test uses a real listener so it fails if the resolver is removed.
2. **RPM cache-freshness classification** (`cache_classifier.rs`) — new `Rpm` arm: content-addressed `repodata/<hex>-*` and `*.rpm`/`*.drpm` cache immutably; `repomd.xml`(+`.asc`) stays revalidated. Previously RPM fell into the 300s conservative default.
3. **Content-addressed integrity** (`cache_classifier.rs`, `proxy_service.rs`) — verify SHA-256 of a content-addressed body before caching it immutable; on mismatch the body is still served but not cached. Gated so non-content-addressed paths and other formats are unaffected.
4. **Interim over-quota guard** (`proxy_service.rs`) — refuse to cache a single object larger than `quota_bytes`. Full per-repo accounting is P4.
5. **Mirrorlist/metalink rejection** (`repository_service.rs`) — Remote RPM upstreams must be a concrete baseurl.

## Testing
- New pure/table tests for the SSRF filter, RPM classifier (incl. bare/short-prefix/nested edge cases), checksum extractor, and quota guard.
- `proxy_service` cache tests (real DB) assert content-addressed mismatch is served-but-not-cached; hosted + other-format proxy paths unchanged (regression).
- `cargo fmt` / `clippy --all-targets -D warnings` clean.
- Pre-existing unrelated failure `test_large_object_client_builder_does_not_apply_total_timeout` is not from this branch.

## Known limitations (tracked)
- Full quota accounting + eviction → **P4** (`artifact-keeper-x70`); the interim guard covers only the buffered metadata path, not streamed packages.
- Range/206 passthrough → `artifact-keeper-1gx.7`.
- Content-addressed integrity currently verifies SHA-256 only → `artifact-keeper-1gx.8`.
- `s3.rs` bare-client SSRF bypass (found in review) → `artifact-keeper-d6d`.

## Docs
Design `docs/plans/2026-07-09-rpm-remote-proxy-design.md`; plan `docs/plans/2026-07-09-rpm-phase1-proxy-hardening-plan.md`.