### PR TITLE
fix(versions): serialize uploaded_by in ArtifactVersionResponse

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2219,6 +2219,10 @@ pub struct ArtifactVersionResponse {
     pub size_bytes: i64,
     pub checksum_sha256: String,
     pub content_type: String,
+    /// Id of the user that uploaded this revision (#2397). Always serialized
+    /// (`null` when unknown, e.g. anonymous uploads) so the versions UI can
+    /// rely on the key being present.
+    pub uploaded_by: Option<Uuid>,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -4034,6 +4038,7 @@ pub async fn list_artifact_versions(
                 size_bytes: v.size_bytes,
                 checksum_sha256: v.checksum_sha256.trim().to_string(),
                 content_type: v.content_type,
+                uploaded_by: v.uploaded_by,
                 created_at: v.created_at,
             })
             .collect(),
@@ -8097,6 +8102,44 @@ mod tests {
         // metadata (#1541).
         assert!(!json.contains("cache_cached_at"));
         assert!(!json.contains("cache_expires_at"));
+    }
+
+    #[test]
+    fn test_artifact_version_response_serializes_uploaded_by() {
+        // (#2397) The versions API must expose who uploaded each revision so
+        // the version-history UI can show the uploader column.
+        let uploader = Uuid::new_v4();
+        let resp = ArtifactVersionResponse {
+            revision: 2,
+            version_label: Some("v1.0.1".to_string()),
+            size_bytes: 2048,
+            checksum_sha256: "abc123".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            uploaded_by: Some(uploader),
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains(&format!("\"uploaded_by\":\"{uploader}\"")));
+        assert!(json.contains("\"version_label\":\"v1.0.1\""));
+        assert!(json.contains("\"revision\":2"));
+    }
+
+    #[test]
+    fn test_artifact_version_response_uploaded_by_null_when_unknown() {
+        // (#2397) Unlike `version_label`, `uploaded_by` is always serialized
+        // -- as `null` when unknown -- so clients can rely on the key.
+        let resp = ArtifactVersionResponse {
+            revision: 1,
+            version_label: None,
+            size_bytes: 1024,
+            checksum_sha256: "def456".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            uploaded_by: None,
+            created_at: chrono::Utc::now(),
+        };
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"uploaded_by\":null"));
+        assert!(!json.contains("version_label"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`GET /api/v1/repositories/{key}/versions/{path}` did not serialize `uploaded_by`, even though the `artifact_versions` table and the `ArtifactVersion` model (from #2367) carry the column and `ArtifactService::list_versions` already selects it. The version-history web UI (web#571) plumbs the field defensively and hides the uploader column until the backend provides it.

This PR adds `uploaded_by: Option<Uuid>` to `ArtifactVersionResponse` and populates it from the stored revision row in `list_artifact_versions`. The field is always serialized (`null` when unknown, e.g. anonymous uploads) so clients can rely on the key being present; `version_label` was confirmed already present in the response. No query or migration changes — the data was already fetched.

Closes #2397

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_artifact_version_response_serializes_uploaded_by` fails on `main` (the struct has no such field) and passes here; `test_artifact_version_response_uploaded_by_null_when_unknown` pins the always-serialized/null contract.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated stack: created a versioning-enabled Generic repository, uploaded two revisions as a known user, and confirmed `GET /api/v1/repositories/{key}/versions/{path}` returns both rows with `uploaded_by` set to that user's id (and `version_label` where supplied).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

`ArtifactVersionResponse` already derives `ToSchema`; the new field is picked up by the existing `#[utoipa::path]` on `list_artifact_versions`. Additive response-field change only — no breaking API surface.
