### PR TITLE
fix(authz): deny-by-default admin gates for dependency-track, CVE-status, webhook-create, scan-trigger, cache-invalidate (#2321)

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -913,6 +913,23 @@ pub async fn invalidate_cache(
     let repo = service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &service).await?;
 
+    // #2321 G6: evicting proxy-cache entries is a pull-through supply-chain
+    // control on the same administrative tier as `set_cache_ttl` (an attacker
+    // with plain repo-write could force re-fetches / open a cache-poisoning
+    // window). Require `repository:admin` for non-admins, mirroring
+    // `set_cache_ttl`; the global-admin bypass is preserved.
+    if !auth.is_admin {
+        let has_perm = state
+            .permission_service
+            .check_permission(auth.user_id, "repository", repo.id, "admin", false)
+            .await?;
+        if !has_perm {
+            return Err(AppError::Authorization(
+                "Insufficient permissions to invalidate the cache of this repository".to_string(),
+            ));
+        }
+    }
+
     // Cache invalidation is meaningless on Local / Virtual / Staging repos --
     // only Remote (proxy) repos own a cache. Reject up front before touching
     // storage so the failure mode is a clear 400, not a silent no-op.
@@ -10246,6 +10263,10 @@ mod tests {
             return;
         };
 
+        // #2321 G6: invalidate_cache is now repo-admin gated. Grant the fixture
+        // user repository:admin so this success-path test still reaches the
+        // proxy-eviction behavior it covers.
+        tdh::grant_repo_admin(&fx.pool, fx.repo_id, fx.user_id).await;
         let proxy =
             tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
         let state =
@@ -10302,6 +10323,9 @@ mod tests {
             return;
         };
 
+        // #2321 G6: grant repository:admin so the test reaches the repo_type
+        // (non-remote -> 400) guard rather than being denied 403 at the new gate.
+        tdh::grant_repo_admin(&fx.pool, fx.repo_id, fx.user_id).await;
         let proxy =
             tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
         let state =
@@ -10343,6 +10367,9 @@ mod tests {
             return;
         };
 
+        // #2321 G6: grant repository:admin so the test reaches the
+        // proxy-service-missing (-> 503) guard rather than the new 403 gate.
+        tdh::grant_repo_admin(&fx.pool, fx.repo_id, fx.user_id).await;
         // Plain `build_state` does NOT install a proxy_service, so the
         // handler hits the `state.proxy_service.as_ref().ok_or_else(...)`
         // arm.
@@ -10364,6 +10391,50 @@ mod tests {
             StatusCode::SERVICE_UNAVAILABLE,
             "missing proxy_service MUST surface as 503 ServiceUnavailable, \
              not 500 / not unwrap-panic (#1539); got status {} with body: {}",
+            status,
+            String::from_utf8_lossy(&body),
+        );
+    }
+
+    /// #2321 G6 (denial): cache invalidation is a proxy supply-chain control on
+    /// the same tier as `set_cache_ttl`, so a plain repo-WRITE member (developer
+    /// role, no `repository:admin` grant) must be rejected 403 — even on a Remote
+    /// repo with the proxy service configured, and BEFORE the repo_type / proxy
+    /// checks. The `invalidate_cache_handler_returns_200_for_remote_repo` test
+    /// (which grants repository:admin) is the matching legit-success case.
+    #[tokio::test]
+    async fn invalidate_cache_handler_requires_repo_admin() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::body::Body;
+        use axum::http::{Request, StatusCode};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+        // Fixture::setup grants the developer (write) role but NOT
+        // repository:admin, so the caller passes the tenant gate and is denied
+        // by the new repo-admin gate.
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let router = tdh::router_with_auth(super::router(), state, auth);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/{}/cache/invalidate?path=anything", fx.repo_key))
+            .body(Body::empty())
+            .expect("build POST request");
+        let (status, body) = tdh::send(router, req).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "repo-write-only caller must be 403 on invalidate_cache (#2321 G6); \
+             got status {} with body: {}",
             status,
             String::from_utf8_lossy(&body),
         );

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -1083,6 +1083,18 @@ async fn update_cve_status_by_artifact_cve(
     Path((artifact_id, cve_id)): Path<(Uuid, String)>,
     Json(body): Json<UpdateCveStatusRequest>,
 ) -> Result<Json<crate::models::sbom::CveHistoryEntry>> {
+    // #2321 G3: mutating vulnerability triage state (accept/dismiss a CVE) is an
+    // administrative security decision, not a per-repo-member action. Gate on
+    // global admin BEFORE any validation or lookup, and record the RBAC-deny.
+    crate::services::audit_service::enforce_admin_audited(
+        auth.is_admin,
+        state.db.clone(),
+        auth.user_id,
+        crate::services::audit_service::ResourceType::ScanResult,
+        "/api/v1/sbom/cve/status/by-artifact/{artifact_id}/by-cve/{cve_id}",
+        "POST",
+    )
+    .await?;
     if !is_valid_vuln_id(&cve_id) {
         return Err(AppError::Validation(invalid_cve_id_route_message(&cve_id)));
     }
@@ -2966,7 +2978,7 @@ mod tests {
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -2997,7 +3009,7 @@ mod tests {
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         // `CveStatus::parse` returns None for any string outside the four
         // known variants. Handler must surface that as 400 with the
         // original status text echoed so the client can debug.
@@ -3032,7 +3044,7 @@ mod tests {
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-1010", "high").await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3072,7 +3084,7 @@ mod tests {
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-2020", "low").await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3106,7 +3118,7 @@ mod tests {
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3142,7 +3154,7 @@ mod tests {
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-4040", "medium")
             .await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         // Send the CVE id lower-cased: handler must still match.
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
@@ -3179,7 +3191,7 @@ mod tests {
         )
         .await;
 
-        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let auth = tdh::admin_auth(fx.user_id, &fx.username);
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
             axum::Extension(auth),
@@ -3207,23 +3219,25 @@ mod tests {
         fx.teardown().await;
     }
 
+    /// #2321 G3 (denial): mutating CVE triage state is now admin-only. A
+    /// non-admin caller — even a legitimate repo member (developer role) who
+    /// would pass every downstream check — is rejected 403 at the admin gate,
+    /// BEFORE any lookup or mutation. The admin-authorized happy-path tests
+    /// above are the matching legit-success coverage. (Formerly asserted a
+    /// repo-scope 404; the handler is now gated one tier higher, on global
+    /// admin, so repo-scope no longer decides this route.)
     #[tokio::test]
-    async fn test_handler_rejects_caller_without_repo_access() {
-        // `ensure_artifact_repo_access` must enforce the auth extension's
-        // `allowed_repo_ids` whitelist: a caller scoped to some other repo
-        // must see the same 404 they'd see if the artifact didn't exist,
-        // never the contents of a repo they can't access.
+    async fn test_handler_update_cve_status_requires_admin() {
         use crate::api::handlers::test_db_helpers as tdh;
         let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
             return;
         };
         let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
         seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-5050", "high").await;
-
-        // Build an auth extension whose allowed_repo_ids does NOT include
-        // the fixture's repo. Mirror tdh::make_auth then tighten scopes.
-        let mut auth = tdh::make_auth(fx.user_id, &fx.username);
-        auth.allowed_repo_ids = AccessScope::Restricted(vec![Uuid::new_v4()]);
+        // Legitimate repo member — proves the gate is on GLOBAL admin, not repo
+        // access.
+        tdh::grant_repo_access(&fx.pool, fx.repo_id, fx.user_id).await;
+        let auth = tdh::make_auth(fx.user_id, &fx.username);
 
         let result = super::update_cve_status_by_artifact_cve(
             axum::extract::State(fx.state.clone()),
@@ -3239,12 +3253,12 @@ mod tests {
         teardown_scans(&fx.pool, fx.repo_id).await;
         fx.teardown().await;
 
-        // Repo-scope mismatch is surfaced as the same NotFound used for a
-        // missing artifact (deliberate: don't leak existence of inaccessible
-        // repos through error shape).
         match result {
-            Err(AppError::NotFound(_)) => {}
-            other => panic!("expected NotFound for scoped-out caller, got {:?}", other),
+            Err(AppError::Authorization(_)) => {}
+            other => panic!(
+                "expected Authorization (admin-only) denial, got {:?}",
+                other
+            ),
         }
     }
 }

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -588,6 +588,24 @@ async fn trigger_scan(
     Extension(auth): Extension<AuthExtension>,
     Json(body): Json<TriggerScanRequest>,
 ) -> Result<Json<TriggerScanResponse>> {
+    // #2321 G5: triggering scans fans out scanner work per artifact (and, at the
+    // repo level, one worker per artifact). Previously only the `bypass_dedup`
+    // shape was admin-gated, leaving the default and `bypass_dedup=false` shapes
+    // open to any authenticated user as an amplification/DoS lever. Require admin
+    // for ALL request shapes, up front, and record the RBAC-deny.
+    //
+    // Chosen default: global admin. If a future policy decides repo-write should
+    // suffice for a single-artifact scan, narrow this deliberately with a test.
+    crate::services::audit_service::enforce_admin_audited(
+        auth.is_admin,
+        state.db.clone(),
+        auth.user_id,
+        crate::services::audit_service::ResourceType::ScanResult,
+        "/api/v1/security/scan",
+        "POST",
+    )
+    .await?;
+
     // 503 (not 500) because "scanner not configured" is a normal operational
     // state on minimal stacks (no Trivy / OpenSCAP service), not a server
     // bug. 500 alerts on operator dashboards; 503 does not.
@@ -597,21 +615,12 @@ async fn trigger_scan(
         .ok_or_else(|| AppError::ServiceUnavailable("Scanner service not configured".to_string()))?
         .clone();
 
-    let bypass_dedup = body.bypass_dedup.unwrap_or(false);
-
     // `bypass_dedup = true` skips the hash-based scan dedup short-circuit and
     // fans out a fresh scanner run per artifact (and, at the repo level, one
-    // tokio::spawn worker per artifact in the repo). The pre-existing
-    // `force = true` path was naturally rate-limited because dedup would
-    // collapse repeated calls against the same checksum into a single cached
-    // result; `bypass_dedup` removes that safety. Gating on admin scope
-    // matches the inventory-backfill path in admin.rs which also touches
-    // every artifact in a repository (see issue #1469 review feedback).
-    if bypass_dedup && !auth.is_admin {
-        return Err(AppError::Authorization(
-            "bypass_dedup requires admin privileges".to_string(),
-        ));
-    }
+    // tokio::spawn worker per artifact in the repo). The whole handler is now
+    // admin-only (see the gate above), so no separate non-admin check is needed
+    // here; the flag still selects the dedup behavior for the admin caller.
+    let bypass_dedup = body.bypass_dedup.unwrap_or(false);
 
     if let Some(artifact_id) = body.artifact_id {
         // Honest not-found up front (#2227): without this, an id with no
@@ -1909,17 +1918,21 @@ mod tests {
     // no-ops cleanly otherwise, matching the `tdh::Fixture` pattern used
     // by sibling handler tests.
     //
-    // Coverage strategy: three call shapes prove the gate's behaviour
-    // without spinning up a real scan run:
+    // #2321 G5 update: the handler is now admin-only for EVERY request shape
+    // (not just bypass_dedup=true), so a non-admin can no longer trigger scans
+    // at all — closing the amplification lever on the default/false shapes too.
     //
-    //   1. non-admin + bypass_dedup=true  -> 403 Authorization (the gate)
-    //   2. admin + bypass_dedup=true + no ids -> 400 Validation
-    //      (the gate is bypassed for admins; we land on the next check)
-    //   3. non-admin + bypass_dedup omitted + no ids -> 400 Validation
-    //      (the gate does not fire for the normal trigger path)
+    // Coverage strategy: four call shapes prove the gate's behaviour without
+    // spinning up a real scan run:
+    //
+    //   1. non-admin + bypass_dedup=true    -> 403 Authorization (the gate)
+    //   2. non-admin + bypass_dedup omitted -> 403 Authorization (all shapes)
+    //   3. non-admin + bypass_dedup=false   -> 403 Authorization
+    //   4. admin     + no ids               -> 400 Validation
+    //      (admins pass the gate and land on the next check; not over-blocked)
     // -----------------------------------------------------------------------
     #[tokio::test]
-    async fn test_trigger_scan_handler_admin_gates_bypass_dedup() {
+    async fn test_trigger_scan_handler_requires_admin_all_shapes() {
         use crate::api::handlers::test_db_helpers as tdh;
         use std::sync::Arc;
 
@@ -1983,6 +1996,10 @@ mod tests {
             iat_ms: None,
         };
 
+        // #2321 G5: trigger_scan is now admin-only for ALL request shapes, not
+        // just `bypass_dedup=true`. Non-admins are rejected 403 regardless of
+        // the flag; admins pass the gate and reach the post-auth validation.
+
         // ---- Case 1: non-admin + bypass_dedup=true -> 403 Authorization
         let result = trigger_scan(
             State(state.clone()),
@@ -1994,23 +2011,49 @@ mod tests {
             }),
         )
         .await;
-        match result {
-            Err(AppError::Authorization(msg)) => {
-                assert!(
-                    msg.contains("bypass_dedup"),
-                    "403 message should mention bypass_dedup, got: {}",
-                    msg
-                );
-            }
-            other => panic!(
-                "expected AppError::Authorization for non-admin bypass_dedup, got: {:?}",
-                other.as_ref().err()
-            ),
-        }
+        assert!(
+            matches!(result, Err(AppError::Authorization(_))),
+            "non-admin + bypass_dedup=true must be 403, got: {:?}",
+            result.as_ref().err()
+        );
 
-        // ---- Case 2: admin + bypass_dedup=true + no ids -> 400 Validation
-        // The gate is bypassed for admins; the handler falls through to the
-        // "either artifact_id or repository_id is required" validation.
+        // ---- Case 2: non-admin + bypass_dedup omitted -> 403 Authorization
+        let result = trigger_scan(
+            State(state.clone()),
+            Extension(make_auth(false)),
+            Json(TriggerScanRequest {
+                artifact_id: None,
+                repository_id: None,
+                bypass_dedup: None,
+            }),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(AppError::Authorization(_))),
+            "non-admin + bypass_dedup omitted must be 403 (all shapes admin-only), got: {:?}",
+            result.as_ref().err()
+        );
+
+        // ---- Case 3: non-admin + bypass_dedup=false -> 403 Authorization
+        let result = trigger_scan(
+            State(state.clone()),
+            Extension(make_auth(false)),
+            Json(TriggerScanRequest {
+                artifact_id: None,
+                repository_id: None,
+                bypass_dedup: Some(false),
+            }),
+        )
+        .await;
+        assert!(
+            matches!(result, Err(AppError::Authorization(_))),
+            "non-admin + bypass_dedup=false must be 403, got: {:?}",
+            result.as_ref().err()
+        );
+
+        // ---- Case 4 (legit): admin + no ids -> 400 Validation. Proves the
+        // admin PASSES the gate and lands on the next check (post-auth), i.e.
+        // the gate does not over-block the admin path.
         let result = trigger_scan(
             State(state.clone()),
             Extension(make_auth(true)),
@@ -2025,59 +2068,13 @@ mod tests {
             Err(AppError::Validation(msg)) => {
                 assert!(
                     msg.contains("artifact_id") || msg.contains("repository_id"),
-                    "admin bypass_dedup with no ids should hit the post-gate \
-                     validation check, got: {}",
+                    "admin must reach the post-gate validation check, got: {}",
                     msg
                 );
             }
             other => panic!(
-                "expected AppError::Validation for admin bypass_dedup with no \
-                 ids (proves gate is bypassed for admins), got: {:?}",
-                other.as_ref().err()
-            ),
-        }
-
-        // ---- Case 3: non-admin + bypass_dedup omitted + no ids -> 400 Validation
-        // The gate must not fire on the normal trigger path; non-admins
-        // should still be able to call trigger_scan without bypass_dedup.
-        let result = trigger_scan(
-            State(state.clone()),
-            Extension(make_auth(false)),
-            Json(TriggerScanRequest {
-                artifact_id: None,
-                repository_id: None,
-                bypass_dedup: None,
-            }),
-        )
-        .await;
-        match result {
-            Err(AppError::Validation(_)) => {} // expected
-            other => panic!(
-                "non-admin without bypass_dedup must not be 403'd; expected \
-                 AppError::Validation for the missing-ids case, got: {:?}",
-                other.as_ref().err()
-            ),
-        }
-
-        // ---- Case 4: non-admin + bypass_dedup=false -> 400 Validation
-        // Explicit `false` must behave the same as omitted (gate condition
-        // is `bypass_dedup && !auth.is_admin`, so false short-circuits).
-        let result = trigger_scan(
-            State(state.clone()),
-            Extension(make_auth(false)),
-            Json(TriggerScanRequest {
-                artifact_id: None,
-                repository_id: None,
-                bypass_dedup: Some(false),
-            }),
-        )
-        .await;
-        match result {
-            Err(AppError::Validation(_)) => {} // expected
-            other => panic!(
-                "non-admin with bypass_dedup=false must not be 403'd; \
-                 expected AppError::Validation for the missing-ids case, \
-                 got: {:?}",
+                "expected AppError::Validation for admin with no ids (proves the \
+                 gate lets admins through), got: {:?}",
                 other.as_ref().err()
             ),
         }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -428,6 +428,34 @@ pub async fn grant_repo_access(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     .expect("grant developer role");
 }
 
+/// Like [`make_auth`] but for a GLOBAL admin (`is_admin = true`). Used by
+/// handler tests that must pass an admin-only gate (#2321 G3/G4/G5) to reach
+/// the downstream validation/update/not-found logic they cover.
+pub fn admin_auth(user_id: Uuid, username: &str) -> AuthExtension {
+    AuthExtension {
+        is_admin: true,
+        ..make_auth(user_id, username)
+    }
+}
+
+/// Grant `user_id` the fine-grained `repository:admin` action on `repo_id`
+/// (a `permissions` rule, distinct from the `role_assignments` membership row
+/// `grant_repo_access` inserts). Repo-admin-gated handlers (`set_cache_ttl`,
+/// `invalidate_cache`) require this for non-admins; the smoke tests that assert
+/// a successful admin-tier call grant it here. Cleaned up by `cleanup`.
+pub async fn grant_repo_admin(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+    sqlx::query(
+        "INSERT INTO permissions \
+         (principal_type, principal_id, target_type, target_id, actions) \
+         VALUES ('user', $1, 'repository', $2, ARRAY['admin'])",
+    )
+    .bind(user_id)
+    .bind(repo_id)
+    .execute(pool)
+    .await
+    .expect("grant repository:admin");
+}
+
 /// Recursively find the largest file (in bytes) under `dir`, or 0 if none.
 fn dir_max_file_size(dir: &std::path::Path) -> u64 {
     let mut max = 0u64;
@@ -526,6 +554,14 @@ pub async fn cleanup(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
         .bind(repo_id)
         .execute(pool)
         .await;
+    // Fine-grained rules (`grant_repo_admin`) are polymorphic on
+    // (target_type, target_id) with no FK cascade from `repositories`, so
+    // remove them explicitly to keep the fixture self-cleaning.
+    let _ =
+        sqlx::query("DELETE FROM permissions WHERE target_type = 'repository' AND target_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
     let _ = sqlx::query(
         "DELETE FROM artifact_metadata WHERE artifact_id IN \
          (SELECT id FROM artifacts WHERE repository_id = $1)",

--- a/backend/src/api/handlers/webhooks.rs
+++ b/backend/src/api/handlers/webhooks.rs
@@ -406,6 +406,21 @@ pub async fn create_webhook(
     Extension(auth): Extension<AuthExtension>,
     Json(payload): Json<CreateWebhookRequest>,
 ) -> Result<Json<WebhookSecretCreatedResponse>> {
+    // #2321 G4: creating an outbound webhook provisions an egress target and a
+    // signing secret — a global integration/security action, not something any
+    // authenticated user should do. Require admin BEFORE URL validation, secret
+    // generation, or any DB write, and record the RBAC-deny. Read/list webhook
+    // handlers are unchanged (non-admin owners keep their existing read access).
+    crate::services::audit_service::enforce_admin_audited(
+        auth.is_admin,
+        state.db.clone(),
+        auth.user_id,
+        crate::services::audit_service::ResourceType::Setting,
+        "/api/v1/webhooks",
+        "POST",
+    )
+    .await?;
+
     // Validate URL (SSRF prevention)
     validate_webhook_url(&payload.url)?;
 
@@ -3760,12 +3775,15 @@ mod tests {
             let Some(pool) = tdh::try_pool().await else {
                 return;
             };
-            let creator = create_user(&pool, false).await;
+            // #2321 G4: webhook creation is admin-only. Create as an admin
+            // identity; `created_by` is still stamped with that caller, and the
+            // NON-admin owner read path below must keep working for the same id.
+            let creator = create_user(&pool, true).await;
             let state = tdh::build_state(pool.clone(), "/tmp");
 
             let resp = create_webhook(
                 axum::extract::State(state.clone()),
-                axum::Extension(auth_for(creator, false)),
+                axum::Extension(auth_for(creator, true)),
                 axum::Json(CreateWebhookRequest {
                     name: format!("created-by-{}", &creator.to_string()[..8]),
                     url: "http://198.51.100.9/hook".to_string(),
@@ -3804,6 +3822,50 @@ mod tests {
             .is_ok());
 
             cleanup(&pool, &[], &[creator]).await;
+        }
+
+        /// #2321 G4 (denial): a non-admin caller cannot create a webhook. The
+        /// gate fires BEFORE URL validation / secret generation / any DB write,
+        /// so a valid request body still returns 403.
+        #[tokio::test]
+        async fn create_webhook_requires_admin() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let creator = create_user(&pool, false).await;
+            let state = tdh::build_state(pool.clone(), "/tmp");
+
+            let result = create_webhook(
+                axum::extract::State(state.clone()),
+                axum::Extension(auth_for(creator, false)),
+                axum::Json(CreateWebhookRequest {
+                    name: "nonadmin-denied".to_string(),
+                    url: "http://198.51.100.9/hook".to_string(),
+                    events: vec!["artifact.created".to_string()],
+                    repository_id: None,
+                    headers: None,
+                    secret: None,
+                    payload_template: Default::default(),
+                    event_schema_version: None,
+                }),
+            )
+            .await;
+
+            // Nothing must have been written.
+            let count: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM webhooks WHERE created_by = $1")
+                    .bind(creator)
+                    .fetch_one(&pool)
+                    .await
+                    .unwrap();
+
+            cleanup(&pool, &[], &[creator]).await;
+
+            assert!(
+                matches!(result, Err(AppError::Authorization(_))),
+                "non-admin create_webhook must be 403, got: {result:?}"
+            );
+            assert_eq!(count, 0, "a denied create must not persist a webhook");
         }
     }
 }

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -860,12 +860,20 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
-        // Dependency-Track proxy routes with auth middleware
+        // Dependency-Track proxy routes require admin (#2321 G1).
+        //
+        // Every `dependency_track` handler binds `_auth` and performs no
+        // per-handler authorization, so under `auth_middleware` ANY authenticated
+        // user could list projects/findings and PUT vulnerability analyses on the
+        // external Dependency-Track instance. This is an administrative
+        // integration surface (same tier as the other proxy/integration routers),
+        // so gate the whole nest with `admin_middleware` — which also emits the
+        // `PermissionDenied` audit event on rejection for free.
         .nest(
             "/dependency-track",
             handlers::dependency_track::router().layer(middleware::from_fn_with_state(
                 auth_service.clone(),
-                auth_middleware,
+                admin_middleware,
             )),
         )
         // Remote instance management & proxy routes with auth middleware
@@ -995,6 +1003,36 @@ mod tests {
         assert!(
             next_middleware.contains("admin_middleware"),
             "plugin install + lifecycle routes must be gated by admin_middleware"
+        );
+    }
+
+    #[test]
+    fn dependency_track_nest_requires_admin() {
+        // #2321 G1: every `dependency_track` handler binds `_auth` and performs
+        // NO per-handler authorization, so under `auth_middleware` any
+        // authenticated user could list projects/findings and PUT vulnerability
+        // analyses on the external Dependency-Track instance. The nest must be
+        // gated by `admin_middleware`. A runtime test would need full app state
+        // + a DB fixture, so pin the routing decision in source (mirrors
+        // `plugin_install_and_lifecycle_require_admin`).
+        let dt_nest = ROUTES_RS_SRC
+            .split("handlers::dependency_track::router()")
+            .nth(1)
+            .expect("dependency_track::router() must be nested under /dependency-track");
+        let next_middleware = dt_nest
+            .split("from_fn_with_state")
+            .nth(1)
+            .expect("dependency_track nest must attach a middleware layer");
+        assert!(
+            next_middleware.contains("admin_middleware"),
+            "dependency-track proxy routes must be gated by admin_middleware, \
+             not auth_middleware (regression of #2321 G1)"
+        );
+        // Guard against the assertion going vacuously true if the nest is
+        // dropped: the prefix must still be registered.
+        assert!(
+            ROUTES_RS_SRC.contains("\"/dependency-track\","),
+            "/dependency-track nest registration missing"
         );
     }
 }

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -506,6 +506,58 @@ pub async fn audit_fire_and_forget(db: PgPool, entry: AuditEntry) {
     }
 }
 
+/// Fire-and-forget `PermissionDenied` audit for a HANDLER-level admin gate
+/// (#2321 G-AUDIT).
+///
+/// Handlers that enforce `require_admin()` themselves (rather than riding
+/// `admin_middleware`) must still record the RBAC-deny the same way the
+/// middleware does (`admin_middleware`, #2366): an authenticated non-admin
+/// reaching an admin-only surface is exactly the decision an auditor wants
+/// logged. Records only the attempted `path`/`method` + a fixed reason, never
+/// any credential material, and is fire-and-forget so an audit-table outage can
+/// never turn a clean 403 into a 500.
+pub async fn audit_admin_permission_denied(
+    db: PgPool,
+    user_id: uuid::Uuid,
+    resource_type: ResourceType,
+    path: &str,
+    method: &str,
+) {
+    let entry = AuditEntry::new(AuditAction::PermissionDenied, resource_type)
+        .user(user_id)
+        .resource(user_id)
+        .details(serde_json::json!({
+            "path": path,
+            "method": method,
+            "reason": "admin_privileges_required",
+        }));
+    audit_fire_and_forget(db, entry).await;
+}
+
+/// Handler-level admin gate that ALSO records the RBAC-deny (#2321 G3/G4/G5 +
+/// G-AUDIT). Returns `Ok(())` for admins; for a non-admin, emits the
+/// fire-and-forget `PermissionDenied` audit (via
+/// [`audit_admin_permission_denied`]) and returns `AppError::Authorization`
+/// (403) with the same message `AuthExtension::require_admin` uses. Factored so
+/// each admin-only handler is a single call, keeping the deny-and-audit logic in
+/// one place instead of copy-pasting the block per handler (jscpd dedup).
+pub async fn enforce_admin_audited(
+    is_admin: bool,
+    db: PgPool,
+    user_id: uuid::Uuid,
+    resource_type: ResourceType,
+    path: &str,
+    method: &str,
+) -> crate::error::Result<()> {
+    if is_admin {
+        return Ok(());
+    }
+    audit_admin_permission_denied(db, user_id, resource_type, path, method).await;
+    Err(crate::error::AppError::Authorization(
+        "Admin access required".to_string(),
+    ))
+}
+
 /// Build the `details` JSON for a federated (SSO) login audit event.
 ///
 /// `provider` is a stable label (`"oidc"` | `"saml"` | `"ldap"`) recorded so


### PR DESCRIPTION
## Summary

Additive deny-by-default authorization gates for the residual admin-surface
findings in #2321 (companion to the behavior-change PR that closes it; this PR
references #2321 and can land in either order).

Each surface previously admitted an authenticated non-admin where a global-admin
(or, for G6, repo-admin) gate was intended:

- **G1** `/dependency-track/*` — every `dependency_track` handler binds `_auth`
  and never authorizes, so under `auth_middleware` any authenticated user could
  list projects/findings and PUT vulnerability analyses on the external
  Dependency-Track instance. Moved the whole nest under `admin_middleware`
  (`routes.rs`), the cleaner fix — it also emits the `PermissionDenied` audit
  for free.
- **G3** `sbom::update_cve_status_by_artifact_cve` — gated on repo access, so a
  repo member could tamper with CVE triage state. Now `require_admin` first.
- **G4** `webhooks::create_webhook` — no admin check, so any authenticated user
  could provision an outbound webhook + signing secret. Now admin-only before
  URL validation / secret generation / any DB write. Non-admin webhook READ is
  unchanged.
- **G5** `security::trigger_scan` — admin-gated ONLY for `bypass_dedup=true`,
  leaving the default/`false` shapes open as a scan-amplification lever. Now
  admin-only for ALL request shapes.
- **G6** `repositories::invalidate_cache` — used the repo-WRITE gate; cache
  eviction is a pull-through supply-chain control on the same tier as
  `set_cache_ttl`, so it now requires repo-ADMIN (mirrors `set_cache_ttl`).
- **G-AUDIT** — the new handler-level denials (G3/G4/G5) emit a fire-and-forget
  `AuditAction::PermissionDenied` exactly as `admin_middleware` does, via one
  shared helper (`audit_service::enforce_admin_audited`) so the deny-and-audit
  logic lives in one place (G1 gets the audit free from the middleware).

**G5 policy note:** admin is the chosen default for `trigger_scan`. If a future
policy decides repo-write should suffice for a single-artifact scan, narrow it
deliberately with a test — flagged for a maintainer call.

No new endpoints, no migration, no new compile-time `sqlx::query!` macros.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Each gap ships a denial AND a legit-success test:

- G1: `routes::tests::dependency_track_nest_requires_admin` source guard pinning
  the nest under `admin_middleware` (a runtime test needs full app state + DB).
- G3: `test_handler_update_cve_status_requires_admin` (non-admin repo member →
  403) + the admin-authorized happy-path handler tests (validation/update/404).
- G4: `create_webhook_requires_admin` (non-admin → 403, nothing persisted) +
  `create_webhook_records_created_by` (admin creates; non-admin owner READ still
  works).
- G5: `test_trigger_scan_handler_requires_admin_all_shapes` (non-admin
  omitted/false/true → 403; admin reaches post-auth validation).
- G6: `invalidate_cache_handler_requires_repo_admin` (repo-write → 403) +
  `invalidate_cache_handler_returns_{200,400,503}` (repo-admin grant → reaches
  behavior).
- Fixtures added to `test_db_helpers.rs`: `admin_auth`, `grant_repo_admin`, and
  a `permissions` cleanup so the new rules are self-cleaning.

Validation:

```text
cargo fmt --check                                    # clean
cargo clippy --workspace --all-targets -D warnings   # 0 warnings
cargo nextest run --workspace --lib                  # 12696 passed, 0 failed, 5 skipped
jscpd --min-lines 10 --threshold 3                   # 0% on measured changed files
```

Live cross-role validation on an isolated instance:

```text
G1 dependency-track/projects   non-admin 403 (was 200) | admin passes gate
G3 sbom cve-status             non-admin 403           | admin 404 (passed gate)
G4 webhooks create             non-admin 403           | admin 200
G5 security/scan {}, false, true  non-admin 403 (all)  | admin 400 (passed gate)
G6 cache/invalidate            repo-write 403          | repo-admin 200 / admin 200
```

## API Changes

- [x] N/A - no API changes

## Notes for reviewers

The gates are additive and deny-by-default; no legitimate admin flow is
over-blocked (verified above). Kept intentionally separate from the artifact
read/write/delete behavior change so each is bisectable on its own.
