### PR TITLE
feat(npm): server-side scope policy for npm virtual repository member resolution

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -3224,6 +3224,219 @@ mod tests {
         ));
     }
 
+    /// DB-backed: `fetch_npm_scope_policy` / `fetch_npm_scope_policies` read
+    /// the `repository_config` rows written by the admin endpoint and
+    /// tolerate every degenerate stored shape — no rows (default policy),
+    /// malformed JSON in the scope list, an unparseable boolean, mixed-case
+    /// stored scopes (case-folded), and an empty id set (no query at all).
+    /// Skips when no `DATABASE_URL` is configured.
+    #[tokio::test]
+    async fn fetch_npm_scope_policy_parses_stored_config_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, _key, _dir) = tdh::create_repo(&pool, "remote", "npm").await;
+        let upsert = |key: &'static str, value: &'static str| {
+            let pool = pool.clone();
+            async move {
+                sqlx::query(
+                    "INSERT INTO repository_config (repository_id, key, value) \
+                     VALUES ($1, $2, $3) \
+                     ON CONFLICT (repository_id, key) DO UPDATE SET value = $3",
+                )
+                .bind(repo_id)
+                .bind(key)
+                .bind(value)
+                .execute(&pool)
+                .await
+                .expect("upsert repository_config");
+            }
+        };
+
+        // Empty id slice: no rows requested, empty map back.
+        assert!(fetch_npm_scope_policies(&pool, &[]).await.is_empty());
+
+        // No rows stored: default (inactive, unrestricted) policy.
+        let empty = fetch_npm_scope_policy(&pool, repo_id).await;
+        assert_eq!(empty, NpmScopePolicy::default());
+        assert!(!empty.is_active());
+
+        // Malformed JSON scope list + unparseable boolean: both degrade to
+        // the unrestricted default rather than erroring the request path.
+        upsert(NPM_ALLOWED_SCOPES_KEY, "not-json").await;
+        upsert(NPM_ALLOW_UNSCOPED_KEY, "garbage").await;
+        let degenerate = fetch_npm_scope_policy(&pool, repo_id).await;
+        assert!(degenerate.allowed_scopes.is_empty());
+        assert_eq!(degenerate.allow_unscoped, None);
+        assert!(!degenerate.is_active());
+
+        // Well-formed rows: scopes case-folded, boolean parsed.
+        upsert(NPM_ALLOWED_SCOPES_KEY, "[\"@Types\",\"@partner\"]").await;
+        upsert(NPM_ALLOW_UNSCOPED_KEY, "false").await;
+        let stored = fetch_npm_scope_policy(&pool, repo_id).await;
+        assert_eq!(stored.allowed_scopes, vec!["@types", "@partner"]);
+        assert_eq!(stored.allow_unscoped, Some(false));
+        assert!(stored.is_active());
+        assert!(stored.allows("@types/node"));
+        assert!(!stored.allows("lodash"));
+
+        // Boolean flips to true: unscoped resolution allowed again.
+        upsert(NPM_ALLOW_UNSCOPED_KEY, "true").await;
+        let flipped = fetch_npm_scope_policy(&pool, repo_id).await;
+        assert_eq!(flipped.allow_unscoped, Some(true));
+        assert!(flipped.allows("lodash"));
+
+        // Cleanup.
+        let _ = sqlx::query("DELETE FROM repository_config WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// DB-backed (#2327 secondary): a virtual repo with two Remote members —
+    /// the first carrying a scope policy that excludes the requested name,
+    /// the second unrestricted — resolves both the metadata and the
+    /// packument through the second member, and the policy-restricted
+    /// member's upstream is NEVER contacted (wiremock `expect(0)`). Covers
+    /// the candidate-selection wiring in `get_package_metadata` and
+    /// `fetch_virtual_packument`. Skips when no `DATABASE_URL` is configured.
+    #[tokio::test]
+    async fn test_virtual_member_scope_policy_filters_candidates_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("virtual", "npm").await else {
+            return;
+        };
+        let package = "scope-policy-pkg";
+
+        // Member A upstream: would serve the package, but must never be
+        // asked because A's scope policy excludes unscoped names.
+        let blocked_upstream = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/{package}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "name": package, "versions": {}
+            })))
+            .expect(0)
+            .mount(&blocked_upstream)
+            .await;
+
+        // Member B upstream: unrestricted, serves the packument.
+        let open_upstream = MockServer::start().await;
+        let packument = serde_json::json!({
+            "name": package,
+            "dist-tags": {"latest": "1.0.0"},
+            "versions": {
+                "1.0.0": {"name": package, "version": "1.0.0",
+                          "dist": {"tarball": format!(
+                              "{}/{}/-/{}-1.0.0.tgz", open_upstream.uri(), package, package)}},
+            }
+        });
+        Mock::given(method("GET"))
+            .and(path(format!("/{package}")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&packument))
+            .mount(&open_upstream)
+            .await;
+
+        let mut member_ids = Vec::new();
+        for (upstream, priority) in [(&blocked_upstream, 1), (&open_upstream, 2)] {
+            let (member_id, _mkey, _mdir) = tdh::create_repo(&fx.pool, "remote", "npm").await;
+            sqlx::query(
+                "UPDATE repositories SET upstream_url = $1, is_public = true WHERE id = $2",
+            )
+            .bind(upstream.uri())
+            .bind(member_id)
+            .execute(&fx.pool)
+            .await
+            .expect("configure member");
+            sqlx::query(
+                "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+                 VALUES ($1, $2, $3)",
+            )
+            .bind(fx.repo_id)
+            .bind(member_id)
+            .bind(priority)
+            .execute(&fx.pool)
+            .await
+            .expect("attach member");
+            member_ids.push(member_id);
+        }
+        // Member A: scoped-only policy — the unscoped test package is out of
+        // scope, so A must be skipped by candidate selection.
+        for (key, value) in [
+            (NPM_ALLOWED_SCOPES_KEY, "[\"@types\"]"),
+            (NPM_ALLOW_UNSCOPED_KEY, "false"),
+        ] {
+            sqlx::query(
+                "INSERT INTO repository_config (repository_id, key, value) VALUES ($1, $2, $3)",
+            )
+            .bind(member_ids[0])
+            .bind(key)
+            .bind(value)
+            .execute(&fx.pool)
+            .await
+            .expect("store member policy");
+        }
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let proxy = tdh::build_proxy_service_with_fs(fx.pool.clone(), storage_path.as_str());
+        let state = tdh::build_state_with_proxy(fx.pool.clone(), storage_path.as_str(), proxy);
+
+        // Metadata loop: resolved via member B (member A skipped by policy).
+        let meta =
+            super::get_package_metadata(&state, &fx.repo_key, package, "http://localhost", false)
+                .await;
+        match meta {
+            Ok(resp) => assert_eq!(resp.status(), StatusCode::OK),
+            Err(r) => panic!(
+                "virtual metadata must resolve via member B: HTTP {}",
+                r.status()
+            ),
+        }
+
+        // Packument loop: same filtering on the version-metadata path.
+        let repo = fx.repo_info("virtual", None);
+        let packument_json = super::fetch_virtual_packument(
+            &state,
+            &repo,
+            &fx.repo_key,
+            package,
+            "http://localhost",
+        )
+        .await;
+        match packument_json {
+            Ok(json) => assert_eq!(json["name"], package),
+            Err(r) => panic!(
+                "virtual packument must resolve via member B: HTTP {}",
+                r.status()
+            ),
+        }
+
+        // Cleanup (wiremock verifies `expect(0)` for member A on drop).
+        for member_id in member_ids {
+            let _ = sqlx::query("DELETE FROM repository_config WHERE repository_id = $1")
+                .bind(member_id)
+                .execute(&fx.pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM virtual_repo_members WHERE member_repo_id = $1")
+                .bind(member_id)
+                .execute(&fx.pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(member_id)
+                .execute(&fx.pool)
+                .await;
+        }
+        fx.teardown().await;
+    }
+
     // -----------------------------------------------------------------------
     // Extracted pure functions (test-only)
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1225,6 +1225,175 @@ async fn fetch_npm_artifacts(
         .collect())
 }
 
