### PR TITLE
ci(release): require a CHANGELOG entry for the release version; add RELEASING.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,44 @@ jobs:
       needs.build-binaries.result == 'success'
     timeout-minutes: 35
     steps:
+      - name: Checkout tag (for CHANGELOG verification)
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # ── CHANGELOG documents the release ─────────────────────────────
+      # Release policy: every final release vX.Y.Z must carry a
+      # non-empty `## [X.Y.Z]` section in CHANGELOG.md (promote the
+      # [Unreleased] section before tagging; see RELEASING.md). This
+      # runs before the image polling so a missing entry fails in
+      # seconds instead of after the 30-minute image wait. Prerelease
+      # tags (contain '-') are exempt. The same rule is enforced by the
+      # version-set-integrity job in the artifact-keeper-test release
+      # gate when it is dispatched with a release version tag.
+      - name: Verify CHANGELOG.md documents this release
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${VERSION} is not a final release version (X.Y.Z); CHANGELOG check skipped."
+            exit 0
+          fi
+          ver_esc="${VERSION//./\\.}"
+          if ! grep -qE "^## \[${ver_esc}\]" CHANGELOG.md; then
+            echo "::error title=CHANGELOG entry missing::CHANGELOG.md has no entry for ${VERSION} -- promote [Unreleased] to a '## [${VERSION}] - <date>' section before tagging. The release stays a DRAFT until the entry exists and the tag is re-cut."
+            exit 1
+          fi
+          content_lines=$(awk -v ver="${VERSION}" '
+            BEGIN { esc = ver; gsub(/\./, "\\.", esc); pat = "^## \\[" esc "\\]" }
+            $0 ~ pat { insec = 1; next }
+            insec && /^## /  { exit }
+            insec && NF > 0  { n++ }
+            END { print n + 0 }
+          ' CHANGELOG.md)
+          if [ "${content_lines}" -eq 0 ]; then
+            echo "::error title=CHANGELOG entry empty::CHANGELOG.md has a '## [${VERSION}]' heading but no content under it -- fill in the release notes before tagging."
+            exit 1
+          fi
+          echo "CHANGELOG.md documents ${VERSION} (${content_lines} content lines). OK."
+
       - name: Wait for and verify required images on ghcr.io and docker.io
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,83 @@
+# Releasing Artifact Keeper
+
+Runbook for cutting a release from `main`. Maintenance releases from
+`release/X.Y.x` branches follow the same sequence; the only difference is
+that fixes reach the branch by cherry-pick from `main` first (see
+"Release Branch Strategy" in [CLAUDE.md](CLAUDE.md) and the
+release-branch-gate workflow).
+
+Throughout, `X.Y.Z` is the version being released and the git tag is
+`vX.Y.Z` (Docker tags drop the `v`).
+
+## Cut sequence
+
+1. **Confirm scope and health.** The milestone for `X.Y.Z` has no open
+   issues you still intend to ship, and `main` is green (CI Complete on the
+   release candidate commit).
+
+2. **Bump the version set.** The version is displayed or pinned in several
+   decoupled places; a partial bump ships a stale version string. Update
+   all of them in one PR (or one PR per repo):
+   - `Cargo.toml` (workspace `version`, this repo) and the regenerated
+     `Cargo.lock`
+   - `backend/src/api/openapi.rs` (hardcoded `version = "..."` in the
+     OpenAPI info block, this repo)
+   - `package.json` `version` in artifact-keeper-web
+   - `charts/artifact-keeper/Chart.yaml` `version` and `appVersion` in
+     artifact-keeper-iac
+
+3. **REQUIRED: promote the CHANGELOG.** Before tagging `vX.Y.Z`, promote
+   the `## [Unreleased]` section in `CHANGELOG.md` to
+   `## [X.Y.Z] - <date>` (and open a fresh empty `## [Unreleased]` above
+   it). Include the Sponsors and Thank You recognition sections per the
+   "Changelog and Release Notes" policy in [CLAUDE.md](CLAUDE.md).
+
+   This step is enforced, not advisory: the release gate's
+   `version-set-integrity` check (artifact-keeper-test) and the
+   `verify-images-published` job in `release.yml` both assert that
+   `CHANGELOG.md` contains a non-empty `## [X.Y.Z]` section for the
+   version being released. A release with no CHANGELOG entry for the
+   version will fail the gate and the GitHub Release will not publish
+   (it stays a draft). Land the promotion on `main` before tagging.
+
+4. **Pre-tag verification (recommended).** Dispatch the Release Gate
+   (Full Suite) in artifact-keeper-test against the candidate images
+   (`backend_tag` / `web_tag`). When dispatched with the release version
+   as `backend_tag`, `version-set-integrity` also verifies the published
+   image set and the CHANGELOG entry before you commit to the tag.
+
+5. **Tag the release.**
+
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z && git push origin vX.Y.Z
+   ```
+
+   The tag triggers `release.yml` (binaries, gates, GitHub Release) and
+   `docker-publish.yml` (backend, web, openscap images on ghcr.io and
+   docker.io).
+
+6. **Watch the gates.** `release.yml` runs the E2E gate, the
+   artifact-keeper-test release gate, and `verify-images-published`
+   (image presence on both registries plus the CHANGELOG entry check).
+   If any required gate fails, the GitHub Release is created as a
+   **draft** with binaries attached but is not published. Fix the cause
+   (for a missing CHANGELOG entry: land the promotion on `main`, delete
+   and re-cut the tag) rather than publishing the draft by hand.
+
+7. **Post-release checks.** Confirm the GitHub Release is published (not
+   draft), release notes are auto-generated (do not hardcode static
+   notes), `:latest` moved only if this is a stable release, and the demo
+   or any pinned environments are updated intentionally (see
+   "Infrastructure & Cost Rules" in CLAUDE.md).
+
+## Policy summary
+
+- Every release documents itself: no `vX.Y.Z` tag without a non-empty
+  `## [X.Y.Z]` section in `CHANGELOG.md`. Enforced by
+  `version-set-integrity` (artifact-keeper-test release gate) and
+  `release.yml` `verify-images-published`.
+- Release notes on GitHub are auto-generated; recognition sections
+  (Sponsors, Thank You) follow the CLAUDE.md policy.
+- Prerelease tags (`-rc.N`, `-beta.N`) are exempt from the CHANGELOG
+  entry requirement; final releases are not.


### PR DESCRIPTION
## Summary

Makes "the CHANGELOG must document the release version" an enforced part of the release policy. v1.2.5 and v1.3.0 both shipped with their changes still under `## [Unreleased]` (neither tag has a promoted `## [X.Y.Z]` section); nothing in the release path caught it.

Two changes:

1. **`release.yml` / `verify-images-published`**: new step, before the registry polling, that checks out the tag and asserts `CHANGELOG.md` contains a non-empty `## [X.Y.Z]` section for the tagged version (the `## [X.Y.Z] - DATE` form is tolerated; exact-version match, so `1.2.50` cannot satisfy `1.2.5`). Missing or empty entry fails the job with a clear message ("promote [Unreleased] to a `## [X.Y.Z]` section before tagging"), which keeps the GitHub Release a draft via the existing gate-status logic. Prerelease tags (`-rc.N` etc.) are exempt, and the check only runs on the tag-triggered release path, so normal PRs and non-release runs are unaffected.

2. **`RELEASING.md`** (new): the cut-sequence runbook. Step 3 is the required CHANGELOG promotion, placed right before the tag step, and notes that the gate enforces it.

A companion PR in artifact-keeper-test adds the same assertion to the `version-set-integrity` job of the release gate (`verify-image-set.sh`), covering pre-tag gate dispatches that pass a real release version as `backend_tag`. The `release.yml` check here is needed because the tag-triggered gate call uses `backend_tag: dev`.

Verification: the step body passes shellcheck and was simulated locally against fixtures: version with a changelog section passes; missing section fails with the promote-[Unreleased] message; heading-with-no-content fails; prerelease tag skips; `## [1.2.50]` does not satisfy `1.2.5`; `## [X.Y.Z] - DATE` headings pass. Existing image-verification behavior is untouched (the new step is additive and runs first).

Closes #2376

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes