### PR TITLE
feat(composer): allow version and name override on upload

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -12,11 +12,11 @@
 //!   PUT  /composer/{repo_key}/api/packages                            - Upload/register package
 //!   POST /composer/{repo_key}/api/packages                            - Upload/register package
 //!
-//! Uploads accept optional `?version=X` and `?name=vendor/pkg` query overrides
-//! (#1717). When provided, the override values become the canonical name/version
-//! stored in the DB and served to clients; the uploaded archive is stored
-//! byte-for-byte and the original `composer.json` is preserved verbatim in the
-//! nested metadata. Immutability still keys off the effective name+version.
+//! Uploads accept optional `?version=X` and `?name=vendor/pkg` query overrides.
+//! When provided, the override values become the canonical name/version stored
+//! in the DB and served to clients; the uploaded archive is stored byte-for-byte
+//! and the original `composer.json` is preserved verbatim in the nested
+//! metadata. Immutability still keys off the effective name+version.
 
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
@@ -1334,7 +1334,7 @@ async fn search(
 // PUT/POST /composer/{repo_key}/api/packages - Upload/register package
 // ---------------------------------------------------------------------------
 
-/// Optional query-parameter overrides for Composer uploads (#1717).
+/// Optional query-parameter overrides for Composer uploads.
 ///
 /// `version` and `name` override the values read from `composer.json` inside
 /// the uploaded archive. Both are optional; omitting either preserves the
@@ -1375,10 +1375,9 @@ async fn upload(
             .into_response()
     })?;
 
