### PR TITLE
chore(release): v1.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-07-12
+
+Security hotfix: closes a token-exchange privilege-escalation where a scope-restricted API token could be exchanged (via docker-login `/v2/token` or Conan `users/authenticate`) into an unrestricted JWT — a read-only token could gain write/delete. Also completes the GHSA-vvc3 write-scope enforcement on the eight remaining format publish handlers.
+
 ### Security
 
 - **Token-exchange no longer launders away an API token's action-scope ceiling** (#2430): a JWT minted in exchange for an API token (Conan `users/authenticate`, OCI `/v2/token` docker-login, Bearer/JWT-as-password swaps, and refresh rotation) now carries the presenting token's action-scope allowlist on a new `Claims.scopes` claim. `AuthExtension::has_scope` keys the decision on that inherited ceiling rather than on `is_api_token`, so a read-only token can no longer be exchanged into a write/delete-capable credential. Interactive password/TOTP logins and federated CI-OIDC continue to mint action-unrestricted tokens (`scopes: None` ⇒ full), and the download-ticket path (`scopes: Some([])`) still denies. Complements the repo-scope ceiling from #2290.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.5.1"
+version = "1.5.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.5.1",
+        version = "1.5.2",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Security hotfix release **v1.5.2**. Bumps version 1.5.1 → 1.5.2 and promotes the CHANGELOG.

Fixes: **#2430** (CRITICAL — token-exchange action-scope laundering: read-only API token → unrestricted JWT via docker-login `/v2/token` or Conan `users/authenticate`) + **#2417** (GHSA-vvc3 write-scope on the 8 remaining format publish handlers). Both validated through the full loop (unit + e2e + pool + red-team + company personas).

Release-mechanics PR — labeled `no-issue-required`.