### PR TITLE
fix(composer): emit absolute dist.url for remote/proxied repos

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -526,13 +526,18 @@ fn composer_inline_uid(name: &str, version: &str, checksum_sha256: &str) -> i64 
 // owned by an in-flight PR, so a local copy avoids parallel-merge drift.
 // ---------------------------------------------------------------------------
 
-/// Rewrite the `dist.url` of a single composer version entry to the relative
-/// in-registry download path, preserving every other field (notably
-/// `dist.reference` and `dist.shasum`). Entries without a `dist.url` (e.g. the
-/// delta rows of the "minified" format) are left untouched. `version_hint` is
-/// used when the entry itself omits a `version` field (the v1 wire shape keys
-/// versions by the map key rather than an inline field).
+/// Rewrite the `dist.url` of a single composer version entry to the ABSOLUTE
+/// in-registry download URL (`base_url` prefixed, same derivation as
+/// [`build_version_entry`]), preserving every other field (notably
+/// `dist.reference` and `dist.shasum`). Composer does not resolve a
+/// root-relative `dist.url` against the repository URL, so a relative form
+/// makes it fall back to a source clone and bypass the proxy cache (#2370).
+/// Entries without a `dist.url` (e.g. the delta rows of the "minified"
+/// format) are left untouched. `version_hint` is used when the entry itself
+/// omits a `version` field (the v1 wire shape keys versions by the map key
+/// rather than an inline field).
 fn rewrite_dist_url_in_entry(
+    base_url: &str,
     repo_key: &str,
     name: &str,
     version_hint: &str,
@@ -570,8 +575,8 @@ fn rewrite_dist_url_in_entry(
     dist.insert(
         "url".to_string(),
         serde_json::Value::String(format!(
-            "/composer/{}/dist/{}/{}/{}.zip",
-            repo_key, name, version, reference
+            "{}/composer/{}/dist/{}/{}/{}.zip",
+            base_url, repo_key, name, version, reference
         )),
     );
 }
@@ -581,7 +586,7 @@ fn rewrite_dist_url_in_entry(
 /// upstream host directly. Handles both wire shapes: the v2 `packages` map of
 /// version *arrays* and the v1 map of version *objects*. Pure + DB-free so it is
 /// unit-testable (#1652).
-fn rewrite_remote_dist_urls(repo_key: &str, doc: &mut serde_json::Value) {
+fn rewrite_remote_dist_urls(base_url: &str, repo_key: &str, doc: &mut serde_json::Value) {
     let Some(packages) = doc.get_mut("packages").and_then(|p| p.as_object_mut()) else {
         return;
     };
@@ -589,13 +594,13 @@ fn rewrite_remote_dist_urls(repo_key: &str, doc: &mut serde_json::Value) {
         match versions {
             serde_json::Value::Array(arr) => {
                 for entry in arr.iter_mut() {
-                    rewrite_dist_url_in_entry(repo_key, name, "dev-main", entry);
+                    rewrite_dist_url_in_entry(base_url, repo_key, name, "dev-main", entry);
                 }
             }
             serde_json::Value::Object(map) => {
                 for (ver, entry) in map.iter_mut() {
                     let hint = ver.clone();
-                    rewrite_dist_url_in_entry(repo_key, name, &hint, entry);
+                    rewrite_dist_url_in_entry(base_url, repo_key, name, &hint, entry);
                 }
             }
             _ => {}
@@ -607,10 +612,10 @@ fn rewrite_remote_dist_urls(repo_key: &str, doc: &mut serde_json::Value) {
 /// re-serialize. On any JSON parse failure the original bytes are returned
 /// unchanged so a non-JSON (or unexpected) upstream body is still served
 /// verbatim rather than dropped. Pure so the transform is unit-testable (#1652).
-fn rewrite_remote_metadata_body(repo_key: &str, content: &Bytes) -> Bytes {
+fn rewrite_remote_metadata_body(base_url: &str, repo_key: &str, content: &Bytes) -> Bytes {
     match serde_json::from_slice::<serde_json::Value>(content) {
         Ok(mut doc) => {
-            rewrite_remote_dist_urls(repo_key, &mut doc);
+            rewrite_remote_dist_urls(base_url, repo_key, &mut doc);
             match serde_json::to_vec(&doc) {
                 Ok(bytes) => Bytes::from(bytes),
                 Err(_) => content.clone(),
@@ -913,8 +918,10 @@ async fn metadata_v2(
                 // the archive back through us (and we can proxy-cache it),
                 // instead of pulling it straight from the off-registry host. The
                 // proxy cache still stores the original upstream bytes; only the
-                // served copy is transformed.
-                let content = rewrite_remote_metadata_body(&repo_key, &content);
+                // served copy is transformed. The rewritten URL is ABSOLUTE
+                // (base-URL prefixed) — Composer does not resolve a relative
+                // dist.url and would bypass the proxy cache (#2370).
+                let content = rewrite_remote_metadata_body(base_url.as_str(), &repo_key, &content);
                 return Ok(build_composer_proxy_response(content, content_type));
             }
         }
@@ -982,8 +989,9 @@ async fn metadata_v1(
                 )
                 .await?;
                 // #1652: rewrite upstream `dist.url`s to route dist downloads
-                // back through us (see metadata_v2 for the rationale).
-                let content = rewrite_remote_metadata_body(&repo_key, &content);
+                // back through us (see metadata_v2 for the rationale); absolute
+                // per #2370.
+                let content = rewrite_remote_metadata_body(base_url.as_str(), &repo_key, &content);
                 return Ok(build_composer_proxy_response(content, content_type));
             }
         }
@@ -3559,11 +3567,11 @@ mod metadata_db_tests {
     #[test]
     fn test_rewrite_remote_dist_urls_v2_array() {
         let mut doc = packagist_v2_doc();
-        rewrite_remote_dist_urls("php-remote", &mut doc);
+        rewrite_remote_dist_urls("https://ak.example.com", "php-remote", &mut doc);
         let entry = &doc["packages"]["monolog/monolog"][0];
         assert_eq!(
             entry["dist"]["url"],
-            "/composer/php-remote/dist/monolog/monolog/2.0.0/aaa111.zip"
+            "https://ak.example.com/composer/php-remote/dist/monolog/monolog/2.0.0/aaa111.zip"
         );
         // reference, shasum, minified, and unrelated fields preserved.
         assert_eq!(entry["dist"]["reference"], "aaa111");
@@ -3591,11 +3599,11 @@ mod metadata_db_tests {
                 }
             }
         });
-        rewrite_remote_dist_urls("legacy", &mut doc);
+        rewrite_remote_dist_urls("https://ak.example.com", "legacy", &mut doc);
         let entry = &doc["packages"]["monolog/monolog"]["1.0.0"];
         assert_eq!(
             entry["dist"]["url"],
-            "/composer/legacy/dist/monolog/monolog/1.0.0/bbb222.zip"
+            "https://ak.example.com/composer/legacy/dist/monolog/monolog/1.0.0/bbb222.zip"
         );
         assert_eq!(entry["dist"]["reference"], "bbb222");
     }
@@ -3607,25 +3615,50 @@ mod metadata_db_tests {
                 "vendor/pkg": [{"name": "vendor/pkg", "version": "9.9.9"}]
             }
         });
-        rewrite_remote_dist_urls("k", &mut doc);
+        rewrite_remote_dist_urls("https://ak.example.com", "k", &mut doc);
         assert!(doc["packages"]["vendor/pkg"][0].get("dist").is_none());
     }
 
     #[test]
     fn test_rewrite_remote_metadata_body_non_json_passthrough() {
         let raw = bytes::Bytes::from_static(b"<html>not json</html>");
-        let out = rewrite_remote_metadata_body("k", &raw);
+        let out = rewrite_remote_metadata_body("https://ak.example.com", "k", &raw);
         assert_eq!(out, raw, "non-JSON upstream body is served verbatim");
     }
 
     #[test]
     fn test_rewrite_remote_metadata_body_rewrites() {
         let raw = bytes::Bytes::from(packagist_v2_doc().to_string());
-        let out = rewrite_remote_metadata_body("php-remote", &raw);
+        let out = rewrite_remote_metadata_body("https://ak.example.com", "php-remote", &raw);
         let parsed: serde_json::Value = serde_json::from_slice(&out).unwrap();
         assert_eq!(
             parsed["packages"]["monolog/monolog"][0]["dist"]["url"],
-            "/composer/php-remote/dist/monolog/monolog/2.0.0/aaa111.zip"
+            "https://ak.example.com/composer/php-remote/dist/monolog/monolog/2.0.0/aaa111.zip"
+        );
+    }
+
+    /// #2370 regression gate: the rewritten remote `dist.url` must be an
+    /// ABSOLUTE http(s) URL rooted at the request base URL. Composer does not
+    /// resolve a root-relative dist.url against the repository URL, so a
+    /// relative form makes it fall back to a source clone and bypass the
+    /// proxy cache.
+    #[test]
+    fn test_rewrite_remote_dist_url_is_absolute() {
+        let base = "https://ak.example.com";
+        let mut doc = packagist_v2_doc();
+        rewrite_remote_dist_urls(base, "php-remote", &mut doc);
+        let url = doc["packages"]["monolog/monolog"][0]["dist"]["url"]
+            .as_str()
+            .unwrap();
+        assert!(
+            url.starts_with(&format!("{}/composer/php-remote/dist/", base)),
+            "dist.url must be prefixed with the request base URL, got {url}"
+        );
+        let parsed = url::Url::parse(url).expect("dist.url must be a valid absolute URL");
+        assert!(
+            parsed.scheme() == "http" || parsed.scheme() == "https",
+            "dist.url must be http(s), got {}",
+            parsed.scheme()
         );
     }
 

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1588,11 +1588,17 @@ mod tests {
         let served: serde_json::Value =
             serde_json::from_slice(&body).expect("served metadata must be JSON");
         let entry = &served["packages"]["monolog/monolog"][0];
-        let expected_url = format!(
+        // #2370: the rewritten dist.url is now ABSOLUTE (RequestBaseUrl-prefixed;
+        // the test request carries no Host header, so the base falls back to
+        // http://localhost) so Composer clients that resolve a repo via a
+        // remote/proxied `metadata-url` template still get a fetchable dist.
+        let dist_url = entry["dist"]["url"].as_str().unwrap_or_default();
+        let expected_suffix = format!(
             "/composer/{key}/dist/monolog/monolog/2.0.0/abc123.zip",
             key = fx.repo_key
         );
-        let ok = entry["dist"]["url"] == serde_json::json!(expected_url)
+        let ok = dist_url.starts_with("http://localhost/")
+            && dist_url.ends_with(&expected_suffix)
             && entry["dist"]["reference"] == serde_json::json!("abc123")
             && entry["dist"]["shasum"] == serde_json::json!("deadbeef")
             && served["minified"] == serde_json::json!("composer/2.0");
@@ -2659,8 +2665,9 @@ mod tests {
 
     /// #2361: the p2 (metadata_v2) wire shape must emit an ABSOLUTE dist.url
     /// for locally-hosted artifacts, prefixed with the request-derived base
-    /// URL — while the proxied/remote rewrite path (#1652, covered by
-    /// `test_remote_metadata_v2_rewrites_dist_url_1652`) is left unchanged.
+    /// URL. #2370 brings the proxied/remote rewrite path (#1652, covered by
+    /// `test_remote_metadata_v2_rewrites_dist_url_1652`) to the same absolute
+    /// shape so remote/proxied `metadata-url` clients get a fetchable dist.
     #[tokio::test]
     async fn test_build_metadata_v2_response_dist_url_absolute_2361() {
         let resp = build_metadata_v2_response(


### PR DESCRIPTION
## Summary
The #1652 remote-rewrite path (`rewrite_dist_url_in_entry`) emitted a **root-relative** `dist.url` (`/composer/{key}/dist/...`) in proxied composer metadata. Composer does not resolve a root-relative `dist.url` against the repository URL, so installs from a Remote/proxied composer repo fell back to a source clone — bypassing the proxy cache entirely.

This is the remote counterpart of #2361 (fixed in #2369 for the Local path via `build_version_entry`); the two paths do not share code, so that fix did not cover this one.

Changes:
- Thread the request base URL (`RequestBaseUrl`, same derivation as the Local path) through `rewrite_remote_metadata_body` → `rewrite_remote_dist_urls` → `rewrite_dist_url_in_entry`, and emit an **absolute** `dist.url`: `{base_url}/composer/{key}/dist/{vendor}/{package}/{version}/{reference}.zip`.
- Both callers (`metadata_v2`, `metadata_v1`) already had `base_url` in scope; they now pass it in.
- `dist.reference` / `dist.shasum` passthrough is unchanged. The root `metadata-url` stays root-relative on purpose (Composer spec resolves it against the repository URL, same as #2361). `build_version_entry` (Local path) and the `download_archive` Remote branch (which resolves the real upstream dist) are untouched.

Closes #2370

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Updated the three existing rewrite unit tests to assert the ABSOLUTE form (they previously pinned the relative form, i.e. they pinned the bug), and added `test_rewrite_remote_dist_url_is_absolute`, which asserts the rewritten `dist.url` is base-URL-prefixed and parses as a valid absolute http(s) URL. The new/updated tests fail on `main` and pass here. The release-gate script fix in artifact-keeper-test (companion PR for #2383) additionally asserts this end-to-end.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — companion PR in artifact-keeper-test (#2383) fetches the metadata-emitted dist.url and asserts it is absolute + AK-routed
- [x] Manually tested locally — on an isolated stack: proxied repo's `/p2/{vendor}/{package}.json` now emits an absolute AK-routed `dist.url`; fetching that URL returns the archive through the proxy cache (cold 2xx, warm byte-identical, still 2xx after upstream removal)
- [x] No regressions in existing tests — full workspace lib suite green; Local-path (`build_version_entry`) behavior unchanged

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (response body URL form only)

## Merge order
The artifact-keeper-test companion PR (release-gate composer dist-cache script, #2383) asserts the absolute `dist.url` this PR emits — merge **this PR first**, then the test-repo PR.