-    // Resolve the canonical package name. A `?name=` override (#1717) is
-    // validated strictly against the official Composer name regex; otherwise
-    // the name is taken from composer.json with the existing loose
-    // `vendor/package` check (preserving backward compatibility).
+    // Resolve the canonical package name. A `?name=` override takes
+    // precedence over the name in composer.json; either way the value is
+    // validated with the official Composer name regex.
     let full_name: String = match query.name.as_deref() {
         Some(n) => {
             crate::formats::composer::validate_composer_name(n).map_err(|e| {
@@ -1391,21 +1390,16 @@ async fn upload(
             n.to_string()
         }
         None => {
-            let n = &composer_json.name;
-            if !n.contains('/') {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid package name '{n}': must be in vendor/package format"),
-                )
-                    .into_response());
-            }
-            n.clone()
+            crate::formats::composer::validate_composer_name(&composer_json.name)
+                .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
+            composer_json.name.clone()
         }
     };
 
-    // Resolve the canonical version. A `?version=` override (#1717) is
-    // validated strictly against Composer's version grammar; otherwise the
-    // version is taken from composer.json, falling back to `dev-main`.
+    // Resolve the canonical version. A `?version=` override takes precedence
+    // over the version in composer.json; either way the value is validated
+    // with Composer's version grammar. When neither is present, fall back to
+    // `dev-main`.
     let version: String = match query.version.as_deref() {
         Some(v) => {
             crate::formats::composer::validate_composer_version(v).map_err(|e| {
@@ -1417,11 +1411,14 @@ async fn upload(
             })?;
             v.to_string()
         }
-        None => composer_json
-            .version
-            .as_deref()
-            .unwrap_or("dev-main")
-            .to_string(),
+        None => match composer_json.version.as_deref() {
+            Some(v) => {
+                crate::formats::composer::validate_composer_version(v)
+                    .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
+                v.to_string()
+            }
+            None => "dev-main".to_string(),
+        },
     };
 
     // Compute SHA256
@@ -3144,10 +3141,10 @@ mod upload_db_tests {
     }
 
     // -----------------------------------------------------------------------
-    // #1717: optional `?version=` and `?name=` query overrides on the upload
-    // endpoint. The override values become the canonical name+version stored
-    // in the DB and returned to the client; the archive is stored untouched
-    // and immutability still keys off the effective name+version. These tests
+    // Optional `?version=` and `?name=` query overrides on the upload endpoint.
+    // The override values become the canonical name+version stored in the DB
+    // and returned to the client; the archive is stored untouched and
+    // immutability still keys off the effective name+version. These tests
     // no-op without `DATABASE_URL` (CI provides one).
     // -----------------------------------------------------------------------
 
@@ -3157,7 +3154,7 @@ mod upload_db_tests {
             return;
         };
         // composer.json carries 0.0.1; the override must win.
-        let zip = build_composer_zip("acme/widget", "0.0.1", "version override (#1717)");
+        let zip = build_composer_zip("acme/widget", "0.0.1", "version override");
         let app = f.router_with_auth(super::router());
         let req = put_composer(format!("/{}/api/packages?version=2.0.0", f.repo_key), zip);
         let (status, body) = tdh::send(app, req).await;
@@ -3202,7 +3199,7 @@ mod upload_db_tests {
             return;
         };
         // composer.json carries old/pkg; the override must win.
-        let zip = build_composer_zip("old/pkg", "1.0.0", "name override (#1717)");
+        let zip = build_composer_zip("old/pkg", "1.0.0", "name override");
         let app = f.router_with_auth(super::router());
         let req = put_composer(format!("/{}/api/packages?name=new/pkg", f.repo_key), zip);
         let (status, body) = tdh::send(app, req).await;
@@ -3251,7 +3248,7 @@ mod upload_db_tests {
             return;
         };
         // composer.json carries old/pkg @ 0.0.1; both overrides must win.
-        let zip = build_composer_zip("old/pkg", "0.0.1", "both overrides (#1717)");
+        let zip = build_composer_zip("old/pkg", "0.0.1", "both overrides");
         let app = f.router_with_auth(super::router());
         let req = put_composer(
             format!(
@@ -3287,7 +3284,7 @@ mod upload_db_tests {
         let Some(f) = tdh::Fixture::setup("local", "composer").await else {
             return;
         };
-        let zip = build_composer_zip("acme/widget", "0.0.1", "conflict (#1717)");
+        let zip = build_composer_zip("acme/widget", "0.0.1", "conflict");
 
         // First upload with override succeeds.
         let app = f.router_with_auth(super::router());
@@ -3324,7 +3321,7 @@ mod upload_db_tests {
         let Some(f) = tdh::Fixture::setup("local", "composer").await else {
             return;
         };
-        let zip = build_composer_zip("acme/widget", "0.0.1", "invalid version (#1717)");
+        let zip = build_composer_zip("acme/widget", "0.0.1", "invalid version");
         let app = f.router_with_auth(super::router());
         let req = put_composer(format!("/{}/api/packages?version=../bad", f.repo_key), zip);
         let (status, body) = tdh::send(app, req).await;
@@ -3356,7 +3353,7 @@ mod upload_db_tests {
         let Some(f) = tdh::Fixture::setup("local", "composer").await else {
             return;
         };
-        let zip = build_composer_zip("acme/widget", "0.0.1", "invalid name (#1717)");
+        let zip = build_composer_zip("acme/widget", "0.0.1", "invalid name");
         let app = f.router_with_auth(super::router());
         let req = put_composer(format!("/{}/api/packages?name=NoSlash", f.repo_key), zip);
         let (status, body) = tdh::send(app, req).await;
@@ -3377,6 +3374,76 @@ mod upload_db_tests {
         assert_eq!(
             count.0, 0,
             "no artifact should be stored when an override is rejected"
+        );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // The name and version read from composer.json are validated with the same
+    // helpers as query overrides, so an invalid archive-derived value is
+    // rejected even when no override is supplied.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_with_invalid_name_in_composer_json_returns_400() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // Name lacks the required vendor/package slash; no override supplied.
+        let zip = build_composer_zip("no-slash", "1.0.0", "invalid archive name");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid name in composer.json must 400: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::bigint FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query artifacts after rejected name");
+        assert_eq!(
+            count.0, 0,
+            "no artifact should be stored when the archive name is invalid"
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_invalid_version_in_composer_json_returns_400() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // Version is not a valid Composer version; no override supplied.
+        let zip = build_composer_zip("acme/widget", "not-a-version", "invalid archive version");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid version in composer.json must 400: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::bigint FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query artifacts after rejected version");
+        assert_eq!(
+            count.0, 0,
+            "no artifact should be stored when the archive version is invalid"
         );
 
         f.teardown().await;

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1375,9 +1375,15 @@ async fn upload(
             .into_response()
     })?;
 
-    // Resolve the canonical package name. A `?name=` override takes
-    // precedence over the name in composer.json; either way the value is
-    // validated with the official Composer name regex.
+    // The name in composer.json is always validated, even when a `?name=`
+    // override is supplied: the archive's own name is preserved verbatim in
+    // the nested metadata, so a malformed archive name must be rejected
+    // regardless of any override.
+    crate::formats::composer::validate_composer_name(&composer_json.name)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
+
+    // Resolve the canonical package name. A `?name=` override takes precedence
+    // over the (already-validated) name in composer.json.
     let full_name: String = match query.name.as_deref() {
         Some(n) => {
             crate::formats::composer::validate_composer_name(n).map_err(|e| {
@@ -1389,17 +1395,20 @@ async fn upload(
             })?;
             n.to_string()
         }
-        None => {
-            crate::formats::composer::validate_composer_name(&composer_json.name)
-                .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
-            composer_json.name.clone()
-        }
+        None => composer_json.name.clone(),
     };
 
+    // The version in composer.json is always validated when present, even when
+    // a `?version=` override is supplied — same rationale as the name above
+    // (the archive's version is preserved in the nested metadata).
+    if let Some(v) = composer_json.version.as_deref() {
+        crate::formats::composer::validate_composer_version(v)
+            .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
+    }
+
     // Resolve the canonical version. A `?version=` override takes precedence
-    // over the version in composer.json; either way the value is validated
-    // with Composer's version grammar. When neither is present, fall back to
-    // `dev-main`.
+    // over the (already-validated) version in composer.json; when neither is
+    // present, fall back to `dev-main`.
     let version: String = match query.version.as_deref() {
         Some(v) => {
             crate::formats::composer::validate_composer_version(v).map_err(|e| {
@@ -1411,14 +1420,11 @@ async fn upload(
             })?;
             v.to_string()
         }
-        None => match composer_json.version.as_deref() {
-            Some(v) => {
-                crate::formats::composer::validate_composer_version(v)
-                    .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
-                v.to_string()
-            }
-            None => "dev-main".to_string(),
-        },
+        None => composer_json
+            .version
+            .as_deref()
+            .unwrap_or("dev-main")
+            .to_string(),
     };
 
     // Compute SHA256
@@ -3445,6 +3451,78 @@ mod upload_db_tests {
             count.0, 0,
             "no artifact should be stored when the archive version is invalid"
         );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // The name and version read from composer.json are validated even when a
+    // valid override is supplied for them: a malformed archive value is still
+    // rejected because it is preserved verbatim in the nested metadata.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_with_invalid_archive_name_and_name_override_returns_400() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // Archive name is invalid ("no-slash") even though a valid override is
+        // supplied — the archive name must still be rejected.
+        let zip = build_composer_zip("no-slash", "1.0.0", "invalid archive name with override");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(
+            format!("/{}/api/packages?name=acme/widget", f.repo_key),
+            zip,
+        );
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid archive name must 400 even with a name override: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::bigint FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query artifacts after rejected archive name");
+        assert_eq!(count.0, 0, "no artifact should be stored");
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_invalid_archive_version_and_version_override_returns_400() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // Archive version is invalid even though a valid override is supplied.
+        let zip = build_composer_zip(
+            "acme/widget",
+            "not-a-version",
+            "invalid archive version with override",
+        );
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages?version=2.0.0", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid archive version must 400 even with a version override: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::bigint FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query artifacts after rejected archive version");
+        assert_eq!(count.0, 0, "no artifact should be stored");
 
         f.teardown().await;
     }

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -11,6 +11,12 @@
 //!   GET  /composer/{repo_key}/search.json?q=query                     - Search packages
 //!   PUT  /composer/{repo_key}/api/packages                            - Upload/register package
 //!   POST /composer/{repo_key}/api/packages                            - Upload/register package
+//!
+//! Uploads accept optional `?version=X` and `?name=vendor/pkg` query overrides
+//! (#1717). When provided, the override values become the canonical name/version
+//! stored in the DB and served to clients; the uploaded archive is stored
+//! byte-for-byte and the original `composer.json` is preserved verbatim in the
+//! nested metadata. Immutability still keys off the effective name+version.
 
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
@@ -1328,10 +1334,24 @@ async fn search(
 // PUT/POST /composer/{repo_key}/api/packages - Upload/register package
 // ---------------------------------------------------------------------------
 
+/// Optional query-parameter overrides for Composer uploads (#1717).
+///
+/// `version` and `name` override the values read from `composer.json` inside
+/// the uploaded archive. Both are optional; omitting either preserves the
+/// existing (archive-derived) behavior. Override values are validated strictly
+/// (Composer version grammar / official name regex) and stored as the canonical
+/// name+version; the uploaded archive itself is never modified.
+#[derive(serde::Deserialize)]
+struct ComposerUploadQuery {
+    version: Option<String>,
+    name: Option<String>,
+}
+
 async fn upload(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(repo_key): Path<String>,
+    Query(query): Query<ComposerUploadQuery>,
     body: Bytes,
 ) -> Result<Response, Response> {
     // Authenticate
@@ -1355,24 +1375,54 @@ async fn upload(
             .into_response()
     })?;
 
-    // Validate package name has vendor/package format
-    let full_name = &composer_json.name;
-    if !full_name.contains('/') {
-        return Err((
-            StatusCode::BAD_REQUEST,
-            format!(
-                "Invalid package name '{}': must be in vendor/package format",
-                full_name
-            ),
-        )
-            .into_response());
-    }
+    // Resolve the canonical package name. A `?name=` override (#1717) is
+    // validated strictly against the official Composer name regex; otherwise
+    // the name is taken from composer.json with the existing loose
+    // `vendor/package` check (preserving backward compatibility).
+    let full_name: String = match query.name.as_deref() {
+        Some(n) => {
+            crate::formats::composer::validate_composer_name(n).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid package name override: {e}"),
+                )
+                    .into_response()
+            })?;
+            n.to_string()
+        }
+        None => {
+            let n = &composer_json.name;
+            if !n.contains('/') {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid package name '{n}': must be in vendor/package format"),
+                )
+                    .into_response());
+            }
+            n.clone()
+        }
+    };
 
-    let version = composer_json
-        .version
-        .as_deref()
-        .unwrap_or("dev-main")
-        .to_string();
+    // Resolve the canonical version. A `?version=` override (#1717) is
+    // validated strictly against Composer's version grammar; otherwise the
+    // version is taken from composer.json, falling back to `dev-main`.
+    let version: String = match query.version.as_deref() {
+        Some(v) => {
+            crate::formats::composer::validate_composer_version(v).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid version override: {e}"),
+                )
+                    .into_response()
+            })?;
+            v.to_string()
+        }
+        None => composer_json
+            .version
+            .as_deref()
+            .unwrap_or("dev-main")
+            .to_string(),
+    };
 
     // Compute SHA256
     let mut hasher = Sha256::new();
@@ -1496,7 +1546,7 @@ async fn upload(
         pkg_svc
             .try_create_or_update_from_artifact(
                 repo.id,
-                full_name,
+                &full_name,
                 &version,
                 size_bytes,
                 &sha256,
@@ -3088,6 +3138,245 @@ mod upload_db_tests {
             size > 0,
             "size_bytes must be the archive length the handler passed, got {}",
             size
+        );
+
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #1717: optional `?version=` and `?name=` query overrides on the upload
+    // endpoint. The override values become the canonical name+version stored
+    // in the DB and returned to the client; the archive is stored untouched
+    // and immutability still keys off the effective name+version. These tests
+    // no-op without `DATABASE_URL` (CI provides one).
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn upload_with_version_override_stores_override_version() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // composer.json carries 0.0.1; the override must win.
+        let zip = build_composer_zip("acme/widget", "0.0.1", "version override (#1717)");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages?version=2.0.0", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "override upload must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        // Response reports the override version.
+        let resp: serde_json::Value =
+            serde_json::from_slice(&body).expect("parse override upload response");
+        assert_eq!(
+            resp["version"], "2.0.0",
+            "response must echo the override version"
+        );
+        assert_eq!(resp["package"], "acme/widget");
+
+        // The artifact row carries the override version, not 0.0.1.
+        let row: Option<(String,)> = sqlx::query_as(
+            "SELECT version FROM artifacts \
+             WHERE repository_id = $1 AND name = $2 AND is_deleted = false",
+        )
+        .bind(f.repo_id)
+        .bind("acme/widget")
+        .fetch_optional(&f.pool)
+        .await
+        .expect("query artifacts");
+        let (ver,) = row.expect("artifact row must exist after override upload");
+        assert_eq!(
+            ver, "2.0.0",
+            "override version must be stored, not composer.json's 0.0.1"
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_name_override_stores_override_name() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // composer.json carries old/pkg; the override must win.
+        let zip = build_composer_zip("old/pkg", "1.0.0", "name override (#1717)");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages?name=new/pkg", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "override upload must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        // The override name is stored under new/pkg, not old/pkg.
+        let new_row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::bigint FROM artifacts \
+             WHERE repository_id = $1 AND name = $2 AND is_deleted = false",
+        )
+        .bind(f.repo_id)
+        .bind("new/pkg")
+        .fetch_one(&f.pool)
+        .await
+        .expect("query artifacts for override name");
+        assert_eq!(
+            new_row.0, 1,
+            "override name 'new/pkg' must be stored, not composer.json's 'old/pkg'"
+        );
+
+        let old_row: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*)::bigint FROM artifacts \
+             WHERE repository_id = $1 AND name = $2",
+        )
+        .bind(f.repo_id)
+        .bind("old/pkg")
+        .fetch_one(&f.pool)
+        .await
+        .expect("query artifacts for composer.json name");
+        assert_eq!(
+            old_row.0, 0,
+            "composer.json name 'old/pkg' must not be stored when a name override is given"
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_both_overrides_stores_override_name_and_version() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        // composer.json carries old/pkg @ 0.0.1; both overrides must win.
+        let zip = build_composer_zip("old/pkg", "0.0.1", "both overrides (#1717)");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(
+            format!(
+                "/{}/api/packages?version=3.0.0&name=acme/widget",
+                f.repo_key
+            ),
+            zip,
+        );
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "override upload must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let row: (String, String) = sqlx::query_as(
+            "SELECT name, version FROM artifacts \
+             WHERE repository_id = $1 AND is_deleted = false",
+        )
+        .bind(f.repo_id)
+        .fetch_one(&f.pool)
+        .await
+        .expect("query artifacts for both-overrides upload");
+        assert_eq!(row.0, "acme/widget", "override name must be stored");
+        assert_eq!(row.1, "3.0.0", "override version must be stored");
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_version_override_conflict_returns_409() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        let zip = build_composer_zip("acme/widget", "0.0.1", "conflict (#1717)");
+
+        // First upload with override succeeds.
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(
+            format!("/{}/api/packages?version=2.0.0", f.repo_key),
+            zip.clone(),
+        );
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "first override upload must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        // Re-upload with the same override name+version must 409 (immutability
+        // now keys off the effective override name+version).
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages?version=2.0.0", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::CONFLICT,
+            "re-upload with same override version must 409: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_invalid_version_override_returns_400() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        let zip = build_composer_zip("acme/widget", "0.0.1", "invalid version (#1717)");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages?version=../bad", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid version override must 400: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        // No artifact should have been stored.
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::bigint FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query artifacts after rejected override");
+        assert_eq!(
+            count.0, 0,
+            "no artifact should be stored when an override is rejected"
+        );
+
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upload_with_invalid_name_override_returns_400() {
+        let Some(f) = tdh::Fixture::setup("local", "composer").await else {
+            return;
+        };
+        let zip = build_composer_zip("acme/widget", "0.0.1", "invalid name (#1717)");
+        let app = f.router_with_auth(super::router());
+        let req = put_composer(format!("/{}/api/packages?name=NoSlash", f.repo_key), zip);
+        let (status, body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "invalid name override must 400: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*)::bigint FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query artifacts after rejected override");
+        assert_eq!(
+            count.0, 0,
+            "no artifact should be stored when an override is rejected"
         );
 
         f.teardown().await;

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -186,37 +186,38 @@ impl FormatHandler for ComposerHandler {
 }
 
 // ---------------------------------------------------------------------------
-// Validation helpers for upload overrides (#1717)
+// Validation helpers for Composer name and version values.
 //
-// Composer has no `composer publish` command; private registries accept uploads
-// over HTTP. Issue #1717 adds optional `?version=` and `?name=` query overrides
-// to the upload endpoint. These pure functions validate override values against
-// Composer's documented grammar so invalid input is rejected with a 400 before
-// any storage or DB write occurs. They deliberately use `std::result::Result`
-// (not `crate::error::Result`) because the override errors are surfaced as
-// plain 400 messages, not `AppError`s.
+// These pure functions validate package name and version values supplied to the
+// upload endpoint — either as `?name=` / `?version=` query overrides or read
+// directly from `composer.json` — against Composer's documented grammar, so
+// invalid input is rejected with a 400 before any storage or DB write occurs.
+// They use `std::result::Result` (not `crate::error::Result`) because the
+// errors are surfaced as plain 400 messages, not `AppError`s.
 // ---------------------------------------------------------------------------
 
-/// Maximum length for a Composer version override, matching the
-/// `artifacts.version` column (`VARCHAR(255)`).
+/// Maximum length for a Composer version, matching the `artifacts.version`
+/// column (`VARCHAR(255)`).
 const MAX_COMPOSER_VERSION_LEN: usize = 255;
 
-/// Maximum length for a Composer package-name override, matching the
-/// `artifacts.name` column (`VARCHAR(512)`).
+/// Maximum length for a Composer package name, matching the `artifacts.name`
+/// column (`VARCHAR(512)`).
 const MAX_COMPOSER_NAME_LEN: usize = 512;
 
 /// Compiled regex for Composer version strings (case-insensitive).
 ///
-/// Accepts Composer's documented version grammar:
-/// - Semver-ish: `v?X.Y[.Z[.W]]` (2-4 numeric components) with an optional
-///   stability suffix (`-dev`, `-patch`/`-p`, `-alpha`/`-a`, `-beta`/`-b`,
-///   `-RC`/`-rc`, `-stable`), each optionally followed by a number.
+/// Implements the version grammar documented by Composer at
+/// <https://getcomposer.org/doc/articles/versions.md> and
+/// <https://getcomposer.org/doc/04-schema.md#version>:
+/// - Semver: `v?X.Y[.Z[.W]]` (1-4 numeric components) with an optional
+///   dot-separated pre-release suffix (`-<id>(.<id>)*`, e.g. `-alpha.1`,
+///   `-RC1`, `-patch`) and optional build metadata (`+<id>(.<id>)*`).
 /// - Branch versions: `dev-<branch>` (e.g. `dev-main`, `dev-feature-x`).
 fn composer_version_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r"(?i)^(dev-[a-z0-9][a-z0-9._-]*|v?\d+(\.\d+){1,3}(-(dev|patch|p|alpha|a|beta|b|rc|stable)\d*)?)$",
+            r"(?i)^(dev-[a-z0-9][a-z0-9._-]*|v?\d+(\.\d+){0,3}(-([0-9a-z-]+(\.[0-9a-z-]+)*))?(\+([0-9a-z-]+(\.[0-9a-z-]+)*))?)$",
         )
         .expect("composer version regex must compile")
     })
@@ -233,11 +234,13 @@ fn composer_name_regex() -> &'static Regex {
     })
 }
 
-/// Validate a Composer version override (Issue #1717).
+/// Validate a Composer version string.
 ///
-/// Accepts the full Composer version grammar (semver with stability suffixes
-/// and `dev-<branch>` forms). Rejects empty input, values exceeding 255
-/// characters, path separators (`/`, `\`), `..`, and null/control characters.
+/// Returns `Ok(())` if `version` matches Composer's version grammar, or an
+/// `Err` describing why it is invalid. Used for both `?version=` query
+/// overrides and the `version` field read from `composer.json`. Rejects empty
+/// input, values exceeding 255 characters, path separators (`/`, `\`), `..`,
+/// and null/control characters.
 pub fn validate_composer_version(version: &str) -> std::result::Result<(), String> {
     if version.is_empty() {
         return Err("version must not be empty".to_string());
@@ -265,11 +268,13 @@ pub fn validate_composer_version(version: &str) -> std::result::Result<(), Strin
     Ok(())
 }
 
-/// Validate a Composer package-name override (Issue #1717).
+/// Validate a Composer package name.
 ///
-/// Uses the official Composer name regex (lowercase `vendor/package`). Also
-/// rejects empty input, values exceeding 512 characters, and null/control
-/// characters.
+/// Returns `Ok(())` if `name` matches the official Composer name regex
+/// (`vendor/package`, lowercase), or an `Err` describing why it is invalid.
+/// Used for both `?name=` query overrides and the `name` field read from
+/// `composer.json`. Also rejects empty input, values exceeding 512 characters,
+/// and null/control characters.
 pub fn validate_composer_name(name: &str) -> std::result::Result<(), String> {
     if name.is_empty() {
         return Err("package name must not be empty".to_string());
@@ -285,7 +290,7 @@ pub fn validate_composer_name(name: &str) -> std::result::Result<(), String> {
     }
     if !composer_name_regex().is_match(name) {
         return Err(format!(
-            "package name '{name}' is not a valid Composer package name; expected lowercase 'vendor/package' form"
+            "package name '{name}' is not a valid Composer package name; expected lowercase 'vendor/package' form (e.g. 'monolog/monolog')"
         ));
     }
     Ok(())
@@ -701,7 +706,7 @@ mod tests {
         }
     }
 
-    // ---- validate_composer_version (#1717) ----
+    // ---- validate_composer_version ----
 
     #[test]
     fn test_validate_composer_version_valid() {
@@ -716,6 +721,11 @@ mod tests {
             "1.0.0-beta",
             "1.0.0-dev",
             "1.0.0-stable",
+            // Dot-separated pre-release identifiers and build metadata (semver).
+            "1.0.0-rc.1",
+            "1.0.0-alpha.1.beta",
+            "1.0.0+build.5",
+            "1.0.0-alpha.1+build",
             "dev-main",
             "dev-feature-x",
             "dev-1.2",
@@ -766,7 +776,7 @@ mod tests {
         assert!(validate_composer_version("1.0.0\0bad").is_err());
     }
 
-    // ---- validate_composer_name (#1717) ----
+    // ---- validate_composer_name ----
 
     #[test]
     fn test_validate_composer_name_valid() {

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -209,15 +209,18 @@ const MAX_COMPOSER_NAME_LEN: usize = 512;
 /// Implements the version grammar documented by Composer at
 /// <https://getcomposer.org/doc/articles/versions.md> and
 /// <https://getcomposer.org/doc/04-schema.md#version>:
-/// - Semver: `v?X.Y[.Z[.W]]` (1-4 numeric components) with an optional
-///   dot-separated pre-release suffix (`-<id>(.<id>)*`, e.g. `-alpha.1`,
-///   `-RC1`, `-patch`) and optional build metadata (`+<id>(.<id>)*`).
+/// - Semver: `v?X.Y[.Z[.W]]` where the first component is numeric and each
+///   subsequent component is numeric or a wildcard (`x`/`*`), with an
+///   optional dot-separated pre-release suffix (`-<id>(.<id>)*`, e.g.
+///   `-alpha.1`, `-RC1`, `-dev`) and optional build metadata
+///   (`+<id>(.<id>)*`). Wildcard components cover Composer branch-alias
+///   versions (e.g. `1.0.x-dev`, `1.2.*-dev`).
 /// - Branch versions: `dev-<branch>` (e.g. `dev-main`, `dev-feature-x`).
 fn composer_version_regex() -> &'static Regex {
     static RE: OnceLock<Regex> = OnceLock::new();
     RE.get_or_init(|| {
         Regex::new(
-            r"(?i)^(dev-[a-z0-9][a-z0-9._-]*|v?\d+(\.\d+){0,3}(-([0-9a-z-]+(\.[0-9a-z-]+)*))?(\+([0-9a-z-]+(\.[0-9a-z-]+)*))?)$",
+            r"(?i)^(dev-[a-z0-9][a-z0-9._-]*|v?\d+(\.(\d+|[x*])){0,3}(-([0-9a-z-]+(\.[0-9a-z-]+)*))?(\+([0-9a-z-]+(\.[0-9a-z-]+)*))?)$",
         )
         .expect("composer version regex must compile")
     })
@@ -257,7 +260,7 @@ pub fn validate_composer_version(version: &str) -> std::result::Result<(), Strin
     if version.contains("..") {
         return Err("version must not contain '..'".to_string());
     }
-    if version.bytes().any(|b| b == 0 || b.is_ascii_control()) {
+    if version.bytes().any(|b| b.is_ascii_control()) {
         return Err("version must not contain null or control characters".to_string());
     }
     if !composer_version_regex().is_match(version) {
@@ -285,7 +288,7 @@ pub fn validate_composer_name(name: &str) -> std::result::Result<(), String> {
             name.len()
         ));
     }
-    if name.bytes().any(|b| b == 0 || b.is_ascii_control()) {
+    if name.bytes().any(|b| b.is_ascii_control()) {
         return Err("package name must not contain null or control characters".to_string());
     }
     if !composer_name_regex().is_match(name) {
@@ -726,6 +729,11 @@ mod tests {
             "1.0.0-alpha.1.beta",
             "1.0.0+build.5",
             "1.0.0-alpha.1+build",
+            // Branch-alias versions with `x`/`*` wildcard components.
+            "1.0.x-dev",
+            "1.2.*-dev",
+            "1.x-dev",
+            "1.0.x",
             "dev-main",
             "dev-feature-x",
             "dev-1.2",
@@ -749,6 +757,10 @@ mod tests {
             ("1.0.0 trailing", "embedded space"),
             ("not-a-version", "garbage"),
             ("v", "bare v prefix"),
+            // Wildcards are only valid as a non-first semver component.
+            ("*", "bare wildcard"),
+            ("x", "bare x wildcard"),
+            ("*.x-dev", "leading wildcard"),
         ];
         for (v, label) in invalid {
             assert!(

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -5,8 +5,10 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use crate::error::{AppError, Result};
 use crate::formats::FormatHandler;
@@ -181,6 +183,112 @@ impl FormatHandler for ComposerHandler {
         // packages.json is generated on demand from DB state
         Ok(None)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers for upload overrides (#1717)
+//
+// Composer has no `composer publish` command; private registries accept uploads
+// over HTTP. Issue #1717 adds optional `?version=` and `?name=` query overrides
+// to the upload endpoint. These pure functions validate override values against
+// Composer's documented grammar so invalid input is rejected with a 400 before
+// any storage or DB write occurs. They deliberately use `std::result::Result`
+// (not `crate::error::Result`) because the override errors are surfaced as
+// plain 400 messages, not `AppError`s.
+// ---------------------------------------------------------------------------
+
+/// Maximum length for a Composer version override, matching the
+/// `artifacts.version` column (`VARCHAR(255)`).
+const MAX_COMPOSER_VERSION_LEN: usize = 255;
+
+/// Maximum length for a Composer package-name override, matching the
+/// `artifacts.name` column (`VARCHAR(512)`).
+const MAX_COMPOSER_NAME_LEN: usize = 512;
+
+/// Compiled regex for Composer version strings (case-insensitive).
+///
+/// Accepts Composer's documented version grammar:
+/// - Semver-ish: `v?X.Y[.Z[.W]]` (2-4 numeric components) with an optional
+///   stability suffix (`-dev`, `-patch`/`-p`, `-alpha`/`-a`, `-beta`/`-b`,
+///   `-RC`/`-rc`, `-stable`), each optionally followed by a number.
+/// - Branch versions: `dev-<branch>` (e.g. `dev-main`, `dev-feature-x`).
+fn composer_version_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(
+            r"(?i)^(dev-[a-z0-9][a-z0-9._-]*|v?\d+(\.\d+){1,3}(-(dev|patch|p|alpha|a|beta|b|rc|stable)\d*)?)$",
+        )
+        .expect("composer version regex must compile")
+    })
+}
+
+/// The official Composer package-name regex from the composer.json schema docs
+/// (<https://getcomposer.org/doc/04-schema.md#name>). Case-sensitive: Composer
+/// package names are lowercase `vendor/package`.
+fn composer_name_regex() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"^[a-z0-9]([_.-]?[a-z0-9]+)*/[a-z0-9](([_.]|-{1,2})?[a-z0-9]+)*$")
+            .expect("composer name regex must compile")
+    })
+}
+
+/// Validate a Composer version override (Issue #1717).
+///
+/// Accepts the full Composer version grammar (semver with stability suffixes
+/// and `dev-<branch>` forms). Rejects empty input, values exceeding 255
+/// characters, path separators (`/`, `\`), `..`, and null/control characters.
+pub fn validate_composer_version(version: &str) -> std::result::Result<(), String> {
+    if version.is_empty() {
+        return Err("version must not be empty".to_string());
+    }
+    if version.len() > MAX_COMPOSER_VERSION_LEN {
+        return Err(format!(
+            "version must not exceed {MAX_COMPOSER_VERSION_LEN} characters (got {})",
+            version.len()
+        ));
+    }
+    if version.contains('/') || version.contains('\\') {
+        return Err("version must not contain path separators ('/' or '\\')".to_string());
+    }
+    if version.contains("..") {
+        return Err("version must not contain '..'".to_string());
+    }
+    if version.bytes().any(|b| b == 0 || b.is_ascii_control()) {
+        return Err("version must not contain null or control characters".to_string());
+    }
+    if !composer_version_regex().is_match(version) {
+        return Err(format!(
+            "version '{version}' is not a valid Composer version; expected a semver form like '1.0.0' or a dev-branch like 'dev-main'"
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a Composer package-name override (Issue #1717).
+///
+/// Uses the official Composer name regex (lowercase `vendor/package`). Also
+/// rejects empty input, values exceeding 512 characters, and null/control
+/// characters.
+pub fn validate_composer_name(name: &str) -> std::result::Result<(), String> {
+    if name.is_empty() {
+        return Err("package name must not be empty".to_string());
+    }
+    if name.len() > MAX_COMPOSER_NAME_LEN {
+        return Err(format!(
+            "package name must not exceed {MAX_COMPOSER_NAME_LEN} characters (got {})",
+            name.len()
+        ));
+    }
+    if name.bytes().any(|b| b == 0 || b.is_ascii_control()) {
+        return Err("package name must not contain null or control characters".to_string());
+    }
+    if !composer_name_regex().is_match(name) {
+        return Err(format!(
+            "package name '{name}' is not a valid Composer package name; expected lowercase 'vendor/package' form"
+        ));
+    }
+    Ok(())
 }
 
 /// Composer path info
@@ -591,5 +699,130 @@ mod tests {
                 absent
             );
         }
+    }
+
+    // ---- validate_composer_version (#1717) ----
+
+    #[test]
+    fn test_validate_composer_version_valid() {
+        let valid = [
+            "1.0.0",
+            "v1.2.3",
+            "1.0",
+            "1.0.0.4",
+            "1.0.0-alpha3",
+            "1.0.0-RC1",
+            "1.0.0-p1",
+            "1.0.0-beta",
+            "1.0.0-dev",
+            "1.0.0-stable",
+            "dev-main",
+            "dev-feature-x",
+            "dev-1.2",
+        ];
+        for v in valid {
+            assert!(
+                validate_composer_version(v).is_ok(),
+                "expected '{v}' to be a valid Composer version"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_composer_version_invalid() {
+        let invalid = [
+            ("", "empty string"),
+            ("../bad", "path traversal"),
+            ("a/b", "forward slash"),
+            ("a\\b", "backslash"),
+            ("1.0.0..0", "double dot"),
+            ("1.0.0 trailing", "embedded space"),
+            ("not-a-version", "garbage"),
+            ("v", "bare v prefix"),
+        ];
+        for (v, label) in invalid {
+            assert!(
+                validate_composer_version(v).is_err(),
+                "expected '{v}' ({label}) to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_composer_version_length_boundary() {
+        // Exactly 255 chars of a valid dev-branch form is accepted.
+        let exactly_255 = format!("dev-{}", "a".repeat(251));
+        assert_eq!(exactly_255.len(), 255);
+        assert!(validate_composer_version(&exactly_255).is_ok());
+
+        // 256 chars is rejected by the length guard.
+        let too_long = format!("dev-{}", "a".repeat(252));
+        assert_eq!(too_long.len(), 256);
+        assert!(validate_composer_version(&too_long).is_err());
+    }
+
+    #[test]
+    fn test_validate_composer_version_rejects_null_byte() {
+        assert!(validate_composer_version("1.0.0\0bad").is_err());
+    }
+
+    // ---- validate_composer_name (#1717) ----
+
+    #[test]
+    fn test_validate_composer_name_valid() {
+        let valid = [
+            "monolog/monolog",
+            "igorw/event-source",
+            "psr/log",
+            "aws/aws-sdk-php-v2",
+            "vendor/pkg.sub",
+            "vendor/pkg_sub",
+            "vendor/pkg--x",
+        ];
+        for n in valid {
+            assert!(
+                validate_composer_name(n).is_ok(),
+                "expected '{n}' to be a valid Composer package name"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_composer_name_invalid() {
+        let invalid = [
+            ("no-slash", "missing slash"),
+            ("UPPER/case", "uppercase vendor"),
+            ("has space/pkg", "embedded space"),
+            ("../etc", "path traversal"),
+            ("vendor//pkg", "double slash"),
+            ("vendor/UPPER", "uppercase package"),
+            ("-leading/pkg", "leading dash in vendor"),
+            ("vendor/-leading", "leading dash in package"),
+            ("vendor/pkg!", "special character"),
+        ];
+        for (n, label) in invalid {
+            assert!(
+                validate_composer_name(n).is_err(),
+                "expected '{n}' ({label}) to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_validate_composer_name_length_boundary() {
+        // Exactly 512 chars of a valid form is accepted.
+        let exactly_512 = format!("{}/{}", "a".repeat(254), "b".repeat(257));
+        assert_eq!(exactly_512.len(), 512);
+        assert!(validate_composer_name(&exactly_512).is_ok());
+
+        // 513 chars is rejected by the length guard.
+        let too_long = format!("{}/{}", "a".repeat(256), "b".repeat(256));
+        assert_eq!(too_long.len(), 513);
+        assert!(validate_composer_name(&too_long).is_err());
+    }
+
+    #[test]
+    fn test_validate_composer_name_rejects_null_byte() {
+        assert!(validate_composer_name("vendor/pk\0g").is_err());
     }
 }


### PR DESCRIPTION
Closes #1717

## Summary
Add optional `?version=` and `?name=vendor/pkg` query-parameter overrides to the Composer upload endpoint (`PUT/POST /composer/{repo_key}/api/packages`).

When an override is provided it becomes the **canonical** name/version stored in the `artifacts` table and served to clients. The uploaded zip archive is stored **byte-for-byte** (never modified), and the original `composer.json` is preserved verbatim inside the nested `composer` metadata object — matching how Artifactory, Nexus, and Cloudsmith handle overrides (override stored separately, archive untouched).

Both the override values **and** the name/version read from `composer.json` are validated with the same helpers before any storage/DB write:

- `version` — Composer's documented version grammar (semver `v?X.Y[.Z[.W]]` with dot-separated pre-release and build metadata, plus `dev-<branch>` forms); rejects path separators, `..`, null/control chars, and >255 chars.
- `name` — the official Composer name regex (lowercase `vendor/package`); rejects missing slash, uppercase, spaces, special chars, and >512 chars.

Immutability is unchanged: duplicate detection and soft-delete cleanup key off the **effective** (override) name+version, so re-publishing the same name+version still returns `409 Conflict`. No migration is required — `artifacts.name` (`VARCHAR(512)`) and `artifacts.version` (`VARCHAR(255)`) are already sufficient.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
