### PR TITLE
security: burn down Trivy code-scanning CVE backlog (scanner bumps, Go 1.26.5, base refresh, cache-bust)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,6 +107,13 @@ jobs:
           # to accept mode=max cache manifests.
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-${{ matrix.cache-tag }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          # Always re-run the package-refresh and runtime stages: their RUN
+          # lines (`dnf upgrade`, `grype db update`) are only correct when
+          # executed against the CURRENT repos, but the registry cache would
+          # otherwise happily serve months-old layers, shipping stale security
+          # errata and a stale grype DB (#2391). The expensive Rust stages
+          # (planner/deps/builder) stay fully cached.
+          no-cache-filters: rootfs-builder,grype-db-seed,runtime
           sbom: true
           provenance: mode=max
           build-args: |
@@ -186,6 +193,9 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:buildcache-${{ matrix.cache-tag }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.OPENSCAP_IMAGE }}:buildcache-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          # Re-run the dnf package-refresh stage against current errata on
+          # every publish instead of serving it from stale cache (#2391).
+          no-cache-filters: rootfs-builder
           sbom: true
           provenance: mode=max
 
@@ -262,6 +272,10 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:buildcache-${{ matrix.cache-tag }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.SCANNER_ADAPTER_IMAGE }}:buildcache-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          # Re-run the runtime stage (`apk add --no-cache`) against current
+          # Alpine errata on every publish instead of serving it from stale
+          # cache (#2391). The Go build stage stays cached.
+          no-cache-filters: runtime
           sbom: true
           provenance: mode=max
 
@@ -334,6 +348,9 @@ jobs:
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-alpine-${{ matrix.cache-tag }}
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:buildcache-alpine-${{ matrix.cache-tag }},mode=max,image-manifest=true,oci-mediatypes=true
+          # Re-run the package-refresh and runtime stages against current
+          # errata on every publish; see the backend job note (#2391).
+          no-cache-filters: grype-db-seed,runtime
           sbom: true
           provenance: mode=max
           build-args: |

--- a/.github/workflows/scheduled-container-scan.yml
+++ b/.github/workflows/scheduled-container-scan.yml
@@ -68,18 +68,15 @@ jobs:
           exit-code: '0'
           skip-setup-trivy: true
 
-      - name: Trivy scan - Backend Alpine
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
-        if: always()
-        with:
-          image-ref: ${{ env.REGISTRY }}/${{ env.BACKEND_IMAGE }}:latest-alpine
-          format: 'sarif'
-          output: 'backend-alpine-trivy.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          trivyignores: '.trivyignore'
-          exit-code: '0'
-          skip-setup-trivy: true
+      # NOTE: the Backend Alpine (`:latest-alpine`) scan was removed (#2391).
+      # The alpine publish job has been suspended (`if: false` in
+      # docker-publish.yml), so `:latest-alpine` is a frozen artifact that is
+      # never rebuilt; scanning it weekly can only re-report CVEs that no code
+      # change can clear (the stale image predates the trivy-CLI removal and
+      # current base/grype pins) and it accumulated the bulk of the stale
+      # code-scanning backlog. Dockerfile.backend.alpine is kept patched;
+      # re-add the scan together with the publish job if the alpine variant
+      # comes back online.
 
       - name: Upload Backend Trivy SARIF
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
@@ -95,13 +92,6 @@ jobs:
           sarif_file: 'openscap-trivy.sarif'
           category: 'trivy-openscap-scheduled'
 
-      - name: Upload Backend Alpine Trivy SARIF
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
-        if: always()
-        with:
-          sarif_file: 'backend-alpine-trivy.sarif'
-          category: 'trivy-backend-alpine-scheduled'
-
       - name: Upload Trivy reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()
@@ -110,7 +100,6 @@ jobs:
           path: |
             backend-trivy.sarif
             openscap-trivy.sarif
-            backend-alpine-trivy.sarif
           retention-days: 90
 
       - name: Check for new findings and create issue
@@ -123,7 +112,7 @@ jobs:
             let totalFindings = 0;
             const summaries = [];
 
-            for (const [name, file] of [['Backend', 'backend-trivy.sarif'], ['OpenSCAP', 'openscap-trivy.sarif'], ['Backend Alpine', 'backend-alpine-trivy.sarif']]) {
+            for (const [name, file] of [['Backend', 'backend-trivy.sarif'], ['OpenSCAP', 'openscap-trivy.sarif']]) {
               if (!fs.existsSync(file)) {
                 summaries.push(`- **${name}**: Scan skipped or failed`);
                 continue;
@@ -180,6 +169,5 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
-          echo "- **Backend Alpine**: $([ -f backend-alpine-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "SARIF reports uploaded to Security tab and as workflow artifacts." >> $GITHUB_STEP_SUMMARY

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,60 +1,62 @@
-# .trivyignore — residual CVEs in the BUNDLED grype scanner CLI binary only.
+# .trivyignore — residual CVEs in the BUNDLED scanner CLI binaries only.
 #
 # Scope and honesty notes (read before adding anything here):
 #
-# * Every entry below is a Go-dependency CVE compiled INTO the one vendored
-#   scanner CLI that the backend still ships and invokes for OFFLINE artifact
-#   scanning:
-#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.114.0)
-#   This is a short-lived CLI subprocess the server shells out to. It is NOT
-#   part of the network-reachable service surface (axum HTTP :8080 / gRPC
-#   :9090). The vulnerable code paths (docker client libs, golang.org/x/net
-#   HTTP/2 server, etc.) are not exercised by how the backend drives grype.
+# * Every entry below is a Go-dependency CVE compiled INTO one of the vendored
+#   scanner CLIs that AK images ship and invoke:
+#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.115.0, backend images)
+#     - /usr/local/bin/trivy  (ghcr.io/aquasecurity/trivy:0.72.0,
+#       scanner-adapter image only — the backend images do NOT bundle trivy)
+#   Both are short-lived CLI subprocesses the services shell out to. They are
+#   NOT part of the network-reachable service surface (axum HTTP :8080 / gRPC
+#   :9090 / adapter HTTP :8080). The vulnerable code paths (docker client
+#   libs, OCI registry clients, sigstore verification, etc.) are not exercised
+#   by how AK drives the tools.
 #
-# * The trivy CLI is NO LONGER bundled in the runtime image (issue #1544): the
-#   backend drives Trivy in server mode against the trivy sidecar (TRIVY_URL)
-#   with a pure-HTTP Twirp fallback, so the in-image binary was dead weight.
-#   The trivy-binary containerd CVE suppressions that used to live here have
-#   been removed accordingly — there is no longer a trivy binary in the image
-#   for them to apply to.
+# * The trivy CLI is NO LONGER bundled in the backend runtime images (issue
+#   #1544): the backend drives Trivy via the sidecar (TRIVY_URL) and the
+#   scanner-adapter (TRIVY_ADAPTER_URL). The only image that ships a trivy
+#   binary is the scanner-adapter.
 #
-# * These are deliberately NOT suppressed in the backend service binary or in
-#   the UBI/Alpine base OS packages. Only vendored-scanner-binary CVEs that have
-#   no fixed *tool release* are listed here.
+# * These are deliberately NOT suppressed in the backend service binary, the
+#   scanner-adapter binary (rebuilt from source with a patched Go toolchain on
+#   every build), or in the UBI/Alpine base OS packages. Only
+#   vendored-scanner-binary CVEs that have no fixed *tool release* are listed.
 #
-# * Grype is pinned to v0.114.0 (latest; no newer build exists yet). For the
-#   CVEs below, either no fixed tool release exists yet, or the upstream
-#   dependency fix has not landed in a tagged release. They will drop off
-#   automatically when grype ships a release rebuilt against the fixed
-#   dependency — re-evaluate on every scanner bump.
+# * Both tools are pinned to the latest upstream release (grype v0.115.0,
+#   trivy 0.72.0, bumped for #2391). For the CVEs below the dependency fix
+#   exists upstream but no tagged tool release has been rebuilt against it
+#   yet (or, where noted, no upstream fix exists at all). They drop off
+#   automatically when the tools ship a release rebuilt against the fixed
+#   dependency — re-evaluate this whole file on every scanner bump.
 #
-# * CI scans with `ignore-unfixed: true`, so the genuinely no-fix-available
-#   entries below already don't alert; they are listed for completeness and so
-#   future maintainers see the full residual set in one place.
+# * CI scans with `ignore-unfixed: true` and `severity: CRITICAL,HIGH`, so
+#   the genuinely no-fix-available and MEDIUM/LOW entries below already don't
+#   alert; they are listed for completeness so future maintainers see the
+#   full residual set in one place.
 #
 # Grype tracker: https://github.com/anchore/grype/releases
+# Trivy tracker: ghcr.io/aquasecurity/trivy tags (GitHub repo has no releases)
 
 # ---------------------------------------------------------------------------
-# grype v0.114.0 binary — github.com/containerd/containerd/v2 @ v2.3.1
-# containerd has fixed releases (2.3.2 etc.) but grype v0.114.0 (latest) has not
-# yet rebuilt against them. Code path: containerd's image/snapshotter client
-# pulled in transitively by grype's OCI source handling; the backend invokes
-# grype against on-disk artifacts/SBOMs, not a containerd daemon. (These CVEs
-# previously also appeared in the now-removed trivy CLI binary; they remain only
-# because the same containerd version is vendored into the grype binary.)
-CVE-2026-47262
-CVE-2026-50195
-CVE-2026-53488
-CVE-2026-53489
-CVE-2026-53492
+# grype v0.115.0 binary — Go stdlib @ go1.26.3
+# Fixed in Go 1.26.4/1.26.5 (1.25.11/1.25.12). grype v0.115.0 (latest) is
+# still built with go1.26.3. Drops off when grype ships a release built on
+# Go >= 1.26.5. (CVE-2026-39822 / CVE-2026-42505 also cover the trivy 0.72.0
+# binary, which is built with go1.26.4.)
+CVE-2026-27145
+CVE-2026-39822
+CVE-2026-42504
+CVE-2026-42505
+CVE-2026-42507
 
 # ---------------------------------------------------------------------------
-# grype v0.114.0 binary — github.com/docker/docker @ v28.5.2+incompatible
+# grype v0.115.0 binary — github.com/docker/docker @ v28.5.2+incompatible
 # CVE-2026-41567 / -41568 / -42306: NO upstream-fixed docker release exists yet
-# (Grype reports FixedVersion=none). CVE-2026-33997 / -34040 are fixed in
-# docker 29.3.1 but grype v0.114.0 (latest) has not rebuilt against it. Code
-# path: grype's Docker engine client for `docker:` image sources; the backend
-# invokes grype against on-disk artifacts/SBOMs, not the Docker daemon.
+# (FixedVersion=none). CVE-2026-33997 / -34040 are fixed in docker 29.3.1 but
+# grype v0.115.0 (latest) has not rebuilt against it. Code path: grype's
+# Docker engine client for `docker:` image sources; the backend invokes grype
+# against on-disk artifacts/SBOMs, not the Docker daemon.
 CVE-2026-33997
 CVE-2026-34040
 CVE-2026-41567
@@ -62,9 +64,21 @@ CVE-2026-41568
 CVE-2026-42306
 
 # ---------------------------------------------------------------------------
-# grype v0.114.0 binary — Go stdlib @ go1.26.3
-# Fixed in Go 1.26.4 / 1.25.11. grype v0.114.0 (latest) is still built with the
-# older toolchain. Drops off when grype ships a release rebuilt on Go >= 1.26.4.
-CVE-2026-27145
-CVE-2026-42504
-CVE-2026-42507
+# trivy 0.72.0 binary (scanner-adapter image) — oras.land/oras-go/v2 @ v2.6.0
+# Fixed in oras-go 2.6.1; trivy 0.72.0 (latest) has not rebuilt against it.
+# Code path: ORAS OCI-artifact client used for trivy's own DB/plugin
+# distribution; the adapter only points trivy at AK's registry for scans.
+CVE-2026-48978
+CVE-2026-50151
+CVE-2026-50162
+GHSA-vh4v-2xq2-g5cg
+
+# ---------------------------------------------------------------------------
+# trivy 0.72.0 binary (scanner-adapter image) — sigstore verification stack
+# github.com/sigstore/sigstore-go @ v1.1.4 (fixed 1.2.0) and
+# github.com/sigstore/timestamp-authority/v2 @ v2.0.6 (fixed 2.1.0); trivy
+# 0.72.0 (latest) has not rebuilt against them. MEDIUM severity — listed for
+# completeness (CI alerts on CRITICAL/HIGH only). Code path: cosign/rekor
+# attestation verification, not exercised by AK's adapter scan flow.
+CVE-2026-49834
+CVE-2026-49835

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Trivy code-scanning backlog burned down** (#2391): bundled scanner tools bumped to the latest releases built on a patched Go toolchain — trivy 0.71.2 → 0.72.0 (scanner-adapter image) and grype v0.114.0 → v0.115.0 (backend images); the scanner-adapter is now compiled with Go 1.26.5 (clears the 35 Go-stdlib CVEs in the adapter binary) and its runtime base moved from EOL alpine 3.20 to 3.24. `docker-publish` now cache-busts the package-refresh stages (`no-cache-filters`) so `dnf upgrade`/`apk` errata and the pre-seeded Grype DB are re-resolved on every publish instead of being served from a stale layer cache. The weekly scheduled scan of `:latest-alpine` was removed — that image's publish job is suspended (`if: false`), so the frozen artifact could only re-report unfixable-by-rebuild CVEs (143 of the 188 open alerts). `.trivyignore` refreshed to the current residual set (no fixed tool release yet), justified per-CVE.
 - The RPM Phase-1 connect-time private-IP check runs in the Upstream resolver context and, as a fail-safe, also blocks private-IP targets for **SSO-metadata** and **webhook** flows that carry their own private-IP allow-toggles. It **fails safe** (over-blocks, never leaks). Deployments that legitimately target a private-IP host for SSO metadata or webhook delivery should track **#2380** (union private-IP allow-toggles across contexts).
 
 ## [1.4.2] - 2026-07-10

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -174,11 +174,12 @@ RUN find /mnt/rootfs -xdev -perm /6000 -type f -exec chmod a-s {} + && \
 # binary's HIGH-severity Go-dependency CVEs and ~150 MB of image size with no
 # functional loss. See issues #1544 and #2088.
 #
-# Grype is pinned to v0.114.0, which is the latest upstream release. There is no
-# newer Grype build that picks up fixed versions of its bundled Go deps
-# (docker, containerd, stdlib), so its residual CVEs are upstream-unfixable for
-# now and are documented/suppressed in /.trivyignore rather than "bumped away".
-FROM ghcr.io/anchore/grype:v0.114.0 AS grype-bin
+# Grype is pinned to v0.115.0, the latest upstream release. It is rebuilt
+# against fixed containerd/go-git/x-crypto versions (clearing those CVEs from
+# v0.114.0), but still bundles Go 1.26.3 stdlib and docker v28.5.2; those
+# residual CVEs have no fixed grype release yet and are documented/suppressed
+# in /.trivyignore rather than "bumped away". Re-evaluate on every bump (#2391).
+FROM ghcr.io/anchore/grype:v0.115.0 AS grype-bin
 
 # ---------- Stage 5b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted
@@ -194,7 +195,10 @@ ENV GRYPE_DB_CACHE_DIR=/grype-db
 RUN mkdir -p /grype-db && grype db update && grype db status
 
 # ---------- Stage 6: UBI 9 Micro runtime ----------
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.8
+# Named so CI can cache-bust the package-refresh stages (`no-cache-filters`);
+# see docker-publish.yml. Without that, the registry build cache can serve the
+# rootfs-builder `dnf upgrade` layer stale and ship months-old errata (#2391).
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.8 AS runtime
 
 # Copy minimal rootfs (glibc, openssl, ca-certs, curl, user/group, dirs)
 COPY --from=rootfs-builder /mnt/rootfs /

--- a/docker/Dockerfile.backend.alpine
+++ b/docker/Dockerfile.backend.alpine
@@ -54,11 +54,12 @@ RUN if [ -n "${APP_VERSION}" ]; then \
 # binary's HIGH-severity Go-dependency CVEs and image size with no functional
 # loss. See issue #1544.
 #
-# Grype is pinned to v0.114.0, the latest upstream release. No newer Grype build
-# picks up fixed versions of its bundled Go deps (docker, containerd, stdlib),
-# so its residual CVEs are upstream-unfixable for now and are documented/
-# suppressed in /.trivyignore rather than "bumped away".
-FROM ghcr.io/anchore/grype:v0.114.0 AS grype-bin
+# Grype is pinned to v0.115.0, the latest upstream release. It is rebuilt
+# against fixed containerd/go-git/x-crypto versions (clearing those CVEs from
+# v0.114.0), but still bundles Go 1.26.3 stdlib and docker v28.5.2; those
+# residual CVEs have no fixed grype release yet and are documented/suppressed
+# in /.trivyignore rather than "bumped away". Re-evaluate on every bump (#2391).
+FROM ghcr.io/anchore/grype:v0.115.0 AS grype-bin
 
 # ---------- Stage 4b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted
@@ -71,7 +72,11 @@ ENV GRYPE_DB_CACHE_DIR=/grype-db
 RUN mkdir -p /grype-db && grype db update && grype db status
 
 # ---------- Stage 5: Alpine runtime ----------
-FROM alpine:3.24
+# Named so CI can cache-bust the package-refresh stages (`no-cache-filters`)
+# if/when the suspended alpine publish job is re-enabled; see
+# docker-publish.yml. Without that, the registry build cache can serve the
+# `apk upgrade` layer stale and ship months-old errata (#2391).
+FROM alpine:3.24 AS runtime
 
 # Refresh the whole base first so the alpine:3.24 layer picks up the latest
 # APK security errata, then install the runtime deps (no libssl needed -

--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -16,7 +16,12 @@
 # ---------- Stage 1: cross-compile the Go adapter ----------
 # Pinned to the BUILDPLATFORM so the toolchain runs natively and cross-compiles
 # to the requested TARGET arch (fast, no emulation for the compile step).
-FROM --platform=$BUILDPLATFORM golang:1.23-alpine AS build
+# Go 1.26 toolchain: the adapter is stdlib-only, so every Go CVE reported
+# against the compiled binary is a stdlib CVE baked in by the builder
+# toolchain. Track the current patched Go minor here (>= 1.26.5 clears the
+# 2026-07 stdlib batch, issue #2391); the go.mod `go` directive stays at the
+# minimum language version.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -36,12 +41,21 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
 # ---------- Stage 2: pull the matching trivy binary ----------
 # buildx selects this image's TARGETPLATFORM variant automatically, so the
 # arm64 build gets the arm64 trivy and the amd64 build gets amd64. Pinned to
-# 0.71.2 (rig-standard; #2090's backend tests assert trivy-0.71.2). Aqua
-# publishes both linux/amd64 and linux/arm64 for this tag.
-FROM ghcr.io/aquasecurity/trivy:0.71.2 AS trivy
+# 0.72.0, the latest release, which is rebuilt against a patched Go toolchain
+# and clears most of the bundled binary's Go-dependency CVEs (#2391; residuals
+# with no fixed trivy release yet are justified per-CVE in /.trivyignore).
+# Nothing couples the backend to a specific trivy version: the 0.71.2 strings
+# in backend/scanner-adapter tests are mock/stub fixtures, and the adapter
+# probes the real version at startup (ProbeVersion). Aqua publishes both
+# linux/amd64 and linux/arm64 for this tag.
+FROM ghcr.io/aquasecurity/trivy:0.72.0 AS trivy
 
 # ---------- Stage 3: minimal runtime ----------
-FROM alpine:3.20
+# alpine 3.20 reached EOL; 3.24 is the current stable with active security
+# errata. The stage is named so CI can cache-bust it (`no-cache-filters`),
+# forcing `apk add --no-cache` to re-resolve current package errata on every
+# publish instead of reusing a stale cached layer.
+FROM alpine:3.24 AS runtime
 
 # ca-certificates: TLS to the trivy vuln-DB registry / HTTPS registries.
 # git + rpm: trivy uses them for certain package/source scanners.


### PR DESCRIPTION
Closes #2391

Burns down the 188 open Trivy code-scanning alerts. All are dependency/base-image CVEs in published container images (CodeQL is clean). Grouped by SARIF analysis category, the actual alert data breaks down as:

| Bucket (scanned binary) | Alerts | Category | Fix in this PR |
|---|---|---|---|
| `usr/local/bin/scanner-adapter` (Go stdlib) | 35 | `trivy-scanner-adapter` | builder image `golang:1.23-alpine` → `golang:1.26-alpine` (go1.26.5, patched stdlib — the adapter is stdlib-only, so the toolchain **is** the dependency set) |
| `usr/local/bin/trivy` (bundled scanner) | 70 | 64 stale-alpine + 6 `trivy-scanner-adapter` | pinned trivy `0.71.2` → `0.72.0` (latest, rebuilt on patched Go); adapter runtime base EOL `alpine:3.20` → `3.24` |
| `usr/local/bin/grype` (bundled scanner) | 39 | 35 stale-alpine + 2×2 backend | pinned grype `v0.114.0` → `v0.115.0` in both backend Dockerfiles (clears the containerd/go-git/x-crypto/x-net set) |
| `artifact-keeper-backend` OS pkgs (libssl3/libcrypto3/curl/libcurl) | 44 | `trivy-backend-alpine-scheduled` | see below — stale-image scan removed |

**The stale `:latest-alpine` scan (143/188 alerts).** The alpine backend publish job is suspended (`if: false` in `docker-publish.yml`), so `ghcr.io/...-backend:latest-alpine` is a frozen artifact that is never rebuilt — it still bundles a trivy CLI and predates the current base/grype pins. The weekly scheduled scan of it can only re-report CVEs no code change can clear. This PR removes that scan (with a pointer comment); `Dockerfile.backend.alpine` itself stays fully patched (verified: `apk upgrade` on a fresh `alpine:3.24` yields **0** fixable OS CVEs) so the variant can come back cleanly if re-enabled.
> Post-merge note: alerts in the retired `trivy-backend-alpine-scheduled` / `trivy-backend-alpine` categories will not auto-close once the category stops uploading; they need a one-time close-out (delete the category's analyses via the code-scanning API, or bulk-dismiss as "won't fix — image retired").

**Root cause of the recurring OS-package debt.** `docker-publish` builds with a registry layer cache and no cache-bust, so the `dnf upgrade` / `apk upgrade` / `grype db update` layers could be served months stale — errata refresh "on every build" never actually re-ran. The package-refresh/runtime stages are now named and listed in `no-cache-filters` (backend, backend-alpine, scanner-adapter, openscap). The expensive Rust/Go build stages remain cached.

**`.trivyignore` refreshed** to the current residual set: CVEs whose dependency fix exists upstream but which no tagged trivy/grype release is rebuilt against yet (grype v0.115.0 still ships go1.26.3 stdlib + docker v28.5.2; trivy 0.72.0 still ships oras-go v2.6.0 + sigstore-go v1.1.4). Each is justified per-CVE per the existing policy; the now-fixed containerd suppressions are removed.

## Verification (local rebuild + re-scan, trivy 0.72.0 with fresh DB)

| Image | Fixable CVEs before (published) | After (rebuilt from this branch) | CI-mode alerts (CRIT/HIGH + `.trivyignore`) |
|---|---|---|---|
| backend (UBI) | 12 | **7** (all documented grype-binary residuals) | **0** |
| scanner-adapter | 51 (38 adapter stdlib + 13 trivy) | **8** (all documented trivy-binary residuals; adapter binary **0**) | **0** |
| backend-alpine base pkgs | 45 fixable OS pkgs in the stale image | **0** on rebuilt `alpine:3.24` + `apk upgrade` | n/a (publish suspended) |

Functional checks:
- `go vet ./... && go build ./... && go test ./...` pass for `docker/scanner-adapter` on go1.26.5.
- Patched scanner-adapter container: `/probe/healthy` 200, `/api/v1/metadata` reports Trivy 0.72.0 (startup version probe works; the `0.71.2` strings in backend/adapter tests are mock fixtures, not a version coupling — verified no runtime gate on the trivy version).
- Patched backend (UBI) image builds end-to-end; `grype version` → 0.115.0, `grype db status` → DB seeded at build time (built 2026-07-10); `artifact-keeper` binary executes (fails fast on missing `JWT_SECRET` as expected).
- Both workflow YAMLs validated.

Merging this PR triggers `docker-publish` (push to main), which rebuilds/publishes backend + scanner-adapter + openscap and uploads fresh SARIF for the live categories — that run closes the `trivy-scanner-adapter` (41) and `trivy-backend` (2) alerts automatically.
