### PR TITLE
feat(telemetry): capture real client IP + user for downloads across all formats

### DIFF
--- a/backend/migrations/151_download_telemetry_ip_index.sql
+++ b/backend/migrations/151_download_telemetry_ip_index.sql
@@ -1,0 +1,6 @@
+-- #2365: per-download IP + user telemetry.
+-- Downloads are now attributed to the real client IP (trusted-proxy-aware)
+-- instead of the historical '0.0.0.0' sentinel. Index the IP dimension so the
+-- admin reporting endpoints (downloads by IP / network-topology views) don't
+-- sequential-scan download_statistics.
+CREATE INDEX idx_download_stats_ip ON download_statistics(ip_address, downloaded_at);

--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -30,6 +30,9 @@ pub fn router() -> Router<SharedState> {
         .route("/backups/:id/cancel", post(cancel_backup))
         .route("/settings", get(get_settings).post(update_settings))
         .route("/stats", get(get_system_stats))
+        .route("/downloads", get(list_downloads))
+        .route("/downloads/by-ip/:ip", get(list_downloads_by_ip))
+        .route("/downloads/by-user/:user_id", get(list_downloads_by_user))
         .route("/cleanup", post(run_cleanup))
         .route("/reindex", post(trigger_reindex))
         .route("/rescan-for-inventory", post(rescan_for_inventory))
@@ -805,6 +808,212 @@ pub async fn get_system_stats(State(state): State<SharedState>) -> Result<Json<S
     }))
 }
 
