### PR TITLE
fix(telemetry): record downloads on download_artifact virtual-member-local branch

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -4758,6 +4758,7 @@ pub async fn download_artifact(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, path)): Path<(String, String)>,
     Query(version_query): Query<ArtifactVersionQuery>,
+    dl_ctx: crate::api::middleware::download_telemetry::DownloadContext,
     request: axum::http::Request<axum::body::Body>,
 ) -> Result<impl IntoResponse> {
     // A HEAD request must return identical headers to GET but no body, and it
@@ -4842,25 +4843,13 @@ pub async fn download_artifact(
         }
     }
 
-    // Get client IP for analytics. Trusted-proxy-aware (#2365): the socket
+    // Client attribution for analytics comes from the shared
+    // `DownloadContext` extractor. Trusted-proxy-aware (#2365): the socket
     // peer is authoritative and X-Forwarded-For is believed only when the
     // peer is inside RATE_LIMIT_TRUSTED_PROXY_CIDRS (#2023) — the previous
     // parse here trusted any XFF. `None` (unresolvable) records as NULL.
-    let client_ip = crate::api::middleware::rate_limit::resolve_client_ip_addr(
-        request.headers(),
-        request
-            .extensions()
-            .get::<axum::extract::ConnectInfo<std::net::SocketAddr>>()
-            .map(|ci| ci.0.ip()),
-        &state.config.rate_limit_trusted_proxy_cidrs,
-    );
-    let client_ip_str = client_ip.map(|ip| ip.to_string());
-
-    let user_agent = request
-        .headers()
-        .get(header::USER_AGENT)
-        .and_then(|v| v.to_str().ok())
-        .map(String::from);
+    let client_ip_str = dl_ctx.client_ip.map(|ip| ip.to_string());
+    let user_agent = dl_ctx.user_agent.clone();
 
     // Check if the storage backend supports redirect downloads (S3 with presigned URLs).
     // This path is gated on PRESIGNED_DOWNLOADS_ENABLED (or the per-backend
