### PR TITLE
ci: add docs-only shim workflow for path-filtered required checks

### DIFF
--- a/.github/workflows/docs-required-shim.yml
+++ b/.github/workflows/docs-required-shim.yml
@@ -1,0 +1,49 @@
+# Docs-only required-check shim.
+#
+# The main CI workflow (ci.yml) uses `paths-ignore` to skip docs-only
+# changes. Branch protection on `main` requires the contexts
+# "🦀 Check Rust", "🧪 Backend Unit Tests", and "✅ CI Complete", so a
+# PR that only touches ignored paths never gets those checks posted and
+# is permanently blocked.
+#
+# This workflow is the standard GitHub-documented counterpart
+# ("Handling skipped but required checks"): it triggers on exactly the
+# paths ci.yml ignores and posts trivially-successful jobs whose names
+# match the required contexts character-for-character.
+#
+# IMPORTANT: keep the `paths` list below in sync with the
+# `paths-ignore` list in ci.yml, and keep the job names in sync with
+# the branch-protection required status checks.
+name: CI (docs-only shim)
+
+on:
+  pull_request:
+    branches: [main, master, develop, 'release/**']
+    paths:
+      - 'site/**'
+      - '**/*.md'
+      - '.beads/**'
+      - 'LICENSE'
+      - 'CLAUDE.md'
+
+permissions:
+  contents: read
+
+jobs:
+  check-rust:
+    name: 🦀 Check Rust
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — real CI skipped by path filter; shim satisfies required check"
+
+  test-backend-unit:
+    name: 🧪 Backend Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — real CI skipped by path filter; shim satisfies required check"
+
+  ci-complete:
+    name: ✅ CI Complete
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "docs-only change — real CI skipped by path filter; shim satisfies required check"


### PR DESCRIPTION
Closes #2378

## Problem

`ci.yml` uses `paths-ignore` (`site/**`, `**/*.md`, `.beads/**`, `LICENSE`, `CLAUDE.md`) on `pull_request`, while branch protection on `main` requires `🦀 Check Rust`, `🧪 Backend Unit Tests`, and `✅ CI Complete`. A docs-only PR therefore never triggers CI, the required contexts never post, and the PR is permanently blocked (currently blocking #2375).

## Change

Adds `.github/workflows/docs-required-shim.yml` — the standard GitHub-documented counterpart for path-filtered required checks ("Handling skipped but required checks"):

- Triggers on `pull_request` with `paths:` set to exactly the list `ci.yml` ignores, so it fires precisely when the real CI is skipped.
- One trivially-successful `echo` job per required context, with each job `name` matching the required context string character-for-character (verified against `branches/main/protection.required_status_checks.contexts`).

## Behavior

- **Docs-only PR** (e.g. CHANGELOG): real CI skipped as before; shim posts the 3 required contexts green → mergeable.
- **Code-only PR**: shim's `paths` filter excludes it entirely; only the real CI posts the contexts — the shim cannot mask real CI.
- **Mixed PR** (docs + code): the real CI runs (paths-ignore only skips when *all* changed files are ignored). Note the shim also fires in this case; this is inherent to GitHub's documented shim pattern.

Maintenance note (documented in the file header): keep the shim's `paths` list in sync with `ci.yml`'s `paths-ignore`, and the job names in sync with the branch-protection required contexts.

This PR itself touches a non-`.md` file, so the real CI runs on it.