### PR TITLE
fix(authz): action-specific write/delete gate on generic REST + OCI artifact paths (#2321 G2)

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -542,6 +542,61 @@ async fn require_oci_repo_write_access(
     }
 }
 
+/// Fine-grained per-action OCI gate, applied AFTER `require_oci_repo_write_access`
+/// (the tenant-membership gate) on the destructive manifest-delete path.
+///
+/// `require_oci_repo_write_access` admits any member (incl. a read/write-only
+/// grantee) and any authed caller on a public repo, collapsing write/delete —
+/// the OCI half of #2321 (G2). When the repo has fine-grained permission rules,
+/// require the requested `action` (or `admin`, which implies all actions), the
+/// same `has_rules -> check_permission` block the REST path enforces. Admins
+/// bypass; a repo with no rules falls through unchanged. Fails closed (503) if
+/// the rule lookup errors, mirroring `require_oci_repo_write_access`.
+#[allow(clippy::result_large_err)] // Response-as-error is used throughout this module
+async fn require_oci_repo_fine_grained_action(
+    state: &SharedState,
+    claims: &crate::services::auth_service::Claims,
+    repo_id: Uuid,
+    action: &str,
+) -> Result<(), Response> {
+    if claims.is_admin {
+        return Ok(());
+    }
+    let has_rules = match state
+        .permission_service
+        .has_any_rules_for_target("repository", repo_id)
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::error!("OCI permission-rule lookup failed: {}", e);
+            return Err(oci_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "DENIED",
+                "repository authorization temporarily unavailable",
+            ));
+        }
+    };
+    if !has_rules {
+        return Ok(());
+    }
+    let has_action = state
+        .permission_service
+        .check_permission(claims.sub, "repository", repo_id, action, false)
+        .await
+        .unwrap_or(false);
+    let has_admin = state
+        .permission_service
+        .check_permission(claims.sub, "repository", repo_id, "admin", false)
+        .await
+        .unwrap_or(false);
+    if has_action || has_admin {
+        Ok(())
+    } else {
+        Err(oci_denied_repo_access())
+    }
+}
+
 /// Build a Docker/OCI scope string for a repository resource.
 fn pull_scope(image_name: &str) -> String {
     format!("repository:{}:pull", image_name)
@@ -7788,6 +7843,14 @@ async fn handle_delete_manifest(
     {
         return resp;
     }
+    // Fine-grained delete gate (#2321 G2): the tenant gate above admits any
+    // member regardless of action, collapsing read/write/delete. Require the
+    // `delete` action when the repo has permission rules, matching the REST
+    // `delete_artifact` path.
+    if let Err(resp) = require_oci_repo_fine_grained_action(state, &claims, repo.id, "delete").await
+    {
+        return resp;
+    }
 
     // Promotion-only release repositories: deleting a manifest is the symmetric
     // mutation to the (already-gated) direct push and would let a plain
@@ -14565,6 +14628,114 @@ mod oci_blob_upload_streaming_tests {
             normal_status,
             StatusCode::ACCEPTED,
             "delete on a normal (non-promotion_only) repo must be unaffected (202)"
+        );
+    }
+
+    /// #2321 G2 (OCI delete): on a repo that carries fine-grained permission
+    /// rules, a non-admin member holding only read/write (NOT `delete`) is
+    /// rejected 403 DENIED on a manifest DELETE, while a distinct non-admin
+    /// member holding the `delete` action succeeds (202). Mirrors the REST
+    /// `delete_artifact` fine-grained gate — the OCI path must not collapse
+    /// write and delete.
+    #[tokio::test]
+    async fn delete_manifest_gated_on_fine_grained_delete_action() {
+        let Some(f) = OciUploadFixture::setup().await else {
+            return;
+        };
+        let digest = format!("sha256:{}", "e".repeat(64));
+        let seed_tag = |tag: &'static str| {
+            let pool = f.inner.pool.clone();
+            let repo_id = f.inner.repo_id;
+            let digest = digest.clone();
+            async move {
+                sqlx::query(
+                    "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
+                     VALUES ($1, 'app', $2, $3, 'application/vnd.oci.image.manifest.v1+json')",
+                )
+                .bind(repo_id)
+                .bind(tag)
+                .bind(&digest)
+                .execute(&pool)
+                .await
+                .expect("seed tag");
+            }
+        };
+
+        // The fixture user is a member (role assignment) but is granted only
+        // read/write on this rules-bearing repo.
+        tdh::grant_repo_actions(
+            &f.inner.pool,
+            f.inner.repo_id,
+            f.inner.user_id,
+            &["read", "write"],
+        )
+        .await;
+
+        // A distinct member who DOES hold the `delete` action.
+        let (deleter_id, _deleter_name) = tdh::create_user(&f.inner.pool).await;
+        tdh::grant_repo_access(&f.inner.pool, f.inner.repo_id, deleter_id).await;
+        tdh::grant_repo_actions(
+            &f.inner.pool,
+            f.inner.repo_id,
+            deleter_id,
+            &["read", "write", "delete"],
+        )
+        .await;
+        let deleter_auth = tdh::bearer_for(&f.inner.state, deleter_id).await;
+
+        // (a) write-only member -> DELETE rejected 403 DENIED, tag intact.
+        seed_tag("relwrite").await;
+        let (blocked_status, _h, blocked_body) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/relwrite", f.inner.repo_key),
+                &f.authorization,
+                Bytes::new(),
+            ),
+        )
+        .await;
+        let surviving: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM oci_tags WHERE repository_id = $1 AND tag = 'relwrite'",
+        )
+        .bind(f.inner.repo_id)
+        .fetch_one(&f.inner.pool)
+        .await
+        .expect("count relwrite tag");
+
+        // (b) delete-granted member -> DELETE proceeds (202).
+        seed_tag("reldelete").await;
+        let (allowed_status, _ah, _ab) = send(
+            f.app(),
+            request(
+                Method::DELETE,
+                format!("/{}/app/manifests/reldelete", f.inner.repo_key),
+                &deleter_auth,
+                Bytes::new(),
+            ),
+        )
+        .await;
+
+        // teardown removes the repo-scoped role_assignments + permissions (by
+        // repo id) and the fixture user/repo; then drop the second user.
+        f.teardown().await;
+        tdh::cleanup_user(&f.inner.pool, deleter_id).await;
+
+        assert_eq!(
+            blocked_status,
+            StatusCode::FORBIDDEN,
+            "write-only member manifest DELETE must return 403"
+        );
+        assert!(
+            String::from_utf8_lossy(&blocked_body).contains("DENIED"),
+            "403 body must carry the OCI DENIED code; got: {}",
+            String::from_utf8_lossy(&blocked_body)
+        );
+        assert_eq!(surviving, 1, "a blocked delete must leave the tag intact");
+        assert_eq!(
+            allowed_status,
+            StatusCode::ACCEPTED,
+            "a member holding the delete action must delete the manifest (202)"
         );
     }
 

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -125,6 +125,80 @@ pub(crate) async fn require_repo_write_access(
     }
 }
 
+/// Pure fine-grained per-action decision, mirroring `upload_write_decision`
+/// (#817) in the chunked-upload path. Admins always pass; a repository with no
+/// permission rules falls through to the default access model; otherwise the
+/// caller must hold the requested action or `admin` (which implies all actions).
+///
+/// Factored out so both branches are unit-testable without a database.
+fn repo_fine_grained_action_allowed(
+    is_admin: bool,
+    has_rules: bool,
+    has_action: bool,
+    has_admin: bool,
+) -> bool {
+    if is_admin {
+        return true;
+    }
+    if !has_rules {
+        return true;
+    }
+    has_action || has_admin
+}
+
+/// Fine-grained per-action authorization, applied AFTER `require_repo_write_access`
+/// (the outer tenant gate) on the generic REST artifact write/delete handlers.
+///
+/// `require_repo_write_access` is only a tenant-membership gate: it treats a
+/// public repository or ANY role-assignment grantee (including a read-only one)
+/// as authorized, collapsing read/write/delete into a single "has access"
+/// predicate. That is the gap #2321 (G2) reports: on a rules-bearing repo a
+/// read-only grantee could still PUT/DELETE, and on a public repo any authed
+/// caller could write. This adds the SAME `has_rules -> check_permission(action)`
+/// block the chunked upload-session path (`upload.rs::create_session`, #817)
+/// already enforces, so the action actually maps to the granted permission.
+///
+/// `action` is `"write"` for uploads and `"delete"` for deletes. Admins bypass;
+/// a repository with no permission rules falls through unchanged (the rules-less
+/// public-repo case is a separate global default-access decision, out of scope
+/// here). A permission-rule lookup error fails closed (503), mirroring
+/// `repo_visibility_middleware` and `create_session`.
+async fn require_repo_fine_grained_action(
+    auth: &AuthExtension,
+    repo_id: Uuid,
+    action: &str,
+    permission_service: &crate::services::permission_service::PermissionService,
+) -> Result<()> {
+    if auth.is_admin {
+        return Ok(());
+    }
+    let has_rules = permission_service
+        .has_any_rules_for_target("repository", repo_id)
+        .await
+        .map_err(|_| {
+            tracing::error!("permission check failed: database unreachable");
+            AppError::ServiceUnavailable("permission service temporarily unavailable".to_string())
+        })?;
+    if !has_rules {
+        return Ok(());
+    }
+    let has_action = permission_service
+        .check_permission(auth.user_id, "repository", repo_id, action, false)
+        .await
+        .unwrap_or(false);
+    let has_admin = permission_service
+        .check_permission(auth.user_id, "repository", repo_id, "admin", false)
+        .await
+        .unwrap_or(false);
+    if repo_fine_grained_action_allowed(auth.is_admin, has_rules, has_action, has_admin) {
+        Ok(())
+    } else {
+        Err(AppError::Authorization(
+            "You do not have permission to perform this action on this repository".to_string(),
+        ))
+    }
+}
+
 /// Ensure a repository is visible to the current user.
 ///
 /// Public repos are visible to everyone. Private repos require authentication
@@ -3975,6 +4049,11 @@ pub async fn upload_artifact(
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
+    // Fine-grained write gate (#2321 G2): the tenant gate above admits any
+    // grantee (incl. a read-only one) and any authed caller on a public repo,
+    // collapsing read/write. Require the `write` action when rules exist, the
+    // same block `upload.rs::create_session` applies to the chunked path.
+    require_repo_fine_grained_action(&auth, repo.id, "write", &state.permission_service).await?;
 
     // Reject direct uploads to promotion-only repositories. Such repos accept
     // artifacts only via the promotion path (staging -> promotion -> approval);
@@ -5025,6 +5104,11 @@ pub async fn delete_artifact(
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
+    // Fine-grained delete gate (#2321 G2): the tenant gate above admits any
+    // grantee (incl. a write-only or read-only one), collapsing write/delete.
+    // Require the `delete` action when rules exist so a write-scoped grantee
+    // cannot destroy artifacts. Mirrors the upload path's `write` gate.
+    require_repo_fine_grained_action(&auth, repo.id, "delete", &state.permission_service).await?;
 
     // Resolve the npm canonical `/-/` URL shape the Web UI emits to the
     // version-segmented path the tarball is actually stored under (#2269),
@@ -8983,6 +9067,44 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // #2321 G2: pure fine-grained per-action decision (write/delete) applied
+    // after the tenant gate on the generic REST + OCI artifact paths. Mirrors
+    // `upload.rs::upload_write_decision`.
+    // -----------------------------------------------------------------------
+    #[test]
+    fn test_repo_fine_grained_action_admin_always_allowed() {
+        // Admins bypass regardless of rules/actions state.
+        assert!(repo_fine_grained_action_allowed(true, false, false, false));
+        assert!(repo_fine_grained_action_allowed(true, true, false, false));
+    }
+
+    #[test]
+    fn test_repo_fine_grained_action_no_rules_falls_through() {
+        // A repo with no permission rules keeps the default access model.
+        assert!(repo_fine_grained_action_allowed(false, false, false, false));
+    }
+
+    #[test]
+    fn test_repo_fine_grained_action_rules_require_matching_action() {
+        // Rules exist but the caller holds neither the action nor admin -> deny.
+        // This is the read-only-grantee-cannot-write / write-only-cannot-delete
+        // collapse that #2321 G2 closes.
+        assert!(!repo_fine_grained_action_allowed(false, true, false, false));
+    }
+
+    #[test]
+    fn test_repo_fine_grained_action_rules_with_action_allowed() {
+        // Holding the requested action (write or delete) passes.
+        assert!(repo_fine_grained_action_allowed(false, true, true, false));
+    }
+
+    #[test]
+    fn test_repo_fine_grained_action_rules_with_admin_action_allowed() {
+        // `admin` implies all actions, so it passes any per-action gate.
+        assert!(repo_fine_grained_action_allowed(false, true, false, true));
+    }
+
+    // -----------------------------------------------------------------------
     // xtenant-write-authz-systemic: behavioral coverage for the two shared
     // tenant gates (`require_repo_write_access` / `require_visible`) that every
     // repository sub-resource handler now routes through. The no-DB
@@ -9582,6 +9704,215 @@ mod tests {
             .execute(&pool)
             .await;
         tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    /// #2321 G2 (write): the generic REST `upload_artifact` handler enforces the
+    /// fine-grained `write` action AFTER the tenant gate. A read-only grantee on
+    /// a rules-bearing private repo is DENIED; adding `write` lets them through;
+    /// an admin bypasses; and a non-member is denied on a PUBLIC repo that
+    /// carries a write rule for someone else (public visibility is read-only).
+    #[tokio::test]
+    async fn upload_artifact_fine_grained_write_gate_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await; // tenant membership
+        let auth = tdh::make_auth(user_id, &username);
+        let dirs = dir.to_string_lossy().to_string();
+        // Replace the repo's fine-grained rule set with exactly `actions`, then
+        // return a fresh state so the per-process rules cache never masks the
+        // change (mirrors `set_cache_ttl_requires_repo_admin_grant_db`).
+        let reset_rule = |actions: &'static [&'static str]| {
+            let pool = pool.clone();
+            let dirs = dirs.clone();
+            async move {
+                let _ = sqlx::query("DELETE FROM permissions WHERE target_id = $1")
+                    .bind(repo_id)
+                    .execute(&pool)
+                    .await;
+                tdh::grant_repo_actions(&pool, repo_id, user_id, actions).await;
+                tdh::build_state(pool.clone(), &dirs)
+            }
+        };
+
+        // (a) read-only grant on a rules-bearing repo -> write DENIED.
+        let denied = upload_artifact(
+            State(reset_rule(&["read"]).await),
+            Extension(Some(auth.clone())),
+            Path((key.clone(), "pkg/1.0.0/pkg.bin".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(AppError::Authorization(_))),
+            "read-only grantee must be denied write, got: {denied:?}"
+        );
+
+        // (d) add the write action -> write ALLOWED.
+        let allowed = upload_artifact(
+            State(reset_rule(&["read", "write"]).await),
+            Extension(Some(auth.clone())),
+            Path((key.clone(), "pkg/1.0.0/pkg.bin".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await;
+        assert!(allowed.is_ok(), "write grant must upload, got: {allowed:?}");
+
+        // (f) admin bypasses the fine-grained gate even under a restrictive rule.
+        let admin = AuthExtension {
+            is_admin: true,
+            ..tdh::make_auth(user_id, &username)
+        };
+        let admin_ok = upload_artifact(
+            State(reset_rule(&["read"]).await),
+            Extension(Some(admin)),
+            Path((key.clone(), "pkg/2.0.0/pkg.bin".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await;
+        assert!(admin_ok.is_ok(), "admin must bypass, got: {admin_ok:?}");
+
+        // (c) PUBLIC repo carrying a write rule for ANOTHER user: a non-member
+        // (no grant of their own) passes the tenant gate on visibility but is
+        // still denied write, because public = read-only visibility, not write.
+        let (pub_repo_id, pub_key, pub_dir) = tdh::create_repo(&pool, "local", "generic").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(pub_repo_id)
+            .execute(&pool)
+            .await
+            .expect("make repo public");
+        let (other_id, _other_name) = tdh::create_user(&pool).await;
+        tdh::grant_repo_actions(&pool, pub_repo_id, other_id, &["read", "write"]).await;
+        let nonmember_pub = upload_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                pub_dir.to_string_lossy().as_ref(),
+            )),
+            Extension(Some(tdh::make_auth(user_id, &username))),
+            Path((pub_key.clone(), "pub/1.0.0/pub.bin".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await;
+        assert!(
+            matches!(nonmember_pub, Err(AppError::Authorization(_))),
+            "non-member must be denied write on a public repo with a write rule, got: {nonmember_pub:?}"
+        );
+
+        tdh::cleanup(&pool, pub_repo_id, other_id).await;
+        let _ = std::fs::remove_dir_all(&pub_dir);
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #2321 G2 (delete): the generic REST `delete_artifact` handler enforces the
+    /// fine-grained `delete` action AFTER the tenant gate, so a WRITE-only
+    /// grantee cannot destroy artifacts. Granting `delete` lets them through.
+    #[tokio::test]
+    async fn delete_artifact_fine_grained_delete_gate_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let auth = Some(tdh::make_auth(user_id, &username));
+        let path = "pkg/1.0.0/pkg-1.0.0.bin".to_string();
+
+        // Publish an artifact as a write+delete grantee so the row exists.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
+        upload_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                dir.to_string_lossy().as_ref(),
+            )),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await
+        .expect("publish must succeed with write+delete grant");
+
+        // (b) downgrade to write-only (no delete) -> DELETE DENIED.
+        let _ = sqlx::query("DELETE FROM permissions WHERE target_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write"]).await;
+        let denied = delete_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                dir.to_string_lossy().as_ref(),
+            )),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(AppError::Authorization(_))),
+            "write-only grantee must be denied delete, got: {denied:?}"
+        );
+
+        // (e) restore the delete action -> DELETE ALLOWED.
+        let _ = sqlx::query("DELETE FROM permissions WHERE target_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["read", "write", "delete"]).await;
+        let allowed = delete_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                dir.to_string_lossy().as_ref(),
+            )),
+            Extension(auth.clone()),
+            Path((key.clone(), path.clone())),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(
+            allowed.is_ok(),
+            "delete grant must delete, got: {allowed:?}"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #2321 G2 binding test: the generic artifact write/delete handlers must
+    /// keep routing through `require_repo_fine_grained_action` after the tenant
+    /// gate. A handler that dropped the call would silently re-collapse
+    /// read/write/delete, so pin it structurally (the DB tests above cannot run
+    /// without a Postgres).
+    #[test]
+    fn test_generic_artifact_handlers_call_fine_grained_gate() {
+        let source = include_str!("repositories.rs");
+        for (handler, action) in [
+            ("upload_artifact", "\"write\""),
+            ("delete_artifact", "\"delete\""),
+        ] {
+            let marker = format!("pub async fn {}(", handler);
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler `{}` not found", handler));
+            let rest = &source[start + marker.len()..];
+            let end = rest.find("\npub async fn ").unwrap_or(rest.len());
+            let body = &rest[..end];
+            assert!(
+                body.contains("require_repo_fine_grained_action(") && body.contains(action),
+                "handler `{}` must call require_repo_fine_grained_action with {} (#2321 G2)",
+                handler,
+                action
+            );
+        }
     }
 
     /// Issue #913 binding test:

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -428,6 +428,61 @@ pub async fn grant_repo_access(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     .expect("grant developer role");
 }
 
+/// Insert a fine-grained `permissions` rule granting `user_id` exactly the
+/// listed `actions` on `repo_id` (e.g. `["read", "write", "delete"]`).
+///
+/// This drives the #817/#2321 fine-grained gate (`has_any_rules_for_target` +
+/// `check_permission`), which is DISTINCT from `grant_repo_access` (a
+/// `role_assignments` membership row). Once any `permissions` rule exists for a
+/// repository, the per-action check on the write/delete handlers stops falling
+/// through, so a destructive test that expects success must grant the exact
+/// action it exercises. Rows are cleaned up by `cleanup` (which deletes all
+/// `permissions WHERE target_id = repo_id`).
+pub async fn grant_repo_actions(pool: &PgPool, repo_id: Uuid, user_id: Uuid, actions: &[&str]) {
+    let actions: Vec<String> = actions.iter().map(|s| s.to_string()).collect();
+    sqlx::query(
+        "INSERT INTO permissions \
+         (principal_type, principal_id, target_type, target_id, actions) \
+         VALUES ('user', $1, 'repository', $2, $3)",
+    )
+    .bind(user_id)
+    .bind(repo_id)
+    .bind(&actions)
+    .execute(pool)
+    .await
+    .expect("insert repository permission rule");
+}
+
+/// Mint a `Bearer <jwt>` authorization header for `user_id` using the same
+/// `AuthService` the handlers validate against (the state's DB + config). Shared
+/// so authz tests that need a SECOND authenticated identity don't copy-paste the
+/// user-row SELECT + token mint (keeps the jscpd dedup gate green).
+pub async fn bearer_for(state: &SharedState, user_id: Uuid) -> String {
+    let auth_service = crate::services::auth_service::AuthService::new(
+        state.db.clone(),
+        Arc::new(state.config.clone()),
+    );
+    let user = sqlx::query_as::<_, User>(
+        r#"SELECT id, username, email, password_hash, display_name, auth_provider,
+                  external_id, is_admin, is_active, is_service_account, must_change_password,
+                  totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,
+                  failed_login_attempts, locked_until, last_failed_login_at,
+                  password_changed_at, last_login_at, created_at, updated_at
+           FROM users WHERE id = $1"#,
+    )
+    .bind(user_id)
+    .fetch_one(&state.db)
+    .await
+    .expect("fetch user for bearer");
+    format!(
+        "Bearer {}",
+        auth_service
+            .generate_tokens(&user)
+            .expect("mint bearer token")
+            .access_token
+    )
+}
+
 /// Recursively find the largest file (in bytes) under `dir`, or 0 if none.
 fn dir_max_file_size(dir: &std::path::Path) -> u64 {
     let mut max = 0u64;
@@ -526,6 +581,14 @@ pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
         .bind(repo_id)
         .execute(pool)
         .await;
+    // Fine-grained rules (`grant_repo_actions`) are polymorphic on
+    // (target_type, target_id) with no FK cascade from `repositories`, so
+    // remove them explicitly to keep the row self-cleaning.
+    let _ =
+        sqlx::query("DELETE FROM permissions WHERE target_type = 'repository' AND target_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
     let _ = sqlx::query(
         "DELETE FROM artifact_metadata WHERE artifact_id IN \
          (SELECT id FROM artifacts WHERE repository_id = $1)",


### PR DESCRIPTION
## Summary

Closes #2321 (G2 — the behavior-changing part of the RBAC hardening).

The generic REST artifact write/delete handlers and the OCI manifest-delete
handler previously ran **only** the tenant-membership gate
(`require_repo_write_access` / `require_oci_repo_write_access`). That gate treats
a public repository, or **any** grantee — including a read-only one — as
authorized, so `read`/`write`/`delete` collapsed into a single "has access"
predicate:

- on a rules-bearing **private** repo, a read-only grantee could `PUT` and
  `DELETE` artifacts;
- on a **public** repo, any authenticated caller could write;
- the OCI `/v2` manifest DELETE had the same collapse.

This aligns those paths with the fine-grained model the chunked upload-session
path (`upload.rs::create_session`, #817) already enforces. After the existing
tenant gate, each handler now runs the same
`has_rules → check_permission(action)` block:

- `repositories.rs::upload_artifact` → action `write`
- `repositories.rs::delete_artifact` → action `delete`
- `oci_v2.rs::handle_delete_manifest` → action `delete`

Admins bypass; a repository with **no** permission rules keeps the default
access model (unchanged); a rule lookup error fails closed (503). The outer
`require_repo_write_access` signature/semantics are untouched, so every other
caller (labels, security, cache-config, virtual members, resumable uploads,
peer-replication, promotion) behaves exactly as before.

Scope note: the absolute "no authenticated write to a **rules-less** public
repo" is a separate global default-access decision and is intentionally **not**
changed here.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New tests (each gap ships a denial **and** a legit-success case):

- Pure decision unit tests for `repo_fine_grained_action_allowed`
  (admin bypass / no-rules fall-through / rules-require-action / write / admin).
- `upload_artifact_fine_grained_write_gate_db`: read-only grant → PUT denied;
  write grant → PUT ok; admin bypass; non-member → PUT to a public repo carrying
  a write rule denied.
- `delete_artifact_fine_grained_delete_gate_db`: write-only grant → DELETE
  denied; delete grant → DELETE ok.
- `delete_manifest_gated_on_fine_grained_delete_action` (OCI): write-only member
  → 403 DENIED; delete-granted member → 202.
- `test_generic_artifact_handlers_call_fine_grained_gate`: source guard pinning
  the gate into both REST handlers so it cannot silently drift.
- `grant_repo_actions(...)` test fixture added to `test_db_helpers.rs`
  (self-cleaning via `cleanup`).

Validation:

```text
cargo fmt --check                         # clean
cargo clippy --workspace --all-targets -D warnings   # 0 warnings
cargo nextest run --workspace --lib       # 12692 passed, 0 failed, 5 skipped
jscpd --min-lines 10 --threshold 3        # under threshold
```

Live cross-role validation on an isolated instance (fresh Postgres):

```text
read-only grant   PUT    -> 403
write grant       PUT    -> 201
write-only grant  DELETE -> 403
delete grant      DELETE -> 200
admin             PUT    -> 201 / DELETE -> 200   (bypass unchanged)
non-member -> public repo w/ write rule  PUT -> 403
```

## API Changes

- [x] N/A - no API changes

## Notes for reviewers

No new endpoints, no migration, no new compile-time `sqlx::query!` macros (the
new checks reuse `PermissionService::has_any_rules_for_target` /
`check_permission`; the test fixture uses runtime `sqlx::query`). The
promotion path (raw-SQL `promotion.rs`) and peer-replication identities
(service-account / admin, which hold write/admin) are unaffected and were
confirmed still working.
