### PR TITLE
feat(audit): functional audit log — emit events + admin query endpoint (#2366)

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -34,6 +34,148 @@ pub fn router() -> Router<SharedState> {
         .route("/reindex", post(trigger_reindex))
         .route("/rescan-for-inventory", post(rescan_for_inventory))
         .route("/storage-backends", get(list_storage_backends))
+        .route("/audit", get(list_audit_logs))
+}
+
+// ---------------------------------------------------------------------------
+// Audit log query endpoint (#2366 functional audit log)
+// ---------------------------------------------------------------------------
+
+/// Default page size for the audit-log query when the caller does not specify.
+const AUDIT_DEFAULT_PER_PAGE: u32 = 50;
+/// Hard cap on page size so a single query cannot pull an unbounded slice.
+const AUDIT_MAX_PER_PAGE: u32 = 200;
+
+/// Normalize/clamp audit-query pagination into a `(offset, limit, page,
+/// per_page)` tuple.
+///
+/// Pure (no I/O) so the coverage gate exercises the pagination arithmetic even
+/// where Postgres is unavailable. `page` is 1-based and floored at 1;
+/// `per_page` defaults to [`AUDIT_DEFAULT_PER_PAGE`] and is clamped to
+/// `1..=AUDIT_MAX_PER_PAGE`.
+pub(crate) fn audit_page_bounds(page: Option<u32>, per_page: Option<u32>) -> (i64, i64, u32, u32) {
+    let page = page.unwrap_or(1).max(1);
+    let per_page = per_page
+        .unwrap_or(AUDIT_DEFAULT_PER_PAGE)
+        .clamp(1, AUDIT_MAX_PER_PAGE);
+    let offset = i64::from(page - 1) * i64::from(per_page);
+    (offset, i64::from(per_page), page, per_page)
+}
+
+/// Filters for `GET /api/v1/admin/audit`.
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct AuditLogQuery {
+    /// Filter by acting/subject user id.
+    pub user_id: Option<Uuid>,
+    /// Filter by action string (e.g. `LOGIN`, `USER_CREATED`, `ARTIFACT_DOWNLOADED`).
+    pub action: Option<String>,
+    /// Filter by resource type (e.g. `user`, `repository`, `artifact`).
+    pub resource_type: Option<String>,
+    /// Filter by the affected resource id.
+    pub resource_id: Option<Uuid>,
+    /// Inclusive lower time bound (RFC 3339).
+    pub from: Option<chrono::DateTime<chrono::Utc>>,
+    /// Inclusive upper time bound (RFC 3339).
+    pub to: Option<chrono::DateTime<chrono::Utc>>,
+    /// 1-based page index (default 1).
+    pub page: Option<u32>,
+    /// Page size (default 50, max 200).
+    pub per_page: Option<u32>,
+}
+
+/// A single audit-log row in a query response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuditLogItem {
+    pub id: Uuid,
+    pub user_id: Option<Uuid>,
+    pub action: String,
+    pub resource_type: String,
+    pub resource_id: Option<Uuid>,
+    pub details: Option<serde_json::Value>,
+    pub ip_address: Option<String>,
+    pub correlation_id: Uuid,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<crate::services::audit_service::AuditLogEntry> for AuditLogItem {
+    fn from(e: crate::services::audit_service::AuditLogEntry) -> Self {
+        Self {
+            id: e.id,
+            user_id: e.user_id,
+            action: e.action,
+            resource_type: e.resource_type,
+            resource_id: e.resource_id,
+            details: e.details,
+            ip_address: e.ip_address,
+            correlation_id: e.correlation_id,
+            created_at: e.created_at,
+        }
+    }
+}
+
+/// Paginated audit-log query response.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AuditLogListResponse {
+    pub items: Vec<AuditLogItem>,
+    pub total: i64,
+    pub page: u32,
+    pub per_page: u32,
+}
+
+/// Query the audit log (admin only).
+///
+/// Returns recorded audit events ordered newest-first, filtered by any
+/// combination of actor/user, action, resource type/id, and time range, with
+/// page/per_page pagination. Backed by the `audit_log` table and
+/// [`AuditService::query`]; admin-only both via the `/admin` `admin_middleware`
+/// and a defense-in-depth check here (#2366).
+#[utoipa::path(
+    get,
+    path = "/audit",
+    context_path = "/api/v1/admin",
+    tag = "admin",
+    params(AuditLogQuery),
+    responses(
+        (status = 200, description = "Audit events", body = AuditLogListResponse),
+        (status = 403, description = "Admin privileges required"),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_audit_logs(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Query(query): Query<AuditLogQuery>,
+) -> Result<Json<AuditLogListResponse>> {
+    // Defense-in-depth: the `/admin` nest already enforces `admin_middleware`,
+    // but never rely on a single gate for a security-sensitive read.
+    if !auth.is_admin {
+        return Err(AppError::Authorization(
+            "Admin privileges required".to_string(),
+        ));
+    }
+
+    let (offset, limit, page, per_page) = audit_page_bounds(query.page, query.per_page);
+
+    let audit_service = crate::services::audit_service::AuditService::new(state.db.clone());
+    let (entries, total) = audit_service
+        .query(
+            query.user_id,
+            query.action.as_deref(),
+            query.resource_type.as_deref(),
+            query.resource_id,
+            query.from,
+            query.to,
+            offset,
+            limit,
+        )
+        .await?;
+
+    Ok(Json(AuditLogListResponse {
+        items: entries.into_iter().map(AuditLogItem::from).collect(),
+        total,
+        page,
+        per_page,
+    }))
 }
 
 /// List available storage backends.
@@ -967,6 +1109,7 @@ pub async fn rescan_for_inventory(
         trigger_reindex,
         rescan_for_inventory,
         list_storage_backends,
+        list_audit_logs,
     ),
     components(schemas(
         ListBackupsQuery,
@@ -982,6 +1125,8 @@ pub async fn rescan_for_inventory(
         ReindexResponse,
         RescanForInventoryRequest,
         RescanForInventoryResponse,
+        AuditLogItem,
+        AuditLogListResponse,
     ))
 )]
 pub struct AdminApiDoc;
@@ -989,6 +1134,55 @@ pub struct AdminApiDoc;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // audit_page_bounds (#2366) — pure pagination arithmetic, no DB required so
+    // the coverage gate exercises it even without Postgres.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_audit_page_bounds_defaults() {
+        // No page/per_page -> page 1, default page size, offset 0.
+        let (offset, limit, page, per_page) = audit_page_bounds(None, None);
+        assert_eq!(offset, 0);
+        assert_eq!(limit, AUDIT_DEFAULT_PER_PAGE as i64);
+        assert_eq!(page, 1);
+        assert_eq!(per_page, AUDIT_DEFAULT_PER_PAGE);
+    }
+
+    #[test]
+    fn test_audit_page_bounds_computes_offset() {
+        // Page 3 at 25/page -> offset 50.
+        let (offset, limit, page, per_page) = audit_page_bounds(Some(3), Some(25));
+        assert_eq!(offset, 50);
+        assert_eq!(limit, 25);
+        assert_eq!(page, 3);
+        assert_eq!(per_page, 25);
+    }
+
+    #[test]
+    fn test_audit_page_bounds_floors_page_at_one() {
+        // Page 0 must not underflow (page-1) or produce a negative offset.
+        let (offset, _limit, page, _pp) = audit_page_bounds(Some(0), Some(10));
+        assert_eq!(offset, 0);
+        assert_eq!(page, 1);
+    }
+
+    #[test]
+    fn test_audit_page_bounds_clamps_per_page_to_max() {
+        // An over-large per_page is clamped to the hard cap.
+        let (_offset, limit, _page, per_page) = audit_page_bounds(Some(1), Some(10_000));
+        assert_eq!(limit, AUDIT_MAX_PER_PAGE as i64);
+        assert_eq!(per_page, AUDIT_MAX_PER_PAGE);
+    }
+
+    #[test]
+    fn test_audit_page_bounds_clamps_zero_per_page_to_one() {
+        // per_page = 0 would return an empty page forever; clamp up to 1.
+        let (_offset, limit, _page, per_page) = audit_page_bounds(Some(1), Some(0));
+        assert_eq!(limit, 1);
+        assert_eq!(per_page, 1);
+    }
 
     // -----------------------------------------------------------------------
     // parse_backup_type

--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -1491,4 +1491,80 @@ mod tests {
         let val = serde_json::json!("not a number");
         assert_eq!(val.as_i64().unwrap_or(100), 100);
     }
+
+    // -----------------------------------------------------------------------
+    // #2366: GET /admin/audit — admin can read recorded events; a non-admin is
+    // refused by the handler's defense-in-depth check. Skips without
+    // `DATABASE_URL`.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_audit_logs_admin_reads_and_non_admin_forbidden_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::audit_service::{AuditAction, AuditEntry, AuditService, ResourceType};
+        use axum::body::Body;
+        use axum::http::{Method, Request, StatusCode};
+        use axum::Extension as AxumExtension;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+
+        // Seed one audit event keyed by a unique resource id.
+        let resource_id = Uuid::new_v4();
+        AuditService::new(pool.clone())
+            .log(
+                AuditEntry::new(AuditAction::UserCreated, ResourceType::User)
+                    .user(user_id)
+                    .resource(resource_id),
+            )
+            .await
+            .expect("seed audit event");
+
+        let state = tdh::build_state(pool.clone(), "/tmp");
+
+        // Admin caller -> 200, and our event is returned when filtered.
+        let mut admin_auth = tdh::make_auth(user_id, &username);
+        admin_auth.is_admin = true;
+        let app = router()
+            .with_state(state.clone())
+            .layer(AxumExtension::<AuthExtension>(admin_auth));
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri(format!("/audit?resource_id={}", resource_id))
+            .body(Body::empty())
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "admin can read audit; body: {}",
+            String::from_utf8_lossy(&body)
+        );
+        let v: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(v["total"], 1);
+        assert_eq!(v["items"][0]["action"], "USER_CREATED");
+        assert_eq!(v["items"][0]["resource_id"], resource_id.to_string());
+
+        // Non-admin caller -> 403 (handler defense-in-depth, independent of the
+        // `/admin` admin_middleware which is not mounted in this unit router).
+        let non_admin = tdh::make_auth(user_id, &username);
+        let app2 = router()
+            .with_state(state)
+            .layer(AxumExtension::<AuthExtension>(non_admin));
+        let req2 = Request::builder()
+            .method(Method::GET)
+            .uri("/audit")
+            .body(Body::empty())
+            .unwrap();
+        let (status2, _) = tdh::send(app2, req2).await;
+        assert_eq!(status2, StatusCode::FORBIDDEN);
+
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(resource_id)
+            .execute(&pool)
+            .await;
+        tdh::cleanup_user(&pool, user_id).await;
+    }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -31,6 +31,9 @@ use crate::formats::maven::MavenHandler;
 use crate::models::access_scope::AccessScope;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::artifact_service::ArtifactService;
+use crate::services::audit_service::{
+    audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
+};
 use crate::services::cache_classifier;
 use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
 use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
@@ -1485,6 +1488,20 @@ pub async fn create_repository(
         Some(auth.username.clone()),
     );
 
+    // Audit trail (#2366): repository created. Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .user(auth.user_id)
+            .resource(repo.id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "key": repo.key,
+                "is_public": repo.is_public,
+            })),
+    )
+    .await;
+
     let mut response = repo_to_response(repo, 0);
     if let Some(ref at) = payload.upstream_auth_type {
         response.upstream_auth_type = Some(at.clone());
@@ -1710,6 +1727,19 @@ pub async fn update_repository(
         repo.id,
         Some(auth.username.clone()),
     );
+
+    // Audit trail (#2366): repository updated. Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::RepositoryUpdated, ResourceType::Repository)
+            .user(auth.user_id)
+            .resource(repo.id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "key": repo.key,
+            })),
+    )
+    .await;
 
     let repo_id = repo.id;
     let response = repo_to_response(repo, storage_used);
@@ -2024,6 +2054,20 @@ pub async fn delete_repository(
         repo.id,
         Some(auth.username.clone()),
     );
+
+    // Audit trail (#2366): repository deleted. Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::RepositoryDeleted, ResourceType::Repository)
+            .user(auth.user_id)
+            .resource(repo.id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "key": repo.key,
+            })),
+    )
+    .await;
+
     Ok(())
 }
 

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -17,7 +17,7 @@ use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
 use crate::services::audit_service::{
     api_token_audit_entry, audit_fire_and_forget, password_change_audit_entry,
-    sessions_invalidated_audit_entry, AuditAction,
+    sessions_invalidated_audit_entry, AuditAction, AuditEntry, ResourceType,
 };
 use crate::services::auth_service::{
     invalidate_user_token_cache_entries, invalidate_user_tokens, AuthService,
@@ -386,6 +386,21 @@ pub async fn create_user(
         .event_bus
         .emit("user.created", user.id, Some(auth.username.clone()));
 
+    // Audit trail (#2366): admin created a user. Actor = acting admin
+    // (`user_id`), target = the new user (`resource`). Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::UserCreated, ResourceType::User)
+            .user(auth.user_id)
+            .resource(user.id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "username": user.username,
+                "is_admin": user.is_admin,
+            })),
+    )
+    .await;
+
     Ok(Json(CreateUserResponse {
         user: user_to_response(user),
         generated_password: if auto_generated { Some(password) } else { None },
@@ -571,6 +586,20 @@ pub async fn update_user(
         .event_bus
         .emit("user.updated", user.id, Some(auth.username.clone()));
 
+    // Audit trail (#2366): admin updated a user record. Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::UserUpdated, ResourceType::User)
+            .user(auth.user_id)
+            .resource(user.id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "is_admin": user.is_admin,
+                "is_active": user.is_active,
+            })),
+    )
+    .await;
+
     Ok(Json(user_to_response(user)))
 }
 
@@ -633,6 +662,16 @@ pub async fn delete_user(
     state
         .event_bus
         .emit("user.deleted", id, Some(auth.username.clone()));
+
+    // Audit trail (#2366): admin deleted a user. Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::UserDeleted, ResourceType::User)
+            .user(auth.user_id)
+            .resource(id)
+            .details(serde_json::json!({ "actor_id": auth.user_id.to_string() })),
+    )
+    .await;
 
     Ok(())
 }
@@ -739,6 +778,20 @@ pub async fn assign_role(
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
 
+    // Audit trail (#2366): role granted to a user — a permission change.
+    // Actor = acting admin, target = the user receiving the role. Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::RoleAssigned, ResourceType::User)
+            .user(auth.user_id)
+            .resource(id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "role_id": payload.role_id.to_string(),
+            })),
+    )
+    .await;
+
     Ok(())
 }
 
@@ -777,6 +830,20 @@ pub async fn revoke_role(
     if result.rows_affected() == 0 {
         return Err(AppError::NotFound("Role assignment not found".to_string()));
     }
+
+    // Audit trail (#2366): role revoked from a user — a permission change.
+    // Best-effort.
+    audit_fire_and_forget(
+        state.db.clone(),
+        AuditEntry::new(AuditAction::RoleRevoked, ResourceType::User)
+            .user(auth.user_id)
+            .resource(user_id)
+            .details(serde_json::json!({
+                "actor_id": auth.user_id.to_string(),
+                "role_id": role_id.to_string(),
+            })),
+    )
+    .await;
 
     Ok(())
 }

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1199,6 +1199,25 @@ pub async fn admin_middleware(
     };
 
     if !auth_ext.is_admin {
+        // Best-effort RBAC-deny audit event (#2366): an authenticated non-admin
+        // reaching an admin-only route is exactly the kind of authorization
+        // decision an auditor wants recorded. Fire-and-forget so an audit-table
+        // outage can never turn a clean 403 into a 500. The attempted path is
+        // recorded (never any credential material).
+        {
+            use crate::services::audit_service::{
+                audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
+            };
+            let entry = AuditEntry::new(AuditAction::PermissionDenied, ResourceType::User)
+                .user(auth_ext.user_id)
+                .resource(auth_ext.user_id)
+                .details(serde_json::json!({
+                    "path": request.uri().path(),
+                    "method": request.method().as_str(),
+                    "reason": "admin_privileges_required",
+                }));
+            audit_fire_and_forget(auth_service.db().clone(), entry).await;
+        }
         return (StatusCode::FORBIDDEN, "Admin access required").into_response();
     }
 

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -2410,4 +2410,77 @@ mod tests {
         tdh::cleanup(&pool, repo_id, user_id).await;
         let _ = std::fs::remove_dir_all(&storage_dir);
     }
+
+    /// #2366: the artifact lifecycle emits audit events. Upload -> download ->
+    /// delete each writes exactly one `audit_log` row for the artifact, keyed
+    /// by the shared service-layer choke points (`finalize_upload`,
+    /// `finish_download`, `delete_with_sync_options`). The download event also
+    /// carries the client IP and acting user. Skips without `DATABASE_URL`.
+    #[tokio::test]
+    async fn test_artifact_lifecycle_emits_audit_events_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, _username) = tdh::create_user(&pool).await;
+        let (repo_id, _repo_key, storage_dir) = tdh::create_repo(&pool, "local", "generic").await;
+
+        let storage: Arc<dyn StorageBackend> = Arc::new(
+            crate::storage::filesystem::FilesystemStorage::new(storage_dir.clone()),
+        );
+        let svc = ArtifactService::new(pool.clone(), storage);
+
+        // Upload -> ARTIFACT_UPLOADED (audit write is awaited inside
+        // finalize_upload, so it has landed by the time upload() returns).
+        let artifact = svc
+            .upload(
+                repo_id,
+                "audit/pkg.txt",
+                "pkg.txt",
+                Some("1.0"),
+                "text/plain",
+                Bytes::from_static(b"audit-bytes"),
+                Some(user_id),
+            )
+            .await
+            .expect("upload succeeds");
+        assert_eq!(
+            tdh::audit_count(&pool, artifact.id, "ARTIFACT_UPLOADED").await,
+            1,
+            "upload emits exactly one ARTIFACT_UPLOADED event"
+        );
+
+        // Download -> ARTIFACT_DOWNLOADED with a resolved client IP + user.
+        let _ = svc
+            .download(
+                repo_id,
+                "audit/pkg.txt",
+                Some(user_id),
+                Some("203.0.113.5".to_string()),
+                Some("test-ua"),
+            )
+            .await
+            .expect("download succeeds");
+        assert_eq!(
+            tdh::audit_count(&pool, artifact.id, "ARTIFACT_DOWNLOADED").await,
+            1,
+            "download emits exactly one ARTIFACT_DOWNLOADED event"
+        );
+
+        // Delete -> ARTIFACT_DELETED.
+        svc.delete(artifact.id).await.expect("delete succeeds");
+        assert_eq!(
+            tdh::audit_count(&pool, artifact.id, "ARTIFACT_DELETED").await,
+            1,
+            "delete emits exactly one ARTIFACT_DELETED event"
+        );
+
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(artifact.id)
+            .execute(&pool)
+            .await;
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
 }

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -881,6 +881,28 @@ impl ArtifactService {
             });
         }
 
+        // Best-effort audit trail (#2366): record who uploaded which artifact.
+        // Fire-and-forget so an audit-table outage can never fail an upload,
+        // mirroring the download/stats contract.
+        {
+            use crate::services::audit_service::{
+                audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
+            };
+            let mut entry = AuditEntry::new(AuditAction::ArtifactUploaded, ResourceType::Artifact)
+                .resource(artifact.id)
+                .details(serde_json::json!({
+                    "repository_id": artifact.repository_id.to_string(),
+                    "path": artifact.path,
+                    "name": artifact.name,
+                    "version": artifact.version,
+                    "size_bytes": artifact.size_bytes,
+                }));
+            if let Some(uid) = uploaded_by {
+                entry = entry.user(uid);
+            }
+            audit_fire_and_forget(self.db.clone(), entry).await;
+        }
+
         Ok(artifact)
     }
 
@@ -958,6 +980,33 @@ impl ArtifactService {
         .execute(&self.db)
         .await
         .ok(); // Ignore stats errors
+
+        // Best-effort audit trail (#2366). An `ARTIFACT_DOWNLOADED` event is the
+        // per-access record auditors need to answer "who fetched this artifact,
+        // and when?". Fire-and-forget: a download must never fail because the
+        // audit table is unavailable, mirroring the download-statistics write
+        // above. The IP is parsed leniently; a malformed value is simply omitted.
+        {
+            use crate::services::audit_service::{
+                audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
+            };
+            let mut entry =
+                AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
+                    .resource(artifact_id)
+                    .details(serde_json::json!({
+                        "repository_id": artifact_info.repository_id.to_string(),
+                        "path": artifact_info.path,
+                        "name": artifact_info.name,
+                        "version": artifact_info.version,
+                    }));
+            if let Some(uid) = user_id {
+                entry = entry.user(uid);
+            }
+            if let Some(ip) = ip_address.and_then(|s| s.parse::<std::net::IpAddr>().ok()) {
+                entry = entry.ip(ip);
+            }
+            audit_fire_and_forget(self.db.clone(), entry).await;
+        }
 
         // Trigger AfterDownload hooks (non-blocking)
         self.trigger_hook_non_blocking(PluginEventType::AfterDownload, artifact_info)
@@ -1265,6 +1314,27 @@ impl ArtifactService {
                     );
                     e
                 });
+        }
+
+        // Best-effort audit trail (#2366): record artifact deletion (soft
+        // delete). Fire-and-forget; never fails the delete.
+        {
+            use crate::services::audit_service::{
+                audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
+            };
+            // The service-layer delete does not carry the acting principal, so
+            // `user_id` (the actor) is intentionally left unset here; the
+            // original uploader is recorded in `details` for context.
+            let entry = AuditEntry::new(AuditAction::ArtifactDeleted, ResourceType::Artifact)
+                .resource(artifact.id)
+                .details(serde_json::json!({
+                    "repository_id": artifact.repository_id.to_string(),
+                    "path": artifact.path,
+                    "name": artifact.name,
+                    "version": artifact.version,
+                    "uploaded_by": artifact.uploaded_by.map(|u| u.to_string()),
+                }));
+            audit_fire_and_forget(self.db.clone(), entry).await;
         }
 
         // Trigger AfterDelete hooks (non-blocking)

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -86,6 +86,14 @@ pub enum AuditAction {
     AgeGateQueued,
     AgeGateApproved,
     AgeGateRejected,
+
+    // Authorization decisions (#2366 functional audit log). Recorded when an
+    // authenticated principal is refused a privileged operation (e.g. a
+    // non-admin reaching an admin-only route) so the audit trail captures
+    // denials, not just successful state changes. Appended at the END of the
+    // enum to keep the additive change conflict-free with in-flight taxonomy
+    // work.
+    PermissionDenied,
 }
 
 impl AuditAction {
@@ -137,6 +145,7 @@ impl AuditAction {
             AuditAction::AgeGateQueued => "AGE_GATE_QUEUED",
             AuditAction::AgeGateApproved => "AGE_GATE_APPROVED",
             AuditAction::AgeGateRejected => "AGE_GATE_REJECTED",
+            AuditAction::PermissionDenied => "PERMISSION_DENIED",
         }
     }
 }
@@ -732,6 +741,12 @@ mod tests {
         assert_eq!(AuditAction::ScanReaped.as_str(), "SCAN_REAPED");
     }
 
+    #[test]
+    fn test_audit_action_as_str_permission_denied() {
+        // #2366: authorization-denial event.
+        assert_eq!(AuditAction::PermissionDenied.as_str(), "PERMISSION_DENIED");
+    }
+
     // -----------------------------------------------------------------------
     // ResourceType::as_str
     // -----------------------------------------------------------------------
