### PR TITLE
fix(quality): enforce repo access on artifact-scoped quality-check reads

### DIFF
--- a/backend/src/api/handlers/quality_gates.rs
+++ b/backend/src/api/handlers/quality_gates.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::artifacts::check_artifact_visibility;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -400,7 +401,7 @@ impl From<crate::models::quality::QualityGateViolation> for GateViolationRespons
 )]
 async fn get_artifact_health(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(artifact_id): Path<Uuid>,
 ) -> Result<Json<ArtifactHealthResponse>> {
     let qc_service = QualityCheckService::new(state.db.clone());
@@ -409,6 +410,10 @@ async fn get_artifact_health(
         .get_artifact_health(artifact_id)
         .await?
         .ok_or_else(|| AppError::NotFound("No health score found for artifact".to_string()))?;
+    // Cross-repo authorization: the caller must be allowed to see this
+    // artifact's repository (token scope + admin bypass + private-repo
+    // membership), else existence-hiding NotFound (#2437).
+    check_artifact_visibility(&Some(auth), artifact_id, &state.db).await?;
     let checks = qc_service.list_checks(artifact_id).await?;
 
     let check_summaries: Vec<CheckSummary> = checks
@@ -673,12 +678,24 @@ async fn trigger_checks(
 )]
 async fn list_checks(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListChecksQuery>,
 ) -> Result<Json<Vec<CheckResponse>>> {
     let artifact_id = query.artifact_id.ok_or_else(|| {
         AppError::Validation("artifact_id query parameter is required".to_string())
     })?;
+    // Resolve existence first so a nonexistent artifact 404s uniformly with a
+    // no-access one (mirrors get_artifact), then enforce cross-repo
+    // authorization before returning any check metadata (#2437).
+    let _repo_id: Uuid = sqlx::query_scalar(
+        "SELECT repository_id FROM artifacts WHERE id = $1 AND is_deleted = false",
+    )
+    .bind(artifact_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?
+    .ok_or_else(|| AppError::NotFound("Artifact not found".to_string()))?;
+    check_artifact_visibility(&Some(auth), artifact_id, &state.db).await?;
     let qc_service = QualityCheckService::new(state.db.clone());
     let checks = qc_service.list_checks(artifact_id).await?;
     let response: Vec<CheckResponse> = checks.into_iter().map(CheckResponse::from).collect();
@@ -758,11 +775,14 @@ pub fn admin_router() -> Router<SharedState> {
 )]
 async fn get_check(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<CheckResponse>> {
     let qc_service = QualityCheckService::new(state.db.clone());
     let check = qc_service.get_check(id).await?;
+    // Enforce cross-repo authorization on the check's artifact before
+    // returning any check metadata (#2437).
+    check_artifact_visibility(&Some(auth), check.artifact_id, &state.db).await?;
     Ok(Json(CheckResponse::from(check)))
 }
 
@@ -782,10 +802,14 @@ async fn get_check(
 )]
 async fn list_check_issues(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(check_id): Path<Uuid>,
 ) -> Result<Json<Vec<IssueResponse>>> {
     let qc_service = QualityCheckService::new(state.db.clone());
+    // Resolve the check (404s if missing) so we can authorize its artifact
+    // before returning any issue metadata (#2437).
+    let check = qc_service.get_check(check_id).await?;
+    check_artifact_visibility(&Some(auth), check.artifact_id, &state.db).await?;
     let issues = qc_service.list_check_issues(check_id).await?;
     let response: Vec<IssueResponse> = issues.into_iter().map(IssueResponse::from).collect();
     Ok(Json(response))
@@ -2200,6 +2224,9 @@ mod tests {
         let (repo_id, _key, dir) = tdh::create_repo(&pool, "local", "rpm").await;
         let artifact_id = seed_artifact(&pool, repo_id).await;
         seed_check(&pool, repo_id, artifact_id, "completed", 5.0).await;
+        // The caller must now be authorized for the artifact's (private) repo
+        // (#2437); grant membership so the #2334 shape assertions still hold.
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
 
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
         let auth = tdh::make_auth(user_id, &username);
@@ -2222,5 +2249,234 @@ mod tests {
         assert_eq!(v.as_array().unwrap().len(), 1);
 
         tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-repo QC metadata authorization (#2437): the artifact-scoped read
+    // routes (`/checks`, `/checks/:id`, `/checks/:id/issues`,
+    // `/health/artifacts/:id`) must run the canonical
+    // `check_artifact_visibility` gate, so a caller with no access to the
+    // artifact's private repo gets an existence-hiding 404 that leaks no QC
+    // metadata, while members/admins/public-repo callers are unaffected.
+    // -----------------------------------------------------------------------
+
+    /// Wire the public quality router to a concrete caller (the real
+    /// `auth_middleware` inserts `Extension<AuthExtension>`, which these
+    /// handlers read).
+    fn quality_app(state: SharedState, auth: AuthExtension) -> axum::Router {
+        router().with_state(state).layer(axum::Extension(auth))
+    }
+
+    /// Fetch a URI returning the status plus the RAW response body string, so
+    /// leak assertions can inspect the exact bytes sent to the client.
+    async fn raw_get(app: axum::Router, uri: &str) -> (axum::http::StatusCode, String) {
+        let (status, body) = tdh::send(app, tdh::get(uri.to_string())).await;
+        (status, String::from_utf8_lossy(&body).to_string())
+    }
+
+    /// A no-access 404 body must not leak any quality-check metadata field.
+    fn assert_no_qc_leak(body: &str) {
+        for needle in ["repository_id", "check_type", "score"] {
+            assert!(
+                !body.contains(needle),
+                "404 body must not leak `{needle}`: {body}"
+            );
+        }
+    }
+
+    /// Seed a private repo + artifact + one completed check.
+    /// Returns (repo_id, artifact_id, check_id, storage_dir).
+    async fn seed_repo_artifact_check(
+        pool: &sqlx::PgPool,
+    ) -> (Uuid, Uuid, Uuid, std::path::PathBuf) {
+        let (repo_id, _k, dir) = tdh::create_repo(pool, "local", "rpm").await;
+        let art = seed_artifact(pool, repo_id).await;
+        let check = seed_check(pool, repo_id, art, "completed", 5.0).await;
+        (repo_id, art, check, dir)
+    }
+
+    // (1) accessible/member user + existing artifact -> 200 with rows.
+    #[tokio::test]
+    async fn test_list_checks_member_user_ok_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, art, _c, dir) = seed_repo_artifact_check(&pool).await;
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(user_id, &username);
+        let (status, v) = json_body(
+            quality_app(state, auth),
+            &format!("/checks?artifact_id={}", art),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // (2) authenticated no-access user -> 404 with no leaked metadata.
+    #[tokio::test]
+    async fn test_list_checks_no_access_404_no_leak_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (outsider_id, outsider) = tdh::create_user(&pool).await;
+        let (repo_id, art, _c, dir) = seed_repo_artifact_check(&pool).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(outsider_id, &outsider);
+        let (status, body) = raw_get(
+            quality_app(state, auth),
+            &format!("/checks?artifact_id={}", art),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_no_qc_leak(&body);
+        tdh::cleanup(&pool, repo_id, outsider_id).await;
+    }
+
+    // (3) missing artifact_id still 400 — the #2334 guard stays FIRST, ahead
+    // of any existence/authz work.
+    #[tokio::test]
+    async fn test_list_checks_missing_artifact_id_still_400_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, _art, _c, dir) = seed_repo_artifact_check(&pool).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(user_id, &username);
+        let (status, _v) = json_body(quality_app(state, auth), "/checks").await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // (4) admin -> 200 (visibility bypass), even with no explicit membership.
+    #[tokio::test]
+    async fn test_list_checks_admin_bypass_ok_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, art, _c, dir) = seed_repo_artifact_check(&pool).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let admin = tdh::admin_auth(user_id, &username);
+        let (status, v) = json_body(
+            quality_app(state, admin),
+            &format!("/checks?artifact_id={}", art),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // (5) nonexistent artifact_id -> 404 (uniform with no-access), no leak.
+    #[tokio::test]
+    async fn test_list_checks_nonexistent_artifact_404_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, _k, dir) = tdh::create_repo(&pool, "local", "rpm").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let admin = tdh::admin_auth(user_id, &username);
+        let (status, body) = raw_get(
+            quality_app(state, admin),
+            &format!("/checks?artifact_id={}", Uuid::new_v4()),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_no_qc_leak(&body);
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // (6) public-repo artifact + any authed non-member -> 200.
+    #[tokio::test]
+    async fn test_list_checks_public_repo_ok_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, art, _c, dir) = seed_repo_artifact_check(&pool).await;
+        let _ = sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(user_id, &username);
+        let (status, v) = json_body(
+            quality_app(state, auth),
+            &format!("/checks?artifact_id={}", art),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(v.as_array().unwrap().len(), 1);
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    // get_check: no-access user -> 404, no leak.
+    #[tokio::test]
+    async fn test_get_check_no_access_404_no_leak_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (outsider_id, outsider) = tdh::create_user(&pool).await;
+        let (repo_id, _art, check, dir) = seed_repo_artifact_check(&pool).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(outsider_id, &outsider);
+        let (status, body) = raw_get(quality_app(state, auth), &format!("/checks/{}", check)).await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_no_qc_leak(&body);
+        tdh::cleanup(&pool, repo_id, outsider_id).await;
+    }
+
+    // list_check_issues: no-access user -> 404, no leak.
+    #[tokio::test]
+    async fn test_list_check_issues_no_access_404_no_leak_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (outsider_id, outsider) = tdh::create_user(&pool).await;
+        let (repo_id, _art, check, dir) = seed_repo_artifact_check(&pool).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(outsider_id, &outsider);
+        let (status, body) = raw_get(
+            quality_app(state, auth),
+            &format!("/checks/{}/issues", check),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_no_qc_leak(&body);
+        tdh::cleanup(&pool, repo_id, outsider_id).await;
+    }
+
+    // get_artifact_health: no-access user -> 404, no leak.
+    #[tokio::test]
+    async fn test_get_artifact_health_no_access_404_no_leak_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (outsider_id, outsider) = tdh::create_user(&pool).await;
+        let (repo_id, art, _c, dir) = seed_repo_artifact_check(&pool).await;
+        // Give the artifact a health score so the existence handling passes and
+        // control reaches the authorization gate.
+        let _ = sqlx::query(
+            "INSERT INTO artifact_health_scores (artifact_id, health_score) VALUES ($1, 90)",
+        )
+        .bind(art)
+        .execute(&pool)
+        .await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(outsider_id, &outsider);
+        let (status, body) = raw_get(
+            quality_app(state, auth),
+            &format!("/health/artifacts/{}", art),
+        )
+        .await;
+        assert_eq!(status, axum::http::StatusCode::NOT_FOUND);
+        assert_no_qc_leak(&body);
+        tdh::cleanup(&pool, repo_id, outsider_id).await;
     }
 }

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -466,3 +466,247 @@ mod credential_change_grpc {
         );
     }
 }
