### PR TITLE
fix(scanner): exempt operator-configured internal-service clients from the connect-time SSRF private-IP gate

### DIFF
--- a/backend/src/api/validation.rs
+++ b/backend/src/api/validation.rs
@@ -119,6 +119,21 @@ pub enum OutboundUrlContext {
     /// OIDC/SSO discovery, token, JWKS and userinfo fetch path against a
     /// configured identity provider.
     SsoDiscovery,
+    /// Operator-configured, trusted internal-service endpoints (e.g. the
+    /// scanner-adapter `TRIVY_ADAPTER_URL`, Dependency-Track, OpenSCAP).
+    ///
+    /// These URLs come from server configuration, not from any
+    /// attacker/user-influenceable input, so RFC1918 / CGNAT / IPv6
+    /// unique-local addresses are permitted unconditionally (the normal
+    /// in-cluster / private-network topology) WITHOUT requiring the
+    /// `AK_SSRF_ALLOW_PRIVATE_CIDRS` allowlist or a per-surface blanket
+    /// toggle. The cloud-metadata / loopback / link-local hard-blocks still
+    /// apply (see [`is_hard_blocked_ipv4`] and [`is_blocked_ipv6`]), so a
+    /// misconfigured or redirect-pivoted internal client still cannot reach
+    /// a metadata endpoint or the loopback interface. This context has no
+    /// env var — the [`private_ip_allowed`] short-circuit permits private
+    /// addresses before any env var is consulted (issue #2389).
+    TrustedInternal,
 }
 
 impl OutboundUrlContext {
@@ -129,6 +144,12 @@ impl OutboundUrlContext {
             OutboundUrlContext::Upstream => "UPSTREAM_ALLOW_PRIVATE_IPS",
             OutboundUrlContext::Webhook => "WEBHOOK_ALLOW_PRIVATE_IPS",
             OutboundUrlContext::SsoDiscovery => "SSO_ALLOW_PRIVATE_IPS",
+            // TrustedInternal permits private addresses via the
+            // `private_ip_allowed` short-circuit, so this env var is never
+            // consulted. Name an undefined var so that even a hypothetical
+            // future caller reaching this arm falls through to "blocked"
+            // (fail-closed) rather than panicking.
+            OutboundUrlContext::TrustedInternal => "AK_TRUSTED_INTERNAL_ALLOW_PRIVATE_IPS",
         }
     }
 }
@@ -266,6 +287,16 @@ pub fn is_blocked_resolved_ip(ip: std::net::IpAddr) -> bool {
     is_blocked_ip_in(ip, OutboundUrlContext::Upstream)
 }
 
+/// Connect-time resolved-IP check for the [`OutboundUrlContext::TrustedInternal`]
+/// context: RFC1918 / CGNAT / IPv6 unique-local are permitted (operator config,
+/// not attacker input) while cloud-metadata, loopback, link-local and
+/// unspecified addresses stay hard-blocked. Used by the internal-service HTTP
+/// client's SSRF DNS resolver so a private-network scanner-adapter is reachable
+/// without relaxing the upstream/proxy guard (issue #2389).
+pub fn is_blocked_resolved_ip_internal(ip: std::net::IpAddr) -> bool {
+    is_blocked_ip_in(ip, OutboundUrlContext::TrustedInternal)
+}
+
 /// Common implementation shared by the per-context validators. The
 /// `ctx` selects which env var the private-IP relaxation toggle reads.
 fn validate_outbound_url_with(url_str: &str, label: &str, ctx: OutboundUrlContext) -> Result<()> {
@@ -318,6 +349,15 @@ fn block_reason_to_error(label: &str, reason: BlockReason) -> AppError {
 /// redirect policy to also relax under the webhook env var.
 pub(crate) fn is_blocked_url(url: &reqwest::Url) -> Option<BlockReason> {
     is_blocked_url_in(url, OutboundUrlContext::Upstream)
+}
+
+/// [`is_blocked_url`] variant for the trusted internal-service redirect
+/// policy. Permits private/CGNAT/ULA redirect targets (operator-configured
+/// endpoints legitimately live on private networks) but keeps the
+/// metadata / loopback / link-local hard-blocks so a redirect cannot pivot
+/// an internal-service client onto a metadata endpoint (issue #2389).
+pub(crate) fn is_blocked_url_internal(url: &reqwest::Url) -> Option<BlockReason> {
+    is_blocked_url_in(url, OutboundUrlContext::TrustedInternal)
 }
 
 /// Context-aware variant of [`is_blocked_url`]. Returning `Some(_)`
@@ -530,6 +570,16 @@ fn is_blocked_ipv6(v6: std::net::Ipv6Addr, ctx: OutboundUrlContext) -> bool {
 /// Metadata IPs and loopback are checked separately and are never
 /// reachable through this path (see `is_hard_blocked_ipv4`).
 fn private_ip_allowed(ip: std::net::IpAddr, ctx: OutboundUrlContext) -> bool {
+    // Operator-configured, trusted internal-service endpoints permit
+    // RFC1918 / CGNAT / IPv6 unique-local addresses unconditionally — the URL
+    // is server config, not attacker/user input (issue #2389). This
+    // short-circuits BEFORE any env var is read, so TrustedInternal (which has
+    // no env var) never reaches `allow_private_ips_enabled`. The metadata /
+    // loopback / link-local hard-blocks are enforced earlier in
+    // `is_hard_blocked_ipv4` / `is_blocked_ipv6` and are NOT reachable here.
+    if matches!(ctx, OutboundUrlContext::TrustedInternal) {
+        return true;
+    }
     if let Some(list) = private_cidr_allowlist_value() {
         return cidr_list_contains(&list, ip);
     }
@@ -1006,6 +1056,58 @@ mod tests {
             validate_outbound_url("http://100.64.0.1/x", "Upstream URL").is_ok(),
             "CGNAT must be allowed when UPSTREAM_ALLOW_PRIVATE_IPS=true"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // TrustedInternal context (issue #2389): operator-configured internal
+    // services may sit on private networks WITHOUT any allowlist env var, but
+    // metadata / loopback / link-local must stay hard-blocked.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_trusted_internal_permits_private_without_env() {
+        // No env var set: TrustedInternal must accept RFC1918 while the
+        // Upstream context still rejects the very same address.
+        let _g = AllowlistGuard::new();
+        let rfc1918 = "10.0.0.5".parse::<std::net::IpAddr>().unwrap();
+        assert!(
+            !is_blocked_ip_in(rfc1918, OutboundUrlContext::TrustedInternal),
+            "10.0.0.5 must be allowed for TrustedInternal with no env set"
+        );
+        assert!(
+            is_blocked_ip_in(rfc1918, OutboundUrlContext::Upstream),
+            "10.0.0.5 must stay blocked for Upstream with no env set"
+        );
+        // A CGNAT and a ULA representative are also operator-reachable.
+        assert!(!is_blocked_ip_in(
+            "100.64.0.1".parse().unwrap(),
+            OutboundUrlContext::TrustedInternal
+        ));
+        assert!(!is_blocked_ip_in(
+            "fc00::1".parse().unwrap(),
+            OutboundUrlContext::TrustedInternal
+        ));
+    }
+
+    #[test]
+    fn test_trusted_internal_retains_hard_blocks() {
+        // The metadata / loopback / link-local hard-blocks are NOT relaxed by
+        // the trusted-internal exemption: is_blocked_resolved_ip_internal must
+        // still reject each of them.
+        let _g = AllowlistGuard::new();
+        for ip in [
+            "169.254.169.254", // cloud metadata (IPv4 link-local)
+            "127.0.0.1",       // IPv4 loopback
+            "::1",             // IPv6 loopback
+            "fe80::1",         // IPv6 link-local
+            "0.0.0.0",         // unspecified
+        ] {
+            let parsed = ip.parse::<std::net::IpAddr>().unwrap();
+            assert!(
+                is_blocked_resolved_ip_internal(parsed),
+                "{ip} must stay hard-blocked even for the internal-service context"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/dependency_track_service.rs
+++ b/backend/src/services/dependency_track_service.rs
@@ -662,7 +662,7 @@ impl DependencyTrackService {
             );
         }
 
-        let client = crate::services::http_client::base_client_builder()
+        let client = crate::services::http_client::internal_service_client_builder()
             .timeout(Duration::from_secs(30))
             .https_only(!allow_http)
             .build()

--- a/backend/src/services/health_monitor_service.rs
+++ b/backend/src/services/health_monitor_service.rs
@@ -105,7 +105,7 @@ pub(crate) fn dependency_track_probe_url(config: &Config) -> Option<&str> {
 
 impl HealthMonitorService {
     pub fn new(db: PgPool, config: MonitorConfig) -> Self {
-        let http_client = crate::services::http_client::base_client_builder()
+        let http_client = crate::services::http_client::internal_service_client_builder()
             .timeout(Duration::from_secs(config.check_timeout_secs))
             .build()
             .unwrap_or_default();

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -59,10 +59,41 @@ fn log_proxy_env() {
 pub fn base_client_builder() -> ClientBuilder {
     log_proxy_env();
 
-    let mut builder = reqwest::Client::builder()
+    let builder = reqwest::Client::builder()
         .redirect(ssrf_redirect_policy())
         .dns_resolver(crate::services::ssrf_dns::ssrf_guard_resolver());
 
+    apply_custom_ca_cert(builder)
+}
+
+/// Return a [`ClientBuilder`] for **operator-configured, trusted
+/// internal-service** endpoints (the scanner-adapter `TRIVY_ADAPTER_URL`,
+/// Dependency-Track, OpenSCAP). It mirrors [`base_client_builder`] — same
+/// custom-CA handling — but wires the SSRF DNS resolver and redirect policy
+/// in the trusted-internal trust class, so a scanner-adapter on a private
+/// network (the normal in-cluster topology) is reachable WITHOUT any
+/// `AK_SSRF_ALLOW_PRIVATE_CIDRS` operator knob. Cloud-metadata, loopback and
+/// link-local addresses stay hard-blocked at connect time and across
+/// redirects (issue #2389).
+///
+/// This must ONLY be used for URLs that come from server configuration, never
+/// for attacker/user-influenceable targets (remote-repo upstreams, proxy
+/// URLs, webhooks, plugins) — those keep using [`base_client_builder`], which
+/// stays fail-closed.
+pub fn internal_service_client_builder() -> ClientBuilder {
+    log_proxy_env();
+
+    let builder = reqwest::Client::builder()
+        .redirect(ssrf_internal_redirect_policy())
+        .dns_resolver(crate::services::ssrf_dns::ssrf_guard_resolver_internal());
+
+    apply_custom_ca_cert(builder)
+}
+
+/// Load operator-provided custom CA certificate(s) (`CUSTOM_CA_CERT_PATH`)
+/// into the builder when configured. Shared by every client builder so the
+/// private-CA handling is identical and lives in one place.
+fn apply_custom_ca_cert(mut builder: ClientBuilder) -> ClientBuilder {
     if let Ok(ca_path) = std::env::var("CUSTOM_CA_CERT_PATH") {
         match std::fs::read(&ca_path) {
             Ok(pem_bytes) => match Certificate::from_pem_bundle(&pem_bytes) {
@@ -129,8 +160,33 @@ pub fn default_client() -> reqwest::Client {
 /// otherwise defeat the entry-point validator. Caps at
 /// [`MAX_REDIRECTS`] hops so a redirect loop cannot tie up a worker.
 fn ssrf_redirect_policy() -> Policy {
-    Policy::custom(|attempt| {
-        if let Some(reason) = crate::api::validation::is_blocked_url(attempt.url()) {
+    ssrf_redirect_policy_with(
+        crate::api::validation::is_blocked_url,
+        "http-client redirect",
+    )
+}
+
+/// Redirect policy for the trusted internal-service clients (#2389). Same
+/// per-hop SSRF re-check as [`ssrf_redirect_policy`], but uses the
+/// trusted-internal block-list so a redirect to a private address is allowed
+/// while a redirect that pivots to a cloud-metadata / loopback / link-local
+/// target is still refused.
+fn ssrf_internal_redirect_policy() -> Policy {
+    ssrf_redirect_policy_with(
+        crate::api::validation::is_blocked_url_internal,
+        "internal-service redirect",
+    )
+}
+
+/// Shared redirect-policy body: re-run `is_blocked` on every hop and refuse
+/// the request if it returns a block reason, capping at [`MAX_REDIRECTS`].
+/// The `is_blocked` fn selects the trust class (upstream vs trusted-internal).
+fn ssrf_redirect_policy_with(
+    is_blocked: fn(&reqwest::Url) -> Option<crate::api::validation::BlockReason>,
+    context_label: &'static str,
+) -> Policy {
+    Policy::custom(move |attempt| {
+        if let Some(reason) = is_blocked(attempt.url()) {
             tracing::warn!(
                 target: "security",
                 redirect_url = %attempt.url(),
@@ -139,7 +195,7 @@ fn ssrf_redirect_policy() -> Policy {
             );
             crate::services::metrics_service::record_outbound_url_blocked(
                 reason.metric_label(),
-                "http-client redirect",
+                context_label,
             );
             return attempt.error("redirect target rejected by SSRF policy");
         }
@@ -154,7 +210,10 @@ fn ssrf_redirect_policy() -> Policy {
 // streaming-invariant: test module exempt — buffering response bodies in test assertions is not an artifact path (#1608)
 #[cfg(test)]
 mod tests {
-    use super::{base_client_builder, default_client, large_object_client_builder};
+    use super::{
+        base_client_builder, default_client, internal_service_client_builder,
+        large_object_client_builder,
+    };
     use std::io::Write;
     use std::time::Duration;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -335,6 +394,46 @@ mod tests {
             "listener must never accept a connection; the SSRF resolver should have \
              blocked the request before any TCP connection was attempted, but a \
              connection was accepted: {accept_result:?}"
+        );
+    }
+
+    /// The trusted internal-service client (#2389) relaxes the private-IP
+    /// gate for operator-configured endpoints, but the loopback / metadata
+    /// hard-blocks must NOT be relaxed: a host resolving to 127.0.0.1 must
+    /// still be refused before any TCP connection is made. Mirrors the
+    /// discriminating listener assertion used for `base_client_builder`.
+    #[tokio::test]
+    async fn test_internal_client_still_refuses_loopback_host() {
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test listener");
+        let port = listener.local_addr().expect("local addr").port();
+
+        let client = internal_service_client_builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let url = format!("http://localhost:{port}/");
+        let err = client
+            .get(&url)
+            .send()
+            .await
+            .expect_err("internal client must still refuse a loopback host");
+        assert!(
+            err.is_connect()
+                || err.is_request()
+                || err.to_string().to_lowercase().contains("ssrf")
+                || err.to_string().to_lowercase().contains("block"),
+            "expected resolver rejection, got: {err}"
+        );
+
+        let accept_result =
+            tokio::time::timeout(Duration::from_millis(200), listener.accept()).await;
+        assert!(
+            accept_result.is_err(),
+            "internal client must never connect to a loopback listener: {accept_result:?}"
         );
     }
 

--- a/backend/src/services/image_scanner.rs
+++ b/backend/src/services/image_scanner.rs
@@ -299,11 +299,11 @@ impl ImageScanner {
     pub fn new(adapter_url: String) -> Self {
         Self {
             adapter_url,
-            http: crate::services::http_client::base_client_builder()
+            http: crate::services::http_client::internal_service_client_builder()
                 .timeout(std::time::Duration::from_secs(300))
                 .build()
                 .unwrap_or_default(),
-            poll_http: crate::services::http_client::base_client_builder()
+            poll_http: crate::services::http_client::internal_service_client_builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .timeout(std::time::Duration::from_secs(30))
                 .build()

--- a/backend/src/services/openscap_scanner.rs
+++ b/backend/src/services/openscap_scanner.rs
@@ -106,7 +106,7 @@ fn workspace_create_error(base: &str, err: &std::io::Error) -> AppError {
 
 impl OpenScapScanner {
     pub fn new(openscap_url: String, profile: String, scan_workspace: String) -> Self {
-        let http = crate::services::http_client::base_client_builder()
+        let http = crate::services::http_client::internal_service_client_builder()
             .timeout(Duration::from_secs(600))
             .build()
             .expect("failed to build HTTP client");

--- a/backend/src/services/scanner_adapter_client.rs
+++ b/backend/src/services/scanner_adapter_client.rs
@@ -182,13 +182,13 @@ impl ScannerAdapterFsClient {
     pub fn new(adapter_url: String) -> Self {
         Self {
             adapter_url,
-            http: crate::services::http_client::base_client_builder()
+            http: crate::services::http_client::internal_service_client_builder()
                 // Generous: the body is the tarred workspace, potentially GBs
                 // for an incus rootfs.
                 .timeout(std::time::Duration::from_secs(900))
                 .build()
                 .unwrap_or_default(),
-            poll_http: crate::services::http_client::base_client_builder()
+            poll_http: crate::services::http_client::internal_service_client_builder()
                 .redirect(reqwest::redirect::Policy::none())
                 .timeout(std::time::Duration::from_secs(30))
                 .build()

--- a/backend/src/services/ssrf_dns.rs
+++ b/backend/src/services/ssrf_dns.rs
@@ -7,37 +7,85 @@ use std::sync::Arc;
 
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 
-/// A `reqwest` DNS resolver that resolves via the OS resolver and then drops
-/// any address rejected by [`crate::api::validation::is_blocked_resolved_ip`].
-/// If every resolved address is blocked, resolution fails (the request never
-/// connects), defeating DNS-rebinding attacks that pass the URL-string check.
-#[derive(Debug, Default, Clone)]
-pub struct SsrfGuardResolver;
-
-/// Convenience: an `Arc<dyn Resolve>` for `ClientBuilder::dns_resolver`.
-pub fn ssrf_guard_resolver() -> Arc<dyn Resolve> {
-    Arc::new(SsrfGuardResolver)
+/// Which trust class the resolver enforces. Selects whether private /
+/// CGNAT / IPv6 unique-local addresses are dropped (the default,
+/// attacker-influenceable upstream/proxy targets) or permitted (trusted
+/// operator-configured internal services). The cloud-metadata / loopback /
+/// link-local hard-blocks apply to both (issue #2389).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResolverMode {
+    /// Fail-closed: block every private/internal address (upstream/proxy).
+    Upstream,
+    /// Trusted operator-configured internal service: permit private/CGNAT/ULA
+    /// but keep metadata/loopback/link-local blocked.
+    TrustedInternal,
 }
 
-/// Pure filter: keep only addresses not rejected by
-/// [`crate::api::validation::is_blocked_resolved_ip`]. Extracted from
-/// [`SsrfGuardResolver::resolve`] so the security-critical mixed-address
-/// case (some resolved addresses blocked, some not) can be unit tested
-/// without any DNS/network I/O.
-fn filter_allowed(addrs: impl IntoIterator<Item = SocketAddr>) -> Vec<SocketAddr> {
+/// A `reqwest` DNS resolver that resolves via the OS resolver and then drops
+/// any address rejected by the SSRF policy for its [`ResolverMode`]. If every
+/// resolved address is blocked, resolution fails (the request never connects),
+/// defeating DNS-rebinding attacks that pass the URL-string check.
+#[derive(Debug, Clone)]
+pub struct SsrfGuardResolver {
+    mode: ResolverMode,
+}
+
+impl Default for SsrfGuardResolver {
+    fn default() -> Self {
+        Self {
+            mode: ResolverMode::Upstream,
+        }
+    }
+}
+
+/// Convenience: an `Arc<dyn Resolve>` for `ClientBuilder::dns_resolver` that
+/// blocks every private/internal address (upstream / remote-proxy / webhook /
+/// SSO — the fail-closed default).
+pub fn ssrf_guard_resolver() -> Arc<dyn Resolve> {
+    Arc::new(SsrfGuardResolver::default())
+}
+
+/// `Arc<dyn Resolve>` for trusted operator-configured internal-service
+/// clients (e.g. the scanner-adapter): permits private/CGNAT/ULA targets but
+/// retains the metadata/loopback/link-local hard-blocks (issue #2389).
+pub fn ssrf_guard_resolver_internal() -> Arc<dyn Resolve> {
+    Arc::new(SsrfGuardResolver {
+        mode: ResolverMode::TrustedInternal,
+    })
+}
+
+/// True when a resolved IP must be dropped for the given [`ResolverMode`].
+fn is_blocked_for(mode: ResolverMode, ip: std::net::IpAddr) -> bool {
+    match mode {
+        ResolverMode::Upstream => crate::api::validation::is_blocked_resolved_ip(ip),
+        ResolverMode::TrustedInternal => {
+            crate::api::validation::is_blocked_resolved_ip_internal(ip)
+        }
+    }
+}
+
+/// Pure filter: keep only addresses not rejected by the SSRF policy for
+/// `mode`. Extracted from [`SsrfGuardResolver::resolve`] so the
+/// security-critical mixed-address case (some resolved addresses blocked,
+/// some not) can be unit tested without any DNS/network I/O.
+fn filter_allowed(
+    mode: ResolverMode,
+    addrs: impl IntoIterator<Item = SocketAddr>,
+) -> Vec<SocketAddr> {
     addrs
         .into_iter()
-        .filter(|sa| !crate::api::validation::is_blocked_resolved_ip(sa.ip()))
+        .filter(|sa| !is_blocked_for(mode, sa.ip()))
         .collect()
 }
 
 impl Resolve for SsrfGuardResolver {
     fn resolve(&self, name: Name) -> Resolving {
+        let mode = self.mode;
         Box::pin(async move {
             let host = name.as_str().to_string();
             // Port 0 is a placeholder; reqwest substitutes the real port.
             let resolved = tokio::net::lookup_host((host.as_str(), 0)).await?;
-            let allowed: Vec<SocketAddr> = filter_allowed(resolved);
+            let allowed: Vec<SocketAddr> = filter_allowed(mode, resolved);
             if allowed.is_empty() {
                 let err: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
@@ -67,7 +115,10 @@ mod tests {
         let blocked_metadata: SocketAddr = "169.254.169.254:0".parse().unwrap();
         let allowed: SocketAddr = "93.184.216.34:0".parse().unwrap();
 
-        let result = filter_allowed([blocked_loopback, allowed, blocked_metadata]);
+        let result = filter_allowed(
+            ResolverMode::Upstream,
+            [blocked_loopback, allowed, blocked_metadata],
+        );
 
         assert_eq!(
             result,
@@ -81,7 +132,7 @@ mod tests {
         let blocked_loopback: SocketAddr = "127.0.0.1:0".parse().unwrap();
         let blocked_metadata: SocketAddr = "169.254.169.254:0".parse().unwrap();
 
-        let result = filter_allowed([blocked_loopback, blocked_metadata]);
+        let result = filter_allowed(ResolverMode::Upstream, [blocked_loopback, blocked_metadata]);
 
         assert!(
             result.is_empty(),
@@ -94,7 +145,7 @@ mod tests {
         let a: SocketAddr = "93.184.216.34:0".parse().unwrap();
         let b: SocketAddr = "8.8.8.8:0".parse().unwrap();
 
-        let result = filter_allowed([a, b]);
+        let result = filter_allowed(ResolverMode::Upstream, [a, b]);
 
         assert_eq!(
             result,
@@ -103,11 +154,32 @@ mod tests {
         );
     }
 
+    /// Internal mode keeps a private RFC1918 address (operator-configured
+    /// scanner-adapter) while STILL dropping metadata/loopback — the exact
+    /// behavior split that #2389 relies on.
+    #[test]
+    fn filter_allowed_internal_keeps_private_drops_hard_blocked() {
+        let private_addr: SocketAddr = "10.0.0.5:0".parse().unwrap();
+        let blocked_metadata: SocketAddr = "169.254.169.254:0".parse().unwrap();
+        let blocked_loopback: SocketAddr = "127.0.0.1:0".parse().unwrap();
+
+        let result = filter_allowed(
+            ResolverMode::TrustedInternal,
+            [blocked_metadata, private_addr, blocked_loopback],
+        );
+
+        assert_eq!(
+            result,
+            vec![private_addr],
+            "internal mode must keep the private address and drop metadata/loopback, got {result:?}"
+        );
+    }
+
     #[tokio::test]
     async fn resolver_rejects_localhost() {
         // `localhost` resolves to 127.0.0.1 / ::1, both blocked.
         let name: Name = "localhost".parse().expect("valid dns name");
-        let result = SsrfGuardResolver.resolve(name).await;
+        let result = SsrfGuardResolver::default().resolve(name).await;
         assert!(
             result.is_err(),
             "localhost must be refused by the SSRF resolver"
@@ -121,7 +193,7 @@ mod tests {
         // address, so the allow-path (not just the reject-path) must let it
         // through with at least one address.
         let name: Name = "1.1.1.1".parse().expect("valid dns name");
-        let mut addrs = SsrfGuardResolver
+        let mut addrs = SsrfGuardResolver::default()
             .resolve(name)
             .await
             .expect("a non-blocked IP literal must resolve successfully");
@@ -129,5 +201,59 @@ mod tests {
             addrs.next().is_some(),
             "expected at least one allowed address"
         );
+    }
+
+    /// The default (upstream) resolver must still refuse a private RFC1918
+    /// literal with no env set — proving the internal-mode exemption does not
+    /// leak into the fail-closed path.
+    #[tokio::test]
+    async fn upstream_resolver_rejects_private_ip_literal() {
+        std::env::remove_var("AK_SSRF_ALLOW_PRIVATE_CIDRS");
+        std::env::remove_var("UPSTREAM_ALLOW_PRIVATE_IPS");
+        std::env::remove_var("UPSTREAM_PRIVATE_IP_ALLOWLIST");
+        let name: Name = "10.0.0.5".parse().expect("valid dns name");
+        let result = SsrfGuardResolver::default().resolve(name).await;
+        assert!(
+            result.is_err(),
+            "upstream resolver must refuse 10.0.0.5 with no allowlist env set"
+        );
+    }
+
+    /// The internal-service resolver must ACCEPT a private RFC1918 literal
+    /// with no env var set (the #2389 fix) …
+    #[tokio::test]
+    async fn internal_resolver_allows_private_ip_literal() {
+        std::env::remove_var("AK_SSRF_ALLOW_PRIVATE_CIDRS");
+        std::env::remove_var("UPSTREAM_ALLOW_PRIVATE_IPS");
+        std::env::remove_var("UPSTREAM_PRIVATE_IP_ALLOWLIST");
+        let name: Name = "10.0.0.5".parse().expect("valid dns name");
+        let mut addrs = SsrfGuardResolver {
+            mode: ResolverMode::TrustedInternal,
+        }
+        .resolve(name)
+        .await
+        .expect("internal-service resolver must allow a private RFC1918 literal");
+        assert!(
+            addrs.next().is_some(),
+            "expected at least one allowed address for the internal resolver"
+        );
+    }
+
+    /// … but the internal-service resolver must STILL refuse metadata,
+    /// loopback and `localhost` (hard-blocks are never relaxed).
+    #[tokio::test]
+    async fn internal_resolver_still_refuses_hard_blocked() {
+        for host in ["169.254.169.254", "127.0.0.1", "localhost"] {
+            let name: Name = host.parse().expect("valid dns name");
+            let result = SsrfGuardResolver {
+                mode: ResolverMode::TrustedInternal,
+            }
+            .resolve(name)
+            .await;
+            assert!(
+                result.is_err(),
+                "internal resolver must still refuse hard-blocked host {host}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

The connect-time SSRF hardening added in #2354 installs an SSRF-validating DNS
resolver and redirect policy on **every** `base_client_builder()` consumer. That
resolver was designed for **attacker-influenceable** upstream/proxy targets
(Remote RPM/YUM mirroring), where a private-IP destination is a genuine SSRF
signal. But the same client is also used by **operator-configured internal
services** — most importantly the scanner-adapter (`TRIVY_ADAPTER_URL`), which in
the normal topology is an in-cluster sidecar on a private (RFC1918) network. As a
result, once #2354 is active, **all** trivy image + filesystem + incus scanning
fails to reach the adapter on any private-network deployment unless the operator
sets a blanket `AK_SSRF_ALLOW_PRIVATE_CIDRS` workaround — which is not a shippable
default and broadens the guard beyond its intent.

This applies the SSRF gate **context-aware**: it distinguishes
attacker-influenceable targets (which stay fail-closed) from trusted
operator-configured internal-service URLs (which come from server config, not
user input) and lets the latter reach a private address **without** any operator
knob, while retaining the cloud-metadata / loopback / link-local hard-blocks.

## Changes

- `api/validation.rs`: new `OutboundUrlContext::TrustedInternal`. It permits
  RFC1918 / CGNAT / IPv6 unique-local via a short-circuit in `private_ip_allowed`
  evaluated **before** any env var is read (the context has no env var). The
  metadata / loopback / link-local hard-blocks in `is_hard_blocked_ipv4` /
  `is_blocked_ipv6` are unchanged and still apply. Adds
  `is_blocked_resolved_ip_internal()` (connect-time resolved-IP check) and
  `is_blocked_url_internal()` (redirect-policy check) for this context.
- `services/ssrf_dns.rs`: `SsrfGuardResolver` now carries a trust-class mode;
  adds `ssrf_guard_resolver_internal()`; the pure `filter_allowed` dispatches to
  the upstream vs internal resolved-IP check. The default resolver is unchanged
  (fail-closed).
- `services/http_client.rs`: new `internal_service_client_builder()` mirroring
  `base_client_builder()` (identical custom-CA handling, factored into a shared
  `apply_custom_ca_cert` helper) but wiring the internal resolver + an internal
  redirect policy. **`base_client_builder()` / `default_client()` keep their
  existing upstream resolver + upstream redirect policy and stay fail-closed** —
  the redirect-policy body was factored into a shared helper without changing
  behavior.
- Switched only the operator-configured internal-service clients to the new
  builder (both request and poll clients where two are built): scanner-adapter
  image scans (`image_scanner.rs`), scanner-adapter filesystem/incus scans
  (`scanner_adapter_client.rs`), OpenSCAP (`openscap_scanner.rs`),
  Dependency-Track (`dependency_track_service.rs`) and the internal-service
  health monitor (`health_monitor_service.rs`).

Attacker/user-influenceable paths (remote-repo upstreams, proxy fetches, plugin
fetches, schedulers, public OSV/GitHub) are left on `base_client_builder()` and
remain fail-closed. Webhook and SSO clients are intentionally untouched (their
per-context toggles are handled separately in #2380).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New unit tests assert the exact behavior split: `TrustedInternal` permits a
private RFC1918 address with **no env var set** while `Upstream` still blocks the
same address (the bug was that the only client was the upstream/fail-closed one);
and the internal resolver/URL checks still hard-block metadata / loopback /
link-local. Existing `base_client_builder` listener + redirect regression tests
are kept unchanged to prove the fail-closed default is intact.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2389