@@ -1212,5 +1227,76 @@ mod tests {
         assert_eq!(details["trigger"], "password_change");
         // Reserved key must not survive into the stored payload.
         assert!(!details.as_object().expect("object").contains_key("actor"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #2366: emit -> query round-trip against a real database. Skips cleanly
+    // when `DATABASE_URL` is unset (the CI coverage job seeds Postgres, so it
+    // is exercised there). Uses `user_id = None` to avoid the users FK.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_log_then_query_roundtrip_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let service = AuditService::new(pool);
+
+        // A unique resource id keys this test's rows so parallel test processes
+        // never see each other's events.
+        let resource_id = Uuid::new_v4();
+        let entry = AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .resource(resource_id)
+            .details(serde_json::json!({ "key": "audit-roundtrip-test" }));
+        let id = service.log(entry).await.expect("log succeeds");
+        assert!(!id.is_nil());
+
+        // Query by the unique resource id: exactly our row comes back, with the
+        // action, resource type/id, and a populated timestamp.
+        let (rows, total) = service
+            .query(
+                None,
+                None,
+                Some("repository"),
+                Some(resource_id),
+                None,
+                None,
+                0,
+                50,
+            )
+            .await
+            .expect("query succeeds");
+        assert_eq!(total, 1, "exactly one event for the unique resource id");
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.action, "REPOSITORY_CREATED");
+        assert_eq!(row.resource_type, "repository");
+        assert_eq!(row.resource_id, Some(resource_id));
+        assert_eq!(row.details.as_ref().unwrap()["key"], "audit-roundtrip-test");
+
+        // A non-matching action filter excludes the row (filter is applied).
+        let (rows2, total2) = service
+            .query(
+                None,
+                Some("LOGIN"),
+                None,
+                Some(resource_id),
+                None,
+                None,
+                0,
+                50,
+            )
+            .await
+            .expect("query succeeds");
+        assert_eq!(total2, 0);
+        assert!(rows2.is_empty());
+
+        // Cleanup our row so the table does not accrete across test runs.
+        // Runtime (non-macro) query so no offline `.sqlx` prepare is needed.
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(resource_id)
+            .execute(&service.db)
+            .await;
     }
 }


### PR DESCRIPTION
## ⚠️ HELD — 1.5.0 feature, do not merge until 1.5.0 opens

Per our release strategy, v1.5.0 value-prop features stay off `main` until the 1.5.0 milestone opens. This PR is ready and validated but should **not** be merged yet.

Closes #2366

## Summary
Makes the audit log functional: the `audit_log` table (migration 005) and `AuditService` already existed and several paths (auth/token/SSO/TOTP/SBOM) already emitted events, but key admin-surface mutations and all artifact access were unrecorded, and there was **no read endpoint**. This wires the remaining event points and adds an admin query API. No migration needed — the existing schema is sufficient.

## Emit (best-effort, fire-and-forget — an audit-table outage never fails the request)
- **Artifact upload / download / delete** — instrumented the shared service-layer choke points (`finalize_upload`, `finish_download`, `delete_with_sync_options`) so every format handler is covered by one code path. The download event records the resolved **client IP** (X-Forwarded-For aware) and **user id**.
- **User create/update/delete** and **role assign/revoke** (users handlers).
- **Repository create/update/delete** (repository handlers).
- **Authorization denials** — `admin_middleware` records a `PERMISSION_DENIED` event when an authenticated non-admin is refused an admin-only route.

Added `AuditAction::PermissionDenied` (appended to the enum).

## Read
`GET /api/v1/admin/audit` — admin-only (enforced by `admin_middleware` **and** a defense-in-depth check in the handler). Filters: `user_id`, `action`, `resource_type`, `resource_id`, `from`, `to`. Pagination: `page` / `per_page` (default 50, max 200). Backed by the existing `AuditService::query`.

## Validation (live, isolated stack)
Performed auditable actions and queried the endpoint:

| action | resource_type | actor | target | ip |
|---|---|---|---|---|
| LOGIN | user | admin | admin | — |
| USER_CREATED | user | admin | new user | — |
| REPOSITORY_CREATED | repository | admin | repo | — |
| API_TOKEN_CREATED / REVOKED | api_token | admin | token | — |
| ARTIFACT_UPLOADED | artifact | admin | artifact | — |
| ARTIFACT_DOWNLOADED | artifact | admin | artifact | **203.0.113.77** (XFF) |
| PERMISSION_DENIED | user | non-admin | — | — |

- Filters verified (`action`, `resource_type`, future `from` → 0) and pagination verified (`per_page=2` → 2 of 7).
- Non-admin `GET /admin/audit` → **403**; anonymous → **401**.
- RBAC-deny event recorded when the non-admin was blocked.

## Tests
- Pure `audit_page_bounds` pagination unit tests (no DB — exercised by the coverage gate).
- `AuditAction::PermissionDenied` as_str unit test.
- DB-backed emit→query round-trip test (skips cleanly without `DATABASE_URL`).

## Gates
`cargo build --lib` / `--release` (Docker) / `fmt --check` / `clippy --workspace -- -D warnings -A dead_code` / touched-module `cargo test` — all green.
