### PR TITLE
fix(maven): resolve virtual downloads at GAV granularity so a local artifact at one version no longer shadows remote members for other versions

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1476,25 +1476,31 @@ async fn serve_artifact(
                 // groupIds: a local `com.example.mylib:common:1.0` shadowed
                 // every remote `com/.../common/...` lookup, returning
                 // 404 instead of falling through to the remote member
-                // (#1287). The Maven-aware variant matches the full
+                // (#1287). The Maven-aware variant matched the full
                 // groupId+artifactId path prefix so only true GA
-                // collisions activate the suppression. The guard
-                // remains a safety net rather than an authority check:
-                // different versions under the same GA still
-                // legitimately share a directory, and we accept the
-                // false-positive within a single GA in exchange for
-                // closing the shadowing attack. If the path fails to
-                // parse as a Maven coordinate (eg. dynamic
-                // metadata.xml requests reach this branch from earlier
-                // fall-through), skip the guard rather than block the
-                // request.
+                // collisions activated the suppression — but GA
+                // granularity was still too coarse: a local member
+                // owning ANY version of a coordinate suppressed remote
+                // resolution for EVERY version, so a request for a
+                // remote-only version 404'd instead of falling through
+                // to the remote member (#2328). The guard now matches
+                // the full groupId+artifactId+version directory, which
+                // is exactly the scope of the dependency-confusion
+                // attack it defends against: only a locally published
+                // G:A:V can be substituted by a remote response, so
+                // only that G:A:V needs remote resolution suppressed.
+                // If the path fails to parse as a Maven coordinate
+                // (eg. dynamic metadata.xml requests reach this branch
+                // from earlier fall-through), skip the guard rather
+                // than block the request.
                 let local_owns = match MavenHandler::parse_coordinates(path) {
                     Ok(coords) => {
-                        proxy_helpers::virtual_non_remote_owns_maven_ga(
+                        proxy_helpers::virtual_non_remote_owns_maven_gav(
                             &state.db,
                             repo.id,
                             &coords.group_id,
                             &coords.artifact_id,
+                            &coords.version,
                         )
                         .await?
                     }
@@ -4716,6 +4722,160 @@ mod tests {
             &body[..],
             pom_body.as_bytes(),
             "virtual must return the upstream POM bytes (#1562)"
+        );
+    }
+
+    /// #2328: a local member owning ONE version of a Maven coordinate must
+    /// not shadow the virtual repo's remote members for OTHER versions of
+    /// the same coordinate. The GA-granular shadowing guard suppressed the
+    /// proxy fan-out for every version once any version existed locally, so
+    /// a request for a remote-only version 404'd. The GAV-granular guard
+    /// only fires for the exact G:A:V the local member owns.
+    ///
+    /// Same topology as the #1562 test ([local prio 1, remote prio 2]) but
+    /// with the local member owning `io.confluent:common:5.2.0`. The
+    /// remote-only `5.3.1` must stream from upstream (was 404), while the
+    /// locally owned `5.2.0` must still be served by the LOCAL member —
+    /// the dependency-confusion protection for the owned GAV is retained.
+    #[tokio::test]
+    async fn test_virtual_serves_remote_only_pom_when_local_owns_other_version_2328() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Path, State};
+        use axum::Extension;
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        // Remote-only version vs. locally owned version of the SAME GA.
+        let remote_pom_path = "io/confluent/common/5.3.1/common-5.3.1.pom";
+        let remote_pom_body = "<project><version>5.3.1</version></project>";
+        let local_pom_path = "io/confluent/common/5.2.0/common-5.2.0.pom";
+        let local_pom_body = "<project><version>5.2.0</version></project>";
+
+        // Upstream serves the remote body for every GET; the bodies differ
+        // so the response provenance (local vs. upstream) is observable.
+        let mock = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(remote_pom_body))
+            .mount(&mock)
+            .await;
+
+        let (remote_id, _remote_key, dir) = tdh::create_repo(&pool, "remote", "maven").await;
+        sqlx::query("UPDATE repositories SET upstream_url = $1 WHERE id = $2")
+            .bind(mock.uri())
+            .bind(remote_id)
+            .execute(&pool)
+            .await
+            .expect("point remote upstream at mock");
+
+        // Local member OWNS 5.2.0 (row + stored bytes), listed at higher
+        // priority than the remote.
+        let (local_id, local_key, local_dir) = tdh::create_repo(&pool, "local", "maven").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(local_id)
+            .execute(&pool)
+            .await
+            .expect("make local member public");
+
+        let (user_id, _username) = tdh::create_user(&pool).await;
+        let proxy = tdh::build_proxy_service_with_fs(pool.clone(), dir.to_str().unwrap());
+        let state = tdh::build_state_with_proxy(pool.clone(), dir.to_str().unwrap(), proxy);
+        let local_info = tdh::make_repo_info(local_id, &local_key, &local_dir, "local", None);
+        tdh::seed_artifact(
+            &state,
+            &pool,
+            &local_info,
+            local_pom_path,
+            local_pom_path,
+            "common",
+            "5.2.0",
+            "application/xml",
+            bytes::Bytes::from_static(local_pom_body.as_bytes()),
+            user_id,
+        )
+        .await;
+
+        // Virtual repo with [local (prio 1), remote (prio 2)].
+        let (virtual_id, virtual_key, _vdir) = tdh::create_repo(&pool, "virtual", "maven").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1), ($1, $3, 2)",
+        )
+        .bind(virtual_id)
+        .bind(local_id)
+        .bind(remote_id)
+        .execute(&pool)
+        .await
+        .expect("link local (prio 1) and remote (prio 2) as virtual members");
+
+        let auth = tdh::make_auth(user_id, "ph-2328-user");
+
+        // 1) The remote-only 5.3.1 must fall through to the remote member
+        //    even though the local member owns 5.2.0 of the same GA.
+        let remote_resp = download(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Path((virtual_key.clone(), remote_pom_path.to_string())),
+            HeaderMap::new(),
+            Default::default(),
+        )
+        .await;
+
+        // 2) The locally owned 5.2.0 must still be served by the LOCAL
+        //    member (owned-GAV dependency-confusion protection retained).
+        let local_resp = download(
+            State(state.clone()),
+            Extension(Some(auth)),
+            Path((virtual_key.clone(), local_pom_path.to_string())),
+            HeaderMap::new(),
+            Default::default(),
+        )
+        .await;
+
+        // cleanup (members cascade on repo delete).
+        for id in [virtual_id, remote_id] {
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(id)
+                .execute(&pool)
+                .await;
+        }
+        tdh::cleanup(&pool, local_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+        let _ = std::fs::remove_dir_all(&local_dir);
+
+        let remote_resp =
+            remote_resp.expect("virtual must serve the remote-only 5.3.1 POM, not 404 (#2328)");
+        assert_eq!(
+            remote_resp.status(),
+            StatusCode::OK,
+            "local 5.2.0 must not shadow the remote-only 5.3.1 (#2328)"
+        );
+        let remote_body = axum::body::to_bytes(remote_resp.into_body(), 1 << 20)
+            .await
+            .expect("read remote body");
+        assert_eq!(
+            &remote_body[..],
+            remote_pom_body.as_bytes(),
+            "5.3.1 must stream the upstream POM bytes (#2328)"
+        );
+
+        let local_resp = local_resp.expect("virtual must serve the locally owned 5.2.0 POM");
+        assert_eq!(
+            local_resp.status(),
+            StatusCode::OK,
+            "locally owned 5.2.0 must still resolve through the virtual"
+        );
+        let local_body = axum::body::to_bytes(local_resp.into_body(), 1 << 20)
+            .await
+            .expect("read local body");
+        assert_eq!(
+            &local_body[..],
+            local_pom_body.as_bytes(),
+            "5.2.0 must come from the LOCAL member, not upstream \
+             (owned-GAV protection must be retained, #2328)"
         );
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3194,51 +3194,67 @@ pub async fn virtual_local_winner_artifact_id(
 }
 
 /// Build the SQL `LIKE` pattern that matches every artifact path under
-/// a given Maven `groupId/artifactId/` directory.
+/// a given Maven `groupId/artifactId/version/` directory.
 ///
 /// Pure helper extracted so the prefix construction has unit-test
-/// coverage without a database. Returns `<group-path>/<artifactId>/%`,
-/// where the dot-to-slash conversion runs before LIKE-escaping so
-/// directory separators in the groupId are preserved, and `%`/`_`/`\`
-/// inside either input become literal characters. Use with
+/// coverage without a database. Returns
+/// `<group-path>/<artifactId>/<version>/%`, where the dot-to-slash
+/// conversion runs before LIKE-escaping so directory separators in the
+/// groupId are preserved, and `%`/`_`/`\` inside any input become
+/// literal characters (versions arrive from the request path, so the
+/// version segment is escaped like the others). Use with
 /// `LIKE ... ESCAPE '\'`.
-pub(crate) fn maven_ga_like_pattern(group_id: &str, artifact_id: &str) -> String {
+///
+/// Matching at GAV rather than GA granularity means a local artifact at
+/// one version no longer shadows remote members for *other* versions of
+/// the same coordinate (#2328), while a true G:A:V collision still
+/// activates the guard.
+pub(crate) fn maven_gav_like_pattern(group_id: &str, artifact_id: &str, version: &str) -> String {
     let group_path = group_id.replace('.', "/");
-    let mut prefix = String::with_capacity(group_path.len() + artifact_id.len() + 3);
+    let mut prefix =
+        String::with_capacity(group_path.len() + artifact_id.len() + version.len() + 4);
     prefix.push_str(&super::escape_like_literal(&group_path));
     prefix.push('/');
     prefix.push_str(&super::escape_like_literal(artifact_id));
+    prefix.push('/');
+    prefix.push_str(&super::escape_like_literal(version));
     prefix.push('/');
     prefix.push('%');
     prefix
 }
 
 /// Maven-aware shadowing guard: returns true if any non-Remote member of
-/// `virtual_repo_id` owns an artifact under the same groupId + artifactId
-/// directory prefix.
+/// `virtual_repo_id` owns an artifact under the same groupId +
+/// artifactId + version directory prefix.
 ///
 /// The generic [`virtual_non_remote_owns_name`] matches by `artifacts.name`
 /// alone, which for Maven is the artifactId component of the GAV. Two
 /// distinct Maven coordinates that happen to share an artifactId (eg.
 /// `com.foo:bar:1.0` vs. `com.baz:bar:1.0`) collide under the generic
 /// guard, suppressing legitimate remote resolution for any sibling
-/// groupId (#1287). Matching on the full groupId/artifactId path prefix
-/// instead means a local `com/example/mylib/common/...` artifact no
-/// longer shadows a remote `com/android/tools/common/...` lookup.
+/// groupId (#1287). A GA-granular prefix was still too wide: a local
+/// member owning ANY version of a coordinate suppressed remote
+/// resolution for EVERY version, so a request for a remote-only version
+/// 404'd instead of falling through to the remote member (#2328).
+/// Matching on the full groupId/artifactId/version path prefix means
+/// the guard only fires for the exact G:A:V the local member owns —
+/// which is also the only case where a remote response could substitute
+/// for a locally published artifact (dependency confusion).
 ///
-/// `group_path` must be the dot-replaced groupId (`com.foo` ->
-/// `com/foo`); the function appends `/<artifact_id>/` and runs a
-/// `path LIKE` against `artifacts.path`. The prefix is escaped to
-/// neutralise `%` / `_` / `\` so a crafted artifactId cannot widen the
-/// match. Uses the `(repository_id, path)` btree (`idx_artifacts_repo_path`).
+/// The pattern is `<group-path>/<artifact_id>/<version>/%` run as a
+/// `path LIKE` against `artifacts.path`. Every segment is escaped to
+/// neutralise `%` / `_` / `\` so a crafted artifactId or version cannot
+/// widen the match. Uses the `(repository_id, path)` btree
+/// (`idx_artifacts_repo_path`).
 ///
 /// Fails closed on DB error (matches `virtual_non_remote_owns_name`).
 #[allow(clippy::result_large_err)]
-pub async fn virtual_non_remote_owns_maven_ga(
+pub async fn virtual_non_remote_owns_maven_gav(
     db: &PgPool,
     virtual_repo_id: Uuid,
     group_id: &str,
     artifact_id: &str,
+    version: &str,
 ) -> Result<bool, Response> {
     let members = fetch_virtual_members(db, virtual_repo_id).await?;
     let non_remote_ids: Vec<Uuid> = members
@@ -3251,7 +3267,7 @@ pub async fn virtual_non_remote_owns_maven_ga(
         return Ok(false);
     }
 
-    let prefix = maven_ga_like_pattern(group_id, artifact_id);
+    let prefix = maven_gav_like_pattern(group_id, artifact_id, version);
 
     let exists = sqlx::query(
         "SELECT 1 FROM artifacts \
@@ -5132,78 +5148,128 @@ mod tests {
         assert_eq!(reverse_suffix_for_like(""), "/");
     }
 
-    // ── maven_ga_like_pattern tests (#1287) ─────────────────────────
+    // ── maven_gav_like_pattern tests (#1287, #2328) ──────────────────
 
     #[test]
-    fn test_maven_ga_like_pattern_simple_groupid() {
-        // Regular groupId/artifactId pair: dots in groupId become
-        // path separators, then a `/<artifactId>/%` suffix is appended.
+    fn test_maven_gav_like_pattern_simple_groupid() {
+        // Regular groupId/artifactId/version triple: dots in groupId
+        // become path separators, then a `/<artifactId>/<version>/%`
+        // suffix is appended.
         assert_eq!(
-            maven_ga_like_pattern("com.android.tools", "common"),
-            "com/android/tools/common/%"
+            maven_gav_like_pattern("com.android.tools", "common", "31.4.0"),
+            "com/android/tools/common/31.4.0/%"
+        );
+        assert_eq!(
+            maven_gav_like_pattern("org.apache.commons", "commons-lang3", "3.14.0"),
+            "org/apache/commons/commons-lang3/3.14.0/%"
         );
     }
 
     #[test]
-    fn test_maven_ga_like_pattern_distinguishes_groupids() {
+    fn test_maven_gav_like_pattern_distinguishes_groupids() {
         // Two artifactIds that collide on `name` alone but live under
         // different groupIds must produce distinct LIKE prefixes.
         // This is the core property #1287 needs.
-        let foo = maven_ga_like_pattern("com.foo", "bar");
-        let baz = maven_ga_like_pattern("com.baz", "bar");
+        let foo = maven_gav_like_pattern("com.foo", "bar", "1.0");
+        let baz = maven_gav_like_pattern("com.baz", "bar", "1.0");
         assert_ne!(foo, baz);
-        assert_eq!(foo, "com/foo/bar/%");
-        assert_eq!(baz, "com/baz/bar/%");
+        assert_eq!(foo, "com/foo/bar/1.0/%");
+        assert_eq!(baz, "com/baz/bar/1.0/%");
     }
 
     #[test]
-    fn test_maven_ga_like_pattern_does_not_match_sibling_groupids() {
+    fn test_maven_gav_like_pattern_distinguishes_versions() {
+        // The core property #2328 needs: a local artifact at one
+        // version must NOT match the directory of a different version
+        // of the same coordinate, so the shadowing guard cannot
+        // suppress remote resolution of remote-only versions.
+        let old = maven_gav_like_pattern("org.apache.commons", "commons-lang3", "3.0.0");
+        let new = maven_gav_like_pattern("org.apache.commons", "commons-lang3", "3.14.0");
+        assert_ne!(old, new);
+        assert_eq!(old, "org/apache/commons/commons-lang3/3.0.0/%");
+        assert_eq!(new, "org/apache/commons/commons-lang3/3.14.0/%");
+        // The 3.14.0 request path lives outside the 3.0.0 pattern's
+        // literal prefix (and vice versa).
+        let requested = "org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.pom";
+        assert!(!requested.starts_with("org/apache/commons/commons-lang3/3.0.0/"));
+        assert!(requested.starts_with("org/apache/commons/commons-lang3/3.14.0/"));
+    }
+
+    #[test]
+    fn test_maven_gav_like_pattern_does_not_match_sibling_groupids() {
         // `com.android.tools/common/...` must NOT be matched by a
         // pattern derived from `com.example.mylib:common`. We assert
-        // the produced prefix is anchored at the full GA directory
+        // the produced prefix is anchored at the full GAV directory
         // boundary.
-        let prefix = maven_ga_like_pattern("com.example.mylib", "common");
-        assert_eq!(prefix, "com/example/mylib/common/%");
+        let prefix = maven_gav_like_pattern("com.example.mylib", "common", "1.0.0");
+        assert_eq!(prefix, "com/example/mylib/common/1.0.0/%");
         // A path under a different groupId does not start with this
         // prefix even though both share the `common` artifactId.
         let unrelated_path = "com/android/tools/common/31.4.0/common-31.4.0.pom";
-        assert!(!unrelated_path.starts_with("com/example/mylib/common/"));
+        assert!(!unrelated_path.starts_with("com/example/mylib/common/1.0.0/"));
         // Sanity: the matching local artifact path DOES start with it.
         let local_path = "com/example/mylib/common/1.0.0/common-1.0.0.pom";
-        assert!(local_path.starts_with("com/example/mylib/common/"));
+        assert!(local_path.starts_with("com/example/mylib/common/1.0.0/"));
         // And the LIKE suffix is open-ended.
         assert!(prefix.ends_with('%'));
     }
 
     #[test]
-    fn test_maven_ga_like_pattern_escapes_metachars() {
-        // A crafted artifactId containing `%` or `_` must not widen
-        // the LIKE match. Both inputs get escaped before being woven
-        // into the pattern.
+    fn test_maven_gav_like_pattern_snapshot_version() {
+        // SNAPSHOT versions keep their literal directory name; the
+        // open-ended `%` then covers the timestamped filenames Maven
+        // resolves inside that directory.
         assert_eq!(
-            maven_ga_like_pattern("a.b", "ev%il"),
-            "a/b/ev\\%il/%",
+            maven_gav_like_pattern("com.example", "app", "1.0-SNAPSHOT"),
+            "com/example/app/1.0-SNAPSHOT/%"
+        );
+    }
+
+    #[test]
+    fn test_maven_gav_like_pattern_escapes_metachars() {
+        // A crafted artifactId or version containing `%` or `_` must
+        // not widen the LIKE match. All inputs get escaped before
+        // being woven into the pattern.
+        assert_eq!(
+            maven_gav_like_pattern("a.b", "ev%il", "1.0"),
+            "a/b/ev\\%il/1.0/%",
             "% inside artifactId must be escaped"
         );
         assert_eq!(
-            maven_ga_like_pattern("a.b", "ev_il"),
-            "a/b/ev\\_il/%",
+            maven_gav_like_pattern("a.b", "ev_il", "1.0"),
+            "a/b/ev\\_il/1.0/%",
             "_ inside artifactId must be escaped"
         );
         // `%` inside the groupId is also escaped (after the
         // dot-to-slash conversion has already happened).
         assert_eq!(
-            maven_ga_like_pattern("a%.b", "c"),
-            "a\\%/b/c/%",
+            maven_gav_like_pattern("a%.b", "c", "1.0"),
+            "a\\%/b/c/1.0/%",
             "% inside groupId must be escaped"
+        );
+        // The version comes straight from the request path, so its
+        // metacharacters must be neutralised too.
+        assert_eq!(
+            maven_gav_like_pattern("a.b", "c", "1%0"),
+            "a/b/c/1\\%0/%",
+            "% inside version must be escaped"
+        );
+        assert_eq!(
+            maven_gav_like_pattern("a.b", "c", "1_0"),
+            "a/b/c/1\\_0/%",
+            "_ inside version must be escaped"
         );
     }
 
     #[test]
-    fn test_maven_ga_like_pattern_escapes_backslash() {
+    fn test_maven_gav_like_pattern_escapes_backslash() {
         // Backslashes get escaped so the ESCAPE '\' clause stays
-        // honest.
-        assert_eq!(maven_ga_like_pattern("a.b", "c\\d"), "a/b/c\\\\d/%");
+        // honest — in every segment, including the version.
+        assert_eq!(
+            maven_gav_like_pattern("a.b", "c\\d", "1.0"),
+            "a/b/c\\\\d/1.0/%"
+        );
+        assert_eq!(maven_gav_like_pattern("a.b", "c", "1\\0"), "a/b/c/1\\\\0/%");
     }
 
     // ── build_remote_repo tests ──────────────────────────────────────

--- a/backend/tests/maven_virtual_groupid_shadowing_test.rs
+++ b/backend/tests/maven_virtual_groupid_shadowing_test.rs
@@ -7,9 +7,11 @@
 //! artifactId. That made a local `com.example.mylib:common:1.0` shadow
 //! every remote `com/android/tools/common/...` lookup, returning 404
 //! instead of falling through to the remote member. The Maven-aware
-//! variant `virtual_non_remote_owns_maven_ga` matches on the full
-//! `groupId/artifactId/` path prefix, so only true GA collisions
-//! activate the suppression.
+//! variant `virtual_non_remote_owns_maven_gav` matches on the full
+//! `groupId/artifactId/version/` path prefix, so only true GAV
+//! collisions activate the suppression: a local artifact at one
+//! version no longer shadows remote members for other versions of the
+//! same coordinate (#2328).
 //!
 //! Requires a PostgreSQL database with migrations applied. Run with:
 //!
@@ -21,7 +23,7 @@
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use artifact_keeper_backend::api::handlers::proxy_helpers::virtual_non_remote_owns_maven_ga;
+use artifact_keeper_backend::api::handlers::proxy_helpers::virtual_non_remote_owns_maven_gav;
 
 async fn insert_repo(pool: &PgPool, key: &str, repo_type: &str) -> Uuid {
     let id = Uuid::new_v4();
@@ -156,24 +158,52 @@ async fn maven_shadowing_guard_does_not_fire_across_different_groupids() {
     // Querying for the REMOTE groupId+artifactId must return false:
     // the local member does not own this GA, so the guard must not
     // suppress remote resolution.
-    let owns_remote_ga =
-        virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.android.tools", "common")
-            .await
-            .expect("guard query should succeed");
+    let owns_remote_ga = virtual_non_remote_owns_maven_gav(
+        &pool,
+        virtual_id,
+        "com.android.tools",
+        "common",
+        "31.4.0",
+    )
+    .await
+    .expect("guard query should succeed");
     assert!(
         !owns_remote_ga,
         "local member's `com.example.mylib:common` must NOT shadow remote `com.android.tools:common` (#1287)"
     );
 
-    // Sanity: querying for the LOCAL groupId+artifactId still returns
-    // true (the guard still does its job for genuine collisions).
-    let owns_local_ga =
-        virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.example.mylib", "common")
-            .await
-            .expect("guard query should succeed");
+    // #2328: a DIFFERENT version of the SAME locally owned coordinate
+    // must not activate the guard either — only the exact G:A:V the
+    // local member owns is protected.
+    let owns_other_version = virtual_non_remote_owns_maven_gav(
+        &pool,
+        virtual_id,
+        "com.example.mylib",
+        "common",
+        "2.0.0",
+    )
+    .await
+    .expect("guard query should succeed");
     assert!(
-        owns_local_ga,
-        "guard must still fire when groupId+artifactId match the local artifact"
+        !owns_other_version,
+        "local `com.example.mylib:common:1.0.0` must NOT shadow version 2.0.0 of the same coordinate (#2328)"
+    );
+
+    // Sanity: querying for the LOCAL groupId+artifactId+version still
+    // returns true (the guard still does its job for genuine
+    // collisions).
+    let owns_local_gav = virtual_non_remote_owns_maven_gav(
+        &pool,
+        virtual_id,
+        "com.example.mylib",
+        "common",
+        "1.0.0",
+    )
+    .await
+    .expect("guard query should succeed");
+    assert!(
+        owns_local_gav,
+        "guard must still fire when groupId+artifactId+version match the local artifact"
     );
 
     cleanup(&pool, virtual_id, &[local_id, remote_id]).await;
@@ -196,7 +226,7 @@ async fn maven_shadowing_guard_no_non_remote_members_returns_false() {
     let remote_id = insert_repo(&pool, &format!("mv-remote-rmonly-{}", suffix), "remote").await;
     add_virtual_member(&pool, virtual_id, remote_id, 1).await;
 
-    let owns = virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.foo", "bar")
+    let owns = virtual_non_remote_owns_maven_gav(&pool, virtual_id, "com.foo", "bar", "1.0")
         .await
         .expect("guard query should succeed");
     assert!(
@@ -236,12 +266,24 @@ async fn maven_shadowing_guard_escapes_like_metachars() {
 
     // A LIKE-style query like `a%a` must not slip past escaping and
     // match the `aaa` artifact: the guard treats `%` as a literal.
-    let widened = virtual_non_remote_owns_maven_ga(&pool, virtual_id, "com.example", "a%a")
-        .await
-        .expect("guard query should succeed");
+    let widened =
+        virtual_non_remote_owns_maven_gav(&pool, virtual_id, "com.example", "a%a", "1.0.0")
+            .await
+            .expect("guard query should succeed");
     assert!(
         !widened,
         "% inside artifactId must be escaped, not act as a wildcard"
+    );
+
+    // Same for a `%` smuggled into the version segment: it must not
+    // widen the match to the locally owned `1.0.0` directory.
+    let widened_version =
+        virtual_non_remote_owns_maven_gav(&pool, virtual_id, "com.example", "aaa", "%")
+            .await
+            .expect("guard query should succeed");
+    assert!(
+        !widened_version,
+        "% inside version must be escaped, not act as a wildcard"
     );
 
     cleanup(&pool, virtual_id, &[local_id]).await;


### PR DESCRIPTION
## Summary

A Maven virtual repository returned 404 for versions that only a Remote member could serve whenever a Local member owned *any other version* of the same coordinate (#2328). The virtual-download shadowing guard matched at `groupId/artifactId` granularity (`group/artifact/%`), so a single locally published version suppressed remote resolution (and cache/upstream probing) for the entire coordinate.

This narrows the guard to `groupId/artifactId/version` granularity:

- `proxy_helpers::maven_ga_like_pattern` → `maven_gav_like_pattern`: the LIKE pattern becomes `group/artifact/version/%`, with the version segment passed through `escape_like_literal` like the other segments (the version arrives from the request path, so `%`/`_`/`\` must stay literal).
- `proxy_helpers::virtual_non_remote_owns_maven_ga` → `virtual_non_remote_owns_maven_gav`, threading `version`.
- `serve_artifact`'s virtual branch (the single production caller) passes the already-parsed `coords.version`.

The dependency-confusion protection the guard exists for is retained at exactly the scope it defends: only the G:A:V a local member actually owns has its remote resolution suppressed — which is also the only G:A:V where a remote response could substitute for a locally published artifact. The metadata path (`fetch_maven_metadata_bytes`) and the checksum sub-path never call this guard and are unchanged.

Closes #2328

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_virtual_serves_remote_only_pom_when_local_owns_other_version_2328` (maven.rs, DB-gated): same `[local prio 1, remote prio 2]` topology as the #1562 test, local member owns `io.confluent:common:5.2.0`; asserts the remote-only `5.3.1` streams upstream bytes through the virtual (404 on `main`) AND the owned `5.2.0` is still served by the local member (protection retained). `test_maven_gav_like_pattern_distinguishes_versions` pins the pattern-level core: the 3.0.0 pattern must not match the 3.14.0 directory.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full lib suite: 12742 passed / 0 failed (throwaway Postgres). `tests/maven_virtual_groupid_shadowing_test.rs` (ignored, DB-required) updated to the GAV signature and extended with a cross-version case plus a `%`-in-version escaping case; all 3 pass. #1562 remote-only fall-through and #2069 metadata-merge tests still green.

Manual verification on an isolated instance (local `mvn-loc1` + remote `mvn-central` → repo1.maven.org + virtual `mvn-virt`), after publishing `commons-lang3-3.0.0.pom` to the local member:
- `GET /maven/mvn-virt/org/apache/commons/commons-lang3/3.14.0/commons-lang3-3.14.0.pom` → 200 upstream bytes (was 404)
- `GET .../3.0.0/commons-lang3-3.0.0.pom` via the virtual → 200, byte-identical to the locally published POM (local member, not upstream)
- `GET .../commons-lang3/maven-metadata.xml` via the virtual → 200, merged (upstream `<latest>3.20.0</latest>` + local 3.0.0)
- Direct member GETs unchanged (remote 3.14.0 → 200, local 3.0.0 → 200, local 3.14.0 → 404)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