@@ -5037,6 +5026,29 @@ pub async fn download_artifact(
             .map_err(|_| {
                 AppError::NotFound("Artifact not found in any member repository".to_string())
             })?;
+
+            // #2398 (sibling of #2394): this arm is only reached when
+            // `download_stream` returned NotFound for the virtual repo
+            // itself, so the #2365 recorder inside it never fired — yet the
+            // response streams a member's BYTES, a real download. When the
+            // shadowing guard proved a non-Remote member owns the exact path
+            // (Remote members were suppressed), attribute the download to
+            // that local member's artifact row. Remote pass-through resolves
+            // no local `artifacts` row and stays unrecorded (#1278). No
+            // double-count: the direct-row path records in `download_stream`
+            // and cannot reach this arm.
+            if owns_locally {
+                if let Some(artifact_id) =
+                    proxy_helpers::virtual_local_winner_artifact_id(&state.db, repo.id, &path).await
+                {
+                    crate::services::artifact_service::record_download(
+                        &state.db,
+                        artifact_id,
+                        &dl_ctx,
+                    )
+                    .await;
+                }
+            }
 
             let ct = result
                 .content_type
@@ -12352,6 +12364,189 @@ mod tests {
         fx.teardown().await;
     }
 
+    // ---------------------------------------------------------------------
+    // download_artifact: download telemetry on the virtual-member-local
+    // branch (#2398, sibling of #2394).
+    //
+    // GET /:key/download/*path on a Virtual repository falls through to
+    // `resolve_virtual_download` when the virtual repo has no direct row.
+    // When the shadowing guard proves a non-Remote member owns the exact
+    // path, the served bytes are that local member's artifact — a real
+    // download that used to bypass the #2365 recorder (only the direct-row
+    // `download_stream` path recorded). Pinned here:
+    //   1. a virtual-local serve via /download/ records exactly ONE
+    //      `download_statistics` row against the member's artifact, with
+    //      the resolved client IP and the user (NULL when anonymous) — one
+    //      row also proves no double-count vs. the direct-row recorder
+    //   2. a virtual remote pass-through records nothing and still inserts
+    //      no `artifacts` row (#1278)
+    // ---------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_download_virtual_local_serve_records_download() {
+        let Some(fx) = tdh::Fixture::setup("virtual", "generic").await else {
+            return;
+        };
+        let (member_id, member_key, member_dir) =
+            tdh::create_repo(&fx.pool, "local", "generic").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(fx.repo_id)
+        .bind(member_id)
+        .execute(&fx.pool)
+        .await
+        .expect("add virtual member");
+
+        let body_bytes: &[u8] = b"virtual-member-download-bytes";
+        let member_repo = tdh::make_repo_info(member_id, &member_key, &member_dir, "local", None);
+        let storage_key = format!("ph-test/{}.bin", Uuid::new_v4());
+        let artifact_id = tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &member_repo,
+            &storage_key,
+            "vdl/blob.bin",
+            "blob",
+            "1.0.0",
+            "application/x-test",
+            Bytes::from_static(body_bytes),
+            fx.user_id,
+        )
+        .await;
+
+        // Authenticated download through the virtual repo. No ConnectInfo
+        // peer exists in a unit router, so DownloadContext falls back to the
+        // parseable X-Forwarded-For value for the client IP.
+        let mut req = tdh::get(format!("/{}/download/vdl/blob.bin", fx.repo_key));
+        req.headers_mut()
+            .insert("x-forwarded-for", "203.0.113.90".parse().unwrap());
+        req.headers_mut()
+            .insert("user-agent", "dl-telemetry-test/2.0".parse().unwrap());
+        let (status, body) = tdh::send(fx.router_with_auth(download_router()), req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(
+            &body[..],
+            body_bytes,
+            "virtual /download/ GET must serve the member's content bytes"
+        );
+
+        let rows = telemetry_rows(&fx.pool, artifact_id).await;
+        assert_eq!(
+            rows.len(),
+            1,
+            "a virtual-local serve must record exactly one download_statistics row \
+             (zero = #2398 regression, more = double-count)"
+        );
+        assert_eq!(rows[0].0, Some(fx.user_id), "user must be attributed");
+        assert_eq!(
+            rows[0].1.as_deref(),
+            Some("203.0.113.90"),
+            "resolved client IP must be recorded, not a sentinel"
+        );
+        assert_eq!(rows[0].2.as_deref(), Some("dl-telemetry-test/2.0"));
+
+        // Anonymous download: user_id records as NULL, not dropped.
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await
+            .expect("make virtual repo public");
+        let mut anon_req = tdh::get(format!("/{}/download/vdl/blob.bin", fx.repo_key));
+        anon_req
+            .headers_mut()
+            .insert("x-forwarded-for", "203.0.113.91".parse().unwrap());
+        let (anon_status, _) = tdh::send(fx.router_anon(download_router()), anon_req).await;
+        assert_eq!(anon_status, axum::http::StatusCode::OK);
+
+        let rows = telemetry_rows(&fx.pool, artifact_id).await;
+        assert_eq!(rows.len(), 2, "anonymous serve must also record");
+        assert_eq!(rows[1].0, None, "anonymous must record a NULL user");
+        assert_eq!(rows[1].1.as_deref(), Some("203.0.113.91"));
+
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup(&fx.pool, member_id, fx.user_id).await;
+        let _ = std::fs::remove_dir_all(&member_dir);
+        fx.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn test_download_virtual_remote_passthrough_does_not_record() {
+        let Some(fx) = tdh::Fixture::setup("virtual", "generic").await else {
+            return;
+        };
+        let (member_id, _member_key, member_dir) =
+            tdh::create_repo(&fx.pool, "remote", "generic").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(fx.repo_id)
+        .bind(member_id)
+        .execute(&fx.pool)
+        .await
+        .expect("add remote virtual member");
+
+        let server = wiremock::MockServer::start().await;
+        let upstream_body: &[u8] = b"remote-download-passthrough-bytes";
+        wiremock::Mock::given(wiremock::matchers::method("GET"))
+            .and(wiremock::matchers::path("/pass/dl.bin"))
+            .respond_with(wiremock::ResponseTemplate::new(200).set_body_bytes(upstream_body))
+            .mount(&server)
+            .await;
+        point_repo_at_upstream(&fx.pool, member_id, &server.uri()).await;
+
+        let proxy =
+            tdh::build_proxy_service_with_fs(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let state =
+            tdh::build_state_with_proxy(fx.pool.clone(), fx.storage_dir.to_str().unwrap(), proxy);
+        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let mut req = tdh::get(format!("/{}/download/pass/dl.bin", fx.repo_key));
+        req.headers_mut()
+            .insert("x-forwarded-for", "203.0.113.92".parse().unwrap());
+        let (status, body) =
+            tdh::send(tdh::router_with_auth(download_router(), state, auth), req).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(&body[..], upstream_body);
+
+        // #1278: a proxy pass-through must not materialize an artifacts row,
+        // and therefore records no download_statistics either.
+        let artifact_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = ANY($1)")
+                .bind(vec![fx.repo_id, member_id])
+                .fetch_one(&fx.pool)
+                .await
+                .expect("count artifacts");
+        assert_eq!(
+            artifact_count, 0,
+            "remote pass-through must not insert into artifacts (#1278)"
+        );
+        let stat_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM download_statistics WHERE artifact_id IN \
+             (SELECT id FROM artifacts WHERE repository_id = ANY($1))",
+        )
+        .bind(vec![fx.repo_id, member_id])
+        .fetch_one(&fx.pool)
+        .await
+        .expect("count stats");
+        assert_eq!(
+            stat_count, 0,
+            "remote pass-through must record no download_statistics"
+        );
+
+        let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1")
+            .bind(fx.repo_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup(&fx.pool, member_id, fx.user_id).await;
+        let _ = std::fs::remove_dir_all(&member_dir);
+        fx.teardown().await;
+    }
+
     // Source-level pin (#1608, epic #1607): the local-serve happy path in
     // `download_artifact` MUST stream via `ArtifactService::download_stream`
     // and `Body::from_stream`, never the buffered `.download(` -> `Bytes`
@@ -14518,6 +14713,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), "npm-test/-/npm-test-1.0.0.tgz".to_string())),
             Query(ArtifactVersionQuery { version: None }),
+            crate::api::middleware::download_telemetry::DownloadContext::default(),
             get_request(),
         )
         .await;
@@ -14535,6 +14731,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), unscoped_stored.clone())),
             Query(ArtifactVersionQuery { version: None }),
+            crate::api::middleware::download_telemetry::DownloadContext::default(),
             get_request(),
         )
         .await;
@@ -14553,6 +14750,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), "nope/-/nope-9.9.9.tgz".to_string())),
             Query(ArtifactVersionQuery { version: None }),
+            crate::api::middleware::download_telemetry::DownloadContext::default(),
             get_request(),
         )
         .await;
@@ -14646,6 +14844,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             Query(ArtifactVersionQuery { version: None }),
+            crate::api::middleware::download_telemetry::DownloadContext::default(),
             get_request(),
         )
         .await;
@@ -14661,6 +14860,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), "tools/does-not-exist.bin".to_string())),
             Query(ArtifactVersionQuery { version: None }),
+            crate::api::middleware::download_telemetry::DownloadContext::default(),
             get_request(),
         )
         .await;


### PR DESCRIPTION
## Summary

Closes #2398

Sibling of #2394 (PR #2396), on the other handler: `GET /{key}/download/{path}`'s virtual-member-local branch streams a locally-owned member's bytes via `resolve_virtual_download` without ever reaching the #2365 `record_download` choke point — that arm is only entered after `download_stream` (which contains the recorder) returned NotFound for the virtual repo itself. Pulls of local artifacts through a virtual repo on the primary download route were therefore unattributed: no IP/user row in `download_statistics`, and absent from CVE blast-radius reporting (#2364).

Changes (`backend/src/api/handlers/repositories.rs` only):

- `download_artifact` now takes the shared `DownloadContext` extractor (trusted-proxy-aware client-IP resolution from #2365/#2023 — the socket peer is authoritative and `X-Forwarded-For` is believed only inside `RATE_LIMIT_TRUSTED_PROXY_CIDRS`). The handler's previous inline IP/User-Agent resolution collapsed onto the context's fields, so the direct/presigned paths keep byte-identical attribution from a single source of truth.
- On the virtual-member-local content branch — where the shadowing guard proved a non-Remote member owns the exact path, so `resolve_virtual_download` finalized among local members — the winner's `artifacts.id` is re-derived via the #2396 helper `virtual_local_winner_artifact_id()` and recorded with `record_download`. Best-effort, same as everywhere else: a resolution failure logs and skips; telemetry never blocks or fails the download.

Invariants preserved:

- Remote/proxied pass-through resolves no local `artifacts` row and stays unrecorded (#1278); `test_cache_artifact_does_not_insert_into_artifacts_table` unchanged and green.
- No double-count: the recording sits inside the `Err(NotFound) + Virtual` arm, which is mutually exclusive with the direct-row path whose recorder lives in `download_stream`; the presigned/redirect recorder is likewise unreachable from this arm.
- Anonymous downloads record `user_id = NULL` (not dropped); an unresolvable client IP records NULL, never a sentinel.

Verified live on an isolated instance (trusted-proxy CIDR set): authed GET through a virtual repo's `/download/` route with `X-Forwarded-For` → one `download_statistics` row with the forwarded IP + user (was: no row); anonymous → row with NULL user; remote pass-through via a virtual remote member → no row and no `artifacts` insert; a direct member download still records exactly once; rows surface in `/api/v1/admin/downloads`.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_download_virtual_local_serve_records_download` fails on `main` (no `download_statistics` row is written; its `rows.len() == 1` assertion also pins against double-counting) and passes here; `test_download_virtual_remote_passthrough_does_not_record` pins the must-not-record pass-through branch (#1278).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (12,707 lib tests green against a migrated Postgres)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