+/// Query parameters for the download-telemetry listing (#2365).
+#[derive(Debug, Default, Deserialize, ToSchema, IntoParams)]
+pub struct ListDownloadsQuery {
+    /// Filter to downloads of one artifact.
+    pub artifact_id: Option<Uuid>,
+    /// Filter to downloads by one user.
+    pub user_id: Option<Uuid>,
+    /// Filter to downloads from one client IP (exact match).
+    pub ip: Option<String>,
+    /// Inclusive lower bound on `downloaded_at` (RFC 3339).
+    pub from: Option<String>,
+    /// Inclusive upper bound on `downloaded_at` (RFC 3339).
+    pub to: Option<String>,
+    pub page: Option<u32>,
+    pub per_page: Option<u32>,
+}
+
+/// One attributed download event.
+#[derive(Debug, Serialize, ToSchema, sqlx::FromRow)]
+pub struct DownloadRecord {
+    pub artifact_id: Uuid,
+    pub user_id: Option<Uuid>,
+    /// Username of the downloader, when the download was authenticated and
+    /// the user still exists.
+    pub username: Option<String>,
+    /// Resolved client IP; NULL for legacy rows and unresolvable clients.
+    pub ip_address: Option<String>,
+    pub user_agent: Option<String>,
+    pub downloaded_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct DownloadListResponse {
+    pub downloads: Vec<DownloadRecord>,
+    pub total: i64,
+    pub page: u32,
+    pub per_page: u32,
+}
+
+/// Parse an optional RFC 3339 query timestamp, rejecting malformed input.
+fn parse_rfc3339_bound(
+    value: Option<&str>,
+    name: &str,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+    value
+        .map(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| AppError::Validation(format!("invalid `{name}` timestamp: {e}")))
+        })
+        .transpose()
+}
+
+/// Append the shared WHERE clauses for the download-telemetry queries.
+fn push_download_filters<'a>(
+    builder: &mut sqlx::QueryBuilder<'a, sqlx::Postgres>,
+    query: &'a ListDownloadsQuery,
+    from: Option<chrono::DateTime<chrono::Utc>>,
+    to: Option<chrono::DateTime<chrono::Utc>>,
+) {
+    builder.push(" WHERE TRUE");
+    if let Some(artifact_id) = query.artifact_id {
+        builder.push(" AND d.artifact_id = ").push_bind(artifact_id);
+    }
+    if let Some(user_id) = query.user_id {
+        builder.push(" AND d.user_id = ").push_bind(user_id);
+    }
+    if let Some(ip) = &query.ip {
+        builder.push(" AND d.ip_address = ").push_bind(ip);
+    }
+    if let Some(from) = from {
+        builder.push(" AND d.downloaded_at >= ").push_bind(from);
+    }
+    if let Some(to) = to {
+        builder.push(" AND d.downloaded_at <= ").push_bind(to);
+    }
+}
+
+/// Shared listing core for the three download-telemetry endpoints.
+async fn query_downloads(
+    db: &sqlx::PgPool,
+    query: &ListDownloadsQuery,
+) -> Result<DownloadListResponse> {
+    let page = query.page.unwrap_or(1).max(1);
+    let per_page = query.per_page.unwrap_or(20).clamp(1, 100);
+    let offset = ((page - 1) * per_page) as i64;
+    let from = parse_rfc3339_bound(query.from.as_deref(), "from")?;
+    let to = parse_rfc3339_bound(query.to.as_deref(), "to")?;
+
+    let mut count_builder = sqlx::QueryBuilder::new("SELECT COUNT(*) FROM download_statistics d");
+    push_download_filters(&mut count_builder, query, from, to);
+    let total: i64 = count_builder
+        .build_query_scalar()
+        .fetch_one(db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT d.artifact_id, d.user_id, u.username, d.ip_address, d.user_agent, \
+         d.downloaded_at \
+         FROM download_statistics d LEFT JOIN users u ON u.id = d.user_id",
+    );
+    push_download_filters(&mut builder, query, from, to);
+    builder
+        .push(" ORDER BY d.downloaded_at DESC LIMIT ")
+        .push_bind(per_page as i64)
+        .push(" OFFSET ")
+        .push_bind(offset);
+    let downloads: Vec<DownloadRecord> = builder
+        .build_query_as()
+        .fetch_all(db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(DownloadListResponse {
+        downloads,
+        total,
+        page,
+        per_page,
+    })
+}
+
+/// List attributed downloads (client IP + user), filterable by artifact,
+/// user, IP, and time range (#2365). Admin-only: download attribution is
+/// sensitive.
+#[utoipa::path(
+    get,
+    path = "/downloads",
+    context_path = "/api/v1/admin",
+    tag = "admin",
+    params(ListDownloadsQuery),
+    responses(
+        (status = 200, description = "Attributed download events", body = DownloadListResponse),
+        (status = 400, description = "Invalid filter parameter"),
+        (status = 403, description = "Admin privileges required")
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_downloads(
+    State(state): State<SharedState>,
+    Query(query): Query<ListDownloadsQuery>,
+) -> Result<Json<DownloadListResponse>> {
+    Ok(Json(query_downloads(&state.db, &query).await?))
+}
+
+/// Downloads originating from one client IP: "what did this network
+/// location pull?" (#2365).
+#[utoipa::path(
+    get,
+    path = "/downloads/by-ip/{ip}",
+    context_path = "/api/v1/admin",
+    tag = "admin",
+    params(
+        ("ip" = String, Path, description = "Client IP address"),
+        ListDownloadsQuery
+    ),
+    responses(
+        (status = 200, description = "Downloads from the IP", body = DownloadListResponse),
+        (status = 400, description = "Invalid IP address"),
+        (status = 403, description = "Admin privileges required")
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_downloads_by_ip(
+    State(state): State<SharedState>,
+    Path(ip): Path<String>,
+    Query(query): Query<ListDownloadsQuery>,
+) -> Result<Json<DownloadListResponse>> {
+    let ip: std::net::IpAddr = ip
+        .parse()
+        .map_err(|_| AppError::Validation("invalid IP address".to_string()))?;
+    let query = ListDownloadsQuery {
+        ip: Some(ip.to_string()),
+        ..query
+    };
+    Ok(Json(query_downloads(&state.db, &query).await?))
+}
+
+/// Downloads performed by one user: "what did this user pull?" (#2365).
+#[utoipa::path(
+    get,
+    path = "/downloads/by-user/{user_id}",
+    context_path = "/api/v1/admin",
+    tag = "admin",
+    params(
+        ("user_id" = Uuid, Path, description = "User id"),
+        ListDownloadsQuery
+    ),
+    responses(
+        (status = 200, description = "Downloads by the user", body = DownloadListResponse),
+        (status = 403, description = "Admin privileges required")
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn list_downloads_by_user(
+    State(state): State<SharedState>,
+    Path(user_id): Path<Uuid>,
+    Query(query): Query<ListDownloadsQuery>,
+) -> Result<Json<DownloadListResponse>> {
+    let query = ListDownloadsQuery {
+        user_id: Some(user_id),
+        ..query
+    };
+    Ok(Json(query_downloads(&state.db, &query).await?))
+}
+
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CleanupRequest {
     pub cleanup_audit_logs: Option<bool>,
@@ -1105,6 +1314,9 @@ pub async fn rescan_for_inventory(
         get_settings,
         update_settings,
         get_system_stats,
+        list_downloads,
+        list_downloads_by_ip,
+        list_downloads_by_user,
         run_cleanup,
         trigger_reindex,
         rescan_for_inventory,
@@ -1120,6 +1332,9 @@ pub async fn rescan_for_inventory(
         RestoreResponse,
         SystemSettings,
         SystemStats,
+        ListDownloadsQuery,
+        DownloadRecord,
+        DownloadListResponse,
         CleanupRequest,
         CleanupResponse,
         ReindexResponse,
@@ -1566,5 +1781,179 @@ mod tests {
             .execute(&pool)
             .await;
         tdh::cleanup_user(&pool, user_id).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // download telemetry (#2365)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_rfc3339_bound_accepts_valid_and_none() {
+        assert_eq!(parse_rfc3339_bound(None, "from").unwrap(), None);
+        let parsed = parse_rfc3339_bound(Some("2026-07-01T00:00:00Z"), "from")
+            .unwrap()
+            .unwrap();
+        assert_eq!(parsed.to_rfc3339(), "2026-07-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn test_parse_rfc3339_bound_rejects_malformed() {
+        let err = parse_rfc3339_bound(Some("yesterday"), "to").unwrap_err();
+        assert!(matches!(err, AppError::Validation(_)));
+    }
+
+    #[tokio::test]
+    async fn test_query_downloads_filters_by_ip_user_and_artifact() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, _repo_key, _dir) = tdh::create_repo(&pool, "local", "generic").await;
+        let artifact_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, \
+             checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, 'dl-telemetry', '1.0.0', 10, $3, 'application/octet-stream', $2) \
+             RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(format!("dl-telemetry/{}.bin", Uuid::new_v4()))
+        .bind(format!("{:0>64}", "1"))
+        .fetch_one(&pool)
+        .await
+        .expect("insert artifact");
+
+        // One authenticated download from 203.0.113.10, one anonymous from
+        // 203.0.113.11.
+        let ctx_authed = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: Some("203.0.113.10".parse().unwrap()),
+            user_id: Some(user_id),
+            user_agent: Some("admin-dl-test/1.0".to_string()),
+        };
+        let ctx_anon = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: Some("203.0.113.11".parse().unwrap()),
+            user_id: None,
+            user_agent: None,
+        };
+        crate::services::artifact_service::record_download(&pool, artifact_id, &ctx_authed).await;
+        crate::services::artifact_service::record_download(&pool, artifact_id, &ctx_anon).await;
+
+        // Filter by artifact: both rows.
+        let by_artifact = query_downloads(
+            &pool,
+            &ListDownloadsQuery {
+                artifact_id: Some(artifact_id),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query by artifact");
+        assert_eq!(by_artifact.total, 2);
+        assert_eq!(by_artifact.downloads.len(), 2);
+
+        // Filter by IP: only the authenticated row, with the username joined.
+        let by_ip = query_downloads(
+            &pool,
+            &ListDownloadsQuery {
+                artifact_id: Some(artifact_id),
+                ip: Some("203.0.113.10".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query by ip");
+        assert_eq!(by_ip.total, 1);
+        let row = &by_ip.downloads[0];
+        assert_eq!(row.user_id, Some(user_id));
+        assert_eq!(row.username.as_deref(), Some(username.as_str()));
+        assert_eq!(row.ip_address.as_deref(), Some("203.0.113.10"));
+        assert_eq!(row.user_agent.as_deref(), Some("admin-dl-test/1.0"));
+
+        // Filter by user: only the authenticated row.
+        let by_user = query_downloads(
+            &pool,
+            &ListDownloadsQuery {
+                artifact_id: Some(artifact_id),
+                user_id: Some(user_id),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query by user");
+        assert_eq!(by_user.total, 1);
+
+        // The anonymous row keeps a NULL user but a real IP.
+        let anon = query_downloads(
+            &pool,
+            &ListDownloadsQuery {
+                artifact_id: Some(artifact_id),
+                ip: Some("203.0.113.11".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("query anon row");
+        assert_eq!(anon.total, 1);
+        assert_eq!(anon.downloads[0].user_id, None);
+
+        // Pagination clamps per_page and honors page.
+        let paged = query_downloads(
+            &pool,
+            &ListDownloadsQuery {
+                artifact_id: Some(artifact_id),
+                page: Some(2),
+                per_page: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("paged query");
+        assert_eq!(paged.total, 2);
+        assert_eq!(paged.downloads.len(), 1);
+        assert_eq!(paged.page, 2);
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_record_download_unresolvable_ip_is_null_not_sentinel() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let (user_id, _username) = tdh::create_user(&pool).await;
+        let (repo_id, _repo_key, _dir) = tdh::create_repo(&pool, "local", "generic").await;
+        let artifact_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, \
+             checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, 'dl-null-ip', '1.0.0', 10, $3, 'application/octet-stream', $2) \
+             RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(format!("dl-null-ip/{}.bin", Uuid::new_v4()))
+        .bind(format!("{:0>64}", "2"))
+        .fetch_one(&pool)
+        .await
+        .expect("insert artifact");
+
+        crate::services::artifact_service::record_download(&pool, artifact_id, &Default::default())
+            .await;
+
+        let (ip, uid): (Option<String>, Option<Uuid>) = sqlx::query_as(
+            "SELECT ip_address, user_id FROM download_statistics WHERE artifact_id = $1",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("stats row");
+        assert_eq!(
+            ip, None,
+            "unresolvable client must record NULL, not 0.0.0.0"
+        );
+        assert_eq!(uid, None);
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
     }
 }

--- a/backend/src/api/handlers/alpine.rs
+++ b/backend/src/api/handlers/alpine.rs
@@ -508,6 +508,7 @@ async fn download_package(
         String,
         String,
     )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     if !filename.ends_with(".apk") {
         return Err((StatusCode::BAD_REQUEST, "File must have .apk extension").into_response());
@@ -599,12 +600,7 @@ async fn download_package(
     match storage.get_stream(&artifact.storage_key).await {
         Ok(stream) => {
             // Record download
-            let _ = sqlx::query!(
-                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-                artifact.id
-            )
-            .execute(&state.db)
-            .await;
+            crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
             Ok(Response::builder()
                 .status(StatusCode::OK)
@@ -630,12 +626,7 @@ async fn download_package(
             )
             .await?;
 
-            let _ = sqlx::query!(
-                "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-                artifact.id
-            )
-            .execute(&state.db)
-            .await;
+            crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
             Ok(Response::builder()
                 .status(StatusCode::OK)

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -355,6 +355,7 @@ async fn version_info(
 async fn download_collection(
     State(state): State<SharedState>,
     Path((repo_key, file_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_ansible_repo(&state.db, &repo_key).await?;
 
@@ -391,6 +392,7 @@ async fn download_collection(
         &artifact.storage_key,
         "application/gzip",
         Some(filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -820,6 +820,7 @@ async fn publish(
 async fn download(
     State(state): State<SharedState>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_cargo_repo(&state.db, &repo_key, &state.repo_cache).await?;
     let name_lower = name.to_lowercase();
@@ -999,12 +1000,7 @@ async fn download(
         .map_err(map_storage_err)?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!("{}-{}.crate", name_lower, version);
 

--- a/backend/src/api/handlers/chef.rs
+++ b/backend/src/api/handlers/chef.rs
@@ -246,6 +246,7 @@ async fn version_info(
 async fn download_cookbook(
     State(state): State<SharedState>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_chef_repo(&state.db, &repo_key).await?;
 
@@ -346,12 +347,7 @@ async fn download_cookbook(
                 .into_response()
         })?;
 
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!("{}-{}.tar.gz", name, version);
 

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -138,6 +138,7 @@ async fn get_podspec(
 async fn download_pod(
     State(state): State<SharedState>,
     Path((repo_key, pod_file)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_cocoapods_repo(&state.db, &repo_key).await?;
 
@@ -248,12 +249,7 @@ async fn download_pod(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     Ok(Response::builder()
         .status(StatusCode::OK)

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1012,6 +1012,7 @@ async fn download_archive(
         String,
         String,
     )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_composer_repo(&state.db, &repo_key).await?;
     let full_name = format!("{}/{}", vendor, package);
@@ -1139,12 +1140,7 @@ async fn download_archive(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!("{}-{}.zip", package, version);
 

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1553,6 +1553,7 @@ async fn recipe_file_download(
         String,
         String,
     )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
 
@@ -1669,12 +1670,7 @@ async fn recipe_file_download(
         .map_err(map_storage_err)?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let ct = content_type_for_conan_file(&file_path);
 
@@ -2356,6 +2352,7 @@ async fn package_file_download(
         String,
         String,
     )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_conan_repo(&state.db, &repo_key).await?;
 
@@ -2478,12 +2475,7 @@ async fn package_file_download(
         .map_err(map_storage_err)?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let ct = content_type_for_conan_file(&file_path);
 

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2288,6 +2288,7 @@ async fn download_package(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, subdir, filename)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_conda_repo(&state.db, &repo_key).await?;
 
@@ -2400,12 +2401,7 @@ async fn download_package(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let content_type = if filename.ends_with(".conda") {
         "application/octet-stream"

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -196,6 +196,7 @@ async fn package_index_gz(
 async fn download_package(
     State(state): State<SharedState>,
     Path((repo_key, filename)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_cran_repo(&state.db, &repo_key).await?;
 
@@ -230,6 +231,7 @@ async fn download_package(
         &artifact.storage_key,
         "application/x-gzip",
         Some(&filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1428,6 +1428,7 @@ fn xz_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
 async fn pool_download(
     State(state): State<SharedState>,
     Path((repo_key, component, path)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
@@ -1531,12 +1532,7 @@ async fn pool_download(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = path.rsplit('/').next().unwrap_or(&path);
 

--- a/backend/src/api/handlers/gitlfs.rs
+++ b/backend/src/api/handlers/gitlfs.rs
@@ -568,6 +568,7 @@ async fn upload_object(
 async fn download_object(
     State(state): State<SharedState>,
     Path((repo_key, oid)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_lfs_repo(&state.db, &repo_key).await?;
     validate_oid(&oid)?;
@@ -674,12 +675,7 @@ async fn download_object(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     Ok(Response::builder()
         .status(StatusCode::OK)

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -204,6 +204,7 @@ async fn resolve_go_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respon
 async fn handle_get(
     State(state): State<SharedState>,
     Path((repo_key, path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_go_repo(&state.db, &repo_key).await?;
     let request = parse_path(&path)?;
@@ -214,10 +215,10 @@ async fn handle_get(
             version_info(&state, &repo, &module, &version).await
         }
         GoProxyRequest::Mod { module, version } => {
-            get_mod_file(&state, &repo, &module, &version).await
+            get_mod_file(&state, &repo, &module, &version, &ctx).await
         }
         GoProxyRequest::Zip { module, version } => {
-            download_zip(&state, &repo, &module, &version).await
+            download_zip(&state, &repo, &module, &version, &ctx).await
         }
         GoProxyRequest::Latest { module } => latest_version(&state, &repo, &module).await,
         GoProxyRequest::SumDb { host, path } => proxy_sumdb(&host, &path).await,
@@ -620,6 +621,7 @@ async fn get_mod_file(
     repo: &RepoInfo,
     module: &str,
     version: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let artifact = sqlx::query!(
         r#"
@@ -734,12 +736,7 @@ async fn get_mod_file(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, ctx).await;
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -758,6 +755,7 @@ async fn download_zip(
     repo: &RepoInfo,
     module: &str,
     version: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let artifact = sqlx::query!(
         r#"
@@ -864,12 +862,7 @@ async fn download_zip(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, ctx).await;
 
     Ok(Response::builder()
         .status(StatusCode::OK)

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -393,6 +393,7 @@ async fn download_chart_via_index(
 async fn download_chart(
     State(state): State<SharedState>,
     Path((repo_key, filename)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_helm_repo(&state.db, &repo_key).await?;
 
@@ -429,6 +430,7 @@ async fn download_chart(
         &artifact.storage_key,
         "application/gzip",
         Some(&filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -202,6 +202,7 @@ async fn package_info(
 async fn download_tarball(
     State(state): State<SharedState>,
     Path((repo_key, tarball_file)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_hex_repo(&state.db, &repo_key).await?;
 
@@ -266,6 +267,7 @@ async fn download_tarball(
         &artifact.storage_key,
         "application/octet-stream",
         Some(filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -223,6 +223,7 @@ async fn model_info(
 async fn download_file(
     State(state): State<SharedState>,
     Path((repo_key, model_id, revision, filename)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_huggingface_repo(&state.db, &repo_key).await?;
 
@@ -276,6 +277,7 @@ async fn download_file(
         &artifact.storage_key,
         "application/octet-stream",
         Some(filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -147,6 +147,7 @@ async fn list_plugins(
 async fn download_plugin(
     State(state): State<SharedState>,
     Path((repo_key, name, version)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_jetbrains_repo(&state.db, &repo_key).await?;
 
@@ -248,12 +249,7 @@ async fn download_plugin(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!("{}-{}.zip", name, version);
 

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -823,6 +823,7 @@ async fn download(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, path)): Path<(String, String)>,
     headers: HeaderMap,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_maven_repo(&state.db, &repo_key).await?;
     let storage = state
@@ -997,7 +998,7 @@ async fn download(
     }
 
     // 4. Serve the artifact file
-    serve_artifact(&state, &repo, &repo_key, &path, auth.as_ref()).await
+    serve_artifact(&state, &repo, &repo_key, &path, auth.as_ref(), &ctx).await
 }
 
 /// Fetch a single Remote virtual member's Maven metadata document at `path`
@@ -1380,6 +1381,7 @@ async fn serve_artifact(
     repo_key: &str,
     path: &str,
     auth: Option<&AuthExtension>,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     // Remote (proxy) repos never persist rows in the `artifacts` table: the
     // proxy cache writes to the package catalog + filesystem only (guarded by
@@ -1648,12 +1650,7 @@ async fn serve_artifact(
         .map_err(map_storage_err)?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, ctx).await;
 
     let ct = content_type_for_path(path);
     let mut builder = Response::builder()
@@ -4019,6 +4016,7 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((repo_key.to_string(), meta_path.to_string())),
             axum::http::HeaderMap::new(),
+            Default::default(),
         )
         .await
         .expect("metadata download must succeed");
@@ -4036,6 +4034,7 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((repo_key.to_string(), format!("{}.{}", meta_path, ext))),
             axum::http::HeaderMap::new(),
+            Default::default(),
         )
         .await
         .expect("checksum download must succeed");
@@ -4580,6 +4579,7 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((virtual_key.clone(), meta_path.clone())),
             HeaderMap::new(),
+            Default::default(),
         )
         .await
         .expect("virtual metadata download must succeed");
@@ -4690,6 +4690,7 @@ mod tests {
             Extension(Some(auth)),
             Path((virtual_key.clone(), pom_path.to_string())),
             HeaderMap::new(),
+            Default::default(),
         )
         .await;
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1822,21 +1822,23 @@ fn rewrite_and_respond_inner(
 async fn download_tarball(
     State(state): State<SharedState>,
     Path((repo_key, package, filename)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let package = normalize_package_name(&package);
     validate_package_name(&package)?;
-    serve_tarball(&state, &repo_key, &package, &filename).await
+    serve_tarball(&state, &repo_key, &package, &filename, &ctx).await
 }
 
 async fn download_scoped_tarball(
     State(state): State<SharedState>,
     Path((repo_key, scope, package, filename)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let scope = normalize_package_name(&scope);
     let package = normalize_package_name(&package);
     let full_name = format!("@{}/{}", scope, package);
     validate_package_name(&full_name)?;
-    serve_tarball(&state, &repo_key, &full_name, &filename).await
+    serve_tarball(&state, &repo_key, &full_name, &filename, &ctx).await
 }
 
 /// Fetch an npm tarball from a virtual member's local storage, matching
@@ -1934,6 +1936,7 @@ async fn serve_tarball(
     repo_key: &str,
     package_name: &str,
     filename: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_npm_repo(&state.db, repo_key).await?;
 
@@ -2160,12 +2163,7 @@ async fn serve_tarball(
         .map_err(map_storage_err)?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, ctx).await;
 
     Ok(build_tarball_response_stream(
         stream,
@@ -4762,6 +4760,7 @@ mod tests {
                 "testpkg".to_string(),
                 "testpkg-1.0.0.tgz".to_string(),
             )),
+            Default::default(),
         )
         .await;
 
@@ -4863,6 +4862,7 @@ mod tests {
                     "bigpkg".to_string(),
                     "bigpkg-1.0.0.tgz".to_string(),
                 )),
+                Default::default(),
             )
             .await;
 
@@ -6189,6 +6189,7 @@ mod db_cov_tests {
             &fx.repo_key,
             package,
             &format!("{package}-9.9.9.tgz"),
+            &Default::default(),
         )
         .await;
         let aged = super::serve_tarball(
@@ -6196,6 +6197,7 @@ mod db_cov_tests {
             &fx.repo_key,
             package,
             &format!("{package}-1.0.0.tgz"),
+            &Default::default(),
         )
         .await;
 

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -646,6 +646,7 @@ async fn flatcontainer_versions(
 async fn flatcontainer_download(
     State(state): State<SharedState>,
     Path((repo_key, package_id, version, filename)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_nuget_repo(&state.db, &repo_key).await?;
     let package_id_lower = package_id.to_lowercase();
@@ -818,12 +819,7 @@ async fn flatcontainer_download(
         };
 
     // Record download.
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     use futures::StreamExt as _;
     Ok(Response::builder()
@@ -2019,6 +2015,7 @@ mod tests {
                 version.to_string(),
                 filename.clone(),
             )),
+            Default::default(),
         )
         .await;
 

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1254,6 +1254,7 @@ async fn upload(
 async fn download(
     State(state): State<SharedState>,
     Path(repo_key): Path<String>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
     axum::Json(body): axum::Json<DownloadRequest>,
 ) -> Result<Response, Response> {
     let repo = resolve_protobuf_repo(&state.db, &repo_key).await?;
@@ -1431,12 +1432,7 @@ async fn download(
 
         // Record download
         let artifact_id: uuid::Uuid = artifact_row.get("id");
-        let _ = sqlx::query(
-            "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        )
-        .bind(artifact_id)
-        .execute(&state.db)
-        .await;
+        crate::services::artifact_service::record_download(&state.db, artifact_id, &ctx).await;
 
         contents.push(DownloadContent { commit, files });
     }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4028,6 +4028,7 @@ pub async fn serve_local_artifact(
     storage_key: &str,
     content_type: &str,
     content_disposition_filename: Option<&str>,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let storage = state
         .storage_for_repo(&repo.storage_location())
@@ -4042,12 +4043,7 @@ pub async fn serve_local_artifact(
         .await
         .map_err(|e| internal_error("Storage", e))?;
 
-    let _ = sqlx::query(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-    )
-    .bind(artifact_id)
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact_id, ctx).await;
 
     Ok(build_download_response(
         content,
@@ -7280,6 +7276,11 @@ mod tests {
         .await
         .expect("insert");
 
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: Some("203.0.113.77".parse().unwrap()),
+            user_id: Some(user_id),
+            user_agent: Some("serve-local-test/1.0".to_string()),
+        };
         let resp = serve_local_artifact(
             &state,
             &repo,
@@ -7287,6 +7288,7 @@ mod tests {
             "cran/foo/1.0/foo.tar.gz",
             "application/gzip",
             Some("foo.tar.gz"),
+            &ctx,
         )
         .await
         .expect("serve");
@@ -7297,6 +7299,20 @@ mod tests {
         );
         let cd = resp.headers().get("Content-Disposition").unwrap();
         assert!(cd.to_str().unwrap().contains("foo.tar.gz"));
+
+        // #2365: the download must be attributed to the real client, not the
+        // historical '0.0.0.0' sentinel with no user.
+        let (ip, ua, uid): (Option<String>, Option<String>, Option<Uuid>) = sqlx::query_as(
+            "SELECT ip_address, user_agent, user_id FROM download_statistics \
+             WHERE artifact_id = $1",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("download_statistics row");
+        assert_eq!(ip.as_deref(), Some("203.0.113.77"));
+        assert_eq!(ua.as_deref(), Some("serve-local-test/1.0"));
+        assert_eq!(uid, Some(user_id));
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
     }

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -422,6 +422,7 @@ async fn version_info(
 async fn download_archive(
     State(state): State<SharedState>,
     Path((repo_key, archive_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_pub_repo(&state.db, &repo_key).await?;
 
@@ -553,12 +554,7 @@ async fn download_archive(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!("{}-{}.tar.gz", pkg_name, version);
 

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -268,6 +268,7 @@ async fn release_info(
 async fn download_module(
     State(state): State<SharedState>,
     Path((repo_key, file_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_puppet_repo(&state.db, &repo_key).await?;
 
@@ -310,6 +311,7 @@ async fn download_module(
         &artifact.storage_key,
         "application/gzip",
         Some(filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1240,6 +1240,7 @@ async fn download_or_metadata(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, project, filename)): Path<(String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_pypi_repo(&state.db, &repo_key).await?;
 
@@ -1257,7 +1258,16 @@ async fn download_or_metadata(
     }
 
     // Regular file download
-    serve_file(&state, &repo, &repo_key, &project, &filename, auth.as_ref()).await
+    serve_file(
+        &state,
+        &repo,
+        &repo_key,
+        &project,
+        &filename,
+        auth.as_ref(),
+        &ctx,
+    )
+    .await
 }
 
 fn pypi_lkg_filename_from_artifact_path(artifact_path: &str) -> String {
@@ -1480,6 +1490,7 @@ async fn serve_file(
     project: &str,
     filename: &str,
     auth: Option<&AuthExtension>,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     // Find artifact by filename (last path segment matches)
     let artifact = sqlx::query!(
@@ -1839,12 +1850,7 @@ async fn serve_file(
     // Proxied and virtual-repo fetches go through
     // build_streaming_file_response() which intentionally skips stats since
     // the artifact is not ours.
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, ctx).await;
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -4846,8 +4852,16 @@ mod tests {
         // must construct a `get_remote_cached_or_refetch` call against
         // the storage backend; the helper hits the cache and returns the
         // wheel bytes; the handler wraps them in a PyPI download response.
-        let result =
-            super::serve_file(&state, &repo_info, &fx.repo_key, project, filename, None).await;
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
 
         // Clean up BEFORE asserting so a panic still leaves the DB clean.
         let cleanup_pool = fx.pool.clone();
@@ -4987,8 +5001,16 @@ mod tests {
         .await
         .expect("seed cached artifact row");
 
-        let result =
-            super::serve_file(&state, &repo_info, &fx.repo_key, project, filename, None).await;
+        let result = super::serve_file(
+            &state,
+            &repo_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
 
         // Clean up BEFORE asserting so a panic still leaves the DB clean. The
         // age_gate_reviews row inserted by `check` cascades on repo delete.
@@ -5196,8 +5218,16 @@ mod tests {
         .await;
 
         let virtual_info = fx.repo_info("virtual", None);
-        let result =
-            super::serve_file(&state, &virtual_info, &fx.repo_key, project, filename, None).await;
+        let result = super::serve_file(
+            &state,
+            &virtual_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
 
         tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;
         cleanup_virtual_member(&fx.pool, member_id, &member_dir).await;
@@ -5249,8 +5279,16 @@ mod tests {
         .await;
 
         let virtual_info = fx.repo_info("virtual", None);
-        let result =
-            super::serve_file(&state, &virtual_info, &fx.repo_key, project, filename, None).await;
+        let result = super::serve_file(
+            &state,
+            &virtual_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
 
         tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;
         cleanup_virtual_member(&fx.pool, member_id, &member_dir).await;
@@ -5294,8 +5332,16 @@ mod tests {
         .await;
 
         let virtual_info = fx.repo_info("virtual", None);
-        let result =
-            super::serve_file(&state, &virtual_info, &fx.repo_key, project, filename, None).await;
+        let result = super::serve_file(
+            &state,
+            &virtual_info,
+            &fx.repo_key,
+            project,
+            filename,
+            None,
+            &Default::default(),
+        )
+        .await;
 
         tdh::cleanup(&fx.pool, fx.repo_id, fx.user_id).await;
         cleanup_virtual_member(&fx.pool, member_id, &member_dir).await;

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4133,7 +4133,7 @@ async fn record_redirect_download(
     db: &sqlx::PgPool,
     artifact_id: Uuid,
     user_id: Option<Uuid>,
-    ip_address: &str,
+    ip_address: Option<&str>,
     user_agent: Option<&str>,
 ) {
     if let Err(e) = sqlx::query(
@@ -4415,15 +4415,19 @@ pub async fn download_artifact(
         }
     }
 
-    // Get client IP for analytics
-    let ip_addr = request
-        .headers()
-        .get("x-forwarded-for")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.split(',').next())
-        .unwrap_or("127.0.0.1")
-        .parse()
-        .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST));
+    // Get client IP for analytics. Trusted-proxy-aware (#2365): the socket
+    // peer is authoritative and X-Forwarded-For is believed only when the
+    // peer is inside RATE_LIMIT_TRUSTED_PROXY_CIDRS (#2023) — the previous
+    // parse here trusted any XFF. `None` (unresolvable) records as NULL.
+    let client_ip = crate::api::middleware::rate_limit::resolve_client_ip_addr(
+        request.headers(),
+        request
+            .extensions()
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0.ip()),
+        &state.config.rate_limit_trusted_proxy_cidrs,
+    );
+    let client_ip_str = client_ip.map(|ip| ip.to_string());
 
     let user_agent = request
         .headers()
@@ -4471,7 +4475,7 @@ pub async fn download_artifact(
                     &state.db,
                     artifact.id,
                     auth.as_ref().map(|a| a.user_id),
-                    &ip_addr.to_string(),
+                    client_ip_str.as_deref(),
                     user_agent.as_deref(),
                 )
                 .await;
@@ -4495,7 +4499,7 @@ pub async fn download_artifact(
             repo.id,
             &path,
             auth.map(|a| a.user_id),
-            Some(ip_addr.to_string()),
+            client_ip_str.clone(),
             user_agent.as_deref(),
         )
         .await;
@@ -5820,7 +5824,7 @@ mod tests {
             &pool,
             artifact_id,
             None,
-            "203.0.113.7",
+            Some("203.0.113.7"),
             Some("redirect-stats-test-agent/1.0"),
         )
         .await;
@@ -5859,7 +5863,7 @@ mod tests {
         // best-effort (log + swallow) so a stats failure never fails the
         // download. Reaching the assertion at all proves no panic/propagation.
         let bogus_artifact = Uuid::new_v4();
-        record_redirect_download(&pool, bogus_artifact, None, "203.0.113.8", None).await;
+        record_redirect_download(&pool, bogus_artifact, None, Some("203.0.113.8"), None).await;
 
         let count: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1")

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -747,6 +747,7 @@ async fn upstream_proxy(
 async fn download_package(
     State(state): State<SharedState>,
     Path((repo_key, pkg_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
 
@@ -811,12 +812,7 @@ async fn download_package(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     Ok(build_rpm_package_response(
         Body::from_stream(stream),

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -197,6 +197,7 @@ async fn gem_versions(
 async fn download_gem(
     State(state): State<SharedState>,
     Path((repo_key, gem_file)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_rubygems_repo(&state.db, &repo_key).await?;
 
@@ -262,6 +263,7 @@ async fn download_gem(
         &artifact.storage_key,
         "application/octet-stream",
         Some(filename),
+        &ctx,
     )
     .await
 }

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -62,6 +62,7 @@ async fn resolve_sbt_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Respo
 async fn download_by_path(
     State(state): State<SharedState>,
     Path((repo_key, artifact_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_sbt_repo(&state.db, &repo_key).await?;
 
@@ -159,12 +160,7 @@ async fn download_by_path(
                 .into_response()
         })?;
 
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let content_type = if artifact.content_type.is_empty() {
         "application/octet-stream"

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -311,13 +311,14 @@ pub async fn query_release_versions_virtual(
 async fn version_path_handler(
     State(state): State<SharedState>,
     Path((repo_key, scope, name, version_path)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let version_path = version_path.trim_start_matches('/');
 
     if version_path.ends_with(".zip") {
         // Download source archive: /:scope/:name/:version.zip
         let version = version_path.trim_end_matches(".zip");
-        return download_archive(state, &repo_key, &scope, &name, version).await;
+        return download_archive(state, &repo_key, &scope, &name, version, &ctx).await;
     }
 
     if version_path.ends_with("/Package.swift") || version_path.contains("/Package.swift") {
@@ -483,6 +484,7 @@ async fn download_archive(
     scope: &str,
     name: &str,
     version: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_swift_repo(&state.db, repo_key).await?;
     let package_id = format!("{}.{}", scope, name);
@@ -591,12 +593,7 @@ async fn download_archive(
         })?;
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, ctx).await;
 
     let checksum = artifact.checksum_sha256.clone();
     let filename = format!("{}-{}-{}.zip", scope, name, version);
@@ -1545,6 +1542,7 @@ mod db_cov_tests {
                 "apple",
                 "swift-nio",
                 "2.40.0",
+                &Default::default(),
             )
             .await;
             let response = match result {

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -207,6 +207,7 @@ async fn download_module(
         String,
         String,
     )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_terraform_repo(&state.db, &repo_key).await?;
     let module_name = format!("{}/{}/{}", namespace, name, provider);
@@ -305,12 +306,7 @@ async fn download_module(
     };
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     // Return 204 with X-Terraform-Get header pointing to the archive download URL
     let download_url = format!(
@@ -725,6 +721,7 @@ async fn download_provider(
         String,
         String,
     )>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_terraform_repo(&state.db, &repo_key).await?;
     let provider_name = format!("{}/{}", namespace, type_name);
@@ -826,12 +823,7 @@ async fn download_provider(
     };
 
     // Record download
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!(
         "terraform-provider-{}_{}_{}.zip",

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -136,6 +136,7 @@ async fn query_extensions(
 async fn download_vsix(
     State(state): State<SharedState>,
     Path((repo_key, publisher, name, version)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_vscode_repo(&state.db, &repo_key).await?;
 
@@ -240,12 +241,7 @@ async fn download_vsix(
                 .into_response()
         })?;
 
-    let _ = sqlx::query!(
-        "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-        artifact.id
-    )
-    .execute(&state.db)
-    .await;
+    crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
 
     let filename = format!("{}.{}-{}.vsix", publisher, name, version);
 

--- a/backend/src/api/middleware/download_telemetry.rs
+++ b/backend/src/api/middleware/download_telemetry.rs
@@ -1,0 +1,177 @@
+//! Per-download telemetry context (#2365).
+//!
+//! [`DownloadContext`] carries the resolved client IP, authenticated user,
+//! and user agent for a download request, so every format handler records
+//! real attribution into `download_statistics` instead of the historical
+//! `'0.0.0.0'` sentinel with no user.
+//!
+//! Client-IP resolution reuses the rate limiter's trusted-proxy contract
+//! ([`resolve_client_ip_addr`], #2023): the socket peer is authoritative and
+//! `X-Forwarded-For` is believed only when the peer is inside a configured
+//! `RATE_LIMIT_TRUSTED_PROXY_CIDRS` range. When nothing resolves, the IP is
+//! recorded as NULL — never a sentinel value.
+
+use std::convert::Infallible;
+use std::net::IpAddr;
+
+use axum::{
+    async_trait,
+    extract::FromRequestParts,
+    http::{header, request::Parts, HeaderMap},
+};
+use uuid::Uuid;
+
+use super::auth::AuthExtension;
+use super::rate_limit::{resolve_client_ip_addr, CidrRange};
+use crate::api::SharedState;
+
+/// Telemetry attribution for a single download request.
+///
+/// Extracted via [`FromRequestParts`], so handlers add a `ctx:
+/// DownloadContext` parameter and pass it to
+/// [`crate::services::artifact_service::record_download`]. Extraction is
+/// infallible: an anonymous request yields `user_id: None` and an
+/// unresolvable client yields `client_ip: None` — recording stays
+/// best-effort and never rejects the download.
+#[derive(Debug, Clone, Default)]
+pub struct DownloadContext {
+    /// Resolved client IP (trusted-proxy-aware), `None` when unresolvable.
+    pub client_ip: Option<IpAddr>,
+    /// Authenticated principal, `None` for anonymous downloads.
+    pub user_id: Option<Uuid>,
+    /// The request's `User-Agent` header, when present and valid UTF-8.
+    pub user_agent: Option<String>,
+}
+
+impl DownloadContext {
+    /// Build a context from bare request parts. Pure and synchronous so the
+    /// resolution rules are unit-testable without an Axum runtime.
+    pub(crate) fn from_parts_inner(
+        headers: &HeaderMap,
+        peer: Option<IpAddr>,
+        auth: Option<&AuthExtension>,
+        trusted_proxies: &[CidrRange],
+    ) -> Self {
+        Self {
+            client_ip: resolve_client_ip_addr(headers, peer, trusted_proxies),
+            user_id: auth.map(|a| a.user_id),
+            user_agent: headers
+                .get(header::USER_AGENT)
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string),
+        }
+    }
+}
+
+#[async_trait]
+impl FromRequestParts<SharedState> for DownloadContext {
+    type Rejection = Infallible;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &SharedState,
+    ) -> Result<Self, Self::Rejection> {
+        let peer = parts
+            .extensions
+            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
+            .map(|ci| ci.0.ip());
+        // `optional_auth_middleware` inserts `Option<AuthExtension>`; the
+        // required-auth middlewares insert a bare `AuthExtension`. Accept
+        // either so the context works under both nests.
+        let auth = parts
+            .extensions
+            .get::<Option<AuthExtension>>()
+            .and_then(|opt| opt.as_ref())
+            .or_else(|| parts.extensions.get::<AuthExtension>());
+        Ok(Self::from_parts_inner(
+            &parts.headers,
+            peer,
+            auth,
+            &state.config.rate_limit_trusted_proxy_cidrs,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::access_scope::AccessScope;
+
+    fn auth_ext(user_id: Uuid) -> AuthExtension {
+        AuthExtension {
+            user_id,
+            username: "downloader".to_string(),
+            email: "downloader@test.com".to_string(),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
+        }
+    }
+
+    fn trusted_loopback() -> Vec<CidrRange> {
+        vec![CidrRange::parse("127.0.0.0/8").unwrap()]
+    }
+
+    #[test]
+    fn test_context_trusted_proxy_peer_takes_xff_ip() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.9".parse().unwrap());
+        headers.insert(header::USER_AGENT, "npm/10.2.0".parse().unwrap());
+        let ctx = DownloadContext::from_parts_inner(
+            &headers,
+            Some("127.0.0.1".parse().unwrap()),
+            None,
+            &trusted_loopback(),
+        );
+        assert_eq!(ctx.client_ip, Some("203.0.113.9".parse().unwrap()));
+        assert_eq!(ctx.user_agent.as_deref(), Some("npm/10.2.0"));
+    }
+
+    #[test]
+    fn test_context_untrusted_peer_ignores_spoofed_xff() {
+        // #2023: an untrusted peer cannot steer attribution via XFF.
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "203.0.113.9".parse().unwrap());
+        let ctx = DownloadContext::from_parts_inner(
+            &headers,
+            Some("198.51.100.20".parse().unwrap()),
+            None,
+            &trusted_loopback(),
+        );
+        assert_eq!(ctx.client_ip, Some("198.51.100.20".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_context_no_peer_falls_back_to_parseable_xff_else_none() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", "192.0.2.33".parse().unwrap());
+        let ctx = DownloadContext::from_parts_inner(&headers, None, None, &[]);
+        assert_eq!(ctx.client_ip, Some("192.0.2.33".parse().unwrap()));
+
+        let ctx = DownloadContext::from_parts_inner(&HeaderMap::new(), None, None, &[]);
+        assert_eq!(
+            ctx.client_ip, None,
+            "unresolvable must be None, not 0.0.0.0"
+        );
+    }
+
+    #[test]
+    fn test_context_anonymous_user_is_none_and_authed_user_is_captured() {
+        let anonymous = DownloadContext::from_parts_inner(&HeaderMap::new(), None, None, &[]);
+        assert_eq!(anonymous.user_id, None);
+
+        let uid = Uuid::new_v4();
+        let auth = auth_ext(uid);
+        let authed = DownloadContext::from_parts_inner(&HeaderMap::new(), None, Some(&auth), &[]);
+        assert_eq!(authed.user_id, Some(uid));
+    }
+
+    #[test]
+    fn test_context_user_agent_none_when_absent() {
+        let ctx = DownloadContext::from_parts_inner(&HeaderMap::new(), None, None, &[]);
+        assert_eq!(ctx.user_agent, None);
+    }
+}

--- a/backend/src/api/middleware/mod.rs
+++ b/backend/src/api/middleware/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod auth;
 pub mod demo;
+pub mod download_telemetry;
 pub mod guest_access;
 pub mod metrics;
 pub mod rate_limit;

--- a/backend/src/api/middleware/rate_limit.rs
+++ b/backend/src/api/middleware/rate_limit.rs
@@ -583,8 +583,13 @@ fn too_many_requests(retry_after: u64, max_requests: u32) -> Response {
 /// First `X-Forwarded-For` token, trimmed, as a string (may be a hostname or
 /// otherwise non-parseable). `None` when the header is absent or empty.
 fn first_xff_token(request: &Request) -> Option<&str> {
-    request
-        .headers()
+    first_xff_token_in(request.headers())
+}
+
+/// [`first_xff_token`] over a bare header map, for callers that only hold
+/// request parts (e.g. the download-telemetry extractor, #2365).
+fn first_xff_token_in(headers: &axum::http::HeaderMap) -> Option<&str> {
+    headers
         .get("x-forwarded-for")?
         .to_str()
         .ok()?
@@ -653,14 +658,30 @@ fn extract_client_ip(request: &Request, trusted_proxies: &[CidrRange]) -> String
 /// back to a parseable `XFF` (direct-test / pre-ConnectInfo topology).
 /// Returns `None` if the address cannot be resolved or does not parse.
 fn extract_client_ip_addr(request: &Request, trusted_proxies: &[CidrRange]) -> Option<IpAddr> {
-    if let Some(connect_info) = request
+    let peer = request
         .extensions()
         .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-    {
-        let peer = connect_info.0.ip();
+        .map(|connect_info| connect_info.0.ip());
+    resolve_client_ip_addr(request.headers(), peer, trusted_proxies)
+}
+
+/// Core client-IP resolution over bare request parts (#2365).
+///
+/// Same trusted-proxy contract as [`extract_client_ip_addr`], which delegates
+/// here: the socket `peer` is authoritative; `X-Forwarded-For` overrides it
+/// **only** when the peer falls inside a configured trusted-proxy CIDR
+/// (#2023). With no peer at all (test harness / pre-`ConnectInfo` topology),
+/// a parseable `XFF` first token is a last-resort fallback. Returns `None`
+/// when nothing resolves — callers must record "unknown", never a sentinel.
+pub(crate) fn resolve_client_ip_addr(
+    headers: &axum::http::HeaderMap,
+    peer: Option<IpAddr>,
+    trusted_proxies: &[CidrRange],
+) -> Option<IpAddr> {
+    if let Some(peer) = peer {
         // Believe XFF only when the immediate peer is a trusted proxy.
         if trusted_proxies.iter().any(|cidr| cidr.contains(peer)) {
-            if let Some(first) = first_xff_token(request) {
+            if let Some(first) = first_xff_token_in(headers) {
                 if let Ok(ip) = first.parse::<IpAddr>() {
                     return Some(ip);
                 }
@@ -673,7 +694,7 @@ fn extract_client_ip_addr(request: &Request, trusted_proxies: &[CidrRange]) -> O
 
     // No ConnectInfo (test harness / pre-ConnectInfo topology): fall back to a
     // parseable XFF first token so keying still distinguishes callers.
-    if let Some(first) = first_xff_token(request) {
+    if let Some(first) = first_xff_token_in(headers) {
         if let Ok(ip) = first.parse::<IpAddr>() {
             return Some(ip);
         }
@@ -1009,6 +1030,68 @@ mod tests {
         assert_eq!(
             extract_client_ip(&request, &no_trusted_proxies()),
             "ip:10.0.0.5"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // resolve_client_ip_addr (parts-level core; #2365)
+    // -----------------------------------------------------------------------
+
+    fn xff_headers(xff: &str) -> axum::http::HeaderMap {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert("x-forwarded-for", xff.parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn test_resolve_client_ip_addr_trusted_peer_uses_xff() {
+        let ip = resolve_client_ip_addr(
+            &xff_headers("203.0.113.7"),
+            Some("127.0.0.1".parse().unwrap()),
+            &loopback_trusted_proxies(),
+        );
+        assert_eq!(ip, Some("203.0.113.7".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_resolve_client_ip_addr_untrusted_peer_ignores_xff() {
+        // Spoofed XFF from an untrusted peer must not steer attribution
+        // (#2023): the socket peer wins.
+        let ip = resolve_client_ip_addr(
+            &xff_headers("203.0.113.7"),
+            Some("198.51.100.9".parse().unwrap()),
+            &no_trusted_proxies(),
+        );
+        assert_eq!(ip, Some("198.51.100.9".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_resolve_client_ip_addr_trusted_peer_unparseable_xff_falls_back_to_peer() {
+        let ip = resolve_client_ip_addr(
+            &xff_headers("not-an-ip"),
+            Some("127.0.0.1".parse().unwrap()),
+            &loopback_trusted_proxies(),
+        );
+        assert_eq!(ip, Some("127.0.0.1".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_resolve_client_ip_addr_no_peer_falls_back_to_parseable_xff() {
+        let ip = resolve_client_ip_addr(&xff_headers("192.0.2.4"), None, &no_trusted_proxies());
+        assert_eq!(ip, Some("192.0.2.4".parse().unwrap()));
+    }
+
+    #[test]
+    fn test_resolve_client_ip_addr_nothing_resolvable_is_none() {
+        // No peer + no (parseable) XFF: None, never a `0.0.0.0` sentinel.
+        let empty = axum::http::HeaderMap::new();
+        assert_eq!(
+            resolve_client_ip_addr(&empty, None, &no_trusted_proxies()),
+            None
+        );
+        assert_eq!(
+            resolve_client_ip_addr(&xff_headers("bogus"), None, &no_trusted_proxies()),
+            None
         );
     }
 

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -11,6 +11,7 @@ use sqlx::PgPool;
 use tracing::warn;
 use uuid::Uuid;
 
+use crate::api::middleware::download_telemetry::DownloadContext;
 use crate::error::{AppError, Result};
 use crate::models::artifact::{Artifact, ArtifactMetadata};
 use crate::services::opensearch_service::{ArtifactDocument, OpenSearchService};
@@ -966,20 +967,14 @@ impl ArtifactService {
         ip_address: Option<&str>,
         user_agent: Option<&str>,
     ) {
-        // Record download statistics
-        sqlx::query!(
-            r#"
-            INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent)
-            VALUES ($1, $2, $3, $4)
-            "#,
-            artifact_id,
+        // Record download statistics (best-effort; #2365). An unparseable
+        // ip string is recorded as NULL rather than a sentinel value.
+        let ctx = DownloadContext {
+            client_ip: ip_address.and_then(|s| s.parse().ok()),
             user_id,
-            ip_address,
-            user_agent
-        )
-        .execute(&self.db)
-        .await
-        .ok(); // Ignore stats errors
+            user_agent: user_agent.map(str::to_string),
+        };
+        record_download(&self.db, artifact_id, &ctx).await;
 
         // Best-effort audit trail (#2366). An `ARTIFACT_DOWNLOADED` event is the
         // per-access record auditors need to answer "who fetched this artifact,
@@ -1525,6 +1520,31 @@ impl ArtifactService {
             map.insert(artifact_id, count);
         }
         Ok(map)
+    }
+}
+
+/// Best-effort recorder for a completed local-artifact download (#2365).
+///
+/// Writes real attribution (validated client IP or NULL, authenticated user
+/// or NULL, user agent) into `download_statistics` — replacing the historical
+/// per-format `'0.0.0.0'` sentinel inserts. Errors are logged at `warn` and
+/// swallowed: statistics must never block or fail the download itself.
+///
+/// Call this only after a **local** artifact row has been resolved; remote
+/// pass-through proxy fetches are not our artifacts and stay unrecorded.
+pub async fn record_download(db: &PgPool, artifact_id: Uuid, ctx: &DownloadContext) {
+    if let Err(e) = sqlx::query(
+        "INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent) \
+         VALUES ($1, $2, $3, $4)",
+    )
+    .bind(artifact_id)
+    .bind(ctx.user_id)
+    .bind(ctx.client_ip.map(|ip| ip.to_string()))
+    .bind(ctx.user_agent.as_deref())
+    .execute(db)
+    .await
+    {
+        warn!(%artifact_id, error = %e, "failed to record download statistics");
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #2365. Unblocks #2364 (CVE blast-radius needs network location of exposed downloads).

Downloads are now attributed to the **real client IP and the authenticated user** across every format, instead of the historical hardcoded `ip_address = '0.0.0.0'` with no `user_id` that 27 format handler paths wrote:

- **New `DownloadContext` extractor** (`api/middleware/download_telemetry.rs`): resolves client IP (trusted-proxy-aware), authenticated `user_id` (`None` for anonymous — never fabricated), and `User-Agent` from request parts. Infallible: telemetry can never reject a download.
- **Shared recorder** `artifact_service::record_download`: best-effort (warn-and-swallow) insert into the existing `download_statistics` table; writes a validated IP string or NULL — the `'0.0.0.0'` sentinel is gone. `finish_download` (the generic streaming path) now delegates to it.
- **All format handlers threaded through it**: npm, maven, pypi, cargo, rubygems, hex, helm, ansible, puppet, huggingface, cran (via `proxy_helpers::serve_local_artifact`), rpm, debian, alpine, go, conan, conda, nuget, swift, terraform (modules + providers), composer, pub, chef, cocoapods, jetbrains, vscode, sbt, gitlfs, protobuf.
- **Trusted-proxy XFF handling on the generic download path**: `repositories.rs::download_artifact` previously trusted any `X-Forwarded-For` (first token, falling back to `127.0.0.1`). It now uses the same `resolve_client_ip_addr` contract as the rate limiter (#2023): the socket peer is authoritative and XFF is believed only when the peer is inside `RATE_LIMIT_TRUSTED_PROXY_CIDRS`. This closes the XFF-spoofing gap on download attribution.
- **Rate-limiter refactor is behavior-preserving**: `extract_client_ip_addr` now delegates to a new parts-level `resolve_client_ip_addr`; all existing rate-limit keying tests pass unchanged.
- **Admin reporting** (admin-only — attribution is sensitive):
  - `GET /api/v1/admin/downloads?artifact_id=&user_id=&ip=&from=&to=&page=&per_page=` — paginated attributed download events (artifact, user id + username, IP, user agent, timestamp)
  - `GET /api/v1/admin/downloads/by-ip/{ip}` — what did this network location pull?
  - `GET /api/v1/admin/downloads/by-user/{user_id}` — what did this user pull?
- **Migration 151**: `idx_download_stats_ip ON download_statistics(ip_address, downloaded_at)` for the by-IP reporting path.

### Invariants preserved
- Remote/virtual **pass-through proxy fetches stay unrecorded** — `record_download` is only called where a local `artifacts` row was already resolved (same call sites as the old sentinel inserts; the #1278 cache-artifact invariant tests still pass).
- Recording stays **fire-and-forget after the stream is established** (#1608) — no buffering, never blocks or fails a download.
- Anonymous pulls record `user_id = NULL`; unresolvable clients record `ip_address = NULL`.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated (`resolve_client_ip_addr` trusted/untrusted/no-peer/unresolvable; `DownloadContext` anonymous/authed/user-agent; RFC-3339 bound parsing)
- [x] Integration tests added/updated (DB-gated: `serve_local_artifact` records real ip+user+ua; `record_download` NULL-not-sentinel; admin `query_downloads` filters by artifact/ip/user + pagination; existing `record_redirect_download` tests updated for `Option<&str>` ip)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (isolated stack behind a proxy with `RATE_LIMIT_TRUSTED_PROXY_CIDRS`: authed npm/maven/pypi pulls record real client IP + user; spoofed XFF from an untrusted peer records the peer IP; anonymous pull records IP + NULL user; remote proxied fetch records no row; admin endpoints admin-only)
- [x] No regressions in existing tests (full `cargo nextest run --workspace --lib` green against Postgres)

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (index-only migration; `DROP INDEX idx_download_stats_ip` reverts)