+// ---------------------------------------------------------------------------
+// npm scope policy (#2327)
+// ---------------------------------------------------------------------------
+
+/// `repository_config` key holding the JSON array of allowed npm scopes.
+pub(crate) const NPM_ALLOWED_SCOPES_KEY: &str = "npm_allowed_scopes";
+/// `repository_config` key holding the unscoped-package toggle ("true"/"false").
+pub(crate) const NPM_ALLOW_UNSCOPED_KEY: &str = "npm_allow_unscoped";
+
+/// Parsed shape of an npm package name for scope-policy evaluation.
+#[derive(Debug, PartialEq, Eq)]
+enum NpmNameShape<'a> {
+    /// `@scope/name` — carries the `@scope` part (including the `@`).
+    Scoped(&'a str),
+    /// Plain `name` with no scope.
+    Unscoped,
+    /// Not a well-formed npm package name (e.g. `@scope` without a name,
+    /// `@/x`, or an empty string).
+    Invalid,
+}
+
+/// Split an npm package name into its scope-policy-relevant shape.
+fn npm_name_shape(package_name: &str) -> NpmNameShape<'_> {
+    if package_name.is_empty() {
+        return NpmNameShape::Invalid;
+    }
+    let Some(rest) = package_name.strip_prefix('@') else {
+        return NpmNameShape::Unscoped;
+    };
+    match rest.split_once('/') {
+        Some((scope, name)) if !scope.is_empty() && !name.is_empty() && !name.contains('/') => {
+            NpmNameShape::Scoped(&package_name[..scope.len() + 1])
+        }
+        _ => NpmNameShape::Invalid,
+    }
+}
+
+/// Validate an npm scope literal (`@scope`) for the policy allow-list.
+///
+/// npm scope names follow the same character rules as package names: ASCII
+/// lowercase letters, digits, `-`, `_` and `.`, not starting with `.` or `_`,
+/// and at most 214 characters. Callers normalise to lowercase before
+/// validating, so uppercase input is accepted but stored case-folded.
+pub(crate) fn is_valid_npm_scope(scope: &str) -> bool {
+    let Some(rest) = scope.strip_prefix('@') else {
+        return false;
+    };
+    !rest.is_empty()
+        && rest.len() <= 214
+        && !rest.starts_with('.')
+        && !rest.starts_with('_')
+        && rest
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_' | '.'))
+}
+
+/// Per-repository npm name-namespace policy (#2327).
+///
+/// Stored in `repository_config` (`npm_allowed_scopes` = JSON array,
+/// `npm_allow_unscoped` = bool) for Remote repositories. Virtual candidate
+/// selection consults the policy before proxying a package name to a Remote
+/// member. A repository with no stored policy is unrestricted (default
+/// behaviour unchanged).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct NpmScopePolicy {
+    /// Allowed `@scope` values, case-folded to lowercase. Empty = no scope
+    /// restriction.
+    pub(crate) allowed_scopes: Vec<String>,
+    /// Whether unscoped package names may be resolved through this
+    /// repository. `None` = not configured; treated as "deny" once the
+    /// policy is otherwise active (fail-closed) and "allow" otherwise.
+    pub(crate) allow_unscoped: Option<bool>,
+}
+
+impl NpmScopePolicy {
+    /// A policy participates in filtering iff an allow-list is present or
+    /// unscoped resolution was explicitly switched off.
+    pub(crate) fn is_active(&self) -> bool {
+        !self.allowed_scopes.is_empty() || self.allow_unscoped == Some(false)
+    }
+
+    /// Whether `package_name` may be resolved through the repository this
+    /// policy belongs to. Inactive policies allow everything; active
+    /// policies fail closed on malformed names.
+    pub(crate) fn allows(&self, package_name: &str) -> bool {
+        if !self.is_active() {
+            return true;
+        }
+        match npm_name_shape(package_name) {
+            NpmNameShape::Scoped(scope) => {
+                self.allowed_scopes.is_empty()
+                    || self
+                        .allowed_scopes
+                        .iter()
+                        .any(|allowed| allowed == &scope.to_ascii_lowercase())
+            }
+            NpmNameShape::Unscoped => self.allow_unscoped == Some(true),
+            NpmNameShape::Invalid => false,
+        }
+    }
+}
+
+/// Batch-load the npm scope policies for a set of member repositories in a
+/// single query. Repositories with no stored policy are absent from the map
+/// (treated as unrestricted). Mirrors the runtime-query style of
+/// `fetch_pypi_upstream_index_path` (no compile-time sqlx macro) so offline
+/// `cargo check` needs no prepared query data.
+async fn fetch_npm_scope_policies(
+    db: &PgPool,
+    repo_ids: &[uuid::Uuid],
+) -> std::collections::HashMap<uuid::Uuid, NpmScopePolicy> {
+    let mut policies: std::collections::HashMap<uuid::Uuid, NpmScopePolicy> =
+        std::collections::HashMap::new();
+    if repo_ids.is_empty() {
+        return policies;
+    }
+    let rows: Vec<(uuid::Uuid, String, String)> = sqlx::query_as(
+        "SELECT repository_id, key, value FROM repository_config \
+         WHERE repository_id = ANY($1) AND key IN ($2, $3)",
+    )
+    .bind(repo_ids)
+    .bind(NPM_ALLOWED_SCOPES_KEY)
+    .bind(NPM_ALLOW_UNSCOPED_KEY)
+    .fetch_all(db)
+    .await
+    .unwrap_or_default();
+
+    for (repo_id, key, value) in rows {
+        let policy = policies.entry(repo_id).or_default();
+        if key == NPM_ALLOWED_SCOPES_KEY {
+            policy.allowed_scopes = serde_json::from_str::<Vec<String>>(&value)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|s| s.to_ascii_lowercase())
+                .collect();
+        } else if key == NPM_ALLOW_UNSCOPED_KEY {
+            policy.allow_unscoped = value.parse::<bool>().ok();
+        }
+    }
+    policies
+}
+
+/// Fetch the npm scope policy for a single repository. Returns the default
+/// (inactive, unrestricted) policy when nothing is configured.
+pub(crate) async fn fetch_npm_scope_policy(db: &PgPool, repo_id: uuid::Uuid) -> NpmScopePolicy {
+    fetch_npm_scope_policies(db, &[repo_id])
+        .await
+        .remove(&repo_id)
+        .unwrap_or_default()
+}
+
+/// Whether a virtual-repo member may serve as a candidate for
+/// `package_name`. Only Remote members are subject to the scope policy;
+/// Local/Staging members (and members with no stored policy) are always
+/// eligible. Pure so the loop wiring is unit-testable without network/DB.
+fn npm_member_eligible(
+    member_repo_type: &RepositoryType,
+    policy: Option<&NpmScopePolicy>,
+    package_name: &str,
+) -> bool {
+    if member_repo_type != &RepositoryType::Remote {
+        return true;
+    }
+    match policy {
+        Some(p) => p.allows(package_name),
+        None => true,
+    }
+}
+
 /// Return the package metadata: the full packument, or the abbreviated document
 /// when the client requests it.
 async fn get_package_metadata(
@@ -1281,6 +1450,10 @@ async fn get_package_metadata(
             );
         }
 
