### PR TITLE
fix(telemetry): record download statistics for virtual content serves via /artifacts/{path}

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3146,6 +3146,53 @@ pub async fn virtual_non_remote_owns_path(
     Ok(exists.is_some())
 }
 
+/// Resolve the local `artifacts` row a virtual-repo content serve delivered,
+/// so the caller can attribute the download to it (#2394 / #2365).
+///
+/// Only meaningful after [`virtual_non_remote_owns_path`] returned `true`:
+/// the caller then suppresses the proxy, Remote members classify as `Skip`,
+/// and [`resolve_virtual_download`] finalizes in strict member-priority
+/// order — so the winning bytes belong to the FIRST non-Remote member (by
+/// `virtual_repo_members.priority`) holding a non-deleted artifact at the
+/// exact path. This query re-derives that row. Remote pass-through has no
+/// local row and stays unrecorded (#1278).
+///
+/// Best-effort: a database error logs at `warn` and yields `None` —
+/// telemetry must never block or fail the download itself.
+pub async fn virtual_local_winner_artifact_id(
+    db: &PgPool,
+    virtual_repo_id: Uuid,
+    path: &str,
+) -> Option<Uuid> {
+    match sqlx::query_scalar::<_, Uuid>(
+        "SELECT a.id FROM artifacts a \
+         JOIN virtual_repo_members vrm ON vrm.member_repo_id = a.repository_id \
+         JOIN repositories r ON r.id = a.repository_id \
+         WHERE vrm.virtual_repo_id = $1 \
+           AND r.repo_type != 'remote' \
+           AND a.path = $2 \
+           AND a.is_deleted = false \
+         ORDER BY vrm.priority \
+         LIMIT 1",
+    )
+    .bind(virtual_repo_id)
+    .bind(path)
+    .fetch_optional(db)
+    .await
+    {
+        Ok(id) => id,
+        Err(e) => {
+            tracing::warn!(
+                %virtual_repo_id,
+                path,
+                error = %e,
+                "failed to resolve virtual download attribution; skipping statistics"
+            );
+            None
+        }
+    }
+}
+
 /// Build the SQL `LIKE` pattern that matches every artifact path under
 /// a given Maven `groupId/artifactId/` directory.
 ///

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3659,6 +3659,7 @@ pub async fn get_artifact_metadata(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, path)): Path<(String, String)>,
     Query(version_query): Query<ArtifactVersionQuery>,
+    dl_ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response> {
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
@@ -3823,6 +3824,22 @@ pub async fn get_artifact_metadata(
         .map_err(|_| {
             AppError::NotFound("Artifact not found in any member repository".to_string())
         })?;
+
+        // #2394: unlike the direct-row branch above (metadata JSON only,
+        // intentionally unrecorded), this branch serves the member's BYTES —
+        // a real download — so it must reach the #2365 recorder. When the
+        // shadowing guard proved a non-Remote member owns the exact path, the
+        // served body is that local member's artifact (Remote members were
+        // suppressed); attribute the download to its row. Remote pass-through
+        // resolves no local `artifacts` row and stays unrecorded (#1278).
+        if owns_locally {
+            if let Some(artifact_id) =
+                proxy_helpers::virtual_local_winner_artifact_id(&state.db, repo.id, &path).await
+            {
+                crate::services::artifact_service::record_download(&state.db, artifact_id, &dl_ctx)
+                    .await;
+            }
+        }
 
         let ct = result
             .content_type
@@ -11697,6 +11714,240 @@ mod tests {
             axum::http::StatusCode::NOT_FOUND,
             "missing local artifact must map to 404 (NotFound contract preserved by #1608)"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // get_artifact_metadata: download telemetry on the virtual content
+    // branch (#2394, completing #2365).
+    //
+    // GET /:key/artifacts/*path has two shapes: a direct `artifacts` row in
+    // the addressed repo returns metadata JSON (a read, not a download),
+    // while a Virtual repo streams the winning member's BYTES — a real
+    // download that used to bypass the #2365 recorder entirely. Pinned here:
+    //   1. a virtual content serve backed by a local member records ONE
+    //      `download_statistics` row against the member's artifact, with the
+    //      resolved client IP and the user (NULL when anonymous)
+    //   2. a metadata-only read records nothing
+    //   3. a virtual remote pass-through records nothing and still inserts
+    //      no `artifacts` row (#1278)
+    // ---------------------------------------------------------------------
+
+    /// Fetch `(user_id, ip_address, user_agent)` telemetry rows for one
+    /// artifact, oldest first.
+    async fn telemetry_rows(
+        pool: &sqlx::PgPool,
+        artifact_id: Uuid,
+    ) -> Vec<(Option<Uuid>, Option<String>, Option<String>)> {
+        sqlx::query_as(
+            "SELECT user_id, ip_address, user_agent FROM download_statistics \
+             WHERE artifact_id = $1 ORDER BY downloaded_at",
+        )
+        .bind(artifact_id)
+        .fetch_all(pool)
+        .await
+        .expect("query download_statistics")
+    }
+
+    #[tokio::test]
+    async fn test_artifacts_get_virtual_local_serve_records_download() {
+        let Some(fx) = tdh::Fixture::setup("virtual", "generic").await else {
+            return;
+        };
+        let (member_id, member_key, member_dir) =
+            tdh::create_repo(&fx.pool, "local", "generic").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(fx.repo_id)
+        .bind(member_id)
+        .execute(&fx.pool)
+        .await
+        .expect("add virtual member");
+
+        let body_bytes: &[u8] = b"virtual-member-content-bytes";
+        let member_repo = tdh::make_repo_info(member_id, &member_key, &member_dir, "local", None);
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        let artifact_id = tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &member_repo,
+            &storage_key,
+            "vpath/blob.bin",
+            "blob",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(body_bytes),
+            fx.user_id,
+        )
+        .await;
+
+        // Authenticated content GET through the virtual repo. No ConnectInfo
+        // peer exists in a unit router, so DownloadContext falls back to the
+        // parseable X-Forwarded-For value for the client IP.
+        let mut req = tdh::get(format!("/{}/artifacts/vpath/blob.bin", fx.repo_key));
+        req.headers_mut()
+            .insert("x-forwarded-for", "203.0.113.77".parse().unwrap());
+        req.headers_mut()
+            .insert("user-agent", "dl-telemetry-test/1.0".parse().unwrap());
+        let (status, body) = tdh::send(fx.router_with_auth(router()), req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(
+            &body[..],
+            body_bytes,
+            "virtual /artifacts/ GET must serve the member's content bytes"
+        );
+
+        let rows = telemetry_rows(&fx.pool, artifact_id).await;
+        assert_eq!(
+            rows.len(),
+            1,
+            "a virtual content serve must record exactly one download_statistics row"
+        );
+        assert_eq!(rows[0].0, Some(fx.user_id), "user must be attributed");
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("203.0.113.77"),
+            "resolved client IP must be recorded, not a sentinel"
+        );
+        assert_eq!(rows[0].2.as_deref(), Some("dl-telemetry-test/1.0"));
+
+        // Anonymous content GET: user_id records as NULL, not dropped.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make virtual repo public");
+        let mut anon_req = tdh::get(format!("/{}/artifacts/vpath/blob.bin", fx.repo_key));
+        anon_req
+            .headers_mut()
+            .insert("x-forwarded-for", "203.0.113.78".parse().unwrap());
+        let (anon_status, _) = tdh::send(fx.router_anon(router()), anon_req).await;
+        assert_eq!(anon_status, axum::http::StatusCode::OK);
+
+        let rows = telemetry_rows(&fx.pool, artifact_id).await;
+        assert_eq!(rows.len(), 2, "anonymous serve must also record");
+        assert_eq!(rows[1].0, None, "anonymous must record a NULL user");
+        assert_eq!(rows[1].1.as_deref(), Some("203.0.113.78"));
+
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup(&fx.pool, member_id, fx.user_id).await;
+        let _ = std::fs::remove_dir_all(&member_dir);
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_artifacts_get_metadata_read_does_not_record() {
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let repo = fx.repo_info("local", None);
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        let artifact_id = tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &storage_key,
+            "meta/only.bin",
+            "only",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(b"metadata-branch-bytes"),
+            fx.user_id,
+        )
+        .await;
+
+        let mut req = tdh::get(format!("/{}/artifacts/meta/only.bin", fx.repo_key));
+        req.headers_mut()
+            .insert("x-forwarded-for", "203.0.113.79".parse().unwrap());
+        let (status, body) = tdh::send(fx.router_with_auth(router()), req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let v: serde_json::Value = serde_json::from_slice(&body)
+            .expect("direct-row branch must return metadata JSON, not content bytes");
+        assert_eq!(v["path"], "meta/only.bin");
+
+        let rows = telemetry_rows(&fx.pool, artifact_id).await;
+        assert!(
+            rows.is_empty(),
+            "a metadata-only read is not a download and must record nothing"
+        );
+
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_artifacts_get_virtual_remote_passthrough_does_not_record() {
+        let Some(fx) = tdh::Fixture::setup("virtual", "generic").await else {
+            return;
+        };
+        let (member_id, _member_key, member_dir) =
+            tdh::create_repo(&fx.pool, "remote", "generic").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(fx.repo_id)
+        .bind(member_id)
+        .execute(&fx.pool)
+        .await
+        .expect("add remote virtual member");
+
+        let server = wiremock::MockServer::start().await;
+        let upstream_body: &[u8] = b"remote-passthrough-bytes";
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/pass/through.bin"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(upstream_body))
+            .mount(&server)
+            .await;
+        point_repo_at_upstream(&fx.pool, member_id, &server.uri()).await;
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let mut req = tdh::get(format!("/{}/artifacts/pass/through.bin", fx.repo_key));
+        req.headers_mut()
+            .insert("x-forwarded-for", "203.0.113.80".parse().unwrap());
+        let (status, body) = tdh::send(tdh::router_with_auth(router(), state, auth), req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(&body[..], upstream_body);
+
+        // #1278: a proxy pass-through must not materialize an artifacts row,
+        // and therefore records no download_statistics either.
+        let artifact_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = ANY($1)")
+                .bind(vec![fx.repo_id, member_id])
+                .fetch_one(&fx.pool)
+                .await
+                .expect("count artifacts");
+        assert_eq!(
+            artifact_count, 0,
+            "remote pass-through must not insert into artifacts (#1278)"
+        );
+        let stat_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM download_statistics WHERE artifact_id IN \
+             (SELECT id FROM artifacts WHERE repository_id = ANY($1))",
+        )
+        .bind(vec![fx.repo_id, member_id])
+        .fetch_one(&fx.pool)
+        .await
+        .expect("count stats");
+        assert_eq!(
+            stat_count, 0,
+            "remote pass-through must record no download_statistics"
+        );
+
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup(&fx.pool, member_id, fx.user_id).await;
+        let _ = std::fs::remove_dir_all(&member_dir);
+        fx.teardown().await;
     }
 
     // Source-level pin (#1608, epic #1607): the local-serve happy path in


### PR DESCRIPTION
## Summary

Closes #2394

`GET /api/v1/repositories/{key}/artifacts/{path}` has two shapes: a direct `artifacts` row in the addressed repository returns metadata JSON (a read, not a download), while a **Virtual** repository streams the winning member's bytes — a real download. That content branch never reached the `record_download` choke point #2365 threaded through `download_artifact` and the format handlers, so pulls through the generic `/artifacts/` route on virtual repos were unattributed (no IP/user row in `download_statistics`, and therefore absent from CVE blast-radius reporting, #2364).

Changes:

- `backend/src/api/handlers/proxy_helpers.rs`: new `virtual_local_winner_artifact_id` — after the shadowing guard proved a non-Remote member owns the exact path (which suppresses the proxy, so `resolve_virtual_download` finalizes among local members in strict priority order), re-derive the winning member's `artifacts.id` with one query. Best-effort: DB errors log at `warn` and yield `None`; telemetry never blocks or fails the download.
- `backend/src/api/handlers/repositories.rs`: `get_artifact_metadata` now extracts the shared `DownloadContext` (trusted-proxy-aware client-IP resolution from #2365/#2023 — no naive XFF parse) and, **only on the virtual content branch with a locally-owned path**, records the download against the member's artifact row via the same `record_download` recorder.

Invariants preserved:

- Metadata-only reads (direct-row branch) record nothing — they are not downloads.
- Remote/proxied pass-through resolves no local `artifacts` row and stays unrecorded (#1278; `test_cache_artifact_does_not_insert_into_artifacts_table` unchanged and green).
- Anonymous downloads record `user_id = NULL` (not dropped); unresolvable client IP records NULL, never a sentinel.
- `GET /{key}/download/{path}` still records exactly once — this route change cannot double-count because the direct-row branch (the only overlap with `download_stream`'s recorder) records nothing.

Verified live on an isolated instance: authed content GET through a virtual repo with `X-Forwarded-For` behind a trusted proxy → one `download_statistics` row with the forwarded IP + user; anonymous → row with NULL user; metadata-only GET → no row; remote pass-through → no row and no `artifacts` insert; rows surface in `/api/v1/admin/downloads` (including the by-IP filter).

Note (follow-up candidate, not in scope here): the `/download/{path}` virtual-member-local branch shares the same pre-existing gap (it streams member bytes via `resolve_virtual_download` without recording); this PR intentionally only changes the `/artifacts/{path}` route #2394 targets. The same helper can close that branch in a follow-up.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_artifacts_get_virtual_local_serve_records_download` fails on `main` (no `download_statistics` row is written) and passes here; `test_artifacts_get_metadata_read_does_not_record` and `test_artifacts_get_virtual_remote_passthrough_does_not_record` pin the two must-not-record branches.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (12,686 lib tests green against a migrated Postgres)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