+
+mod common;
+
+// ---------------------------------------------------------------------------
+// Bug — #2437: cross-repo quality-check metadata leak (BOLA).
+// Class:  Broken object-level authorization on artifact-scoped QC reads.
+// Seam:   the artifact-scoped `/quality/checks*` + `/quality/health/artifacts`
+//         handlers, exercised end-to-end over the real router against a live
+//         DB (the external HTTP vantage), not a helper.
+// What:   `GET /quality/checks?artifact_id=<X>`, `/quality/checks/:id`,
+//         `/quality/checks/:id/issues` and `/quality/health/artifacts/:id`
+//         returned quality-check metadata for ANY authenticated caller with no
+//         check that the caller can see the artifact's (private) repository,
+//         leaking cross-tenant `repository_id` / `check_type` / `score` data.
+// Asserts: a non-member (tenant B) gets an existence-hiding 404 whose body
+//         leaks none of those fields, while the repo member (tenant A / owner)
+//         still gets 200 with the row. Covers `/checks` and `/checks/:id`.
+//
+// DB-gated (this is the one live-DB seam in this file); run with:
+//   DATABASE_URL="postgresql://.../artifact_registry" \
+//     cargo test --test security_regression_tests -- --ignored
+// ---------------------------------------------------------------------------
+mod qc_metadata_leak_2437 {
+    // streaming-invariant: test file exempt — buffering a 404/200 response body
+    // in an assertion is not an artifact path (#1608).
+    #![allow(clippy::disallowed_methods)]
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Extension;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use artifact_keeper_backend::api::handlers::quality_gates;
+    use artifact_keeper_backend::api::middleware::auth::AuthExtension;
+    use artifact_keeper_backend::api::{AppState, SharedState};
+    use artifact_keeper_backend::config::Config;
+    use artifact_keeper_backend::models::access_scope::AccessScope;
+
+    use super::common;
+
+    fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+        let config = Config {
+            database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
+            storage_path: storage_path.into(),
+            jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+            ..Default::default()
+        };
+        let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = Arc::new(
+            artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(storage_path),
+        );
+        let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+            HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        Arc::new(AppState::new(config, pool, storage, registry))
+    }
+
+    /// A non-admin, unrestricted-scope caller for `user_id` (the shape the
+    /// real `auth_middleware` injects for a JWT-authenticated local user).
+    fn auth_for(user_id: Uuid) -> AuthExtension {
+        AuthExtension {
+            user_id,
+            username: format!("u-{}", &user_id.to_string()[..8]),
+            email: "u@test.local".to_string(),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
+        }
+    }
+
+    async fn create_private_repo(pool: &PgPool) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("qc2437-{}", &id.to_string()[..8]);
+        let dir = std::env::temp_dir().join(&key);
+        std::fs::create_dir_all(&dir).expect("create storage dir");
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local', 'rpm'::repository_format, false)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(dir.to_string_lossy().as_ref())
+        .execute(pool)
+        .await
+        .expect("insert private repo");
+        (id, dir.to_string_lossy().to_string())
+    }
+
+    async fn seed_artifact(pool: &PgPool, repo_id: Uuid) -> Uuid {
+        let path = format!("qc2437/{}", Uuid::new_v4());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by) \
+             VALUES ($1, $2, 'qc2437', '1.0', 1, 'deadbeef', 'application/octet-stream', $3, NULL) \
+             RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(&path)
+        .bind(&path)
+        .fetch_one(pool)
+        .await
+        .expect("seed artifact")
+    }
+
+    async fn seed_check(pool: &PgPool, repo_id: Uuid, artifact_id: Uuid) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO quality_check_results (artifact_id, repository_id, check_type, status) \
+             VALUES ($1, $2, 'metadata', 'completed') RETURNING id",
+        )
+        .bind(artifact_id)
+        .bind(repo_id)
+        .fetch_one(pool)
+        .await
+        .expect("seed quality_check_result")
+    }
+
+    async fn grant_member(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+             SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+             ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("grant developer role");
+    }
+
+    async fn get_status_body(
+        app: axum::Router,
+        uri: &str,
+        auth: AuthExtension,
+    ) -> (StatusCode, String) {
+        let resp = app
+            .layer(Extension(auth))
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    fn assert_no_leak(body: &str) {
+        for needle in ["repository_id", "check_type", "score"] {
+            assert!(
+                !body.contains(needle),
+                "cross-tenant 404 body must not leak `{needle}`: {body}"
+            );
+        }
+    }
+
+    async fn cleanup(pool: &PgPool, repo_id: Uuid, users: &[Uuid]) {
+        let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM artifacts WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        for u in users {
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(u)
+                .execute(pool)
+                .await;
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL pointed at a Postgres with migrations applied"]
+    async fn regression_2437_cross_repo_qc_metadata_bola() {
+        let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+            .await
+            .unwrap();
+
+        // Tenant A owns a private repo + artifact + quality check; tenant B has
+        // no membership on it.
+        let user_a = common::insert_active_user(&pool, "qc2437-a").await;
+        let user_b = common::insert_active_user(&pool, "qc2437-b").await;
+        let (repo_id, storage) = create_private_repo(&pool).await;
+        let artifact_id = seed_artifact(&pool, repo_id).await;
+        let check_id = seed_check(&pool, repo_id, artifact_id).await;
+        grant_member(&pool, repo_id, user_a).await;
+
+        let state = build_state(pool.clone(), &storage);
+        let app = || quality_gates::router().with_state(state.clone());
+
+        // The exact BOLA: tenant B lists another tenant's checks -> 404, no leak.
+        let (status, body) = get_status_body(
+            app(),
+            &format!("/checks?artifact_id={artifact_id}"),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "cross-tenant list must be an existence-hiding 404"
+        );
+        assert_no_leak(&body);
+
+        // ... and the /checks/:id sibling route is equally gated.
+        let (status, body) =
+            get_status_body(app(), &format!("/checks/{check_id}"), auth_for(user_b)).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "cross-tenant get_check 404");
+        assert_no_leak(&body);
+
+        // Owner (tenant A member) still sees the row: legitimate use intact.
+        let (status, body) = get_status_body(
+            app(),
+            &format!("/checks?artifact_id={artifact_id}"),
+            auth_for(user_a),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "owner list must still succeed");
+        let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(
+            v.as_array().unwrap().len(),
+            1,
+            "owner sees the seeded check"
+        );
+
+        let (status, _body) =
+            get_status_body(app(), &format!("/checks/{check_id}"), auth_for(user_a)).await;
+        assert_eq!(status, StatusCode::OK, "owner get_check must still succeed");
+
+        cleanup(&pool, repo_id, &[user_a, user_b]).await;
+    }
+}


### PR DESCRIPTION
## Summary

The four artifact-scoped quality-check read routes returned quality-check
metadata keyed only by `artifact_id` / check `id`, with no check that the
caller is allowed to see the artifact's repository. Any authenticated user
could therefore read quality-check results (including `repository_id`,
`check_type`, `score`, issue details and health scores) for artifacts in
private repositories belonging to other tenants.

This applies the canonical `check_artifact_visibility` gate — the same
token-repo-scope + admin-bypass + private-repo-membership check `get_artifact`
already uses — to all four routes, so a caller without access gets the
existing existence-hiding `404 "Artifact not found"` instead of the data:

- `GET /api/v1/quality/checks?artifact_id=…` (`list_checks`) — resolves
  artifact existence first (so a nonexistent artifact 404s uniformly with a
  no-access one), then authorizes. The `#2334` `artifact_id`-required `400`
  guard is kept as the first statement and its contract is unchanged.
- `GET /api/v1/quality/checks/:id` (`get_check`) — authorizes the resolved
  check's artifact before returning.
- `GET /api/v1/quality/checks/:id/issues` (`list_check_issues`) — same.
- `GET /api/v1/quality/health/artifacts/:artifact_id` (`get_artifact_health`)
  — authorizes after the existing existence handling.

Admin callers and public-repo artifacts are unaffected. `trigger_checks` and
the admin `/admin/quality-checks` list (#2419) already enforce their own
authorization and are not touched.

Closes #2437

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added, in `quality_gates.rs` unit tests: member/accessible user → 200 with
rows; authenticated no-access user → 404 with a body that leaks none of
`repository_id`/`check_type`/`score`; missing `artifact_id` still 400 (guard
stays first); admin bypass → 200; nonexistent artifact → 404; public-repo
artifact → 200; plus a no-access → 404 case for each of `get_check`,
`list_check_issues` and `get_artifact_health`. Added a DB-gated cross-tenant
integration test `regression_2437_cross_repo_qc_metadata_bola` in
`security_regression_tests.rs` that exercises `/quality/checks` and
`/quality/checks/:id` over the real router: tenant B (non-member) → 404 with
no leaked fields, owner A → 200 with the row.

The existing `#2334` regression test now grants the caller repo membership so
its shape assertions hold under the new authorization.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

The routes, request/response shapes and status codes are unchanged for
authorized callers; only unauthorized callers move from `200` to the existing
`404`.