+        // Batch-load per-member npm scope policies once per request (#2327).
+        let member_ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
+        let scope_policies = fetch_npm_scope_policies(&state.db, &member_ids).await;
+
         for member in &members {
             // For Local/Staging members, query artifacts from the DB.
             if member.repo_type == RepositoryType::Local
@@ -1303,6 +1476,19 @@ async fn get_package_metadata(
 
             // For Remote members, proxy metadata from upstream.
             if member.repo_type != RepositoryType::Remote {
+                continue;
+            }
+            // Honour the member's npm scope policy before proxying (#2327).
+            if !npm_member_eligible(
+                &member.repo_type,
+                scope_policies.get(&member.id),
+                package_name,
+            ) {
+                debug!(
+                    member_key = %member.key,
+                    package = %package_name,
+                    "npm virtual member skipped by scope policy"
+                );
                 continue;
             }
             let Some(ref upstream_url) = member.upstream_url else {
@@ -1488,6 +1674,10 @@ async fn fetch_virtual_packument(
         );
     }
 
+    // Batch-load per-member npm scope policies once per request (#2327).
+    let member_ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
+    let scope_policies = fetch_npm_scope_policies(&state.db, &member_ids).await;
+
     for member in &members {
         if member.repo_type == RepositoryType::Local || member.repo_type == RepositoryType::Staging
         {
@@ -1519,6 +1709,19 @@ async fn fetch_virtual_packument(
         }
 
         if member.repo_type != RepositoryType::Remote {
+            continue;
+        }
+        // Honour the member's npm scope policy before proxying (#2327).
+        if !npm_member_eligible(
+            &member.repo_type,
+            scope_policies.get(&member.id),
+            package_name,
+        ) {
+            debug!(
+                member_key = %member.key,
+                package = %package_name,
+                "npm virtual member skipped by scope policy"
+            );
             continue;
         }
         let Some(ref upstream_url) = member.upstream_url else {
@@ -2878,6 +3081,148 @@ fn respond_with_packument(value: serde_json::Value, want_abbreviated: bool) -> R
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // npm scope policy (#2327)
+    // -----------------------------------------------------------------------
+
+    fn policy(scopes: &[&str], allow_unscoped: Option<bool>) -> NpmScopePolicy {
+        NpmScopePolicy {
+            allowed_scopes: scopes.iter().map(|s| s.to_string()).collect(),
+            allow_unscoped,
+        }
+    }
+
+    #[test]
+    fn npm_name_shape_classifies_names() {
+        assert_eq!(
+            npm_name_shape("@types/node"),
+            NpmNameShape::Scoped("@types")
+        );
+        assert_eq!(npm_name_shape("lodash"), NpmNameShape::Unscoped);
+        assert_eq!(npm_name_shape(""), NpmNameShape::Invalid);
+        assert_eq!(npm_name_shape("@types"), NpmNameShape::Invalid);
+        assert_eq!(npm_name_shape("@/node"), NpmNameShape::Invalid);
+        assert_eq!(npm_name_shape("@types/"), NpmNameShape::Invalid);
+        assert_eq!(npm_name_shape("@a/b/c"), NpmNameShape::Invalid);
+    }
+
+    #[test]
+    fn scope_policy_allow_list_without_unscoped() {
+        let p = policy(&["@types"], Some(false));
+        assert!(p.is_active());
+        assert!(p.allows("@types/node"));
+        assert!(!p.allows("@partner/x"));
+        assert!(!p.allows("lodash"));
+    }
+
+    #[test]
+    fn scope_policy_allow_list_with_unscoped() {
+        let p = policy(&["@types"], Some(true));
+        assert!(p.is_active());
+        assert!(p.allows("lodash"));
+        assert!(p.allows("@types/node"));
+        assert!(!p.allows("@partner/x"));
+    }
+
+    #[test]
+    fn scope_policy_default_allows_everything() {
+        let p = NpmScopePolicy::default();
+        assert!(!p.is_active());
+        assert!(p.allows("lodash"));
+        assert!(p.allows("@anything/x"));
+        // Even a malformed name passes through an inactive policy: legacy
+        // behaviour is preserved bit-for-bit when nothing is configured.
+        assert!(p.allows("@broken"));
+    }
+
+    #[test]
+    fn scope_policy_explicit_allow_unscoped_true_only_is_inactive() {
+        // {allowed_scopes: [], allow_unscoped: true} places no restriction.
+        let p = policy(&[], Some(true));
+        assert!(!p.is_active());
+        assert!(p.allows("lodash"));
+        assert!(p.allows("@anything/x"));
+    }
+
+    #[test]
+    fn scope_policy_unscoped_only_restriction() {
+        // Empty allow-list + explicit unscoped=false: any scope is fine,
+        // unscoped names are not.
+        let p = policy(&[], Some(false));
+        assert!(p.is_active());
+        assert!(p.allows("@anything/x"));
+        assert!(!p.allows("lodash"));
+    }
+
+    #[test]
+    fn scope_policy_unscoped_unset_fails_closed_when_active() {
+        // Allow-list present but allow_unscoped never configured: unscoped
+        // resolution is denied (fail-closed).
+        let p = policy(&["@types"], None);
+        assert!(p.is_active());
+        assert!(p.allows("@types/node"));
+        assert!(!p.allows("lodash"));
+    }
+
+    #[test]
+    fn scope_policy_match_is_case_insensitive() {
+        // Loader case-folds stored scopes; the requested name may still
+        // arrive in mixed case.
+        let p = policy(&["@types"], Some(false));
+        assert!(p.allows("@Types/Node"));
+        assert!(p.allows("@TYPES/node"));
+    }
+
+    #[test]
+    fn scope_policy_malformed_name_denied_when_active() {
+        let p = policy(&["@types"], Some(true));
+        assert!(!p.allows("@types"));
+        assert!(!p.allows("@/x"));
+        assert!(!p.allows(""));
+    }
+
+    #[test]
+    fn npm_scope_literal_validation() {
+        assert!(is_valid_npm_scope("@types"));
+        assert!(is_valid_npm_scope("@my-org.sub_team"));
+        assert!(!is_valid_npm_scope("types"));
+        assert!(!is_valid_npm_scope("@"));
+        assert!(!is_valid_npm_scope("@Types")); // callers lowercase first
+        assert!(!is_valid_npm_scope("@.hidden"));
+        assert!(!is_valid_npm_scope("@_private"));
+        assert!(!is_valid_npm_scope("@sc/ope"));
+        assert!(!is_valid_npm_scope(&format!("@{}", "a".repeat(215))));
+    }
+
+    #[test]
+    fn member_eligibility_only_gates_remote_members() {
+        let restrictive = policy(&["@types"], Some(false));
+        // Remote member with an active policy: filtered by name.
+        assert!(npm_member_eligible(
+            &RepositoryType::Remote,
+            Some(&restrictive),
+            "@types/node"
+        ));
+        assert!(!npm_member_eligible(
+            &RepositoryType::Remote,
+            Some(&restrictive),
+            "lodash"
+        ));
+        // Remote member with no stored policy: always eligible.
+        assert!(npm_member_eligible(&RepositoryType::Remote, None, "lodash"));
+        // Local/Staging members are never subject to the scope policy.
+        assert!(npm_member_eligible(
+            &RepositoryType::Local,
+            Some(&restrictive),
+            "lodash"
+        ));
+        assert!(npm_member_eligible(
+            &RepositoryType::Staging,
+            Some(&restrictive),
+            "lodash"
+        ));
+    }
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (test-only)

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -391,6 +391,11 @@ pub fn router() -> Router<SharedState> {
         )
         // Cache TTL configuration for proxy/remote repositories
         .route("/:key/cache-ttl", put(set_cache_ttl).get(get_cache_ttl))
+        // npm scope policy for Remote members of npm virtual repositories (#2327)
+        .route(
+            "/:key/npm-scope-policy",
+            put(set_npm_scope_policy).get(get_npm_scope_policy),
+        )
         // Cache invalidation for a specific path on a Remote (proxy) repository
         // (#1539). POST keeps the action explicit; the underlying
         // `ProxyService::invalidate_cache` is idempotent so a second call for
@@ -929,6 +934,205 @@ pub async fn get_cache_ttl(
     Ok(Json(CacheTtlResponse {
         repository_key: key,
         cache_ttl_seconds: ttl,
+    }))
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct SetNpmScopePolicyRequest {
+    /// npm scopes (each starting with `@`) that may be resolved through this
+    /// repository. An empty list places no scope restriction.
+    pub allowed_scopes: Vec<String>,
+    /// Whether unscoped package names may be resolved through this
+    /// repository. Defaults to `false` when an allow-list is submitted.
+    #[serde(default)]
+    pub allow_unscoped: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct NpmScopePolicyResponse {
+    pub repository_key: String,
+    pub allowed_scopes: Vec<String>,
+    pub allow_unscoped: bool,
+    /// Whether the stored policy actually restricts anything. `false` means
+    /// virtual resolution treats this repository as unrestricted.
+    pub active: bool,
+}
+
+/// Reject npm scope-policy writes against repositories whose resolution code
+/// path will never read the value back. Only Remote members of npm virtual
+/// repositories consume the policy (#2327); writing it for Local, Virtual or
+/// Staging repos — or non-npm formats — produces dead state with no consumer.
+fn is_npm_scope_policy_configurable(
+    repo_type: &RepositoryType,
+    format: &RepositoryFormat,
+) -> Result<()> {
+    if repo_type != &RepositoryType::Remote {
+        return Err(AppError::Validation(
+            "npm scope policy is only configurable on remote (proxy) repositories".to_string(),
+        ));
+    }
+    if format != &RepositoryFormat::Npm {
+        return Err(AppError::Validation(
+            "npm scope policy is only configurable on npm-format repositories".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Set the npm scope policy for a Remote repository (#2327).
+///
+/// Mirrors the auth + repo-access pattern of `set_cache_ttl`: candidate
+/// selection for virtual npm resolution is a supply-chain control on the same
+/// administrative tier, so non-admins need `repository:admin` on the target.
+#[utoipa::path(
+    put,
+    path = "/{key}/npm-scope-policy",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+    ),
+    request_body = SetNpmScopePolicyRequest,
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "npm scope policy updated", body = NpmScopePolicyResponse),
+        (status = 400, description = "Validation error (e.g. non-remote repo or invalid scope)"),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn set_npm_scope_policy(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(key): Path<String>,
+    Json(payload): Json<SetNpmScopePolicyRequest>,
+) -> Result<Json<NpmScopePolicyResponse>> {
+    let auth = require_auth(auth)?;
+    auth.require_scope("write")?;
+
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+    require_repo_write_access(&auth, &repo, &service).await?;
+
+    // Fine-grained permission check: non-admins need "admin" on the target
+    // repository (mirrors `set_cache_ttl`; the global-admin bypass is
+    // preserved).
+    if !auth.is_admin {
+        let has_perm = state
+            .permission_service
+            .check_permission(auth.user_id, "repository", repo.id, "admin", false)
+            .await?;
+        if !has_perm {
+            return Err(AppError::Authorization(
+                "Insufficient permissions to change the npm scope policy of this repository"
+                    .to_string(),
+            ));
+        }
+    }
+
+    is_npm_scope_policy_configurable(&repo.repo_type, &repo.format)?;
+
+    // Normalise and validate the allow-list: lowercase (matching is
+    // case-insensitive), dedupe, and require each entry to be a well-formed
+    // `@scope` literal.
+    let mut allowed_scopes: Vec<String> = payload
+        .allowed_scopes
+        .iter()
+        .map(|s| s.trim().to_ascii_lowercase())
+        .collect();
+    allowed_scopes.sort();
+    allowed_scopes.dedup();
+    for scope in &allowed_scopes {
+        if !crate::api::handlers::npm::is_valid_npm_scope(scope) {
+            return Err(AppError::Validation(format!(
+                "Invalid npm scope '{}': scopes must start with '@' followed by \
+                 lowercase letters, digits, '-', '_' or '.' (not leading '.'/'_')",
+                scope
+            )));
+        }
+    }
+
+    let scopes_json = serde_json::to_string(&allowed_scopes)
+        .map_err(|e| AppError::Internal(format!("Failed to serialize scope list: {}", e)))?;
+    upsert_repo_config(
+        &state.db,
+        repo.id,
+        crate::api::handlers::npm::NPM_ALLOWED_SCOPES_KEY,
+        &scopes_json,
+    )
+    .await?;
+    upsert_repo_config(
+        &state.db,
+        repo.id,
+        crate::api::handlers::npm::NPM_ALLOW_UNSCOPED_KEY,
+        if payload.allow_unscoped {
+            "true"
+        } else {
+            "false"
+        },
+    )
+    .await?;
+
+    let active = !allowed_scopes.is_empty() || !payload.allow_unscoped;
+    Ok(Json(NpmScopePolicyResponse {
+        repository_key: key,
+        allowed_scopes,
+        allow_unscoped: payload.allow_unscoped,
+        active,
+    }))
+}
+
+/// Get the npm scope policy for a repository (#2327).
+///
+/// Same administrative tier as the write path: the policy is an
+/// administrative supply-chain control, so reads require `repository:admin`
+/// (or global admin) as well.
+#[utoipa::path(
+    get,
+    path = "/{key}/npm-scope-policy",
+    context_path = "/api/v1/repositories",
+    tag = "repositories",
+    params(
+        ("key" = String, Path, description = "Repository key"),
+    ),
+    security(("bearer_auth" = [])),
+    responses(
+        (status = 200, description = "Current npm scope policy", body = NpmScopePolicyResponse),
+        (status = 401, description = "Authentication required"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+pub async fn get_npm_scope_policy(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<Option<AuthExtension>>,
+    Path(key): Path<String>,
+) -> Result<Json<NpmScopePolicyResponse>> {
+    let auth = require_auth(auth)?;
+    auth.require_scope("read")?;
+
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+
+    if !auth.is_admin {
+        let has_perm = state
+            .permission_service
+            .check_permission(auth.user_id, "repository", repo.id, "admin", false)
+            .await?;
+        if !has_perm {
+            return Err(AppError::Authorization(
+                "Insufficient permissions to read the npm scope policy of this repository"
+                    .to_string(),
+            ));
+        }
+    }
+
+    let policy = crate::api::handlers::npm::fetch_npm_scope_policy(&state.db, repo.id).await;
+    let active = policy.is_active();
+    Ok(Json(NpmScopePolicyResponse {
+        repository_key: key,
+        allow_unscoped: policy.allow_unscoped.unwrap_or(!active),
+        allowed_scopes: policy.allowed_scopes,
+        active,
     }))
 }
 
@@ -6030,6 +6234,8 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         update_repository,
         delete_repository,
         set_cache_ttl,
+        set_npm_scope_policy,
+        get_npm_scope_policy,
         list_pypi_tracks,
         put_pypi_track,
         delete_pypi_track,
@@ -6059,6 +6265,8 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         RepositoryListResponse,
         SetCacheTtlRequest,
         CacheTtlResponse,
+        SetNpmScopePolicyRequest,
+        NpmScopePolicyResponse,
         InvalidateCacheQuery,
         InvalidateCacheResponse,
         PypiTrackRequest,

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -10003,6 +10003,281 @@ mod tests {
         tdh::cleanup(&pool, repo_id, user_id).await;
     }
 
+    // -----------------------------------------------------------------------
+    // npm scope policy handlers (#2327) — DB-backed
+    // -----------------------------------------------------------------------
+
+    /// Drive `set_npm_scope_policy` through its real extractor types.
+    async fn put_npm_policy(
+        state: SharedState,
+        ext: Option<AuthExtension>,
+        key: &str,
+        scopes: &[&str],
+        allow_unscoped: bool,
+    ) -> Result<Json<NpmScopePolicyResponse>> {
+        set_npm_scope_policy(
+            State(state),
+            Extension(ext),
+            Path(key.to_string()),
+            Json(SetNpmScopePolicyRequest {
+                allowed_scopes: scopes.iter().map(|s| s.to_string()).collect(),
+                allow_unscoped,
+            }),
+        )
+        .await
+    }
+
+    /// Drive `get_npm_scope_policy` through its real extractor types.
+    async fn get_npm_policy(
+        state: SharedState,
+        ext: Option<AuthExtension>,
+        key: &str,
+    ) -> Result<Json<NpmScopePolicyResponse>> {
+        get_npm_scope_policy(State(state), Extension(ext), Path(key.to_string())).await
+    }
+
+    /// DB-backed: PUT persists a normalised policy into `repository_config`
+    /// and GET round-trips it; the empty/default read reports an inactive,
+    /// unrestricted policy; re-PUTting an unrestricted policy deactivates it.
+    /// Skips when no `DATABASE_URL` is configured.
+    #[tokio::test]
+    async fn npm_scope_policy_put_get_round_trip_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "npm").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let admin = AuthExtension {
+            is_admin: true,
+            ..tdh::make_auth(user_id, &username)
+        };
+
+        // Default case: nothing stored yet -> inactive and unrestricted.
+        let default = get_npm_policy(state.clone(), Some(admin.clone()), &key)
+            .await
+            .expect("GET default policy")
+            .0;
+        assert!(default.allowed_scopes.is_empty());
+        assert!(default.allow_unscoped, "default must report unrestricted");
+        assert!(!default.active);
+
+        // PUT: mixed case + duplicate scopes are lowercased and deduped.
+        let put = put_npm_policy(
+            state.clone(),
+            Some(admin.clone()),
+            &key,
+            &["@Types", "@types", "@partner"],
+            false,
+        )
+        .await
+        .expect("PUT policy")
+        .0;
+        assert_eq!(put.allowed_scopes, vec!["@partner", "@types"]);
+        assert!(!put.allow_unscoped);
+        assert!(put.active);
+
+        // GET round-trips the stored policy.
+        let got = get_npm_policy(state.clone(), Some(admin.clone()), &key)
+            .await
+            .expect("GET stored policy")
+            .0;
+        assert_eq!(got.allowed_scopes, vec!["@partner", "@types"]);
+        assert!(!got.allow_unscoped);
+        assert!(got.active);
+
+        // The rows landed in repository_config under the documented keys.
+        let stored: Vec<(String, String)> = sqlx::query_as(
+            "SELECT key, value FROM repository_config \
+             WHERE repository_id = $1 AND key IN ('npm_allowed_scopes', 'npm_allow_unscoped') \
+             ORDER BY key",
+        )
+        .bind(repo_id)
+        .fetch_all(&pool)
+        .await
+        .expect("read repository_config");
+        assert_eq!(
+            stored,
+            vec![
+                ("npm_allow_unscoped".to_string(), "false".to_string()),
+                (
+                    "npm_allowed_scopes".to_string(),
+                    "[\"@partner\",\"@types\"]".to_string()
+                ),
+            ]
+        );
+
+        // Re-PUT an unrestricted policy: upsert path + deactivation.
+        let cleared = put_npm_policy(state.clone(), Some(admin.clone()), &key, &[], true)
+            .await
+            .expect("PUT unrestricted policy")
+            .0;
+        assert!(!cleared.active);
+        let reread = get_npm_policy(state, Some(admin), &key)
+            .await
+            .expect("GET cleared policy")
+            .0;
+        assert!(reread.allowed_scopes.is_empty());
+        assert!(reread.allow_unscoped);
+        assert!(!reread.active);
+
+        // Cleanup.
+        let _ = sqlx::query("DELETE FROM repository_config WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    /// DB-backed: the npm scope policy endpoints sit on the same
+    /// administrative tier as `set_cache_ttl` — anonymous callers get an
+    /// authentication error, a non-admin with plain write access is denied,
+    /// and a `repository:admin` grant (or global admin) lets them through.
+    /// Skips when no `DATABASE_URL` is configured.
+    #[tokio::test]
+    async fn npm_scope_policy_requires_repo_admin_grant_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "npm").await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let ext = tdh::make_auth(user_id, &username);
+
+        // Anonymous: authentication error on both verbs.
+        let anon_put = put_npm_policy(state.clone(), None, &key, &["@types"], false).await;
+        assert!(
+            matches!(anon_put, Err(AppError::Authentication(_))),
+            "anonymous PUT must fail authentication: {anon_put:?}"
+        );
+        let anon_get = get_npm_policy(state.clone(), None, &key).await;
+        assert!(
+            matches!(anon_get, Err(AppError::Authentication(_))),
+            "anonymous GET must fail authentication: {anon_get:?}"
+        );
+
+        // Non-admin with developer (write) access but no repository:admin.
+        let denied_put =
+            put_npm_policy(state.clone(), Some(ext.clone()), &key, &["@types"], false).await;
+        assert!(
+            matches!(denied_put, Err(AppError::Authorization(_))),
+            "PUT without repository:admin must be denied: {denied_put:?}"
+        );
+        let denied_get = get_npm_policy(state, Some(ext.clone()), &key).await;
+        assert!(
+            matches!(denied_get, Err(AppError::Authorization(_))),
+            "GET without repository:admin must be denied: {denied_get:?}"
+        );
+
+        // Grant repository:admin; a fresh state avoids the per-process
+        // permission cache from the deny lookups above.
+        sqlx::query(
+            "INSERT INTO permissions (principal_type, principal_id, target_type, target_id, actions) \
+             VALUES ('user', $1, 'repository', $2, ARRAY['admin'])",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("grant repository:admin");
+        let state2 = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let allowed_put =
+            put_npm_policy(state2.clone(), Some(ext.clone()), &key, &["@types"], false).await;
+        assert!(
+            allowed_put.is_ok(),
+            "non-admin WITH repository:admin must be allowed to PUT: {allowed_put:?}"
+        );
+        let allowed_get = get_npm_policy(state2, Some(ext), &key).await;
+        assert!(
+            allowed_get.is_ok(),
+            "non-admin WITH repository:admin must be allowed to GET: {allowed_get:?}"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query("DELETE FROM permissions WHERE principal_id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repository_config WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    /// DB-backed: writes are rejected with a validation error on non-Remote
+    /// repositories, on non-npm formats, and for malformed scope literals —
+    /// the value would otherwise be dead state with no consumer (#2327).
+    /// Skips when no `DATABASE_URL` is configured.
+    #[tokio::test]
+    async fn npm_scope_policy_rejects_unconsumable_targets_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (local_id, local_key, dir) = tdh::create_repo(&pool, "local", "npm").await;
+        let (maven_id, maven_key, _) = tdh::create_repo(&pool, "remote", "maven").await;
+        let (npm_id, npm_key, _) = tdh::create_repo(&pool, "remote", "npm").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let admin = AuthExtension {
+            is_admin: true,
+            ..tdh::make_auth(user_id, &username)
+        };
+
+        // Non-Remote repo type: rejected before any write.
+        let non_remote =
+            put_npm_policy(state.clone(), Some(admin.clone()), &local_key, &[], false).await;
+        match non_remote {
+            Err(AppError::Validation(msg)) => {
+                assert!(msg.contains("remote"), "unexpected message: {msg}")
+            }
+            other => panic!("expected Validation error for non-remote repo, got: {other:?}"),
+        }
+
+        // Remote but non-npm format: rejected.
+        let non_npm =
+            put_npm_policy(state.clone(), Some(admin.clone()), &maven_key, &[], false).await;
+        match non_npm {
+            Err(AppError::Validation(msg)) => {
+                assert!(msg.contains("npm-format"), "unexpected message: {msg}")
+            }
+            other => panic!("expected Validation error for non-npm format, got: {other:?}"),
+        }
+
+        // Malformed scope literal (no leading '@'): rejected with the scope
+        // named in the message; nothing is persisted.
+        let bad_scope = put_npm_policy(state, Some(admin), &npm_key, &["types"], false).await;
+        match bad_scope {
+            Err(AppError::Validation(msg)) => {
+                assert!(
+                    msg.contains("Invalid npm scope 'types'"),
+                    "unexpected message: {msg}"
+                )
+            }
+            other => panic!("expected Validation error for bad scope, got: {other:?}"),
+        }
+        let leftover: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM repository_config \
+             WHERE repository_id = $1 AND key IN ('npm_allowed_scopes', 'npm_allow_unscoped')",
+        )
+        .bind(npm_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count repository_config");
+        assert_eq!(leftover, 0, "rejected PUT must not persist anything");
+
+        // Cleanup.
+        tdh::cleanup(&pool, local_id, user_id).await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = ANY($1)")
+            .bind(vec![maven_id, npm_id])
+            .execute(&pool)
+            .await;
+    }
+
     /// #2321 G2 (write): the generic REST `upload_artifact` handler enforces the
     /// fine-grained `write` action AFTER the tenant gate. A read-only grantee on
     /// a rules-bearing private repo is DENIED; adding `write` lets them through;


### PR DESCRIPTION
## Summary

Adds an optional, admin-defined npm scope allow-list per Remote repository that npm virtual resolution honors before querying that member. Closes #2327.

Today the npm virtual member loops (packument metadata and version metadata) forward every requested package name to every Remote member, so an administrator cannot express "this broad public remote should only serve `@types/*`" at the server. This PR adds:

- **`NpmScopePolicy`** (`npm.rs`): a pure, unit-tested policy value (`allowed_scopes` + `allow_unscoped`) with `allows()`/`is_active()` and an npm name-shape parser. Matching is case-insensitive; malformed names are denied once a policy is active (fail-closed); a repository with no stored policy is unrestricted, so **default behavior is unchanged bit-for-bit**.
- **Storage** in the existing `repository_config` KV table (`npm_allowed_scopes` = JSON array, `npm_allow_unscoped` = bool). No migration, no `Repository` struct change. Loader uses runtime `sqlx::query_as` (no prepared-query data needed) and batch-loads all member policies in one query per request.
- **Enforcement** only in the two virtual candidate-selection loops (`get_package_metadata` virtual branch and `fetch_virtual_packument`), via a pure `npm_member_eligible()` helper applied strictly after the existing `repo_type != Remote` skip. Local/Staging members and the local-ownership isolation from #1217/#2311 are untouched. Skips emit a `debug!` trace (`npm virtual member skipped by scope policy`).
- **Admin API** (`repositories.rs`): `PUT`/`GET /api/v1/repositories/{key}/npm-scope-policy`, mirroring the `cache-ttl` handlers — auth + tenant write gate + `repository:admin` for non-admins (global-admin bypass preserved), Remote-only and npm-format-only writes, scope-literal validation (`@` + lowercase npm name characters), utoipa-annotated and registered.

Deferred scope (tarball/download path, direct-remote enforcement, glob patterns, create-time config + UI, cross-format generalization) is tracked in #2424.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated — 11 new table-driven tests covering `allows()`/`is_active()` (allow-list with/without unscoped, empty/default policy, unscoped-only restriction, unset-unscoped fail-closed, case-insensitive match, malformed-name denial), name-shape parsing, scope-literal validation, and `npm_member_eligible` (Remote gated; Local/Staging and no-policy members always eligible)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — on an isolated stack: policy `{allowed_scopes:["@types"], allow_unscoped:false}` on a Remote member of a virtual: `GET /npm/<virtual>/lodash` → 404 (member skipped), `GET /npm/<virtual>/@types%2fnode` → 200, packument version path `GET /npm/<virtual>/@types/node/24.0.0` → 200 and `.../lodash/4.17.21` → 404; a second virtual with a no-policy remote resolves `lodash` → 200 (default unchanged); `GET .../npm-scope-policy` returns the stored policy; PUT on a virtual repo → 400; invalid scope literal → 400; anonymous PUT → 401
- [x] No regressions in existing tests — full backend lib suite: 12765 passed, 0 failed (DB-backed tests run against a migrated throwaway Postgres); `cargo fmt --check` and `cargo clippy --lib --tests -- -D warnings` clean

## API Changes

- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes
