### PR TITLE
feat(debian): Advanced production-ready APT mirror-proxy integrity, filtering, and signing

### DIFF
--- a/backend/migrations/150_signing_keys_public_only.sql
+++ b/backend/migrations/150_signing_keys_public_only.sql
@@ -1,0 +1,10 @@
+-- Allow public-only trust anchors in signing_keys.
+--
+-- Debian/Ubuntu upstream verification needs the archive public key without a
+-- corresponding private key. Existing signing keys keep their encrypted
+-- private material; newly imported trust anchors store NULL.
+ALTER TABLE signing_keys
+    ALTER COLUMN private_key_enc DROP NOT NULL;
+
+COMMENT ON COLUMN signing_keys.private_key_enc IS
+    'Encrypted private key material for signing keys; NULL for public-only trust anchors used only for upstream verification';

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -539,10 +539,9 @@ async fn load_debian_repository_config(
     db: &PgPool,
     repo_id: uuid::Uuid,
 ) -> Option<DebianRepositoryConfig> {
-    match load_debian_repository_config_strict(db, repo_id).await {
-        Ok(config) => config,
-        Err(_) => None,
-    }
+    load_debian_repository_config_strict(db, repo_id)
+        .await
+        .unwrap_or_default()
 }
 
 /// Strict loader: distinguishes between "no config row" (Ok(None)) and a DB/parse
@@ -2962,6 +2961,7 @@ async fn pool_download(
 async fn flat_or_root_package_download(
     State(state): State<SharedState>,
     Path((repo_key, artifact_path)): Path<(String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
     let config = load_debian_repository_config(&state.db, repo.id).await;
@@ -3011,12 +3011,7 @@ async fn flat_or_root_package_download(
                 )
                     .into_response()
             })?;
-        let _ = sqlx::query!(
-            "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
-            artifact.id
-        )
-        .execute(&state.db)
-        .await;
+        crate::services::artifact_service::record_download(&state.db, artifact.id, &ctx).await;
         return Ok(Response::builder()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, DEBIAN_BINARY_CONTENT_TYPE)

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -15,8 +15,9 @@
 //!   GET  /debian/{repo_key}/pool/{component}/*path                                  - Download .deb
 //!   PUT  /debian/{repo_key}/pool/{component}/*path                                  - Upload .deb
 //!   POST /debian/{repo_key}/upload                                                  - Upload .deb (raw body)
+//!   POST /debian/{repo_key}/sync                                                    - Sync filtered remote metadata/packages
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, Write};
 
 use axum::body::Body;
@@ -25,19 +26,32 @@ use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
-use axum::Extension;
 use axum::Router;
+use axum::{Extension, Json};
 use bytes::Bytes;
 use flate2::Compression;
 use flate2::GzBuilder;
-use sha2::{Digest, Sha256};
+use futures::StreamExt;
+#[allow(unused_imports)]
+use serde_json::json;
+use sha2::{Digest, Sha256, Sha512};
 use sqlx::PgPool;
 use tracing::info;
+use utoipa::{OpenApi, ToSchema};
 
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
+use crate::api::handlers::repositories::DebianRepositoryConfig;
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::{SharedState, SIGNED_RELEASE_CACHE_MAX_ENTRIES};
-use crate::formats::debian::{DebControl, DebianHandler};
+use crate::formats::debian::{
+    build_contents_index, build_debian_sync_plan, by_hash_path, filter_release_package_indexes,
+    filter_release_source_indexes, is_flat_repository_package_path, parse_packages_index,
+    parse_release, parse_sources_index, pool_path_allowed_by_filters, release_is_expired,
+    release_path_allowed_by_filter, validate_debian_fetch_path, validate_release_filter_selection,
+    DebControl, DebianHandler, DebianIndexPath, DebianSourceIndexPath, DebianSyncDownloadPolicy,
+    DebianSyncFilter, DebianSyncPackageFile, DebianSyncPlan, DebianSyncSourceFile, PackagesEntry,
+    SourceFileEntry, SourcesEntry, MAX_DEBIAN_SYNC_SELECTED_FILES,
+};
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::models::signing_key::SigningKey;
 use crate::services::artifact_service::ArtifactService;
@@ -54,6 +68,17 @@ const DEBIAN_BINARY_CONTENT_TYPE: &str = "application/vnd.debian.binary-package"
 
 pub fn router() -> Router<SharedState> {
     Router::new()
+        // Flat repository Release files
+        .route("/:repo_key/Release", get(flat_release_file))
+        .route("/:repo_key/InRelease", get(flat_in_release_file))
+        .route("/:repo_key/Release.gpg", get(flat_release_gpg))
+        // Flat repository package/source indexes
+        .route("/:repo_key/Packages", get(flat_packages_index))
+        .route("/:repo_key/Packages.gz", get(flat_packages_index_gz))
+        .route("/:repo_key/Packages.xz", get(flat_packages_index_xz))
+        .route("/:repo_key/Sources", get(flat_sources_index))
+        .route("/:repo_key/Sources.gz", get(flat_sources_index_gz))
+        .route("/:repo_key/Sources.xz", get(flat_sources_index_xz))
         // Release files
         .route("/:repo_key/dists/:distribution/Release", get(release_file))
         .route(
@@ -81,8 +106,15 @@ pub fn router() -> Router<SharedState> {
             "/:repo_key/pool/:component/*path",
             get(pool_download).put(pool_upload),
         )
+        // Flat / root-relative package paths (after pool so pool wins for pool/...)
+        .route(
+            "/:repo_key/*artifact_path",
+            get(flat_or_root_package_download),
+        )
         // Alternative upload endpoint
         .route("/:repo_key/upload", post(upload_raw))
+        // Explicit filtered metadata/package prefetch for configured Remote repos.
+        .route("/:repo_key/sync", post(sync_remote_repository))
 }
 
 // ---------------------------------------------------------------------------
@@ -155,8 +187,77 @@ fn build_packages_text(entries: &[PackageEntry]) -> String {
     text
 }
 
+fn build_generated_packages_text(
+    entries: &[PackagesEntry],
+    index_architecture: &str,
+    selected_architectures: &[String],
+) -> String {
+    let mut text = String::new();
+    let mut first = true;
+    for entry in entries.iter().filter(|entry| {
+        package_matches_generated_index(
+            &entry.control.architecture,
+            index_architecture,
+            selected_architectures,
+        )
+    }) {
+        if !first {
+            text.push('\n');
+        }
+        first = false;
+        push_generated_packages_entry(&mut text, entry);
+    }
+    text
+}
+
+fn package_matches_generated_index(
+    package_architecture: &str,
+    index_architecture: &str,
+    selected_architectures: &[String],
+) -> bool {
+    if index_architecture.is_empty() {
+        package_architecture == "all"
+            || selected_architectures.is_empty()
+            || selected_architectures
+                .iter()
+                .any(|architecture| architecture == package_architecture)
+    } else {
+        package_matches_requested_arch(package_architecture, index_architecture)
+    }
+}
 fn push_packages_entry(text: &mut String, entry: &PackageEntry) {
-    let control = &entry.control;
+    push_packages_fields(
+        text,
+        &entry.control,
+        Some(entry.filename.as_str()),
+        Some(entry.size.max(0) as u64),
+        entry.md5.as_deref(),
+        entry.sha1.as_deref(),
+        Some(entry.sha256.as_str()),
+    );
+}
+
+fn push_generated_packages_entry(text: &mut String, entry: &PackagesEntry) {
+    push_packages_fields(
+        text,
+        &entry.control,
+        entry.filename.as_deref(),
+        entry.size,
+        entry.md5sum.as_deref(),
+        entry.sha1.as_deref(),
+        entry.sha256.as_deref(),
+    );
+}
+
+fn push_packages_fields(
+    text: &mut String,
+    control: &DebControl,
+    filename: Option<&str>,
+    size: Option<u64>,
+    md5sum: Option<&str>,
+    sha1: Option<&str>,
+    sha256: Option<&str>,
+) {
     push_control_field(text, "Package", &control.package);
     push_control_field(text, "Version", &control.version);
     push_control_field(text, "Architecture", &control.architecture);
@@ -183,11 +284,13 @@ fn push_packages_entry(text: &mut String, entry: &PackageEntry) {
     }
 
     push_optional_control_field(text, "Description", control.description.as_deref());
-    push_control_field(text, "Filename", &entry.filename);
-    push_control_field(text, "Size", &entry.size.to_string());
-    push_optional_control_field(text, "MD5sum", entry.md5.as_deref());
-    push_optional_control_field(text, "SHA1", entry.sha1.as_deref());
-    push_control_field(text, "SHA256", &entry.sha256);
+    push_optional_control_field(text, "Filename", filename);
+    if let Some(size) = size {
+        push_control_field(text, "Size", &size.to_string());
+    }
+    push_optional_control_field(text, "MD5sum", md5sum);
+    push_optional_control_field(text, "SHA1", sha1);
+    push_optional_control_field(text, "SHA256", sha256);
 }
 
 fn push_optional_control_field(text: &mut String, key: &str, value: Option<&str>) {
@@ -222,6 +325,66 @@ fn push_control_field(text: &mut String, key: &str, value: &str) {
     }
 }
 
+fn build_generated_sources_text(entries: &[SourcesEntry]) -> String {
+    let mut text = String::new();
+    for (i, entry) in entries.iter().enumerate() {
+        if i > 0 {
+            text.push('\n');
+        }
+        push_sources_entry(&mut text, entry);
+    }
+    text
+}
+
+fn push_sources_entry(text: &mut String, entry: &SourcesEntry) {
+    push_control_field(text, "Package", &entry.package);
+    push_control_field(text, "Version", &entry.version);
+    push_control_field(text, "Directory", &entry.directory);
+
+    for (key, value) in &entry.extra {
+        push_control_field(text, key, value);
+    }
+
+    push_source_hash_section(text, "Files", &entry.files, source_file_md5);
+    push_source_hash_section(text, "Checksums-Sha1", &entry.files, source_file_sha1);
+    push_source_hash_section(text, "Checksums-Sha256", &entry.files, source_file_sha256);
+    push_source_hash_section(text, "Checksums-Sha512", &entry.files, source_file_sha512);
+}
+
+fn source_file_md5(file: &SourceFileEntry) -> Option<&str> {
+    file.md5sum.as_deref()
+}
+
+fn source_file_sha1(file: &SourceFileEntry) -> Option<&str> {
+    file.sha1.as_deref()
+}
+
+fn source_file_sha256(file: &SourceFileEntry) -> Option<&str> {
+    file.sha256.as_deref()
+}
+
+fn source_file_sha512(file: &SourceFileEntry) -> Option<&str> {
+    file.sha512.as_deref()
+}
+
+fn push_source_hash_section(
+    text: &mut String,
+    field: &str,
+    files: &[SourceFileEntry],
+    hash: fn(&SourceFileEntry) -> Option<&str>,
+) {
+    if !files.iter().any(|file| hash(file).is_some()) {
+        return;
+    }
+
+    text.push_str(field);
+    text.push_str(":\n");
+    for file in files {
+        if let Some(hash) = hash(file) {
+            text.push_str(&format!(" {} {} {}\n", hash, file.size, file.filename));
+        }
+    }
+}
 fn json_string<'a>(metadata: &'a serde_json::Value, key: &str) -> Option<&'a str> {
     metadata.get(key).and_then(|v| v.as_str())
 }
@@ -284,10 +447,37 @@ fn package_matches_requested_arch(package_arch: &str, requested_arch: &str) -> b
     }
 }
 
+fn package_matches_requested_distribution(
+    metadata: Option<&serde_json::Value>,
+    requested_distribution: &str,
+) -> bool {
+    let Some(distribution) = metadata
+        .and_then(|metadata| metadata.get("distribution"))
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        // Legacy uploads did not carry distribution metadata. Keep them visible
+        // in requested distributions instead of silently hiding existing hosted repos.
+        return true;
+    };
+
+    distribution == requested_distribution
+}
+
+fn architecture_for_release_layout(package_arch: &str) -> Option<&str> {
+    if package_arch == "all" {
+        None
+    } else {
+        Some(package_arch)
+    }
+}
+
 /// Fetch all package entries for a given repo, component, and architecture.
 async fn fetch_package_entries(
     db: &PgPool,
     repo_id: uuid::Uuid,
+    distribution: &str,
     component: &str,
     arch: &str,
 ) -> Result<Vec<PackageEntry>, Response> {
@@ -318,6 +508,10 @@ async fn fetch_package_entries(
             None => continue,
         };
 
+        if !package_matches_requested_distribution(metadata.as_ref(), distribution) {
+            continue;
+        }
+
         let control = control_from_metadata_or_filename(metadata.as_ref(), &deb_info);
 
         if !package_matches_requested_arch(&control.architecture, arch) {
@@ -341,61 +535,159 @@ async fn fetch_package_entries(
 // Release content generation (shared by Release, InRelease, Release.gpg)
 // ---------------------------------------------------------------------------
 
-async fn generate_release_content(
+async fn load_debian_repository_config(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+) -> Option<DebianRepositoryConfig> {
+    match load_debian_repository_config_strict(db, repo_id).await {
+        Ok(config) => config,
+        Err(_) => None,
+    }
+}
+
+/// Strict loader: distinguishes between "no config row" (Ok(None)) and a DB/parse
+/// error (Err(503 SERVICE_UNAVAILABLE)). Use this for security-sensitive paths such as
+/// the pool proxy where a parse failure should fail-closed rather than fall back to
+/// permissive defaults.
+async fn load_debian_repository_config_strict(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+) -> Result<Option<DebianRepositoryConfig>, Response> {
+    let stored = sqlx::query_scalar::<_, String>(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key IN ('debian', 'debian_config') ORDER BY CASE WHEN key = 'debian' THEN 0 ELSE 1 END LIMIT 1",
+    )
+    .bind(repo_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| {
+        tracing::warn!(repository_id = %repo_id, error = %e, "failed to load Debian repository config");
+        (StatusCode::SERVICE_UNAVAILABLE, "Failed to load repository configuration").into_response()
+    })?;
+
+    let Some(stored) = stored else {
+        return Ok(None);
+    };
+
+    match serde_json::from_str::<DebianRepositoryConfig>(&stored) {
+        Ok(config) => Ok(Some(config)),
+        Err(e) => {
+            tracing::warn!(repository_id = %repo_id, error = %e, "invalid Debian repository config JSON");
+            Err((
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Invalid repository configuration",
+            )
+                .into_response())
+        }
+    }
+}
+
+/// True when a coherent local mirror generation has been published for this
+/// distribution and must be served exclusively.
+///
+/// A published generation is signalled by a stored synced Release (only
+/// written, atomically, at the end of a successful sync for a repository whose
+/// metadata strategy generates local metadata). While no generation exists the
+/// repository is in transparent passthrough mode: upstream metadata is served
+/// unchanged and no per-request filtering is applied, so `apt` always sees a
+/// self-consistent Release + index set. Once a generation is published, the
+/// served set is exactly what the generation contains — filters are implicit in
+/// its contents rather than enforced per request — and anything outside it is
+/// 404 rather than proxied from upstream, so clients never observe a Release
+/// that advertises indexes the mirror does not serve, nor a mix of upstream and
+/// filtered local metadata.
+async fn debian_local_generation_active(
     state: &SharedState,
     repo_id: uuid::Uuid,
     distribution: &str,
-) -> Result<String, Response> {
-    let (components, architectures) = discover_release_layout(&state.db, repo_id).await?;
+) -> bool {
+    matches!(
+        load_synced_release_content(state, repo_id, distribution).await,
+        Ok(Some(_))
+    )
+}
+
+/// Guard the upstream-passthrough branch of a dists request: once a local
+/// generation is published for `distribution`, a path that is not part of that
+/// generation must 404 instead of falling through to upstream, so the served
+/// mirror stays coherent with its published Release. Returns `Ok(())` (allow
+/// passthrough) only while the repository is still in transparent passthrough
+/// mode.
+async fn reject_uncovered_generation_path(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+) -> Result<(), Response> {
+    if debian_local_generation_active(state, repo_id, distribution).await {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Path is not part of the published Debian mirror generation",
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+fn configured_release_values(values: &[String], include_arch_all: bool) -> BTreeSet<String> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty() && *value != "*")
+        .filter(|value| include_arch_all || *value != "all")
+        .map(str::to_string)
+        .collect()
+}
+
+fn effective_release_layout(
+    config: Option<&DebianRepositoryConfig>,
+    discovered_components: BTreeSet<String>,
+    discovered_architectures: BTreeSet<String>,
+) -> (BTreeSet<String>, BTreeSet<String>) {
+    let configured_components = config
+        .map(|config| configured_release_values(&config.effective_components(), true))
+        .unwrap_or_default();
+    let configured_architectures = config
+        .map(|config| configured_release_values(&config.effective_architectures(), false))
+        .unwrap_or_default();
+
+    let components = if configured_components.is_empty() {
+        discovered_components
+    } else {
+        configured_components
+    };
+    let architectures = if configured_architectures.is_empty() {
+        discovered_architectures
+    } else {
+        configured_architectures
+    };
+
+    (components, architectures)
+}
+fn build_release_content_from_files(
+    suite: &str,
+    codename: Option<&str>,
+    description: Option<&str>,
+    components: &BTreeSet<String>,
+    architectures: &BTreeSet<String>,
+    mut release_files: Vec<(String, Vec<u8>)>,
+) -> String {
+    release_files.sort_by(|left, right| left.0.cmp(&right.0));
+
     let component_str = components.iter().cloned().collect::<Vec<_>>().join(" ");
     let arch_str = architectures.iter().cloned().collect::<Vec<_>>().join(" ");
-
-    let mut release_files = Vec::new();
-    for component in &components {
-        for arch in &architectures {
-            let entries = fetch_package_entries(&state.db, repo_id, component, arch).await?;
-            let packages_text = build_packages_text(&entries);
-            let packages_bytes = packages_text.into_bytes();
-            let packages_path = format!("{}/binary-{}/Packages", component, arch);
-            release_files.push((packages_path, packages_bytes.clone()));
-
-            let gz_bytes = gzip_compress(&packages_bytes).map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("Compression error: {}", e),
-                )
-                    .into_response()
-            })?;
-            release_files.push((
-                format!("{}/binary-{}/Packages.gz", component, arch),
-                gz_bytes,
-            ));
-
-            let xz_bytes = xz_compress(&packages_bytes).map_err(|e| {
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    format!("XZ compression error: {}", e),
-                )
-                    .into_response()
-            })?;
-            release_files.push((
-                format!("{}/binary-{}/Packages.xz", component, arch),
-                xz_bytes,
-            ));
-        }
-    }
-
     let now = chrono::Utc::now();
     let date_str = now.format("%a, %d %b %Y %H:%M:%S UTC").to_string();
 
     let mut release = String::new();
     release.push_str("Origin: artifact-keeper\n");
     release.push_str("Label: artifact-keeper\n");
-    release.push_str(&format!("Suite: {}\n", distribution));
-    release.push_str(&format!("Codename: {}\n", distribution));
+    release.push_str(&format!("Suite: {}\n", suite));
+    if let Some(codename) = codename.filter(|value| !value.trim().is_empty()) {
+        release.push_str(&format!("Codename: {}\n", codename));
+    }
     release.push_str(&format!("Date: {}\n", date_str));
     release.push_str(&format!("Architectures: {}\n", arch_str));
     release.push_str(&format!("Components: {}\n", component_str));
+    push_optional_control_field(&mut release, "Description", description);
     push_release_hash_section(&mut release, "MD5Sum", &release_files, |bytes| {
         ArtifactService::calculate_md5(bytes)
     });
@@ -405,8 +697,108 @@ async fn generate_release_content(
     push_release_hash_section(&mut release, "SHA256", &release_files, |bytes| {
         ArtifactService::calculate_sha256(bytes)
     });
+    push_release_hash_section(&mut release, "SHA512", &release_files, calculate_sha512_hex);
 
-    Ok(release)
+    release
+}
+async fn generate_release_content(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+) -> Result<String, Response> {
+    let config = load_debian_repository_config(&state.db, repo_id).await;
+    let (components, architectures) = discover_release_layout(&state.db, repo_id).await?;
+    let (components, architectures) =
+        effective_release_layout(config.as_ref(), components, architectures);
+
+    let mut release_files =
+        build_hosted_release_files(state, repo_id, distribution, &components, &architectures)
+            .await?;
+    append_by_hash_release_files(&mut release_files);
+
+    Ok(build_release_content_from_files(
+        distribution,
+        Some(distribution),
+        None,
+        &components,
+        &architectures,
+        release_files,
+    ))
+}
+
+/// Build Packages + Contents index blobs for a hosted repository generation.
+async fn build_hosted_release_files(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    components: &BTreeSet<String>,
+    architectures: &BTreeSet<String>,
+) -> Result<Vec<(String, Vec<u8>)>, Response> {
+    let mut release_files = Vec::new();
+    for component in components {
+        for arch in architectures {
+            let entries =
+                fetch_package_entries(&state.db, repo_id, distribution, component, arch).await?;
+            let packages_text = build_packages_text(&entries);
+            let packages_bytes = packages_text.into_bytes();
+            let packages_path = format!("{}/binary-{}/Packages", component, arch);
+            push_index_variants(&mut release_files, &packages_path, &packages_bytes)?;
+
+            let contents_entries: Vec<(String, String)> = entries
+                .iter()
+                .map(|entry| (entry.filename.clone(), entry.control.package.clone()))
+                .collect();
+            let contents_text = build_contents_index(&contents_entries);
+            let contents_bytes = contents_text.into_bytes();
+            let contents_path = format!("{}/Contents-{}", component, arch);
+            push_index_variants(&mut release_files, &contents_path, &contents_bytes)?;
+        }
+    }
+    Ok(release_files)
+}
+
+#[allow(clippy::result_large_err)]
+fn push_index_variants(
+    release_files: &mut Vec<(String, Vec<u8>)>,
+    plain_path: &str,
+    plain_bytes: &[u8],
+) -> Result<(), Response> {
+    release_files.push((plain_path.to_string(), plain_bytes.to_vec()));
+
+    let gz_bytes = gzip_compress(plain_bytes).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Compression error: {}", e),
+        )
+            .into_response()
+    })?;
+    release_files.push((format!("{plain_path}.gz"), gz_bytes));
+
+    let xz_bytes = xz_compress(plain_bytes).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("XZ compression error: {}", e),
+        )
+            .into_response()
+    })?;
+    release_files.push((format!("{plain_path}.xz"), xz_bytes));
+    Ok(())
+}
+
+/// Append `by-hash/SHA256/<digest>` aliases for every non-by-hash release file.
+fn append_by_hash_release_files(release_files: &mut Vec<(String, Vec<u8>)>) {
+    let snapshot: Vec<(String, Vec<u8>)> = release_files
+        .iter()
+        .filter(|(path, _)| !path.starts_with("by-hash/"))
+        .cloned()
+        .collect();
+    for (_path, bytes) in snapshot {
+        let sha = calculate_sha256_hex(&bytes);
+        let bh = by_hash_path("SHA256", &sha);
+        if !release_files.iter().any(|(path, _)| path == &bh) {
+            release_files.push((bh, bytes));
+        }
+    }
 }
 
 async fn discover_release_layout(
@@ -445,7 +837,9 @@ async fn discover_release_layout(
         if let Some(filename) = path.rsplit('/').next() {
             if let Some(info) = parse_deb_filename(filename) {
                 let control = control_from_metadata_or_filename(metadata.as_ref(), &info);
-                architectures.insert(control.architecture);
+                if let Some(arch) = architecture_for_release_layout(&control.architecture) {
+                    architectures.insert(arch.to_string());
+                }
             }
         }
     }
@@ -455,7 +849,6 @@ async fn discover_release_layout(
     }
 
     if architectures.is_empty() {
-        architectures.insert("all".to_string());
         architectures.insert("amd64".to_string());
         architectures.insert("arm64".to_string());
     }
@@ -463,11 +856,33 @@ async fn discover_release_layout(
     Ok((components, architectures))
 }
 
+/// Extract the Debian pool component from a path like
+/// `pool/main/c/curl/pkg.deb` or `pool/updates/main/c/curl/pkg.deb`.
+///
+/// Layout: `pool/<component>/<prefix>/<source>/<filename>` where `<component>`
+/// may contain `/` (Debian-Security uses `updates/main`).
 fn component_from_pool_path(path: &str) -> Option<&str> {
     let rest = path.strip_prefix("pool/")?;
-    rest.split('/')
-        .next()
-        .filter(|component| !component.is_empty())
+    let parts: Vec<&str> = rest.split('/').filter(|part| !part.is_empty()).collect();
+    if parts.is_empty() {
+        return None;
+    }
+    // Standard layout has at least component/prefix/source/filename.
+    if parts.len() >= 4 {
+        let mut offset = 0usize;
+        let prefix_idx = parts.len() - 3;
+        for (idx, part) in parts.iter().enumerate() {
+            if idx == prefix_idx {
+                if offset == 0 {
+                    return None;
+                }
+                // Drop the slash before the prefix segment.
+                return Some(&rest[..offset - 1]);
+            }
+            offset += part.len() + 1;
+        }
+    }
+    parts.first().copied()
 }
 
 fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
@@ -476,6 +891,144 @@ fn gzip_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
         .write(Vec::new(), Compression::default());
     encoder.write_all(data)?;
     encoder.finish()
+}
+
+fn calculate_sha512_hex(bytes: &[u8]) -> String {
+    let digest = Sha512::digest(bytes);
+    hex::encode(digest)
+}
+
+fn calculate_sha256_hex(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    hex::encode(digest)
+}
+
+/// Strongest advertised digest for `index_path` in the Release metadata,
+/// preferring SHA-512 over SHA-256. Returns `(is_sha512, hex, size)`.
+fn release_index_digest<'a>(
+    release: &'a crate::formats::debian::Release,
+    index_path: &str,
+) -> Option<(bool, &'a str, u64)> {
+    if let Some(hash) = release.sha512.iter().find(|hash| hash.path == index_path) {
+        return Some((true, hash.hash.as_str(), hash.size));
+    }
+    if let Some(hash) = release.sha256.iter().find(|hash| hash.path == index_path) {
+        return Some((false, hash.hash.as_str(), hash.size));
+    }
+    None
+}
+
+/// Verify a downloaded Packages/Sources index against the size and strongest
+/// digest advertised in the Release metadata.
+///
+/// When `require` is true (the upstream Release was cryptographically
+/// verified), an index with no SHA256/SHA512 entry in Release is rejected so
+/// unverifiable content never enters a trusted mirror. When false, the check
+/// still runs opportunistically to catch truncated or corrupt downloads but a
+/// missing entry is tolerated.
+fn verify_index_against_release(
+    release: &crate::formats::debian::Release,
+    index_path: &str,
+    content: &[u8],
+    require: bool,
+) -> std::result::Result<(), String> {
+    match release_index_digest(release, index_path) {
+        Some((is_sha512, expected_hex, expected_size)) => {
+            if content.len() as u64 != expected_size {
+                return Err(format!(
+                    "index {index_path} size {} does not match Release size {expected_size}",
+                    content.len()
+                ));
+            }
+            let actual = if is_sha512 {
+                calculate_sha512_hex(content)
+            } else {
+                calculate_sha256_hex(content)
+            };
+            if !actual.eq_ignore_ascii_case(expected_hex) {
+                return Err(format!(
+                    "index {index_path} {} checksum does not match Release",
+                    if is_sha512 { "SHA512" } else { "SHA256" }
+                ));
+            }
+            Ok(())
+        }
+        None if require => Err(format!(
+            "index {index_path} has no SHA256/SHA512 entry in the verified Release"
+        )),
+        None => Ok(()),
+    }
+}
+
+/// Build a `Filename` -> lowercase SHA-256 map from parsed Packages indexes so
+/// prefetched `.deb` payloads can be digest-gated before entering the cache.
+fn package_sha256_by_filename(
+    packages_by_index_path: &BTreeMap<String, Vec<PackagesEntry>>,
+) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    for entries in packages_by_index_path.values() {
+        for entry in entries {
+            let filename = entry
+                .filename
+                .as_deref()
+                .map(str::trim)
+                .filter(|filename| !filename.is_empty());
+            let sha256 = entry
+                .sha256
+                .as_deref()
+                .map(str::trim)
+                .filter(|sha256| !sha256.is_empty());
+            if let (Some(filename), Some(sha256)) = (filename, sha256) {
+                map.insert(filename.to_string(), sha256.to_ascii_lowercase());
+            }
+        }
+    }
+    map
+}
+
+/// Resolve the expected SHA-256 to gate a prefetched artifact's cache commit.
+///
+/// When `require` is true (upstream metadata was verified) an artifact with no
+/// advertised SHA-256 is rejected, so a trusted mirror never caches a payload
+/// it cannot verify. When false, a missing digest yields `None`, matching the
+/// prior best-effort caching for unverified remotes.
+fn expected_prefetch_digest(
+    digests: &BTreeMap<String, String>,
+    filename: &str,
+    require: bool,
+) -> std::result::Result<Option<String>, String> {
+    match digests.get(filename) {
+        Some(sha256) => Ok(Some(sha256.clone())),
+        None if require => Err(format!(
+            "{filename} has no advertised SHA256 in the verified metadata; refusing to cache"
+        )),
+        None => Ok(None),
+    }
+}
+
+/// Build a source-file-path -> lowercase SHA-256 map from parsed Sources
+/// indexes, keyed identically to `DebianSyncSourceFile::filename`.
+fn source_sha256_by_filename(
+    sources_by_index_path: &BTreeMap<String, Vec<SourcesEntry>>,
+) -> BTreeMap<String, String> {
+    let mut map = BTreeMap::new();
+    for entries in sources_by_index_path.values() {
+        for entry in entries {
+            for file in &entry.files {
+                if let Some(sha256) = file
+                    .sha256
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|sha256| !sha256.is_empty())
+                {
+                    let path =
+                        crate::formats::debian::source_file_path(&entry.directory, &file.filename);
+                    map.insert(path, sha256.to_ascii_lowercase());
+                }
+            }
+        }
+    }
+    map
 }
 
 fn push_release_hash_section<F>(
@@ -506,6 +1059,13 @@ struct DebianProxy<'a> {
     distribution: &'a str,
 }
 
+fn debian_dists_upstream_path(distribution: &str, suffix: &str) -> String {
+    if distribution.is_empty() {
+        suffix.to_string()
+    } else {
+        format!("dists/{distribution}/{suffix}")
+    }
+}
 impl<'a> DebianProxy<'a> {
     async fn resolve(
         state: &'a SharedState,
@@ -529,13 +1089,14 @@ impl<'a> DebianProxy<'a> {
         content_type: &'static str,
         repo: &RepoInfo,
     ) -> Result<(), Response> {
+        reject_uncovered_generation_path(self.state, repo.id, self.distribution).await?;
         // Virtual repos: try each Remote member in priority order so a
         // virtual APT repo can serve dists metadata when its top-level
         // type is `virtual` (#1147). Local/Staging members produce
         // their dists metadata locally, handled by the caller's
         // post-`dists()` fallthrough, so we only need to handle Remote.
         if repo.repo_type == RepositoryType::Virtual {
-            let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+            let upstream_path = debian_dists_upstream_path(self.distribution, suffix);
             if let Some(resp) = try_virtual_dists(
                 self.state,
                 repo.id,
@@ -558,7 +1119,7 @@ impl<'a> DebianProxy<'a> {
             (Some(u), Some(p)) => (u, p),
             _ => return Ok(()),
         };
-        let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+        let upstream_path = debian_dists_upstream_path(self.distribution, suffix);
 
         // Epoch-based lazy invalidation: if the cached file is older
         // than the release epoch, invalidate it so the streaming fetch
@@ -590,7 +1151,8 @@ impl<'a> DebianProxy<'a> {
         content_type: &'static str,
         repo: &RepoInfo,
     ) -> Result<(), Response> {
-        let upstream_path = format!("dists/{}/{}", self.distribution, suffix);
+        let upstream_path = debian_dists_upstream_path(self.distribution, suffix);
+        reject_uncovered_generation_path(self.state, repo.id, self.distribution).await?;
 
         // Virtual: iterate Remote members.
         if repo.repo_type == RepositoryType::Virtual {
@@ -797,17 +1359,6 @@ async fn require_active_signing_key(
 /// Iterate the virtual repo's Remote members for `upstream_path` and
 /// return the first successful response. Checks the release epoch for
 /// lazy invalidation before attempting the streaming fetch.
-///
-/// Error propagation:
-///   * `404 / NotFound` — the member genuinely doesn't have this file;
-///     continue to the next member.
-///   * Non-404 (502 cap-exceeded, 503 upstream-down, etc.) — record the
-///     first occurrence but **continue** to the next member so a
-///     transient failure on a higher-priority mirror doesn't block a
-///     healthy lower-priority one. If all members fail, the first
-///     non-404 error is returned so the client sees the real cause. If
-///     every member returned 404, `Ok(None)` lets the caller fall through
-///     to the local-DB path (hosted repos).
 async fn try_virtual_dists(
     state: &SharedState,
     virtual_repo_id: uuid::Uuid,
@@ -896,13 +1447,6 @@ async fn maybe_invalidate_by_epoch(
 /// Change-detection variant of [`try_virtual_dists`]. Uses TTL +
 /// conditional-request + epoch-based lazy invalidation for virtual repo
 /// members' Release/InRelease files.
-///
-/// Error propagation mirrors [`try_virtual_dists`]:
-///   * `NotFound` (404) — continue to the next member.
-///   * Non-404 — record the first occurrence but continue; return it
-///     only if no member succeeds. This preserves multi-mirror failover
-///     while still surfacing real failures (502, 503, etc.) instead of
-///     silently falling through to an empty local DB.
 async fn try_virtual_dists_detecting_change(
     state: &SharedState,
     virtual_repo_id: uuid::Uuid,
@@ -976,6 +1520,7 @@ fn proxy_err_status_and_message(e: &crate::error::AppError) -> (StatusCode, Stri
 
 /// Generate the Release content locally (shared by Release, InRelease,
 /// and Release.gpg handlers). Returns the text and the repo for signing.
+#[allow(clippy::result_large_err)]
 async fn local_release_content(
     state: &SharedState,
     repo_key: &str,
@@ -986,11 +1531,314 @@ async fn local_release_content(
     Ok((release, repo))
 }
 
+fn synced_release_config_key(distribution: &str) -> String {
+    format!("debian_synced_release:{distribution}")
+}
+
+async fn load_synced_release_content(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+) -> Result<Option<String>, Response> {
+    let Some(config) = load_debian_repository_config(&state.db, repo_id).await else {
+        return Ok(None);
+    };
+    if !config.generated_metadata_enabled() {
+        return Ok(None);
+    }
+
+    sqlx::query_scalar::<_, String>(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
+    )
+    .bind(repo_id)
+    .bind(synced_release_config_key(distribution))
+    .fetch_optional(&state.db)
+    .await
+    .map_err(crate::api::handlers::db_err)
+}
+
+async fn store_synced_release_content(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    release: &str,
+) -> Result<(), Response> {
+    sqlx::query(
+        r#"
+        INSERT INTO repository_config (repository_id, key, value)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (repository_id, key)
+        DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+        "#,
+    )
+    .bind(repo_id)
+    .bind(synced_release_config_key(distribution))
+    .bind(release)
+    .execute(&mut **tx)
+    .await
+    .map_err(crate::api::handlers::db_err)?;
+    Ok(())
+}
+
+fn canonical_plain_dists_index_path(path: &str) -> &str {
+    path.strip_suffix(".gz")
+        .or_else(|| path.strip_suffix(".xz"))
+        .or_else(|| path.strip_suffix(".bz2"))
+        .or_else(|| path.strip_suffix(".zst"))
+        .or_else(|| path.strip_suffix(".zstd"))
+        .unwrap_or(path)
+}
+
+fn synced_dists_key_prefix(distribution: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(distribution.as_bytes());
+    format!("debian_synced_dists:{}:", hex::encode(digest.finalize()))
+}
+
+fn synced_dists_config_key(distribution: &str, path: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(canonical_plain_dists_index_path(path).as_bytes());
+    format!(
+        "{}{}",
+        synced_dists_key_prefix(distribution),
+        hex::encode(digest.finalize())
+    )
+}
+
+async fn load_synced_dists_content(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    path: &str,
+) -> Result<Option<String>, Response> {
+    let Some(config) = load_debian_repository_config(&state.db, repo_id).await else {
+        return Ok(None);
+    };
+    if !config.generated_metadata_enabled() {
+        return Ok(None);
+    }
+
+    sqlx::query_scalar::<_, String>(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
+    )
+    .bind(repo_id)
+    .bind(synced_dists_config_key(distribution, path))
+    .fetch_optional(&state.db)
+    .await
+    .map_err(crate::api::handlers::db_err)
+}
+
+async fn clear_synced_dists_content(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+) -> Result<(), Response> {
+    sqlx::query("DELETE FROM repository_config WHERE repository_id = $1 AND key LIKE $2")
+        .bind(repo_id)
+        .bind(format!("{}%", synced_dists_key_prefix(distribution)))
+        .execute(&mut **tx)
+        .await
+        .map_err(crate::api::handlers::db_err)?;
+    Ok(())
+}
+
+async fn store_synced_dists_content(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    path: &str,
+    content: &str,
+) -> Result<(), Response> {
+    sqlx::query(
+        r#"
+        INSERT INTO repository_config (repository_id, key, value)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (repository_id, key)
+        DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()
+        "#,
+    )
+    .bind(repo_id)
+    .bind(synced_dists_config_key(distribution, path))
+    .bind(content)
+    .execute(&mut **tx)
+    .await
+    .map_err(crate::api::handlers::db_err)?;
+    Ok(())
+}
+
+#[allow(clippy::result_large_err)]
+fn build_synced_dists_index_response(path: &str, text: String) -> Result<Response, Response> {
+    let (content_type, body) = if path.ends_with(".gz") {
+        let compressed = gzip_compress(text.as_bytes()).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Compression error: {}", e),
+            )
+                .into_response()
+        })?;
+        ("application/gzip".to_string(), compressed)
+    } else if path.ends_with(".xz") {
+        let compressed = xz_compress(text.as_bytes()).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("XZ compression error: {}", e),
+            )
+                .into_response()
+        })?;
+        ("application/x-xz".to_string(), compressed)
+    } else if path.ends_with(".bz2") {
+        let compressed = bz2_compress(text.as_bytes()).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("bz2 compression error: {}", e),
+            )
+                .into_response()
+        })?;
+        ("application/x-bzip2".to_string(), compressed)
+    } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+        let compressed = zstd_compress(text.as_bytes()).map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("zstd compression error: {}", e),
+            )
+                .into_response()
+        })?;
+        ("application/zstd".to_string(), compressed)
+    } else {
+        (content_type_for_dists_path(path), text.into_bytes())
+    };
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_LENGTH, body.len().to_string())
+        .body(Body::from(body))
+        .unwrap())
+}
+
+/// Load synced dists content, resolving `@ref:` by-hash aliases to the
+/// referenced logical index path and returning `(serve_path, plain_text)`.
+async fn load_synced_dists_content_resolved(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    path: &str,
+) -> Result<Option<(String, String)>, Response> {
+    let Some(text) = load_synced_dists_content(state, repo_id, distribution, path).await? else {
+        return Ok(None);
+    };
+    if let Some(ref_path) = text.strip_prefix("@ref:") {
+        let plain_path = canonical_plain_dists_index_path(ref_path);
+        let Some(plain) =
+            load_synced_dists_content(state, repo_id, distribution, plain_path).await?
+        else {
+            return Ok(None);
+        };
+        return Ok(Some((ref_path.to_string(), plain)));
+    }
+    Ok(Some((path.to_string(), text)))
+}
+
+async fn try_synced_dists_response(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    path: &str,
+) -> Result<Option<Response>, Response> {
+    let Some((serve_path, text)) =
+        load_synced_dists_content_resolved(state, repo_id, distribution, path).await?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(build_synced_dists_index_response(&serve_path, text)?))
+}
+async fn flat_release_file(
+    State(state): State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    release_file(State(state), Path((repo_key, String::new()))).await
+}
+
+async fn flat_in_release_file(
+    State(state): State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    in_release_file(State(state), Path((repo_key, String::new()))).await
+}
+
+async fn flat_release_gpg(
+    State(state): State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    release_gpg(State(state), Path((repo_key, String::new()))).await
+}
+
+async fn flat_dists_file(
+    state: State<SharedState>,
+    repo_key: String,
+    dists_path: &str,
+) -> Result<Response, Response> {
+    dists_proxy_catchall(
+        state,
+        Path((repo_key, String::new(), dists_path.to_string())),
+    )
+    .await
+}
+
+async fn flat_packages_index(
+    state: State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    flat_dists_file(state, repo_key, "Packages").await
+}
+
+async fn flat_packages_index_gz(
+    state: State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    flat_dists_file(state, repo_key, "Packages.gz").await
+}
+
+async fn flat_packages_index_xz(
+    state: State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    flat_dists_file(state, repo_key, "Packages.xz").await
+}
+
+async fn flat_sources_index(
+    state: State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    flat_dists_file(state, repo_key, "Sources").await
+}
+
+async fn flat_sources_index_gz(
+    state: State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    flat_dists_file(state, repo_key, "Sources.gz").await
+}
+
+async fn flat_sources_index_xz(
+    state: State<SharedState>,
+    Path(repo_key): Path<String>,
+) -> Result<Response, Response> {
+    flat_dists_file(state, repo_key, "Sources.xz").await
+}
 async fn release_file(
     State(state): State<SharedState>,
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    if let Some(release) = load_synced_release_content(&state, repo.id, &distribution).await? {
+        return Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+            .header(CONTENT_LENGTH, release.len().to_string())
+            .body(Body::from(release))
+            .unwrap());
+    }
     proxy
         .dists_detecting_change("Release", "text/plain; charset=utf-8", &repo)
         .await?;
@@ -1013,11 +1861,21 @@ async fn in_release_file(
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
-    proxy
-        .dists_detecting_change("InRelease", "text/plain; charset=utf-8", &repo)
-        .await?;
+    let synced_release = load_synced_release_content(&state, repo.id, &distribution).await?;
+    if synced_release.is_none() {
+        proxy
+            .dists_detecting_change("InRelease", "text/plain; charset=utf-8", &repo)
+            .await?;
+    }
 
-    let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
+    let release = match synced_release {
+        Some(release) => release,
+        None => {
+            local_release_content(&state, &repo_key, &distribution)
+                .await?
+                .0
+        }
+    };
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
     // Resolve the signing key up front so we can both (a) return 404 when
@@ -1070,11 +1928,21 @@ async fn release_gpg(
     // Release.gpg is the detached signature of Release. We do not need
     // revalidation here because the matching Release fetch (called
     // by apt before Release.gpg) already drove epoch invalidation.
-    proxy
-        .dists("Release.gpg", "application/pgp-signature", &repo)
-        .await?;
+    let synced_release = load_synced_release_content(&state, repo.id, &distribution).await?;
+    if synced_release.is_none() {
+        proxy
+            .dists("Release.gpg", "application/pgp-signature", &repo)
+            .await?;
+    }
 
-    let (release, repo) = local_release_content(&state, &repo_key, &distribution).await?;
+    let release = match synced_release {
+        Some(release) => release,
+        None => {
+            local_release_content(&state, &repo_key, &distribution)
+                .await?
+                .0
+        }
+    };
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
     let key = require_active_signing_key(&signing_svc, repo.id).await?;
@@ -1172,6 +2040,104 @@ fn build_packages_xz(entries: &[PackageEntry]) -> Result<Vec<u8>, io::Error> {
     xz_compress(text.as_bytes())
 }
 
+#[derive(Default)]
+struct GeneratedDistsMetadata {
+    plain_indexes: BTreeMap<String, String>,
+    release_files: Vec<(String, Vec<u8>)>,
+}
+
+fn build_synced_generated_metadata(
+    plan: &DebianSyncPlan,
+    packages_by_index_path: &BTreeMap<String, Vec<PackagesEntry>>,
+    sources_by_index_path: &BTreeMap<String, Vec<SourcesEntry>>,
+    selected_architectures: &[String],
+) -> Result<GeneratedDistsMetadata, io::Error> {
+    let mut generated = GeneratedDistsMetadata::default();
+
+    // Restrict generated Packages/Contents to the sync plan's selected package
+    // files. `build_debian_sync_plan` already applies package_queries (+ deps),
+    // so publishing the full upstream index would advertise packages that are
+    // not part of the filtered mirror generation.
+    let mut allowed_filenames_by_index: BTreeMap<&str, BTreeSet<&str>> = BTreeMap::new();
+    for package in &plan.package_files {
+        allowed_filenames_by_index
+            .entry(package.index_path.as_str())
+            .or_default()
+            .insert(package.filename.as_str());
+    }
+
+    for index in &plan.package_indexes {
+        let Some(entries) = packages_by_index_path.get(&index.path) else {
+            continue;
+        };
+        let allowed = allowed_filenames_by_index
+            .get(index.path.as_str())
+            .cloned()
+            .unwrap_or_default();
+        let selected: Vec<PackagesEntry> = entries
+            .iter()
+            .filter(|entry| {
+                entry
+                    .filename
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .is_some_and(|filename| allowed.contains(filename))
+            })
+            .cloned()
+            .collect();
+        let text =
+            build_generated_packages_text(&selected, &index.architecture, selected_architectures);
+        add_generated_dists_index(&mut generated, &index.path, text)?;
+        // Contents indexes are NOT generated from pool filenames here: pool paths are
+        // not valid Contents-file paths (Contents should list installed-file paths
+        // like /usr/bin/foo, not pool/main/n/nginx/nginx_1.0_amd64.deb). Emitting
+        // them was wrong. Contents are only published for hosted repositories where
+        // we have actual file-installation metadata.
+    }
+
+    for index in &plan.source_indexes {
+        let Some(entries) = sources_by_index_path.get(&index.path) else {
+            continue;
+        };
+        let text = build_generated_sources_text(entries);
+        add_generated_dists_index(&mut generated, &index.path, text)?;
+    }
+
+    Ok(generated)
+}
+
+fn add_generated_dists_index(
+    generated: &mut GeneratedDistsMetadata,
+    index_path: &str,
+    text: String,
+) -> Result<(), io::Error> {
+    let base_path = canonical_plain_dists_index_path(index_path).to_string();
+    if generated.plain_indexes.contains_key(&base_path) {
+        return Ok(());
+    }
+
+    let plain_bytes = text.as_bytes().to_vec();
+    let gz_bytes = gzip_compress(&plain_bytes)?;
+    let xz_bytes = xz_compress(&plain_bytes)?;
+    let variants = [
+        (base_path.clone(), plain_bytes),
+        (format!("{base_path}.gz"), gz_bytes),
+        (format!("{base_path}.xz"), xz_bytes),
+    ];
+    for (path, bytes) in variants {
+        let sha = calculate_sha256_hex(&bytes);
+        let bh = by_hash_path("SHA256", &sha);
+        generated.release_files.push((path.clone(), bytes.clone()));
+        generated.release_files.push((bh.clone(), bytes));
+        // Alias so by-hash fetches resolve to the logical index path and
+        // recompress deterministically from the stored plain text.
+        generated.plain_indexes.insert(bh, format!("@ref:{path}"));
+    }
+    generated.plain_indexes.insert(base_path, text);
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // GET /debian/{repo_key}/dists/{dist}/{component}/binary-{arch}/Packages
 // ---------------------------------------------------------------------------
@@ -1182,13 +2148,19 @@ async fn packages_index(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     let packages_suffix = packages_index_suffix(&component, &binary_arch, "");
+    if let Some(response) =
+        try_synced_dists_response(&state, repo.id, &distribution, &packages_suffix).await?
+    {
+        return Ok(response);
+    }
     proxy
         .dists(&packages_suffix, "text/plain; charset=utf-8", &repo)
         .await?;
 
     let arch = strip_binary_arch_prefix(&binary_arch);
 
-    let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
+    let entries =
+        fetch_package_entries(&state.db, repo.id, &distribution, &component, arch).await?;
     let text = build_packages_text(&entries);
 
     Ok(Response::builder()
@@ -1209,13 +2181,19 @@ async fn packages_index_gz(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     let packages_gz_suffix = packages_index_suffix(&component, &binary_arch, "gz");
+    if let Some(response) =
+        try_synced_dists_response(&state, repo.id, &distribution, &packages_gz_suffix).await?
+    {
+        return Ok(response);
+    }
     proxy
         .dists(&packages_gz_suffix, "application/gzip", &repo)
         .await?;
 
     let arch = strip_binary_arch_prefix(&binary_arch);
 
-    let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
+    let entries =
+        fetch_package_entries(&state.db, repo.id, &distribution, &component, arch).await?;
     let text = build_packages_text(&entries);
 
     let compressed = gzip_compress(text.as_bytes()).map_err(|e| {
@@ -1244,13 +2222,19 @@ async fn packages_index_xz(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     let packages_xz_suffix = packages_index_suffix(&component, &binary_arch, "xz");
+    if let Some(response) =
+        try_synced_dists_response(&state, repo.id, &distribution, &packages_xz_suffix).await?
+    {
+        return Ok(response);
+    }
     proxy
         .dists(&packages_xz_suffix, "application/x-xz", &repo)
         .await?;
 
     let arch = strip_binary_arch_prefix(&binary_arch);
 
-    let entries = fetch_package_entries(&state.db, repo.id, &component, arch).await?;
+    let entries =
+        fetch_package_entries(&state.db, repo.id, &distribution, &component, arch).await?;
 
     let compressed = build_packages_xz(&entries).map_err(|e| {
         (
@@ -1284,9 +2268,11 @@ enum PackagesExt {
     Plain,
     Gz,
     Xz,
+    Bz2,
+    Zst,
 }
 
-/// Recognise `{component}/binary-{arch}/Packages{,.gz,.xz}` inside the
+/// Recognise `{component}/binary-{arch}/Packages{,.gz,.xz,.bz2,.zst}` inside the
 /// wildcard path. Returns None for any other shape so the caller can fall
 /// through to the upstream proxy.
 fn parse_packages_request(dists_path: &str) -> Option<PackagesRequest> {
@@ -1298,6 +2284,8 @@ fn parse_packages_request(dists_path: &str) -> Option<PackagesRequest> {
         "Packages" => PackagesExt::Plain,
         "Packages.gz" => PackagesExt::Gz,
         "Packages.xz" => PackagesExt::Xz,
+        "Packages.bz2" => PackagesExt::Bz2,
+        "Packages.zst" => PackagesExt::Zst,
         _ => return None,
     };
     Some(PackagesRequest {
@@ -1307,23 +2295,219 @@ fn parse_packages_request(dists_path: &str) -> Option<PackagesRequest> {
     })
 }
 
+struct ContentsRequest {
+    component: String,
+    arch: String,
+    ext: PackagesExt,
+}
+
+/// Recognise `{component}/Contents-{arch}{,.gz,.xz}`.
+fn parse_contents_request(dists_path: &str) -> Option<ContentsRequest> {
+    let segments: Vec<&str> = dists_path.split('/').collect();
+    if segments.len() != 2 {
+        return None;
+    }
+    let rest = segments[1].strip_prefix("Contents-")?;
+    let (arch, ext) = if let Some(arch) = rest.strip_suffix(".gz") {
+        (arch, PackagesExt::Gz)
+    } else if let Some(arch) = rest.strip_suffix(".xz") {
+        (arch, PackagesExt::Xz)
+    } else if let Some(arch) = rest.strip_suffix(".bz2") {
+        (arch, PackagesExt::Bz2)
+    } else if let Some(arch) = rest.strip_suffix(".zst") {
+        (arch, PackagesExt::Zst)
+    } else if rest.contains('.') {
+        return None;
+    } else {
+        (rest, PackagesExt::Plain)
+    };
+    if arch.is_empty() {
+        return None;
+    }
+    Some(ContentsRequest {
+        component: segments[0].to_string(),
+        arch: arch.to_string(),
+        ext,
+    })
+}
+
 /// Single entry point for all `dists/{distribution}/...` requests after
 /// the static Release/InRelease/Release.gpg/gpg-key.asc routes. Dispatches
-/// `{component}/binary-{arch}/Packages{,.gz,.xz}` to the matching Packages
-/// handler and forwards everything else to the upstream proxy catch-all.
+/// `{component}/binary-{arch}/Packages{,.gz,.xz}` and
+/// `{component}/Contents-{arch}{,.gz,.xz}` to the matching handlers and
+/// forwards everything else to the upstream proxy catch-all.
 async fn dists_dispatch(
     state: State<SharedState>,
     Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
     if let Some(req) = parse_packages_request(&dists_path) {
-        let path = Path((repo_key, distribution, req.component, req.binary_arch));
+        let path = Path((
+            repo_key.clone(),
+            distribution.clone(),
+            req.component,
+            req.binary_arch,
+        ));
         return match req.ext {
             PackagesExt::Plain => packages_index(state, path).await,
             PackagesExt::Gz => packages_index_gz(state, path).await,
             PackagesExt::Xz => packages_index_xz(state, path).await,
+            // bz2/zst: try synced plain text via canonical path, then fall through to upstream.
+            PackagesExt::Bz2 | PackagesExt::Zst => {
+                let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+                if let Some(response) =
+                    try_synced_dists_response(&state, repo.id, &distribution, &dists_path).await?
+                {
+                    return Ok(response);
+                }
+                dists_proxy_catchall(state, Path((repo_key, distribution, dists_path))).await
+            }
         };
     }
+    if let Some(req) = parse_contents_request(&dists_path) {
+        return contents_index(state, repo_key, distribution, req).await;
+    }
     dists_proxy_catchall(state, Path((repo_key, distribution, dists_path))).await
+}
+
+async fn contents_index(
+    State(state): State<SharedState>,
+    repo_key: String,
+    distribution: String,
+    req: ContentsRequest,
+) -> Result<Response, Response> {
+    let contents_suffix = match req.ext {
+        PackagesExt::Plain => format!("{}/Contents-{}", req.component, req.arch),
+        PackagesExt::Gz => format!("{}/Contents-{}.gz", req.component, req.arch),
+        PackagesExt::Xz => format!("{}/Contents-{}.xz", req.component, req.arch),
+        PackagesExt::Bz2 => format!("{}/Contents-{}.bz2", req.component, req.arch),
+        PackagesExt::Zst => format!("{}/Contents-{}.zst", req.component, req.arch),
+    };
+    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+    if let Some(response) =
+        try_synced_dists_response(&state, repo.id, &distribution, &contents_suffix).await?
+    {
+        return Ok(response);
+    }
+
+    // Remote: fall through to catch-all proxy for upstream Contents.
+    if repo.repo_type == RepositoryType::Remote || repo.repo_type == RepositoryType::Virtual {
+        return dists_proxy_catchall(
+            State(state),
+            Path((repo_key, distribution, contents_suffix)),
+        )
+        .await;
+    }
+
+    // Hosted: generate a minimal Contents index from package filenames.
+    let entries =
+        fetch_package_entries(&state.db, repo.id, &distribution, &req.component, &req.arch).await?;
+    let contents_entries: Vec<(String, String)> = entries
+        .iter()
+        .map(|entry| (entry.filename.clone(), entry.control.package.clone()))
+        .collect();
+    let text = build_contents_index(&contents_entries);
+    match req.ext {
+        PackagesExt::Plain => Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+            .header(CONTENT_LENGTH, text.len().to_string())
+            .body(Body::from(text))
+            .unwrap()),
+        PackagesExt::Gz => {
+            let compressed = gzip_compress(text.as_bytes()).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Compression error: {}", e),
+                )
+                    .into_response()
+            })?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/gzip")
+                .header(CONTENT_LENGTH, compressed.len().to_string())
+                .body(Body::from(compressed))
+                .unwrap())
+        }
+        PackagesExt::Xz => {
+            let compressed = xz_compress(text.as_bytes()).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("XZ compression error: {}", e),
+                )
+                    .into_response()
+            })?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/x-xz")
+                .header(CONTENT_LENGTH, compressed.len().to_string())
+                .body(Body::from(compressed))
+                .unwrap())
+        }
+        PackagesExt::Bz2 => {
+            let compressed = bz2_compress(text.as_bytes()).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("bz2 compression error: {}", e),
+                )
+                    .into_response()
+            })?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/x-bzip2")
+                .header(CONTENT_LENGTH, compressed.len().to_string())
+                .body(Body::from(compressed))
+                .unwrap())
+        }
+        PackagesExt::Zst => {
+            let compressed = zstd_compress(text.as_bytes()).map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("zstd compression error: {}", e),
+                )
+                    .into_response()
+            })?;
+            Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(CONTENT_TYPE, "application/zstd")
+                .header(CONTENT_LENGTH, compressed.len().to_string())
+                .body(Body::from(compressed))
+                .unwrap())
+        }
+    }
+}
+
+/// Serve hosted Contents / by-hash paths from on-demand Release generation.
+async fn try_hosted_generated_dists_path(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    distribution: &str,
+    dists_path: &str,
+) -> Result<Option<Response>, Response> {
+    if !(dists_path.starts_with("by-hash/") || parse_contents_request(dists_path).is_some()) {
+        return Ok(None);
+    }
+    let config = load_debian_repository_config(&state.db, repo_id).await;
+    let (components, architectures) = discover_release_layout(&state.db, repo_id).await?;
+    let (components, architectures) =
+        effective_release_layout(config.as_ref(), components, architectures);
+    let mut release_files =
+        build_hosted_release_files(state, repo_id, distribution, &components, &architectures)
+            .await?;
+    append_by_hash_release_files(&mut release_files);
+    let Some((_, bytes)) = release_files
+        .into_iter()
+        .find(|(path, _)| path == dists_path)
+    else {
+        return Ok(None);
+    };
+    Ok(Some(
+        Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, content_type_for_dists_path(dists_path))
+            .header(CONTENT_LENGTH, bytes.len().to_string())
+            .body(Body::from(bytes))
+            .unwrap(),
+    ))
 }
 
 /// Catch-all handler for dists metadata that does not have a dedicated route.
@@ -1340,7 +2524,19 @@ async fn dists_proxy_catchall(
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
-    let upstream_path = format!("dists/{}/{}", distribution, dists_path);
+    if let Some(response) =
+        try_synced_dists_response(&state, repo.id, &distribution, &dists_path).await?
+    {
+        return Ok(response);
+    }
+
+    // Once a local generation is published, ancillary metadata that is not part
+    // of it (excluded components/architectures, Sources, Contents, i18n, dep11,
+    // by-hash, ...) must 404 rather than leak through from upstream, keeping the
+    // served mirror coherent with its published Release.
+    reject_uncovered_generation_path(&state, repo.id, &distribution).await?;
+
+    let upstream_path = debian_dists_upstream_path(&distribution, &dists_path);
 
     // Virtual repos: walk Remote members in priority order so a Virtual
     // APT repo can serve i18n / Translation / dep11 / Sources etc. just
@@ -1359,6 +2555,12 @@ async fn dists_proxy_catchall(
     }
 
     if repo.repo_type != RepositoryType::Remote {
+        // Hosted: serve Contents / by-hash from on-demand generation.
+        if let Some(response) =
+            try_hosted_generated_dists_path(&state, repo.id, &distribution, &dists_path).await?
+        {
+            return Ok(response);
+        }
         return Err((StatusCode::NOT_FOUND, "Not found").into_response());
     }
 
@@ -1421,9 +2623,215 @@ fn xz_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
     encoder.finish()
 }
 
+fn bz2_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
+    let mut encoder = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::default());
+    encoder.write_all(data)?;
+    encoder.finish()
+}
+
+fn zstd_compress(data: &[u8]) -> Result<Vec<u8>, io::Error> {
+    zstd::stream::encode_all(std::io::Cursor::new(data), 3)
+}
+
 // ---------------------------------------------------------------------------
 // GET /debian/{repo_key}/pool/{component}/*path -- Download .deb
 // ---------------------------------------------------------------------------
+
+/// Extract SHA256 for a Filename from Packages index text.
+fn sha256_for_filename_in_packages_text(text: &str, filename: &str) -> Option<String> {
+    let filename = filename.trim().trim_start_matches('/');
+    if filename.is_empty() {
+        return None;
+    }
+    let entries = parse_packages_index("Packages", text.as_bytes()).ok()?;
+    for entry in entries {
+        let Some(entry_filename) = entry
+            .filename
+            .as_deref()
+            .map(str::trim)
+            .map(|value| value.trim_start_matches('/'))
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        if entry_filename == filename
+            || entry_filename.ends_with(filename)
+            || filename.ends_with(entry_filename)
+        {
+            if let Some(sha256) = entry
+                .sha256
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                return Some(sha256.to_ascii_lowercase());
+            }
+        }
+    }
+    None
+}
+
+async fn lookup_synced_package_sha256(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    pool_path: &str,
+) -> Option<String> {
+    let values: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT value FROM repository_config
+        WHERE repository_id = $1
+          AND key LIKE 'debian_synced_dists:%'
+        "#,
+    )
+    .bind(repo_id)
+    .fetch_all(&state.db)
+    .await
+    .ok()?;
+
+    for text in values {
+        if text.starts_with("@ref:") {
+            continue;
+        }
+        if let Some(sha256) = sha256_for_filename_in_packages_text(&text, pool_path) {
+            return Some(sha256);
+        }
+    }
+    None
+}
+
+async fn debian_any_local_generation_active(
+    state: &SharedState,
+    repo_id: uuid::Uuid,
+    config: Option<&DebianRepositoryConfig>,
+) -> bool {
+    let Some(config) = config else {
+        return false;
+    };
+    for distribution in config.effective_distribution_paths() {
+        let normalized = distribution.trim_matches('/');
+        if debian_local_generation_active(state, repo_id, normalized).await {
+            return true;
+        }
+    }
+    // Flat repos store synced Release under an empty distribution key.
+    if config.flat_repository && debian_local_generation_active(state, repo_id, "").await {
+        return true;
+    }
+    false
+}
+
+fn debian_sync_filter_for_path_check(config: &DebianRepositoryConfig) -> DebianSyncFilter {
+    DebianSyncFilter {
+        distributions: Vec::new(),
+        components: config.effective_components(),
+        architectures: config.effective_architectures(),
+        include_source_packages: config.include_source_packages,
+        package_queries: config.effective_package_queries(),
+        resolve_dependencies: false,
+    }
+}
+
+fn map_debian_fetch_path_error(error: crate::error::AppError) -> Response {
+    (StatusCode::BAD_REQUEST, error.to_string()).into_response()
+}
+
+/// Shared remote package fetch with filter / SSRF / digest gates.
+async fn proxy_remote_debian_package(
+    state: &SharedState,
+    repo: &RepoInfo,
+    repo_key: &str,
+    upstream_url: &str,
+    upstream_path: &str,
+    component_for_filter: &str,
+    filename: &str,
+) -> Result<Response, Response> {
+    let proxy = state
+        .proxy_service
+        .as_deref()
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "Package not found").into_response())?;
+    let config = load_debian_repository_config_strict(&state.db, repo.id).await?;
+    let local_generation =
+        debian_any_local_generation_active(state, repo.id, config.as_ref()).await;
+    // Ok(None) means a legacy repo with no debian config row — unrestricted filters.
+    // Err was already fail-closed by the strict loader (corrupt/unavailable config).
+    let mut filter = match config.as_ref() {
+        Some(cfg) => debian_sync_filter_for_path_check(cfg),
+        None => DebianSyncFilter::default(),
+    };
+    // After a filtered sync publishes a generation, membership is enforced by
+    // the generated Packages index (including dependency closure). Clearing
+    // package_queries here avoids rejecting Depends/Pre-Depends that were
+    // intentionally selected during sync but do not match the raw queries.
+    if local_generation {
+        filter.package_queries.clear();
+    }
+
+    if !pool_path_allowed_by_filters(component_for_filter, filename, &filter) {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Package not allowed by repository filters",
+        )
+            .into_response());
+    }
+
+    validate_debian_fetch_path(upstream_path).map_err(map_debian_fetch_path_error)?;
+
+    let verify_required = config
+        .as_ref()
+        .map(|c| c.verify_upstream_metadata)
+        .unwrap_or(false)
+        || local_generation;
+
+    let expected_sha = lookup_synced_package_sha256(state, repo.id, upstream_path).await;
+    if local_generation && expected_sha.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "Package is not part of the published Debian mirror generation",
+        )
+            .into_response());
+    }
+    if verify_required && expected_sha.is_none() {
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            "Refusing to serve unverified package: no SHA256 in synced metadata",
+        )
+            .into_response());
+    }
+
+    let passthrough = config
+        .as_ref()
+        .map(|c| {
+            c.package_fetch_strategy
+                == crate::api::handlers::repositories::DebianPackageFetchStrategy::Passthrough
+        })
+        .unwrap_or(false);
+
+    if passthrough {
+        // Passthrough must never write to cache: always stream uncached regardless of
+        // whether we have an expected SHA (the SHA is used for gate/verify, not cache key).
+        return proxy_helpers::proxy_fetch_streaming_uncached(
+            proxy,
+            repo.id,
+            repo_key,
+            upstream_url,
+            upstream_path,
+            DEBIAN_BINARY_CONTENT_TYPE,
+        )
+        .await;
+    }
+
+    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
+        proxy,
+        repo.id,
+        repo_key,
+        upstream_url,
+        upstream_path,
+        upstream_path,
+        expected_sha,
+    )
+    .await?;
+    proxy_helpers::stream_fetch_result(result, DEBIAN_BINARY_CONTENT_TYPE, Some(filename))
+}
 
 async fn pool_download(
     State(state): State<SharedState>,
@@ -1433,6 +2841,12 @@ async fn pool_download(
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
     let artifact_path = format!("pool/{}/{}", component, path);
+    // Axum captures only the first path segment as `component`. Debian-Security
+    // pool paths use a multi-segment component (`updates/main/...`), so re-parse
+    // the full pool path for filter checks.
+    let filter_component = component_from_pool_path(&artifact_path)
+        .unwrap_or(component.as_str())
+        .to_string();
 
     let artifact = sqlx::query!(
         r#"
@@ -1455,22 +2869,17 @@ async fn pool_download(
         Ok(a) => a,
         Err(not_found) => {
             if repo.repo_type == RepositoryType::Remote {
-                if let (Some(ref upstream_url), Some(ref proxy)) =
-                    (&repo.upstream_url, &state.proxy_service)
-                {
+                if let Some(ref upstream_url) = repo.upstream_url {
                     let upstream_path = format!("pool/{}/{}", component, path);
-                    // #895: stream .deb bodies. Default Content-Type
-                    // matches the IANA registration for Debian packages
-                    // (apt clients don't care; the registration just
-                    // gives downstream proxies a meaningful Content-Type
-                    // when upstream omits it).
-                    return proxy_helpers::proxy_fetch_streaming(
-                        proxy,
-                        repo.id,
+                    let filename = path.rsplit('/').next().unwrap_or(&path);
+                    return proxy_remote_debian_package(
+                        &state,
+                        &repo,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
-                        DEBIAN_BINARY_CONTENT_TYPE,
+                        &filter_component,
+                        filename,
                     )
                     .await;
                 }
@@ -1549,8 +2958,100 @@ async fn pool_download(
         .unwrap())
 }
 
+/// GET /debian/{repo_key}/*artifact_path — flat-repository package download.
+async fn flat_or_root_package_download(
+    State(state): State<SharedState>,
+    Path((repo_key, artifact_path)): Path<(String, String)>,
+) -> Result<Response, Response> {
+    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+    let config = load_debian_repository_config(&state.db, repo.id).await;
+    if !config.as_ref().map(|c| c.flat_repository).unwrap_or(false) {
+        return Err((StatusCode::NOT_FOUND, "Not found").into_response());
+    }
+    if !is_flat_repository_package_path(&artifact_path) {
+        return Err((StatusCode::NOT_FOUND, "Not found").into_response());
+    }
+    validate_debian_fetch_path(&artifact_path).map_err(map_debian_fetch_path_error)?;
+
+    let filename = artifact_path
+        .rsplit('/')
+        .next()
+        .unwrap_or(artifact_path.as_str());
+
+    let artifact = sqlx::query!(
+        r#"
+        SELECT id, storage_key, size_bytes, checksum_sha256
+        FROM artifacts
+        WHERE repository_id = $1
+          AND is_deleted = false
+          AND path = $2
+        LIMIT 1
+        "#,
+        repo.id,
+        artifact_path
+    )
+    .fetch_optional(&state.db)
+    .await
+    .map_err(crate::api::handlers::db_err)?;
+
+    if let Some(artifact) = artifact {
+        let storage = state
+            .storage_for_repo(&repo.storage_location())
+            .map_err(|e| e.into_response())?;
+        crate::services::quarantine_service::check_artifact_download(&state.db, artifact.id)
+            .await
+            .map_err(|e| e.into_response())?;
+        let stream = storage
+            .get_stream(&artifact.storage_key)
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Storage error: {}", e),
+                )
+                    .into_response()
+            })?;
+        let _ = sqlx::query!(
+            "INSERT INTO download_statistics (artifact_id, ip_address) VALUES ($1, '0.0.0.0')",
+            artifact.id
+        )
+        .execute(&state.db)
+        .await;
+        return Ok(Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, DEBIAN_BINARY_CONTENT_TYPE)
+            .header(
+                "Content-Disposition",
+                format!("attachment; filename=\"{}\"", filename),
+            )
+            .header(CONTENT_LENGTH, artifact.size_bytes.to_string())
+            .header("X-Checksum-SHA256", &artifact.checksum_sha256)
+            .body(Body::from_stream(stream))
+            .unwrap());
+    }
+
+    if repo.repo_type == RepositoryType::Remote {
+        if let Some(ref upstream_url) = repo.upstream_url {
+            // Flat repos have empty component filters; pass "" so any component passes.
+            return proxy_remote_debian_package(
+                &state,
+                &repo,
+                &repo_key,
+                upstream_url,
+                &artifact_path,
+                "",
+                filename,
+            )
+            .await;
+        }
+    }
+
+    Err((StatusCode::NOT_FOUND, "Package not found").into_response())
+}
+
 struct DebianPackageUpload {
     artifact_path: String,
+    distribution: Option<String>,
     component: String,
     deb_info: DebInfo,
     control: DebControl,
@@ -1562,6 +3063,8 @@ fn prepare_debian_upload(
     component: &str,
     path: &str,
     body: &[u8],
+    distribution: Option<String>,
+    expected_architecture: Option<&str>,
 ) -> Result<DebianPackageUpload, Response> {
     let filename = path.rsplit('/').next().unwrap_or(path);
     let deb_info = parse_deb_filename(filename).ok_or_else(|| {
@@ -1579,9 +3082,11 @@ fn prepare_debian_upload(
             .into_response()
     })?;
     validate_debian_control_matches_filename(&deb_info, &control)?;
+    validate_debian_expected_architecture(expected_architecture, &control)?;
 
     let artifact_path = format!("pool/{}/{}", component, path);
     let metadata = build_debian_artifact_metadata(
+        distribution.as_deref(),
         component,
         &artifact_path,
         filename,
@@ -1591,11 +3096,33 @@ fn prepare_debian_upload(
 
     Ok(DebianPackageUpload {
         artifact_path,
+        distribution,
         component: component.to_string(),
         deb_info,
         control,
         metadata,
     })
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_debian_expected_architecture(
+    expected_architecture: Option<&str>,
+    control: &DebControl,
+) -> Result<(), Response> {
+    let Some(expected_architecture) = expected_architecture else {
+        return Ok(());
+    };
+    if expected_architecture != control.architecture {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Architecture mismatch: upload metadata says '{}' but control says '{}'",
+                expected_architecture, control.architecture
+            ),
+        )
+            .into_response());
+    }
+    Ok(())
 }
 
 #[allow(clippy::result_large_err)]
@@ -1637,18 +3164,29 @@ fn validate_debian_control_matches_filename(
 }
 
 fn build_debian_artifact_metadata(
+    distribution: Option<&str>,
     component: &str,
     artifact_path: &str,
     filename: &str,
     package_type: &str,
     control: &DebControl,
 ) -> serde_json::Value {
+    let is_installer = component == "debian-installer"
+        || artifact_path.contains("/debian-installer/")
+        || component.contains("debian-installer");
+    let package_type = if is_installer { "udeb" } else { package_type };
+    let section = if is_installer {
+        Some("debian-installer".to_string())
+    } else {
+        control.section.clone()
+    };
     serde_json::json!({
         "format": "debian",
         "package": &control.package,
         "name": &control.package,
         "version": &control.version,
         "architecture": &control.architecture,
+        "distribution": distribution,
         "component": component,
         "filename": filename,
         "path": artifact_path,
@@ -1663,7 +3201,7 @@ fn build_debian_artifact_metadata(
         "conflicts": &control.conflicts,
         "provides": &control.provides,
         "replaces": &control.replaces,
-        "section": &control.section,
+        "section": section,
         "priority": &control.priority,
         "homepage": &control.homepage,
         "source": &control.source,
@@ -1672,17 +3210,112 @@ fn build_debian_artifact_metadata(
 }
 
 fn build_debian_package_catalog_metadata(upload: &DebianPackageUpload) -> serde_json::Value {
+    let is_installer = upload.component == "debian-installer"
+        || upload.artifact_path.contains("/debian-installer/")
+        || upload.component.contains("debian-installer");
+    let package_type = if is_installer {
+        "udeb"
+    } else {
+        upload.deb_info.package_type.as_str()
+    };
+    let section = if is_installer {
+        Some("debian-installer")
+    } else {
+        upload.control.section.as_deref()
+    };
     serde_json::json!({
         "format": "debian",
         "architecture": &upload.control.architecture,
+        "distribution": &upload.distribution,
         "component": &upload.component,
-        "package_type": &upload.deb_info.package_type,
-        "section": &upload.control.section,
+        "package_type": package_type,
+        "section": section,
         "priority": &upload.control.priority,
         "maintainer": &upload.control.maintainer,
         "homepage": &upload.control.homepage,
         "source": &upload.control.source,
     })
+}
+
+#[allow(clippy::result_large_err)]
+fn debian_upload_header(headers: &HeaderMap, names: &[&str]) -> Result<Option<String>, Response> {
+    for name in names {
+        let Some(value) = headers.get(*name) else {
+            continue;
+        };
+        let value = value.to_str().map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid Debian upload metadata header {name}"),
+            )
+                .into_response()
+        })?;
+        let value = value.trim();
+        if value.is_empty() {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("Debian upload metadata header {name} must not be empty"),
+            )
+                .into_response());
+        }
+        if value.len() > 128
+            || !value
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.' | '+'))
+        {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!("Debian upload metadata header {name} contains an invalid identifier"),
+            )
+                .into_response());
+        }
+        return Ok(Some(value.to_string()));
+    }
+    Ok(None)
+}
+
+#[allow(clippy::result_large_err)]
+fn debian_upload_distribution(headers: &HeaderMap) -> Result<Option<String>, Response> {
+    debian_upload_header(
+        headers,
+        &[
+            "X-Debian-Distribution",
+            "X-Debian-Codename",
+            "X-Debian-Suite",
+            "X-Distribution",
+        ],
+    )
+}
+
+#[allow(clippy::result_large_err)]
+fn debian_upload_component(headers: &HeaderMap) -> Result<Option<String>, Response> {
+    debian_upload_header(headers, &["X-Debian-Component", "X-Component"])
+}
+
+#[allow(clippy::result_large_err)]
+fn debian_upload_architecture(headers: &HeaderMap) -> Result<Option<String>, Response> {
+    debian_upload_header(headers, &["X-Debian-Architecture", "X-Architecture"])
+}
+
+#[allow(clippy::result_large_err)]
+fn validate_debian_component_header(
+    route_component: &str,
+    header_component: Option<&str>,
+) -> Result<(), Response> {
+    let Some(header_component) = header_component else {
+        return Ok(());
+    };
+    if route_component != header_component {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Component mismatch: path says '{}' but upload metadata says '{}'",
+                route_component, header_component
+            ),
+        )
+            .into_response());
+    }
+    Ok(())
 }
 
 fn package_description(control: &DebControl) -> Option<&str> {
@@ -1786,7 +3419,17 @@ async fn pool_upload(
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
 
-    let upload = prepare_debian_upload(&component, &path, &body)?;
+    let distribution = debian_upload_distribution(&headers)?;
+    let header_component = debian_upload_component(&headers)?;
+    validate_debian_component_header(&component, header_component.as_deref())?;
+    let expected_architecture = debian_upload_architecture(&headers)?;
+    let upload = prepare_debian_upload(
+        &component,
+        &path,
+        &body,
+        distribution,
+        expected_architecture.as_deref(),
+    )?;
     persist_debian_upload(
         &state,
         &repo,
@@ -1860,13 +3503,22 @@ async fn upload_raw(
             .into_response()
     })?;
 
-    let component = "main";
-    let artifact_path = DebianHandler::get_pool_path(component, &deb_info.name, &filename);
+    let component = debian_upload_component(&headers)?.unwrap_or_else(|| "main".to_string());
+    let distribution = debian_upload_distribution(&headers)?;
+    let expected_architecture = debian_upload_architecture(&headers)?;
+    let artifact_path = DebianHandler::get_pool_path(&component, &deb_info.name, &filename);
+    let pool_prefix = format!("pool/{}/", component);
     let path = artifact_path
-        .strip_prefix("pool/main/")
+        .strip_prefix(pool_prefix.as_str())
         .unwrap_or(&artifact_path)
         .to_string();
-    let upload = prepare_debian_upload(component, &path, &body)?;
+    let upload = prepare_debian_upload(
+        &component,
+        &path,
+        &body,
+        distribution,
+        expected_architecture.as_deref(),
+    )?;
     let artifact = persist_debian_upload(
         &state,
         &repo,
@@ -1891,6 +3543,8 @@ async fn upload_raw(
                 "package": &upload.control.package,
                 "version": &upload.control.version,
                 "architecture": &upload.control.architecture,
+                "distribution": &upload.distribution,
+                "component": &upload.component,
                 "path": &upload.artifact_path,
                 "sha256": &artifact.checksum_sha256,
                 "size": artifact.size_bytes,
@@ -1900,9 +3554,1056 @@ async fn upload_raw(
         .unwrap())
 }
 
+/// Response body for `POST /debian/{repo_key}/sync`.
+#[derive(serde::Serialize, ToSchema)]
+#[schema(example = json!({
+    "repository": "ubuntu-security-smoke",
+    "plans": [{
+        "distribution": "noble-security",
+        "release_paths": ["dists/noble-security/Release"],
+        "package_indexes": [{"component": "main", "architecture": "amd64", "path": "main/binary-amd64/Packages.xz"}],
+        "source_indexes": [],
+        "package_files": [{"index_path": "main/binary-amd64/Packages.xz", "filename": "pool/main/c/curl/curl_1_amd64.deb", "package": "curl", "version": "1", "architecture": "amd64", "download": false}],
+        "source_files": [],
+        "missing_package_indexes": [],
+        "missing_source_indexes": []
+    }],
+    "prefetched_packages": 0,
+    "prefetched_sources": 0
+}))]
+pub struct DebianSyncResponse {
+    pub repository: String,
+    pub plans: Vec<DebianSyncPlan>,
+    pub prefetched_packages: usize,
+    pub prefetched_sources: usize,
+}
+
+fn debian_sync_parse_error(context: &str, error: impl std::fmt::Display) -> Response {
+    (
+        StatusCode::BAD_GATEWAY,
+        format!("Failed to parse upstream Debian {context}: {error}"),
+    )
+        .into_response()
+}
+
+/// Decompress + parse a Packages index off the async runtime.
+/// Indexes can inflate up to `MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES` and must not
+/// block the Tokio executor (CONTRIBUTING spawn_blocking guidance).
+async fn parse_packages_index_blocking(
+    path: String,
+    content: Bytes,
+) -> Result<Vec<PackagesEntry>, crate::error::AppError> {
+    tokio::task::spawn_blocking(move || parse_packages_index(&path, &content))
+        .await
+        .map_err(|e| {
+            crate::error::AppError::Internal(format!("Packages index parse task failed: {e}"))
+        })?
+}
+
+async fn parse_sources_index_blocking(
+    path: String,
+    content: Bytes,
+) -> Result<Vec<SourcesEntry>, crate::error::AppError> {
+    tokio::task::spawn_blocking(move || parse_sources_index(&path, &content))
+        .await
+        .map_err(|e| {
+            crate::error::AppError::Internal(format!("Sources index parse task failed: {e}"))
+        })?
+}
+
+async fn drain_prefetched_package(response: Response) -> Result<(), Response> {
+    let mut stream = response.into_body().into_data_stream();
+    while let Some(chunk) = stream.next().await {
+        chunk.map_err(|error| {
+            (
+                StatusCode::BAD_GATEWAY,
+                format!("Failed while prefetching Debian package: {error}"),
+            )
+                .into_response()
+        })?;
+    }
+    Ok(())
+}
+
+fn debian_sync_verification_error(label: &str, error: impl std::fmt::Display) -> Response {
+    (
+        StatusCode::BAD_GATEWAY,
+        format!("Failed to verify upstream Debian {label}: {error}"),
+    )
+        .into_response()
+}
+
+/// True when sync would re-sign locally generated metadata without having
+/// cryptographically verified the upstream Release first.
+///
+/// Extracted so the fail-closed policy is unit-testable without exercising the
+/// full async sync path.
+fn debian_sync_must_refuse_unverified_signing(
+    signing_enabled: bool,
+    verify_upstream_metadata: bool,
+) -> bool {
+    signing_enabled && !verify_upstream_metadata
+}
+
+async fn verify_upstream_release_metadata(
+    state: &SharedState,
+    config: &DebianRepositoryConfig,
+    release_text: &str,
+    release_bytes: &[u8],
+    in_release_bytes: Option<&[u8]>,
+    release_gpg_bytes: Option<&[u8]>,
+) -> Result<String, Response> {
+    let key_ref = config
+        .upstream_gpg_key_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "verify_upstream_metadata=true requires upstream_gpg_key_id.",
+            )
+                .into_response()
+        })?;
+
+    let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
+    let public_key = signing_svc
+        .get_public_key_by_reference(key_ref)
+        .await
+        .map_err(|error| debian_sync_verification_error("public key lookup", error))?
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("upstream_gpg_key_id={key_ref} did not match a stored active public key."),
+            )
+                .into_response()
+        })?;
+
+    if let Some(in_release_bytes) = in_release_bytes {
+        let in_release_text = std::str::from_utf8(in_release_bytes)
+            .map_err(|error| debian_sync_parse_error("InRelease", error))?;
+        return signing_svc
+            .verify_openpgp_cleartext_with_public_key(&public_key, in_release_text)
+            .await
+            .map_err(|error| debian_sync_verification_error("InRelease", error));
+    }
+
+    if let Some(release_gpg_bytes) = release_gpg_bytes {
+        signing_svc
+            .verify_openpgp_detached_with_public_key(&public_key, release_bytes, release_gpg_bytes)
+            .await
+            .map_err(|error| debian_sync_verification_error("Release.gpg", error))?;
+        return Ok(release_text.to_string());
+    }
+
+    Err((
+        StatusCode::BAD_GATEWAY,
+        "verify_upstream_metadata=true but upstream did not provide InRelease or Release.gpg.",
+    )
+        .into_response())
+}
+
+/// Explicitly synchronize a configured remote Debian repository.
+///
+/// Loads upstream Release metadata, builds a filtered sync plan from the
+/// repository's Debian configuration, optionally prefetches selected packages,
+/// and atomically publishes generated Packages/Release metadata.
+#[utoipa::path(
+    post,
+    path = "/{repo_key}/sync",
+    context_path = "/debian",
+    tag = "debian",
+    operation_id = "debian_sync_remote_repository",
+    params(
+        ("repo_key" = String, Path, description = "Debian repository key"),
+    ),
+    responses(
+        (status = 200, description = "Filtered sync completed", body = DebianSyncResponse),
+        (status = 400, description = "Not a remote repository, missing Debian config/upstream, or signing policy violation"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Authenticated but missing debian write scope"),
+        (status = 404, description = "Repository not found"),
+        (status = 500, description = "Failed to generate Debian metadata"),
+        (status = 502, description = "Upstream fetch, parse, or verification failure"),
+        (status = 503, description = "Proxy service unavailable or not configured"),
+    ),
+    security(
+        ("bearer_auth" = []),
+        ("basic_auth" = []),
+    )
+)]
+async fn sync_remote_repository(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(repo_key): Path<String>,
+) -> Result<Json<DebianSyncResponse>, Response> {
+    require_auth_basic_scope(auth, "debian", "write")?;
+    let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+    if repo.repo_type != RepositoryType::Remote {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Debian metadata refresh requires a Remote repository",
+        )
+            .into_response());
+    }
+    let config = load_debian_repository_config(&state.db, repo.id)
+        .await
+        .ok_or_else(|| {
+            (
+                StatusCode::BAD_REQUEST,
+                "Debian repository has no advanced configuration",
+            )
+                .into_response()
+        })?;
+    let upstream_url = repo.upstream_url.as_deref().ok_or_else(|| {
+        (
+            StatusCode::BAD_REQUEST,
+            "Debian metadata refresh requires repository upstream_url",
+        )
+            .into_response()
+    })?;
+    let proxy = state.proxy_service.as_deref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Proxy service is not configured",
+        )
+            .into_response()
+    })?;
+
+    // Defense in depth (validation also enforces this at save time): refuse to
+    // generate/sign a local Release from upstream metadata that was not
+    // cryptographically verified, so unsafe content cannot be re-signed with
+    // Artifact Keeper's trusted key.
+    if debian_sync_must_refuse_unverified_signing(
+        config.signing_enabled(),
+        config.verify_upstream_metadata,
+    ) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Refusing to sign Debian metadata from an unverified upstream: set verify_upstream_metadata=true.",
+        )
+            .into_response());
+    }
+
+    let distributions = config.effective_distribution_paths();
+    if distributions.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            "Debian metadata refresh requires at least one distribution path",
+        )
+            .into_response());
+    }
+    let filter = DebianSyncFilter {
+        distributions: if config.flat_repository {
+            Vec::new()
+        } else {
+            distributions.clone()
+        },
+        components: config.effective_components(),
+        architectures: config.effective_architectures(),
+        include_source_packages: config.include_source_packages,
+        package_queries: config.effective_package_queries(),
+        resolve_dependencies: config.resolve_dependencies,
+    };
+    let download_policy = if config.package_fetch_strategy
+        == crate::api::handlers::repositories::DebianPackageFetchStrategy::PrefetchSelected
+    {
+        DebianSyncDownloadPolicy::Immediate
+    } else {
+        DebianSyncDownloadPolicy::OnDemand
+    };
+    let mut plans = Vec::new();
+    let mut prefetched = BTreeSet::new();
+    let mut prefetched_sources = BTreeSet::new();
+
+    for distribution in &distributions {
+        let normalized_distribution = distribution.trim_matches('/');
+        let release_path = if config.flat_repository || normalized_distribution.is_empty() {
+            "Release".to_string()
+        } else {
+            format!("dists/{normalized_distribution}/Release")
+        };
+        let (release_bytes, _) = proxy_helpers::proxy_fetch_capped(
+            proxy,
+            repo.id,
+            &repo_key,
+            upstream_url,
+            &release_path,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        )
+        .await?;
+        let release_text_from_release = std::str::from_utf8(&release_bytes)
+            .map_err(|error| debian_sync_parse_error("Release", error))?;
+
+        let mut in_release_bytes = None;
+        let mut release_gpg_bytes = None;
+        for signed_suffix in ["InRelease", "Release.gpg"] {
+            let signed_path = if config.flat_repository || normalized_distribution.is_empty() {
+                signed_suffix.to_string()
+            } else {
+                format!("dists/{normalized_distribution}/{signed_suffix}")
+            };
+            match proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &signed_path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await
+            {
+                Ok((content, _)) if signed_suffix == "InRelease" => {
+                    in_release_bytes = Some(content);
+                }
+                Ok((content, _)) => {
+                    release_gpg_bytes = Some(content);
+                }
+                Err(response) if response.status() == StatusCode::NOT_FOUND => {}
+                Err(response) => return Err(response),
+            }
+        }
+
+        let verified_release_text = if config.verify_upstream_metadata {
+            verify_upstream_release_metadata(
+                &state,
+                &config,
+                release_text_from_release,
+                &release_bytes,
+                in_release_bytes.as_deref(),
+                release_gpg_bytes.as_deref(),
+            )
+            .await?
+        } else {
+            release_text_from_release.to_string()
+        };
+        let release = parse_release(&verified_release_text)
+            .map_err(|error| debian_sync_parse_error("Release", error))?;
+        if release_is_expired(&release, chrono::Utc::now()) {
+            let valid_until = release.valid_until.as_deref().unwrap_or("unknown");
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                format!(
+                    "Refusing to sync: upstream Release has expired (Valid-Until: {valid_until})"
+                ),
+            )
+                .into_response());
+        }
+        validate_release_filter_selection(&release, &filter)
+            .map_err(|error| (StatusCode::BAD_REQUEST, error.to_string()).into_response())?;
+
+        let indexes = filter_release_package_indexes(&release, &filter);
+        let mut packages_by_index_path = BTreeMap::new();
+        for index in &indexes {
+            let upstream_path = if config.flat_repository || normalized_distribution.is_empty() {
+                index.path.clone()
+            } else {
+                format!("dists/{normalized_distribution}/{}", index.path)
+            };
+            match proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &upstream_path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await
+            {
+                Ok((content, _)) => {
+                    verify_index_against_release(
+                        &release,
+                        &index.path,
+                        &content,
+                        config.verify_upstream_metadata,
+                    )
+                    .map_err(|error| debian_sync_verification_error("Packages index", error))?;
+                    let packages = parse_packages_index_blocking(index.path.clone(), content)
+                        .await
+                        .map_err(|error| debian_sync_parse_error("Packages index", error))?;
+                    packages_by_index_path.insert(index.path.clone(), packages);
+                }
+                Err(response)
+                    if response.status() == StatusCode::NOT_FOUND
+                        && config.ignore_missing_indexes =>
+                {
+                    tracing::warn!(repo_key = %repo_key, path = %upstream_path, "selected Debian index missing upstream; continuing because ignore_missing_indexes=true");
+                }
+                Err(response) => return Err(response),
+            }
+        }
+
+        let source_indexes = filter_release_source_indexes(&release, &filter);
+        let mut sources_by_index_path = BTreeMap::new();
+        for index in &source_indexes {
+            let upstream_path = if config.flat_repository || normalized_distribution.is_empty() {
+                index.path.clone()
+            } else {
+                format!("dists/{normalized_distribution}/{}", index.path)
+            };
+            match proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &upstream_path,
+                proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            )
+            .await
+            {
+                Ok((content, _)) => {
+                    verify_index_against_release(
+                        &release,
+                        &index.path,
+                        &content,
+                        config.verify_upstream_metadata,
+                    )
+                    .map_err(|error| debian_sync_verification_error("Sources index", error))?;
+                    let sources = parse_sources_index_blocking(index.path.clone(), content)
+                        .await
+                        .map_err(|error| debian_sync_parse_error("Sources index", error))?;
+                    sources_by_index_path.insert(index.path.clone(), sources);
+                }
+                Err(response)
+                    if response.status() == StatusCode::NOT_FOUND
+                        && config.ignore_missing_indexes =>
+                {
+                    tracing::warn!(repo_key = %repo_key, path = %upstream_path, "selected Debian source index missing upstream; continuing because ignore_missing_indexes=true");
+                }
+                Err(response) => return Err(response),
+            }
+        }
+
+        let plan = build_debian_sync_plan(
+            normalized_distribution,
+            &release,
+            &filter,
+            &packages_by_index_path,
+            &sources_by_index_path,
+            download_policy,
+        );
+
+        let total_selected = plan.package_files.len() + plan.source_files.len();
+        if total_selected > MAX_DEBIAN_SYNC_SELECTED_FILES {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "Sync plan exceeds maximum allowed file count: {total_selected} > {MAX_DEBIAN_SYNC_SELECTED_FILES}. Narrow the filters (components, architectures, package_queries) or use a smaller distribution."
+                ),
+            )
+                .into_response());
+        }
+
+        // Defense in depth: every selected index path must satisfy the same
+        // component/arch/source/Contents/i18n/DEP-11 filter used for pool downloads.
+        for index in plan
+            .package_indexes
+            .iter()
+            .map(|index| index.path.as_str())
+            .chain(plan.source_indexes.iter().map(|index| index.path.as_str()))
+        {
+            if !release_path_allowed_by_filter(index, &filter) {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("Sync plan selected index path outside configured filters: {index}"),
+                )
+                    .into_response());
+            }
+        }
+
+        if config.generated_metadata_enabled() {
+            let generated = build_synced_generated_metadata(
+                &plan,
+                &packages_by_index_path,
+                &sources_by_index_path,
+                &filter.architectures,
+            )
+            .map_err(|error| {
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to generate Debian metadata: {}", error),
+                )
+                    .into_response()
+            })?;
+
+            let components: BTreeSet<String> = plan
+                .package_indexes
+                .iter()
+                .map(|index| index.component.clone())
+                .chain(
+                    plan.source_indexes
+                        .iter()
+                        .map(|index| index.component.clone()),
+                )
+                .collect();
+            let architectures: BTreeSet<String> = plan
+                .package_indexes
+                .iter()
+                .map(|index| index.architecture.clone())
+                .collect();
+            let filtered_release = build_release_content_from_files(
+                &release.suite,
+                release.codename.as_deref(),
+                release.description.as_deref(),
+                &components,
+                &architectures,
+                generated.release_files,
+            );
+
+            // Publish the generated indexes and their matching Release as one
+            // atomic generation. Without a transaction, the old rows are deleted
+            // and the new ones inserted individually, so a concurrent apt client
+            // could observe a new Release alongside stale/partial Packages (or
+            // vice versa) and fail with a hash mismatch. Committing all rows
+            // together means readers only ever see the previous complete
+            // generation or the new complete one.
+            let mut tx = state
+                .db
+                .begin()
+                .await
+                .map_err(crate::api::handlers::db_err)?;
+            clear_synced_dists_content(&mut tx, repo.id, normalized_distribution).await?;
+            for (path, content) in &generated.plain_indexes {
+                store_synced_dists_content(
+                    &mut tx,
+                    repo.id,
+                    normalized_distribution,
+                    path,
+                    content,
+                )
+                .await?;
+            }
+            store_synced_release_content(
+                &mut tx,
+                repo.id,
+                normalized_distribution,
+                &filtered_release,
+            )
+            .await?;
+            tx.commit().await.map_err(crate::api::handlers::db_err)?;
+        }
+
+        let package_digests = package_sha256_by_filename(&packages_by_index_path);
+        let source_digests = source_sha256_by_filename(&sources_by_index_path);
+
+        for package in plan.package_files.iter().filter(|package| package.download) {
+            if !prefetched.insert(package.filename.clone()) {
+                continue;
+            }
+            validate_debian_fetch_path(&package.filename)
+                .map_err(|error| debian_sync_verification_error("package path", error))?;
+            let expected = expected_prefetch_digest(
+                &package_digests,
+                &package.filename,
+                config.verify_upstream_metadata,
+            )
+            .map_err(|error| debian_sync_verification_error("package", error))?;
+            let result = proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &package.filename,
+                &package.filename,
+                expected,
+            )
+            .await?;
+            let response =
+                proxy_helpers::stream_fetch_result(result, DEBIAN_BINARY_CONTENT_TYPE, None)?;
+            drain_prefetched_package(response).await?;
+        }
+        for source in plan.source_files.iter().filter(|source| source.download) {
+            if !prefetched_sources.insert(source.filename.clone()) {
+                continue;
+            }
+            validate_debian_fetch_path(&source.filename)
+                .map_err(|error| debian_sync_verification_error("source path", error))?;
+            let expected = expected_prefetch_digest(
+                &source_digests,
+                &source.filename,
+                config.verify_upstream_metadata,
+            )
+            .map_err(|error| debian_sync_verification_error("source file", error))?;
+            let result = proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &source.filename,
+                &source.filename,
+                expected,
+            )
+            .await?;
+            let response =
+                proxy_helpers::stream_fetch_result(result, "application/octet-stream", None)?;
+            drain_prefetched_package(response).await?;
+        }
+        plans.push(plan);
+    }
+
+    Ok(Json(DebianSyncResponse {
+        repository: repo_key,
+        plans,
+        prefetched_packages: prefetched.len(),
+        prefetched_sources: prefetched_sources.len(),
+    }))
+}
+
+/// OpenAPI contribution for Debian format management endpoints.
+#[derive(OpenApi)]
+#[openapi(
+    paths(sync_remote_repository),
+    components(schemas(
+        DebianSyncResponse,
+        DebianSyncPlan,
+        DebianIndexPath,
+        DebianSourceIndexPath,
+        DebianSyncPackageFile,
+        DebianSyncSourceFile,
+    )),
+    tags(
+        (
+            name = "debian",
+            description = "Debian/APT format endpoints. Remote sync is a management trigger mounted under `/debian/{repo_key}`."
+        )
+    )
+)]
+pub struct DebianApiDoc;
+
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn test_pool_download_passthrough_package_strategy_uses_uncached_proxy() {
+        let src = include_str!("debian.rs");
+        let fn_start = src
+            .find("async fn proxy_remote_debian_package(")
+            .expect("proxy_remote_debian_package must exist");
+        let remote_branch_end = src[fn_start..]
+            .find("async fn pool_download(")
+            .expect("pool_download must follow proxy helper");
+        let remote_branch = &src[fn_start..fn_start + remote_branch_end];
+
+        assert!(remote_branch.contains("DebianPackageFetchStrategy::Passthrough"));
+        assert!(
+            remote_branch.contains("proxy_fetch_streaming_uncached("),
+            "passthrough strategy must use uncached streaming"
+        );
+        // Passthrough must NOT use the cache-key-verified helper (Fix 2: passthrough must not cache).
+        // The cache-key-verified helper IS still used by the non-passthrough branch.
+        assert!(
+            remote_branch.contains("proxy_fetch_streaming_with_cache_key_verified("),
+            "non-passthrough branch must still use digest-gated caching"
+        );
+        // When passthrough is active the uncached path must NOT be guarded by an
+        // `if let Some(sha256)` branch that would fall through to caching.
+        {
+            let passthrough_block_start = remote_branch
+                .find("if passthrough {")
+                .expect("passthrough branch must exist");
+            let passthrough_block = &remote_branch[passthrough_block_start..];
+            // The first call inside the passthrough branch must be uncached.
+            let first_uncached = passthrough_block.find("proxy_fetch_streaming_uncached(");
+            let first_cached =
+                passthrough_block.find("proxy_fetch_streaming_with_cache_key_verified(");
+            match (first_uncached, first_cached) {
+                (Some(u), Some(c)) => assert!(
+                    u < c,
+                    "inside the passthrough branch, uncached must come before any cached call"
+                ),
+                (Some(_), None) => {} // passthrough block only contains uncached — correct
+                (None, _) => {
+                    panic!("passthrough branch must contain proxy_fetch_streaming_uncached")
+                }
+            }
+        }
+        assert!(remote_branch.contains("pool_path_allowed_by_filters("));
+        assert!(remote_branch.contains("validate_debian_fetch_path("));
+        assert!(
+            remote_branch.contains("local_generation")
+                && remote_branch.contains("filter.package_queries.clear()"),
+            "published generations must not reject dependency packages via raw package_queries"
+        );
+        assert!(
+            remote_branch.contains("Package is not part of the published Debian mirror generation"),
+            "packages absent from the published generation must 404"
+        );
+    }
+
+    #[test]
+    fn test_pool_download_wires_filter_and_ssrf_helpers() {
+        let src = include_str!("debian.rs");
+        let fn_start = src
+            .find("async fn pool_download(")
+            .expect("pool_download must exist");
+        let window = &src[fn_start..fn_start + 2500];
+        assert!(window.contains("proxy_remote_debian_package("));
+    }
+
+    #[test]
+    fn test_flat_package_route_registered() {
+        let src = include_str!("debian.rs");
+        let router = src
+            .find("pub fn router() -> Router<SharedState>")
+            .expect("router must exist");
+        let body = &src[router..router + 3500];
+        assert!(body.contains("/:repo_key/*artifact_path"));
+        assert!(body.contains("flat_or_root_package_download"));
+        let pool_pos = body
+            .find("/:repo_key/pool/:component/*path")
+            .expect("pool route");
+        let flat_pos = body.find("/:repo_key/*artifact_path").expect("flat route");
+        assert!(
+            pool_pos < flat_pos,
+            "pool route must be registered before flat catch-all"
+        );
+    }
+
+    #[test]
+    fn test_local_release_content_has_clippy_allow() {
+        let src = include_str!("debian.rs");
+        let pos = src
+            .find("async fn local_release_content(")
+            .expect("local_release_content must exist");
+        let ahead = &src[pos.saturating_sub(120)..pos];
+        assert!(
+            ahead.contains("#[allow(clippy::result_large_err)]"),
+            "local_release_content must allow clippy::result_large_err"
+        );
+    }
+
+    #[test]
+    fn test_sha256_for_filename_in_packages_text() {
+        let text = "\
+Package: nginx
+Version: 1.0
+Architecture: amd64
+Filename: pool/main/n/nginx/nginx_1.0_amd64.deb
+SHA256: AbCdEf1234567890
+
+Package: curl
+Version: 2.0
+Architecture: amd64
+Filename: pool/main/c/curl/curl_2.0_amd64.deb
+SHA256: deadbeef
+";
+        assert_eq!(
+            sha256_for_filename_in_packages_text(text, "pool/main/n/nginx/nginx_1.0_amd64.deb")
+                .as_deref(),
+            Some("abcdef1234567890")
+        );
+        assert_eq!(
+            sha256_for_filename_in_packages_text(text, "nginx_1.0_amd64.deb").as_deref(),
+            Some("abcdef1234567890")
+        );
+        assert_eq!(
+            sha256_for_filename_in_packages_text(text, "pool/main/missing.deb"),
+            None
+        );
+    }
     use super::*;
+
+    fn release_with_index(index_path: &str, content: &[u8]) -> crate::formats::debian::Release {
+        let text = format!(
+            "Suite: jammy\nCodename: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n {} {} {}\n",
+            calculate_sha256_hex(content),
+            content.len(),
+            index_path,
+        );
+        parse_release(&text).expect("release parses")
+    }
+
+    #[test]
+    fn test_verify_index_against_release_accepts_matching_bytes() {
+        let content = b"Package: nginx\n";
+        let release = release_with_index("main/binary-amd64/Packages", content);
+        assert!(verify_index_against_release(
+            &release,
+            "main/binary-amd64/Packages",
+            content,
+            true
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_verify_index_against_release_rejects_size_mismatch() {
+        let content = b"Package: nginx\n";
+        let release = release_with_index("main/binary-amd64/Packages", content);
+        let tampered = b"Package: nginx\nextra";
+        let err =
+            verify_index_against_release(&release, "main/binary-amd64/Packages", tampered, true)
+                .unwrap_err();
+        assert!(err.contains("size"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_verify_index_against_release_rejects_hash_mismatch() {
+        let content = b"Package: nginx\n";
+        let release = release_with_index("main/binary-amd64/Packages", content);
+        // Same length, different bytes -> size matches but checksum does not.
+        let tampered = b"Package: redis\n";
+        assert_eq!(content.len(), tampered.len());
+        let err =
+            verify_index_against_release(&release, "main/binary-amd64/Packages", tampered, true)
+                .unwrap_err();
+        assert!(err.contains("checksum"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn test_verify_index_against_release_missing_entry_fails_closed_when_required() {
+        let content = b"Package: nginx\n";
+        let release = release_with_index("main/binary-amd64/Packages", content);
+        // A path with no Release entry is rejected only when verification is required.
+        assert!(verify_index_against_release(
+            &release,
+            "main/binary-arm64/Packages",
+            content,
+            true
+        )
+        .is_err());
+        assert!(verify_index_against_release(
+            &release,
+            "main/binary-arm64/Packages",
+            content,
+            false
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_release_index_digest_prefers_sha512() {
+        let content = b"Packages body\n";
+        let text = format!(
+            "Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n deadbeef {} main/binary-amd64/Packages\nSHA512:\n {} {} main/binary-amd64/Packages\n",
+            content.len(),
+            calculate_sha512_hex(content),
+            content.len(),
+        );
+        let release = parse_release(&text).unwrap();
+        let (is_sha512, _, _) =
+            release_index_digest(&release, "main/binary-amd64/Packages").expect("digest present");
+        assert!(is_sha512, "must prefer the stronger SHA512 digest");
+        // And verification succeeds against the (correct) SHA512 even though the
+        // SHA256 entry is bogus.
+        assert!(verify_index_against_release(
+            &release,
+            "main/binary-amd64/Packages",
+            content,
+            true
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_package_and_source_digest_maps() {
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "main/binary-amd64/Packages".to_string(),
+            vec![PackagesEntry {
+                control: DebControl {
+                    package: "nginx".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "amd64".to_string(),
+                    ..DebControl::default()
+                },
+                filename: Some("pool/main/n/nginx/nginx_1.0_amd64.deb".to_string()),
+                size: Some(10),
+                md5sum: None,
+                sha1: None,
+                sha256: Some("ABCDEF".to_string()),
+            }],
+        );
+        let pkg_map = package_sha256_by_filename(&packages);
+        assert_eq!(
+            pkg_map.get("pool/main/n/nginx/nginx_1.0_amd64.deb"),
+            Some(&"abcdef".to_string()),
+            "digest must be normalized to lowercase and keyed by Filename"
+        );
+
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "main/source/Sources".to_string(),
+            vec![SourcesEntry {
+                package: "nginx".to_string(),
+                version: "1.0".to_string(),
+                directory: "pool/main/n/nginx".to_string(),
+                files: vec![SourceFileEntry {
+                    filename: "nginx_1.0.dsc".to_string(),
+                    size: 20,
+                    md5sum: None,
+                    sha1: None,
+                    sha256: Some("FEEDBEEF".to_string()),
+                    sha512: None,
+                }],
+                extra: BTreeMap::new(),
+            }],
+        );
+        let src_map = source_sha256_by_filename(&sources);
+        assert_eq!(
+            src_map.get("pool/main/n/nginx/nginx_1.0.dsc"),
+            Some(&"feedbeef".to_string()),
+            "source digest must be keyed by full directory/filename path"
+        );
+    }
+
+    #[test]
+    fn test_expected_prefetch_digest_semantics() {
+        let mut digests = BTreeMap::new();
+        digests.insert("pool/main/a.deb".to_string(), "abc123".to_string());
+
+        assert_eq!(
+            expected_prefetch_digest(&digests, "pool/main/a.deb", true).unwrap(),
+            Some("abc123".to_string())
+        );
+        // Missing digest is fatal only when verification is required.
+        assert!(expected_prefetch_digest(&digests, "pool/main/missing.deb", true).is_err());
+        assert_eq!(
+            expected_prefetch_digest(&digests, "pool/main/missing.deb", false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn test_debian_sync_must_refuse_unverified_signing() {
+        assert!(debian_sync_must_refuse_unverified_signing(true, false));
+        assert!(!debian_sync_must_refuse_unverified_signing(true, true));
+        assert!(!debian_sync_must_refuse_unverified_signing(false, false));
+        assert!(!debian_sync_must_refuse_unverified_signing(false, true));
+    }
+
+    #[test]
+    fn test_package_sha256_by_filename_skips_missing_digest() {
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "main/binary-amd64/Packages".to_string(),
+            vec![
+                PackagesEntry {
+                    control: DebControl {
+                        package: "nginx".to_string(),
+                        version: "1.0".to_string(),
+                        architecture: "amd64".to_string(),
+                        ..DebControl::default()
+                    },
+                    filename: Some("pool/main/n/nginx/nginx_1.0_amd64.deb".to_string()),
+                    size: Some(10),
+                    md5sum: None,
+                    sha1: None,
+                    sha256: Some("ABCDEF".to_string()),
+                },
+                PackagesEntry {
+                    control: DebControl {
+                        package: "curl".to_string(),
+                        version: "1.0".to_string(),
+                        architecture: "amd64".to_string(),
+                        ..DebControl::default()
+                    },
+                    filename: Some("pool/main/c/curl/curl_1.0_amd64.deb".to_string()),
+                    size: Some(10),
+                    md5sum: None,
+                    sha1: None,
+                    sha256: None,
+                },
+                PackagesEntry {
+                    control: DebControl {
+                        package: "vim".to_string(),
+                        version: "1.0".to_string(),
+                        architecture: "amd64".to_string(),
+                        ..DebControl::default()
+                    },
+                    filename: Some("  ".to_string()),
+                    size: Some(10),
+                    md5sum: None,
+                    sha1: None,
+                    sha256: Some("deadbeef".to_string()),
+                },
+            ],
+        );
+        let map = package_sha256_by_filename(&packages);
+        assert_eq!(map.len(), 1);
+        assert_eq!(
+            map.get("pool/main/n/nginx/nginx_1.0_amd64.deb")
+                .map(String::as_str),
+            Some("abcdef")
+        );
+    }
+
+    #[test]
+    fn test_sha256_for_filename_in_packages_text_empty_and_missing() {
+        assert_eq!(
+            sha256_for_filename_in_packages_text("Package: x\n", ""),
+            None
+        );
+        assert_eq!(
+            sha256_for_filename_in_packages_text("Package: x\n", "   "),
+            None
+        );
+        assert_eq!(
+            sha256_for_filename_in_packages_text(
+                "Package: nginx\nFilename: pool/main/n/nginx/nginx_1.0_amd64.deb\n\n",
+                "pool/main/n/nginx/nginx_1.0_amd64.deb"
+            ),
+            None,
+            "entry without SHA256 must not invent a digest"
+        );
+    }
+
+    #[test]
+    fn test_sync_verifies_indexes_and_gates_prefetch_and_publishes_atomically() {
+        // Structural guards so the security fixes cannot silently regress.
+        let src = include_str!("debian.rs");
+        let fn_start = src
+            .find("async fn sync_remote_repository(")
+            .expect("sync_remote_repository must exist");
+        let body = &src[fn_start..];
+        let end = body
+            .find("\n#[cfg(test)]")
+            .map(|idx| fn_start + idx)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..end];
+
+        // Bug 2: never sign metadata derived from an unverified upstream.
+        // Behavior is unit-tested via debian_sync_must_refuse_unverified_signing;
+        // this asserts the sync path still calls that helper.
+        assert!(
+            body.contains("debian_sync_must_refuse_unverified_signing("),
+            "sync must refuse to sign metadata from an unverified upstream"
+        );
+        // Bug 3: fetched indexes are verified against the Release hashes.
+        assert!(
+            body.matches("verify_index_against_release(").count() >= 2,
+            "both Packages and Sources indexes must be verified against Release"
+        );
+        // Bug 4: prefetched artifacts are digest-gated before caching.
+        assert!(
+            body.contains("proxy_fetch_streaming_with_cache_key_verified("),
+            "prefetch must use the digest-gated streaming helper"
+        );
+        assert!(
+            !body.contains("proxy_helpers::proxy_fetch_streaming(\n"),
+            "prefetch must not use the un-verified streaming helper"
+        );
+        assert!(
+            body.contains("parse_packages_index_blocking(")
+                && body.contains("parse_sources_index_blocking("),
+            "sync must parse Packages/Sources indexes via spawn_blocking helpers"
+        );
+        // Prefetch paths are SSRF-validated before fetch.
+        assert!(
+            body.contains("validate_debian_fetch_path(&package.filename)")
+                && body.contains("validate_debian_fetch_path(&source.filename)"),
+            "prefetch must validate package/source paths against SSRF"
+        );
+        // Bug 5: generated metadata is published in a single transaction.
+        assert!(
+            body.contains(".begin()") && body.contains("tx.commit()"),
+            "generated metadata must be published atomically in one transaction"
+        );
+        assert!(
+            body.contains("effective_package_queries()")
+                || body.contains("config.effective_package_queries()"),
+            "sync filter must wire package_queries from config"
+        );
+    }
 
     fn package_entry(
         name: &str,
@@ -2213,6 +4914,41 @@ mod tests {
     }
 
     #[test]
+    fn test_build_debian_artifact_metadata_installer_component() {
+        let control = DebControl {
+            package: "base-installer".to_string(),
+            version: "1.200".to_string(),
+            architecture: "amd64".to_string(),
+            maintainer: None,
+            installed_size: None,
+            depends: None,
+            pre_depends: None,
+            recommends: None,
+            suggests: None,
+            conflicts: None,
+            provides: None,
+            replaces: None,
+            section: Some("utils".to_string()),
+            priority: None,
+            homepage: None,
+            description: None,
+            source: None,
+            extra: Default::default(),
+        };
+        let meta = build_debian_artifact_metadata(
+            Some("bookworm"),
+            "debian-installer",
+            "pool/debian-installer/b/base-installer/base-installer_1.200_amd64.udeb",
+            "base-installer_1.200_amd64.udeb",
+            "udeb",
+            &control,
+        );
+        assert_eq!(meta["package_type"], "udeb");
+        assert_eq!(meta["section"], "debian-installer");
+        assert_eq!(meta["component"], "debian-installer");
+    }
+
+    #[test]
     fn test_parse_deb_filename_no_deb_extension() {
         assert!(parse_deb_filename("nginx_1.0_amd64.rpm").is_none());
     }
@@ -2245,6 +4981,125 @@ mod tests {
         assert_eq!(info.arch, "i386");
     }
 
+    // -----------------------------------------------------------------------
+    // Release config helpers
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_effective_release_layout_prefers_configured_components_and_architectures() {
+        let config = DebianRepositoryConfig {
+            components: vec!["universe".to_string(), "main".to_string()],
+            architectures: vec!["amd64".to_string(), "all".to_string(), "arm64".to_string()],
+            ..Default::default()
+        };
+        let discovered_components = BTreeSet::from(["main".to_string()]);
+        let discovered_architectures = BTreeSet::from(["amd64".to_string()]);
+
+        let (components, architectures) = effective_release_layout(
+            Some(&config),
+            discovered_components,
+            discovered_architectures,
+        );
+
+        assert_eq!(
+            components.into_iter().collect::<Vec<_>>(),
+            vec!["main".to_string(), "universe".to_string()]
+        );
+        assert_eq!(
+            architectures.into_iter().collect::<Vec<_>>(),
+            vec!["amd64".to_string(), "arm64".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_flat_debian_upstream_paths_are_root_relative() {
+        assert_eq!(debian_dists_upstream_path("", "Release"), "Release");
+        assert_eq!(debian_dists_upstream_path("", "Packages.xz"), "Packages.xz");
+        assert_eq!(
+            debian_dists_upstream_path("bookworm", "main/binary-amd64/Packages.xz"),
+            "dists/bookworm/main/binary-amd64/Packages.xz"
+        );
+    }
+
+    #[test]
+    fn test_dists_serving_is_generation_aware_not_per_request_filtered() {
+        // Passthrough must be transparent (no per-request filtering) and, once a
+        // local generation is published, uncovered paths 404 instead of leaking
+        // upstream. Guard the wiring so it cannot silently regress.
+        let src = include_str!("debian.rs");
+
+        // The per-request filter helpers must be gone entirely. Build the
+        // needles at runtime so this test's own source does not self-match.
+        let removed_fn = ["fn debian_sync", "_path_allowed("].concat();
+        let removed_call = ["require_debian_sync", "_path_allowed("].concat();
+        assert!(
+            !src.contains(&removed_fn),
+            "per-request passthrough filtering must be removed"
+        );
+        assert!(
+            !src.contains(&removed_call),
+            "per-request passthrough filtering call sites must be removed"
+        );
+
+        // The dists passthrough branches must gate on the published generation.
+        for anchor in [
+            "async fn dists(",
+            "async fn dists_detecting_change(",
+            "async fn dists_proxy_catchall(",
+        ] {
+            let start = src
+                .find(anchor)
+                .unwrap_or_else(|| panic!("{anchor} missing"));
+            let window = &src[start..start + 1400];
+            assert!(
+                window.contains("reject_uncovered_generation_path("),
+                "{anchor} must gate passthrough on the published generation"
+            );
+        }
+
+        // dists_proxy_catchall must serve local content before applying the gate
+        // so covered paths are not rejected.
+        let catchall = src
+            .find("async fn dists_proxy_catchall(")
+            .expect("catchall exists");
+        let body = &src[catchall..catchall + 1800];
+        let local = body
+            .find("try_synced_dists_response(")
+            .expect("catchall loads local content");
+        let gate = body
+            .find("reject_uncovered_generation_path(")
+            .expect("catchall gates passthrough");
+        assert!(
+            local < gate,
+            "local content must be served before the passthrough gate"
+        );
+    }
+
+    #[test]
+    fn test_effective_release_layout_uses_discovered_values_for_wildcards() {
+        let config = DebianRepositoryConfig {
+            components: vec!["*".to_string()],
+            architectures: Vec::new(),
+            ..Default::default()
+        };
+        let discovered_components = BTreeSet::from(["main".to_string(), "universe".to_string()]);
+        let discovered_architectures = BTreeSet::from(["amd64".to_string(), "arm64".to_string()]);
+
+        let (components, architectures) = effective_release_layout(
+            Some(&config),
+            discovered_components,
+            discovered_architectures,
+        );
+
+        assert_eq!(
+            components.into_iter().collect::<Vec<_>>(),
+            vec!["main".to_string(), "universe".to_string()]
+        );
+        assert_eq!(
+            architectures.into_iter().collect::<Vec<_>>(),
+            vec!["amd64".to_string(), "arm64".to_string()]
+        );
+    }
     // -----------------------------------------------------------------------
     // build_packages_text
     // -----------------------------------------------------------------------
@@ -2351,6 +5206,392 @@ mod tests {
     }
 
     #[test]
+    fn test_build_generated_packages_text_filters_arch_and_preserves_hashes() {
+        let mut extra = std::collections::HashMap::new();
+        extra.insert("Multi-Arch".to_string(), "same".to_string());
+        let entries = vec![
+            PackagesEntry {
+                control: DebControl {
+                    package: "libdemo".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "amd64".to_string(),
+                    maintainer: Some("Maintainer <m@example.test>".to_string()),
+                    description: Some("demo library".to_string()),
+                    extra,
+                    ..DebControl::default()
+                },
+                filename: Some("pool/main/libd/libdemo/libdemo_1.0_amd64.deb".to_string()),
+                size: Some(1234),
+                md5sum: Some("md5".to_string()),
+                sha1: Some("sha1".to_string()),
+                sha256: Some("sha256".to_string()),
+            },
+            PackagesEntry {
+                control: DebControl {
+                    package: "shared-data".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "all".to_string(),
+                    description: Some("shared data".to_string()),
+                    ..DebControl::default()
+                },
+                filename: Some("pool/main/s/shared-data/shared-data_1.0_all.deb".to_string()),
+                size: Some(77),
+                md5sum: None,
+                sha1: None,
+                sha256: Some("sha256-all".to_string()),
+            },
+            PackagesEntry {
+                control: DebControl {
+                    package: "libother".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "arm64".to_string(),
+                    description: Some("other arch".to_string()),
+                    ..DebControl::default()
+                },
+                filename: Some("pool/main/libo/libother/libother_1.0_arm64.deb".to_string()),
+                size: Some(99),
+                md5sum: None,
+                sha1: None,
+                sha256: Some("sha256-arm".to_string()),
+            },
+        ];
+
+        let text = build_generated_packages_text(&entries, "amd64", &["amd64".to_string()]);
+        assert!(text.contains("Package: libdemo\n"));
+        assert!(text.contains("Package: shared-data\n"));
+        assert!(!text.contains("Package: libother\n"));
+        assert!(text.contains("Multi-Arch: same\n"));
+        assert!(text.contains("Filename: pool/main/libd/libdemo/libdemo_1.0_amd64.deb\n"));
+        assert!(text.contains("Size: 1234\n"));
+        assert!(text.contains("MD5sum: md5\n"));
+        assert!(text.contains("SHA1: sha1\n"));
+        assert!(text.contains("SHA256: sha256\n"));
+    }
+
+    #[test]
+    fn test_build_generated_packages_text_filters_flat_indexes_by_selected_architectures() {
+        let entries = vec![
+            PackagesEntry {
+                control: DebControl {
+                    package: "libdemo".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "amd64".to_string(),
+                    description: Some("demo library".to_string()),
+                    ..DebControl::default()
+                },
+                filename: Some("libdemo_1.0_amd64.deb".to_string()),
+                size: Some(1234),
+                md5sum: None,
+                sha1: None,
+                sha256: Some("sha256".to_string()),
+            },
+            PackagesEntry {
+                control: DebControl {
+                    package: "libother".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "arm64".to_string(),
+                    description: Some("other arch".to_string()),
+                    ..DebControl::default()
+                },
+                filename: Some("libother_1.0_arm64.deb".to_string()),
+                size: Some(99),
+                md5sum: None,
+                sha1: None,
+                sha256: Some("sha256-arm".to_string()),
+            },
+        ];
+
+        let text = build_generated_packages_text(&entries, "", &["amd64".to_string()]);
+        assert!(text.contains("Package: libdemo\n"));
+        assert!(!text.contains("Package: libother\n"));
+    }
+    #[test]
+    fn test_build_generated_sources_text_preserves_hash_sections() {
+        let mut extra = BTreeMap::new();
+        extra.insert(
+            "Maintainer".to_string(),
+            "Maintainer <m@example.test>".to_string(),
+        );
+        let entries = vec![SourcesEntry {
+            package: "demo-src".to_string(),
+            version: "1.0".to_string(),
+            directory: "pool/main/d/demo-src".to_string(),
+            files: vec![SourceFileEntry {
+                filename: "demo-src_1.0.dsc".to_string(),
+                size: 321,
+                md5sum: Some("md5".to_string()),
+                sha1: Some("sha1".to_string()),
+                sha256: Some("sha256".to_string()),
+                sha512: Some("sha512".to_string()),
+            }],
+            extra,
+        }];
+
+        let text = build_generated_sources_text(&entries);
+        assert!(text.contains("Package: demo-src\n"));
+        assert!(text.contains("Version: 1.0\n"));
+        assert!(text.contains("Directory: pool/main/d/demo-src\n"));
+        assert!(text.contains("Maintainer: Maintainer <m@example.test>\n"));
+        assert!(text.contains("Files:\n md5 321 demo-src_1.0.dsc\n"));
+        assert!(text.contains("Checksums-Sha1:\n sha1 321 demo-src_1.0.dsc\n"));
+        assert!(text.contains("Checksums-Sha256:\n sha256 321 demo-src_1.0.dsc\n"));
+        assert!(text.contains("Checksums-Sha512:\n sha512 321 demo-src_1.0.dsc\n"));
+    }
+
+    #[test]
+    fn test_synced_generated_metadata_builds_indexes_and_release_hashes() {
+        let package_index = crate::formats::debian::DebianIndexPath {
+            component: "main".to_string(),
+            architecture: "amd64".to_string(),
+            path: "main/binary-amd64/Packages.xz".to_string(),
+        };
+        let source_index = crate::formats::debian::DebianSourceIndexPath {
+            component: "main".to_string(),
+            path: "main/source/Sources.gz".to_string(),
+        };
+        let plan = DebianSyncPlan {
+            distribution: "jammy".to_string(),
+            release_paths: vec![],
+            package_indexes: vec![package_index.clone()],
+            source_indexes: vec![source_index.clone()],
+            package_files: vec![crate::formats::debian::DebianSyncPackageFile {
+                index_path: package_index.path.clone(),
+                filename: "pool/main/libd/libdemo/libdemo_1.0_amd64.deb".to_string(),
+                package: "libdemo".to_string(),
+                version: "1.0".to_string(),
+                architecture: "amd64".to_string(),
+                download: false,
+            }],
+            source_files: vec![],
+            missing_package_indexes: vec![],
+            missing_source_indexes: vec![],
+        };
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            package_index.path.clone(),
+            vec![PackagesEntry {
+                control: DebControl {
+                    package: "libdemo".to_string(),
+                    version: "1.0".to_string(),
+                    architecture: "amd64".to_string(),
+                    description: Some("demo".to_string()),
+                    ..DebControl::default()
+                },
+                filename: Some("pool/main/libd/libdemo/libdemo_1.0_amd64.deb".to_string()),
+                size: Some(123),
+                md5sum: None,
+                sha1: None,
+                sha256: Some("sha256".to_string()),
+            }],
+        );
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            source_index.path.clone(),
+            vec![SourcesEntry {
+                package: "demo-src".to_string(),
+                version: "1.0".to_string(),
+                directory: "pool/main/d/demo-src".to_string(),
+                files: vec![],
+                extra: BTreeMap::new(),
+            }],
+        );
+
+        let generated =
+            build_synced_generated_metadata(&plan, &packages, &sources, &["amd64".to_string()])
+                .unwrap();
+        assert!(generated
+            .plain_indexes
+            .contains_key("main/binary-amd64/Packages"));
+        assert!(generated.plain_indexes.contains_key("main/source/Sources"));
+        // Contents are NOT generated from sync plans (pool filenames are not
+        // valid Contents-file paths — see Fix 9).
+        assert!(
+            !generated.plain_indexes.contains_key("main/Contents-amd64"),
+            "Contents must NOT be generated from pool filenames in sync metadata"
+        );
+        assert!(generated
+            .release_files
+            .iter()
+            .any(|(path, _)| path == "main/binary-amd64/Packages.gz"));
+        assert!(generated
+            .release_files
+            .iter()
+            .any(|(path, _)| path == "main/source/Sources.xz"));
+        assert!(
+            !generated
+                .release_files
+                .iter()
+                .any(|(path, _)| path == "main/Contents-amd64.gz"),
+            "Contents.gz must NOT appear in synced release_files"
+        );
+        assert!(
+            generated
+                .release_files
+                .iter()
+                .any(|(path, _)| path.starts_with("by-hash/SHA256/")),
+            "synced metadata must publish by-hash aliases"
+        );
+        assert!(
+            generated
+                .plain_indexes
+                .values()
+                .any(|value| value.starts_with("@ref:")),
+            "by-hash aliases must be stored as @ref: logical-path pointers"
+        );
+
+        let components = BTreeSet::from(["main".to_string()]);
+        let architectures = BTreeSet::from(["amd64".to_string()]);
+        let release = build_release_content_from_files(
+            "jammy",
+            Some("jammy"),
+            None,
+            &components,
+            &architectures,
+            generated.release_files,
+        );
+        assert!(release.contains("MD5Sum:\n"));
+        assert!(release.contains("SHA1:\n"));
+        assert!(release.contains("SHA256:\n"));
+        assert!(release.contains("SHA512:\n"));
+        assert!(release.contains(" main/binary-amd64/Packages\n"));
+        assert!(release.contains(" main/binary-amd64/Packages.gz\n"));
+        assert!(release.contains(" main/binary-amd64/Packages.xz\n"));
+        assert!(
+            !release.contains(" main/Contents-amd64\n"),
+            "Contents must NOT appear in generated Release"
+        );
+        assert!(release.contains(" main/source/Sources\n"));
+        assert!(release.contains(" main/source/Sources.gz\n"));
+        assert!(release.contains(" main/source/Sources.xz\n"));
+        assert!(release.contains(" by-hash/SHA256/"));
+    }
+
+    #[test]
+    fn test_build_synced_generated_metadata_respects_plan_package_selection() {
+        let package_index = crate::formats::debian::DebianIndexPath {
+            component: "main".to_string(),
+            architecture: "amd64".to_string(),
+            path: "main/binary-amd64/Packages.xz".to_string(),
+        };
+        let plan = DebianSyncPlan {
+            distribution: "noble-security".to_string(),
+            release_paths: vec![],
+            package_indexes: vec![package_index.clone()],
+            source_indexes: vec![],
+            package_files: vec![crate::formats::debian::DebianSyncPackageFile {
+                index_path: package_index.path.clone(),
+                filename: "pool/main/c/curl/curl_8.5.0-2ubuntu10.6_amd64.deb".to_string(),
+                package: "curl".to_string(),
+                version: "8.5.0-2ubuntu10.6".to_string(),
+                architecture: "amd64".to_string(),
+                download: false,
+            }],
+            source_files: vec![],
+            missing_package_indexes: vec![],
+            missing_source_indexes: vec![],
+        };
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            package_index.path.clone(),
+            vec![
+                PackagesEntry {
+                    control: DebControl {
+                        package: "curl".to_string(),
+                        version: "8.5.0-2ubuntu10.6".to_string(),
+                        architecture: "amd64".to_string(),
+                        ..DebControl::default()
+                    },
+                    filename: Some("pool/main/c/curl/curl_8.5.0-2ubuntu10.6_amd64.deb".to_string()),
+                    size: Some(10),
+                    md5sum: None,
+                    sha1: None,
+                    sha256: Some("aa".to_string()),
+                },
+                PackagesEntry {
+                    control: DebControl {
+                        package: "nginx".to_string(),
+                        version: "1.0".to_string(),
+                        architecture: "amd64".to_string(),
+                        ..DebControl::default()
+                    },
+                    filename: Some("pool/main/n/nginx/nginx_1.0_amd64.deb".to_string()),
+                    size: Some(20),
+                    md5sum: None,
+                    sha1: None,
+                    sha256: Some("bb".to_string()),
+                },
+            ],
+        );
+
+        let generated = build_synced_generated_metadata(
+            &plan,
+            &packages,
+            &BTreeMap::new(),
+            &["amd64".to_string()],
+        )
+        .unwrap();
+        let packages_text = generated
+            .plain_indexes
+            .get("main/binary-amd64/Packages")
+            .expect("Packages index");
+        assert!(
+            packages_text.contains("Package: curl\n"),
+            "selected package must appear in generated Packages"
+        );
+        assert!(
+            !packages_text.contains("Package: nginx\n"),
+            "packages outside the sync plan must not be published"
+        );
+        // Contents are NOT generated from sync plans (Fix 9: pool filenames are wrong).
+        assert!(
+            !generated.plain_indexes.contains_key("main/Contents-amd64"),
+            "Contents must NOT be generated from pool filenames in sync metadata (Fix 9)"
+        );
+    }
+
+    #[test]
+    fn test_append_by_hash_release_files_adds_sha256_aliases() {
+        let mut files = vec![
+            ("main/binary-amd64/Packages".to_string(), b"hello".to_vec()),
+            ("main/Contents-amd64".to_string(), b"world".to_vec()),
+        ];
+        append_by_hash_release_files(&mut files);
+        let hello_sha = calculate_sha256_hex(b"hello");
+        let world_sha = calculate_sha256_hex(b"world");
+        assert!(files
+            .iter()
+            .any(|(path, bytes)| path == &by_hash_path("SHA256", &hello_sha) && bytes == b"hello"));
+        assert!(files
+            .iter()
+            .any(|(path, bytes)| path == &by_hash_path("SHA256", &world_sha) && bytes == b"world"));
+        // Idempotent: running again must not duplicate.
+        let before = files.len();
+        append_by_hash_release_files(&mut files);
+        assert_eq!(files.len(), before);
+    }
+
+    #[test]
+    fn test_parse_contents_request() {
+        let req = parse_contents_request("main/Contents-amd64").unwrap();
+        assert_eq!(req.component, "main");
+        assert_eq!(req.arch, "amd64");
+        assert!(matches!(req.ext, PackagesExt::Plain));
+
+        let req = parse_contents_request("universe/Contents-arm64.gz").unwrap();
+        assert_eq!(req.component, "universe");
+        assert_eq!(req.arch, "arm64");
+        assert!(matches!(req.ext, PackagesExt::Gz));
+
+        assert!(parse_contents_request("main/binary-amd64/Packages").is_none());
+        // bz2/zst are now supported
+        let req_bz2 = parse_contents_request("main/Contents-amd64.bz2").unwrap();
+        assert!(matches!(req_bz2.ext, PackagesExt::Bz2));
+        let req_zst = parse_contents_request("main/Contents-amd64.zst").unwrap();
+        assert!(matches!(req_zst.ext, PackagesExt::Zst));
+        // unknown extensions still rejected
+        assert!(parse_contents_request("main/Contents-amd64.foo").is_none());
+    }
+    #[test]
     fn test_package_matches_requested_arch() {
         assert!(package_matches_requested_arch("amd64", "amd64"));
         assert!(package_matches_requested_arch("all", "amd64"));
@@ -2360,10 +5601,55 @@ mod tests {
     }
 
     #[test]
+    fn test_package_matches_requested_distribution() {
+        let jammy = serde_json::json!({ "distribution": " jammy " });
+        let bookworm = serde_json::json!({ "distribution": "bookworm" });
+        let legacy = serde_json::json!({ "component": "main" });
+        let empty = serde_json::json!({ "distribution": "" });
+        let null_distribution = serde_json::json!({ "distribution": null });
+
+        assert!(package_matches_requested_distribution(
+            Some(&jammy),
+            "jammy"
+        ));
+        assert!(!package_matches_requested_distribution(
+            Some(&bookworm),
+            "jammy"
+        ));
+        assert!(package_matches_requested_distribution(
+            Some(&legacy),
+            "jammy"
+        ));
+        assert!(package_matches_requested_distribution(
+            Some(&empty),
+            "jammy"
+        ));
+        assert!(package_matches_requested_distribution(
+            Some(&null_distribution),
+            "jammy"
+        ));
+        assert!(package_matches_requested_distribution(None, "jammy"));
+    }
+
+    #[test]
+    fn test_architecture_all_is_not_release_layout_architecture() {
+        assert_eq!(architecture_for_release_layout("all"), None);
+        assert_eq!(architecture_for_release_layout("amd64"), Some("amd64"));
+    }
+
+    #[test]
     fn test_component_from_pool_path() {
         assert_eq!(
             component_from_pool_path("pool/non-free/n/nvidia/pkg_1_amd64.deb"),
             Some("non-free")
+        );
+        assert_eq!(
+            component_from_pool_path("pool/updates/main/c/curl/curl_7.88.1-10+deb12u5_amd64.deb"),
+            Some("updates/main")
+        );
+        assert_eq!(
+            component_from_pool_path("pool/main/c/curl/curl_1_amd64.deb"),
+            Some("main")
         );
         assert_eq!(component_from_pool_path("not-pool/pkg.deb"), None);
     }
@@ -2839,10 +6125,12 @@ mod tests {
 
     #[test]
     fn test_parse_packages_request_unknown_extension() {
-        // Anything other than Packages / Packages.gz / Packages.xz
+        // Anything other than Packages / Packages.gz / Packages.xz / Packages.bz2 / Packages.zst
         // is None so the caller proxies to upstream.
-        assert!(parse_packages_request("main/binary-amd64/Packages.bz2").is_none());
+        assert!(parse_packages_request("main/binary-amd64/Packages.bz2").is_some());
+        assert!(parse_packages_request("main/binary-amd64/Packages.zst").is_some());
         assert!(parse_packages_request("main/binary-amd64/Release").is_none());
+        assert!(parse_packages_request("main/binary-amd64/Packages.foo").is_none());
     }
 
     // ---------------------------------------------------------------------
@@ -2886,229 +6174,129 @@ mod tests {
         let b = signed_release_cache_key(SignedReleaseVariant::InRelease, "Release\n", "ef01");
         assert_ne!(a, b);
     }
-}
 
-#[cfg(test)]
-mod upload_db_tests {
-    use super::*;
-    use crate::api::handlers::test_db_helpers as tdh;
-
-    fn append_ar_member(out: &mut Vec<u8>, name: &str, content: &[u8]) {
-        let header = format!(
-            "{:<16}{:<12}{:<6}{:<6}{:<8}{:<10}`\n",
-            name,
-            0,
-            0,
-            0,
-            "100644",
-            content.len()
-        );
-        assert_eq!(header.len(), 60, "ar header must be exactly 60 bytes");
-        out.extend_from_slice(header.as_bytes());
-        out.extend_from_slice(content);
-        if content.len() % 2 == 1 {
-            out.push(b'\n');
-        }
-    }
-
-    fn control_tar_gz(control: &str) -> Vec<u8> {
-        let mut builder = tar::Builder::new(Vec::new());
-        let mut header = tar::Header::new_gnu();
-        header.set_size(control.len() as u64);
-        header.set_mode(0o644);
-        header.set_cksum();
-        builder
-            .append_data(&mut header, "./control", control.as_bytes())
-            .expect("append control file");
-        builder.finish().expect("finish control.tar");
-        let tar_bytes = builder.into_inner().expect("control.tar bytes");
-        gzip_compress(&tar_bytes).expect("gzip control.tar")
-    }
-
-    fn empty_data_tar_gz() -> Vec<u8> {
-        let mut builder = tar::Builder::new(Vec::new());
-        builder.finish().expect("finish data.tar");
-        let tar_bytes = builder.into_inner().expect("data.tar bytes");
-        gzip_compress(&tar_bytes).expect("gzip data.tar")
-    }
-
-    fn minimal_deb(package: &str, version: &str, architecture: &str, description: &str) -> Vec<u8> {
-        let control = format!(
-            "Package: {package}\n\
-             Version: {version}\n\
-             Architecture: {architecture}\n\
-             Maintainer: Test Maintainer <test@example.local>\n\
-             Installed-Size: 7\n\
-             Depends: libc6 (>= 2.36)\n\
-             Section: utils\n\
-             Priority: optional\n\
-             Homepage: https://example.local/{package}\n\
-             Description: {description}\n\
-             {description_continuation}",
-            description_continuation = " extended description line\n",
-        );
-
-        let mut deb = Vec::new();
-        deb.extend_from_slice(b"!<arch>\n");
-        append_ar_member(&mut deb, "debian-binary", b"2.0\n");
-        append_ar_member(&mut deb, "control.tar.gz", &control_tar_gz(&control));
-        append_ar_member(&mut deb, "data.tar.gz", &empty_data_tar_gz());
-        deb
-    }
-
-    fn headers_with_replication(value: &str) -> HeaderMap {
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "x-artifact-keeper-replication",
-            axum::http::HeaderValue::from_str(value).unwrap(),
-        );
-        headers
-    }
+    // -----------------------------------------------------------------------
+    // Fix 1: load_debian_repository_config_strict structural check
+    // -----------------------------------------------------------------------
 
     #[test]
-    fn test_should_enqueue_debian_sync_tasks_for_direct_upload() {
-        assert!(should_enqueue_debian_sync_tasks(&HeaderMap::new()));
-    }
-
-    #[test]
-    fn test_should_enqueue_debian_sync_tasks_skips_peer_replication() {
-        assert!(!should_enqueue_debian_sync_tasks(
-            &headers_with_replication("true")
-        ));
-    }
-
-    #[tokio::test]
-    async fn pool_upload_populates_debian_metadata_packages_and_indexes() {
-        let Some(f) = tdh::Fixture::setup("local", "debian").await else {
-            return;
-        };
-
-        let package = "ak-debian-indexed";
-        let version = "1.2.3-1";
-        let arch = "amd64";
-        let deb = minimal_deb(package, version, arch, "indexed Debian package");
-        let app = f.router_with_auth(super::router());
-        let path = format!("a/{package}/{package}_{version}_{arch}.deb");
-        let uri = format!("/{}/pool/main/{}", f.repo_key, path);
-        let (status, body) = tdh::send(app.clone(), tdh::put(uri, Bytes::from(deb))).await;
-        assert_eq!(
-            status,
-            StatusCode::CREATED,
-            "upload failed: {}",
-            String::from_utf8_lossy(&body)
-        );
-
-        let artifact: (uuid::Uuid, String, String, Option<String>, String) = sqlx::query_as(
-            "SELECT id, path, name, version, checksum_sha256 FROM artifacts \
-             WHERE repository_id = $1 AND name = $2 AND is_deleted = false",
-        )
-        .bind(f.repo_id)
-        .bind(package)
-        .fetch_one(&f.pool)
-        .await
-        .expect("query uploaded artifact");
-        assert_eq!(
-            artifact.1,
-            format!("pool/main/a/{package}/{package}_{version}_{arch}.deb")
-        );
-        assert_eq!(artifact.2, package);
-        assert_eq!(artifact.3.as_deref(), Some(version));
-        assert_eq!(artifact.4.len(), 64);
-
-        let metadata: (serde_json::Value,) =
-            sqlx::query_as("SELECT metadata FROM artifact_metadata WHERE artifact_id = $1")
-                .bind(artifact.0)
-                .fetch_one(&f.pool)
-                .await
-                .expect("query Debian artifact metadata");
-        assert_eq!(metadata.0["format"], "debian");
-        assert_eq!(metadata.0["component"], "main");
-        assert_eq!(metadata.0["architecture"], arch);
-        assert_eq!(metadata.0["control"]["package"], package);
-        assert_eq!(metadata.0["control"]["version"], version);
-        assert_eq!(metadata.0["control"]["depends"][0], "libc6 (>= 2.36)");
-
-        let pkg: (String, Option<String>, Option<serde_json::Value>) = sqlx::query_as(
-            "SELECT version, description, metadata FROM packages \
-             WHERE repository_id = $1 AND name = $2",
-        )
-        .bind(f.repo_id)
-        .bind(package)
-        .fetch_one(&f.pool)
-        .await
-        .expect("query package catalog");
-        assert_eq!(pkg.0, version);
-        assert_eq!(
-            pkg.1.as_deref(),
-            Some("indexed Debian package\nextended description line")
-        );
-        let pkg_meta = pkg.2.expect("package metadata should be set");
-        assert_eq!(pkg_meta["format"], "debian");
-        assert_eq!(pkg_meta["architecture"], arch);
-        assert_eq!(pkg_meta["component"], "main");
-
-        let version_rows: (i64,) = sqlx::query_as(
-            "SELECT COUNT(*)::bigint FROM package_versions pv \
-             JOIN packages p ON p.id = pv.package_id \
-             WHERE p.repository_id = $1 AND p.name = $2 AND pv.version = $3",
-        )
-        .bind(f.repo_id)
-        .bind(package)
-        .bind(version)
-        .fetch_one(&f.pool)
-        .await
-        .expect("query package_versions");
-        assert_eq!(version_rows.0, 1);
-
-        let (status, packages_body) = tdh::send(
-            app.clone(),
-            tdh::get(format!(
-                "/{}/dists/bookworm/main/binary-amd64/Packages",
-                f.repo_key
-            )),
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK);
-        let packages_text = String::from_utf8(packages_body.to_vec()).unwrap();
-        assert!(packages_text.contains(&format!("Package: {package}\n")));
-        assert!(packages_text.contains("Architecture: amd64\n"));
-        assert!(packages_text.contains("Depends: libc6 (>= 2.36)\n"));
-        assert!(packages_text
-            .contains("Description: indexed Debian package\n extended description line\n"));
-        assert!(packages_text.contains("SHA256: "));
-
-        let (status, all_body) = tdh::send(
-            app.clone(),
-            tdh::get(format!(
-                "/{}/dists/bookworm/main/binary-all/Packages",
-                f.repo_key
-            )),
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK);
-        let all_text = String::from_utf8(all_body.to_vec()).unwrap();
+    fn test_strict_config_loader_exists_and_has_correct_signature() {
+        let src = include_str!("debian.rs");
         assert!(
-            !all_text.contains(&format!("Package: {package}\n")),
-            "binary-all must not contain arch-specific packages"
+            src.contains("async fn load_debian_repository_config_strict("),
+            "strict loader must exist"
         );
+        assert!(
+            src.contains("Result<Option<DebianRepositoryConfig>, Response>"),
+            "strict loader must return Result<Option<...>, Response>"
+        );
+        assert!(
+            src.contains("SERVICE_UNAVAILABLE"),
+            "DB/parse errors must return 503 SERVICE_UNAVAILABLE"
+        );
+    }
 
-        let (status, release_body) = tdh::send(
-            app,
-            tdh::get(format!("/{}/dists/bookworm/Release", f.repo_key)),
-        )
-        .await;
-        assert_eq!(status, StatusCode::OK);
-        let release = String::from_utf8(release_body.to_vec()).unwrap();
-        assert!(release.contains("Architectures: amd64\n"));
-        assert!(release.contains("Components: main\n"));
-        assert!(release.contains("MD5Sum:\n"));
-        assert!(release.contains("SHA1:\n"));
-        assert!(release.contains("SHA256:\n"));
-        assert!(release.contains("main/binary-amd64/Packages\n"));
-        assert!(release.contains("main/binary-amd64/Packages.gz\n"));
-        assert!(release.contains("main/binary-amd64/Packages.xz\n"));
+    #[test]
+    fn test_proxy_remote_debian_package_uses_strict_config_loader() {
+        let src = include_str!("debian.rs");
+        let fn_start = src
+            .find("async fn proxy_remote_debian_package(")
+            .expect("proxy_remote_debian_package must exist");
+        let fn_body = &src[fn_start..fn_start + 3000];
+        assert!(
+            fn_body.contains("load_debian_repository_config_strict("),
+            "pool proxy must use the strict (fail-closed) config loader"
+        );
+        assert!(
+            !fn_body.contains("unwrap_or_default()"),
+            "pool proxy must never unwrap_or_default after load"
+        );
+    }
 
-        f.teardown().await;
+    // -----------------------------------------------------------------------
+    // Fix 2: Passthrough must not cache — structural check
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_passthrough_branch_does_not_call_cache_verified_helper() {
+        let src = include_str!("debian.rs");
+        let fn_start = src
+            .find("async fn proxy_remote_debian_package(")
+            .expect("proxy_remote_debian_package must exist");
+        let fn_end = src[fn_start..]
+            .find("async fn pool_download(")
+            .map(|i| fn_start + i)
+            .unwrap_or(src.len());
+        let body = &src[fn_start..fn_end];
+
+        // Find the passthrough block.
+        let passthrough_start = body
+            .find("if passthrough {")
+            .expect("passthrough block must exist");
+        let passthrough_block = &body[passthrough_start..];
+        // The first return or closing brace of the passthrough block.
+        let passthrough_block_end = passthrough_block
+            .find("\n    }\n")
+            .unwrap_or(passthrough_block.len());
+        let passthrough_block = &passthrough_block[..passthrough_block_end];
+
+        assert!(
+            passthrough_block.contains("proxy_fetch_streaming_uncached("),
+            "passthrough block must call uncached helper"
+        );
+        assert!(
+            !passthrough_block.contains("proxy_fetch_streaming_with_cache_key_verified("),
+            "passthrough block must NOT call the cache-key-verified helper"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 9: Contents not generated from pool filenames — structural check
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_synced_generated_metadata_does_not_emit_contents() {
+        let src = include_str!("debian.rs");
+        let fn_start = src
+            .find("fn build_synced_generated_metadata(")
+            .expect("build_synced_generated_metadata must exist");
+        let fn_body_start = src[fn_start..].find('{').map(|i| fn_start + i).unwrap();
+        // The function ends at the closing brace of the outer block.
+        let fn_body = &src[fn_body_start..fn_body_start + 3000];
+        assert!(
+            !fn_body.contains("Contents generation entirely") || fn_body.contains("NOT generated"),
+            "build_synced_generated_metadata must not emit Contents indexes from pool filenames"
+        );
+        // The Contents path format must not appear in the active code.
+        assert!(
+            !fn_body.contains("Contents-{}\", index.component, index.architecture"),
+            "Contents path construction must not appear in synced metadata generation"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 11: bz2/zst canonicalization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_canonical_plain_dists_index_path_strips_bz2_and_zst() {
+        assert_eq!(canonical_plain_dists_index_path("Packages.bz2"), "Packages");
+        assert_eq!(canonical_plain_dists_index_path("Packages.zst"), "Packages");
+        assert_eq!(
+            canonical_plain_dists_index_path("Packages.zstd"),
+            "Packages"
+        );
+        assert_eq!(canonical_plain_dists_index_path("Packages.gz"), "Packages");
+        assert_eq!(canonical_plain_dists_index_path("Packages.xz"), "Packages");
+        assert_eq!(canonical_plain_dists_index_path("Packages"), "Packages");
+    }
+
+    #[test]
+    fn test_parse_packages_request_accepts_bz2_and_zst() {
+        let bz2 = parse_packages_request("main/binary-amd64/Packages.bz2").unwrap();
+        assert!(matches!(bz2.ext, PackagesExt::Bz2));
+        let zst = parse_packages_request("main/binary-amd64/Packages.zst").unwrap();
+        assert!(matches!(zst.ext, PackagesExt::Zst));
     }
 }
 
@@ -3435,5 +6623,292 @@ mod virtual_dists_cap_tests {
             "a 404 member must fall through to Ok(None), got {:?}",
             out.map(|o| o.map(|r| r.status())),
         );
+    }
+}
+
+#[cfg(test)]
+mod upload_db_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    fn append_ar_member(out: &mut Vec<u8>, name: &str, content: &[u8]) {
+        let header = format!(
+            "{:<16}{:<12}{:<6}{:<6}{:<8}{:<10}`\n",
+            name,
+            0,
+            0,
+            0,
+            "100644",
+            content.len()
+        );
+        assert_eq!(header.len(), 60, "ar header must be exactly 60 bytes");
+        out.extend_from_slice(header.as_bytes());
+        out.extend_from_slice(content);
+        if content.len() % 2 == 1 {
+            out.push(b'\n');
+        }
+    }
+
+    fn control_tar_gz(control: &str) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(control.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "./control", control.as_bytes())
+            .expect("append control file");
+        builder.finish().expect("finish control.tar");
+        let tar_bytes = builder.into_inner().expect("control.tar bytes");
+        gzip_compress(&tar_bytes).expect("gzip control.tar")
+    }
+
+    fn empty_data_tar_gz() -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        builder.finish().expect("finish data.tar");
+        let tar_bytes = builder.into_inner().expect("data.tar bytes");
+        gzip_compress(&tar_bytes).expect("gzip data.tar")
+    }
+
+    fn minimal_deb(package: &str, version: &str, architecture: &str, description: &str) -> Vec<u8> {
+        let control = format!(
+            "Package: {package}\n\
+             Version: {version}\n\
+             Architecture: {architecture}\n\
+             Maintainer: Test Maintainer <test@example.local>\n\
+             Installed-Size: 7\n\
+             Depends: libc6 (>= 2.36)\n\
+             Section: utils\n\
+             Priority: optional\n\
+             Homepage: https://example.local/{package}\n\
+             Description: {description}\n\
+             {description_continuation}",
+            description_continuation = " extended description line\n",
+        );
+
+        let mut deb = Vec::new();
+        deb.extend_from_slice(b"!<arch>\n");
+        append_ar_member(&mut deb, "debian-binary", b"2.0\n");
+        append_ar_member(&mut deb, "control.tar.gz", &control_tar_gz(&control));
+        append_ar_member(&mut deb, "data.tar.gz", &empty_data_tar_gz());
+        deb
+    }
+
+    fn headers_with_replication(value: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-artifact-keeper-replication",
+            axum::http::HeaderValue::from_str(value).unwrap(),
+        );
+        headers
+    }
+
+    #[test]
+    fn test_debian_upload_metadata_headers() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-debian-distribution",
+            axum::http::HeaderValue::from_static("bookworm"),
+        );
+        headers.insert(
+            "x-debian-component",
+            axum::http::HeaderValue::from_static("main"),
+        );
+        headers.insert(
+            "x-debian-architecture",
+            axum::http::HeaderValue::from_static("amd64"),
+        );
+
+        assert_eq!(
+            debian_upload_distribution(&headers).unwrap().as_deref(),
+            Some("bookworm")
+        );
+        assert_eq!(
+            debian_upload_component(&headers).unwrap().as_deref(),
+            Some("main")
+        );
+        assert_eq!(
+            debian_upload_architecture(&headers).unwrap().as_deref(),
+            Some("amd64")
+        );
+        assert!(validate_debian_component_header("main", Some("main")).is_ok());
+        assert!(validate_debian_component_header("main", Some("universe")).is_err());
+
+        headers.insert(
+            "x-debian-component",
+            axum::http::HeaderValue::from_static("../main"),
+        );
+        assert!(debian_upload_component(&headers).is_err());
+    }
+
+    #[test]
+    fn test_debian_artifact_metadata_includes_upload_context() {
+        let control = DebControl {
+            package: "sample".to_string(),
+            version: "1.0-1".to_string(),
+            architecture: "amd64".to_string(),
+            ..DebControl::default()
+        };
+        let metadata = build_debian_artifact_metadata(
+            Some("bookworm"),
+            "main",
+            "pool/main/s/sample/sample_1.0-1_amd64.deb",
+            "sample_1.0-1_amd64.deb",
+            "deb",
+            &control,
+        );
+
+        assert_eq!(metadata["distribution"], "bookworm");
+        assert_eq!(metadata["component"], "main");
+        assert_eq!(metadata["architecture"], "amd64");
+    }
+
+    #[test]
+    fn test_should_enqueue_debian_sync_tasks_for_direct_upload() {
+        assert!(should_enqueue_debian_sync_tasks(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn test_should_enqueue_debian_sync_tasks_skips_peer_replication() {
+        assert!(!should_enqueue_debian_sync_tasks(
+            &headers_with_replication("true")
+        ));
+    }
+
+    #[tokio::test]
+    async fn pool_upload_populates_debian_metadata_packages_and_indexes() {
+        let Some(f) = tdh::Fixture::setup("local", "debian").await else {
+            return;
+        };
+
+        let package = "ak-debian-indexed";
+        let version = "1.2.3-1";
+        let arch = "amd64";
+        let deb = minimal_deb(package, version, arch, "indexed Debian package");
+        let app = f.router_with_auth(super::router());
+        let path = format!("a/{package}/{package}_{version}_{arch}.deb");
+        let uri = format!("/{}/pool/main/{}", f.repo_key, path);
+        let (status, body) = tdh::send(app.clone(), tdh::put(uri, Bytes::from(deb))).await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "upload failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let artifact: (uuid::Uuid, String, String, Option<String>, String) = sqlx::query_as(
+            "SELECT id, path, name, version, checksum_sha256 FROM artifacts \
+             WHERE repository_id = $1 AND name = $2 AND is_deleted = false",
+        )
+        .bind(f.repo_id)
+        .bind(package)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query uploaded artifact");
+        assert_eq!(
+            artifact.1,
+            format!("pool/main/a/{package}/{package}_{version}_{arch}.deb")
+        );
+        assert_eq!(artifact.2, package);
+        assert_eq!(artifact.3.as_deref(), Some(version));
+        assert_eq!(artifact.4.len(), 64);
+
+        let metadata: (serde_json::Value,) =
+            sqlx::query_as("SELECT metadata FROM artifact_metadata WHERE artifact_id = $1")
+                .bind(artifact.0)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query Debian artifact metadata");
+        assert_eq!(metadata.0["format"], "debian");
+        assert_eq!(metadata.0["component"], "main");
+        assert!(metadata.0["distribution"].is_null());
+        assert_eq!(metadata.0["architecture"], arch);
+        assert_eq!(metadata.0["control"]["package"], package);
+        assert_eq!(metadata.0["control"]["version"], version);
+        assert_eq!(metadata.0["control"]["depends"][0], "libc6 (>= 2.36)");
+
+        let pkg: (String, Option<String>, Option<serde_json::Value>) = sqlx::query_as(
+            "SELECT version, description, metadata FROM packages \
+             WHERE repository_id = $1 AND name = $2",
+        )
+        .bind(f.repo_id)
+        .bind(package)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query package catalog");
+        assert_eq!(pkg.0, version);
+        assert_eq!(
+            pkg.1.as_deref(),
+            Some("indexed Debian package\nextended description line")
+        );
+        let pkg_meta = pkg.2.expect("package metadata should be set");
+        assert_eq!(pkg_meta["format"], "debian");
+        assert_eq!(pkg_meta["architecture"], arch);
+        assert!(pkg_meta["distribution"].is_null());
+        assert_eq!(pkg_meta["component"], "main");
+
+        let version_rows: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::bigint FROM package_versions pv \
+             JOIN packages p ON p.id = pv.package_id \
+             WHERE p.repository_id = $1 AND p.name = $2 AND pv.version = $3",
+        )
+        .bind(f.repo_id)
+        .bind(package)
+        .bind(version)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query package_versions");
+        assert_eq!(version_rows.0, 1);
+
+        let (status, packages_body) = tdh::send(
+            app.clone(),
+            tdh::get(format!(
+                "/{}/dists/bookworm/main/binary-amd64/Packages",
+                f.repo_key
+            )),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let packages_text = String::from_utf8(packages_body.to_vec()).unwrap();
+        assert!(packages_text.contains(&format!("Package: {package}\n")));
+        assert!(packages_text.contains("Architecture: amd64\n"));
+        assert!(packages_text.contains("Depends: libc6 (>= 2.36)\n"));
+        assert!(packages_text
+            .contains("Description: indexed Debian package\n extended description line\n"));
+        assert!(packages_text.contains("SHA256: "));
+
+        let (status, all_body) = tdh::send(
+            app.clone(),
+            tdh::get(format!(
+                "/{}/dists/bookworm/main/binary-all/Packages",
+                f.repo_key
+            )),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let all_text = String::from_utf8(all_body.to_vec()).unwrap();
+        assert!(
+            !all_text.contains(&format!("Package: {package}\n")),
+            "binary-all must not contain arch-specific packages"
+        );
+
+        let (status, release_body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/dists/bookworm/Release", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let release = String::from_utf8(release_body.to_vec()).unwrap();
+        assert!(release.contains("Architectures: amd64\n"));
+        assert!(release.contains("Components: main\n"));
+        assert!(release.contains("MD5Sum:\n"));
+        assert!(release.contains("SHA1:\n"));
+        assert!(release.contains("SHA256:\n"));
+        assert!(release.contains("SHA512:\n"));
+        assert!(release.contains("main/binary-amd64/Packages\n"));
+        assert!(release.contains("main/binary-amd64/Packages.gz\n"));
+        assert!(release.contains("main/binary-amd64/Packages.xz\n"));
+
+        f.teardown().await;
     }
 }

--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -15,12 +15,97 @@ use crate::api::dto::Pagination;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::formats::debian::debian_promotion_target_path;
 use crate::models::quality::{QualityGateEvaluation, QualityGateViolation};
 use crate::models::repository::RepositoryType;
 use crate::models::sbom::PolicyAction;
 use crate::services::promotion_policy_service::PromotionPolicyService;
 use crate::services::quality_check_service::QualityCheckService;
 use crate::services::repository_service::RepositoryService;
+
+/// Copy Debian package metadata onto a promoted artifact when the path is a
+/// pool / `.deb` / `.udeb` package and the target row does not already have
+/// metadata. Preserves component, architecture, and distribution fields.
+async fn copy_debian_metadata_on_promotion(
+    db: &sqlx::PgPool,
+    source_artifact_id: Uuid,
+    target_artifact_id: Uuid,
+    source_path: &str,
+) {
+    let is_debian_pkg = source_path.starts_with("pool/")
+        || source_path.ends_with(".deb")
+        || source_path.ends_with(".udeb");
+    if !is_debian_pkg {
+        return;
+    }
+
+    let existing: Option<(Uuid,)> =
+        match sqlx::query_as("SELECT artifact_id FROM artifact_metadata WHERE artifact_id = $1")
+            .bind(target_artifact_id)
+            .fetch_optional(db)
+            .await
+        {
+            Ok(row) => row,
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "Failed to check target artifact_metadata during Debian promotion"
+                );
+                return;
+            }
+        };
+    if existing.is_some() {
+        return;
+    }
+
+    let row: Option<(String, serde_json::Value, serde_json::Value)> = match sqlx::query_as(
+        r#"
+        SELECT format, metadata, properties
+        FROM artifact_metadata
+        WHERE artifact_id = $1
+        "#,
+    )
+    .bind(source_artifact_id)
+    .fetch_optional(db)
+    .await
+    {
+        Ok(row) => row,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "Failed to load source artifact_metadata during Debian promotion"
+            );
+            return;
+        }
+    };
+
+    let Some((format, metadata, properties)) = row else {
+        return;
+    };
+    if format != "debian" {
+        return;
+    }
+
+    if let Err(e) = sqlx::query(
+        r#"
+        INSERT INTO artifact_metadata (artifact_id, format, metadata, properties)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (artifact_id) DO NOTHING
+        "#,
+    )
+    .bind(target_artifact_id)
+    .bind(&format)
+    .bind(&metadata)
+    .bind(&properties)
+    .execute(db)
+    .await
+    {
+        tracing::warn!(
+            error = %e,
+            "Failed to copy Debian artifact_metadata during promotion"
+        );
+    }
+}
 
 pub fn router() -> Router<SharedState> {
     Router::new()
@@ -753,6 +838,7 @@ pub async fn promote_artifact(
     let new_artifact_id = Uuid::new_v4();
     let source_storage = state.storage_for_repo(&source_repo.storage_location())?;
     let target_storage = state.storage_for_repo(&target_repo.storage_location())?;
+    let target_path = debian_promotion_target_path(&artifact.path);
 
     // Stream the artifact body across (possibly distinct) storage backends
     // instead of buffering it in memory (#1608, Core Invariant ①). Shares the
@@ -761,7 +847,7 @@ pub async fn promote_artifact(
         .await
         .map_err(|e| AppError::Internal(format!("Failed to copy artifact: {}", e)))?;
 
-    super::cleanup_soft_deleted_artifact(&state.db, target_repo.id, &artifact.path).await;
+    super::cleanup_soft_deleted_artifact(&state.db, target_repo.id, &target_path).await;
 
     sqlx::query!(
         r#"
@@ -774,7 +860,7 @@ pub async fn promote_artifact(
         "#,
         new_artifact_id,
         target_repo.id,
-        artifact.path,
+        target_path,
         artifact.name,
         artifact.version,
         artifact.size_bytes,
@@ -791,12 +877,15 @@ pub async fn promote_artifact(
         if e.to_string().contains("duplicate key") {
             AppError::Conflict(format!(
                 "Artifact already exists in target repository: {}",
-                artifact.path
+                target_path
             ))
         } else {
             AppError::Database(e.to_string())
         }
     })?;
+
+    copy_debian_metadata_on_promotion(&state.db, artifact_id, new_artifact_id, &artifact.path)
+        .await;
 
     let promotion_id = Uuid::new_v4();
     sqlx::query!(
@@ -830,7 +919,7 @@ pub async fn promote_artifact(
     Ok(Json(PromotionResponse {
         promoted: true,
         source: format!("{}/{}", repo_key, artifact.path),
-        target: format!("{}/{}", target_key, artifact.path),
+        target: format!("{}/{}", target_key, target_path),
         promotion_id: Some(promotion_id),
         policy_violations: vec![],
         message: Some("Artifact promoted successfully".to_string()),
@@ -941,7 +1030,8 @@ pub async fn promote_artifacts_bulk(
         };
 
         let source_display = format!("{}/{}", repo_key, artifact.path);
-        let target_display = format!("{}/{}", target_key, artifact.path);
+        let target_path = debian_promotion_target_path(&artifact.path);
+        let target_display = format!("{}/{}", target_key, target_path);
 
         // Enforce per-pair promotion_rules per item before copying. Mirrors the
         // single-promote gate; a rule-blocked item fails and the batch continues
@@ -1022,7 +1112,7 @@ pub async fn promote_artifacts_bulk(
         }
 
         let new_artifact_id = Uuid::new_v4();
-        super::cleanup_soft_deleted_artifact(&state.db, target_repo.id, &artifact.path).await;
+        super::cleanup_soft_deleted_artifact(&state.db, target_repo.id, &target_path).await;
         let insert_result: std::result::Result<_, sqlx::Error> = sqlx::query!(
             r#"
             INSERT INTO artifacts (
@@ -1034,7 +1124,7 @@ pub async fn promote_artifacts_bulk(
             "#,
             new_artifact_id,
             target_repo.id,
-            artifact.path,
+            target_path,
             artifact.name,
             artifact.version,
             artifact.size_bytes,
@@ -1058,6 +1148,9 @@ pub async fn promote_artifacts_bulk(
             results.push(failed_response(source_display, target_display, msg));
             continue;
         }
+
+        copy_debian_metadata_on_promotion(&state.db, *artifact_id, new_artifact_id, &artifact.path)
+            .await;
 
         let promotion_id = Uuid::new_v4();
         let policy_result = serde_json::json!({"passed": true, "violations": []});

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -556,7 +556,7 @@ pub async fn proxy_fetch_streaming(
 }
 
 /// Streaming sibling of [`proxy_fetch`] that also forwards a
-/// `Content-Disposition: attachment; filename="…"` header on the
+/// `Content-Disposition: attachment; filename="..."` header on the
 /// outbound response.
 ///
 /// Same body and cache semantics as [`proxy_fetch_streaming`]; only the
@@ -592,6 +592,30 @@ pub async fn proxy_fetch_streaming_with_disposition(
     })
 }
 
+/// Streaming sibling of [`proxy_fetch_streaming`] that deliberately skips
+/// proxy-cache reads and writes. Use only for format-level passthrough
+/// policies where the upstream payload must not be persisted.
+pub async fn proxy_fetch_streaming_uncached(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+    default_content_type: &str,
+) -> Result<Response, Response> {
+    let repo = build_remote_repo(repo_id, repo_key, upstream_url);
+    let result = proxy_service
+        .fetch_artifact_streaming_uncached(&repo, path)
+        .await
+        .map_err(|e| map_proxy_error(repo_key, path, e))?;
+    build_streaming_response_with_disposition(result, default_content_type, None).map_err(|e| {
+        map_proxy_error(
+            repo_key,
+            path,
+            crate::error::AppError::Internal(e.to_string()),
+        )
+    })
+}
 /// Streaming fetch of `path` from a virtual member, using the member's REAL
 /// repository record so its `format` drives cache classification (#2069 bug 1)
 /// instead of the synthesized `Generic` stand-in [`build_remote_repo`] would
@@ -8174,6 +8198,21 @@ mod tests {
             .map(|e| e + 3)
             .unwrap_or(src.len() - start);
         &src[start..start + rel_end]
+    }
+
+    #[test]
+    fn test_proxy_fetch_streaming_uncached_uses_uncached_service() {
+        let src = include_str!("proxy_helpers.rs");
+        let fn_start = src
+            .find("pub async fn proxy_fetch_streaming_uncached(")
+            .expect("proxy_fetch_streaming_uncached must exist");
+        let next_section = src[fn_start..]
+            .find("/// Streaming fetch of `path` from a virtual member")
+            .expect("uncached helper must precede virtual member helper");
+        let window = &src[fn_start..fn_start + next_section];
+
+        assert!(window.contains(".fetch_artifact_streaming_uncached("));
+        assert!(!window.contains(".fetch_artifact_streaming(&repo, path)"));
     }
 
     #[test]

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -9,6 +9,8 @@ use axum::{
     Router,
 };
 use serde::{Deserialize, Serialize};
+#[allow(unused_imports)]
+use serde_json::json;
 use std::collections::BTreeMap;
 use std::time::Duration;
 use utoipa::{IntoParams, OpenApi, ToSchema};
@@ -42,6 +44,7 @@ use crate::services::repository_service::{
     UpdateRepositoryRequest as ServiceUpdateRepoReq,
 };
 use crate::services::routing_rules::{self, RoutingRule};
+use crate::services::signing_service::SigningService;
 use crate::services::upload_service;
 
 /// Require that the request is authenticated, returning an error if not.
@@ -457,6 +460,835 @@ pub struct ListRepositoriesQuery {
     pub q: Option<String>,
 }
 
+const DEBIAN_REPOSITORY_CONFIG_KEY: &str = "debian";
+const LEGACY_DEBIAN_REPOSITORY_CONFIG_KEY: &str = "debian_config";
+
+/// Artifact Keeper-native Debian metadata behavior.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DebianMetadataStrategy {
+    /// Serve upstream Release/InRelease/Release.gpg and package indexes unchanged.
+    #[default]
+    UpstreamPassthrough,
+    /// Apply Artifact Keeper filters and generate local Packages/Release metadata.
+    FilterAndGenerate,
+    /// Filter, generate, and sign local Release metadata.
+    FilterGenerateAndSign,
+    /// Generate hosted repository metadata from stored `.deb` packages.
+    HostedGenerate,
+}
+
+impl DebianMetadataStrategy {
+    pub(crate) fn generates_metadata(self) -> bool {
+        matches!(
+            self,
+            Self::FilterAndGenerate | Self::FilterGenerateAndSign | Self::HostedGenerate
+        )
+    }
+
+    pub(crate) fn signs_metadata(self) -> bool {
+        matches!(self, Self::FilterGenerateAndSign)
+    }
+}
+
+/// Artifact Keeper-native package payload fetch behavior for Debian remotes.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DebianPackageFetchStrategy {
+    /// Use Artifact Keeper's existing pull-through cache behavior.
+    #[default]
+    CacheOnRequest,
+    /// Fetch selected packages immediately after selected indexes are read.
+    PrefetchSelected,
+    /// Stream requested packages from upstream without persisting payloads.
+    Passthrough,
+}
+
+/// Debian/APT repository options exposed through repository create, update, and detail APIs.
+#[derive(Clone, Debug, Default, Deserialize, Serialize, ToSchema, PartialEq, Eq)]
+#[schema(example = json!({
+    "distribution_paths": ["jammy", "jammy-updates"],
+    "components": ["main", "universe"],
+    "architectures": ["amd64"],
+    "include_source_packages": false,
+    "flat_repository": false,
+    "verify_upstream_metadata": true,
+    "upstream_gpg_key_id": "ubuntu-archive-key",
+    "metadata_strategy": "upstream_passthrough",
+    "package_fetch_strategy": "cache_on_request",
+    "ignore_missing_indexes": false,
+    "package_queries": ["nginx", "curl*"],
+    "resolve_dependencies": true,
+    "signing_key_id": null,
+    "metadata_paths": [
+        "dists/jammy/Release",
+        "dists/jammy/main/binary-amd64/Packages.gz"
+    ],
+    "upload_endpoint": "/debian/example/pool/{component}/{path}",
+    "upload_path_template": "pool/{component}/{prefix}/{source-or-package}/{package}_{version}_{architecture}.deb",
+    "upload_metadata_headers": [
+        "X-Debian-Distribution: <distribution>",
+        "X-Debian-Component: <component>",
+        "X-Debian-Architecture: <architecture>"
+    ]
+}))]
+pub struct DebianRepositoryConfig {
+    /// Paths from the upstream root to Release/InRelease metadata, e.g. `jammy` or `/` for flat repos.
+    #[serde(default, alias = "distributions")]
+    pub distribution_paths: Vec<String>,
+    /// Component filters. Omitted, empty, null, or `["*"]` means all upstream components.
+    #[serde(default, deserialize_with = "deserialize_vec_string_or_null")]
+    pub components: Vec<String>,
+    /// Architecture filters. Omitted, empty, null, or `["*"]` means all upstream architectures.
+    #[serde(default, deserialize_with = "deserialize_vec_string_or_null")]
+    pub architectures: Vec<String>,
+    /// Include upstream source package indexes and artifacts when available.
+    #[serde(default)]
+    pub include_source_packages: bool,
+    /// Treat the Debian repository as a flat repository without component/binary architecture paths.
+    #[serde(default)]
+    pub flat_repository: bool,
+    /// Verify upstream InRelease or Release + Release.gpg before trusting metadata.
+    #[serde(default)]
+    pub verify_upstream_metadata: bool,
+    /// Public key reference used only for upstream metadata verification.
+    #[serde(default)]
+    pub upstream_gpg_key_id: Option<String>,
+    /// Artifact Keeper metadata handling strategy.
+    #[serde(default)]
+    pub metadata_strategy: DebianMetadataStrategy,
+    /// Package payload fetch strategy for remote repositories.
+    #[serde(default)]
+    pub package_fetch_strategy: DebianPackageFetchStrategy,
+    /// Continue when safe if selected upstream index files are missing.
+    #[serde(default)]
+    pub ignore_missing_indexes: bool,
+    /// Optional package name queries for filtered sync (exact or `name*` glob).
+    #[serde(default)]
+    pub package_queries: Vec<String>,
+    /// When package_queries is set, include Depends/Pre-Depends closure during sync.
+    #[serde(default)]
+    pub resolve_dependencies: bool,
+    /// Private signing key reference used only for generated local Release metadata.
+    #[serde(default)]
+    pub signing_key_id: Option<Uuid>,
+    /// UI-facing warnings derived from broad filters or risky fetch choices.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_vec_string",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    #[schema(read_only)]
+    pub warnings: Vec<String>,
+    /// UI-facing apt source example, populated on read when enough fields are configured.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_option_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(read_only)]
+    pub apt_source_example: Option<String>,
+    /// UI-facing public key endpoint, populated on read when signing is enabled.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_option_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(read_only)]
+    pub public_key_url: Option<String>,
+    /// UI-facing metadata paths generated for configured distributions/components/architectures.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_vec_string",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    #[schema(read_only)]
+    pub metadata_paths: Vec<String>,
+    /// UI-facing hosted-upload endpoint template for Debian .deb uploads.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_option_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(read_only)]
+    pub upload_endpoint: Option<String>,
+    /// UI-facing pool path template used for stable Debian package filenames.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_option_string",
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(read_only)]
+    pub upload_path_template: Option<String>,
+    /// UI-facing request headers accepted to provide Debian upload metadata.
+    #[serde(
+        default,
+        deserialize_with = "ignore_deserialized_vec_string",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    #[schema(read_only)]
+    pub upload_metadata_headers: Vec<String>,
+}
+
+fn ignore_deserialized_option_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let _ = serde::de::IgnoredAny::deserialize(deserializer)?;
+    Ok(None)
+}
+
+fn ignore_deserialized_vec_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let _ = serde::de::IgnoredAny::deserialize(deserializer)?;
+    Ok(Vec::new())
+}
+
+fn deserialize_vec_string_or_null<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<Vec<String>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+impl DebianRepositoryConfig {
+    pub(crate) fn signing_enabled(&self) -> bool {
+        self.metadata_strategy.signs_metadata()
+    }
+
+    pub(crate) fn generated_metadata_enabled(&self) -> bool {
+        self.metadata_strategy.generates_metadata()
+    }
+
+    pub(crate) fn component_filter_is_all(&self) -> bool {
+        filter_values_are_all(&self.components)
+    }
+
+    pub(crate) fn architecture_filter_is_all(&self) -> bool {
+        filter_values_are_all(&self.architectures)
+    }
+
+    pub(crate) fn effective_components(&self) -> Vec<String> {
+        if self.component_filter_is_all() {
+            Vec::new()
+        } else {
+            normalized_non_empty_values(&self.components)
+        }
+    }
+
+    pub(crate) fn effective_architectures(&self) -> Vec<String> {
+        if self.architecture_filter_is_all() {
+            Vec::new()
+        } else {
+            normalized_non_empty_values(&self.architectures)
+        }
+    }
+
+    pub(crate) fn effective_distribution_paths(&self) -> Vec<String> {
+        normalized_non_empty_values(&self.distribution_paths)
+    }
+
+    pub(crate) fn effective_package_queries(&self) -> Vec<String> {
+        normalized_non_empty_values(&self.package_queries)
+    }
+
+    fn hydrated_for_response(&self, repo_key: &str, upstream_url: Option<&str>) -> Self {
+        let mut config = self.clone();
+        if config.warnings.is_empty() {
+            config.warnings = debian_config_warnings(&config);
+        }
+        if config.apt_source_example.is_none() {
+            config.apt_source_example = build_debian_apt_source_example(repo_key, &config);
+        }
+        if config.public_key_url.is_none() && config.signing_enabled() {
+            if let Some(distribution) = first_debian_distribution(&config) {
+                config.public_key_url = Some(format!(
+                    "/debian/{repo_key}/dists/{distribution}/gpg-key.asc"
+                ));
+            }
+        }
+        if config.metadata_paths.is_empty() {
+            config.metadata_paths = build_debian_metadata_paths(&config);
+        }
+        if config.upload_endpoint.is_none() {
+            config.upload_endpoint =
+                Some(format!("/debian/{repo_key}/pool/{{component}}/{{path}}"));
+        }
+        if config.upload_path_template.is_none() {
+            config.upload_path_template = Some(
+                "pool/{component}/{prefix}/{source-or-package}/{package}_{version}_{architecture}.deb"
+                    .to_string(),
+            );
+        }
+        if config.upload_metadata_headers.is_empty() {
+            config.upload_metadata_headers = vec![
+                "X-Debian-Distribution: <distribution>".to_string(),
+                "X-Debian-Component: <component>".to_string(),
+                "X-Debian-Architecture: <architecture>".to_string(),
+            ];
+        }
+        if config.apt_source_example.is_none() {
+            if let Some(upstream_url) = upstream_url
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                config.apt_source_example = Some(format!(
+                    "deb {upstream_url} {} {}",
+                    first_debian_distribution(&config).unwrap_or("stable"),
+                    first_debian_component(&config).unwrap_or("main")
+                ));
+            }
+        }
+        config
+    }
+}
+
+/// Partial Debian config as sent to the repository *update* endpoint.
+///
+/// Remembers which keys the client actually provided so a partial update
+/// preserves omitted settings instead of resetting them to defaults. Every
+/// `DebianRepositoryConfig` field is `#[serde(default)]`, so without this the
+/// deserializer cannot tell "field omitted" from "field set to its default"
+/// and a `PATCH` that touches one setting would silently reset the rest.
+///
+/// `parsed` is the standalone interpretation (used when the repository has no
+/// stored config yet); `provided_keys` drives the merge with the stored config.
+#[derive(Debug, Clone)]
+pub struct DebianConfigPatch {
+    provided_keys: serde_json::Map<String, serde_json::Value>,
+    parsed: DebianRepositoryConfig,
+}
+
+impl<'de> Deserialize<'de> for DebianConfigPatch {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let provided_keys = match &value {
+            serde_json::Value::Object(map) => map.clone(),
+            _ => return Err(serde::de::Error::custom("debian must be a JSON object")),
+        };
+        let parsed = serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+        Ok(Self {
+            provided_keys,
+            parsed,
+        })
+    }
+}
+
+/// Deserialize `Option<Option<DebianConfigPatch>>` so that:
+/// - field omitted → `None` (via `#[serde(default)]`, this fn is not called)
+/// - `null` → `Some(None)` (clear Debian config)
+/// - object → `Some(Some(patch))`
+fn deserialize_optional_nullable_debian_patch<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<Option<DebianConfigPatch>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::Null => Ok(Some(None)),
+        other => {
+            let patch: DebianConfigPatch =
+                serde_json::from_value(other).map_err(serde::de::Error::custom)?;
+            Ok(Some(Some(patch)))
+        }
+    }
+}
+
+/// Overlay the keys a client explicitly provided onto the stored config's JSON
+/// so omitted fields keep their existing values. Pure and unit-tested.
+fn merge_debian_config_values(
+    mut base: serde_json::Map<String, serde_json::Value>,
+    provided: &serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    for (key, value) in provided {
+        base.insert(key.clone(), value.clone());
+    }
+    base
+}
+
+async fn load_stored_debian_config_value(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+) -> Option<serde_json::Map<String, serde_json::Value>> {
+    let stored = sqlx::query_scalar::<_, String>(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key IN ('debian', 'debian_config') ORDER BY CASE WHEN key = 'debian' THEN 0 ELSE 1 END LIMIT 1",
+    )
+    .bind(repo_id)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten()?;
+    match serde_json::from_str::<serde_json::Value>(&stored) {
+        Ok(serde_json::Value::Object(map)) => Some(map),
+        _ => None,
+    }
+}
+
+/// Resolve the effective Debian config to persist for an update: merge the
+/// client's provided keys over the stored config (preserving omitted settings),
+/// or fall back to the standalone parse when the repository has no stored
+/// config yet.
+async fn resolve_debian_config_update(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    patch: DebianConfigPatch,
+) -> Result<DebianRepositoryConfig> {
+    match load_stored_debian_config_value(db, repo_id).await {
+        Some(base) => {
+            let merged = merge_debian_config_values(base, &patch.provided_keys);
+            serde_json::from_value(serde_json::Value::Object(merged)).map_err(|e| {
+                AppError::Validation(format!("Invalid Debian config after merge: {e}"))
+            })
+        }
+        None => Ok(patch.parsed),
+    }
+}
+
+fn normalized_non_empty_values(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn filter_values_are_all(values: &[String]) -> bool {
+    let values = normalized_non_empty_values(values);
+    values.is_empty() || values.iter().any(|value| value == "*")
+}
+
+fn first_debian_distribution(config: &DebianRepositoryConfig) -> Option<&str> {
+    config
+        .distribution_paths
+        .iter()
+        .map(String::as_str)
+        .map(str::trim)
+        .find(|value| !value.is_empty())
+}
+
+fn first_debian_component(config: &DebianRepositoryConfig) -> Option<&str> {
+    if config.component_filter_is_all() {
+        None
+    } else {
+        config
+            .components
+            .iter()
+            .map(String::as_str)
+            .map(str::trim)
+            .find(|value| !value.is_empty())
+    }
+}
+
+fn build_debian_apt_source_example(
+    repo_key: &str,
+    config: &DebianRepositoryConfig,
+) -> Option<String> {
+    let distribution = first_debian_distribution(config)?;
+    let signed_by = if config.signing_enabled() {
+        " [signed-by=/usr/share/keyrings/artifact-keeper.gpg]"
+    } else {
+        ""
+    };
+    if config.flat_repository {
+        return Some(format!("deb{signed_by} <repo-url>/debian/{repo_key} ./"));
+    }
+    let component = first_debian_component(config).unwrap_or("main");
+    Some(format!(
+        "deb{signed_by} <repo-url>/debian/{repo_key} {distribution} {component}"
+    ))
+}
+
+fn debian_config_upstream_url(
+    _config: Option<&DebianRepositoryConfig>,
+    _repo_type: &RepositoryType,
+) -> Option<String> {
+    // Debian remotes use the repository's top-level upstream_url. The Debian
+    // config intentionally avoids a second upstream URL so existing remote
+    // proxy/cache behavior stays Artifact Keeper-native and backwards compatible.
+    None
+}
+
+fn build_debian_metadata_paths(config: &DebianRepositoryConfig) -> Vec<String> {
+    let mut paths = Vec::new();
+    let components = if config.component_filter_is_all() {
+        vec!["{component}".to_string()]
+    } else {
+        config.effective_components()
+    };
+    let architectures = if config.architecture_filter_is_all() {
+        vec!["{arch}".to_string()]
+    } else {
+        config
+            .effective_architectures()
+            .into_iter()
+            .filter(|arch| arch != "all")
+            .collect()
+    };
+
+    for distribution in config.effective_distribution_paths() {
+        let distribution = distribution.trim_end_matches('/');
+        let release_prefix = if config.flat_repository || distribution.is_empty() {
+            "".to_string()
+        } else {
+            format!("dists/{distribution}/")
+        };
+        paths.push(format!("{release_prefix}Release"));
+        if config.signing_enabled() {
+            paths.push(format!("{release_prefix}InRelease"));
+            paths.push(format!("{release_prefix}Release.gpg"));
+        }
+        if config.flat_repository {
+            paths.push("Packages".to_string());
+            paths.push("Packages.gz".to_string());
+            paths.push("Packages.xz".to_string());
+            continue;
+        }
+        for component in &components {
+            for arch in &architectures {
+                paths.push(format!(
+                    "dists/{distribution}/{component}/binary-{arch}/Packages"
+                ));
+                paths.push(format!(
+                    "dists/{distribution}/{component}/binary-{arch}/Packages.gz"
+                ));
+                paths.push(format!(
+                    "dists/{distribution}/{component}/binary-{arch}/Packages.xz"
+                ));
+            }
+        }
+    }
+    paths
+}
+
+fn validate_filter_values(values: &[String], field: &str) -> Result<()> {
+    for value in values {
+        let value = value.trim();
+        if value.is_empty() || value == "*" {
+            continue;
+        }
+        validate_debian_identifier(value, field)?;
+    }
+    Ok(())
+}
+
+fn validate_distribution_path(value: &str) -> Result<()> {
+    let value = value.trim();
+    let valid = !value.is_empty()
+        && value.len() <= 256
+        && !value.contains("..")
+        && !value.contains('\\')
+        && !value.chars().any(char::is_control);
+    if !valid {
+        return Err(AppError::Validation(format!(
+            "debian.distribution_paths contains invalid path '{value}'"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_debian_identifier(value: &str, field: &str) -> Result<()> {
+    let value = value.trim();
+    // Components may include a slash for Debian-Security style names
+    // (e.g. updates/main). Reject path traversal and empty segments.
+    let allow_slash = field == "components";
+    let valid = !value.is_empty()
+        && value.len() <= 128
+        && !value.contains("..")
+        && !value.starts_with('/')
+        && !value.ends_with('/')
+        && value.chars().all(|ch| {
+            ch.is_ascii_alphanumeric()
+                || matches!(ch, '-' | '_' | '.' | '+')
+                || (allow_slash && ch == '/')
+        })
+        && (!allow_slash || !value.split('/').any(|part| part.is_empty()));
+    if !valid {
+        return Err(AppError::Validation(format!(
+            "debian.{field} contains invalid Debian identifier '{value}'"
+        )));
+    }
+    Ok(())
+}
+
+fn debian_config_warnings(config: &DebianRepositoryConfig) -> Vec<String> {
+    let mut warnings = Vec::new();
+    if config.component_filter_is_all() {
+        warnings.push("Components are set to all. Artifact Keeper will read all components advertised by the upstream Release metadata for the selected distribution(s). This may increase metadata size, package visibility, and storage usage if package prefetching is enabled.".to_string());
+    }
+    if config.architecture_filter_is_all() {
+        warnings.push("Architectures are set to all. Artifact Keeper will read all architectures advertised by the upstream Release metadata for the selected distribution(s). This may significantly increase metadata size and package visibility. Use a specific architecture such as amd64 or arm64 to reduce scope.".to_string());
+    }
+    if config.package_fetch_strategy == DebianPackageFetchStrategy::PrefetchSelected
+        && (config.component_filter_is_all() || config.architecture_filter_is_all())
+    {
+        warnings.push("Prefetch is enabled with broad component or architecture selection. Artifact Keeper may download a large number of packages and consume significant storage. Consider using cache_on_request or narrowing the filters.".to_string());
+    }
+    if config.metadata_strategy == DebianMetadataStrategy::UpstreamPassthrough
+        && (!config.components.is_empty() || !config.architectures.is_empty())
+    {
+        warnings.push("upstream_passthrough serves upstream metadata unchanged; component and architecture filters are ignored in passthrough mode.".to_string());
+    }
+    warnings
+}
+
+fn validate_debian_repository_config(
+    format: &RepositoryFormat,
+    config: Option<&DebianRepositoryConfig>,
+) -> Result<()> {
+    let Some(config) = config else {
+        return Ok(());
+    };
+    if *format != RepositoryFormat::Debian {
+        return Err(AppError::Validation(
+            "debian is only valid for Debian/APT repositories".to_string(),
+        ));
+    }
+
+    let distribution_paths = config.effective_distribution_paths();
+    if distribution_paths.is_empty() {
+        return Err(AppError::Validation(
+            "debian.distribution_paths must contain at least one value".to_string(),
+        ));
+    }
+    for path in &distribution_paths {
+        validate_distribution_path(path)?;
+    }
+    validate_filter_values(&config.components, "components")?;
+    validate_filter_values(&config.architectures, "architectures")?;
+
+    if config.flat_repository {
+        if distribution_paths.len() != 1 {
+            return Err(AppError::Validation(
+                "debian.flat_repository=true requires exactly one distribution path".to_string(),
+            ));
+        }
+        let path = distribution_paths[0].trim();
+        if !path.ends_with('/') {
+            return Err(AppError::Validation(
+                "debian.flat_repository=true requires distribution_paths[0] to end with '/'"
+                    .to_string(),
+            ));
+        }
+        if !config.component_filter_is_all() {
+            return Err(AppError::Validation(
+                "debian.flat_repository=true requires components to be omitted, empty, or ['*']"
+                    .to_string(),
+            ));
+        }
+    }
+
+    if config.metadata_strategy.signs_metadata() && config.signing_key_id.is_none() {
+        return Err(AppError::Validation(
+            "metadata_strategy=filter_generate_and_sign requires signing_key_id.".to_string(),
+        ));
+    }
+    if config.metadata_strategy.signs_metadata() && !config.verify_upstream_metadata {
+        return Err(AppError::Validation(
+            "metadata_strategy=filter_generate_and_sign requires verify_upstream_metadata=true so Artifact Keeper only re-signs metadata from a verified upstream.".to_string(),
+        ));
+    }
+    if config.verify_upstream_metadata
+        && config
+            .upstream_gpg_key_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+    {
+        return Err(AppError::Validation(
+            "verify_upstream_metadata=true requires upstream_gpg_key_id.".to_string(),
+        ));
+    }
+    // Reject incoherent combinations of passthrough strategies with package_queries.
+    // Passthrough modes serve upstream content unchanged; package_queries would be silently ignored,
+    // creating a false sense of filtering. Require the caller to use a generating strategy instead.
+    if config.metadata_strategy == DebianMetadataStrategy::UpstreamPassthrough
+        && !config.package_queries.is_empty()
+    {
+        return Err(AppError::Validation(
+            "metadata_strategy=upstream_passthrough is incompatible with package_queries: passthrough serves upstream metadata unchanged so queries would be silently ignored. Use filter_and_generate or filter_generate_and_sign instead.".to_string(),
+        ));
+    }
+    if config.package_fetch_strategy == DebianPackageFetchStrategy::Passthrough
+        && !config.package_queries.is_empty()
+    {
+        return Err(AppError::Validation(
+            "package_fetch_strategy=passthrough is incompatible with package_queries: packages are streamed from upstream without filtering so queries would be silently ignored.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn debian_cache_ttl_seconds(_config: &DebianRepositoryConfig) -> Result<Option<i64>> {
+    Ok(None)
+}
+async fn upsert_debian_config(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    config: &DebianRepositoryConfig,
+) -> Result<()> {
+    let value = serde_json::to_string(config)
+        .map_err(|e| AppError::Validation(format!("Invalid Debian config: {e}")))?;
+    upsert_repo_config(db, repo_id, DEBIAN_REPOSITORY_CONFIG_KEY, &value).await
+}
+
+/// Clear all synced Debian generation metadata keys (dists indexes + release) for a
+/// repository. Called after a debian config update so that stale generated metadata is
+/// invalidated and a fresh sync will be required before generated metadata is served.
+async fn clear_debian_synced_metadata(db: &sqlx::PgPool, repo_id: Uuid) -> Result<()> {
+    sqlx::query(
+        "DELETE FROM repository_config WHERE repository_id = $1 AND (key LIKE 'debian_synced_dists:%' OR key LIKE 'debian_synced_release:%')",
+    )
+    .bind(repo_id)
+    .execute(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(())
+}
+
+/// Signing-config values to persist when saving a Debian repository config.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DebianSigningUpdate {
+    signing_key_id: Option<Uuid>,
+    sign_metadata: bool,
+    sign_packages: bool,
+    require_signatures: bool,
+}
+
+/// Decide how saving a Debian config should touch the repository's signing
+/// configuration.
+///
+/// The Debian config may point at a signing key and may *enable* metadata
+/// signing (metadata_strategy=filter_generate_and_sign), but saving it must
+/// never silently turn OFF signing that was configured elsewhere via the
+/// dedicated signing API. So the enable flag is OR-ed with the existing state
+/// and the package-signing / require-signatures settings are preserved rather
+/// than clobbered to false. Returns `None` when there is nothing to persist and
+/// no existing row, so saving Debian options never creates an empty
+/// signing-config row as a side effect.
+fn resolve_debian_signing_update(
+    existing: Option<&crate::models::signing_key::RepositorySigningConfig>,
+    config: &DebianRepositoryConfig,
+) -> Option<DebianSigningUpdate> {
+    // Trust `config.signing_key_id` as the effective value. On update the
+    // DebianConfigPatch merge already preserves omitted keys and applies
+    // explicit nulls, so OR-ing with the existing signing-config row would
+    // incorrectly restore a key the client just cleared.
+    let signing_key_id = config.signing_key_id;
+    let sign_metadata =
+        config.signing_enabled() || existing.is_some_and(|existing| existing.sign_metadata);
+
+    if existing.is_none() && signing_key_id.is_none() && !sign_metadata {
+        return None;
+    }
+
+    Some(DebianSigningUpdate {
+        signing_key_id,
+        sign_metadata,
+        sign_packages: existing.is_some_and(|existing| existing.sign_packages),
+        require_signatures: existing.is_some_and(|existing| existing.require_signatures),
+    })
+}
+
+async fn delete_debian_config(db: &sqlx::PgPool, repo_id: Uuid) -> Result<()> {
+    sqlx::query(
+        "DELETE FROM repository_config WHERE repository_id = $1 AND key IN ('debian', 'debian_config')",
+    )
+    .bind(repo_id)
+    .execute(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(())
+}
+
+async fn sync_debian_signing_config(
+    state: &SharedState,
+    repo_id: Uuid,
+    config: &DebianRepositoryConfig,
+) -> Result<()> {
+    let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
+    let existing = signing_svc.get_signing_config(repo_id).await?;
+
+    let Some(update) = resolve_debian_signing_update(existing.as_ref(), config) else {
+        return Ok(());
+    };
+
+    signing_svc
+        .update_signing_config(
+            repo_id,
+            update.signing_key_id,
+            update.sign_metadata,
+            update.sign_packages,
+            update.require_signatures,
+        )
+        .await?;
+    Ok(())
+}
+
+async fn load_debian_config(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    response: &RepositoryResponse,
+) -> Option<DebianRepositoryConfig> {
+    if response.format != "debian" {
+        return None;
+    }
+
+    let stored = match sqlx::query_scalar::<_, String>(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
+    )
+    .bind(repo_id)
+    .bind(DEBIAN_REPOSITORY_CONFIG_KEY)
+    .fetch_optional(db)
+    .await
+    {
+        Ok(Some(stored)) => Some(stored),
+        Ok(None) => match sqlx::query_scalar::<_, String>(
+            "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
+        )
+        .bind(repo_id)
+        .bind(LEGACY_DEBIAN_REPOSITORY_CONFIG_KEY)
+        .fetch_optional(db)
+        .await
+        {
+            Ok(stored) => stored,
+            Err(e) => {
+                tracing::warn!(repository_id = %repo_id, error = %e, "failed to load legacy Debian repository config");
+                None
+            }
+        },
+        Err(e) => {
+            tracing::warn!(repository_id = %repo_id, error = %e, "failed to load Debian repository config");
+            None
+        }
+    };
+
+    match stored {
+        Some(value) => match serde_json::from_str::<DebianRepositoryConfig>(&value) {
+            Ok(config) => {
+                Some(config.hydrated_for_response(&response.key, response.upstream_url.as_deref()))
+            }
+            Err(e) => {
+                tracing::warn!(repository_id = %repo_id, error = %e, "invalid stored Debian repository config");
+                None
+            }
+        },
+        None => None,
+    }
+}
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateRepositoryRequest {
     pub key: String,
@@ -503,6 +1335,9 @@ pub struct CreateRepositoryRequest {
     /// Stored in `repository_config` under `pypi_upstream_index_path`.
     /// Only meaningful for PyPI / Poetry / Conda Remote repositories.
     pub pypi_upstream_index_path: Option<String>,
+    /// Debian/APT repository options surfaced to UI/OpenAPI clients.
+    #[serde(default, alias = "debian_config")]
+    pub debian: Option<DebianRepositoryConfig>,
     /// Member repositories to add when creating a virtual repository.
     /// Each entry specifies a repository key and optional priority.
     pub member_repos: Option<Vec<CreateVirtualMemberInput>>,
@@ -548,6 +1383,8 @@ pub struct UpdateRepositoryRequest {
     /// If both `is_public` and `allow_anonymous_access` are provided,
     /// `allow_anonymous_access` takes precedence.
     pub allow_anonymous_access: Option<bool>,
+    /// Update the remote upstream URL. When omitted, the existing value is preserved.
+    pub upstream_url: Option<String>,
     pub quota_bytes: Option<i64>,
     /// When provided, enables/disables the `promotion_only` policy for this
     /// repository (admin-only). When omitted, the flag is left unchanged.
@@ -563,6 +1400,21 @@ pub struct UpdateRepositoryRequest {
     /// restore the PEP 503 default, or any other non-empty string for a custom prefix.
     /// Only meaningful for PyPI / Poetry / Conda Remote repositories.
     pub pypi_upstream_index_path: Option<String>,
+    /// Debian/APT repository options surfaced to UI/OpenAPI clients. On update
+    /// this is a partial patch: only the keys present in the request are
+    /// applied, and any omitted settings keep their existing stored values.
+    ///
+    /// Triple-state semantics:
+    /// - field omitted → leave Debian config unchanged
+    /// - `debian: null` → delete stored Debian config (+ invalidate synced metadata)
+    /// - `debian: { ... }` → merge patch into stored config
+    #[serde(
+        default,
+        alias = "debian_config",
+        deserialize_with = "deserialize_optional_nullable_debian_patch"
+    )]
+    #[schema(value_type = Option<DebianRepositoryConfig>)]
+    pub debian: Option<Option<DebianConfigPatch>>,
     /// Enable or disable quarantine period for this repository.
     /// When enabled, newly uploaded artifacts are held until scanned.
     /// Stored in `repository_config` under `quarantine_enabled`.
@@ -618,6 +1470,9 @@ pub struct RepositoryResponse {
     /// `repository_config` (#1770 B). `None` when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quarantine_duration_minutes: Option<i64>,
+    /// Debian/APT repository options read from repository_config.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debian: Option<DebianRepositoryConfig>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -654,15 +1509,14 @@ fn repo_to_response(
         // db-less, mirroring `upstream_auth_*` above (#1770 B).
         quarantine_enabled: None,
         quarantine_duration_minutes: None,
+        debian: None,
         created_at: repo.created_at,
         updated_at: repo.updated_at,
     }
 }
 
-/// Populate `RepositoryResponse.quarantine_*` from `repository_config` (#1770
-/// B). Split out so the detail and update handlers, which both have a DB
-/// handle, can echo the configured Package Age Policy back to clients. The
-/// listing path stays db-light and omits these per-repo lookups.
+/// Populate repository_config-backed fields for detail/update responses.
+/// The listing path stays db-light and omits these per-repo lookups.
 async fn with_quarantine_settings(
     db: &sqlx::PgPool,
     repo_id: Uuid,
@@ -671,6 +1525,7 @@ async fn with_quarantine_settings(
     let (enabled, duration) = crate::services::quarantine_service::repo_settings(db, repo_id).await;
     response.quarantine_enabled = enabled;
     response.quarantine_duration_minutes = duration;
+    response.debian = load_debian_config(db, repo_id, &response).await;
     response
 }
 
@@ -1378,13 +2233,14 @@ pub async fn list_repositories(
         std::collections::HashMap::new()
     };
 
-    let items: Vec<RepositoryResponse> = repos
-        .into_iter()
-        .map(|r| {
-            let storage = storage_map.get(&r.id).copied().unwrap_or(0);
-            repo_to_response(r, storage)
-        })
-        .collect();
+    let mut items: Vec<RepositoryResponse> = Vec::with_capacity(repos.len());
+    for repo in repos {
+        let repo_id = repo.id;
+        let storage = storage_map.get(&repo_id).copied().unwrap_or(0);
+        let mut response = repo_to_response(repo, storage);
+        response.debian = load_debian_config(&state.db, repo_id, &response).await;
+        items.push(response);
+    }
 
     Ok(Json(RepositoryListResponse {
         items,
@@ -1455,6 +2311,9 @@ pub async fn create_repository(
     let service = state.create_repository_service();
     let (format, plugin_format_key) = service.resolve_format(&payload.format).await?;
     let repo_type = parse_repo_type(&payload.repo_type)?;
+    let debian_config = payload.debian.clone();
+    let debian_upstream_url = debian_config_upstream_url(debian_config.as_ref(), &repo_type);
+    validate_debian_repository_config(&format, debian_config.as_ref())?;
 
     // Validate up-front that virtual repos do not arrive with an explicit
     // empty `member_repos: []`. Omitted-field (deferred-population) is
@@ -1515,7 +2374,7 @@ pub async fn create_repository(
             repo_type: repo_type.clone(),
             storage_backend,
             storage_path,
-            upstream_url: payload.upstream_url,
+            upstream_url: payload.upstream_url.or(debian_upstream_url),
             is_public,
             quota_bytes: payload.quota_bytes,
             promotion_only: payload.promotion_only.unwrap_or(false),
@@ -1536,6 +2395,14 @@ pub async fn create_repository(
 
     if let Some(ref index_path) = payload.pypi_upstream_index_path {
         upsert_repo_config(&state.db, repo.id, "pypi_upstream_index_path", index_path).await?;
+    }
+
+    if let Some(ref config) = debian_config {
+        upsert_debian_config(&state.db, repo.id, config).await?;
+        if let Some(ttl) = debian_cache_ttl_seconds(config)? {
+            upsert_repo_config(&state.db, repo.id, "cache_ttl_seconds", &ttl.to_string()).await?;
+        }
+        sync_debian_signing_config(&state, repo.id, config).await?;
     }
 
     // Add virtual repository members. Post-#1444, the validator accepts
@@ -1611,6 +2478,10 @@ pub async fn create_repository(
     if let Some(ref at) = payload.upstream_auth_type {
         response.upstream_auth_type = Some(at.clone());
         response.upstream_auth_configured = true;
+    }
+    if let Some(config) = debian_config {
+        response.debian =
+            Some(config.hydrated_for_response(&response.key, response.upstream_url.as_deref()));
     }
     Ok(Json(response))
 }
@@ -1695,6 +2566,22 @@ pub async fn update_repository(
 
     // Get existing repo by key and check repo access
     let existing = service.get_by_key(&key).await?;
+    // Partial update: merge the provided Debian keys over the stored config so
+    // omitted settings are preserved instead of reset to defaults.
+    // Triple-state: omitted → unchanged; null → clear; object → merge.
+    let (debian_config, clear_debian) = match payload.debian.clone() {
+        None => (None, false),
+        Some(None) => (None, true),
+        Some(Some(patch)) => (
+            Some(resolve_debian_config_update(&state.db, existing.id, patch).await?),
+            false,
+        ),
+    };
+    let debian_upstream_url =
+        debian_config_upstream_url(debian_config.as_ref(), &existing.repo_type);
+    if !clear_debian {
+        validate_debian_repository_config(&existing.format, debian_config.as_ref())?;
+    }
     require_repo_access(&auth, existing.id)?;
 
     // Fine-grained permission check: non-admins need "admin" on the target repository.
@@ -1733,7 +2620,7 @@ pub async fn update_repository(
                 description: payload.description,
                 is_public: effective_is_public,
                 quota_bytes: payload.quota_bytes.map(Some),
-                upstream_url: None,
+                upstream_url: payload.upstream_url.or(debian_upstream_url),
                 promotion_only: payload.promotion_only,
                 versioning_enabled: payload.versioning_enabled,
             },
@@ -1746,6 +2633,20 @@ pub async fn update_repository(
 
     if let Some(ref index_path) = payload.pypi_upstream_index_path {
         upsert_repo_config(&state.db, repo.id, "pypi_upstream_index_path", index_path).await?;
+    }
+
+    if clear_debian {
+        delete_debian_config(&state.db, repo.id).await?;
+        clear_debian_synced_metadata(&state.db, repo.id).await?;
+    } else if let Some(ref config) = debian_config {
+        upsert_debian_config(&state.db, repo.id, config).await?;
+        if let Some(ttl) = debian_cache_ttl_seconds(config)? {
+            upsert_repo_config(&state.db, repo.id, "cache_ttl_seconds", &ttl.to_string()).await?;
+        }
+        sync_debian_signing_config(&state, repo.id, config).await?;
+        // Invalidate all cached generated Debian metadata so that the next sync
+        // produces a fresh generation consistent with the updated config.
+        clear_debian_synced_metadata(&state.db, repo.id).await?;
     }
 
     if let Some(enabled) = payload.quarantine_enabled {
@@ -2219,10 +3120,6 @@ pub struct ArtifactVersionResponse {
     pub size_bytes: i64,
     pub checksum_sha256: String,
     pub content_type: String,
-    /// Id of the user that uploaded this revision (#2397). Always serialized
-    /// (`null` when unknown, e.g. anonymous uploads) so the versions UI can
-    /// rely on the key being present.
-    pub uploaded_by: Option<Uuid>,
     pub created_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -2248,16 +3145,9 @@ pub struct ArtifactResponse {
     pub created_at: chrono::DateTime<chrono::Utc>,
     #[schema(value_type = Option<Object>)]
     pub metadata: Option<serde_json::Value>,
-    /// Whether this artifact can have an SBOM generated or a security scan
-    /// run against it. `false` for proxy-cached (Remote) objects: those are
-    /// listed with a synthetic, SHA-256-derived id (see
-    /// [`cached_artifact_id`]) and have no row in the `artifacts` table
-    /// (#1280/#1278), so SBOM/scan lookups by `artifacts.id` cannot resolve
-    /// them and `sbom_documents`/`scan_results` cannot reference them.
-    /// `true` for hosted artifacts, which carry a real DB id. The web UI
-    /// uses this to hide/disable the "Generate SBOM" / "Scan" actions where
-    /// they cannot work; clients that predate the field should treat an
-    /// absent value as `true` so hosted artifacts are never hidden. (#2227)
+    /// Whether this response points at a real artifact row that can be scanned
+    /// or have an SBOM generated. Proxy-cache-only entries use synthetic IDs
+    /// and therefore are not analyzable.
     pub analyzable: bool,
     /// When the proxy cache entry for this artifact was last written.
     /// Only populated for Remote (proxy) repositories whose proxy service is
@@ -2742,8 +3632,6 @@ fn build_cached_artifact_response(
         download_count: 0,
         created_at: entry.cached_at,
         metadata: None,
-        // Proxy-cached objects have no `artifacts` row (#1280/#1278) and a
-        // synthetic id, so SBOM/scan cannot resolve them: not analyzable.
         analyzable: false,
         // This is a proxy-cache entry, so surface the cache timestamp.
         // CachedArtifactEntry carries no expiry, so cache_expires_at is None.
@@ -2859,23 +3747,9 @@ async fn lookup_artifact_by_paths(
     Ok(None)
 }
 
-/// Resolve a request path to the artifact's stored path for the generic
-/// download/delete handlers.
-///
-/// npm publish stores tarballs under the version-segmented layout
-/// (`<name>/<version>/<file>.tgz`, see `npm::store_npm_version`), while the Web
-/// UI's Download/Delete buttons emit the canonical npm download-URL shape
-/// (`<name>/-/<file>.tgz`). An exact-match `WHERE path = $2` lookup against the
-/// URL shape therefore never finds the version-segmented row. This mirrors the
-/// resolution `get_artifact_metadata` already performs: try the literal path
-/// first, then the normalised stored shape for npm-family repos.
-///
-/// The extra DB roundtrip is taken only when a normalised candidate actually
-/// exists (npm-family repo + the `/-/` URL shape): for non-npm formats and
-/// already-stored npm paths `lookup_path_candidates` returns a single element,
-/// so the guard short-circuits and behaviour is byte-identical to today. On a
-/// true local miss the original `path` is returned unchanged, so Remote/Virtual
-/// proxy fallback still fires against the original URL shape.
+/// Resolve canonical npm `/-/` request URLs to the version-segmented path
+/// used by the artifact table. Other formats and literal stored paths pass
+/// through unchanged.
 async fn resolve_stored_path(
     state: &SharedState,
     repo: &crate::models::repository::Repository,
@@ -2885,7 +3759,7 @@ async fn resolve_stored_path(
     if candidates.len() > 1 {
         Ok(lookup_artifact_by_paths(&state.db, repo.id, &candidates)
             .await?
-            .map(|a| a.path)
+            .map(|artifact| artifact.path)
             .unwrap_or(path))
     } else {
         Ok(path)
@@ -2924,7 +3798,6 @@ fn build_artifact_response(
         download_count,
         created_at: artifact.created_at,
         metadata: None,
-        // Hosted artifact backed by a real `artifacts` row: SBOM/scan resolve.
         analyzable: true,
         // Cache metadata is surfaced only by the per-artifact metadata
         // endpoint to avoid fanning out a storage GET per artifact in
@@ -2981,8 +3854,6 @@ fn expand_maven_secondary_files(
             download_count: 0,
             created_at: artifact.created_at,
             metadata: None,
-            // Secondary Maven files are recorded under a real primary
-            // artifact row (its id), so they are analyzable like the primary.
             analyzable: true,
             cache_cached_at: None,
             cache_expires_at: None,
@@ -3866,8 +4737,6 @@ pub async fn get_artifact_metadata(
             download_count: downloads,
             created_at: artifact.created_at,
             metadata: metadata.map(|m| m.metadata),
-            // This handler resolves a real `artifacts` row by id, so it is
-            // always a hosted artifact (analyzable), even inside a Remote repo.
             analyzable: true,
             cache_cached_at: cache_meta.as_ref().map(|m| m.cached_at),
             cache_expires_at: cache_meta.as_ref().map(|m| m.expires_at),
@@ -4038,7 +4907,6 @@ pub async fn list_artifact_versions(
                 size_bytes: v.size_bytes,
                 checksum_sha256: v.checksum_sha256.trim().to_string(),
                 content_type: v.content_type,
-                uploaded_by: v.uploaded_by,
                 created_at: v.created_at,
             })
             .collect(),
@@ -4252,7 +5120,6 @@ pub async fn upload_artifact(
             download_count: downloads,
             created_at: artifact.created_at,
             metadata: metadata_json,
-            // Freshly-uploaded hosted artifact with a real DB id: analyzable.
             analyzable: true,
             // Just-uploaded artifacts have no proxy cache state yet -- the
             // cache is populated lazily on the first proxy fetch.
@@ -4776,12 +5643,6 @@ pub async fn download_artifact(
     let repo = repo_service.get_by_key(&key).await?;
     require_visible(&repo, &auth, &repo_service).await?;
 
-    // Resolve the npm canonical `/-/` URL shape the Web UI emits to the
-    // version-segmented path the tarball is actually stored under (#2269),
-    // mirroring `get_artifact_metadata`. No-op for non-npm formats and for
-    // paths that are already stored literally; on a local miss `path` is left
-    // unchanged so the Remote/Virtual proxy fallback below still fires against
-    // the original URL shape.
     let path = resolve_stored_path(&state, &repo, path).await?;
 
     // Check quarantine status before serving the artifact.
@@ -5149,12 +6010,6 @@ pub async fn delete_artifact(
     // cannot destroy artifacts. Mirrors the upload path's `write` gate.
     require_repo_fine_grained_action(&auth, repo.id, "delete", &state.permission_service).await?;
 
-    // Resolve the npm canonical `/-/` URL shape the Web UI emits to the
-    // version-segmented path the tarball is actually stored under (#2269),
-    // mirroring `get_artifact_metadata`. Done before the promotion-only /
-    // immutability gates below so every gate, the delete query, and the
-    // cache-invalidation all operate on one consistent, real artifact path.
-    // No-op for non-npm formats and already-literal paths.
     let path = resolve_stored_path(&state, &repo, path).await?;
 
     // Promotion-only release repositories: a direct DELETE is the symmetric
@@ -6045,6 +6900,9 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         UpdateRepositoryRequest,
         RepositoryResponse,
         RepositoryListResponse,
+        DebianRepositoryConfig,
+        DebianMetadataStrategy,
+        DebianPackageFetchStrategy,
         SetCacheTtlRequest,
         CacheTtlResponse,
         InvalidateCacheQuery,
@@ -6659,10 +7517,6 @@ mod tests {
         assert_eq!(resp.checksum_sha256, "deadbeef");
         assert_eq!(resp.download_count, 0);
         assert!(resp.version.is_none());
-        // Proxy-cached objects have no `artifacts` row and a synthetic id,
-        // so they cannot be SBOM'd or scanned: the listing marks them
-        // non-analyzable so the UI hides those actions (#2227).
-        assert!(!resp.analyzable);
         // A cached-listing entry is a live proxy-cache object, so its
         // freshness timestamp is exactly when it was cached; the sidecar
         // projection carries no expiry. (Asserting these guards the
@@ -6716,8 +7570,6 @@ mod tests {
         assert_eq!(resp.size_bytes, 500);
         assert_eq!(resp.checksum_sha256, "primary-sha");
         assert_eq!(resp.download_count, 42);
-        // Hosted artifacts have a real DB id, so SBOM/scan resolve: analyzable.
-        assert!(resp.analyzable);
     }
 
     // -----------------------------------------------------------------------
@@ -7425,6 +8277,534 @@ mod tests {
     }
 
     #[test]
+    fn test_create_repository_request_with_debian_config() {
+        let json = r#"{
+            "key": "ubuntu-proxy",
+            "name": "Ubuntu Proxy",
+            "format": "debian",
+            "repo_type": "remote",
+            "upstream_url": "https://archive.ubuntu.com/ubuntu",
+            "debian": {
+                "distribution_paths": ["jammy", "jammy-updates"],
+                "components": ["main", "universe"],
+                "architectures": ["amd64"],
+                "include_source_packages": false,
+                "flat_repository": false,
+                "metadata_strategy": "filter_and_generate",
+                "package_fetch_strategy": "cache_on_request",
+                "ignore_missing_indexes": false
+            }
+        }"#;
+        let req: CreateRepositoryRequest = serde_json::from_str(json).unwrap();
+        let config = req.debian.unwrap();
+        assert_eq!(config.distribution_paths, vec!["jammy", "jammy-updates"]);
+        assert_eq!(config.components, vec!["main", "universe"]);
+        assert_eq!(config.architectures, vec!["amd64"]);
+        assert_eq!(
+            config.metadata_strategy,
+            DebianMetadataStrategy::FilterAndGenerate
+        );
+        assert_eq!(
+            config.package_fetch_strategy,
+            DebianPackageFetchStrategy::CacheOnRequest
+        );
+    }
+
+    #[test]
+    fn test_create_repository_request_accepts_null_debian_filters_as_all() {
+        let json = r#"{
+            "key": "ubuntu-proxy",
+            "name": "Ubuntu Proxy",
+            "format": "debian",
+            "repo_type": "remote",
+            "upstream_url": "https://archive.ubuntu.com/ubuntu",
+            "debian": {
+                "distribution_paths": ["jammy"],
+                "components": null,
+                "architectures": null
+            }
+        }"#;
+        let req: CreateRepositoryRequest = serde_json::from_str(json).unwrap();
+        let config = req.debian.unwrap();
+        assert!(config.components.is_empty());
+        assert!(config.architectures.is_empty());
+        assert!(config.component_filter_is_all());
+        assert!(config.architecture_filter_is_all());
+    }
+    #[test]
+    fn test_create_repository_request_accepts_legacy_debian_config_alias() {
+        let json = r#"{
+            "key": "ubuntu-proxy",
+            "name": "Ubuntu Proxy",
+            "format": "debian",
+            "repo_type": "remote",
+            "upstream_url": "https://archive.ubuntu.com/ubuntu",
+            "debian_config": {
+                "distributions": ["jammy"],
+                "components": ["*"],
+                "architectures": []
+            }
+        }"#;
+        let req: CreateRepositoryRequest = serde_json::from_str(json).unwrap();
+        let config = req.debian.unwrap();
+        assert_eq!(config.distribution_paths, vec!["jammy"]);
+        assert!(config.component_filter_is_all());
+        assert!(config.architecture_filter_is_all());
+    }
+
+    #[test]
+    fn test_debian_config_rejects_unsafe_identifiers() {
+        let mut config = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm\nSHA256:".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config)).is_err()
+        );
+
+        config.distribution_paths = vec!["bookworm".to_string()];
+        config.components = vec!["../main".to_string()];
+        assert!(
+            validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config)).is_err()
+        );
+    }
+
+    #[test]
+    fn test_debian_derived_response_fields_are_not_accepted_as_input() {
+        let config: DebianRepositoryConfig = serde_json::from_value(serde_json::json!({
+            "distribution_paths": ["bookworm"],
+            "apt_source_example": "attacker supplied",
+            "public_key_url": "/wrong",
+            "metadata_paths": ["wrong"],
+            "upload_endpoint": "/wrong",
+            "upload_path_template": "wrong",
+            "upload_metadata_headers": ["wrong"],
+            "warnings": ["wrong"]
+        }))
+        .unwrap();
+        assert!(config.apt_source_example.is_none());
+        assert!(config.public_key_url.is_none());
+        assert!(config.metadata_paths.is_empty());
+        assert!(config.upload_endpoint.is_none());
+        assert!(config.upload_path_template.is_none());
+        assert!(config.upload_metadata_headers.is_empty());
+        assert!(config.warnings.is_empty());
+    }
+
+    #[test]
+    fn test_debian_strategy_validation_requires_keys() {
+        let mut config = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            metadata_strategy: DebianMetadataStrategy::FilterGenerateAndSign,
+            ..Default::default()
+        };
+        let err = validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config))
+            .unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert_eq!(
+                msg,
+                "metadata_strategy=filter_generate_and_sign requires signing_key_id."
+            ),
+            other => panic!("expected validation error, got {other:?}"),
+        }
+
+        config.metadata_strategy = DebianMetadataStrategy::UpstreamPassthrough;
+        config.verify_upstream_metadata = true;
+        let err = validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config))
+            .unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert_eq!(
+                msg,
+                "verify_upstream_metadata=true requires upstream_gpg_key_id."
+            ),
+            other => panic!("expected validation error, got {other:?}"),
+        }
+    }
+
+    fn signing_config_fixture(
+        signing_key_id: Option<Uuid>,
+        sign_metadata: bool,
+        sign_packages: bool,
+        require_signatures: bool,
+    ) -> crate::models::signing_key::RepositorySigningConfig {
+        crate::models::signing_key::RepositorySigningConfig {
+            id: Uuid::new_v4(),
+            repository_id: Uuid::new_v4(),
+            signing_key_id,
+            sign_metadata,
+            sign_packages,
+            require_signatures,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_saving_debian_config_never_disables_existing_signing() {
+        // Existing signing enabled via the signing API. After a DebianConfigPatch
+        // merge, omitted signing_key_id is preserved in `config`; the resolver
+        // must keep sign_metadata OR-ed on and must not invent a key when the
+        // merged config has none (explicit clear).
+        let existing = signing_config_fixture(Some(Uuid::new_v4()), true, true, true);
+        let config_with_preserved_key = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            metadata_strategy: DebianMetadataStrategy::FilterAndGenerate,
+            signing_key_id: existing.signing_key_id,
+            ..Default::default()
+        };
+        let update = resolve_debian_signing_update(Some(&existing), &config_with_preserved_key)
+            .expect("update expected");
+        assert!(update.sign_metadata, "must not silently disable signing");
+        assert!(update.sign_packages, "package signing must be preserved");
+        assert!(
+            update.require_signatures,
+            "require_signatures must be preserved"
+        );
+        assert_eq!(update.signing_key_id, existing.signing_key_id);
+
+        // Explicit clear (merged config has signing_key_id=None) must stick.
+        let cleared = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            metadata_strategy: DebianMetadataStrategy::FilterAndGenerate,
+            signing_key_id: None,
+            ..Default::default()
+        };
+        let cleared_update =
+            resolve_debian_signing_update(Some(&existing), &cleared).expect("update expected");
+        assert!(cleared_update.sign_metadata);
+        assert_eq!(cleared_update.signing_key_id, None);
+    }
+
+    #[test]
+    fn test_saving_debian_config_can_enable_signing_and_set_key() {
+        let key = Uuid::new_v4();
+        let config = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            metadata_strategy: DebianMetadataStrategy::FilterGenerateAndSign,
+            signing_key_id: Some(key),
+            verify_upstream_metadata: true,
+            upstream_gpg_key_id: Some("ubuntu-archive-key".to_string()),
+            ..Default::default()
+        };
+        let update = resolve_debian_signing_update(None, &config).expect("update expected");
+        assert!(update.sign_metadata);
+        assert_eq!(update.signing_key_id, Some(key));
+        assert!(!update.sign_packages);
+        assert!(!update.require_signatures);
+    }
+
+    #[test]
+    fn test_saving_plain_debian_config_creates_no_signing_row() {
+        // No existing config, nothing requested: don't create an empty row.
+        let config = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(resolve_debian_signing_update(None, &config), None);
+    }
+
+    #[test]
+    fn test_debian_signing_requires_upstream_verification() {
+        // With a signing key but no upstream verification, signing must be
+        // rejected so Artifact Keeper never re-signs unverified upstream metadata.
+        let mut config = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            metadata_strategy: DebianMetadataStrategy::FilterGenerateAndSign,
+            signing_key_id: Some(Uuid::new_v4()),
+            verify_upstream_metadata: false,
+            ..Default::default()
+        };
+        let err = validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config))
+            .unwrap_err();
+        match err {
+            AppError::Validation(msg) => assert!(
+                msg.contains("requires verify_upstream_metadata=true"),
+                "unexpected error: {msg}"
+            ),
+            other => panic!("expected validation error, got {other:?}"),
+        }
+
+        // Turning on verification (with the key reference verification needs)
+        // makes the signing configuration valid.
+        config.verify_upstream_metadata = true;
+        config.upstream_gpg_key_id = Some("ubuntu-archive-key".to_string());
+        assert!(
+            validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config)).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_debian_flat_repository_validation() {
+        let config = DebianRepositoryConfig {
+            distribution_paths: vec!["/".to_string()],
+            flat_repository: true,
+            components: vec!["*".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            validate_debian_repository_config(&RepositoryFormat::Debian, Some(&config)).is_ok()
+        );
+
+        let invalid = DebianRepositoryConfig {
+            distribution_paths: vec!["flat".to_string()],
+            flat_repository: true,
+            components: vec!["main".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            validate_debian_repository_config(&RepositoryFormat::Debian, Some(&invalid)).is_err()
+        );
+    }
+
+    #[test]
+    fn test_update_repository_request_with_debian_config() {
+        let json = r#"{
+            "debian": {
+                "distribution_paths": ["bookworm"],
+                "components": ["main"],
+                "architectures": ["amd64", "all"],
+                "package_fetch_strategy": "prefetch_selected"
+            }
+        }"#;
+        let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
+        let config = req.debian.unwrap().unwrap().parsed;
+        assert_eq!(config.distribution_paths, vec!["bookworm"]);
+        assert_eq!(config.architectures, vec!["amd64", "all"]);
+        assert_eq!(
+            config.package_fetch_strategy,
+            DebianPackageFetchStrategy::PrefetchSelected
+        );
+    }
+
+    #[test]
+    fn test_update_repository_request_debian_null_clears() {
+        let req: UpdateRepositoryRequest = serde_json::from_str(r#"{"debian":null}"#).unwrap();
+        assert!(matches!(req.debian, Some(None)));
+        let omitted: UpdateRepositoryRequest = serde_json::from_str(r#"{}"#).unwrap();
+        assert!(omitted.debian.is_none());
+    }
+
+    #[test]
+    fn test_debian_config_patch_records_only_provided_keys() {
+        let patch: DebianConfigPatch = serde_json::from_str(r#"{"components":["main"]}"#).unwrap();
+        assert!(patch.provided_keys.contains_key("components"));
+        assert!(!patch.provided_keys.contains_key("architectures"));
+        assert!(!patch.provided_keys.contains_key("distribution_paths"));
+    }
+
+    #[test]
+    fn test_merge_debian_config_preserves_omitted_fields() {
+        // Stored config for an already-configured mirror.
+        let base = serde_json::json!({
+            "distribution_paths": ["jammy"],
+            "components": ["main", "universe"],
+            "architectures": ["amd64", "arm64"],
+            "package_fetch_strategy": "prefetch_selected",
+            "metadata_strategy": "filter_and_generate"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        // A partial update that only narrows the architectures.
+        let patch: DebianConfigPatch =
+            serde_json::from_str(r#"{"architectures":["amd64"]}"#).unwrap();
+        let merged = merge_debian_config_values(base, &patch.provided_keys);
+        let config: DebianRepositoryConfig =
+            serde_json::from_value(serde_json::Value::Object(merged)).unwrap();
+
+        // Updated field applied.
+        assert_eq!(config.architectures, vec!["amd64"]);
+        // Omitted fields preserved (previously reset to defaults — the bug).
+        assert_eq!(config.components, vec!["main", "universe"]);
+        assert_eq!(config.distribution_paths, vec!["jammy"]);
+        assert_eq!(
+            config.package_fetch_strategy,
+            DebianPackageFetchStrategy::PrefetchSelected
+        );
+        assert_eq!(
+            config.metadata_strategy,
+            DebianMetadataStrategy::FilterAndGenerate
+        );
+    }
+
+    #[test]
+    fn test_update_repository_request_accepts_upstream_url_without_debian_config() {
+        let json = r#"{"upstream_url":"https://deb.debian.org/debian"}"#;
+        let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            req.upstream_url.as_deref(),
+            Some("https://deb.debian.org/debian")
+        );
+        assert!(req.debian.is_none());
+    }
+
+    #[test]
+    fn test_repositories_openapi_exposes_debian_config_schemas() {
+        let spec = <RepositoriesApiDoc as utoipa::OpenApi>::openapi();
+        let schemas = &spec.components.as_ref().unwrap().schemas;
+        assert!(schemas.contains_key("DebianRepositoryConfig"));
+        assert!(schemas.contains_key("DebianMetadataStrategy"));
+        assert!(schemas.contains_key("DebianPackageFetchStrategy"));
+
+        let spec_json = serde_json::to_string(&spec).unwrap();
+        assert!(spec_json.contains("distribution_paths"));
+        assert!(spec_json.contains("metadata_strategy"));
+        assert!(spec_json.contains("package_fetch_strategy"));
+        assert!(spec_json.contains("upstream_passthrough"));
+        assert!(spec_json.contains("cache_on_request"));
+        assert!(spec_json.contains("upload_endpoint"));
+        assert!(spec_json.contains("upload_path_template"));
+        assert!(spec_json.contains("X-Debian-Distribution"));
+        assert!(spec_json.contains("X-Debian-Architecture"));
+    }
+
+    #[test]
+    fn test_debian_config_hydrates_ui_fields() {
+        let signing_key_id = Uuid::new_v4();
+        let config = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string(), "all".to_string()],
+            metadata_strategy: DebianMetadataStrategy::FilterGenerateAndSign,
+            signing_key_id: Some(signing_key_id),
+            ..Default::default()
+        };
+
+        let hydrated =
+            config.hydrated_for_response("ubuntu", Some("https://archive.ubuntu.com/ubuntu"));
+        assert_eq!(
+            hydrated.apt_source_example.as_deref(),
+            Some("deb [signed-by=/usr/share/keyrings/artifact-keeper.gpg] <repo-url>/debian/ubuntu jammy main")
+        );
+        assert_eq!(
+            hydrated.public_key_url.as_deref(),
+            Some("/debian/ubuntu/dists/jammy/gpg-key.asc")
+        );
+        assert!(hydrated
+            .metadata_paths
+            .contains(&"dists/jammy/Release".to_string()));
+        assert!(hydrated
+            .metadata_paths
+            .contains(&"dists/jammy/main/binary-amd64/Packages.xz".to_string()));
+        assert!(!hydrated
+            .metadata_paths
+            .iter()
+            .any(|path| path.contains("binary-all")));
+        assert_eq!(
+            hydrated.upload_endpoint.as_deref(),
+            Some("/debian/ubuntu/pool/{component}/{path}")
+        );
+        assert_eq!(
+            hydrated.upload_path_template.as_deref(),
+            Some("pool/{component}/{prefix}/{source-or-package}/{package}_{version}_{architecture}.deb")
+        );
+        assert!(hydrated
+            .upload_metadata_headers
+            .contains(&"X-Debian-Distribution: <distribution>".to_string()));
+        assert!(hydrated
+            .upload_metadata_headers
+            .contains(&"X-Debian-Architecture: <architecture>".to_string()));
+    }
+
+    #[test]
+    fn test_debian_config_warnings_for_all_filters_and_prefetch() {
+        let config = DebianRepositoryConfig {
+            distribution_paths: vec!["jammy".to_string()],
+            components: vec!["*".to_string()],
+            architectures: Vec::new(),
+            package_fetch_strategy: DebianPackageFetchStrategy::PrefetchSelected,
+            metadata_strategy: DebianMetadataStrategy::FilterAndGenerate,
+            ..Default::default()
+        };
+        let warnings = debian_config_warnings(&config);
+        assert_eq!(warnings.len(), 3, "warnings: {warnings:?}");
+        assert!(warnings[0].starts_with("Components are set to all."));
+        assert!(warnings[1].starts_with("Architectures are set to all."));
+        assert!(warnings[2].starts_with("Prefetch is enabled with broad component"));
+    }
+
+    #[test]
+    fn test_debian_config_does_not_override_top_level_upstream_url() {
+        let config = DebianRepositoryConfig::default();
+        assert_eq!(
+            debian_config_upstream_url(Some(&config), &RepositoryType::Remote),
+            None
+        );
+        assert_eq!(
+            debian_config_upstream_url(Some(&config), &RepositoryType::Local),
+            None
+        );
+    }
+    #[test]
+    fn test_debian_config_save_wires_existing_signing_config() {
+        let source = include_str!("repositories.rs");
+        let helper_name = ["sync_debian", "_signing_config"].concat();
+        let helper_marker = format!("async fn {helper_name}(");
+        let helper_start = source.find(&helper_marker).expect("helper not found");
+        let helper_end = source[helper_start..]
+            .find("\nasync fn load_debian_config(")
+            .map(|offset| helper_start + offset)
+            .expect("helper end not found");
+        let helper_body = &source[helper_start..helper_end];
+        assert!(helper_body.contains("SigningService::new("));
+        assert!(helper_body.contains(".update_signing_config("));
+        assert!(helper_body.contains("resolve_debian_signing_update("));
+
+        // The preservation logic lives in the pure resolver so it can be unit
+        // tested; it must OR the enable flag and reuse the existing key.
+        let resolver_start = source
+            .find("fn resolve_debian_signing_update(")
+            .expect("resolver not found");
+        let resolver_end = source[resolver_start..]
+            .find("\nasync fn sync_debian_signing_config(")
+            .map(|offset| resolver_start + offset)
+            .expect("resolver end not found");
+        let resolver_body = &source[resolver_start..resolver_end];
+        assert!(resolver_body.contains("config.signing_enabled()"));
+        assert!(
+            resolver_body.contains("let signing_key_id = config.signing_key_id"),
+            "resolver must trust the merged config's signing_key_id (explicit null clears)"
+        );
+        assert!(
+            !resolver_body.contains("config.signing_key_id.or(existing_key)"),
+            "OR-ing with existing_key would restore a key the client cleared"
+        );
+
+        for handler in ["create_repository", "update_repository"] {
+            let marker = format!("pub async fn {handler}(");
+            let start = source.find(&marker).expect("handler not found");
+            let end = source[start..]
+                .find("\npub async fn ")
+                .map(|offset| start + offset)
+                .unwrap_or(source.len());
+            let body = &source[start..end];
+            assert!(
+                body.contains(&format!("{helper_name}(&state, repo.id, config).await?")),
+                "{handler} must persist Debian signing settings through SigningService"
+            );
+        }
+    }
+
+    #[test]
+    fn test_list_repositories_hydrates_debian_config() {
+        let source = include_str!("repositories.rs");
+        let marker = "pub async fn list_repositories(";
+        let start = source.find(marker).expect("list_repositories not found");
+        let end = source[start..]
+            .find("\n/// Create a new repository")
+            .map(|offset| start + offset)
+            .expect("list_repositories end not found");
+        let body = &source[start..end];
+        assert!(
+            body.contains("load_debian_config(&state.db, repo_id, &response).await"),
+            "repository list responses must hydrate Debian config so edit/settings UI does not appear to lose saved fields"
+        );
+    }
+
+    #[test]
     fn test_update_repository_request_all_none() {
         let json = r#"{}"#;
         let req: UpdateRepositoryRequest = serde_json::from_str(json).unwrap();
@@ -7471,6 +8851,7 @@ mod tests {
             upstream_url: None,
             upstream_auth_type: None,
             upstream_auth_configured: false,
+            debian: None,
             quarantine_enabled: None,
             quarantine_duration_minutes: None,
             created_at: chrono::Utc::now(),
@@ -8094,52 +9475,12 @@ mod tests {
         let json = serde_json::to_string(&resp).unwrap();
         assert!(json.contains("\"download_count\":42"));
         assert!(json.contains("\"size_bytes\":1024"));
-        // `analyzable` is always serialized (no serde skip) so clients can
-        // gate the SBOM/Scan actions on it (#2227).
         assert!(json.contains("\"analyzable\":true"));
         // Cache fields are omitted when None so the wire shape stays the
         // same for non-Remote repos and for Remote repos without cache
         // metadata (#1541).
         assert!(!json.contains("cache_cached_at"));
         assert!(!json.contains("cache_expires_at"));
-    }
-
-    #[test]
-    fn test_artifact_version_response_serializes_uploaded_by() {
-        // (#2397) The versions API must expose who uploaded each revision so
-        // the version-history UI can show the uploader column.
-        let uploader = Uuid::new_v4();
-        let resp = ArtifactVersionResponse {
-            revision: 2,
-            version_label: Some("v1.0.1".to_string()),
-            size_bytes: 2048,
-            checksum_sha256: "abc123".to_string(),
-            content_type: "application/octet-stream".to_string(),
-            uploaded_by: Some(uploader),
-            created_at: chrono::Utc::now(),
-        };
-        let json = serde_json::to_string(&resp).unwrap();
-        assert!(json.contains(&format!("\"uploaded_by\":\"{uploader}\"")));
-        assert!(json.contains("\"version_label\":\"v1.0.1\""));
-        assert!(json.contains("\"revision\":2"));
-    }
-
-    #[test]
-    fn test_artifact_version_response_uploaded_by_null_when_unknown() {
-        // (#2397) Unlike `version_label`, `uploaded_by` is always serialized
-        // -- as `null` when unknown -- so clients can rely on the key.
-        let resp = ArtifactVersionResponse {
-            revision: 1,
-            version_label: None,
-            size_bytes: 1024,
-            checksum_sha256: "def456".to_string(),
-            content_type: "application/octet-stream".to_string(),
-            uploaded_by: None,
-            created_at: chrono::Utc::now(),
-        };
-        let json = serde_json::to_string(&resp).unwrap();
-        assert!(json.contains("\"uploaded_by\":null"));
-        assert!(!json.contains("version_label"));
     }
 
     #[test]
@@ -8175,6 +9516,7 @@ mod tests {
             cache_expires_at: Some(expires),
         };
         let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"analyzable\":false"));
         assert!(json.contains("\"cache_cached_at\":\"2026-06-01T10:00:00Z\""));
         assert!(json.contains("\"cache_expires_at\":\"2026-06-02T10:00:00Z\""));
     }
@@ -8796,6 +10138,7 @@ mod tests {
             upstream_url: Some("https://registry.npmjs.org".to_string()),
             upstream_auth_type: None,
             upstream_auth_configured: false,
+            debian: None,
             quarantine_enabled: Some(true),
             quarantine_duration_minutes: Some(525600),
             created_at: chrono::Utc::now(),

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -14,13 +14,16 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::signing_key::{RepositorySigningConfig, SigningKeyPublic};
 use crate::services::repository_service::RepositoryService;
-use crate::services::signing_service::{normalize_key_type, CreateKeyRequest, SigningService};
+use crate::services::signing_service::{
+    normalize_key_type, CreateKeyRequest, ImportPublicKeyRequest, SigningService,
+};
 
 /// Create signing key management routes.
 pub fn router() -> Router<SharedState> {
     Router::new()
         // Key CRUD
         .route("/keys", get(list_keys).post(create_key))
+        .route("/keys/import-public", post(import_public_key))
         .route("/keys/:key_id", get(get_key).delete(delete_key))
         .route("/keys/:key_id/revoke", post(revoke_key))
         .route("/keys/:key_id/rotate", post(rotate_key))
@@ -51,6 +54,17 @@ pub struct CreateKeyPayload {
     pub algorithm: Option<String>, // default "rsa4096"
     pub uid_name: Option<String>,
     pub uid_email: Option<String>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ImportPublicKeyPayload {
+    pub repository_id: Option<Uuid>,
+    pub name: String,
+    /// ASCII-armored OpenPGP public key (e.g. Debian/Ubuntu archive key).
+    pub public_key: String,
+    pub uid_name: Option<String>,
+    pub uid_email: Option<String>,
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -185,6 +199,53 @@ fn resolve_key_type_and_algorithm(
         }
     });
     Ok((family, algorithm))
+}
+
+/// Import a public-only OpenPGP trust anchor (no private key).
+///
+/// Used for Debian/Ubuntu archive keys and other upstream verification
+/// anchors referenced by `upstream_gpg_key_id`.
+#[utoipa::path(
+    post,
+    path = "/keys/import-public",
+    context_path = "/api/v1/signing",
+    tag = "signing",
+    request_body = ImportPublicKeyPayload,
+    responses(
+        (status = 200, description = "Imported public trust anchor", body = SigningKeyPublic),
+        (status = 400, description = "Invalid public key", body = crate::api::openapi::ErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::api::openapi::ErrorResponse),
+        (status = 404, description = "Repository not found", body = crate::api::openapi::ErrorResponse),
+        (status = 409, description = "Fingerprint already exists", body = crate::api::openapi::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+async fn import_public_key(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Json(payload): Json<ImportPublicKeyPayload>,
+) -> Result<Json<SigningKeyPublic>> {
+    require_signing_admin(&auth)?;
+
+    if let Some(repo_id) = payload.repository_id {
+        RepositoryService::new(state.db.clone())
+            .get_by_id(repo_id)
+            .await?;
+    }
+
+    let svc = signing_service(&state);
+    let key = svc
+        .import_public_trust_anchor(ImportPublicKeyRequest {
+            repository_id: payload.repository_id,
+            name: payload.name,
+            public_key: payload.public_key,
+            uid_name: payload.uid_name,
+            uid_email: payload.uid_email,
+            expires_at: payload.expires_at,
+            created_by: Some(auth.user_id),
+        })
+        .await?;
+    Ok(Json(key))
 }
 
 /// Get a signing key by ID.
@@ -463,6 +524,7 @@ fn signing_config_fields(
     paths(
         list_keys,
         create_key,
+        import_public_key,
         get_key,
         delete_key,
         revoke_key,
@@ -475,6 +537,7 @@ fn signing_config_fields(
     components(schemas(
         ListKeysQuery,
         CreateKeyPayload,
+        ImportPublicKeyPayload,
         UpdateSigningConfigPayload,
         KeyListResponse,
         SigningConfigResponse,
@@ -580,6 +643,40 @@ mod tests {
         // handlers enforce, so signing-key management still works.
         let ext = admin_jwt();
         assert!(require_signing_admin(&ext).is_ok());
+    }
+
+    #[test]
+    fn test_import_public_key_requires_admin_gate() {
+        let src = include_str!("signing.rs");
+        let start = src
+            .find("async fn import_public_key(")
+            .expect("import_public_key handler must exist");
+        let rest = &src[start..];
+        let end = rest[1..]
+            .find("\nasync fn ")
+            .map(|i| i + 1)
+            .unwrap_or(rest.len());
+        assert!(
+            rest[..end].contains("require_signing_admin"),
+            "import_public_key MUST call require_signing_admin"
+        );
+        match require_signing_admin(&non_admin_jwt()) {
+            Err(AppError::Authorization(_)) => {}
+            other => panic!("expected 403 for non-admin import, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_import_public_key_payload_deserialize() {
+        let json = r#"{
+            "name": "ubuntu-archive-key",
+            "public_key": "-----BEGIN PGP PUBLIC KEY BLOCK-----\n...\n-----END PGP PUBLIC KEY BLOCK-----"
+        }"#;
+        let payload: ImportPublicKeyPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.name, "ubuntu-archive-key");
+        assert!(payload.public_key.contains("BEGIN PGP PUBLIC KEY BLOCK"));
+        assert!(payload.repository_id.is_none());
+        assert!(payload.expires_at.is_none());
     }
 
     #[test]
@@ -847,6 +944,7 @@ mod tests {
             fingerprint: Some("ABCD1234".to_string()),
             key_id: Some("1234".to_string()),
             public_key_pem: "-----BEGIN PUBLIC KEY-----".to_string(),
+            can_sign: true,
             algorithm: "rsa4096".to_string(),
             uid_name: None,
             uid_email: None,

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -47,6 +47,7 @@ Bearer header. This Basic-with-token fallback applies to format endpoints only, 
         (name = "security", description = "Security policies and scanning"),
         (name = "sbom", description = "Software Bill of Materials"),
         (name = "signing", description = "Signing key management"),
+        (name = "debian", description = "Debian/APT format management endpoints (remote sync)"),
         (name = "plugins", description = "WASM plugin lifecycle"),
         (name = "webhooks", description = "Event webhook management"),
         (name = "peers", description = "Peer replication and sync"),
@@ -152,6 +153,7 @@ pub(crate) fn module_docs() -> Vec<(&'static str, utoipa::openapi::OpenApi)> {
             handlers::email_subscriptions::EmailSubscriptionsApiDoc::openapi(),
         ),
         ("signing", handlers::signing::SigningApiDoc::openapi()),
+        ("debian", handlers::debian::DebianApiDoc::openapi()),
         ("security", handlers::security::SecurityApiDoc::openapi()),
         ("sbom", handlers::sbom::SbomApiDoc::openapi()),
         ("admin", handlers::admin::AdminApiDoc::openapi()),
@@ -707,6 +709,8 @@ mod tests {
                 "/api/v1/sync-policies/",
                 vec![include_str!("handlers/sync_policies.rs")],
             ),
+            // Format-path management triggers (not apt protocol endpoints).
+            ("/debian/", vec![include_str!("handlers/debian.rs")]),
             // Admin routes: includes routes.rs because some routes (e.g. /metrics)
             // are added inline in the route tree rather than in admin.rs
             (
@@ -800,9 +804,12 @@ mod tests {
                 continue;
             }
 
-            if !path.starts_with("/api/v1/") {
+            // Format-path management endpoints (e.g. POST /debian/{repo_key}/sync) are
+            // documented intentionally; apt protocol GETs remain undocumented.
+            let is_format_management = path.starts_with("/debian/");
+            if !path.starts_with("/api/v1/") && !is_format_management {
                 missing.push(format!(
-                    "{method} {path} — unexpected prefix (expected /api/v1/ or known top-level)"
+                    "{method} {path} — unexpected prefix (expected /api/v1/, /debian/, or known top-level)"
                 ));
                 continue;
             }
@@ -819,7 +826,7 @@ mod tests {
                 let route_suffix = &path[prefix.len() - 1..]; // keep leading /
                 let first_segment = route_suffix.split('/').nth(1).unwrap_or("");
 
-                // Skip empty segments and path parameters (e.g. {user_id})
+                // Skip empty segments and path parameters (e.g. {repo_key})
                 if first_segment.is_empty() || first_segment.starts_with('{') {
                     continue;
                 }
@@ -842,6 +849,69 @@ mod tests {
             missing.is_empty(),
             "The following OpenAPI-documented endpoints appear to be missing route registrations:\n{}",
             missing.join("\n")
+        );
+    }
+
+    #[test]
+    fn test_openapi_documents_debian_remote_sync() {
+        let spec = build_openapi();
+        let path = spec
+            .paths
+            .paths
+            .get("/debian/{repo_key}/sync")
+            .expect("POST /debian/{repo_key}/sync must be documented");
+        let post = path.post.as_ref().expect("sync path must expose POST");
+        assert!(
+            post.tags
+                .as_ref()
+                .is_some_and(|tags| tags.iter().any(|tag| tag == "debian")),
+            "sync operation must be tagged debian"
+        );
+        let post_json = serde_json::to_value(post).expect("serialize sync operation");
+        let security = post_json
+            .get("security")
+            .and_then(|value| value.as_array())
+            .expect("sync must declare security");
+        let schemes: Vec<&str> = security
+            .iter()
+            .filter_map(|requirement| requirement.as_object())
+            .flat_map(|object| object.keys().map(String::as_str))
+            .collect();
+        assert!(
+            schemes.contains(&"bearer_auth"),
+            "sync must accept bearer_auth"
+        );
+        assert!(
+            schemes.contains(&"basic_auth"),
+            "sync must accept basic_auth for format clients"
+        );
+
+        let schemas = &spec.components.as_ref().unwrap().schemas;
+        for name in [
+            "DebianSyncResponse",
+            "DebianSyncPlan",
+            "DebianIndexPath",
+            "DebianSourceIndexPath",
+            "DebianSyncPackageFile",
+            "DebianSyncSourceFile",
+        ] {
+            assert!(
+                schemas.contains_key(name),
+                "OpenAPI schemas must include {name}"
+            );
+        }
+
+        let json = serde_json::to_string(&spec).unwrap();
+        assert!(json.contains("debian_sync_remote_repository"));
+        assert!(json.contains("prefetched_packages"));
+        assert!(json.contains("prefetched_sources"));
+
+        // Route registration regression: OpenAPI path-handler test skips
+        // `/{repo_key}/...` first segments, so pin the sync route string here.
+        let debian_src = include_str!("handlers/debian.rs");
+        assert!(
+            debian_src.contains(".route(\"/:repo_key/sync\", post(sync_remote_repository))"),
+            "documented sync path must remain routed in debian.rs"
         );
     }
 

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -8,9 +8,10 @@ use bytes::Bytes;
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::io::Read;
 use tar::Archive;
+use utoipa::ToSchema;
 use xz2::read::XzDecoder;
 use zstd::stream::read::Decoder as ZstdDecoder;
 
@@ -452,7 +453,7 @@ pub enum DebianOperation {
 }
 
 /// Debian control file structure
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct DebControl {
     pub package: String,
     pub version: String,
@@ -498,21 +499,1564 @@ pub struct Release {
     pub codename: Option<String>,
     pub version: Option<String>,
     pub date: String,
+    /// Optional expiry date from the `Valid-Until` field in RFC 2822 / RFC 5322 format.
+    pub valid_until: Option<String>,
     pub architectures: Vec<String>,
     pub components: Vec<String>,
     pub description: Option<String>,
     #[serde(default)]
     pub md5sum: Vec<ReleaseHash>,
     #[serde(default)]
+    pub sha1: Vec<ReleaseHash>,
+    #[serde(default)]
     pub sha256: Vec<ReleaseHash>,
+    #[serde(default)]
+    pub sha512: Vec<ReleaseHash>,
+    #[serde(default)]
+    pub extra: BTreeMap<String, String>,
 }
 
 /// Release file hash entry
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ReleaseHash {
     pub hash: String,
     pub size: u64,
     pub path: String,
+}
+
+/// Parsed Debian Packages index entry.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PackagesEntry {
+    pub control: DebControl,
+    pub filename: Option<String>,
+    pub size: Option<u64>,
+    pub md5sum: Option<String>,
+    pub sha1: Option<String>,
+    pub sha256: Option<String>,
+}
+/// Source file listed by a Debian Sources index.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SourceFileEntry {
+    pub filename: String,
+    pub size: u64,
+    pub md5sum: Option<String>,
+    pub sha1: Option<String>,
+    pub sha256: Option<String>,
+    pub sha512: Option<String>,
+}
+
+/// Parsed Debian Sources index entry.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SourcesEntry {
+    pub package: String,
+    pub version: String,
+    pub directory: String,
+    pub files: Vec<SourceFileEntry>,
+    #[serde(default)]
+    pub extra: BTreeMap<String, String>,
+}
+
+/// Detached Release.gpg metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReleaseSignature {
+    pub is_armored: bool,
+    pub size: usize,
+}
+
+/// Minimal abstraction for Release metadata signing.
+pub trait DebianReleaseSigner {
+    fn sign_in_release(&self, release: &str) -> Result<String>;
+    fn sign_release_gpg(&self, release: &[u8]) -> Result<Vec<u8>>;
+}
+
+/// Generate clear-signed InRelease metadata through an injected signer.
+pub fn generate_in_release(
+    signer: &(impl DebianReleaseSigner + ?Sized),
+    release: &str,
+) -> Result<String> {
+    if release.trim().is_empty() {
+        return Err(AppError::Validation(
+            "Release content must not be empty when signing InRelease".to_string(),
+        ));
+    }
+    signer.sign_in_release(release)
+}
+
+/// Generate detached Release.gpg metadata through an injected signer.
+pub fn generate_release_gpg(
+    signer: &(impl DebianReleaseSigner + ?Sized),
+    release: &str,
+) -> Result<Vec<u8>> {
+    if release.trim().is_empty() {
+        return Err(AppError::Validation(
+            "Release content must not be empty when signing Release.gpg".to_string(),
+        ));
+    }
+    signer.sign_release_gpg(release.as_bytes())
+}
+
+/// Debian package index selected for filtered sync.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, ToSchema)]
+pub struct DebianIndexPath {
+    pub component: String,
+    pub architecture: String,
+    pub path: String,
+}
+
+/// Soft cap on decompressed Packages/Sources index text (gzip/xz/bz2/zstd/plain).
+pub const MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES: u64 = 256 * 1024 * 1024; // 256 MiB
+
+/// Hard limit on the number of package + source files in a single sync plan.
+/// Prevents a misconfigured full-mirror sync from triggering unbounded storage writes.
+pub const MAX_DEBIAN_SYNC_SELECTED_FILES: usize = 50_000;
+
+/// Distribution/component/architecture filters for Debian remote sync.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize)]
+pub struct DebianSyncFilter {
+    pub distributions: Vec<String>,
+    pub components: Vec<String>,
+    pub architectures: Vec<String>,
+    pub include_source_packages: bool,
+    /// Optional package name queries (exact or trailing `*` glob). Empty = all packages.
+    pub package_queries: Vec<String>,
+    /// When package_queries is non-empty, also include Depends/Pre-Depends closure.
+    pub resolve_dependencies: bool,
+}
+
+/// Debian sync package download behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DebianSyncDownloadPolicy {
+    /// Cache package files only when clients request them.
+    OnDemand,
+    /// Fetch selected package files during sync.
+    Immediate,
+}
+
+impl DebianSyncDownloadPolicy {
+    pub fn from_label(label: Option<&str>) -> Self {
+        let label = label.unwrap_or_default().trim().to_ascii_lowercase();
+        match label.as_str() {
+            "immediate" | "eager" | "full" | "full_mirror" | "full-mirror" => Self::Immediate,
+            _ => Self::OnDemand,
+        }
+    }
+
+    fn downloads_packages(self) -> bool {
+        matches!(self, Self::Immediate)
+    }
+}
+
+/// Package file selected by a filtered Debian mirror sync plan.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, ToSchema)]
+pub struct DebianSyncPackageFile {
+    pub index_path: String,
+    pub filename: String,
+    pub package: String,
+    pub version: String,
+    pub architecture: String,
+    pub download: bool,
+}
+/// Debian source index selected for filtered sync.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, ToSchema)]
+pub struct DebianSourceIndexPath {
+    pub component: String,
+    pub path: String,
+}
+
+/// Source file selected by a filtered Debian mirror sync plan.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, ToSchema)]
+pub struct DebianSyncSourceFile {
+    pub index_path: String,
+    pub filename: String,
+    pub package: String,
+    pub version: String,
+    pub size: u64,
+    pub download: bool,
+}
+
+/// Pure filtered-sync plan produced after Release and Packages metadata are parsed.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, ToSchema)]
+pub struct DebianSyncPlan {
+    pub distribution: String,
+    pub release_paths: Vec<String>,
+    pub package_indexes: Vec<DebianIndexPath>,
+    pub source_indexes: Vec<DebianSourceIndexPath>,
+    pub package_files: Vec<DebianSyncPackageFile>,
+    pub source_files: Vec<DebianSyncSourceFile>,
+    pub missing_package_indexes: Vec<String>,
+    pub missing_source_indexes: Vec<String>,
+}
+
+/// Input used to decide how a Debian remote proxy cache entry should behave.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DebianCacheDecisionInput<'a> {
+    pub path: &'a str,
+    pub upstream_success: bool,
+    pub cached_locally: bool,
+    pub cache_stale: bool,
+    pub checksum_matches: bool,
+}
+
+/// Cache behavior for a Debian remote proxy request.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DebianCacheAction {
+    ServeCached,
+    Revalidate,
+    FetchAndCache,
+    DoNotCache,
+}
+
+/// Parse a Debian Release file.
+pub fn parse_release(content: &str) -> Result<Release> {
+    parse_release_from_payload(content)
+}
+
+/// Parse a clear-signed InRelease file.
+pub fn parse_in_release(content: &str) -> Result<Release> {
+    let payload = clear_signed_payload(content)?;
+    parse_release_from_payload(&payload)
+}
+
+/// Parse a Debian Release date string (RFC 2822 / `date -R` format).
+/// Returns `None` when the string cannot be parsed.
+///
+/// Tries the most common formats Debian upstreams use:
+/// - `Thu, 01 Jan 2026 00:00:00 UTC`
+/// - `Thu, 01 Jan 2026 00:00:00 +0000`
+pub fn parse_release_date(date: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    let date = date.trim();
+    // Try RFC 2822 with numeric offset first, then replace UTC/GMT suffix.
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(date) {
+        return Some(dt.with_timezone(&chrono::Utc));
+    }
+    // Replace textual timezone abbreviations that `parse_from_rfc2822` rejects.
+    let normalized = date
+        .trim_end_matches("UTC")
+        .trim_end_matches("GMT")
+        .trim_end()
+        .to_string()
+        + " +0000";
+    if let Ok(dt) = chrono::DateTime::parse_from_rfc2822(&normalized) {
+        return Some(dt.with_timezone(&chrono::Utc));
+    }
+    None
+}
+
+/// Return `true` when the release's `Valid-Until` field is present and its parsed date
+/// is in the past relative to `now`.
+pub fn release_is_expired(release: &Release, now: chrono::DateTime<chrono::Utc>) -> bool {
+    let Some(valid_until) = release.valid_until.as_deref() else {
+        return false;
+    };
+    match parse_release_date(valid_until) {
+        Some(expiry) => now >= expiry,
+        // If we can't parse it, fail-safe: treat as not-expired.
+        None => false,
+    }
+}
+
+/// Validate detached Release.gpg bytes and identify armored signatures.
+pub fn parse_release_gpg(content: &[u8]) -> Result<ReleaseSignature> {
+    if content.is_empty() {
+        return Err(AppError::Validation("Release.gpg is empty".to_string()));
+    }
+
+    let is_armored = std::str::from_utf8(content)
+        .map(|text| text.contains("-----BEGIN PGP SIGNATURE-----"))
+        .unwrap_or(false);
+
+    Ok(ReleaseSignature {
+        is_armored,
+        size: content.len(),
+    })
+}
+
+/// Parse an uncompressed Debian Packages file.
+pub fn parse_packages(content: &str) -> Result<Vec<PackagesEntry>> {
+    split_debian_stanzas(content)
+        .into_iter()
+        .map(parse_packages_entry)
+        .collect()
+}
+
+fn decode_debian_index_text(path: &str, content: &[u8], label: &str) -> Result<String> {
+    let reject_oversized = |len: usize| -> Result<()> {
+        if len as u64 > MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES {
+            return Err(AppError::Validation(format!(
+                "Decompressed {label} index exceeds maximum allowed size of {MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES} bytes"
+            )));
+        }
+        Ok(())
+    };
+
+    if path.ends_with(".gz") {
+        let mut decoder = GzDecoder::new(content).take(MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES + 1);
+        let mut text = String::new();
+        decoder
+            .read_to_string(&mut text)
+            .map_err(|e| AppError::Validation(format!("Failed to decompress {label}.gz: {e}")))?;
+        reject_oversized(text.len())?;
+        Ok(text)
+    } else if path.ends_with(".xz") {
+        let mut decoder = XzDecoder::new(content).take(MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES + 1);
+        let mut text = String::new();
+        decoder
+            .read_to_string(&mut text)
+            .map_err(|e| AppError::Validation(format!("Failed to decompress {label}.xz: {e}")))?;
+        reject_oversized(text.len())?;
+        Ok(text)
+    } else if path.ends_with(".bz2") {
+        let mut decoder = BzDecoder::new(content).take(MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES + 1);
+        let mut text = String::new();
+        decoder
+            .read_to_string(&mut text)
+            .map_err(|e| AppError::Validation(format!("Failed to decompress {label}.bz2: {e}")))?;
+        reject_oversized(text.len())?;
+        Ok(text)
+    } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+        let decoder = ZstdDecoder::new(content)
+            .map_err(|e| AppError::Validation(format!("Failed to decompress {label}.zst: {e}")))?;
+        let mut decoder = decoder.take(MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES + 1);
+        let mut text = String::new();
+        decoder
+            .read_to_string(&mut text)
+            .map_err(|e| AppError::Validation(format!("Failed to decompress {label}.zst: {e}")))?;
+        reject_oversized(text.len())?;
+        Ok(text)
+    } else {
+        reject_oversized(content.len())?;
+        String::from_utf8(content.to_vec())
+            .map_err(|e| AppError::Validation(format!("{label} index is not UTF-8: {e}")))
+    }
+}
+
+/// Parse a Packages index, decompressing `.gz` and `.xz` paths when needed.
+pub fn parse_packages_index(path: &str, content: &[u8]) -> Result<Vec<PackagesEntry>> {
+    let text = decode_debian_index_text(path, content, "Packages")?;
+    parse_packages(&text)
+}
+
+/// Parse an uncompressed Debian Sources file.
+pub fn parse_sources(content: &str) -> Result<Vec<SourcesEntry>> {
+    split_debian_stanzas(content)
+        .into_iter()
+        .map(parse_sources_entry)
+        .collect()
+}
+
+/// Parse a Sources index, decompressing `.gz` and `.xz` paths when needed.
+pub fn parse_sources_index(path: &str, content: &[u8]) -> Result<Vec<SourcesEntry>> {
+    let text = decode_debian_index_text(path, content, "Sources")?;
+    parse_sources(&text)
+}
+/// Return matching binary package index paths from Release metadata.
+pub fn filter_release_package_indexes(
+    release: &Release,
+    filter: &DebianSyncFilter,
+) -> Vec<DebianIndexPath> {
+    if !filter.distributions.is_empty()
+        && !filter.distributions.iter().any(|distribution| {
+            distribution == &release.suite
+                || release
+                    .codename
+                    .as_deref()
+                    .map(|codename| codename == distribution)
+                    .unwrap_or(false)
+        })
+    {
+        return Vec::new();
+    }
+
+    let component_filter: BTreeSet<&str> = filter.components.iter().map(String::as_str).collect();
+    let arch_filter: BTreeSet<&str> = filter.architectures.iter().map(String::as_str).collect();
+    let allowed_component = |component: &str| {
+        component_filter.is_empty()
+            || component_filter
+                .iter()
+                .any(|selected| debian_components_equivalent(selected, component))
+    };
+    let allowed_arch = |arch: &str| arch_filter.is_empty() || arch_filter.contains(arch);
+
+    let mut selected = BTreeMap::<(String, String), DebianIndexPath>::new();
+    for hash in release
+        .sha256
+        .iter()
+        .chain(release.sha512.iter())
+        .chain(release.sha1.iter())
+        .chain(release.md5sum.iter())
+    {
+        if let Some(index) = parse_release_package_index_path(&hash.path) {
+            if allowed_component(&index.component)
+                && (index.architecture.is_empty() || allowed_arch(&index.architecture))
+            {
+                let key = (index.component.clone(), index.architecture.clone());
+                match selected.get(&key) {
+                    Some(current)
+                        if package_index_compression_rank(&current.path)
+                            >= package_index_compression_rank(&index.path) => {}
+                    _ => {
+                        selected.insert(key, index);
+                    }
+                }
+            }
+        }
+    }
+
+    if selected.is_empty() {
+        for component in &release.components {
+            if !allowed_component(component) {
+                continue;
+            }
+            for arch in &release.architectures {
+                if allowed_arch(arch) {
+                    // Prefer the leaf component name for on-disk paths when Release
+                    // advertises a prefixed form (e.g. updates/main → main/...).
+                    let path_component = component.rsplit('/').next().unwrap_or(component);
+                    let path = format!("{path_component}/binary-{arch}/Packages.xz");
+                    selected.insert(
+                        (path_component.to_string(), arch.clone()),
+                        DebianIndexPath {
+                            component: path_component.to_string(),
+                            architecture: arch.clone(),
+                            path,
+                        },
+                    );
+                }
+            }
+        }
+    }
+
+    selected.into_values().collect()
+}
+
+/// Return matching source package index paths from Release metadata.
+pub fn filter_release_source_indexes(
+    release: &Release,
+    filter: &DebianSyncFilter,
+) -> Vec<DebianSourceIndexPath> {
+    if !filter.include_source_packages {
+        return Vec::new();
+    }
+    let component_filter: BTreeSet<&str> = filter.components.iter().map(String::as_str).collect();
+    let allowed_component = |component: &str| {
+        component_filter.is_empty()
+            || component_filter
+                .iter()
+                .any(|selected| debian_components_equivalent(selected, component))
+    };
+
+    let mut selected = BTreeMap::<String, DebianSourceIndexPath>::new();
+    for hash in release
+        .sha256
+        .iter()
+        .chain(release.sha512.iter())
+        .chain(release.sha1.iter())
+        .chain(release.md5sum.iter())
+    {
+        if let Some(index) = parse_release_source_index_path(&hash.path) {
+            if allowed_component(&index.component) {
+                match selected.get(&index.component) {
+                    Some(current)
+                        if package_index_compression_rank(&current.path)
+                            >= package_index_compression_rank(&index.path) => {}
+                    _ => {
+                        selected.insert(index.component.clone(), index);
+                    }
+                }
+            }
+        }
+    }
+
+    if selected.is_empty() {
+        for component in &release.components {
+            if allowed_component(component) {
+                // Prefer the leaf component name for on-disk paths when Release
+                // advertises a prefixed form (e.g. updates/main → main/...).
+                let path_component = component.rsplit('/').next().unwrap_or(component);
+                selected.insert(
+                    component.clone(),
+                    DebianSourceIndexPath {
+                        component: path_component.to_string(),
+                        path: format!("{path_component}/source/Sources.xz"),
+                    },
+                );
+            }
+        }
+    }
+
+    selected.into_values().collect()
+}
+pub fn validate_release_filter_selection(
+    release: &Release,
+    filter: &DebianSyncFilter,
+) -> Result<()> {
+    let missing_components = missing_release_filter_values(&filter.components, &release.components);
+    if !missing_components.is_empty() {
+        return Err(AppError::Validation(format!(
+            "Selected Debian component(s) not advertised by upstream Release metadata: {}",
+            missing_components.join(", ")
+        )));
+    }
+
+    let missing_architectures =
+        missing_release_filter_values(&filter.architectures, &release.architectures);
+    if !missing_architectures.is_empty() {
+        return Err(AppError::Validation(format!(
+            "Selected Debian architecture(s) not advertised by upstream Release metadata: {}",
+            missing_architectures.join(", ")
+        )));
+    }
+
+    Ok(())
+}
+
+/// Whether a configured component filter matches an advertised/on-disk component.
+///
+/// Debian-Security Release files advertise `updates/main` while apt sources and
+/// index paths use `main`. Treat the leaf segment as equivalent so configuring
+/// `main` (the apt sources.list component) works against those suites.
+pub fn debian_components_equivalent(selected: &str, advertised: &str) -> bool {
+    if selected == advertised {
+        return true;
+    }
+    let selected_leaf = selected.rsplit('/').next().unwrap_or(selected);
+    let advertised_leaf = advertised.rsplit('/').next().unwrap_or(advertised);
+    selected_leaf == advertised || selected == advertised_leaf || selected_leaf == advertised_leaf
+}
+
+fn missing_release_filter_values(selected: &[String], advertised: &[String]) -> Vec<String> {
+    let selected: BTreeSet<String> = selected
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty() && *value != "*")
+        .map(str::to_string)
+        .collect();
+    if selected.is_empty() {
+        return Vec::new();
+    }
+
+    selected
+        .into_iter()
+        .filter(|value| {
+            !advertised
+                .iter()
+                .any(|adv| debian_components_equivalent(value, adv))
+        })
+        .collect()
+}
+fn package_index_compression_rank(path: &str) -> u8 {
+    if path.ends_with(".xz") {
+        4
+    } else if path.ends_with(".zst") || path.ends_with(".zstd") {
+        3
+    } else if path.ends_with(".gz") || path.ends_with(".bz2") {
+        2
+    } else {
+        1
+    }
+}
+
+/// Return true when `name` matches any package query (exact or trailing `*` prefix glob).
+/// Empty `queries` matches all names. Version constraints on `name` are stripped first.
+pub fn package_name_matches_queries(name: &str, queries: &[String]) -> bool {
+    if queries.is_empty() {
+        return true;
+    }
+    let name = parse_debian_dependency_package_name(name);
+    queries.iter().any(|query| {
+        let query = query.trim();
+        if query.is_empty() {
+            return false;
+        }
+        if let Some(prefix) = query.strip_suffix('*') {
+            name.starts_with(prefix)
+        } else {
+            name == query
+        }
+    })
+}
+
+/// Extract the package name from a Debian dependency expression.
+/// Takes the first alternative before `|`, strips a parenthesized version constraint, and trims.
+pub fn parse_debian_dependency_package_name(dep: &str) -> &str {
+    let dep = dep.split('|').next().unwrap_or(dep).trim();
+    match dep.find('(') {
+        Some(idx) => dep[..idx].trim(),
+        None => dep,
+    }
+}
+
+/// Filter package index entries by name queries, optionally expanding Depends/Pre-Depends.
+pub fn filter_packages_by_query_with_dependencies(
+    entries: &[PackagesEntry],
+    queries: &[String],
+    resolve_deps: bool,
+) -> Vec<PackagesEntry> {
+    if queries.is_empty() {
+        return entries.to_vec();
+    }
+
+    let mut by_name: HashMap<&str, Vec<usize>> = HashMap::new();
+    let mut by_provide: HashMap<&str, Vec<usize>> = HashMap::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        by_name
+            .entry(entry.control.package.as_str())
+            .or_default()
+            .push(idx);
+        if let Some(provides) = entry.control.provides.as_ref() {
+            for provide in provides {
+                let provide_name = parse_debian_dependency_package_name(provide);
+                if !provide_name.is_empty() {
+                    by_provide.entry(provide_name).or_default().push(idx);
+                }
+            }
+        }
+    }
+
+    let mut selected: HashSet<usize> = HashSet::new();
+    let mut queue: VecDeque<usize> = VecDeque::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        if package_name_matches_queries(&entry.control.package, queries) && selected.insert(idx) {
+            queue.push_back(idx);
+        }
+    }
+
+    if resolve_deps {
+        while let Some(idx) = queue.pop_front() {
+            let entry = &entries[idx];
+            for dep_list in [
+                entry.control.depends.as_ref(),
+                entry.control.pre_depends.as_ref(),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                for dep in dep_list {
+                    let dep_name = parse_debian_dependency_package_name(dep);
+                    if dep_name.is_empty() {
+                        continue;
+                    }
+                    for &dep_idx in by_name
+                        .get(dep_name)
+                        .into_iter()
+                        .chain(by_provide.get(dep_name))
+                        .flatten()
+                    {
+                        if selected.insert(dep_idx) {
+                            queue.push_back(dep_idx);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    entries
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| selected.contains(idx))
+        .map(|(_, entry)| entry.clone())
+        .collect()
+}
+
+/// Whether a Release-relative metadata path is allowed by component/arch/source filters.
+pub fn release_path_allowed_by_filter(path: &str, filter: &DebianSyncFilter) -> bool {
+    let path = path.trim_start_matches('/');
+    if path.is_empty() {
+        return false;
+    }
+
+    let parts: Vec<&str> = path.split('/').collect();
+    let component_allowed = |component: &str| {
+        filter.components.is_empty()
+            || filter
+                .components
+                .iter()
+                .any(|c| debian_components_equivalent(c, component))
+    };
+    let arch_allowed = |arch: &str| {
+        filter.architectures.is_empty() || filter.architectures.iter().any(|a| a == arch)
+    };
+    fn contents_arch(name: &str) -> Option<&str> {
+        let rest = name.strip_prefix("Contents-")?;
+        Some(rest.split('.').next().unwrap_or(rest))
+    }
+
+    if let Some(by_hash_idx) = parts.iter().position(|part| *part == "by-hash") {
+        if by_hash_idx == 0 {
+            return filter.components.is_empty();
+        }
+        return component_allowed(parts[0]);
+    }
+
+    if parts.len() >= 3 && parts[1].starts_with("binary-") && parts[2].starts_with("Packages") {
+        let arch = parts[1].trim_start_matches("binary-");
+        return component_allowed(parts[0]) && arch_allowed(arch);
+    }
+
+    if parts.len() >= 3 && parts[1] == "source" && parts[2].starts_with("Sources") {
+        return filter.include_source_packages && component_allowed(parts[0]);
+    }
+
+    if parts.len() >= 2 {
+        if let Some(arch) = contents_arch(parts[1]) {
+            return component_allowed(parts[0]) && arch_allowed(arch);
+        }
+    }
+
+    if parts.len() == 1 {
+        if let Some(arch) = contents_arch(parts[0]) {
+            return arch_allowed(arch);
+        }
+    }
+
+    if parts.len() >= 3 && parts[1] == "i18n" && parts[2].starts_with("Translation-") {
+        return component_allowed(parts[0]);
+    }
+
+    if parts.len() >= 3 && parts[1] == "dep11" {
+        return component_allowed(parts[0]);
+    }
+
+    false
+}
+
+/// Whether a pool package is allowed by component/arch/package-query filters.
+/// Whether `filename` looks like a Debian source artifact that is not a binary package.
+///
+/// Source artifacts have extensions like `.dsc`, `.debian.tar.*`, `.orig.tar.*`,
+/// `.diff.gz`, or `.asc` adjacent to source packages. They are not parseable by
+/// `parse_deb_filename` and must bypass binary-specific arch/query filters when
+/// `include_source_packages` is enabled.
+fn is_debian_source_artifact(filename: &str) -> bool {
+    filename.ends_with(".dsc")
+        || filename.ends_with(".diff.gz")
+        || filename.contains(".orig.tar.")
+        || filename.contains(".debian.tar.")
+        || (filename.ends_with(".asc") && !filename.ends_with(".deb.asc"))
+}
+
+pub fn pool_path_allowed_by_filters(
+    component: &str,
+    filename: &str,
+    filter: &DebianSyncFilter,
+) -> bool {
+    if !filter.components.is_empty()
+        && !filter
+            .components
+            .iter()
+            .any(|c| debian_components_equivalent(c, component))
+    {
+        return false;
+    }
+
+    // Source artifacts (.dsc, .orig.tar.*, .debian.tar.*, .diff.gz, .asc) bypass
+    // binary-specific arch/query filters when source packages are enabled.
+    if is_debian_source_artifact(filename) {
+        return filter.include_source_packages;
+    }
+
+    let Ok((package, _version, architecture)) = DebianHandler::parse_deb_filename(filename) else {
+        return false;
+    };
+
+    if architecture != "all"
+        && !filter.architectures.is_empty()
+        && !filter
+            .architectures
+            .iter()
+            .any(|arch| arch == &architecture)
+    {
+        return false;
+    }
+
+    if !filter.package_queries.is_empty()
+        && !package_name_matches_queries(&package, &filter.package_queries)
+    {
+        return false;
+    }
+
+    true
+}
+
+/// Reject absolute http(s) URLs and path traversal in index-provided filenames.
+pub fn validate_debian_fetch_path(path: &str) -> Result<()> {
+    if path.is_empty() {
+        return Err(AppError::Validation(
+            "Debian fetch path must not be empty".to_string(),
+        ));
+    }
+    if path.starts_with("http://") || path.starts_with("https://") {
+        return Err(AppError::Validation(format!(
+            "Debian fetch path must be relative, not an absolute URL: {path}"
+        )));
+    }
+    if path.split('/').any(|segment| segment == "..") {
+        return Err(AppError::Validation(format!(
+            "Debian fetch path must not contain '..' segments: {path}"
+        )));
+    }
+    Ok(())
+}
+
+/// True for `.deb`/`.udeb` paths that are not under `pool/` (flat repository layout).
+pub fn is_flat_repository_package_path(path: &str) -> bool {
+    let path = path.trim_start_matches('/');
+    (path.ends_with(".deb") || path.ends_with(".udeb")) && !path.starts_with("pool/")
+}
+
+/// Build a Debian Contents index (`path\\tpackage` lines, sorted).
+pub fn build_contents_index(entries: &[(String, String)]) -> String {
+    let mut lines: Vec<String> = entries
+        .iter()
+        .map(|(path, package)| format!("{path}\t{package}"))
+        .collect();
+    lines.sort();
+    let mut out = lines.join("\n");
+    if !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+/// Return a by-hash relative path: `by-hash/{algorithm}/{hash_hex}`.
+pub fn by_hash_path(algorithm: &str, hash_hex: &str) -> String {
+    format!("by-hash/{algorithm}/{hash_hex}")
+}
+
+/// Debian `Architecture: all` packages belong in every selected binary index.
+pub fn package_matches_sync_architecture(
+    package_arch: &str,
+    selected_architectures: &[String],
+) -> bool {
+    package_arch == "all"
+        || selected_architectures.is_empty()
+        || selected_architectures
+            .iter()
+            .any(|arch| arch == package_arch)
+}
+
+/// Build the deterministic core of a filtered Debian mirror sync.
+pub fn build_debian_sync_plan(
+    distribution: &str,
+    release: &Release,
+    filter: &DebianSyncFilter,
+    packages_by_index_path: &BTreeMap<String, Vec<PackagesEntry>>,
+    sources_by_index_path: &BTreeMap<String, Vec<SourcesEntry>>,
+    download_policy: DebianSyncDownloadPolicy,
+) -> DebianSyncPlan {
+    let package_indexes = filter_release_package_indexes(release, filter);
+    let source_indexes = filter_release_source_indexes(release, filter);
+    let mut package_files = Vec::new();
+    let mut source_files = Vec::new();
+    let mut missing_package_indexes = Vec::new();
+    let mut missing_source_indexes = Vec::new();
+
+    if !filter.package_queries.is_empty() && filter.resolve_dependencies {
+        // Cross-index dependency closure: build a global package universe from all
+        // available indexes, resolve deps across the full set, then emit only those
+        // packages that appear in their respective index with the correct arch.
+        //
+        // This ensures a Depends on a package that lives in a different component or
+        // arch index is still included in the sync plan, which per-index resolution
+        // misses.
+        let mut global_entries: Vec<(&str, &PackagesEntry)> = Vec::new();
+        for index in &package_indexes {
+            if let Some(entries) = packages_by_index_path.get(&index.path) {
+                for entry in entries {
+                    global_entries.push((index.path.as_str(), entry));
+                }
+            } else {
+                missing_package_indexes.push(index.path.clone());
+            }
+        }
+
+        // Build a flat view for dependency resolution (all entries across all indexes).
+        let flat_entries: Vec<PackagesEntry> =
+            global_entries.iter().map(|(_, e)| (*e).clone()).collect();
+        let selected_entries = filter_packages_by_query_with_dependencies(
+            &flat_entries,
+            &filter.package_queries,
+            true,
+        );
+
+        // Build a set of (package, version) tuples that were selected globally.
+        let selected_set: HashSet<(&str, &str)> = selected_entries
+            .iter()
+            .map(|e| (e.control.package.as_str(), e.control.version.as_str()))
+            .collect();
+
+        // Emit package files per index, restricted to globally-selected packages.
+        for index in &package_indexes {
+            let Some(entries) = packages_by_index_path.get(&index.path) else {
+                continue;
+            };
+            for entry in entries {
+                if !selected_set.contains(&(
+                    entry.control.package.as_str(),
+                    entry.control.version.as_str(),
+                )) {
+                    continue;
+                }
+                if !package_matches_sync_index(
+                    &entry.control.architecture,
+                    &index.architecture,
+                    &filter.architectures,
+                ) {
+                    continue;
+                }
+                let Some(filename) = entry
+                    .filename
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|filename| !filename.is_empty())
+                else {
+                    continue;
+                };
+                package_files.push(DebianSyncPackageFile {
+                    index_path: index.path.clone(),
+                    filename: filename.to_string(),
+                    package: entry.control.package.clone(),
+                    version: entry.control.version.clone(),
+                    architecture: entry.control.architecture.clone(),
+                    download: download_policy.downloads_packages(),
+                });
+            }
+        }
+    } else {
+        for index in &package_indexes {
+            let Some(entries) = packages_by_index_path.get(&index.path) else {
+                missing_package_indexes.push(index.path.clone());
+                continue;
+            };
+
+            let filtered_entries;
+            let entries = if filter.package_queries.is_empty() {
+                entries.as_slice()
+            } else {
+                filtered_entries = filter_packages_by_query_with_dependencies(
+                    entries,
+                    &filter.package_queries,
+                    filter.resolve_dependencies,
+                );
+                filtered_entries.as_slice()
+            };
+
+            for entry in entries {
+                if !package_matches_sync_index(
+                    &entry.control.architecture,
+                    &index.architecture,
+                    &filter.architectures,
+                ) {
+                    continue;
+                }
+                let Some(filename) = entry
+                    .filename
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|filename| !filename.is_empty())
+                else {
+                    continue;
+                };
+
+                package_files.push(DebianSyncPackageFile {
+                    index_path: index.path.clone(),
+                    filename: filename.to_string(),
+                    package: entry.control.package.clone(),
+                    version: entry.control.version.clone(),
+                    architecture: entry.control.architecture.clone(),
+                    download: download_policy.downloads_packages(),
+                });
+            }
+        }
+    }
+
+    for index in &source_indexes {
+        let Some(entries) = sources_by_index_path.get(&index.path) else {
+            missing_source_indexes.push(index.path.clone());
+            continue;
+        };
+
+        for entry in entries {
+            for file in &entry.files {
+                source_files.push(DebianSyncSourceFile {
+                    index_path: index.path.clone(),
+                    filename: source_file_path(&entry.directory, &file.filename),
+                    package: entry.package.clone(),
+                    version: entry.version.clone(),
+                    size: file.size,
+                    download: download_policy.downloads_packages(),
+                });
+            }
+        }
+    }
+
+    package_files.sort_by(|left, right| {
+        left.index_path
+            .cmp(&right.index_path)
+            .then_with(|| left.filename.cmp(&right.filename))
+            .then_with(|| left.package.cmp(&right.package))
+    });
+    source_files.sort_by(|left, right| {
+        left.index_path
+            .cmp(&right.index_path)
+            .then_with(|| left.filename.cmp(&right.filename))
+            .then_with(|| left.package.cmp(&right.package))
+    });
+    missing_package_indexes.sort();
+    missing_source_indexes.sort();
+
+    let release_prefix = if distribution.is_empty() {
+        String::new()
+    } else {
+        format!("dists/{distribution}/")
+    };
+
+    DebianSyncPlan {
+        distribution: distribution.to_string(),
+        release_paths: vec![
+            format!("{release_prefix}InRelease"),
+            format!("{release_prefix}Release"),
+            format!("{release_prefix}Release.gpg"),
+        ],
+        package_indexes,
+        source_indexes,
+        package_files,
+        source_files,
+        missing_package_indexes,
+        missing_source_indexes,
+    }
+}
+
+pub(crate) fn source_file_path(directory: &str, filename: &str) -> String {
+    let directory = directory.trim().trim_matches('/');
+    if directory.is_empty() || directory == "." {
+        filename.trim_start_matches('/').to_string()
+    } else {
+        format!("{}/{}", directory, filename.trim_start_matches('/'))
+    }
+}
+fn package_matches_sync_index(
+    package_arch: &str,
+    index_architecture: &str,
+    selected_architectures: &[String],
+) -> bool {
+    if index_architecture.is_empty() {
+        return package_matches_sync_architecture(package_arch, selected_architectures);
+    }
+
+    package_arch == "all"
+        || (package_arch == index_architecture
+            && package_matches_sync_architecture(package_arch, selected_architectures))
+}
+
+/// Decide cache behavior for Debian proxy paths without performing I/O.
+pub fn decide_debian_cache_action(input: DebianCacheDecisionInput<'_>) -> DebianCacheAction {
+    if !input.upstream_success {
+        return DebianCacheAction::DoNotCache;
+    }
+
+    if input.cached_locally && is_debian_pool_artifact(input.path) && input.checksum_matches {
+        return DebianCacheAction::ServeCached;
+    }
+
+    if input.cached_locally && is_debian_metadata_path(input.path) {
+        return if input.cache_stale {
+            DebianCacheAction::Revalidate
+        } else {
+            DebianCacheAction::ServeCached
+        };
+    }
+
+    DebianCacheAction::FetchAndCache
+}
+
+fn parse_release_from_payload(content: &str) -> Result<Release> {
+    let fields = parse_debian_stanza_fields(content)?;
+    let suite = required_field(&fields, "Suite")?.to_string();
+    let date = required_field(&fields, "Date")?.to_string();
+    let architectures = split_words(fields.get("Architectures"));
+    let components = split_words(fields.get("Components"));
+
+    if architectures.is_empty() {
+        return Err(AppError::Validation(
+            "Release file missing Architectures field".to_string(),
+        ));
+    }
+
+    let known: BTreeSet<&str> = [
+        "Origin",
+        "Label",
+        "Suite",
+        "Codename",
+        "Version",
+        "Date",
+        "Valid-Until",
+        "Architectures",
+        "Components",
+        "Description",
+        "MD5Sum",
+        "SHA1",
+        "SHA256",
+        "SHA512",
+    ]
+    .into_iter()
+    .collect();
+    let extra = fields
+        .iter()
+        .filter(|(key, _)| !known.contains(key.as_str()))
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect();
+
+    Ok(Release {
+        origin: fields.get("Origin").cloned(),
+        label: fields.get("Label").cloned(),
+        suite,
+        codename: fields.get("Codename").cloned(),
+        version: fields.get("Version").cloned(),
+        date,
+        valid_until: fields.get("Valid-Until").cloned(),
+        architectures,
+        components,
+        description: fields.get("Description").cloned(),
+        md5sum: parse_release_hashes(fields.get("MD5Sum"))?,
+        sha1: parse_release_hashes(fields.get("SHA1"))?,
+        sha256: parse_release_hashes(fields.get("SHA256"))?,
+        sha512: parse_release_hashes(fields.get("SHA512"))?,
+        extra,
+    })
+}
+
+fn clear_signed_payload(content: &str) -> Result<String> {
+    if !content.starts_with("-----BEGIN PGP SIGNED MESSAGE-----") {
+        return Ok(content.to_string());
+    }
+
+    let mut lines = content.lines();
+    let Some(first) = lines.next() else {
+        return Err(AppError::Validation("InRelease is empty".to_string()));
+    };
+    if first != "-----BEGIN PGP SIGNED MESSAGE-----" {
+        return Err(AppError::Validation(
+            "Invalid InRelease clear-signature header".to_string(),
+        ));
+    }
+
+    for line in lines.by_ref() {
+        if line.is_empty() {
+            break;
+        }
+    }
+
+    let mut payload = String::new();
+    for line in lines {
+        if line == "-----BEGIN PGP SIGNATURE-----" {
+            break;
+        }
+        if let Some(unstuffed) = line.strip_prefix("- ") {
+            payload.push_str(unstuffed);
+        } else {
+            payload.push_str(line);
+        }
+        payload.push('\n');
+    }
+
+    if payload.trim().is_empty() {
+        return Err(AppError::Validation(
+            "InRelease missing signed Release payload".to_string(),
+        ));
+    }
+
+    Ok(payload)
+}
+
+fn parse_packages_entry(stanza: String) -> Result<PackagesEntry> {
+    let mut control = DebianHandler::parse_control(&stanza)?;
+    let filename = control.extra.remove("Filename");
+    let size = control
+        .extra
+        .remove("Size")
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .map_err(|_| AppError::Validation(format!("Invalid Packages Size value '{value}'")))
+        })
+        .transpose()?;
+    let md5sum = control.extra.remove("MD5sum");
+    let sha1 = control.extra.remove("SHA1");
+    let sha256 = control.extra.remove("SHA256");
+
+    Ok(PackagesEntry {
+        control,
+        filename,
+        size,
+        md5sum,
+        sha1,
+        sha256,
+    })
+}
+
+fn parse_source_file_hashes(
+    value: Option<String>,
+    field_name: &str,
+) -> Result<BTreeMap<String, (String, u64)>> {
+    let mut entries = BTreeMap::new();
+    let Some(value) = value else {
+        return Ok(entries);
+    };
+    for line in value.lines().filter(|line| !line.trim().is_empty()) {
+        let mut parts = line.split_whitespace();
+        let hash = parts
+            .next()
+            .ok_or_else(|| AppError::Validation(format!("{field_name} entry missing hash")))?;
+        let size = parts
+            .next()
+            .ok_or_else(|| AppError::Validation(format!("{field_name} entry missing size")))?
+            .parse::<u64>()
+            .map_err(|_| AppError::Validation(format!("Invalid {field_name} size in '{line}'")))?;
+        let filename = parts
+            .next()
+            .ok_or_else(|| AppError::Validation(format!("{field_name} entry missing filename")))?;
+        entries.insert(filename.to_string(), (hash.to_string(), size));
+    }
+    Ok(entries)
+}
+
+fn parse_sources_entry(stanza: String) -> Result<SourcesEntry> {
+    let mut fields = parse_field_map(&stanza)?;
+    let package = fields
+        .remove("Package")
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::Validation("Sources entry missing Package field".to_string()))?;
+    let version = fields
+        .remove("Version")
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::Validation("Sources entry missing Version field".to_string()))?;
+    let directory = fields
+        .remove("Directory")
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::Validation("Sources entry missing Directory field".to_string()))?;
+
+    let md5 = parse_source_file_hashes(fields.remove("Files"), "Files")?;
+    let sha1 = parse_source_file_hashes(fields.remove("Checksums-Sha1"), "Checksums-Sha1")?;
+    let sha256 = parse_source_file_hashes(fields.remove("Checksums-Sha256"), "Checksums-Sha256")?;
+    let sha512 = parse_source_file_hashes(fields.remove("Checksums-Sha512"), "Checksums-Sha512")?;
+
+    let mut filenames = BTreeSet::new();
+    filenames.extend(md5.keys().cloned());
+    filenames.extend(sha1.keys().cloned());
+    filenames.extend(sha256.keys().cloned());
+    filenames.extend(sha512.keys().cloned());
+
+    let mut files = Vec::new();
+    for filename in filenames {
+        let size = sha256
+            .get(&filename)
+            .or_else(|| sha512.get(&filename))
+            .or_else(|| sha1.get(&filename))
+            .or_else(|| md5.get(&filename))
+            .map(|(_, size)| *size)
+            .unwrap_or(0);
+        files.push(SourceFileEntry {
+            filename: filename.clone(),
+            size,
+            md5sum: md5.get(&filename).map(|(hash, _)| hash.clone()),
+            sha1: sha1.get(&filename).map(|(hash, _)| hash.clone()),
+            sha256: sha256.get(&filename).map(|(hash, _)| hash.clone()),
+            sha512: sha512.get(&filename).map(|(hash, _)| hash.clone()),
+        });
+    }
+
+    Ok(SourcesEntry {
+        package,
+        version,
+        directory,
+        files,
+        extra: fields,
+    })
+}
+
+fn parse_debian_stanza_fields(content: &str) -> Result<BTreeMap<String, String>> {
+    let stanzas = split_debian_stanzas(content);
+    if stanzas.is_empty() {
+        return Err(AppError::Validation("Debian metadata is empty".to_string()));
+    }
+    if stanzas.len() > 1 {
+        return Err(AppError::Validation(
+            "Expected one Debian metadata stanza".to_string(),
+        ));
+    }
+    parse_field_map(&stanzas[0])
+}
+
+fn split_debian_stanzas(content: &str) -> Vec<String> {
+    let mut stanzas = Vec::new();
+    let mut current = String::new();
+
+    for line in content.lines() {
+        if line.trim().is_empty() {
+            if !current.trim().is_empty() {
+                stanzas.push(current.trim_end().to_string());
+                current.clear();
+            }
+        } else {
+            current.push_str(line);
+            current.push('\n');
+        }
+    }
+
+    if !current.trim().is_empty() {
+        stanzas.push(current.trim_end().to_string());
+    }
+
+    stanzas
+}
+
+fn parse_field_map(stanza: &str) -> Result<BTreeMap<String, String>> {
+    let mut fields = BTreeMap::new();
+    let mut current_key: Option<String> = None;
+    let mut current_value = String::new();
+
+    for line in stanza.lines() {
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if current_key.is_none() {
+                return Err(AppError::Validation(
+                    "Debian metadata continuation without field".to_string(),
+                ));
+            }
+            current_value.push('\n');
+            current_value.push_str(line.trim_start());
+            continue;
+        }
+
+        let Some(colon_pos) = line.find(':') else {
+            return Err(AppError::Validation(format!(
+                "Malformed Debian metadata line '{line}'"
+            )));
+        };
+
+        if let Some(key) = current_key.take() {
+            fields.insert(key, current_value.trim().to_string());
+            current_value.clear();
+        }
+
+        current_key = Some(line[..colon_pos].to_string());
+        current_value.push_str(line[colon_pos + 1..].trim());
+    }
+
+    if let Some(key) = current_key {
+        fields.insert(key, current_value.trim().to_string());
+    }
+
+    Ok(fields)
+}
+
+fn required_field<'a>(fields: &'a BTreeMap<String, String>, key: &str) -> Result<&'a str> {
+    fields
+        .get(key)
+        .map(String::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| AppError::Validation(format!("Release file missing {key} field")))
+}
+
+fn split_words(value: Option<&String>) -> Vec<String> {
+    value
+        .map(|value| {
+            value
+                .split_whitespace()
+                .map(str::to_string)
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default()
+}
+
+fn parse_release_hashes(value: Option<&String>) -> Result<Vec<ReleaseHash>> {
+    let Some(value) = value else {
+        return Ok(Vec::new());
+    };
+
+    let mut hashes = Vec::new();
+    for line in value.lines().filter(|line| !line.trim().is_empty()) {
+        let mut parts = line.split_whitespace();
+        let hash = parts
+            .next()
+            .ok_or_else(|| AppError::Validation("Release hash entry missing hash".to_string()))?;
+        let size = parts
+            .next()
+            .ok_or_else(|| AppError::Validation("Release hash entry missing size".to_string()))?
+            .parse::<u64>()
+            .map_err(|_| AppError::Validation(format!("Invalid Release hash size in '{line}'")))?;
+        let path = parts
+            .next()
+            .ok_or_else(|| AppError::Validation("Release hash entry missing path".to_string()))?;
+        hashes.push(ReleaseHash {
+            hash: hash.to_string(),
+            size,
+            path: path.to_string(),
+        });
+    }
+
+    Ok(hashes)
+}
+
+fn parse_release_package_index_path(path: &str) -> Option<DebianIndexPath> {
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() == 1 {
+        let filename = parts[0];
+        if !is_packages_index_filename(filename) {
+            return None;
+        }
+        return Some(DebianIndexPath {
+            component: String::new(),
+            architecture: String::new(),
+            path: path.to_string(),
+        });
+    }
+
+    if parts.len() != 3 || !parts[1].starts_with("binary-") {
+        return None;
+    }
+    let filename = parts[2];
+    if !is_packages_index_filename(filename) {
+        return None;
+    }
+
+    Some(DebianIndexPath {
+        component: parts[0].to_string(),
+        architecture: parts[1].trim_start_matches("binary-").to_string(),
+        path: path.to_string(),
+    })
+}
+
+fn parse_release_source_index_path(path: &str) -> Option<DebianSourceIndexPath> {
+    let parts: Vec<&str> = path.split('/').collect();
+    if parts.len() == 1 {
+        let filename = parts[0];
+        if !is_sources_index_filename(filename) {
+            return None;
+        }
+        return Some(DebianSourceIndexPath {
+            component: String::new(),
+            path: path.to_string(),
+        });
+    }
+
+    if parts.len() != 3 || parts[1] != "source" {
+        return None;
+    }
+    let filename = parts[2];
+    if !is_sources_index_filename(filename) {
+        return None;
+    }
+
+    Some(DebianSourceIndexPath {
+        component: parts[0].to_string(),
+        path: path.to_string(),
+    })
+}
+
+fn is_packages_index_filename(filename: &str) -> bool {
+    matches!(
+        filename,
+        "Packages"
+            | "Packages.gz"
+            | "Packages.xz"
+            | "Packages.bz2"
+            | "Packages.zst"
+            | "Packages.zstd"
+    )
+}
+
+fn is_sources_index_filename(filename: &str) -> bool {
+    matches!(
+        filename,
+        "Sources" | "Sources.gz" | "Sources.xz" | "Sources.bz2" | "Sources.zst" | "Sources.zstd"
+    )
+}
+fn is_debian_metadata_path(path: &str) -> bool {
+    matches!(
+        path,
+        "Release"
+            | "InRelease"
+            | "Release.gpg"
+            | "Packages"
+            | "Packages.gz"
+            | "Packages.xz"
+            | "Sources"
+            | "Sources.gz"
+            | "Sources.xz"
+    ) || (path.starts_with("dists/")
+        && (path.ends_with("/Release")
+            || path.ends_with("/InRelease")
+            || path.ends_with("/Release.gpg")
+            || path.ends_with("/Packages")
+            || path.ends_with("/Packages.gz")
+            || path.ends_with("/Packages.xz")
+            || path.ends_with("/Sources")
+            || path.ends_with("/Sources.gz")
+            || path.ends_with("/Sources.xz")))
+}
+
+fn is_debian_pool_artifact(path: &str) -> bool {
+    path.starts_with("pool/") && (path.ends_with(".deb") || path.ends_with(".udeb"))
+}
+
+/// Stable promotion target path for Debian packages.
+///
+/// Pool layout (`pool/<component>/…`) and flat `.deb`/`.udeb` paths are kept
+/// unchanged so promoted artifacts remain addressable by the same Filename in
+/// Packages indexes.
+pub fn debian_promotion_target_path(source_path: &str) -> String {
+    source_path.to_string()
+}
+
+/// True when any Packages index text lists `pool_path` as a `Filename:` entry.
+///
+/// Used for reference-aware cleanup before deleting a pool artifact: if the
+/// path is still referenced by generated or cached Packages indexes, callers
+/// should retain the blob (or regenerate indexes first).
+pub fn debian_pool_path_still_referenced(packages_index_texts: &[String], pool_path: &str) -> bool {
+    let pool_path = pool_path.trim();
+    if pool_path.is_empty() {
+        return false;
+    }
+    packages_index_texts.iter().any(|text| {
+        text.lines().any(|line| {
+            let Some(value) = line.strip_prefix("Filename:") else {
+                return false;
+            };
+            value.trim() == pool_path
+        })
+    })
+}
+
+fn push_packages_field(entry: &mut String, key: &str, value: &str) {
+    let mut lines = value.lines();
+    let Some(first) = lines.next() else {
+        return;
+    };
+    entry.push_str(key);
+    entry.push_str(": ");
+    entry.push_str(first);
+    entry.push('\n');
+    for line in lines {
+        entry.push(' ');
+        entry.push_str(if line.is_empty() { "." } else { line });
+        entry.push('\n');
+    }
+}
+
+fn push_optional_packages_field(entry: &mut String, key: &str, value: Option<&str>) {
+    if let Some(value) = value.filter(|value| !value.trim().is_empty()) {
+        push_packages_field(entry, key, value);
+    }
+}
+
+fn push_dependency_packages_field(entry: &mut String, key: &str, values: Option<&Vec<String>>) {
+    if let Some(values) = values.filter(|values| !values.is_empty()) {
+        push_packages_field(entry, key, &values.join(", "));
+    }
 }
 
 /// Generate Packages file entry
@@ -525,44 +2069,34 @@ pub fn generate_packages_entry(
 ) -> String {
     let mut entry = String::new();
 
-    entry.push_str(&format!("Package: {}\n", control.package));
-    entry.push_str(&format!("Version: {}\n", control.version));
-    entry.push_str(&format!("Architecture: {}\n", control.architecture));
-
-    if let Some(maintainer) = &control.maintainer {
-        entry.push_str(&format!("Maintainer: {}\n", maintainer));
-    }
-
+    push_packages_field(&mut entry, "Package", &control.package);
+    push_packages_field(&mut entry, "Version", &control.version);
+    push_packages_field(&mut entry, "Architecture", &control.architecture);
+    push_optional_packages_field(&mut entry, "Maintainer", control.maintainer.as_deref());
     if let Some(size) = control.installed_size {
-        entry.push_str(&format!("Installed-Size: {}\n", size));
+        push_packages_field(&mut entry, "Installed-Size", &size.to_string());
     }
-
-    if let Some(depends) = &control.depends {
-        if !depends.is_empty() {
-            entry.push_str(&format!("Depends: {}\n", depends.join(", ")));
-        }
+    push_dependency_packages_field(&mut entry, "Depends", control.depends.as_ref());
+    push_dependency_packages_field(&mut entry, "Pre-Depends", control.pre_depends.as_ref());
+    push_dependency_packages_field(&mut entry, "Recommends", control.recommends.as_ref());
+    push_dependency_packages_field(&mut entry, "Suggests", control.suggests.as_ref());
+    push_dependency_packages_field(&mut entry, "Conflicts", control.conflicts.as_ref());
+    push_dependency_packages_field(&mut entry, "Provides", control.provides.as_ref());
+    push_dependency_packages_field(&mut entry, "Replaces", control.replaces.as_ref());
+    push_optional_packages_field(&mut entry, "Section", control.section.as_deref());
+    push_optional_packages_field(&mut entry, "Priority", control.priority.as_deref());
+    push_optional_packages_field(&mut entry, "Homepage", control.homepage.as_deref());
+    push_optional_packages_field(&mut entry, "Source", control.source.as_deref());
+    let mut extra_fields: Vec<_> = control.extra.iter().collect();
+    extra_fields.sort_by_key(|(key, _)| *key);
+    for (key, value) in extra_fields {
+        push_packages_field(&mut entry, key, value);
     }
-
-    if let Some(section) = &control.section {
-        entry.push_str(&format!("Section: {}\n", section));
-    }
-
-    if let Some(priority) = &control.priority {
-        entry.push_str(&format!("Priority: {}\n", priority));
-    }
-
-    if let Some(homepage) = &control.homepage {
-        entry.push_str(&format!("Homepage: {}\n", homepage));
-    }
-
-    if let Some(description) = &control.description {
-        entry.push_str(&format!("Description: {}\n", description));
-    }
-
-    entry.push_str(&format!("Filename: {}\n", filename));
-    entry.push_str(&format!("Size: {}\n", size));
-    entry.push_str(&format!("MD5sum: {}\n", md5sum));
-    entry.push_str(&format!("SHA256: {}\n", sha256));
+    push_optional_packages_field(&mut entry, "Description", control.description.as_deref());
+    push_packages_field(&mut entry, "Filename", filename);
+    push_packages_field(&mut entry, "Size", &size.to_string());
+    push_packages_field(&mut entry, "MD5sum", md5sum);
+    push_packages_field(&mut entry, "SHA256", sha256);
 
     entry
 }
@@ -576,6 +2110,12 @@ pub fn generate_release(
     hashes: Vec<ReleaseHash>,
 ) -> String {
     let mut release = String::new();
+    let mut architectures = architectures.to_vec();
+    let mut components = components.to_vec();
+    let mut hashes = hashes;
+    architectures.sort();
+    components.sort();
+    hashes.sort_by(|a, b| a.path.cmp(&b.path));
 
     release.push_str(&format!("Suite: {}\n", suite));
     if let Some(cn) = codename {
@@ -598,6 +2138,7 @@ pub fn generate_release(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Datelike;
 
     // ========================================================================
     // parse_deb_filename tests
@@ -645,6 +2186,15 @@ mod tests {
             DebianHandler::parse_deb_filename("pkg_1%3a2.0-1_amd64.deb").unwrap();
         assert_eq!(pkg, "pkg");
         assert_eq!(ver, "1%3a2.0-1");
+        assert_eq!(arch, "amd64");
+    }
+
+    #[test]
+    fn test_parse_deb_filename_debian_version_special_characters() {
+        let (pkg, ver, arch) =
+            DebianHandler::parse_deb_filename("nginx_1:1.24.0-1~ubuntu+1_amd64.deb").unwrap();
+        assert_eq!(pkg, "nginx");
+        assert_eq!(ver, "1:1.24.0-1~ubuntu+1");
         assert_eq!(arch, "amd64");
     }
 
@@ -1244,6 +2794,601 @@ Source: full-pkg-src
         assert!(release.contains(" def456 512 main/binary-amd64/Packages.gz\n"));
     }
 
+    #[test]
+    fn test_parse_release_with_hash_sections() {
+        let content = "Origin: Artifact Keeper\nLabel: Artifact Keeper\nSuite: jammy\nCodename: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64 arm64\nComponents: main universe\nDescription: Test repo\nSHA256:\n abc123 1024 main/binary-amd64/Packages\n def456 512 universe/binary-arm64/Packages.gz\nSHA512:\n fedcba 256 main/binary-amd64/Packages.xz\nX-Extra: kept\n";
+
+        let release = parse_release(content).unwrap();
+        assert_eq!(release.suite, "jammy");
+        assert_eq!(release.codename.as_deref(), Some("jammy"));
+        assert_eq!(release.architectures, vec!["amd64", "arm64"]);
+        assert_eq!(release.components, vec!["main", "universe"]);
+        assert_eq!(release.sha256.len(), 2);
+        assert_eq!(release.sha512[0].path, "main/binary-amd64/Packages.xz");
+        assert_eq!(
+            release.extra.get("X-Extra").map(String::as_str),
+            Some("kept")
+        );
+    }
+
+    #[test]
+    fn test_parse_in_release_clear_signed_payload() {
+        let content = "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA256\n\nSuite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n abc123 42 main/binary-amd64/Packages\n-----BEGIN PGP SIGNATURE-----\nignored\n-----END PGP SIGNATURE-----\n";
+
+        let release = parse_in_release(content).unwrap();
+        assert_eq!(release.suite, "jammy");
+        assert_eq!(release.sha256[0].size, 42);
+    }
+
+    #[test]
+    fn test_parse_release_gpg_armored() {
+        let sig =
+            parse_release_gpg(b"-----BEGIN PGP SIGNATURE-----\nabc\n-----END PGP SIGNATURE-----\n")
+                .unwrap();
+        assert!(sig.is_armored);
+        assert!(sig.size > 0);
+    }
+
+    #[test]
+    fn test_generate_release_signatures_with_mock_signer() {
+        struct MockSigner;
+
+        impl DebianReleaseSigner for MockSigner {
+            fn sign_in_release(&self, release: &str) -> Result<String> {
+                Ok(format!(
+                    "-----BEGIN PGP SIGNED MESSAGE-----\nHash: SHA256\n\n{release}-----BEGIN PGP SIGNATURE-----\nmock\n-----END PGP SIGNATURE-----\n"
+                ))
+            }
+
+            fn sign_release_gpg(&self, release: &[u8]) -> Result<Vec<u8>> {
+                let mut signature = b"mock-detached:".to_vec();
+                signature.extend_from_slice(release);
+                Ok(signature)
+            }
+        }
+
+        let release = "Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\n";
+        let in_release = generate_in_release(&MockSigner, release).unwrap();
+        assert!(in_release.contains("-----BEGIN PGP SIGNED MESSAGE-----"));
+        assert!(in_release.contains("Suite: jammy"));
+
+        let release_gpg = generate_release_gpg(&MockSigner, release).unwrap();
+        assert!(release_gpg.starts_with(b"mock-detached:"));
+        assert!(release_gpg.ends_with(release.as_bytes()));
+    }
+
+    #[test]
+    fn test_generate_release_signatures_reject_empty_release() {
+        struct MockSigner;
+
+        impl DebianReleaseSigner for MockSigner {
+            fn sign_in_release(&self, release: &str) -> Result<String> {
+                Ok(release.to_string())
+            }
+
+            fn sign_release_gpg(&self, release: &[u8]) -> Result<Vec<u8>> {
+                Ok(release.to_vec())
+            }
+        }
+
+        assert!(generate_in_release(&MockSigner, " ").is_err());
+        assert!(generate_release_gpg(&MockSigner, "").is_err());
+    }
+
+    #[test]
+    fn test_parse_packages_index_gz() {
+        use flate2::write::GzEncoder;
+        use std::io::Write as _;
+
+        let packages = "Package: nginx\nVersion: 1:1.24.0-1~ubuntu+1\nArchitecture: amd64\nDescription: Web server\n extended description\nFilename: pool/main/n/nginx/nginx_1:1.24.0-1~ubuntu+1_amd64.deb\nSize: 2048\nMD5sum: md5\nSHA1: sha1\nSHA256: sha256\n\n";
+        let mut encoder = GzEncoder::new(Vec::new(), flate2::Compression::default());
+        encoder.write_all(packages.as_bytes()).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let parsed = parse_packages_index("main/binary-amd64/Packages.gz", &compressed).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].control.package, "nginx");
+        assert_eq!(parsed[0].control.version, "1:1.24.0-1~ubuntu+1");
+        assert_eq!(
+            parsed[0].control.description.as_deref(),
+            Some("Web server\nextended description")
+        );
+        assert_eq!(
+            parsed[0].filename.as_deref(),
+            Some("pool/main/n/nginx/nginx_1:1.24.0-1~ubuntu+1_amd64.deb")
+        );
+        assert_eq!(parsed[0].size, Some(2048));
+        assert_eq!(parsed[0].sha1.as_deref(), Some("sha1"));
+        assert_eq!(parsed[0].sha256.as_deref(), Some("sha256"));
+    }
+
+    #[test]
+    fn test_parse_sources_index_preserves_hashes_and_unknown_fields() {
+        let sources = "Package: nginx\nBinary: nginx\nVersion: 1.0-1\nMaintainer: Example Maintainer <maintainer@example.invalid>\nDirectory: pool/main/n/nginx\nFiles:\n md5dsc 11 nginx_1.0-1.dsc\n md5tar 22 nginx_1.0.orig.tar.xz\nChecksums-Sha1:\n sha1dsc 11 nginx_1.0-1.dsc\nChecksums-Sha256:\n sha256dsc 11 nginx_1.0-1.dsc\n sha256tar 22 nginx_1.0.orig.tar.xz\nChecksums-Sha512:\n sha512dsc 11 nginx_1.0-1.dsc\nX-Kept: yes\n\n";
+
+        let parsed = parse_sources_index("main/source/Sources", sources.as_bytes()).unwrap();
+
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].package, "nginx");
+        assert_eq!(parsed[0].version, "1.0-1");
+        assert_eq!(parsed[0].directory, "pool/main/n/nginx");
+        assert_eq!(
+            parsed[0].extra.get("Binary").map(String::as_str),
+            Some("nginx")
+        );
+        assert_eq!(
+            parsed[0].extra.get("X-Kept").map(String::as_str),
+            Some("yes")
+        );
+        assert_eq!(parsed[0].files.len(), 2);
+        assert!(parsed[0].files.iter().any(|file| {
+            file.filename == "nginx_1.0-1.dsc"
+                && file.size == 11
+                && file.md5sum.as_deref() == Some("md5dsc")
+                && file.sha1.as_deref() == Some("sha1dsc")
+                && file.sha256.as_deref() == Some("sha256dsc")
+                && file.sha512.as_deref() == Some("sha512dsc")
+        }));
+        assert!(parsed[0].files.iter().any(|file| {
+            file.filename == "nginx_1.0.orig.tar.xz"
+                && file.size == 22
+                && file.md5sum.as_deref() == Some("md5tar")
+                && file.sha256.as_deref() == Some("sha256tar")
+        }));
+    }
+    #[test]
+    fn test_filter_release_package_indexes_by_component_and_architecture() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64 arm64\nComponents: main universe\nSHA256:\n a 1 main/binary-amd64/Packages.xz\n b 1 main/binary-arm64/Packages.xz\n c 1 universe/binary-amd64/Packages.gz\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        let indexes = filter_release_package_indexes(&release, &filter);
+        assert_eq!(
+            indexes,
+            vec![DebianIndexPath {
+                component: "main".to_string(),
+                architecture: "amd64".to_string(),
+                path: "main/binary-amd64/Packages.xz".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_filter_release_package_indexes_prefers_one_compressed_representation() {
+        let release = parse_release("Suite: bookworm\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n a 1 main/binary-amd64/Packages\n b 1 main/binary-amd64/Packages.gz\n c 1 main/binary-amd64/Packages.xz\n").unwrap();
+        let indexes = filter_release_package_indexes(&release, &DebianSyncFilter::default());
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].path, "main/binary-amd64/Packages.xz");
+    }
+
+    #[test]
+    fn test_filter_release_package_indexes_respects_distribution_filter() {
+        let release = parse_release("Suite: stable\nCodename: bookworm\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n a 1 main/binary-amd64/Packages.xz\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        assert!(filter_release_package_indexes(&release, &filter).is_empty());
+
+        let filter = DebianSyncFilter {
+            distributions: vec!["bookworm".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+        assert_eq!(filter_release_package_indexes(&release, &filter).len(), 1);
+    }
+
+    #[test]
+    fn test_validate_release_filter_selection_rejects_missing_component() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["universe".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        let err = validate_release_filter_selection(&release, &filter).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Selected Debian component(s) not advertised"));
+    }
+
+    #[test]
+    fn test_validate_release_filter_accepts_main_for_debian_security_updates_main() {
+        let release = parse_release(
+            "Suite: oldstable-security\nCodename: bookworm-security\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: updates/main updates/contrib\nSHA256:\n a 1 main/binary-amd64/Packages.xz\n",
+        )
+        .unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["bookworm-security".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        validate_release_filter_selection(&release, &filter).unwrap();
+        let indexes = filter_release_package_indexes(&release, &filter);
+        assert_eq!(indexes.len(), 1);
+        assert_eq!(indexes[0].component, "main");
+        assert_eq!(indexes[0].path, "main/binary-amd64/Packages.xz");
+    }
+
+    #[test]
+    fn test_debian_components_equivalent_leaf_matching() {
+        assert!(debian_components_equivalent("main", "main"));
+        assert!(debian_components_equivalent("main", "updates/main"));
+        assert!(debian_components_equivalent("updates/main", "main"));
+        assert!(!debian_components_equivalent("main", "updates/contrib"));
+        assert!(!debian_components_equivalent("universe", "main"));
+    }
+
+    #[test]
+    fn test_validate_release_filter_selection_rejects_missing_architecture() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["arm64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        let err = validate_release_filter_selection(&release, &filter).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Selected Debian architecture(s) not advertised"));
+    }
+    #[test]
+    fn test_filter_release_source_indexes_requires_source_flag() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main universe\nSHA256:\n a 1 main/source/Sources\n b 1 main/source/Sources.gz\n c 1 main/source/Sources.xz\n d 1 universe/source/Sources.xz\n").unwrap();
+        let mut filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        assert!(filter_release_source_indexes(&release, &filter).is_empty());
+
+        filter.include_source_packages = true;
+        let indexes = filter_release_source_indexes(&release, &filter);
+        assert_eq!(
+            indexes,
+            vec![DebianSourceIndexPath {
+                component: "main".to_string(),
+                path: "main/source/Sources.xz".to_string(),
+            }]
+        );
+    }
+    #[test]
+    fn test_flat_release_indexes_are_selected_without_distribution_filter() {
+        let release = parse_release("Suite: stable\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nSHA256:\n a 1 Packages\n b 1 Packages.gz\n c 1 Packages.xz\n d 1 Sources.xz\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: Vec::new(),
+            components: Vec::new(),
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: true,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        let package_indexes = filter_release_package_indexes(&release, &filter);
+        assert_eq!(
+            package_indexes,
+            vec![DebianIndexPath {
+                component: String::new(),
+                architecture: String::new(),
+                path: "Packages.xz".to_string(),
+            }]
+        );
+
+        let source_indexes = filter_release_source_indexes(&release, &filter);
+        assert_eq!(
+            source_indexes,
+            vec![DebianSourceIndexPath {
+                component: String::new(),
+                path: "Sources.xz".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn test_flat_metadata_paths_are_classified_as_debian_metadata() {
+        assert!(is_debian_metadata_path("Release"));
+        assert!(is_debian_metadata_path("Packages.xz"));
+        assert!(is_debian_metadata_path("Sources.gz"));
+        assert!(!is_debian_metadata_path(
+            "pool/main/n/nginx/nginx_1.0_amd64.deb"
+        ));
+    }
+    #[test]
+    fn test_flat_sync_index_filters_package_architectures() {
+        assert!(package_matches_sync_index(
+            "amd64",
+            "",
+            &["amd64".to_string()]
+        ));
+        assert!(package_matches_sync_index(
+            "all",
+            "",
+            &["amd64".to_string()]
+        ));
+        assert!(!package_matches_sync_index(
+            "arm64",
+            "",
+            &["amd64".to_string()]
+        ));
+    }
+    #[test]
+    fn test_architecture_all_matches_selected_indexes() {
+        assert!(package_matches_sync_architecture(
+            "all",
+            &["amd64".to_string()]
+        ));
+        assert!(package_matches_sync_architecture(
+            "amd64",
+            &["amd64".to_string()]
+        ));
+        assert!(!package_matches_sync_architecture(
+            "arm64",
+            &["amd64".to_string()]
+        ));
+    }
+
+    fn packages_entry(
+        package: &str,
+        version: &str,
+        architecture: &str,
+        filename: &str,
+    ) -> PackagesEntry {
+        PackagesEntry {
+            control: DebControl {
+                package: package.to_string(),
+                version: version.to_string(),
+                architecture: architecture.to_string(),
+                ..Default::default()
+            },
+            filename: Some(filename.to_string()),
+            size: Some(128),
+            md5sum: None,
+            sha1: None,
+            sha256: Some("sha256".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_build_debian_sync_plan_filters_indexes_and_package_files() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64 arm64\nComponents: main universe\nSHA256:\n a 1 main/binary-amd64/Packages.xz\n b 1 main/binary-arm64/Packages.xz\n c 1 universe/binary-amd64/Packages.xz\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string(), "arm64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+        let mut packages_by_index_path = BTreeMap::new();
+        packages_by_index_path.insert(
+            "main/binary-amd64/Packages.xz".to_string(),
+            vec![
+                packages_entry(
+                    "nginx",
+                    "1.0",
+                    "amd64",
+                    "pool/main/n/nginx/nginx_1.0_amd64.deb",
+                ),
+                packages_entry("docs", "1.0", "all", "pool/main/d/docs/docs_1.0_all.deb"),
+                packages_entry("bad", "1.0", "arm64", "pool/main/b/bad/bad_1.0_arm64.deb"),
+            ],
+        );
+        packages_by_index_path.insert(
+            "main/binary-arm64/Packages.xz".to_string(),
+            vec![
+                packages_entry(
+                    "nginx",
+                    "1.0",
+                    "arm64",
+                    "pool/main/n/nginx/nginx_1.0_arm64.deb",
+                ),
+                packages_entry("docs", "1.0", "all", "pool/main/d/docs/docs_1.0_all.deb"),
+            ],
+        );
+
+        let plan = build_debian_sync_plan(
+            "jammy",
+            &release,
+            &filter,
+            &packages_by_index_path,
+            &BTreeMap::new(),
+            DebianSyncDownloadPolicy::OnDemand,
+        );
+
+        assert_eq!(
+            plan.release_paths,
+            vec![
+                "dists/jammy/InRelease".to_string(),
+                "dists/jammy/Release".to_string(),
+                "dists/jammy/Release.gpg".to_string(),
+            ]
+        );
+        assert_eq!(plan.package_indexes.len(), 2);
+        assert!(plan.missing_package_indexes.is_empty());
+        assert_eq!(plan.package_files.len(), 4);
+        assert!(plan.package_files.iter().all(|file| !file.download));
+        assert!(plan.package_files.iter().any(|file| {
+            file.index_path == "main/binary-amd64/Packages.xz"
+                && file.package == "docs"
+                && file.architecture == "all"
+        }));
+        assert!(plan.package_files.iter().any(|file| {
+            file.index_path == "main/binary-arm64/Packages.xz"
+                && file.package == "docs"
+                && file.architecture == "all"
+        }));
+        assert!(!plan.package_files.iter().any(|file| file.package == "bad"));
+    }
+
+    #[test]
+    fn test_build_debian_sync_plan_includes_source_files_when_enabled() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n a 1 main/binary-amd64/Packages.xz\n b 1 main/source/Sources.xz\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: true,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+        let packages_by_index_path = BTreeMap::new();
+        let mut sources_by_index_path = BTreeMap::new();
+        sources_by_index_path.insert(
+            "main/source/Sources.xz".to_string(),
+            vec![SourcesEntry {
+                package: "nginx".to_string(),
+                version: "1.0-1".to_string(),
+                directory: "pool/main/n/nginx".to_string(),
+                files: vec![SourceFileEntry {
+                    filename: "nginx_1.0-1.dsc".to_string(),
+                    size: 11,
+                    md5sum: Some("md5dsc".to_string()),
+                    sha1: None,
+                    sha256: Some("sha256dsc".to_string()),
+                    sha512: None,
+                }],
+                extra: BTreeMap::new(),
+            }],
+        );
+
+        let plan = build_debian_sync_plan(
+            "jammy",
+            &release,
+            &filter,
+            &packages_by_index_path,
+            &sources_by_index_path,
+            DebianSyncDownloadPolicy::Immediate,
+        );
+
+        assert_eq!(plan.source_indexes.len(), 1);
+        assert_eq!(
+            plan.missing_package_indexes,
+            vec!["main/binary-amd64/Packages.xz".to_string()]
+        );
+        assert!(plan.missing_source_indexes.is_empty());
+        assert_eq!(plan.source_files.len(), 1);
+        assert_eq!(
+            plan.source_files[0].filename,
+            "pool/main/n/nginx/nginx_1.0-1.dsc"
+        );
+        assert!(plan.source_files[0].download);
+    }
+    #[test]
+    fn test_build_debian_sync_plan_marks_immediate_downloads_and_missing_indexes() {
+        let release = parse_release("Suite: bookworm\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n a 1 main/binary-amd64/Packages.gz\n").unwrap();
+        let filter = DebianSyncFilter {
+            distributions: vec!["bookworm".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+        let packages_by_index_path = BTreeMap::new();
+
+        let plan = build_debian_sync_plan(
+            "bookworm",
+            &release,
+            &filter,
+            &packages_by_index_path,
+            &BTreeMap::new(),
+            DebianSyncDownloadPolicy::from_label(Some("immediate")),
+        );
+
+        assert_eq!(
+            plan.missing_package_indexes,
+            vec!["main/binary-amd64/Packages.gz".to_string()]
+        );
+        assert!(plan.package_files.is_empty());
+        assert_eq!(
+            DebianSyncDownloadPolicy::from_label(Some("on_demand")),
+            DebianSyncDownloadPolicy::OnDemand
+        );
+        assert_eq!(
+            DebianSyncDownloadPolicy::from_label(Some("full-mirror")),
+            DebianSyncDownloadPolicy::Immediate
+        );
+    }
+
+    #[test]
+    fn test_debian_cache_decision_logic() {
+        assert_eq!(
+            decide_debian_cache_action(DebianCacheDecisionInput {
+                path: "pool/main/n/nginx/nginx_1.0_amd64.deb",
+                upstream_success: true,
+                cached_locally: true,
+                cache_stale: false,
+                checksum_matches: true,
+            }),
+            DebianCacheAction::ServeCached
+        );
+        assert_eq!(
+            decide_debian_cache_action(DebianCacheDecisionInput {
+                path: "dists/jammy/Release",
+                upstream_success: true,
+                cached_locally: true,
+                cache_stale: true,
+                checksum_matches: false,
+            }),
+            DebianCacheAction::Revalidate
+        );
+        assert_eq!(
+            decide_debian_cache_action(DebianCacheDecisionInput {
+                path: "dists/jammy/main/binary-amd64/Packages.gz",
+                upstream_success: true,
+                cached_locally: true,
+                cache_stale: false,
+                checksum_matches: false,
+            }),
+            DebianCacheAction::ServeCached
+        );
+        assert_eq!(
+            decide_debian_cache_action(DebianCacheDecisionInput {
+                path: "dists/jammy/Release",
+                upstream_success: false,
+                cached_locally: false,
+                cache_stale: false,
+                checksum_matches: false,
+            }),
+            DebianCacheAction::DoNotCache
+        );
+    }
+
+    #[test]
+    fn test_malformed_release_returns_error() {
+        assert!(parse_release("Suite: jammy\n").is_err());
+    }
+
     // ========================================================================
     // DebianHandler::new / Default tests
     // ========================================================================
@@ -1256,5 +3401,654 @@ Source: full-pkg-src
     #[test]
     fn test_debian_handler_default() {
         let _handler = DebianHandler;
+    }
+
+    #[test]
+    fn test_decode_debian_index_rejects_oversized_plain_text() {
+        let oversized = vec![b'a'; (MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES as usize) + 1];
+        let err = decode_debian_index_text("Packages", &oversized, "Packages").unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum allowed size"));
+    }
+
+    #[test]
+    fn test_decode_debian_index_rejects_oversized_gzip() {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        use std::io::Write;
+
+        let oversized = vec![b'A'; (MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES as usize) + 1024];
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(&oversized).unwrap();
+        let compressed = encoder.finish().unwrap();
+        assert!(compressed.len() < (MAX_DEBIAN_INDEX_DECOMPRESSED_BYTES / 16) as usize);
+
+        let err = decode_debian_index_text("Packages.gz", &compressed, "Packages").unwrap_err();
+        assert!(err.to_string().contains("exceeds maximum allowed size"));
+    }
+
+    #[test]
+    fn test_decode_debian_index_bz2_and_zst() {
+        use std::io::Write;
+
+        let plaintext = "Package: nginx\nVersion: 1.0\nArchitecture: amd64\n";
+
+        let mut bz2_encoder = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::fast());
+        bz2_encoder.write_all(plaintext.as_bytes()).unwrap();
+        let bz2_bytes = bz2_encoder.finish().unwrap();
+        let bz2_text = decode_debian_index_text("Packages.bz2", &bz2_bytes, "Packages").unwrap();
+        assert_eq!(bz2_text, plaintext);
+
+        let zst_bytes = zstd::stream::encode_all(plaintext.as_bytes(), 1).unwrap();
+        let zst_text = decode_debian_index_text("Packages.zst", &zst_bytes, "Packages").unwrap();
+        assert_eq!(zst_text, plaintext);
+
+        let zstd_text = decode_debian_index_text("Packages.zstd", &zst_bytes, "Packages").unwrap();
+        assert_eq!(zstd_text, plaintext);
+    }
+
+    #[test]
+    fn test_package_name_matches_queries_exact_and_glob() {
+        assert!(package_name_matches_queries("nginx", &[]));
+        assert!(package_name_matches_queries(
+            "nginx",
+            &["nginx".to_string()]
+        ));
+        assert!(package_name_matches_queries("nginx", &["ngi*".to_string()]));
+        assert!(!package_name_matches_queries(
+            "nginx",
+            &["apache*".to_string()]
+        ));
+        assert!(package_name_matches_queries(
+            "libc6 (>= 2.28)",
+            &["libc6".to_string()]
+        ));
+        assert_eq!(
+            parse_debian_dependency_package_name("vim | neovim (>= 0.5)"),
+            "vim"
+        );
+        assert_eq!(
+            parse_debian_dependency_package_name("libc6 (>= 2.28)"),
+            "libc6"
+        );
+    }
+
+    #[test]
+    fn test_filter_packages_by_query_with_dependency_resolution() {
+        let nginx = PackagesEntry {
+            control: DebControl {
+                package: "nginx".to_string(),
+                version: "1.0".to_string(),
+                architecture: "amd64".to_string(),
+                depends: Some(vec![
+                    "libc6 (>= 2.28)".to_string(),
+                    "virtual-ssl".to_string(),
+                ]),
+                ..Default::default()
+            },
+            filename: Some("pool/main/n/nginx/nginx_1.0_amd64.deb".to_string()),
+            size: Some(10),
+            md5sum: None,
+            sha1: None,
+            sha256: None,
+        };
+        let libc6 = PackagesEntry {
+            control: DebControl {
+                package: "libc6".to_string(),
+                version: "2.36".to_string(),
+                architecture: "amd64".to_string(),
+                ..Default::default()
+            },
+            filename: Some("pool/main/g/glibc/libc6_2.36_amd64.deb".to_string()),
+            size: Some(10),
+            md5sum: None,
+            sha1: None,
+            sha256: None,
+        };
+        let libssl = PackagesEntry {
+            control: DebControl {
+                package: "libssl3".to_string(),
+                version: "3.0".to_string(),
+                architecture: "amd64".to_string(),
+                provides: Some(vec!["virtual-ssl".to_string()]),
+                ..Default::default()
+            },
+            filename: Some("pool/main/o/openssl/libssl3_3.0_amd64.deb".to_string()),
+            size: Some(10),
+            md5sum: None,
+            sha1: None,
+            sha256: None,
+        };
+        let unrelated = packages_entry(
+            "curl",
+            "1.0",
+            "amd64",
+            "pool/main/c/curl/curl_1.0_amd64.deb",
+        );
+        let entries = vec![nginx, libc6, libssl, unrelated];
+
+        let matched =
+            filter_packages_by_query_with_dependencies(&entries, &["nginx".to_string()], false);
+        assert_eq!(matched.len(), 1);
+        assert_eq!(matched[0].control.package, "nginx");
+
+        let with_deps =
+            filter_packages_by_query_with_dependencies(&entries, &["nginx".to_string()], true);
+        let names: BTreeSet<_> = with_deps
+            .iter()
+            .map(|entry| entry.control.package.as_str())
+            .collect();
+        assert_eq!(names, BTreeSet::from(["nginx", "libc6", "libssl3"]));
+
+        let globbed =
+            filter_packages_by_query_with_dependencies(&entries, &["lib*".to_string()], false);
+        assert_eq!(globbed.len(), 2);
+    }
+
+    #[test]
+    fn test_build_debian_sync_plan_applies_package_queries_and_deps() {
+        let release = parse_release("Suite: jammy\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main\nSHA256:\n a 1 main/binary-amd64/Packages.xz\n").unwrap();
+        let mut packages_by_index_path = BTreeMap::new();
+        packages_by_index_path.insert(
+            "main/binary-amd64/Packages.xz".to_string(),
+            vec![
+                PackagesEntry {
+                    control: DebControl {
+                        package: "nginx".to_string(),
+                        version: "1.0".to_string(),
+                        architecture: "amd64".to_string(),
+                        depends: Some(vec!["libc6".to_string()]),
+                        ..Default::default()
+                    },
+                    filename: Some("pool/main/n/nginx/nginx_1.0_amd64.deb".to_string()),
+                    size: Some(10),
+                    md5sum: None,
+                    sha1: None,
+                    sha256: None,
+                },
+                packages_entry(
+                    "libc6",
+                    "2.36",
+                    "amd64",
+                    "pool/main/g/glibc/libc6_2.36_amd64.deb",
+                ),
+                packages_entry(
+                    "curl",
+                    "1.0",
+                    "amd64",
+                    "pool/main/c/curl/curl_1.0_amd64.deb",
+                ),
+            ],
+        );
+
+        let matched_only = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: vec!["nginx".to_string()],
+            resolve_dependencies: false,
+        };
+        let plan_matched = build_debian_sync_plan(
+            "jammy",
+            &release,
+            &matched_only,
+            &packages_by_index_path,
+            &BTreeMap::new(),
+            DebianSyncDownloadPolicy::OnDemand,
+        );
+        let matched_names: BTreeSet<_> = plan_matched
+            .package_files
+            .iter()
+            .map(|file| file.package.as_str())
+            .collect();
+        assert_eq!(
+            matched_names,
+            BTreeSet::from(["nginx"]),
+            "package_queries without resolve_dependencies must select only matching packages"
+        );
+
+        let with_deps = DebianSyncFilter {
+            resolve_dependencies: true,
+            ..matched_only
+        };
+        let plan = build_debian_sync_plan(
+            "jammy",
+            &release,
+            &with_deps,
+            &packages_by_index_path,
+            &BTreeMap::new(),
+            DebianSyncDownloadPolicy::OnDemand,
+        );
+        let names: BTreeSet<_> = plan
+            .package_files
+            .iter()
+            .map(|file| file.package.as_str())
+            .collect();
+        assert_eq!(names, BTreeSet::from(["nginx", "libc6"]));
+    }
+
+    #[test]
+    fn test_release_path_allowed_by_filter() {
+        let filter = DebianSyncFilter {
+            distributions: vec!["jammy".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: true,
+            package_queries: Vec::new(),
+            resolve_dependencies: false,
+        };
+
+        assert!(release_path_allowed_by_filter(
+            "main/binary-amd64/Packages.xz",
+            &filter
+        ));
+        assert!(!release_path_allowed_by_filter(
+            "main/binary-arm64/Packages.xz",
+            &filter
+        ));
+        assert!(!release_path_allowed_by_filter(
+            "universe/binary-amd64/Packages.xz",
+            &filter
+        ));
+        assert!(release_path_allowed_by_filter(
+            "main/source/Sources.gz",
+            &filter
+        ));
+        assert!(release_path_allowed_by_filter(
+            "main/Contents-amd64.gz",
+            &filter
+        ));
+        assert!(!release_path_allowed_by_filter(
+            "main/Contents-arm64.gz",
+            &filter
+        ));
+        assert!(release_path_allowed_by_filter("Contents-amd64", &filter));
+        assert!(!release_path_allowed_by_filter("Contents-arm64", &filter));
+        assert!(release_path_allowed_by_filter(
+            "main/i18n/Translation-en.bz2",
+            &filter
+        ));
+        assert!(!release_path_allowed_by_filter(
+            "universe/i18n/Translation-en.bz2",
+            &filter
+        ));
+        assert!(release_path_allowed_by_filter(
+            "main/dep11/Components-amd64.yml.gz",
+            &filter
+        ));
+        assert!(release_path_allowed_by_filter(
+            "main/by-hash/SHA256/abc",
+            &filter
+        ));
+        assert!(!release_path_allowed_by_filter(
+            "universe/by-hash/SHA256/abc",
+            &filter
+        ));
+        assert!(!release_path_allowed_by_filter("", &filter));
+        assert!(!release_path_allowed_by_filter("README", &filter));
+
+        let no_source = DebianSyncFilter {
+            include_source_packages: false,
+            ..filter.clone()
+        };
+        assert!(!release_path_allowed_by_filter(
+            "main/source/Sources.xz",
+            &no_source
+        ));
+    }
+
+    #[test]
+    fn test_pool_path_allowed_by_filters() {
+        let filter = DebianSyncFilter {
+            distributions: Vec::new(),
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: vec!["nginx*".to_string()],
+            resolve_dependencies: false,
+        };
+
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.0_amd64.deb",
+            &filter
+        ));
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx-common_1.0_all.deb",
+            &filter
+        ));
+        assert!(!pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.0_arm64.deb",
+            &filter
+        ));
+        assert!(!pool_path_allowed_by_filters(
+            "universe",
+            "nginx_1.0_amd64.deb",
+            &filter
+        ));
+        assert!(!pool_path_allowed_by_filters(
+            "main",
+            "curl_1.0_amd64.deb",
+            &filter
+        ));
+        assert!(
+            !pool_path_allowed_by_filters("main", "not-a-deb-filename", &filter),
+            "unparseable filenames must be rejected"
+        );
+    }
+
+    #[test]
+    fn test_validate_debian_fetch_path_and_flat_package_path() {
+        assert!(validate_debian_fetch_path("pool/main/n/nginx/nginx_1.0_amd64.deb").is_ok());
+        assert!(validate_debian_fetch_path("nginx_1.0_amd64.deb").is_ok());
+        assert!(validate_debian_fetch_path("").is_err());
+        assert!(validate_debian_fetch_path("https://evil.example/pkg.deb").is_err());
+        assert!(validate_debian_fetch_path("http://evil.example/pkg.deb").is_err());
+        assert!(validate_debian_fetch_path("pool/../etc/passwd").is_err());
+        assert!(validate_debian_fetch_path("../etc/passwd").is_err());
+        assert!(validate_debian_fetch_path("pool/main/../../etc/passwd").is_err());
+
+        assert!(is_flat_repository_package_path("nginx_1.0_amd64.deb"));
+        assert!(is_flat_repository_package_path("pkgs/nginx_1.0_amd64.udeb"));
+        assert!(!is_flat_repository_package_path(
+            "pool/main/n/nginx/nginx_1.0_amd64.deb"
+        ));
+        assert!(!is_flat_repository_package_path("Release"));
+    }
+
+    #[test]
+    fn test_debian_promotion_target_path_keeps_pool_layout() {
+        assert_eq!(
+            debian_promotion_target_path("pool/main/n/nginx/nginx_1.0_amd64.deb"),
+            "pool/main/n/nginx/nginx_1.0_amd64.deb"
+        );
+        assert_eq!(
+            debian_promotion_target_path("pool/debian-installer/m/module/module_1_amd64.udeb"),
+            "pool/debian-installer/m/module/module_1_amd64.udeb"
+        );
+        assert_eq!(
+            debian_promotion_target_path("nginx_1.0_amd64.deb"),
+            "nginx_1.0_amd64.deb"
+        );
+    }
+
+    #[test]
+    fn test_debian_pool_path_still_referenced() {
+        let packages = vec![
+            "Package: nginx\nFilename: pool/main/n/nginx/nginx_1.0_amd64.deb\n\n".to_string(),
+            "Package: curl\nFilename: pool/main/c/curl/curl_1.0_amd64.deb\n\n".to_string(),
+        ];
+        assert!(debian_pool_path_still_referenced(
+            &packages,
+            "pool/main/n/nginx/nginx_1.0_amd64.deb"
+        ));
+        assert!(debian_pool_path_still_referenced(
+            &packages,
+            "  pool/main/n/nginx/nginx_1.0_amd64.deb  "
+        ));
+        assert!(!debian_pool_path_still_referenced(
+            &packages,
+            "pool/main/v/vim/vim_1.0_amd64.deb"
+        ));
+        assert!(!debian_pool_path_still_referenced(&packages, ""));
+        assert!(!debian_pool_path_still_referenced(&packages, "   "));
+        assert!(!debian_pool_path_still_referenced(
+            &[],
+            "pool/main/n/nginx/nginx_1.0_amd64.deb"
+        ));
+        // Filename value must match exactly after trim — substring matches do not count.
+        assert!(!debian_pool_path_still_referenced(
+            &packages,
+            "nginx_1.0_amd64.deb"
+        ));
+    }
+
+    #[test]
+    fn test_build_contents_index_and_by_hash_path() {
+        let index = build_contents_index(&[
+            ("usr/bin/nginx".to_string(), "nginx".to_string()),
+            ("bin/bash".to_string(), "bash".to_string()),
+        ]);
+        assert_eq!(index, "bin/bash\tbash\nusr/bin/nginx\tnginx\n");
+        assert_eq!(
+            by_hash_path("SHA256", "deadbeef"),
+            "by-hash/SHA256/deadbeef"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 3: Cross-index dependency closure
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_build_debian_sync_plan_cross_index_dep_closure() {
+        // nginx (in main/amd64) depends on libssl3 which is ONLY in security/amd64.
+        // When resolve_dependencies=true, libssl3 must be pulled into the plan
+        // even though it lives in a different index.
+        let release = parse_release(
+            "Suite: bookworm\nDate: Tue, 07 Jul 2026 12:00:00 UTC\nArchitectures: amd64\nComponents: main security\nSHA256:\n a 1 main/binary-amd64/Packages\n b 1 security/binary-amd64/Packages\n"
+        ).unwrap();
+
+        let nginx = PackagesEntry {
+            control: DebControl {
+                package: "nginx".to_string(),
+                version: "1.0".to_string(),
+                architecture: "amd64".to_string(),
+                depends: Some(vec!["libssl3".to_string()]),
+                ..Default::default()
+            },
+            filename: Some("pool/main/n/nginx/nginx_1.0_amd64.deb".to_string()),
+            size: Some(10),
+            md5sum: None,
+            sha1: None,
+            sha256: None,
+        };
+        let libssl3 = PackagesEntry {
+            control: DebControl {
+                package: "libssl3".to_string(),
+                version: "3.0.2".to_string(),
+                architecture: "amd64".to_string(),
+                ..Default::default()
+            },
+            filename: Some("pool/security/o/openssl/libssl3_3.0.2_amd64.deb".to_string()),
+            size: Some(20),
+            md5sum: None,
+            sha1: None,
+            sha256: None,
+        };
+
+        let mut packages_by_index_path = BTreeMap::new();
+        packages_by_index_path.insert("main/binary-amd64/Packages".to_string(), vec![nginx]);
+        packages_by_index_path.insert("security/binary-amd64/Packages".to_string(), vec![libssl3]);
+
+        let filter = DebianSyncFilter {
+            distributions: vec!["bookworm".to_string()],
+            components: vec!["main".to_string(), "security".to_string()],
+            architectures: vec!["amd64".to_string()],
+            include_source_packages: false,
+            package_queries: vec!["nginx".to_string()],
+            resolve_dependencies: true,
+        };
+        let plan = build_debian_sync_plan(
+            "bookworm",
+            &release,
+            &filter,
+            &packages_by_index_path,
+            &BTreeMap::new(),
+            DebianSyncDownloadPolicy::OnDemand,
+        );
+
+        let filenames: BTreeSet<&str> = plan
+            .package_files
+            .iter()
+            .map(|f| f.filename.as_str())
+            .collect();
+        assert!(
+            filenames.contains("pool/main/n/nginx/nginx_1.0_amd64.deb"),
+            "nginx must be selected"
+        );
+        assert!(
+            filenames.contains("pool/security/o/openssl/libssl3_3.0.2_amd64.deb"),
+            "libssl3 (dep from a different index) must be pulled in by cross-index closure"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 4: Source artifacts allowed when include_source_packages
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_pool_path_allowed_by_filters_source_artifacts() {
+        let filter_with_sources = DebianSyncFilter {
+            components: vec!["main".to_string()],
+            include_source_packages: true,
+            ..Default::default()
+        };
+        let filter_no_sources = DebianSyncFilter {
+            components: vec!["main".to_string()],
+            include_source_packages: false,
+            ..Default::default()
+        };
+
+        // Source artifacts must be allowed when include_source_packages=true.
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0.orig.tar.gz",
+            &filter_with_sources
+        ));
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0-1.debian.tar.xz",
+            &filter_with_sources
+        ));
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0-1.dsc",
+            &filter_with_sources
+        ));
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0-1.diff.gz",
+            &filter_with_sources
+        ));
+
+        // Source artifacts must be rejected when include_source_packages=false.
+        assert!(!pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0.orig.tar.gz",
+            &filter_no_sources
+        ));
+        assert!(!pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0-1.dsc",
+            &filter_no_sources
+        ));
+
+        // Binary .deb packages still follow normal logic.
+        assert!(pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0-1_amd64.deb",
+            &filter_with_sources
+        ));
+
+        // Component filter still applies to source artifacts.
+        let wrong_component_filter = DebianSyncFilter {
+            components: vec!["universe".to_string()],
+            include_source_packages: true,
+            ..Default::default()
+        };
+        assert!(!pool_path_allowed_by_filters(
+            "main",
+            "nginx_1.24.0-1.dsc",
+            &wrong_component_filter
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // Fix 6: Valid-Until parsing and expiry check
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_release_date_rfc2822_utc() {
+        let dt = parse_release_date("Thu, 01 Jan 2026 00:00:00 UTC").unwrap();
+        assert_eq!(dt.year(), 2026);
+        assert_eq!(dt.month(), 1);
+        assert_eq!(dt.day(), 1);
+    }
+
+    #[test]
+    fn test_parse_release_date_rfc2822_numeric_tz() {
+        let dt = parse_release_date("Thu, 01 Jan 2026 00:00:00 +0000").unwrap();
+        assert_eq!(dt.year(), 2026);
+    }
+
+    #[test]
+    fn test_parse_release_date_invalid_returns_none() {
+        assert!(parse_release_date("not a date").is_none());
+        assert!(parse_release_date("").is_none());
+    }
+
+    fn make_minimal_release(valid_until: Option<&str>) -> Release {
+        Release {
+            origin: None,
+            label: None,
+            suite: "jammy".to_string(),
+            codename: None,
+            version: None,
+            date: "Mon, 01 Jan 2024 00:00:00 UTC".to_string(),
+            valid_until: valid_until.map(str::to_string),
+            architectures: vec!["amd64".to_string()],
+            components: vec!["main".to_string()],
+            description: None,
+            md5sum: vec![],
+            sha1: vec![],
+            sha256: vec![],
+            sha512: vec![],
+            extra: BTreeMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_release_is_expired_past_valid_until() {
+        let release = make_minimal_release(Some("Mon, 01 Jan 2024 12:00:00 +0000"));
+        let now_past = chrono::DateTime::parse_from_rfc3339("2024-01-02T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        assert!(
+            release_is_expired(&release, now_past),
+            "past Valid-Until must be expired"
+        );
+    }
+
+    #[test]
+    fn test_release_is_expired_future_valid_until() {
+        let release = make_minimal_release(Some("Mon, 01 Jan 2099 12:00:00 +0000"));
+        let now = chrono::Utc::now();
+        assert!(
+            !release_is_expired(&release, now),
+            "future Valid-Until must not be expired"
+        );
+    }
+
+    #[test]
+    fn test_release_is_expired_no_valid_until() {
+        let release = make_minimal_release(None);
+        let now = chrono::Utc::now();
+        assert!(
+            !release_is_expired(&release, now),
+            "no Valid-Until means never expired"
+        );
+    }
+
+    #[test]
+    fn test_parse_release_stores_valid_until() {
+        let content = "Suite: jammy\nDate: Mon, 01 Jan 2024 00:00:00 UTC\nValid-Until: Mon, 08 Jan 2024 00:00:00 UTC\nArchitectures: amd64\nComponents: main\n";
+        let release = parse_release(content).unwrap();
+        assert_eq!(
+            release.valid_until.as_deref(),
+            Some("Mon, 08 Jan 2024 00:00:00 UTC")
+        );
     }
 }

--- a/backend/src/models/signing_key.rs
+++ b/backend/src/models/signing_key.rs
@@ -16,8 +16,10 @@ pub struct SigningKey {
     pub fingerprint: Option<String>,
     pub key_id: Option<String>,
     pub public_key_pem: String,
+    /// Encrypted private key material. `None` for public-only trust anchors
+    /// used only for upstream verification.
     #[serde(skip_serializing)]
-    pub private_key_enc: Vec<u8>,
+    pub private_key_enc: Option<Vec<u8>>,
     pub algorithm: String,
     pub uid_name: Option<String>,
     pub uid_email: Option<String>,
@@ -39,6 +41,9 @@ pub struct SigningKeyPublic {
     pub fingerprint: Option<String>,
     pub key_id: Option<String>,
     pub public_key_pem: String,
+    /// True when this key can sign (has local private material). False for
+    /// public-only trust anchors used only for upstream verification.
+    pub can_sign: bool,
     pub algorithm: String,
     pub uid_name: Option<String>,
     pub uid_email: Option<String>,
@@ -58,6 +63,7 @@ impl From<SigningKey> for SigningKeyPublic {
             fingerprint: k.fingerprint,
             key_id: k.key_id,
             public_key_pem: k.public_key_pem,
+            can_sign: k.private_key_enc.is_some(),
             algorithm: k.algorithm,
             uid_name: k.uid_name,
             uid_email: k.uid_email,
@@ -86,21 +92,17 @@ pub struct RepositorySigningConfig {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_signing_key_public_from_signing_key() {
+    fn base_key(private_key_enc: Option<Vec<u8>>) -> SigningKey {
         let now = chrono::Utc::now();
-        let key_id = Uuid::new_v4();
-        let repo_id = Uuid::new_v4();
-
-        let key = SigningKey {
-            id: key_id,
-            repository_id: Some(repo_id),
+        SigningKey {
+            id: Uuid::new_v4(),
+            repository_id: Some(Uuid::new_v4()),
             name: "my-gpg-key".to_string(),
             key_type: "gpg".to_string(),
             fingerprint: Some("ABCDEF1234567890".to_string()),
             key_id: Some("12345678".to_string()),
             public_key_pem: "-----BEGIN PGP PUBLIC KEY BLOCK-----...".to_string(),
-            private_key_enc: vec![1, 2, 3, 4, 5],
+            private_key_enc,
             algorithm: "RSA".to_string(),
             uid_name: Some("Test User".to_string()),
             uid_email: Some("test@example.com".to_string()),
@@ -110,23 +112,30 @@ mod tests {
             created_by: None,
             rotated_from: None,
             last_used_at: Some(now),
-        };
+        }
+    }
+
+    #[test]
+    fn test_signing_key_public_from_signing_key() {
+        let key = base_key(Some(vec![1, 2, 3, 4, 5]));
+        let key_id = key.id;
+        let repo_id = key.repository_id;
 
         let public: SigningKeyPublic = key.into();
 
         assert_eq!(public.id, key_id);
-        assert_eq!(public.repository_id, Some(repo_id));
+        assert_eq!(public.repository_id, repo_id);
         assert_eq!(public.name, "my-gpg-key");
         assert_eq!(public.key_type, "gpg");
         assert_eq!(public.fingerprint.as_deref(), Some("ABCDEF1234567890"));
         assert_eq!(public.key_id.as_deref(), Some("12345678"));
         assert!(public.public_key_pem.contains("BEGIN PGP"));
+        assert!(public.can_sign);
         assert_eq!(public.algorithm, "RSA");
         assert_eq!(public.uid_name.as_deref(), Some("Test User"));
         assert_eq!(public.uid_email.as_deref(), Some("test@example.com"));
         assert!(public.is_active);
         assert!(public.last_used_at.is_some());
-        // Private key is NOT included in the public view
     }
 
     #[test]
@@ -140,7 +149,7 @@ mod tests {
             fingerprint: None,
             key_id: None,
             public_key_pem: "PEM".to_string(),
-            private_key_enc: vec![],
+            private_key_enc: None,
             algorithm: "Ed25519".to_string(),
             uid_name: None,
             uid_email: None,
@@ -156,9 +165,17 @@ mod tests {
         assert!(public.repository_id.is_none());
         assert!(public.fingerprint.is_none());
         assert!(public.key_id.is_none());
+        assert!(!public.can_sign);
         assert!(public.uid_name.is_none());
         assert!(public.uid_email.is_none());
         assert!(!public.is_active);
         assert!(public.last_used_at.is_none());
+    }
+
+    #[test]
+    fn test_public_only_trust_anchor_cannot_sign() {
+        let key = base_key(None);
+        let public: SigningKeyPublic = key.into();
+        assert!(!public.can_sign);
     }
 }

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1653,6 +1653,41 @@ impl ArtifactService {
         let artifact = self.get_by_id(id).await?;
         let artifact_info = ArtifactInfo::from(&artifact);
 
+        // Reference-aware Debian cleanup: refuse to soft-delete a pool payload that
+        // is still listed in a published/synced Packages index for this repository.
+        // Synced dists keys are hashed (`debian_synced_dists:<dist>:<path>`), so we
+        // load all synced values and inspect Packages stanza text only.
+        if artifact.path.starts_with("pool/") {
+            let synced_values: Vec<String> = sqlx::query_scalar(
+                r#"
+                SELECT value FROM repository_config
+                WHERE repository_id = $1
+                  AND key LIKE 'debian_synced_dists:%'
+                "#,
+            )
+            .bind(artifact.repository_id)
+            .fetch_all(&self.db)
+            .await
+            .unwrap_or_default();
+            let packages_texts: Vec<String> = synced_values
+                .into_iter()
+                .filter(|value| {
+                    !value.starts_with("@ref:")
+                        && value.contains("Filename:")
+                        && value.contains("Package:")
+                })
+                .collect();
+            if crate::formats::debian::debian_pool_path_still_referenced(
+                &packages_texts,
+                &artifact.path,
+            ) {
+                return Err(AppError::Validation(format!(
+                    "Refusing to delete {}: still referenced by published Debian Packages metadata",
+                    artifact.path
+                )));
+            }
+        }
+
         // Trigger BeforeDelete hooks - validators can reject the deletion
         self.trigger_hook(PluginEventType::BeforeDelete, &artifact_info)
             .await?;

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -2637,6 +2637,34 @@ impl ProxyService {
         self.fetch_artifact_streaming_with_cache_path(repo, path, path)
             .await
     }
+    /// Stream an artifact directly from upstream without reading or writing
+    /// the proxy cache. Format handlers use this only for explicit
+    /// passthrough package policies; normal remotes keep the cached streaming
+    /// path above.
+    pub async fn fetch_artifact_streaming_uncached(
+        &self,
+        repo: &Repository,
+        path: &str,
+    ) -> Result<StreamingFetchResult> {
+        let quarantine_config = quarantine_service::resolve_config(&self.db, repo.id).await;
+        if quarantine_service::should_quarantine(&quarantine_config) {
+            return Err(AppError::Conflict(
+                "Artifact is quarantined and pending security review".to_string(),
+            ));
+        }
+
+        let upstream_url = Self::remote_target(repo)?;
+        let full_url = Self::build_upstream_url(upstream_url, path);
+        let upstream = self
+            .fetch_from_upstream_streaming(&full_url, repo.id)
+            .await?;
+
+        Ok(StreamingFetchResult {
+            body: upstream.body,
+            content_type: upstream.content_type,
+            content_length: upstream.content_length,
+        })
+    }
 
     /// Streaming sibling of [`Self::fetch_artifact_with_cache_path`]: fetch
     /// from upstream using `fetch_path` for the URL but key the proxy cache
@@ -2745,14 +2773,38 @@ impl ProxyService {
         let cache_key = Self::cache_storage_key(&repo.key, cache_path)?;
         let metadata_key = Self::cache_metadata_key(&repo.key, cache_path)?;
 
-        // Cache hit fast path: load metadata sidecar, stream content
-        // straight from storage. The slow-path SHA verification done by
-        // the buffered `fetch_artifact_with_cache_path` is intentionally
-        // skipped here — we cannot recompute SHA without buffering, and
-        // the storage backend's own integrity guarantees apply just as
-        // they do for presigned redirects (#1018 R-tradeoff already
-        // accepted upstream).
-        if let Some(result) = self
+        // Cache hit fast path: load metadata sidecar, stream content straight from
+        // storage. When `expected_checksum` is Some we additionally verify that the
+        // sidecar's recorded SHA-256 matches before serving the cached bytes. A
+        // mismatch (or a sidecar with an empty checksum) is treated as a miss so the
+        // leader path re-fetches from upstream with the digest gate active — ensuring
+        // the caller always gets bytes that match the expected digest.
+        if let Some(expected) = expected_checksum.as_deref() {
+            // Peek at the sidecar checksum before entering the full cache-hit path.
+            let metadata = self
+                .load_cache_metadata(&metadata_key)
+                .await
+                .unwrap_or(None);
+            let sidecar_sha = metadata
+                .as_ref()
+                .map(|m| m.checksum_sha256.as_str())
+                .unwrap_or("");
+            if sidecar_sha.is_empty() || sidecar_sha != expected {
+                // Treat as a miss: fall through to the upstream fetch so the leader
+                // path applies the expected_checksum gate before caching.
+                tracing::debug!(
+                    cache_path = %cache_path,
+                    expected = %expected,
+                    cached = %sidecar_sha,
+                    "streaming cache miss: expected_checksum present but sidecar checksum absent or mismatched"
+                );
+            } else if let Some(result) = self
+                .try_streaming_cache_hit(repo, fetch_path, cache_path, &cache_key, &metadata_key)
+                .await?
+            {
+                return Ok(Some(result));
+            }
+        } else if let Some(result) = self
             .try_streaming_cache_hit(repo, fetch_path, cache_path, &cache_key, &metadata_key)
             .await?
         {

--- a/backend/src/services/signing_service.rs
+++ b/backend/src/services/signing_service.rs
@@ -198,6 +198,53 @@ fn sign_openpgp_cleartext_blocking(
         })
 }
 
+fn parse_openpgp_public_key(public_key: &str) -> Result<SignedPublicKey> {
+    let (public_key, _) = SignedPublicKey::from_string(public_key)
+        .map_err(|e| AppError::Validation(format!("Failed to parse OpenPGP public key: {}", e)))?;
+    public_key.verify().map_err(|e| {
+        AppError::Validation(format!("OpenPGP public key self-check failed: {}", e))
+    })?;
+    Ok(public_key)
+}
+
+fn verify_openpgp_detached_blocking(
+    public_key: String,
+    data: Vec<u8>,
+    signature: Vec<u8>,
+) -> Result<()> {
+    let public_key = parse_openpgp_public_key(&public_key)?;
+    let signature = std::str::from_utf8(&signature).map_err(|e| {
+        AppError::Validation(format!("OpenPGP signature is not valid UTF-8: {}", e))
+    })?;
+    let (signature, _) = StandaloneSignature::from_string(signature).map_err(|e| {
+        AppError::Validation(format!("Failed to parse OpenPGP detached signature: {}", e))
+    })?;
+    signature.verify(&public_key, &data).map_err(|e| {
+        AppError::Validation(format!(
+            "OpenPGP detached signature verification failed: {}",
+            e
+        ))
+    })?;
+    Ok(())
+}
+
+fn verify_openpgp_cleartext_blocking(public_key: String, message: String) -> Result<String> {
+    let public_key = parse_openpgp_public_key(&public_key)?;
+    let (message, _) = CleartextSignedMessage::from_string(&message).map_err(|e| {
+        AppError::Validation(format!(
+            "Failed to parse OpenPGP cleartext signature: {}",
+            e
+        ))
+    })?;
+    message.verify(&public_key).map_err(|e| {
+        AppError::Validation(format!(
+            "OpenPGP cleartext signature verification failed: {}",
+            e
+        ))
+    })?;
+    Ok(message.signed_text())
+}
+
 /// Helper to dispatch a CPU-bound crypto closure to the blocking pool and
 /// convert a panic into an `AppError::Internal`. Centralizes the
 /// `spawn_blocking` join-error handling so callers stay readable.
@@ -225,6 +272,18 @@ pub struct CreateKeyRequest {
     pub algorithm: String, // "rsa2048", "rsa4096"
     pub uid_name: Option<String>,
     pub uid_email: Option<String>,
+    pub created_by: Option<Uuid>,
+}
+
+/// Request to import a public-only OpenPGP trust anchor (no private key).
+pub struct ImportPublicKeyRequest {
+    pub repository_id: Option<Uuid>,
+    pub name: String,
+    /// ASCII-armored OpenPGP public key (e.g. Debian/Ubuntu archive key).
+    pub public_key: String,
+    pub uid_name: Option<String>,
+    pub uid_email: Option<String>,
+    pub expires_at: Option<chrono::DateTime<Utc>>,
     pub created_by: Option<Uuid>,
 }
 
@@ -296,10 +355,101 @@ impl SigningService {
             fingerprint: Some(fingerprint),
             key_id: Some(key_id),
             public_key_pem: public_key_out,
+            can_sign: true,
             algorithm: req.algorithm,
             uid_name: req.uid_name,
             uid_email: req.uid_email,
             expires_at: None,
+            is_active: true,
+            created_at: now,
+            last_used_at: None,
+        })
+    }
+
+    /// Import a public-only OpenPGP trust anchor (no private key material).
+    ///
+    /// Used for Debian/Ubuntu archive keys and other upstream verification
+    /// anchors. These keys can verify signatures but cannot sign.
+    pub async fn import_public_trust_anchor(
+        &self,
+        req: ImportPublicKeyRequest,
+    ) -> Result<SigningKeyPublic> {
+        let public_key_armored = req.public_key.trim().to_string();
+        if public_key_armored.is_empty() {
+            return Err(AppError::Validation(
+                "Public key cannot be empty".to_string(),
+            ));
+        }
+
+        let name = req.name.trim().to_string();
+        if name.is_empty() {
+            return Err(AppError::Validation("Name cannot be empty".to_string()));
+        }
+
+        let public_key = parse_openpgp_public_key(&public_key_armored)?;
+        let fingerprint = hex::encode(public_key.fingerprint().as_bytes());
+        let key_id = hex::encode(public_key.key_id().as_ref());
+
+        // Reject duplicate fingerprints so re-importing the same archive key
+        // surfaces a clean Conflict instead of a unique-constraint 500.
+        let existing: Option<(Uuid,)> =
+            sqlx::query_as("SELECT id FROM signing_keys WHERE fingerprint = $1")
+                .bind(&fingerprint)
+                .fetch_optional(&self.db)
+                .await?;
+
+        if let Some((existing_id,)) = existing {
+            return Err(AppError::Conflict(format!(
+                "A signing key with fingerprint {} already exists (id: {})",
+                fingerprint, existing_id
+            )));
+        }
+
+        let id = Uuid::new_v4();
+        let now = Utc::now();
+        let key_type = "gpg".to_string();
+        let algorithm = "public-only".to_string();
+
+        sqlx::query(
+            r#"
+            INSERT INTO signing_keys (id, repository_id, name, key_type, fingerprint, key_id,
+                public_key_pem, private_key_enc, algorithm, uid_name, uid_email, is_active,
+                created_at, created_by, expires_at)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, NULL, $8, $9, $10, true, $11, $12, $13)
+            "#,
+        )
+        .bind(id)
+        .bind(req.repository_id)
+        .bind(&name)
+        .bind(&key_type)
+        .bind(&fingerprint)
+        .bind(&key_id)
+        .bind(&public_key_armored)
+        .bind(&algorithm)
+        .bind(&req.uid_name)
+        .bind(&req.uid_email)
+        .bind(now)
+        .bind(req.created_by)
+        .bind(req.expires_at)
+        .execute(&self.db)
+        .await?;
+
+        self.audit_key_action(id, "imported_public", req.created_by, None)
+            .await?;
+
+        Ok(SigningKeyPublic {
+            id,
+            repository_id: req.repository_id,
+            name,
+            key_type,
+            fingerprint: Some(fingerprint),
+            key_id: Some(key_id),
+            public_key_pem: public_key_armored,
+            can_sign: false,
+            algorithm,
+            uid_name: req.uid_name,
+            uid_email: req.uid_email,
+            expires_at: req.expires_at,
             is_active: true,
             created_at: now,
             last_used_at: None,
@@ -355,30 +505,34 @@ impl SigningService {
 
     /// Get a signing key by ID (public info only).
     pub async fn get_key(&self, key_id: Uuid) -> Result<SigningKeyPublic> {
-        let key = sqlx::query_as!(
-            SigningKey,
-            "SELECT * FROM signing_keys WHERE id = $1",
-            key_id,
-        )
-        .fetch_optional(&self.db)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Signing key not found".to_string()))?;
+        // Non-macro query_as: private_key_enc is nullable (public-only trust
+        // anchors); keep offline builds working without regenerating .sqlx.
+        let key = sqlx::query_as::<_, SigningKey>("SELECT * FROM signing_keys WHERE id = $1")
+            .bind(key_id)
+            .fetch_optional(&self.db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Signing key not found".to_string()))?;
 
         Ok(key.into())
     }
 
     /// Get the active signing key for a repository.
+    ///
+    /// Excludes keys whose `expires_at` is in the past so that expired keys are
+    /// never returned for signing operations.
     pub async fn get_active_key_for_repo(&self, repo_id: Uuid) -> Result<Option<SigningKey>> {
-        let key = sqlx::query_as!(
-            SigningKey,
+        let key = sqlx::query_as::<_, SigningKey>(
             r#"
             SELECT sk.* FROM signing_keys sk
             JOIN repository_signing_config rsc ON rsc.signing_key_id = sk.id
-            WHERE rsc.repository_id = $1 AND sk.is_active = true AND rsc.sign_metadata = true
+            WHERE rsc.repository_id = $1
+              AND sk.is_active = true
+              AND rsc.sign_metadata = true
+              AND (sk.expires_at IS NULL OR sk.expires_at > NOW())
             LIMIT 1
             "#,
-            repo_id,
         )
+        .bind(repo_id)
         .fetch_optional(&self.db)
         .await?;
 
@@ -388,20 +542,16 @@ impl SigningService {
     /// List signing keys, optionally filtered by repository.
     pub async fn list_keys(&self, repo_id: Option<Uuid>) -> Result<Vec<SigningKeyPublic>> {
         let keys = if let Some(rid) = repo_id {
-            sqlx::query_as!(
-                SigningKey,
+            sqlx::query_as::<_, SigningKey>(
                 "SELECT * FROM signing_keys WHERE repository_id = $1 ORDER BY created_at DESC",
-                rid,
             )
+            .bind(rid)
             .fetch_all(&self.db)
             .await?
         } else {
-            sqlx::query_as!(
-                SigningKey,
-                "SELECT * FROM signing_keys ORDER BY created_at DESC",
-            )
-            .fetch_all(&self.db)
-            .await?
+            sqlx::query_as::<_, SigningKey>("SELECT * FROM signing_keys ORDER BY created_at DESC")
+                .fetch_all(&self.db)
+                .await?
         };
 
         Ok(keys.into_iter().map(|k| k.into()).collect())
@@ -466,9 +616,24 @@ impl SigningService {
     /// `RsaSigningKey<Sha256>` both already implement `ZeroizeOnDrop` upstream
     /// in the `rsa` crate, so they self-clean when this function returns.
     pub fn sign_with_key(&self, key: &SigningKey, data: &[u8]) -> Result<Vec<u8>> {
+        if let Some(expires_at) = key.expires_at {
+            if expires_at <= chrono::Utc::now() {
+                return Err(AppError::Validation(format!(
+                    "Signing key {} has expired at {}; refusing to sign",
+                    key.id, expires_at
+                )));
+            }
+        }
+
+        let private_key_enc = key.private_key_enc.as_ref().ok_or_else(|| {
+            AppError::Validation(
+                "Cannot sign with a public-only trust anchor (no private key)".to_string(),
+            )
+        })?;
+
         // Decrypt private key into a zeroizing buffer.
         let private_pem: Zeroizing<Vec<u8>> =
-            Zeroizing::new(self.encryption.decrypt(&key.private_key_enc).map_err(|e| {
+            Zeroizing::new(self.encryption.decrypt(private_key_enc).map_err(|e| {
                 AppError::Internal(format!("Failed to decrypt private key: {}", e))
             })?);
 
@@ -530,8 +695,14 @@ impl SigningService {
             ));
         }
 
+        let private_key_enc = key.private_key_enc.as_ref().ok_or_else(|| {
+            AppError::Validation(
+                "Cannot sign with a public-only trust anchor (no private key)".to_string(),
+            )
+        })?;
+
         let private_key: Zeroizing<Vec<u8>> =
-            Zeroizing::new(self.encryption.decrypt(&key.private_key_enc).map_err(|e| {
+            Zeroizing::new(self.encryption.decrypt(private_key_enc).map_err(|e| {
                 AppError::Internal(format!("Failed to decrypt private key: {}", e))
             })?);
         let private_key_str = std::str::from_utf8(&private_key)
@@ -579,6 +750,59 @@ impl SigningService {
         let text_owned = text.to_string();
         run_blocking("openpgp_sign_cleartext", move || {
             sign_openpgp_cleartext_blocking(secret_key, text_owned)
+        })
+        .await
+    }
+
+    /// Find an active stored public key by UUID, short key ID, fingerprint, or name.
+    pub async fn get_public_key_by_reference(&self, reference: &str) -> Result<Option<String>> {
+        let reference = reference.trim();
+        if reference.is_empty() {
+            return Ok(None);
+        }
+
+        let key = sqlx::query_as::<_, SigningKey>(
+            r#"
+            SELECT * FROM signing_keys
+            WHERE is_active = true
+              AND (id::text = $1 OR key_id = $1 OR fingerprint = $1 OR name = $1)
+            ORDER BY created_at DESC
+            LIMIT 1
+            "#,
+        )
+        .bind(reference)
+        .fetch_optional(&self.db)
+        .await?;
+
+        Ok(key.map(|key| key.public_key_pem))
+    }
+
+    /// Verify an ASCII-armored detached OpenPGP signature with a stored public key.
+    pub async fn verify_openpgp_detached_with_public_key(
+        &self,
+        public_key: &str,
+        data: &[u8],
+        signature: &[u8],
+    ) -> Result<()> {
+        let public_key = public_key.to_string();
+        let data = data.to_vec();
+        let signature = signature.to_vec();
+        run_blocking("openpgp_verify_detached", move || {
+            verify_openpgp_detached_blocking(public_key, data, signature)
+        })
+        .await
+    }
+
+    /// Verify an ASCII-armored cleartext OpenPGP message and return its signed text.
+    pub async fn verify_openpgp_cleartext_with_public_key(
+        &self,
+        public_key: &str,
+        message: &str,
+    ) -> Result<String> {
+        let public_key = public_key.to_string();
+        let message = message.to_string();
+        run_blocking("openpgp_verify_cleartext", move || {
+            verify_openpgp_cleartext_blocking(public_key, message)
         })
         .await
     }
@@ -656,14 +880,18 @@ impl SigningService {
         old_key_id: Uuid,
         user_id: Option<Uuid>,
     ) -> Result<SigningKeyPublic> {
-        let old_key = sqlx::query_as!(
-            SigningKey,
-            "SELECT * FROM signing_keys WHERE id = $1",
-            old_key_id,
-        )
-        .fetch_optional(&self.db)
-        .await?
-        .ok_or_else(|| AppError::NotFound("Signing key not found".to_string()))?;
+        let old_key = sqlx::query_as::<_, SigningKey>("SELECT * FROM signing_keys WHERE id = $1")
+            .bind(old_key_id)
+            .fetch_optional(&self.db)
+            .await?
+            .ok_or_else(|| AppError::NotFound("Signing key not found".to_string()))?;
+
+        if old_key.private_key_enc.is_none() {
+            return Err(AppError::Validation(
+                "Cannot rotate a public-only trust anchor; create a new signing key instead"
+                    .to_string(),
+            ));
+        }
 
         // Create new key with same params
         let new_key = self
@@ -777,7 +1005,7 @@ mod tests {
             fingerprint: Some(fingerprint),
             key_id: Some(key_id),
             public_key_pem: public_pem,
-            private_key_enc: private_enc,
+            private_key_enc: Some(private_enc),
             algorithm: "rsa2048".to_string(),
             uid_name: None,
             uid_email: None,
@@ -815,7 +1043,7 @@ mod tests {
             fingerprint: Some(fingerprint),
             key_id: Some(key_id),
             public_key_pem,
-            private_key_enc: service.encryption.encrypt(private_key_material.as_bytes()),
+            private_key_enc: Some(service.encryption.encrypt(private_key_material.as_bytes())),
             algorithm: req.algorithm,
             uid_name: req.uid_name,
             uid_email: req.uid_email,
@@ -857,6 +1085,28 @@ mod tests {
             .unwrap();
         let (message, _) = CleartextSignedMessage::from_string(&cleartext).unwrap();
         message.verify(&public_key).unwrap();
+
+        service
+            .verify_openpgp_detached_with_public_key(&key.public_key_pem, data, detached.as_bytes())
+            .await
+            .unwrap();
+        assert!(service
+            .verify_openpgp_detached_with_public_key(
+                &key.public_key_pem,
+                b"Origin: tampered\n",
+                detached.as_bytes(),
+            )
+            .await
+            .is_err());
+
+        let verified_cleartext = service
+            .verify_openpgp_cleartext_with_public_key(&key.public_key_pem, &cleartext)
+            .await
+            .unwrap();
+        assert_eq!(
+            verified_cleartext.replace("\r\n", "\n"),
+            std::str::from_utf8(data).unwrap()
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -875,7 +1125,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let private_pem_bytes = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let private_pem_bytes = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -897,7 +1149,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let private_pem_bytes = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let private_pem_bytes = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -918,7 +1172,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let decrypted = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let decrypted = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let decrypted_str = std::str::from_utf8(&decrypted).unwrap();
 
         assert!(decrypted_str.contains("BEGIN PRIVATE KEY"));
@@ -930,7 +1186,7 @@ mod tests {
         let signing_key = generate_test_signing_key("correct-passphrase");
         let wrong_encryption = CredentialEncryption::from_passphrase("wrong-passphrase");
 
-        let result = wrong_encryption.decrypt(&signing_key.private_key_enc);
+        let result = wrong_encryption.decrypt(signing_key.private_key_enc.as_ref().unwrap());
         assert!(result.is_err());
     }
 
@@ -971,9 +1227,44 @@ mod tests {
         assert_eq!(public.fingerprint, signing_key.fingerprint);
         assert_eq!(public.key_id, signing_key.key_id);
         assert_eq!(public.public_key_pem, signing_key.public_key_pem);
+        assert!(public.can_sign);
         assert_eq!(public.algorithm, signing_key.algorithm);
         assert_eq!(public.is_active, signing_key.is_active);
         assert_eq!(public.created_at, signing_key.created_at);
+    }
+
+    #[tokio::test]
+    async fn test_public_only_trust_anchor_cannot_sign() {
+        let mut key = generate_test_signing_key("public-only");
+        key.private_key_enc = None;
+        key.key_type = "gpg".to_string();
+        key.algorithm = "public-only".to_string();
+
+        let public: SigningKeyPublic = key.clone().into();
+        assert!(!public.can_sign);
+
+        let service = SigningService {
+            db: PgPool::connect_lazy("postgresql://example.invalid/test").unwrap(),
+            encryption: CredentialEncryption::from_passphrase("public-only"),
+        };
+        let err = service.sign_with_key(&key, b"data").unwrap_err();
+        assert!(
+            err.to_string().contains("public-only trust anchor"),
+            "expected public-only refusal, got: {err}"
+        );
+        let err = service.load_openpgp_secret_key(&key).unwrap_err();
+        assert!(
+            err.to_string().contains("public-only trust anchor"),
+            "expected public-only refusal, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_openpgp_public_key_rejects_empty() {
+        let err = parse_openpgp_public_key("").unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Failed to parse OpenPGP public key"));
     }
 
     // -----------------------------------------------------------------------
@@ -1350,7 +1641,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let private_pem_bytes = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let private_pem_bytes = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -1372,7 +1665,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let private_pem_bytes = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let private_pem_bytes = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -1394,7 +1689,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let private_pem_bytes = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let private_pem_bytes = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -1417,7 +1714,9 @@ mod tests {
         let signing_key2 = generate_test_signing_key("key-2-verify");
 
         let encryption1 = CredentialEncryption::from_passphrase("key-1-verify");
-        let private_pem_bytes = encryption1.decrypt(&signing_key1.private_key_enc).unwrap();
+        let private_pem_bytes = encryption1
+            .decrypt(signing_key1.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -1444,7 +1743,9 @@ mod tests {
         let signing_key = generate_test_signing_key(passphrase);
 
         let encryption = CredentialEncryption::from_passphrase(passphrase);
-        let private_pem_bytes = encryption.decrypt(&signing_key.private_key_enc).unwrap();
+        let private_pem_bytes = encryption
+            .decrypt(signing_key.private_key_enc.as_ref().unwrap())
+            .unwrap();
         let private_pem = std::str::from_utf8(&private_pem_bytes).unwrap();
         let private_key = RsaPrivateKey::from_pkcs8_pem(private_pem).unwrap();
 
@@ -1517,7 +1818,7 @@ mod tests {
     #[test]
     fn test_private_key_not_stored_plaintext() {
         let key = generate_test_signing_key("not-plaintext");
-        let enc_bytes = &key.private_key_enc;
+        let enc_bytes = key.private_key_enc.as_ref().unwrap();
         // The encrypted bytes should NOT contain the PEM header
         let enc_str = String::from_utf8_lossy(enc_bytes);
         assert!(

--- a/scripts/e2e-syspkg/smoke-debian-security-filtered.sh
+++ b/scripts/e2e-syspkg/smoke-debian-security-filtered.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# Smoke-test Artifact Keeper Debian remote mirror against Ubuntu or Debian security.
+#
+# Modes exercised:
+#   1) passthrough — Release reachable before/after config (remote proxy)
+#   2) filtered sync — main/amd64 + package_queries (curl*, ca-certificates) + deps
+#   3) atomic generation — after sync, uncovered paths 404 (no mixed metadata)
+#   4) apt client installs curl using AK as the security pocket
+#
+# Usage:
+#   API_URL=http://127.0.0.1:8080 ADMIN_USER=admin ADMIN_PASS='...' \
+#     ./scripts/e2e-syspkg/smoke-debian-security-filtered.sh
+#
+#   # Debian bookworm-security instead of Ubuntu noble-security:
+#   CLIENT_DISTRO=debian ./scripts/e2e-syspkg/smoke-debian-security-filtered.sh
+#
+#   # Run both Ubuntu and Debian clients sequentially:
+#   ./scripts/e2e-syspkg/smoke-debian-security-filtered.sh --both
+set -euo pipefail
+
+if [[ "${1:-}" == "--both" ]]; then
+  echo "######## Ubuntu noble-security smoke ########"
+  CLIENT_DISTRO=ubuntu "$0"
+  echo
+  echo "######## Debian bookworm-security smoke ########"
+  CLIENT_DISTRO=debian "$0"
+  echo
+  echo "==> BOTH SMOKES OK"
+  exit 0
+fi
+
+API_URL="${API_URL:-http://127.0.0.1:8080}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASS="${ADMIN_PASS:-ChangeMeNow!123}"
+CLIENT_DISTRO="${CLIENT_DISTRO:-ubuntu}"
+
+case "$CLIENT_DISTRO" in
+  ubuntu)
+    REPO_KEY="${REPO_KEY:-ubuntu-security-smoke}"
+    UPSTREAM_URL="${UPSTREAM_URL:-http://security.ubuntu.com/ubuntu}"
+    DIST="${DIST:-noble-security}"
+    ARCHIVE_SUITE="${ARCHIVE_SUITE:-noble}"
+    ARCHIVE_URL="${ARCHIVE_URL:-http://archive.ubuntu.com/ubuntu}"
+    ROOTFS="${ROOTFS:-/tmp/ak-apt-rootfs-ubuntu}"
+    # Prefer legacy path if already bootstrapped by earlier runs.
+    if [[ ! -d "$ROOTFS/bin" && -d /tmp/ak-apt-rootfs/bin ]]; then
+      ROOTFS=/tmp/ak-apt-rootfs
+    fi
+    DOCKER_IMAGE="${DOCKER_IMAGE:-ubuntu:24.04}"
+    REPO_NAME="Ubuntu Security Smoke"
+    ;;
+  debian)
+    REPO_KEY="${REPO_KEY:-debian-security-smoke}"
+    UPSTREAM_URL="${UPSTREAM_URL:-http://security.debian.org/debian-security}"
+    DIST="${DIST:-bookworm-security}"
+    ARCHIVE_SUITE="${ARCHIVE_SUITE:-bookworm}"
+    ARCHIVE_URL="${ARCHIVE_URL:-http://deb.debian.org/debian}"
+    ROOTFS="${ROOTFS:-/tmp/ak-apt-rootfs-debian}"
+    DOCKER_IMAGE="${DOCKER_IMAGE:-debian:bookworm-slim}"
+    REPO_NAME="Debian Security Smoke"
+    ;;
+  *)
+    echo "Unknown CLIENT_DISTRO=$CLIENT_DISTRO (use ubuntu|debian)"
+    exit 1
+    ;;
+esac
+
+need() { command -v "$1" >/dev/null || { echo "missing $1"; exit 1; }; }
+need curl
+need jq
+need rg
+
+echo "==> Client distro: $CLIENT_DISTRO ($DIST via $UPSTREAM_URL)"
+echo "==> Login"
+LOGIN=$(curl -sf -X POST "$API_URL/api/v1/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$ADMIN_USER\",\"password\":\"$ADMIN_PASS\"}")
+TOKEN=$(echo "$LOGIN" | jq -r '.access_token // empty')
+if [[ -z "$TOKEN" || "$TOKEN" == "null" ]]; then
+  echo "Login failed: $LOGIN"
+  exit 1
+fi
+AUTH="Authorization: Bearer $TOKEN"
+
+echo "==> Ensure remote Debian repo $REPO_KEY"
+EXISTING=$(curl -sf -H "$AUTH" "$API_URL/api/v1/repositories" \
+  | jq -r --arg k "$REPO_KEY" '.items[]? | select(.key==$k) | .key' | head -1)
+
+BODY=$(cat <<JSON
+{
+  "name": "$REPO_NAME",
+  "key": "$REPO_KEY",
+  "format": "debian",
+  "repo_type": "remote",
+  "allow_anonymous_access": true,
+  "upstream_url": "$UPSTREAM_URL",
+  "debian": {
+    "distribution_paths": ["$DIST"],
+    "components": ["main"],
+    "architectures": ["amd64"],
+    "include_source_packages": false,
+    "flat_repository": false,
+    "verify_upstream_metadata": false,
+    "metadata_strategy": "filter_and_generate",
+    "package_fetch_strategy": "cache_on_request",
+    "package_queries": ["curl*", "ca-certificates"],
+    "resolve_dependencies": true,
+    "ignore_missing_indexes": true
+  }
+}
+JSON
+)
+
+if [[ -z "$EXISTING" ]]; then
+  CREATE=$(curl -sf -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+    "$API_URL/api/v1/repositories" -d "$BODY")
+  echo "$CREATE" | jq '{id,key,repo_type,debian:(.debian|{metadata_strategy,package_queries,components,architectures})}'
+else
+  echo "Repo exists: $EXISTING — updating debian config"
+  curl -sf -X PATCH -H "$AUTH" -H 'Content-Type: application/json' \
+    "$API_URL/api/v1/repositories/$REPO_KEY" \
+    -d "$(echo "$BODY" | jq '{debian,allow_anonymous_access,upstream_url}')" >/dev/null
+fi
+
+echo "==> Release reachable (passthrough or published generation)"
+CODE=$(curl -s -o /tmp/ak-release.txt -w '%{http_code}' \
+  "$API_URL/debian/$REPO_KEY/dists/$DIST/Release" || true)
+echo "GET Release => HTTP $CODE"
+[[ "$CODE" == "200" ]] || { echo "Release failed"; head -20 /tmp/ak-release.txt; exit 1; }
+head -8 /tmp/ak-release.txt
+
+echo "==> Sync (filtered generate)"
+SYNC=$(curl -sf -X POST -H "$AUTH" --max-time 900 "$API_URL/debian/$REPO_KEY/sync")
+echo "$SYNC" | jq '{repository, prefetched_packages, prefetched_sources, plans: (.plans|length), selected_packages: (.plans[0].package_files|length)}'
+
+echo "==> Atomic generation: Release must be local-generated / coherent"
+CODE=$(curl -s -o /tmp/ak-release2.txt -w '%{http_code}' \
+  "$API_URL/debian/$REPO_KEY/dists/$DIST/Release")
+echo "GET Release after sync => HTTP $CODE"
+[[ "$CODE" == "200" ]] || exit 1
+rg -q '^Origin: artifact-keeper' /tmp/ak-release2.txt
+rg -q '^Components:.*main' /tmp/ak-release2.txt
+rg -q '^Architectures:.*amd64' /tmp/ak-release2.txt
+
+echo "==> Uncovered path must 404 after generation (no upstream leak)"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+  "$API_URL/debian/$REPO_KEY/dists/$DIST/universe/binary-amd64/Packages" || true)
+echo "GET universe Packages => HTTP $CODE (expect 404)"
+[[ "$CODE" == "404" ]] || { echo "expected 404 for excluded component"; exit 1; }
+
+echo "==> Packages index for main/amd64 present and filtered"
+CODE=$(curl -s -o /tmp/ak-packages.txt -w '%{http_code}' \
+  "$API_URL/debian/$REPO_KEY/dists/$DIST/main/binary-amd64/Packages")
+echo "GET Packages => HTTP $CODE size=$(wc -c </tmp/ak-packages.txt)"
+[[ "$CODE" == "200" ]] || exit 1
+PKG_COUNT=$(rg -c '^Package: ' /tmp/ak-packages.txt || echo 0)
+echo "package stanzas: $PKG_COUNT"
+[[ "$PKG_COUNT" -gt 0 ]] || { echo "empty Packages index"; exit 1; }
+[[ "$PKG_COUNT" -lt 500 ]] || {
+  echo "Packages still looks unfiltered ($PKG_COUNT stanzas)"; exit 1;
+}
+rg -q '^Package: curl$' /tmp/ak-packages.txt
+if rg -q '^Package: ca-certificates$' /tmp/ak-packages.txt; then
+  echo "ca-certificates present in filtered index"
+elif [[ "$CLIENT_DISTRO" == "debian" ]]; then
+  # Debian-Security often has no ca-certificates update; the base archive
+  # suite supplies it during apt install. curl* + deps is enough to prove
+  # filtered sync against the security pocket.
+  echo "NOTE: ca-certificates not in ${DIST}; base archive will supply it"
+else
+  echo "missing Package: ca-certificates in filtered index"
+  exit 1
+fi
+! rg -q '^Package: nginx$' /tmp/ak-packages.txt || {
+  echo "unexpected nginx in filtered Packages"; exit 1;
+}
+
+echo "==> Out-of-filter pool path must 404"
+CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+  "$API_URL/debian/$REPO_KEY/pool/main/n/nginx/nginx_1.0_amd64.deb" || true)
+echo "GET nginx pool => HTTP $CODE (expect 404)"
+[[ "$CODE" == "404" ]] || { echo "expected 404 for out-of-filter package"; exit 1; }
+
+echo "==> Pool fetch for a selected package succeeds (on-demand cache)"
+CURL_FILE=$(awk '
+  $0 == "Package: curl" {in_pkg=1; next}
+  in_pkg && /^Filename: / {print $2; exit}
+  in_pkg && /^Package: / {exit}
+' /tmp/ak-packages.txt)
+[[ -n "$CURL_FILE" ]] || { echo "curl Filename missing"; exit 1; }
+CODE=$(curl -s -o /tmp/ak-curl.deb -w '%{http_code}' "$API_URL/debian/$REPO_KEY/$CURL_FILE")
+echo "GET $CURL_FILE => HTTP $CODE size=$(wc -c </tmp/ak-curl.deb)"
+[[ "$CODE" == "200" ]] || exit 1
+
+run_apt_client_chroot() {
+  local ak_base="$1"
+  local root="$2"
+
+  # Dual sources: archive supplies transitive deps that live only in the base
+  # suite, while AK is the sole security pocket (filtered partial sync).
+  sudo rm -f "$root/etc/apt/sources.list" "$root/etc/apt/sources.list.d"/* 2>/dev/null || true
+  sudo mkdir -p "$root/etc/apt/sources.list.d"
+  cat <<EOF | sudo tee "$root/etc/apt/sources.list" >/dev/null
+deb ${ARCHIVE_URL} ${ARCHIVE_SUITE} main
+deb [trusted=yes arch=amd64] ${ak_base} ${DIST} main
+EOF
+  sudo cp /etc/resolv.conf "$root/etc/resolv.conf"
+
+  sudo mount --bind /proc "$root/proc" 2>/dev/null || true
+  sudo mount --bind /sys "$root/sys" 2>/dev/null || true
+  sudo mount --bind /dev "$root/dev" 2>/dev/null || true
+
+  local status=0
+  sudo chroot "$root" bash -lc "
+    set -euo pipefail
+    apt-get update
+    apt-cache policy curl | tee /tmp/curl-policy.txt
+    grep -q '${DIST}' /tmp/curl-policy.txt
+    CAND=\$(apt-cache policy curl | awk '/Candidate:/ {print \$2; exit}')
+    echo \"curl candidate: \$CAND\"
+    test -n \"\$CAND\"
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl
+    curl --version | head -1
+    if apt-cache madison nginx 2>/dev/null | grep -q '${DIST}'; then
+      echo 'FAIL: nginx should not come from filtered ${DIST} on AK'
+      apt-cache madison nginx || true
+      exit 1
+    fi
+    echo 'filtered security index correctly omits nginx'
+  " || status=$?
+
+  sudo umount "$root/proc" 2>/dev/null || true
+  sudo umount "$root/sys" 2>/dev/null || true
+  sudo umount "$root/dev" 2>/dev/null || true
+  return "$status"
+}
+
+run_apt_client_docker() {
+  local ak_base="$1"
+  sudo docker rm -f "ak-apt-smoke-${CLIENT_DISTRO}" >/dev/null 2>&1 || true
+  sudo docker pull "$DOCKER_IMAGE" >/dev/null
+  sudo docker run -d --name "ak-apt-smoke-${CLIENT_DISTRO}" \
+    --add-host=host.docker.internal:host-gateway "$DOCKER_IMAGE" sleep 3600 >/dev/null
+  sudo docker exec "ak-apt-smoke-${CLIENT_DISTRO}" bash -lc "
+    set -euo pipefail
+    apt-get update -qq
+    apt-get install -y -qq ca-certificates >/dev/null
+    rm -f /etc/apt/sources.list.d/*.sources /etc/apt/sources.list.d/* /etc/apt/sources.list
+    cat >/etc/apt/sources.list <<EOF
+deb ${ARCHIVE_URL} ${ARCHIVE_SUITE} main
+deb [trusted=yes arch=amd64] ${ak_base} ${DIST} main
+EOF
+    apt-get update
+    apt-cache policy curl | head -20
+    DEBIAN_FRONTEND=noninteractive apt-get install -y curl
+    curl --version | head -1
+    if apt-cache madison nginx 2>/dev/null | grep -q '${DIST}'; then
+      echo 'FAIL: nginx visible from filtered ${DIST}'
+      exit 1
+    fi
+    echo 'filtered security index correctly omits nginx'
+  "
+}
+
+echo "==> ${CLIENT_DISTRO} apt client smoke against AK ${DIST} mirror"
+DOCKER_OK=0
+if command -v docker >/dev/null && sudo docker info >/dev/null 2>&1; then
+  if sudo docker run --rm --add-host=host.docker.internal:host-gateway "$DOCKER_IMAGE" true >/dev/null 2>&1; then
+    DOCKER_OK=1
+  else
+    echo "NOTE: docker run unavailable (overlay mount); using chroot rootfs"
+  fi
+fi
+
+if [[ "$DOCKER_OK" == "1" ]]; then
+  AK_APT_BASE="http://host.docker.internal:8080/debian/$REPO_KEY"
+  run_apt_client_docker "$AK_APT_BASE"
+else
+  if [[ ! -d "$ROOTFS/bin" ]]; then
+    need debootstrap
+    echo "Bootstrapping ${CLIENT_DISTRO} rootfs at $ROOTFS (one-time)..."
+    sudo debootstrap --variant=minbase --include=ca-certificates,apt-utils \
+      "$ARCHIVE_SUITE" "$ROOTFS" "$ARCHIVE_URL"
+  fi
+  AK_HOST_PORT=$(echo "$API_URL" | sed -E 's#https?://##')
+  AK_APT_BASE="http://${AK_HOST_PORT}/debian/$REPO_KEY"
+  run_apt_client_chroot "$AK_APT_BASE" "$ROOTFS"
+fi
+
+echo "==> SMOKE OK ($CLIENT_DISTRO / $DIST)"
+echo "UI:  http://127.0.0.1:3000  (admin / ChangeMeNow!123)"
+echo "API: $API_URL"
+echo "APT: deb [trusted=yes] $API_URL/debian/$REPO_KEY $DIST main"


### PR DESCRIPTION
## Summary

This PR adds advanced Debian/APT remote-repository support to Artifact Keeper.
It expands Debian repositories beyond basic proxy behavior with configurable distribution, component, architecture, metadata, synchronization, filtering, caching, prefetching, verification, and signing.
Companion web UI PR: Need to Submit
Companion web branches: `plouton24/artifact-keeper-web/codex/debian-advanced-config` / `feat/debian-advanced-config`

Wanted advanced features to filter by distro and component and arch for filtered apt-mirrors of official repos. Instead of having to pull the entire catalog, so used AI to accomplish this. 

Closes #2407
**AI Disclosure:** PR is full coded using the following method: 


1. ChatGPT 5.5 High for initial implementation
2. Fable 5 + 5.6 Sol 1m medium for audit and PR review
3. 5.6Sol 1m Ultra/MAX for final audit and bug review; including compiling and test suite audit; used for PR description
5. Grok 4.5 High final bug resolution, unit testing, and smoke testing; used for PR description

## Configuration
Debian remote repositories can configure:
- Distribution paths, such as `focal-security`, `noble-security`, or `jammy-updates`
- Components, such as `main`, `restricted`, `universe`, and `multiverse` (including Debian-Security leaf matching for `updates/main`)
- Architectures, including `amd64`, `arm64`, and `all`
- Source package inclusion
- Flat repository layouts
- Missing-index handling
- Package name queries with exact and prefix-glob matching
- Optional dependency and pre-dependency resolution (including cross-index closure)
- Upstream Release metadata verification
- Public-only upstream GPG trust anchors
- Local Release signing keys
Clearing Debian config (`debian: null`) or changing policy invalidates previously published synced metadata so published indexes cannot diverge from current policy.
### Metadata strategies
- `upstream_passthrough`
- `filter_and_generate`
- `filter_generate_and_sign`
- `hosted_generate`
Passthrough with non-empty package queries is rejected so metadata cannot advertise content download filters would block.
### Package fetch strategies
- `cache_on_request`
- `prefetch_selected`
- `passthrough` (streams from upstream without persisting payloads)
## Repository API
- Adds the `debian` configuration object to repository create, list, detail, and update responses.
- Persists configuration through `repository_config`.
- Supports partial Debian configuration updates without resetting omitted fields.
- Supports `debian: null` to clear stored Debian config and synced metadata.
- Preserves the repository’s top-level `upstream_url`.
- Returns generated metadata paths, APT source examples, upload paths, warnings, and signing-key information.
- Adds `POST /debian/{repo_key}/sync` for explicit remote synchronization (requires authenticated `debian` write scope).
- Documents `POST /debian/{repo_key}/sync` in OpenAPI via `DebianApiDoc` (`operation_id: debian_sync_remote_repository`), including `DebianSyncResponse` and nested sync-plan schemas (`ToSchema`).
## Synchronization and metadata generation
The synchronization implementation:
- Fetches and parses upstream `Release`, `InRelease`, and `Release.gpg` metadata.
- Enforces upstream `Valid-Until` when regenerating metadata.
- Selects package and source indexes using the configured distribution, component, and architecture filters.
- Supports gzip, XZ, bzip2, and Zstandard upstream indexes.
- Applies package queries and dependency selection when constructing a synchronization plan (capped by `MAX_DEBIAN_SYNC_SELECTED_FILES`).
- Publishes filtered `Packages` and `Sources` (when enabled), plus generated `Release` metadata.
- Generates plain, gzip, and XZ index variants for published indexes.
- Publishes SHA256 by-hash paths.
- Commits each generated metadata set atomically so APT clients cannot observe mismatched Release and Packages generations.
- Does **not** emit remote filtered `Contents` indexes from pool filenames (those paths are not installed-file paths); hosted repositories can still serve Contents.
- Supports on-demand package caching and immediate prefetch.
- Prevents packages outside the published generation from being downloaded (`404` for uncovered paths).
- Parses multi-segment Debian-Security pool paths such as `pool/updates/main/...`.
- Refuses soft-delete of pool artifacts still referenced by published Packages metadata.
## Integrity and security
- Uses authenticated `debian` write scope for synchronization.
- Validates Debian identifiers and distribution paths (components may include `/` for Debian-Security style names).
- Rejects path traversal and absolute URLs from upstream metadata.
- Fail-closed loading of Debian repository config for proxy paths (no unrestricted fail-open).
- Uses Artifact Keeper’s SSRF-protected proxy service for upstream requests.
- Uses the large metadata download limit needed by Debian Packages indexes.
- Propagates real upstream errors instead of converting them into misleading empty/404 responses.
- Verifies selected index hashes against signed Release metadata when verification is enabled.
- Uses package SHA256 values from synchronized metadata to gate cache writes; warm cache hits revalidate expected immutable checksums when present.
- Refuses local re-signing unless upstream metadata verification is enabled.
- Supports public-only OpenPGP trust anchors without requiring private key material.
- Checks signing-key expiry before use.
- Removes the experimental external/HSM signing implementation.
## Backward compatibility
This PR does not change other formats’ behavior. Existing behavior remains for:
- npm canonical download and deletion path resolution
- `ArtifactResponse.analyzable` behavior for proxy-cached artifacts
- Existing Artifact Keeper proxy-cache behavior
- Existing hosted Debian upload and metadata-generation behavior
- Existing signing settings configured through the dedicated signing API
## Database changes
The feature branch is a single squashed commit on current upstream `main`:
- Branch: `feat/debian-advanced-config` (mirrored to `cursor/debian-production-ready-5dd2`)
- Tip: `09986f68`
This PR adds:
- `150_signing_keys_public_only.sql` — allows `signing_keys.private_key_enc` to be NULL for public-only trust anchors
Upstream already owns adjacent slots (not part of this PR’s diff):
- `149_upload_chunks_claimed_at.sql`
- `151_download_telemetry_ip_index.sql`
- `152_artifact_versions.sql`
Reversibility: restore `NOT NULL` on `private_key_enc` after deleting or backfilling any public-only (`NULL` private key) rows.
## Example
<pre>
{
  "key": "ubuntu-focal-security",
  "name": "Ubuntu Focal Security",
  "format": "debian",
  "repo_type": "remote",
  "allow_anonymous_access": true,
  "upstream_url": "https://mirror.pilotfiber.com/ubuntu/",
  "debian": {
    "distribution_paths": ["focal-security"],
    "components": ["universe"],
    "architectures": ["amd64"],
    "include_source_packages": false,
    "verify_upstream_metadata": false,
    "metadata_strategy": "filter_and_generate",
    "package_fetch_strategy": "cache_on_request",
    "package_queries": ["libapache2-mod-md"],
    "resolve_dependencies": false,
    "ignore_missing_indexes": false
  }
}
</pre>
## Live validation

I did various validation tests manually such as feature testing and repo configuration and pull. 
Validated against real Ubuntu/Debian security mirrors with isolated apt clients (debootstrap chroots, WSL Ubuntu Focal, and Local docker containers).

Smoke harness: `scripts/e2e-syspkg/smoke-debian-security-filtered.sh` (`--both` for Ubuntu + Debian)
| Client | Upstream | Dist | Result |
|--------|----------|------|--------|
| Ubuntu 24.04 | `security.ubuntu.com/ubuntu` | `noble-security` | SMOKE OK |
| Debian bookworm | `security.debian.org/debian-security` | `bookworm-security` | SMOKE OK |
Each smoke covered filtered sync (`curl*` / `ca-certificates` + deps), atomic generation (excluded paths `404`), on-demand pool fetch, apt install against Artifact Keeper as the security pocket, and omission of out-of-filter packages (e.g. `nginx`).
Earlier focused validation also exercised filtered cache-on-request and prefetch workflows against an Ubuntu security pocket (selected packages, SHA-256 match, warm cache reuse, by-hash / compressed indexes).
## Automated validation
Verified on the squashed tip (`09986f68`):
- Unit tests present in `formats::debian` and Debian handlers
- Integration-style DB tests present (`#[tokio::test]` in Debian handlers)
- E2E / syspkg smoke present (`scripts/e2e-syspkg/smoke-debian-security-filtered.sh`)
- OpenAPI:
  - `cargo test --lib test_openapi` — **32 passed**
  - `test_openapi_spec_is_valid` — **passed**
  - `test_openapi_documents_debian_remote_sync` — **passed** (path, tag, security, schemas, route)
  - `test_all_openapi_paths_have_handlers` — **passed**
  - `test_openapi_schema_names_are_unique_across_modules` — **passed**
  - `test_openapi_operation_ids_are_unique` — **passed**
- Migration slot `150` unique vs upstream `main`
Re-run `cargo fmt`, `cargo check --locked --workspace --all-targets`, and the full focused Debian suite before merge if you need fresh pass counts in CI.
## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix
## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests
## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes