### PR TITLE
feat(audit): structured audit event export with published schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -475,6 +475,16 @@ JWT_EXPIRATION_SECS=86400
 # PLUGINS_DIR=./plugins
 
 # -----------------------------------------------------------------------------
+# Diagnostics log format (backend)
+# -----------------------------------------------------------------------------
+# Format of the diagnostics log lines written to stdout by the tracing
+# subscriber (#2413). `pretty` (default) is the human-readable multi-line
+# output; `json` emits one JSON object per line for structured stdout
+# collection by a SIEM / log shipper. Unrecognised values fall back to
+# `pretty`. Independent of the audit stream (AUDIT_STREAM, below).
+# LOG_FORMAT=pretty
+
+# -----------------------------------------------------------------------------
 # OpenTelemetry (backend, disabled when OTEL_EXPORTER_OTLP_ENDPOINT is unset)
 # -----------------------------------------------------------------------------
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/.env.example
+++ b/.env.example
@@ -485,6 +485,19 @@ JWT_EXPIRATION_SECS=86400
 # LOG_FORMAT=pretty
 
 # -----------------------------------------------------------------------------
+# Structured audit-event stream (backend, #2413)
+# -----------------------------------------------------------------------------
+# Emit every recorded audit action as a self-contained NDJSON record so it can
+# be shipped to a SIEM by collecting stdout, without polling the admin API or
+# reading Postgres. Each emitted line is an instance of the published schema at
+# backend/schemas/audit-event.v1.schema.json (category="audit" marks audit lines).
+#   off    -- no audit records emitted (default)
+#   stdout -- one NDJSON audit record per line on stdout
+# Pair with LOG_FORMAT=json for a fully structured stdout. See
+# docs/audit-events.md for the envelope reference and delivery semantics.
+# AUDIT_STREAM=off
+
+# -----------------------------------------------------------------------------
 # OpenTelemetry (backend, disabled when OTEL_EXPORTER_OTLP_ENDPOINT is unset)
 # -----------------------------------------------------------------------------
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317

--- a/backend/schemas/audit-event.v1.schema.json
+++ b/backend/schemas/audit-event.v1.schema.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://artifact-keeper.dev/schemas/audit-event.v1.schema.json",
+  "title": "Artifact Keeper audit event",
+  "description": "One exported audit event (#2413). Every recorded audit action is emitted as one self-contained NDJSON line matching this schema. `category` is always \"audit\" so a collector can distinguish audit events from ordinary diagnostics without parsing message text. `event_id` equals the audit_log row id (the SIEM to admin-API join key). Additive fields within schema_version 1 are non-breaking; new `action` and `actor.type` values may be added, so consumers must tolerate unknown values.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "category",
+    "event_id",
+    "timestamp",
+    "action",
+    "outcome",
+    "actor",
+    "source_ip",
+    "resource",
+    "correlation_id",
+    "details"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Envelope schema version. Bumped only on a breaking change."
+    },
+    "category": {
+      "type": "string",
+      "const": "audit",
+      "description": "Machine marker distinguishing audit events from diagnostics."
+    },
+    "event_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Event id, shared with the audit_log row."
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Emit-time timestamp (UTC, RFC 3339)."
+    },
+    "action": {
+      "type": "string",
+      "description": "Action name (SCREAMING_SNAKE). Consumers must tolerate unknown values."
+    },
+    "outcome": {
+      "$ref": "#/$defs/Outcome"
+    },
+    "actor": {
+      "$ref": "#/$defs/Actor"
+    },
+    "source_ip": {
+      "type": ["string", "null"],
+      "description": "Source IP for request-scoped events; null otherwise."
+    },
+    "resource": {
+      "$ref": "#/$defs/Resource"
+    },
+    "correlation_id": {
+      "type": "string",
+      "description": "Request/operation correlation id; joins to request logs and traces."
+    },
+    "details": {
+      "type": ["object", "null"],
+      "description": "Typed payload for representative events (enforced by the action-discriminated allOf rules below), or a permissive object for actions not yet typed. Known secret-bearing keys are centrally redacted before storage and export."
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["action"],
+        "properties": { "action": { "enum": ["REPOSITORY_CREATED", "REPOSITORY_UPDATED", "REPOSITORY_DELETED"] } }
+      },
+      "then": { "properties": { "details": { "anyOf": [{ "$ref": "#/$defs/RepositoryDetails" }, { "$ref": "#/$defs/TruncatedDetails" }, { "type": "null" }] } } }
+    },
+    {
+      "if": {
+        "required": ["action"],
+        "properties": { "action": { "enum": ["ROLE_ASSIGNED", "ROLE_REVOKED", "REPOSITORY_PERMISSION_CHANGED"] } }
+      },
+      "then": { "properties": { "details": { "anyOf": [{ "$ref": "#/$defs/PermissionDetails" }, { "$ref": "#/$defs/TruncatedDetails" }, { "type": "null" }] } } }
+    },
+    {
+      "if": {
+        "required": ["action"],
+        "properties": { "action": { "enum": ["API_TOKEN_CREATED", "API_TOKEN_REVOKED"] } }
+      },
+      "then": { "properties": { "details": { "anyOf": [{ "$ref": "#/$defs/TokenDetails" }, { "$ref": "#/$defs/TruncatedDetails" }, { "type": "null" }] } } }
+    },
+    {
+      "if": {
+        "required": ["action"],
+        "properties": { "action": { "enum": ["LOGIN_FAILED", "PERMISSION_DENIED"] } }
+      },
+      "then": { "properties": { "details": { "anyOf": [{ "$ref": "#/$defs/AuthDetails" }, { "$ref": "#/$defs/TruncatedDetails" }, { "type": "null" }] } } }
+    },
+    {
+      "if": {
+        "required": ["action"],
+        "properties": { "action": { "enum": ["ARTIFACT_UPLOADED", "ARTIFACT_DOWNLOADED", "ARTIFACT_DELETED"] } }
+      },
+      "then": { "properties": { "details": { "anyOf": [{ "$ref": "#/$defs/ArtifactDetails" }, { "$ref": "#/$defs/TruncatedDetails" }, { "type": "null" }] } } }
+    },
+    {
+      "if": {
+        "required": ["action"],
+        "properties": { "action": { "const": "SETTING_CHANGED" } }
+      },
+      "then": { "properties": { "details": { "anyOf": [{ "$ref": "#/$defs/SettingDetails" }, { "$ref": "#/$defs/TruncatedDetails" }, { "type": "null" }] } } }
+    }
+  ],
+  "$defs": {
+    "TruncatedDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["details_truncated", "original_size_bytes"],
+      "properties": {
+        "details_truncated": { "const": true },
+        "original_size_bytes": { "type": "integer", "minimum": 65537 }
+      }
+    },
+    "Outcome": {
+      "type": "string",
+      "enum": ["success", "failure", "denied"],
+      "description": "Result flavor, derived from the action name."
+    },
+    "ActorType": {
+      "type": "string",
+      "examples": ["system", "user", "anonymous", "service_account"],
+      "description": "Principal classification. `service_account` is reserved and not yet emitted."
+    },
+    "Actor": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["id", "name", "type"],
+      "properties": {
+        "id": {
+          "type": ["string", "null"],
+          "format": "uuid",
+          "description": "Acting user id, when known."
+        },
+        "name": {
+          "type": ["string", "null"],
+          "description": "Best-effort display name / label; null when unknown. Informational only: on failed-authentication events (anonymous actors) this can carry the attempted, unauthenticated username — key detection logic on actor.type and actor.id."
+        },
+        "type": {
+          "$ref": "#/$defs/ActorType"
+        }
+      }
+    },
+    "Resource": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["type", "id", "name"],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Resource type (user, repository, artifact, ...)."
+        },
+        "id": {
+          "type": ["string", "null"],
+          "format": "uuid",
+          "description": "Resource id, when the action targets a specific row."
+        },
+        "name": {
+          "type": ["string", "null"],
+          "description": "Best-effort resource name; null when unknown."
+        }
+      }
+    },
+    "RepositoryDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["actor_id", "key", "is_public"],
+      "description": "details for REPOSITORY_CREATED / REPOSITORY_UPDATED / REPOSITORY_DELETED.",
+      "properties": {
+        "actor_id": { "type": "string", "format": "uuid" },
+        "key": { "type": "string" },
+        "is_public": { "type": "boolean" },
+        "format": { "type": "string" },
+        "visibility": { "type": "string" },
+        "age_gate_enabled": { "type": "boolean" },
+        "age_gate_min_age_days": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "PermissionDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["actor_id", "role_id", "grantee_id"],
+      "description": "details for ROLE_ASSIGNED / ROLE_REVOKED / REPOSITORY_PERMISSION_CHANGED.",
+      "properties": {
+        "actor_id": { "type": "string", "format": "uuid" },
+        "role_id": { "type": "string", "format": "uuid" },
+        "grantee_id": { "type": "string", "format": "uuid" },
+        "repository_id": { "type": "string", "format": "uuid" }
+      }
+    },
+    "TokenDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["token_id", "surface"],
+      "description": "details for API_TOKEN_CREATED / API_TOKEN_REVOKED. Never includes the token secret.",
+      "properties": {
+        "token_id": { "type": "string" },
+        "token_name": { "type": "string" },
+        "surface": { "type": "string" }
+      }
+    },
+    "AuthDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [],
+      "description": "details for LOGIN_FAILED / PERMISSION_DENIED and related authorization events.",
+      "properties": {
+        "username": { "type": "string" },
+        "path": { "type": "string" },
+        "method": { "type": "string" },
+        "reason": { "type": "string" },
+        "provider": { "type": "string" },
+        "auth_method": { "type": "string" }
+      }
+    },
+    "ArtifactDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["repository_id", "path", "name"],
+      "description": "details for ARTIFACT_UPLOADED / ARTIFACT_DOWNLOADED / ARTIFACT_DELETED.",
+      "properties": {
+        "repository_id": { "type": "string", "format": "uuid" },
+        "path": { "type": "string" },
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "size_bytes": { "type": "integer", "minimum": 0 },
+        "digest": { "type": "string" },
+        "uploaded_by": { "type": "string", "format": "uuid" }
+      }
+    },
+    "SettingDetails": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["key"],
+      "description": "details for SETTING_CHANGED. Secret-bearing values are redacted by the caller.",
+      "properties": {
+        "key": { "type": "string" },
+        "old_value": { "type": "string" },
+        "new_value": { "type": "string" }
+      }
+    }
+  }
+}

--- a/backend/src/api/handlers/age_gate.rs
+++ b/backend/src/api/handlers/age_gate.rs
@@ -14,6 +14,7 @@ use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::repository::RepositoryType;
 use crate::services::age_gate_service::AgeGateReview;
+use crate::services::audit_export::details as audit_details;
 use crate::services::audit_service::{AuditAction, AuditEntry, AuditService, ResourceType};
 use crate::services::repository_service::RepositoryService as RepoSvc;
 
@@ -145,14 +146,6 @@ fn build_review_audit_details(
         "package": review.package_name,
         "version": review.package_version,
         "reason": reason,
-    })
-}
-
-/// Build the audit-log details for a per-repo age-gate config update.
-fn build_repo_config_audit_details(enabled: bool, min_age_days: i32) -> serde_json::Value {
-    serde_json::json!({
-        "age_gate_enabled": enabled,
-        "age_gate_min_age_days": min_age_days,
     })
 }
 
@@ -366,10 +359,19 @@ pub async fn update_repo_age_gate(
             AuditEntry::new(AuditAction::RepositoryUpdated, ResourceType::Repository)
                 .user(auth.user_id)
                 .resource(repo.id)
-                .details(build_repo_config_audit_details(
-                    body.enabled,
-                    body.min_age_days,
-                )),
+                .actor_name(auth.username.clone())
+                .resource_name(repo.key.clone())
+                .details_typed(audit_details::RepositoryDetails {
+                    actor_id: auth.user_id,
+                    key: repo.key.clone(),
+                    is_public: repo.is_public,
+                    format: Some(crate::services::repository_service::derive_format_key(
+                        &repo.format,
+                    )),
+                    visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
+                    age_gate_enabled: Some(body.enabled),
+                    age_gate_min_age_days: Some(body.min_age_days),
+                }),
         )
         .await;
 
@@ -495,13 +497,6 @@ mod tests {
         assert_eq!(details["package"], "react");
         assert_eq!(details["version"], "18.0.0");
         assert_eq!(details["reason"], "looks safe");
-    }
-
-    #[test]
-    fn build_repo_config_audit_details_includes_fields() {
-        let d = build_repo_config_audit_details(true, 14);
-        assert_eq!(d["age_gate_enabled"], true);
-        assert_eq!(d["age_gate_min_age_days"], 14);
     }
 
     #[test]

--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -32,15 +32,19 @@ use std::sync::atomic::Ordering;
 
 /// Fire-and-forget auth audit log. Failures are silently ignored so audit
 /// issues never break the auth flow.
-async fn audit_auth(
+async fn audit_auth<T: serde::Serialize>(
     state: &SharedState,
     action: AuditAction,
     user_id: Option<Uuid>,
-    details: serde_json::Value,
+    actor_name: Option<&str>,
+    details: T,
 ) {
-    let mut entry = AuditEntry::new(action, ResourceType::User).details(details);
+    let mut entry = AuditEntry::new(action, ResourceType::User).details_typed(details);
     if let Some(id) = user_id {
         entry = entry.user(id).resource(id);
+    }
+    if let Some(name) = actor_name {
+        entry = entry.actor_name(name);
     }
     let _ = AuditService::new(state.db.clone()).log(entry).await;
 }
@@ -244,10 +248,11 @@ async fn enforce_local_login_sso_policy(
                 state,
                 AuditAction::LoginFailed,
                 Some(user_id),
-                serde_json::json!({
-                    "username": username,
-                    "reason": "local_login_disabled_sso",
-                }),
+                Some(username),
+                crate::services::audit_export::details::AuthDetails::failed_login(
+                    Some(username),
+                    Some("local_login_disabled_sso"),
+                ),
             )
             .await;
             Err(AppError::Authentication(
@@ -293,7 +298,11 @@ pub async fn login(
                 &state,
                 AuditAction::LoginFailed,
                 None,
-                serde_json::json!({ "username": payload.username }),
+                None,
+                crate::services::audit_export::details::AuthDetails::failed_login(
+                    Some(&payload.username),
+                    None,
+                ),
             )
             .await;
             return Err(err);
@@ -336,7 +345,14 @@ pub async fn login(
         // break-glass login so it is visible in the audit trail.
         login_details["sso_break_glass"] = serde_json::json!(true);
     }
-    audit_auth(&state, AuditAction::Login, Some(user.id), login_details).await;
+    audit_auth(
+        &state,
+        AuditAction::Login,
+        Some(user.id),
+        Some(&user.username),
+        login_details,
+    )
+    .await;
 
     Ok(login_response(
         &tokens,
@@ -388,6 +404,7 @@ pub async fn logout(
             &state,
             AuditAction::Logout,
             Some(auth.user_id),
+            Some(&auth.username),
             serde_json::json!({}),
         )
         .await;
@@ -429,6 +446,7 @@ pub async fn refresh_token(
         &state,
         AuditAction::Login,
         Some(user.id),
+        Some(&user.username),
         serde_json::json!({ "method": "token_refresh" }),
     )
     .await;

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -31,6 +31,7 @@ use crate::formats::maven::MavenHandler;
 use crate::models::access_scope::AccessScope;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::artifact_service::ArtifactService;
+use crate::services::audit_export::details as audit_details;
 use crate::services::audit_service::{
     audit_fire_and_forget, AuditAction, AuditEntry, ResourceType,
 };
@@ -38,8 +39,8 @@ use crate::services::cache_classifier;
 use crate::services::permission_service::{SYSTEM_SENTINEL_ID, SYSTEM_TARGET_TYPE};
 use crate::services::proxy_service::DEFAULT_CACHE_TTL_SECS;
 use crate::services::repository_service::{
-    CreateRepositoryRequest as ServiceCreateRepoReq, RepoVisibility, RepositoryService,
-    UpdateRepositoryRequest as ServiceUpdateRepoReq,
+    derive_format_key, CreateRepositoryRequest as ServiceCreateRepoReq, RepoVisibility,
+    RepositoryService, UpdateRepositoryRequest as ServiceUpdateRepoReq,
 };
 use crate::services::routing_rules::{self, RoutingRule};
 use crate::services::upload_service;
@@ -1803,11 +1804,17 @@ pub async fn create_repository(
         AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
             .user(auth.user_id)
             .resource(repo.id)
-            .details(serde_json::json!({
-                "actor_id": auth.user_id.to_string(),
-                "key": repo.key,
-                "is_public": repo.is_public,
-            })),
+            .actor_name(auth.username.clone())
+            .resource_name(repo.key.clone())
+            .details_typed(audit_details::RepositoryDetails {
+                actor_id: auth.user_id,
+                key: repo.key.clone(),
+                is_public: repo.is_public,
+                format: Some(derive_format_key(&repo.format)),
+                visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
+                age_gate_enabled: None,
+                age_gate_min_age_days: None,
+            }),
     )
     .await;
 
@@ -2044,10 +2051,17 @@ pub async fn update_repository(
         AuditEntry::new(AuditAction::RepositoryUpdated, ResourceType::Repository)
             .user(auth.user_id)
             .resource(repo.id)
-            .details(serde_json::json!({
-                "actor_id": auth.user_id.to_string(),
-                "key": repo.key,
-            })),
+            .actor_name(auth.username.clone())
+            .resource_name(repo.key.clone())
+            .details_typed(audit_details::RepositoryDetails {
+                actor_id: auth.user_id,
+                key: repo.key.clone(),
+                is_public: repo.is_public,
+                format: Some(derive_format_key(&repo.format)),
+                visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
+                age_gate_enabled: None,
+                age_gate_min_age_days: None,
+            }),
     )
     .await;
 
@@ -2371,10 +2385,17 @@ pub async fn delete_repository(
         AuditEntry::new(AuditAction::RepositoryDeleted, ResourceType::Repository)
             .user(auth.user_id)
             .resource(repo.id)
-            .details(serde_json::json!({
-                "actor_id": auth.user_id.to_string(),
-                "key": repo.key,
-            })),
+            .actor_name(auth.username.clone())
+            .resource_name(repo.key.clone())
+            .details_typed(audit_details::RepositoryDetails {
+                actor_id: auth.user_id,
+                key: repo.key.clone(),
+                is_public: repo.is_public,
+                format: Some(derive_format_key(&repo.format)),
+                visibility: Some(if repo.is_public { "public" } else { "private" }.to_owned()),
+                age_gate_enabled: None,
+                age_gate_min_age_days: None,
+            }),
     )
     .await;
 

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -60,10 +60,17 @@ async fn audit_federated_login(
     provider: &str,
     extra: serde_json::Value,
 ) {
+    let actor_name = extra
+        .get("username")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
     let mut entry = AuditEntry::new(action, ResourceType::User)
         .details(federated_login_details(provider, extra));
     if let Some(id) = user_id {
         entry = entry.user(id).resource(id);
+    }
+    if let Some(name) = actor_name {
+        entry = entry.actor_name(name);
     }
     audit_fire_and_forget(state.db.clone(), entry).await;
 }

--- a/backend/src/api/handlers/totp.rs
+++ b/backend/src/api/handlers/totp.rs
@@ -374,7 +374,12 @@ pub async fn verify_totp(
             AuditEntry::new(AuditAction::LoginFailed, ResourceType::User)
                 .user(claims.sub)
                 .resource(claims.sub)
-                .details(serde_json::json!({ "reason": "totp_not_enabled" })),
+                .details_typed(
+                    crate::services::audit_export::details::AuthDetails::failed_login(
+                        None,
+                        Some("totp_not_enabled"),
+                    ),
+                ),
         )
         .await;
         return Err(AppError::Authentication(
@@ -455,10 +460,14 @@ pub async fn verify_totp(
                 AuditEntry::new(AuditAction::LoginFailed, ResourceType::User)
                     .user(claims.sub)
                     .resource(claims.sub)
-                    .details(serde_json::json!({
-                        "reason": "invalid_totp_code",
-                        "method": "totp",
-                    })),
+                    .details_typed(crate::services::audit_export::details::AuthDetails {
+                        username: None,
+                        path: None,
+                        method: Some("totp".to_owned()),
+                        reason: Some("invalid_totp_code".to_owned()),
+                        provider: None,
+                        auth_method: None,
+                    }),
             )
             .await;
             return Err(AppError::Authentication("Invalid TOTP code".to_string()));

--- a/backend/src/api/handlers/users.rs
+++ b/backend/src/api/handlers/users.rs
@@ -15,6 +15,7 @@ use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
 use crate::models::user::{AuthProvider, User};
+use crate::services::audit_export::details as audit_details;
 use crate::services::audit_service::{
     api_token_audit_entry, audit_fire_and_forget, password_change_audit_entry,
     sessions_invalidated_audit_entry, AuditAction, AuditEntry, ResourceType,
@@ -785,10 +786,13 @@ pub async fn assign_role(
         AuditEntry::new(AuditAction::RoleAssigned, ResourceType::User)
             .user(auth.user_id)
             .resource(id)
-            .details(serde_json::json!({
-                "actor_id": auth.user_id.to_string(),
-                "role_id": payload.role_id.to_string(),
-            })),
+            .actor_name(auth.username.clone())
+            .details_typed(audit_details::PermissionDetails {
+                actor_id: auth.user_id,
+                role_id: payload.role_id,
+                grantee_id: id,
+                repository_id: None,
+            }),
     )
     .await;
 
@@ -838,10 +842,13 @@ pub async fn revoke_role(
         AuditEntry::new(AuditAction::RoleRevoked, ResourceType::User)
             .user(auth.user_id)
             .resource(user_id)
-            .details(serde_json::json!({
-                "actor_id": auth.user_id.to_string(),
-                "role_id": role_id.to_string(),
-            })),
+            .actor_name(auth.username.clone())
+            .details_typed(audit_details::PermissionDetails {
+                actor_id: auth.user_id,
+                role_id,
+                grantee_id: user_id,
+                repository_id: None,
+            }),
     )
     .await;
 

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1211,11 +1211,14 @@ pub async fn admin_middleware(
             let entry = AuditEntry::new(AuditAction::PermissionDenied, ResourceType::User)
                 .user(auth_ext.user_id)
                 .resource(auth_ext.user_id)
-                .details(serde_json::json!({
-                    "path": request.uri().path(),
-                    "method": request.method().as_str(),
-                    "reason": "admin_privileges_required",
-                }));
+                .actor_name(auth_ext.username.clone())
+                .details_typed(
+                    crate::services::audit_export::details::AuthDetails::permission_denied(
+                        request.uri().path(),
+                        request.method().as_str(),
+                        "admin_privileges_required",
+                    ),
+                );
             audit_fire_and_forget(auth_service.db().clone(), entry).await;
         }
         return (StatusCode::FORBIDDEN, "Admin access required").into_response();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -145,6 +145,16 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         &otel_service_name,
     );
 
+    // Initialize the structured audit-event stream (#2413) from AUDIT_STREAM,
+    // following the same pre-Config env-read pattern as telemetry. Default
+    // `off`; `stdout` opts in to NDJSON audit records on stdout.
+    let _audit_stream_guard =
+        artifact_keeper_backend::services::audit_export::init_audit_stream_from_env();
+    tracing::info!(
+        audit_stream = _audit_stream_guard.mode().name(),
+        "audit event stream configured"
+    );
+
     // Load configuration
     let config = Config::from_env()?;
 

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1043,13 +1043,16 @@ impl ArtifactService {
             };
             let mut entry = AuditEntry::new(AuditAction::ArtifactUploaded, ResourceType::Artifact)
                 .resource(artifact.id)
-                .details(serde_json::json!({
-                    "repository_id": artifact.repository_id.to_string(),
-                    "path": artifact.path,
-                    "name": artifact.name,
-                    "version": artifact.version,
-                    "size_bytes": artifact.size_bytes,
-                }));
+                .resource_name(artifact.path.clone())
+                .details_typed(crate::services::audit_export::details::ArtifactDetails {
+                    repository_id: artifact.repository_id,
+                    path: artifact.path.clone(),
+                    name: artifact.name.clone(),
+                    version: artifact.version.clone(),
+                    size_bytes: u64::try_from(artifact.size_bytes).ok(),
+                    digest: Some(format!("sha256:{}", artifact.checksum_sha256)),
+                    uploaded_by: artifact.uploaded_by,
+                });
             if let Some(uid) = uploaded_by {
                 entry = entry.user(uid);
             }
@@ -1376,12 +1379,16 @@ impl ArtifactService {
             let mut entry =
                 AuditEntry::new(AuditAction::ArtifactDownloaded, ResourceType::Artifact)
                     .resource(artifact_id)
-                    .details(serde_json::json!({
-                        "repository_id": artifact_info.repository_id.to_string(),
-                        "path": artifact_info.path,
-                        "name": artifact_info.name,
-                        "version": artifact_info.version,
-                    }));
+                    .resource_name(artifact_info.path.clone())
+                    .details_typed(crate::services::audit_export::details::ArtifactDetails {
+                        repository_id: artifact_info.repository_id,
+                        path: artifact_info.path.clone(),
+                        name: artifact_info.name.clone(),
+                        version: artifact_info.version.clone(),
+                        size_bytes: u64::try_from(artifact_info.size_bytes).ok(),
+                        digest: Some(format!("sha256:{}", artifact_info.checksum_sha256)),
+                        uploaded_by: artifact_info.uploaded_by,
+                    });
             if let Some(uid) = user_id {
                 entry = entry.user(uid);
             }
@@ -1710,13 +1717,16 @@ impl ArtifactService {
             // original uploader is recorded in `details` for context.
             let entry = AuditEntry::new(AuditAction::ArtifactDeleted, ResourceType::Artifact)
                 .resource(artifact.id)
-                .details(serde_json::json!({
-                    "repository_id": artifact.repository_id.to_string(),
-                    "path": artifact.path,
-                    "name": artifact.name,
-                    "version": artifact.version,
-                    "uploaded_by": artifact.uploaded_by.map(|u| u.to_string()),
-                }));
+                .resource_name(artifact.path.clone())
+                .details_typed(crate::services::audit_export::details::ArtifactDetails {
+                    repository_id: artifact.repository_id,
+                    path: artifact.path.clone(),
+                    name: artifact.name.clone(),
+                    version: artifact.version.clone(),
+                    size_bytes: u64::try_from(artifact.size_bytes).ok(),
+                    digest: Some(format!("sha256:{}", artifact.checksum_sha256)),
+                    uploaded_by: artifact.uploaded_by,
+                });
             audit_fire_and_forget(self.db.clone(), entry).await;
         }
 

--- a/backend/src/services/audit_export.rs
+++ b/backend/src/services/audit_export.rs
@@ -1,0 +1,1203 @@
+//! Structured audit-event export (#2413).
+//!
+//! Every recorded audit action is also emitted as a self-contained,
+//! machine-distinguishable structured log record so operators can ship the
+//! audit trail to a SIEM by collecting stdout — without polling the admin API
+//! or reading Postgres. The emitted line IS an instance of the published JSON
+//! Schema (`backend/schemas/audit-event.v1.schema.json`): collectors read exactly
+//! what the schema describes, with no message-text parsing and no nested
+//! JSON-string unwrapping.
+//!
+//! Design (see the plan for the full rationale):
+//!
+//! * **Envelope, not ad-hoc fields.** [`AuditEventRecord`] is a serde type with
+//!   a stable, versioned shape: `schema_version`, `category` (always `"audit"`
+//!   — the machine marker), `event_id` (shared with the DB row, the SIEM ↔
+//!   admin-API join key), `timestamp`, `action`, `outcome`, `actor`,
+//!   `source_ip`, `resource`, `correlation_id`, and typed `details`.
+//! * **Dedicated stream, not stringified tracing fields.** Records are
+//!   serialized with serde, enqueued without blocking request workers, and
+//!   written as complete NDJSON lines through the [`AuditSink`] seam. The
+//!   stream has its own always-on path that an
+//!   operator's `RUST_LOG` filter can never accidentally silence, and the seam
+//!   is where a future OTLP-logs exporter plugs in without reopening the design.
+//! * **Emit regardless of the DB write.** [`crate::services::audit_service`]
+//!   emits the record before the row INSERT, so a DB outage (or the
+//!   fire-and-forget swallow path) never also loses the SIEM copy. `event_id`
+//!   is minted client-side so the exported record and the DB row share one ID.
+//!
+//! Opt-in via `AUDIT_STREAM=stdout` (default `off`); see
+//! [`init_audit_stream_from_env`].
+
+use std::net::IpAddr;
+use std::sync::{mpsc, Arc, OnceLock, RwLock};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::services::audit_service::{AuditAction, AuditEntry};
+
+/// Envelope schema version. Bumped only on a breaking change to the emitted
+/// shape; additive fields are non-breaking (documented in
+/// `docs/audit-events.md`).
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The `category` value stamped on every audit record. A collector matches on
+/// this to distinguish audit events from ordinary diagnostics without parsing
+/// message text.
+pub const AUDIT_CATEGORY: &str = "audit";
+
+// ---------------------------------------------------------------------------
+// Outcome
+// ---------------------------------------------------------------------------
+
+/// The result flavor of an audited action, derived from the action name
+/// ([`AuditAction::outcome`]) so no DB column or migration is needed — the
+/// audit_log table keeps encoding outcome in the action string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Outcome {
+    /// The action completed / the state change was applied.
+    Success,
+    /// The action was attempted and failed (e.g. `LOGIN_FAILED`).
+    Failure,
+    /// The principal was refused (e.g. `PERMISSION_DENIED`, `AGE_GATE_REJECTED`).
+    Denied,
+}
+
+impl AuditAction {
+    /// Map an action to its [`Outcome`] for the export envelope.
+    ///
+    /// A total classification: the failure/denied-flavored actions encode the
+    /// result in their name, everything else is a `success`. This match is
+    /// intentionally exhaustive so adding a new action forces an explicit
+    /// outcome decision at compile time.
+    pub fn outcome(&self) -> Outcome {
+        match self {
+            AuditAction::LoginFailed | AuditAction::BackupFailed | AuditAction::RestoreFailed => {
+                Outcome::Failure
+            }
+            AuditAction::PermissionDenied | AuditAction::AgeGateRejected => Outcome::Denied,
+            AuditAction::Login
+            | AuditAction::Logout
+            | AuditAction::PasswordChanged
+            | AuditAction::ApiTokenCreated
+            | AuditAction::ApiTokenRevoked
+            | AuditAction::UserCreated
+            | AuditAction::UserUpdated
+            | AuditAction::UserDeleted
+            | AuditAction::UserDisabled
+            | AuditAction::RoleAssigned
+            | AuditAction::RoleRevoked
+            | AuditAction::RepositoryCreated
+            | AuditAction::RepositoryUpdated
+            | AuditAction::RepositoryDeleted
+            | AuditAction::RepositoryPermissionChanged
+            | AuditAction::ArtifactUploaded
+            | AuditAction::ArtifactDownloaded
+            | AuditAction::ArtifactDeleted
+            | AuditAction::ArtifactMetadataUpdated
+            | AuditAction::BackupStarted
+            | AuditAction::BackupCompleted
+            | AuditAction::RestoreStarted
+            | AuditAction::RestoreCompleted
+            | AuditAction::PeerRegistered
+            | AuditAction::PeerUnregistered
+            | AuditAction::PeerSyncStarted
+            | AuditAction::PeerSyncCompleted
+            | AuditAction::SettingChanged
+            | AuditAction::PluginInstalled
+            | AuditAction::PluginUninstalled
+            | AuditAction::PluginEnabled
+            | AuditAction::PluginDisabled
+            | AuditAction::EmailSubscriptionCreated
+            | AuditAction::EmailSubscriptionDeleted
+            | AuditAction::SbomGenerated
+            | AuditAction::SbomRead
+            | AuditAction::ScanReaped
+            | AuditAction::TotpEnabled
+            | AuditAction::TotpDisabled
+            | AuditAction::SessionsInvalidated
+            | AuditAction::AgeGateQueued
+            | AuditAction::AgeGateApproved => Outcome::Success,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+/// How the acting principal is classified in the envelope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActorType {
+    /// A system-initiated emitter (a janitor / scheduler / reconciliation job).
+    /// The `details.actor` label set via
+    /// [`AuditEntry::system_actor`](crate::services::audit_service::AuditEntry::system_actor)
+    /// becomes the actor `name`.
+    System,
+    /// An authenticated human/user principal (`user_id` present).
+    User,
+    /// No authenticated principal (e.g. `LOGIN_FAILED` for an unknown user).
+    Anonymous,
+    /// Reserved: a non-human service-account principal. Not yet emitted —
+    /// emitters do not currently carry principal kind. Present in the schema so
+    /// consumers can be written against it ahead of the follow-up that wires it.
+    #[allow(dead_code)]
+    ServiceAccount,
+}
+
+/// The acting principal: id, best-effort name, and classification.
+///
+/// `name` is populated only where the emitter already had it in hand (no
+/// query-time join at emit time); an absent name serializes to `null` and is
+/// documented as such.
+#[derive(Debug, Clone, Serialize)]
+pub struct Actor {
+    /// The acting user's id, when known (`audit_log.user_id`).
+    pub id: Option<Uuid>,
+    /// Best-effort display name / label. `null` when the emitter did not carry
+    /// one.
+    pub name: Option<String>,
+    /// Principal classification.
+    #[serde(rename = "type")]
+    pub kind: ActorType,
+}
+
+// ---------------------------------------------------------------------------
+// Resource
+// ---------------------------------------------------------------------------
+
+/// The resource an audited action targeted.
+#[derive(Debug, Clone, Serialize)]
+pub struct Resource {
+    /// Resource type (`ResourceType::as_str`): `user`, `repository`, ….
+    #[serde(rename = "type")]
+    pub kind: &'static str,
+    /// Resource id, when the action targets a specific row.
+    pub id: Option<Uuid>,
+    /// Best-effort resource name/label. `null` when the emitter did not carry
+    /// one.
+    pub name: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Envelope
+// ---------------------------------------------------------------------------
+
+/// One exported audit event. The serialized form of this type is exactly the
+/// emitted NDJSON line and exactly what the published JSON Schema describes.
+#[derive(Debug, Clone, Serialize)]
+pub struct AuditEventRecord {
+    /// Envelope version ([`SCHEMA_VERSION`]).
+    pub schema_version: u32,
+    /// Always [`AUDIT_CATEGORY`] — the machine marker distinguishing audit
+    /// events from diagnostics.
+    pub category: &'static str,
+    /// Event id, shared with the `audit_log` row (SIEM ↔ admin-API join key).
+    pub event_id: Uuid,
+    /// Emit-time timestamp (UTC). Approximates the row's `created_at`; the
+    /// authoritative join key across systems is `event_id`.
+    pub timestamp: DateTime<Utc>,
+    /// Action name (`AuditAction::as_str`, SCREAMING_SNAKE).
+    pub action: &'static str,
+    /// Derived result flavor ([`Outcome`]).
+    pub outcome: Outcome,
+    /// The acting principal.
+    pub actor: Actor,
+    /// Source IP when known (request-scoped events).
+    pub source_ip: Option<IpAddr>,
+    /// The targeted resource.
+    pub resource: Resource,
+    /// Request/operation correlation id (joins to request logs and traces;
+    /// #2414). For background jobs, one value per logical operation.
+    pub correlation_id: String,
+    /// Typed detail payload for the representative security-lifecycle events;
+    /// a permissive object for actions not yet typed. Never carries
+    /// credentials, tokens, or authorization material.
+    pub details: Option<serde_json::Value>,
+}
+
+/// Maximum encoded size of a `details` payload copied into an exported record.
+///
+/// Applied to the export copy ONLY — the DB row always keeps the full
+/// (sanitized) payload, so this bound can never lose data from the
+/// authoritative audit trail. It exists to keep the stdout queue's worst-case
+/// memory finite ([`AUDIT_QUEUE_CAPACITY`] × line size).
+const AUDIT_DETAILS_MAX_BYTES: usize = 64 * 1024;
+
+/// Bound the exported copy of a `details` payload, replacing an oversized
+/// value with a small truncation marker (`TruncatedDetails` in the published
+/// schema).
+fn bounded_details_for_export(details: &serde_json::Value) -> serde_json::Value {
+    let encoded_len = serde_json::to_vec(details).map(|v| v.len()).unwrap_or(0);
+    if encoded_len > AUDIT_DETAILS_MAX_BYTES {
+        tracing::warn!(
+            encoded_len,
+            limit = AUDIT_DETAILS_MAX_BYTES,
+            "audit details exceeded export limit; streaming a bounded marker (the DB row keeps the full payload)"
+        );
+        serde_json::json!({
+            "details_truncated": true,
+            "original_size_bytes": encoded_len,
+        })
+    } else {
+        details.clone()
+    }
+}
+
+impl AuditEventRecord {
+    /// Build the export record from a finished [`AuditEntry`].
+    ///
+    /// Pure and side-effect free (no I/O, no DB): the `timestamp` is captured
+    /// as emit time and everything else is read off the builder. Keeping this
+    /// separate from emission is what makes the contract unit-testable without
+    /// touching the global sink.
+    pub fn from_entry(entry: &AuditEntry) -> Self {
+        let action = entry.action();
+        // `details.actor` is the system-actor label; its presence is the
+        // system-vs-human distinction the audit trail already carries.
+        let system_label = entry
+            .details_ref()
+            .and_then(|d| d.get("actor"))
+            .and_then(|v| v.as_str());
+        // Envelope actor id: the export-only override wins where the DB row's
+        // `user_id` deliberately records a different principal (the legacy
+        // subject-keyed password/session events); otherwise `user_id`.
+        let actor_id = entry.actor_id_override().or(entry.user_id());
+        let actor = if let Some(label) = system_label {
+            Actor {
+                id: entry.user_id(),
+                name: Some(label.to_string()),
+                kind: ActorType::System,
+            }
+        } else if actor_id.is_some() {
+            Actor {
+                id: actor_id,
+                name: entry.actor_name_ref().map(str::to_owned),
+                kind: ActorType::User,
+            }
+        } else {
+            Actor {
+                id: None,
+                name: entry.actor_name_ref().map(str::to_owned),
+                kind: ActorType::Anonymous,
+            }
+        };
+
+        Self {
+            schema_version: SCHEMA_VERSION,
+            category: AUDIT_CATEGORY,
+            event_id: entry.event_id(),
+            timestamp: Utc::now(),
+            action: action.as_str(),
+            outcome: entry.outcome_override().unwrap_or_else(|| action.outcome()),
+            actor,
+            source_ip: entry.ip_address(),
+            resource: Resource {
+                kind: entry.resource_type().as_str(),
+                id: entry.resource_id(),
+                name: entry.resource_name_ref().map(str::to_owned),
+            },
+            correlation_id: entry.correlation_id().to_owned(),
+            details: entry.details_ref().map(bounded_details_for_export),
+        }
+    }
+
+    /// Serialize to a single newline-terminated NDJSON line.
+    ///
+    /// The record is composed only of strings, integers, UUIDs, timestamps and
+    /// a `serde_json::Value` payload, so serialization cannot fail in practice;
+    /// on the impossible error path we log and return an empty string rather
+    /// than panic on the audit write path.
+    pub fn to_ndjson_line(&self) -> String {
+        match serde_json::to_string(self) {
+            Ok(mut line) => {
+                line.push('\n');
+                line
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "failed to serialize audit export record; dropping stream copy");
+                String::new()
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Typed detail payloads (#2413 §6)
+// ---------------------------------------------------------------------------
+
+/// Typed `details` payloads for the representative security-lifecycle events.
+///
+/// These anchor the published JSON Schema (`backend/schemas/audit-event.v1.schema.json`):
+/// each struct is a stable, documented shape for the `details` object of the
+/// actions it covers. Attach one with
+/// [`AuditEntry::details_typed`](crate::services::audit_service::AuditEntry::details_typed),
+/// which routes through the same anti-spoof sanitization as the ad-hoc
+/// [`AuditEntry::details`](crate::services::audit_service::AuditEntry::details)
+/// path.
+///
+/// Only the representative families are typed; other actions keep ad-hoc
+/// `json!` payloads and are schema-valid under the permissive `details`
+/// fallback (see `docs/audit-events.md`). None of these ever carry credentials,
+/// tokens, or other authorization material.
+///
+/// `Option` fields are omitted from the emitted JSON when absent
+/// (`skip_serializing_if`) so a payload only carries what the emitter knew.
+pub mod details {
+    use serde::Serialize;
+    use uuid::Uuid;
+
+    /// `REPOSITORY_CREATED` / `REPOSITORY_UPDATED` / `REPOSITORY_DELETED`.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct RepositoryDetails {
+        /// Acting principal id, retained for compatibility with the existing
+        /// database details payload. The envelope actor is authoritative.
+        pub actor_id: Uuid,
+        /// Repository key / slug.
+        pub key: String,
+        /// Existing boolean visibility field retained for admin-API consumers.
+        pub is_public: bool,
+        /// Package format (`maven`, `npm`, `cargo`, …), when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub format: Option<String>,
+        /// Visibility (`public`, `private`, …), when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub visibility: Option<String>,
+        /// Age-gate toggle when `REPOSITORY_UPDATED` represents a policy change.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub age_gate_enabled: Option<bool>,
+        /// Minimum upstream publish age for that policy change.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub age_gate_min_age_days: Option<i32>,
+    }
+
+    /// `ROLE_ASSIGNED` / `ROLE_REVOKED` / `REPOSITORY_PERMISSION_CHANGED`.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct PermissionDetails {
+        /// Acting principal id, retained for existing details consumers.
+        pub actor_id: Uuid,
+        /// Role id for role assignment/revocation events.
+        pub role_id: Uuid,
+        /// The grantee principal id (currently a user).
+        pub grantee_id: Uuid,
+        /// Repository id for repository-scoped grants, when applicable.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub repository_id: Option<Uuid>,
+    }
+
+    /// `API_TOKEN_CREATED` / `API_TOKEN_REVOKED`. The token SECRET is never
+    /// included — only identifying metadata.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct TokenDetails {
+        /// The token's id (not the secret).
+        pub token_id: String,
+        /// The token's display name, when set.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub token_name: Option<String>,
+        /// The endpoint family that minted/revoked it (`user`, `profile`,
+        /// `repo`, `service_account`).
+        pub surface: String,
+    }
+
+    /// `LOGIN_FAILED` / `PERMISSION_DENIED` and related authorization events.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct AuthDetails {
+        /// The username attempted, for a failed login of an unknown/!matched
+        /// principal. Never a password or credential.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub username: Option<String>,
+        /// The request path the principal was denied.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub path: Option<String>,
+        /// HTTP method for authorization denials, or authentication method for
+        /// failed multi-factor authentication.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub method: Option<String>,
+        /// The permission/reason the request was refused.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub reason: Option<String>,
+        /// Federated provider kind (`oidc`, `saml`, `ldap`), when applicable.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub provider: Option<String>,
+        /// Stable authentication family label, when applicable.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub auth_method: Option<String>,
+    }
+
+    /// `ARTIFACT_UPLOADED` / `ARTIFACT_DOWNLOADED` / `ARTIFACT_DELETED`.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct ArtifactDetails {
+        /// The repository the artifact lives in.
+        pub repository_id: Uuid,
+        /// The artifact path within the repository.
+        pub path: String,
+        /// Artifact display name.
+        pub name: String,
+        /// The version/coordinate, when applicable.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub version: Option<String>,
+        /// Size in bytes, when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub size_bytes: Option<u64>,
+        /// Content digest (e.g. `sha256:…`), when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub digest: Option<String>,
+        /// Original uploader, when known (not necessarily the delete actor).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub uploaded_by: Option<Uuid>,
+    }
+
+    /// `SETTING_CHANGED` — a security/system configuration change. Secret-bearing
+    /// values are redacted by the caller; only the key and non-secret summaries
+    /// belong here.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct SettingDetails {
+        /// The setting key that changed.
+        pub key: String,
+        /// A non-secret summary of the previous value, when safe to record.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub old_value: Option<String>,
+        /// A non-secret summary of the new value, when safe to record.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub new_value: Option<String>,
+    }
+
+    impl TokenDetails {
+        /// Build token metadata from a lifecycle event. Mirrors the invariant of
+        /// the existing `api_token_audit_entry` helper: the secret is never a
+        /// field here, so it cannot leak into the audit stream.
+        pub fn new(token_id: Uuid, token_name: Option<&str>, surface: &str) -> Self {
+            Self {
+                token_id: token_id.to_string(),
+                token_name: token_name.map(str::to_owned),
+                surface: surface.to_owned(),
+            }
+        }
+    }
+
+    impl AuthDetails {
+        /// Failed local authentication attempt.
+        pub fn failed_login(username: Option<&str>, reason: Option<&str>) -> Self {
+            Self {
+                username: username.map(str::to_owned),
+                path: None,
+                method: None,
+                reason: reason.map(str::to_owned),
+                provider: None,
+                auth_method: None,
+            }
+        }
+
+        /// Failed federated authentication attempt.
+        pub fn failed_federated(username: Option<&str>, provider: &str) -> Self {
+            Self {
+                username: username.map(str::to_owned),
+                path: None,
+                method: None,
+                reason: None,
+                provider: Some(provider.to_owned()),
+                auth_method: Some("federated".to_owned()),
+            }
+        }
+
+        /// Authorization denial at an HTTP boundary.
+        pub fn permission_denied(path: &str, method: &str, reason: &str) -> Self {
+            Self {
+                username: None,
+                path: Some(path.to_owned()),
+                method: Some(method.to_owned()),
+                reason: Some(reason.to_owned()),
+                provider: None,
+                auth_method: None,
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sink seam
+// ---------------------------------------------------------------------------
+
+/// A destination for emitted audit NDJSON lines.
+///
+/// The seam isolates the transport from the envelope/schema/tests: production
+/// writes to stdout, tests capture in-process, and a future OTLP-logs exporter
+/// implements this trait without touching the record shape.
+pub trait AuditSink: Send + Sync {
+    /// Write one already-newline-terminated NDJSON line.
+    fn emit(&self, line: &str);
+    /// Whether this sink wants records at all. `false` lets the emitter skip
+    /// serialization entirely when the stream is off.
+    fn enabled(&self) -> bool {
+        true
+    }
+}
+
+/// The disabled sink (default, `AUDIT_STREAM=off`): drops everything and
+/// reports itself disabled so no record is ever serialized.
+struct NoopSink;
+impl AuditSink for NoopSink {
+    fn emit(&self, _line: &str) {}
+    fn enabled(&self) -> bool {
+        false
+    }
+}
+
+/// Maximum number of audit records waiting on stdout. A bounded queue prevents
+/// a stalled container log driver from turning audit traffic into unbounded
+/// memory growth. Producers use `try_send`, so stdout backpressure never blocks
+/// a Tokio request worker.
+const AUDIT_QUEUE_CAPACITY: usize = 4096;
+
+/// Production sink: enqueue records to a dedicated blocking stdout writer.
+struct StdoutSink {
+    sender: mpsc::SyncSender<String>,
+}
+impl AuditSink for StdoutSink {
+    fn emit(&self, line: &str) {
+        match self.sender.try_send(line.to_owned()) {
+            Ok(()) => {}
+            Err(mpsc::TrySendError::Full(_)) => {
+                crate::services::metrics_service::record_audit_stream_failure("queue_full");
+            }
+            Err(mpsc::TrySendError::Disconnected(_)) => {
+                crate::services::metrics_service::record_audit_stream_failure(
+                    "writer_disconnected",
+                );
+            }
+        }
+    }
+}
+
+fn spawn_stdout_sink() -> std::io::Result<(Arc<dyn AuditSink>, std::thread::JoinHandle<()>)> {
+    let (sender, receiver) = mpsc::sync_channel::<String>(AUDIT_QUEUE_CAPACITY);
+    let worker = std::thread::Builder::new()
+        .name("audit-stdout-writer".to_owned())
+        .spawn(move || {
+            use std::io::Write;
+
+            for line in receiver {
+                let stdout = std::io::stdout();
+                let mut lock = stdout.lock();
+                if let Err(error) = lock.write_all(line.as_bytes()).and_then(|_| lock.flush()) {
+                    crate::services::metrics_service::record_audit_stream_failure("write_error");
+                    eprintln!(
+                        "audit stdout writer failed; structured audit delivery stopped: {error}"
+                    );
+                    break;
+                }
+            }
+        })?;
+    Ok((Arc::new(StdoutSink { sender }), worker))
+}
+
+fn sink_cell() -> &'static RwLock<Arc<dyn AuditSink>> {
+    static CELL: OnceLock<RwLock<Arc<dyn AuditSink>>> = OnceLock::new();
+    CELL.get_or_init(|| RwLock::new(Arc::new(NoopSink)))
+}
+
+/// The currently installed process audit sink.
+fn current_sink() -> Arc<dyn AuditSink> {
+    sink_cell()
+        .read()
+        .unwrap_or_else(|p| p.into_inner())
+        .clone()
+}
+
+/// Whether the process audit stream currently accepts records at all.
+///
+/// Callers that build export records ahead of emission (the janitor's batched
+/// path) use this to skip record construction entirely when the stream is off.
+pub fn stream_enabled() -> bool {
+    current_sink().enabled()
+}
+
+/// Build and emit the export record for a finished [`AuditEntry`].
+///
+/// The `AUDIT_STREAM=off` default costs one sink check per audit event and
+/// nothing more: the record is not even constructed when the stream is off.
+/// Never returns an error — delivery failures are counted and the audit
+/// stream never gates the originating operation.
+pub fn emit_entry(entry: &AuditEntry) {
+    let sink = current_sink();
+    if !sink.enabled() {
+        return;
+    }
+    let record = AuditEventRecord::from_entry(entry);
+    let line = record.to_ndjson_line();
+    if !line.is_empty() {
+        sink.emit(&line);
+    }
+}
+
+/// Emit one already-built audit record to the process audit sink.
+///
+/// Cheap when the stream is off (short-circuits before serialization) and
+/// non-blocking when enabled (the stdout sink uses bounded `try_send`). Never
+/// returns an error. Prefer [`emit_entry`] where the record is not already in
+/// hand — it also skips record construction on the disabled path.
+pub fn emit_audit_event(record: &AuditEventRecord) {
+    let sink = current_sink();
+    if !sink.enabled() {
+        return;
+    }
+    let line = record.to_ndjson_line();
+    if !line.is_empty() {
+        sink.emit(&line);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// The audit-stream delivery mode, selected via `AUDIT_STREAM`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuditStreamMode {
+    /// No audit records are emitted (default for v1).
+    Off,
+    /// Audit records are written as NDJSON to stdout.
+    Stdout,
+}
+
+impl AuditStreamMode {
+    /// Parse an `AUDIT_STREAM` value. Anything other than an explicit
+    /// stdout/on/true opt-in is `off`, so an operator typo never silently
+    /// starts double-emitting.
+    fn from_value(val: &str) -> Self {
+        match val.trim().to_lowercase().as_str() {
+            "stdout" | "on" | "true" | "1" => Self::Stdout,
+            _ => Self::Off,
+        }
+    }
+
+    /// Read from `AUDIT_STREAM`. Defaults to `off` when unset.
+    pub fn from_env() -> Self {
+        Self::from_value(&std::env::var("AUDIT_STREAM").unwrap_or_default())
+    }
+
+    /// Canonical name, for the startup log line.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Stdout => "stdout",
+        }
+    }
+}
+
+/// Initialize the process audit sink from `AUDIT_STREAM` and return the
+/// resolved mode. Follows the pre-`Config` env-read pattern telemetry uses so
+/// it can run alongside `init_tracing` in `main`.
+#[must_use = "dropping the guard disables the audit stream"]
+pub struct AuditStreamGuard {
+    mode: AuditStreamMode,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+impl AuditStreamGuard {
+    /// Active stream mode after initialization.
+    pub fn mode(&self) -> AuditStreamMode {
+        self.mode
+    }
+}
+
+impl Drop for AuditStreamGuard {
+    fn drop(&mut self) {
+        // Drop the process-held sender first. The detached worker observes
+        // channel closure and drains on a best-effort basis. Do not join here:
+        // a blocked container stdout must not hang graceful shutdown either.
+        *sink_cell().write().unwrap_or_else(|p| p.into_inner()) = Arc::new(NoopSink);
+        let _ = self.worker.take();
+    }
+}
+
+pub fn init_audit_stream_from_env() -> AuditStreamGuard {
+    let mode = AuditStreamMode::from_env();
+    let (resolved_mode, sink, worker): (
+        AuditStreamMode,
+        Arc<dyn AuditSink>,
+        Option<std::thread::JoinHandle<()>>,
+    ) = match mode {
+        AuditStreamMode::Stdout => match spawn_stdout_sink() {
+            Ok((sink, worker)) => (AuditStreamMode::Stdout, sink, Some(worker)),
+            Err(error) => {
+                tracing::error!(%error, "failed to start audit stdout writer; stream disabled");
+                (AuditStreamMode::Off, Arc::new(NoopSink), None)
+            }
+        },
+        AuditStreamMode::Off => (AuditStreamMode::Off, Arc::new(NoopSink), None),
+    };
+    *sink_cell().write().unwrap_or_else(|p| p.into_inner()) = sink;
+    AuditStreamGuard {
+        mode: resolved_mode,
+        worker,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test sink
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) mod test_sink {
+    //! In-process capture sink + a swap guard so `log()`-path emission can be
+    //! asserted without process isolation. A global mutex serializes tests that
+    //! touch the shared sink; the guard restores the previous sink on drop.
+
+    use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    static SINK_TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    /// Captures every emitted line for assertions.
+    #[derive(Default)]
+    pub struct BufferSink {
+        lines: Mutex<Vec<String>>,
+    }
+
+    impl BufferSink {
+        /// Snapshot of the lines captured so far.
+        pub fn lines(&self) -> Vec<String> {
+            self.lines.lock().unwrap_or_else(|p| p.into_inner()).clone()
+        }
+
+        /// Parse the captured lines as JSON values (each line must be valid
+        /// NDJSON).
+        pub fn records(&self) -> Vec<serde_json::Value> {
+            self.lines()
+                .iter()
+                .map(|l| serde_json::from_str(l).expect("emitted line is valid NDJSON"))
+                .collect()
+        }
+    }
+
+    impl AuditSink for BufferSink {
+        fn emit(&self, line: &str) {
+            self.lines
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .push(line.to_string());
+        }
+    }
+
+    /// Holds the sink swap for the duration of a test and restores it on drop.
+    pub struct SinkGuard {
+        prev: Arc<dyn AuditSink>,
+        // Held to serialize sink-dependent tests; released after `prev` is
+        // restored (fields drop in declaration order).
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl Drop for SinkGuard {
+        fn drop(&mut self) {
+            *sink_cell().write().unwrap_or_else(|p| p.into_inner()) = self.prev.clone();
+        }
+    }
+
+    /// Install a fresh [`BufferSink`] as the process sink, returning it plus a
+    /// guard that restores the prior sink when dropped.
+    pub fn install() -> (Arc<BufferSink>, SinkGuard) {
+        let lock = SINK_TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        let buffer = Arc::new(BufferSink::default());
+        let dyn_buf: Arc<dyn AuditSink> = buffer.clone();
+        let prev = {
+            let mut w = sink_cell().write().unwrap_or_else(|p| p.into_inner());
+            let old = w.clone();
+            *w = dyn_buf;
+            old
+        };
+        (buffer, SinkGuard { prev, _lock: lock })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::audit_service::{AuditEntry, ResourceType};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    // ── Outcome derivation ──────────────────────────────────────────────
+
+    #[test]
+    fn test_outcome_failure_variants() {
+        assert_eq!(AuditAction::LoginFailed.outcome(), Outcome::Failure);
+        assert_eq!(AuditAction::BackupFailed.outcome(), Outcome::Failure);
+        assert_eq!(AuditAction::RestoreFailed.outcome(), Outcome::Failure);
+    }
+
+    #[test]
+    fn test_outcome_denied_variants() {
+        assert_eq!(AuditAction::PermissionDenied.outcome(), Outcome::Denied);
+        assert_eq!(AuditAction::AgeGateRejected.outcome(), Outcome::Denied);
+    }
+
+    #[test]
+    fn test_outcome_success_default() {
+        for a in [
+            AuditAction::Login,
+            AuditAction::Logout,
+            AuditAction::ApiTokenCreated,
+            AuditAction::RepositoryCreated,
+            AuditAction::ArtifactUploaded,
+            AuditAction::ScanReaped,
+            AuditAction::BackupCompleted,
+            AuditAction::AgeGateApproved,
+        ] {
+            assert_eq!(a.outcome(), Outcome::Success, "{}", a.as_str());
+        }
+    }
+
+    #[test]
+    fn test_outcome_serializes_lowercase() {
+        assert_eq!(
+            serde_json::to_value(Outcome::Denied).unwrap(),
+            serde_json::json!("denied")
+        );
+    }
+
+    // ── Actor typing ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_from_entry_user_actor_with_name() {
+        let uid = Uuid::new_v4();
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User)
+            .user(uid)
+            .actor_name("alice");
+        let rec = AuditEventRecord::from_entry(&entry);
+        assert_eq!(rec.actor.kind, ActorType::User);
+        assert_eq!(rec.actor.id, Some(uid));
+        assert_eq!(rec.actor.name.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn test_from_entry_anonymous_actor_when_no_user_and_not_system() {
+        let entry = AuditEntry::new(AuditAction::LoginFailed, ResourceType::User);
+        let rec = AuditEventRecord::from_entry(&entry);
+        assert_eq!(rec.actor.kind, ActorType::Anonymous);
+        assert_eq!(rec.actor.id, None);
+    }
+
+    #[test]
+    fn test_from_entry_system_actor_from_details_label() {
+        let entry = AuditEntry::new(AuditAction::ScanReaped, ResourceType::ScanResult)
+            .system_actor("system:stuck_scan_janitor");
+        let rec = AuditEventRecord::from_entry(&entry);
+        assert_eq!(rec.actor.kind, ActorType::System);
+        assert_eq!(rec.actor.name.as_deref(), Some("system:stuck_scan_janitor"));
+    }
+
+    // ── Envelope shape ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_from_entry_populates_envelope() {
+        let uid = Uuid::new_v4();
+        let rid = Uuid::new_v4();
+        let ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 7));
+        let entry = AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .user(uid)
+            .resource(rid)
+            .ip(ip)
+            .correlation("corr-xyz");
+        let rec = AuditEventRecord::from_entry(&entry);
+        assert_eq!(rec.schema_version, SCHEMA_VERSION);
+        assert_eq!(rec.category, "audit");
+        assert_eq!(rec.action, "REPOSITORY_CREATED");
+        assert_eq!(rec.outcome, Outcome::Success);
+        assert_eq!(rec.resource.kind, "repository");
+        assert_eq!(rec.resource.id, Some(rid));
+        assert_eq!(rec.source_ip, Some(ip));
+        assert_eq!(rec.correlation_id, "corr-xyz");
+        assert_eq!(rec.event_id, entry.event_id());
+    }
+
+    /// The subject-keyed builders (password/session events) keep `subject` in
+    /// the DB row's `user_id` but export the true initiator: the envelope-only
+    /// `.actor_id()` override wins over `user_id` for `actor.id`.
+    #[test]
+    fn test_from_entry_actor_id_override_wins_over_user_id() {
+        let subject = Uuid::new_v4();
+        let admin = Uuid::new_v4();
+        let entry = AuditEntry::new(AuditAction::PasswordChanged, ResourceType::User)
+            .user(subject)
+            .resource(subject)
+            .actor_id(admin);
+        let rec = AuditEventRecord::from_entry(&entry);
+        assert_eq!(rec.actor.kind, ActorType::User);
+        assert_eq!(rec.actor.id, Some(admin), "envelope actor is the initiator");
+        assert_eq!(rec.resource.id, Some(subject));
+    }
+
+    /// Size-bounding applies to the exported copy ONLY: the record carries the
+    /// truncation marker while the builder — i.e. the DB row — keeps the full
+    /// payload.
+    #[test]
+    fn test_from_entry_truncates_oversized_details_in_export_copy_only() {
+        let entry = AuditEntry::new(AuditAction::SettingChanged, ResourceType::Setting)
+            .details(serde_json::json!({"value": "x".repeat(AUDIT_DETAILS_MAX_BYTES)}));
+        let rec = AuditEventRecord::from_entry(&entry);
+        let exported = rec.details.expect("exported details present");
+        assert_eq!(exported["details_truncated"], true);
+        assert!(exported["original_size_bytes"].as_u64().unwrap() > AUDIT_DETAILS_MAX_BYTES as u64);
+        let stored = entry.details_ref().expect("stored details present");
+        assert_eq!(
+            stored["value"].as_str().unwrap().len(),
+            AUDIT_DETAILS_MAX_BYTES,
+            "DB copy keeps the full payload"
+        );
+    }
+
+    #[test]
+    fn test_to_ndjson_line_is_single_parseable_line() {
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        let line = AuditEventRecord::from_entry(&entry).to_ndjson_line();
+        assert!(line.ends_with('\n'));
+        assert_eq!(line.matches('\n').count(), 1, "exactly one line");
+        let v: serde_json::Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(v["category"], "audit");
+        assert_eq!(v["schema_version"], SCHEMA_VERSION);
+    }
+
+    /// Envelope snapshot pinning field names + casing — this is the compat
+    /// contract, so a rename must fail a test, never slip through.
+    #[test]
+    fn test_envelope_field_names_and_casing() {
+        let entry = AuditEntry::new(AuditAction::PermissionDenied, ResourceType::User);
+        let v = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        let obj = v.as_object().unwrap();
+        for key in [
+            "schema_version",
+            "category",
+            "event_id",
+            "timestamp",
+            "action",
+            "outcome",
+            "actor",
+            "source_ip",
+            "resource",
+            "correlation_id",
+            "details",
+        ] {
+            assert!(obj.contains_key(key), "missing envelope key: {key}");
+        }
+        // Nested renames: `type` (not `kind`) inside actor and resource.
+        assert!(v["actor"].as_object().unwrap().contains_key("type"));
+        assert!(v["resource"].as_object().unwrap().contains_key("type"));
+    }
+
+    // ── Sink / emission ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_default_sink_disabled_emits_nothing() {
+        // With no stream installed (or explicitly off) emission is a no-op:
+        // capture with a buffer, restore, and confirm the disabled path.
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        let rec = AuditEventRecord::from_entry(&entry);
+        // NoopSink reports disabled.
+        assert!(!NoopSink.enabled());
+        // to_ndjson_line still works standalone.
+        assert!(rec.to_ndjson_line().contains("\"category\":\"audit\""));
+    }
+
+    /// Records matching a unique correlation id. The process sink is global, so
+    /// a concurrent `log()` in another test could append to the same buffer;
+    /// filtering by a per-test unique correlation makes the assertions immune to
+    /// that interleaving.
+    fn recs_for(buffer: &super::test_sink::BufferSink, corr: &str) -> Vec<serde_json::Value> {
+        buffer
+            .records()
+            .into_iter()
+            .filter(|r| r["correlation_id"] == corr)
+            .collect()
+    }
+
+    #[test]
+    fn test_emit_captures_exactly_one_line_via_buffer_sink() {
+        let (buffer, _guard) = test_sink::install();
+        let corr = format!("emit-one-{}", Uuid::new_v4());
+        let entry = AuditEntry::new(AuditAction::RepositoryDeleted, ResourceType::Repository)
+            .correlation(&corr);
+        emit_audit_event(&AuditEventRecord::from_entry(&entry));
+        let recs = recs_for(&buffer, &corr);
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["category"], "audit");
+        assert_eq!(recs[0]["action"], "REPOSITORY_DELETED");
+    }
+
+    #[test]
+    fn test_stream_enabled_and_emit_entry_via_installed_sink() {
+        let (buffer, _guard) = test_sink::install();
+        assert!(stream_enabled(), "installed buffer sink reports enabled");
+        let corr = format!("emit-entry-{}", Uuid::new_v4());
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User).correlation(&corr);
+        emit_entry(&entry);
+        let recs = recs_for(&buffer, &corr);
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["event_id"], entry.event_id().to_string());
+    }
+
+    #[test]
+    fn test_buffer_sink_captures_multiple_in_order() {
+        let (buffer, _guard) = test_sink::install();
+        let base = Uuid::new_v4();
+        let corrs: Vec<String> = (0..3).map(|i| format!("{base}-{i}")).collect();
+        for corr in &corrs {
+            let entry = AuditEntry::new(AuditAction::Login, ResourceType::User).correlation(corr);
+            emit_audit_event(&AuditEventRecord::from_entry(&entry));
+        }
+        // Filter to this test's records; append order is preserved.
+        let mine: Vec<String> = buffer
+            .records()
+            .into_iter()
+            .filter_map(|r| r["correlation_id"].as_str().map(str::to_owned))
+            .filter(|c| corrs.contains(c))
+            .collect();
+        assert_eq!(mine, corrs);
+    }
+
+    // ── AuditStreamMode ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_stream_mode_from_value() {
+        assert_eq!(
+            AuditStreamMode::from_value("stdout"),
+            AuditStreamMode::Stdout
+        );
+        assert_eq!(AuditStreamMode::from_value("ON"), AuditStreamMode::Stdout);
+        assert_eq!(AuditStreamMode::from_value("true"), AuditStreamMode::Stdout);
+        assert_eq!(AuditStreamMode::from_value(""), AuditStreamMode::Off);
+        assert_eq!(AuditStreamMode::from_value("off"), AuditStreamMode::Off);
+        assert_eq!(AuditStreamMode::from_value("bogus"), AuditStreamMode::Off);
+    }
+
+    #[test]
+    fn test_stream_mode_name() {
+        assert_eq!(AuditStreamMode::Off.name(), "off");
+        assert_eq!(AuditStreamMode::Stdout.name(), "stdout");
+    }
+
+    // ── Typed detail payloads (#2413 §6) ────────────────────────────────
+
+    #[test]
+    fn test_repository_details_omits_absent_optionals() {
+        let d = details::RepositoryDetails {
+            actor_id: Uuid::new_v4(),
+            key: "maven-releases".into(),
+            is_public: false,
+            format: Some("maven".into()),
+            visibility: None,
+            age_gate_enabled: None,
+            age_gate_min_age_days: None,
+        };
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(v["key"], "maven-releases");
+        assert_eq!(v["format"], "maven");
+        assert!(
+            !v.as_object().unwrap().contains_key("visibility"),
+            "absent Option is omitted, not null"
+        );
+    }
+
+    #[test]
+    fn test_permission_details_shape() {
+        let role_id = Uuid::new_v4();
+        let grantee_id = Uuid::new_v4();
+        let d = details::PermissionDetails {
+            actor_id: Uuid::new_v4(),
+            role_id,
+            grantee_id,
+            repository_id: None,
+        };
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(v["role_id"], role_id.to_string());
+        assert_eq!(v["grantee_id"], grantee_id.to_string());
+    }
+
+    #[test]
+    fn test_token_details_never_carries_secret() {
+        let d = details::TokenDetails::new(Uuid::new_v4(), Some("ci-token"), "profile");
+        let v = serde_json::to_value(&d).unwrap();
+        let obj = v.as_object().unwrap();
+        assert_eq!(v["surface"], "profile");
+        assert_eq!(v["token_name"], "ci-token");
+        // The struct has no field that could hold the secret.
+        assert!(!obj.contains_key("secret"));
+        assert!(!obj.contains_key("token"));
+        assert!(!obj.contains_key("value"));
+    }
+
+    #[test]
+    fn test_token_details_omits_absent_name() {
+        let d = details::TokenDetails::new(Uuid::new_v4(), None, "service_account");
+        let v = serde_json::to_value(&d).unwrap();
+        assert!(!v.as_object().unwrap().contains_key("token_name"));
+    }
+
+    #[test]
+    fn test_auth_details_shape() {
+        let d = details::AuthDetails {
+            username: Some("attacker".into()),
+            path: Some("/api/v1/admin/users".into()),
+            method: Some("GET".into()),
+            reason: Some("admin_privileges_required".into()),
+            provider: None,
+            auth_method: None,
+        };
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(v["username"], "attacker");
+        assert_eq!(v["path"], "/api/v1/admin/users");
+        assert_eq!(v["reason"], "admin_privileges_required");
+    }
+
+    #[test]
+    fn test_artifact_details_shape() {
+        let repository_id = Uuid::new_v4();
+        let d = details::ArtifactDetails {
+            repository_id,
+            path: "@scope/pkg/-/pkg-1.2.3.tgz".into(),
+            name: "pkg-1.2.3.tgz".into(),
+            version: Some("1.2.3".into()),
+            size_bytes: Some(4096),
+            digest: Some("sha256:abcd".into()),
+            uploaded_by: None,
+        };
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(v["repository_id"], repository_id.to_string());
+        assert_eq!(v["size_bytes"], 4096);
+        assert_eq!(v["digest"], "sha256:abcd");
+    }
+
+    #[test]
+    fn test_setting_details_shape() {
+        let d = details::SettingDetails {
+            key: "auth.session_ttl".into(),
+            old_value: Some("3600".into()),
+            new_value: Some("1800".into()),
+        };
+        let v = serde_json::to_value(&d).unwrap();
+        assert_eq!(v["key"], "auth.session_ttl");
+        assert_eq!(v["old_value"], "3600");
+        assert_eq!(v["new_value"], "1800");
+    }
+
+    /// A typed detail payload lands in the envelope's `details` unchanged and is
+    /// emitted as part of the record.
+    #[test]
+    fn test_typed_details_round_trip_through_envelope() {
+        let corr = format!("typed-{}", Uuid::new_v4());
+        let entry = AuditEntry::new(AuditAction::ApiTokenCreated, ResourceType::ApiToken)
+            .correlation(&corr)
+            .details_typed(details::TokenDetails::new(
+                Uuid::new_v4(),
+                Some("ci"),
+                "profile",
+            ));
+        let rec = AuditEventRecord::from_entry(&entry);
+        let v = serde_json::to_value(&rec).unwrap();
+        assert_eq!(v["details"]["surface"], "profile");
+        assert_eq!(v["details"]["token_name"], "ci");
+    }
+}

--- a/backend/src/services/audit_schema.rs
+++ b/backend/src/services/audit_schema.rs
@@ -1,0 +1,447 @@
+//! Published audit-event JSON Schema + drift gate (#2413).
+//!
+//! `backend/schemas/audit-event.v1.schema.json` is the committed, machine-readable
+//! contract for the exported audit stream. It lives inside the crate (so the
+//! Docker build context carries it) and is embedded here with `include_str!` so
+//! the running binary and the tests validate against the exact bytes that ship
+//! in the repo.
+//!
+//! The enforcement is inverted from a generate-and-diff gate: rather than
+//! regenerate the schema from the Rust types, a normal `--lib` test serializes
+//! live [`AuditEventRecord`](crate::services::audit_export::AuditEventRecord)
+//! instances (and one instance of every typed detail struct) and validates them
+//! against the committed schema with a dependency-free JSON-Schema-subset
+//! checker. If a Rust field is renamed, retyped, or dropped, the emitted JSON no
+//! longer conforms and CI fails — so the typed payloads cannot silently diverge
+//! from the published contract, which is exactly what the issue asks for. No new
+//! runtime or dev dependency is pulled in for this.
+
+/// The committed audit-event JSON Schema, embedded from the crate.
+pub const SCHEMA_JSON: &str = include_str!("../../schemas/audit-event.v1.schema.json");
+
+/// Parse the committed schema. Panics only if the committed file is not valid
+/// JSON, which the self-consistency test catches in ordinary CI.
+pub fn schema() -> serde_json::Value {
+    serde_json::from_str(SCHEMA_JSON).expect("committed audit-event schema is valid JSON")
+}
+
+#[cfg(test)]
+mod validator {
+    //! A tiny JSON-Schema-subset validator: enough of draft 2020-12 to gate the
+    //! audit envelope and its typed detail payloads without an external crate.
+    //! Supported keywords: `$ref` (into `#/$defs/*`), `type` (string or array),
+    //! `const`, `enum`, `required`, `properties`, `additionalProperties: false`,
+    //! `anyOf`, and the `allOf` + `if`/`then` subset used for action
+    //! discrimination.
+    //! `format`, `minimum`, and descriptions are advisory and ignored.
+
+    use serde_json::Value;
+
+    /// Validate `instance` against `schema` (resolving `$ref`s against `root`).
+    /// Returns a list of human-readable errors; empty means valid.
+    pub fn validate(schema: &Value, instance: &Value, root: &Value) -> Vec<String> {
+        let mut errors = Vec::new();
+        validate_at(schema, instance, root, "$", &mut errors);
+        errors
+    }
+
+    fn resolve<'a>(reference: &str, root: &'a Value) -> Option<&'a Value> {
+        // Only local `#/$defs/Name` refs are used by the committed schema.
+        let name = reference.strip_prefix("#/$defs/")?;
+        root.get("$defs")?.get(name)
+    }
+
+    fn type_matches(ty: &str, instance: &Value) -> bool {
+        match ty {
+            "string" => instance.is_string(),
+            "integer" => instance.is_i64() || instance.is_u64(),
+            "number" => instance.is_number(),
+            "object" => instance.is_object(),
+            "array" => instance.is_array(),
+            "boolean" => instance.is_boolean(),
+            "null" => instance.is_null(),
+            _ => false,
+        }
+    }
+
+    fn validate_at(
+        schema: &Value,
+        instance: &Value,
+        root: &Value,
+        path: &str,
+        errors: &mut Vec<String>,
+    ) {
+        if let Some(Value::Array(parts)) = schema.get("allOf") {
+            for part in parts {
+                validate_at(part, instance, root, path, errors);
+            }
+        }
+
+        if let Some(Value::Array(alternatives)) = schema.get("anyOf") {
+            let matched = alternatives.iter().any(|alternative| {
+                let mut alternative_errors = Vec::new();
+                validate_at(alternative, instance, root, path, &mut alternative_errors);
+                alternative_errors.is_empty()
+            });
+            if !matched {
+                errors.push(format!("{path}: did not match anyOf alternatives"));
+            }
+        }
+
+        if let Some(condition) = schema.get("if") {
+            let mut condition_errors = Vec::new();
+            validate_at(condition, instance, root, path, &mut condition_errors);
+            if condition_errors.is_empty() {
+                if let Some(then_schema) = schema.get("then") {
+                    validate_at(then_schema, instance, root, path, errors);
+                }
+            }
+        }
+
+        if let Some(Value::String(reference)) = schema.get("$ref") {
+            match resolve(reference, root) {
+                Some(target) => validate_at(target, instance, root, path, errors),
+                None => errors.push(format!("{path}: unresolved $ref {reference}")),
+            }
+            return;
+        }
+
+        if let Some(expected) = schema.get("const") {
+            if instance != expected {
+                errors.push(format!("{path}: expected const {expected}, got {instance}"));
+            }
+        }
+
+        if let Some(Value::Array(choices)) = schema.get("enum") {
+            if !choices.iter().any(|c| c == instance) {
+                errors.push(format!("{path}: {instance} not in enum {choices:?}"));
+            }
+        }
+
+        if let Some(ty) = schema.get("type") {
+            let ok = match ty {
+                Value::String(s) => type_matches(s, instance),
+                Value::Array(alts) => alts
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .any(|s| type_matches(s, instance)),
+                _ => true,
+            };
+            if !ok {
+                errors.push(format!("{path}: type mismatch, want {ty}, got {instance}"));
+            }
+        }
+
+        // Object-shape keywords only apply when the instance is actually an
+        // object (a `["object","null"]` field carrying null skips these).
+        if let Value::Object(map) = instance {
+            if let Some(Value::Array(required)) = schema.get("required") {
+                for key in required.iter().filter_map(Value::as_str) {
+                    if !map.contains_key(key) {
+                        errors.push(format!("{path}: missing required property '{key}'"));
+                    }
+                }
+            }
+
+            let props = schema.get("properties").and_then(Value::as_object);
+            if let Some(props) = props {
+                for (key, sub) in props {
+                    if let Some(child) = map.get(key) {
+                        validate_at(sub, child, root, &format!("{path}.{key}"), errors);
+                    }
+                }
+            }
+
+            if schema.get("additionalProperties") == Some(&Value::Bool(false)) {
+                for key in map.keys() {
+                    let known = props.map(|p| p.contains_key(key)).unwrap_or(false);
+                    if !known {
+                        errors.push(format!("{path}: unexpected property '{key}'"));
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::audit_export::{details, AuditEventRecord};
+    use crate::services::audit_service::{AuditAction, AuditEntry, ResourceType};
+    use serde_json::json;
+    use std::net::{IpAddr, Ipv4Addr};
+    use uuid::Uuid;
+
+    fn root() -> serde_json::Value {
+        schema()
+    }
+
+    fn assert_valid(instance: &serde_json::Value) {
+        let s = root();
+        let errors = validator::validate(&s, instance, &s);
+        assert!(errors.is_empty(), "expected valid, got: {errors:?}");
+    }
+
+    fn assert_valid_against(def: &str, instance: &serde_json::Value) {
+        let s = root();
+        let def_schema = s["$defs"][def].clone();
+        let errors = validator::validate(&def_schema, instance, &s);
+        assert!(errors.is_empty(), "{def}: expected valid, got: {errors:?}");
+
+        let emitted_keys: std::collections::BTreeSet<_> = instance
+            .as_object()
+            .expect("typed details serialize as an object")
+            .keys()
+            .cloned()
+            .collect();
+        let schema_keys: std::collections::BTreeSet<_> = def_schema["properties"]
+            .as_object()
+            .expect("typed details schema has properties")
+            .keys()
+            .cloned()
+            .collect();
+        assert_eq!(
+            emitted_keys, schema_keys,
+            "{def}: serialized fields and published properties drifted"
+        );
+    }
+
+    // ── the committed file itself ───────────────────────────────────────
+
+    #[test]
+    fn test_committed_schema_is_valid_json_and_self_consistent() {
+        let s = root();
+        assert_eq!(s["properties"]["schema_version"]["const"], json!(1));
+        assert_eq!(s["properties"]["category"]["const"], json!("audit"));
+        assert_eq!(s["additionalProperties"], json!(true));
+        // Stable outcome values are closed; actor types are open for additive
+        // compatibility and publish their current values as examples.
+        assert_eq!(
+            s["$defs"]["Outcome"]["enum"],
+            json!(["success", "failure", "denied"])
+        );
+        assert_eq!(
+            s["$defs"]["ActorType"]["examples"],
+            json!(["system", "user", "anonymous", "service_account"])
+        );
+        // All typed detail defs are published.
+        for def in [
+            "TruncatedDetails",
+            "RepositoryDetails",
+            "PermissionDetails",
+            "TokenDetails",
+            "AuthDetails",
+            "ArtifactDetails",
+            "SettingDetails",
+        ] {
+            assert!(s["$defs"][def].is_object(), "missing $def {def}");
+        }
+    }
+
+    // ── live envelope records validate ──────────────────────────────────
+
+    #[test]
+    fn test_representative_envelopes_validate() {
+        let uid = Uuid::new_v4();
+        let published_keys: std::collections::BTreeSet<_> = root()["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        let entries = vec![
+            AuditEntry::new(AuditAction::Login, ResourceType::User)
+                .user(uid)
+                .actor_name("alice")
+                .ip(IpAddr::V4(Ipv4Addr::new(203, 0, 113, 5))),
+            AuditEntry::new(AuditAction::LoginFailed, ResourceType::User)
+                .details_typed(details::AuthDetails::failed_login(Some("attacker"), None)),
+            AuditEntry::new(AuditAction::ScanReaped, ResourceType::ScanResult)
+                .system_actor("system:stuck_scan_janitor"),
+            AuditEntry::new(AuditAction::PermissionDenied, ResourceType::User)
+                .user(uid)
+                .details_typed(details::AuthDetails::permission_denied(
+                    "/api/v1/admin",
+                    "GET",
+                    "admin_privileges_required",
+                )),
+            AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+                .user(uid)
+                .resource(Uuid::new_v4())
+                .resource_name("maven-releases")
+                .details_typed(details::RepositoryDetails {
+                    actor_id: uid,
+                    key: "maven-releases".into(),
+                    is_public: false,
+                    format: Some("maven".into()),
+                    visibility: Some("private".into()),
+                    age_gate_enabled: None,
+                    age_gate_min_age_days: None,
+                }),
+        ];
+        for entry in &entries {
+            let v = serde_json::to_value(AuditEventRecord::from_entry(entry)).unwrap();
+            assert_valid(&v);
+            let emitted_keys: std::collections::BTreeSet<_> =
+                v.as_object().unwrap().keys().cloned().collect();
+            assert_eq!(
+                emitted_keys, published_keys,
+                "envelope fields and published properties drifted"
+            );
+        }
+    }
+
+    #[test]
+    fn test_envelope_with_typed_details_validates() {
+        let entry = AuditEntry::new(AuditAction::ApiTokenCreated, ResourceType::ApiToken)
+            .user(Uuid::new_v4())
+            .details_typed(details::TokenDetails::new(
+                Uuid::new_v4(),
+                Some("ci"),
+                "profile",
+            ));
+        let v = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        assert_valid(&v);
+    }
+
+    #[test]
+    fn test_action_discriminator_rejects_wrong_representative_details() {
+        let entry = AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .details(serde_json::json!({
+                "key": "maven-releases",
+                "is_public": false,
+            }));
+        let instance = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        let s = root();
+        let errors = validator::validate(&s, &instance, &s);
+        assert!(
+            errors.iter().any(|error| error.contains("anyOf")),
+            "repository action must be checked against RepositoryDetails: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn test_action_discriminator_accepts_bounded_truncation_marker() {
+        let entry = AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .details(serde_json::json!({"value": "x".repeat(70_000)}));
+        let instance = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        assert_eq!(instance["details"]["details_truncated"], true);
+        assert_valid(&instance);
+    }
+
+    // ── typed detail structs validate against their $defs ───────────────
+
+    #[test]
+    fn test_typed_details_validate_against_defs() {
+        assert_valid_against(
+            "RepositoryDetails",
+            &serde_json::to_value(details::RepositoryDetails {
+                actor_id: Uuid::new_v4(),
+                key: "maven-releases".into(),
+                is_public: false,
+                format: Some("maven".into()),
+                visibility: Some("private".into()),
+                age_gate_enabled: Some(true),
+                age_gate_min_age_days: Some(14),
+            })
+            .unwrap(),
+        );
+        assert_valid_against(
+            "PermissionDetails",
+            &serde_json::to_value(details::PermissionDetails {
+                actor_id: Uuid::new_v4(),
+                role_id: Uuid::new_v4(),
+                grantee_id: Uuid::new_v4(),
+                repository_id: Some(Uuid::new_v4()),
+            })
+            .unwrap(),
+        );
+        assert_valid_against(
+            "TokenDetails",
+            &serde_json::to_value(details::TokenDetails::new(
+                Uuid::new_v4(),
+                Some("ci"),
+                "profile",
+            ))
+            .unwrap(),
+        );
+        assert_valid_against(
+            "AuthDetails",
+            &serde_json::to_value(details::AuthDetails {
+                username: Some("attacker".into()),
+                path: Some("/api/v1/admin".into()),
+                method: Some("GET".into()),
+                reason: Some("admin_privileges_required".into()),
+                provider: Some("oidc".into()),
+                auth_method: Some("federated".into()),
+            })
+            .unwrap(),
+        );
+        assert_valid_against(
+            "ArtifactDetails",
+            &serde_json::to_value(details::ArtifactDetails {
+                repository_id: Uuid::new_v4(),
+                path: "pkg-1.2.3.tgz".into(),
+                name: "pkg-1.2.3.tgz".into(),
+                version: Some("1.2.3".into()),
+                size_bytes: Some(4096),
+                digest: Some("sha256:abcd".into()),
+                uploaded_by: Some(Uuid::new_v4()),
+            })
+            .unwrap(),
+        );
+        assert_valid_against(
+            "SettingDetails",
+            &serde_json::to_value(details::SettingDetails {
+                key: "auth.session_ttl".into(),
+                old_value: Some("3600".into()),
+                new_value: Some("1800".into()),
+            })
+            .unwrap(),
+        );
+    }
+
+    // ── the validator actually rejects (guards the gate itself) ─────────
+
+    #[test]
+    fn test_schema_allows_additive_top_level_field() {
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        let mut v = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        v.as_object_mut()
+            .unwrap()
+            .insert("rogue".into(), json!("x"));
+        let s = root();
+        let errors = validator::validate(&s, &v, &s);
+        assert!(
+            errors.is_empty(),
+            "additive fields are v1-compatible: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn test_validator_rejects_bad_outcome_enum() {
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        let mut v = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        v["outcome"] = json!("bogus");
+        let s = root();
+        let errors = validator::validate(&s, &v, &s);
+        assert!(
+            errors.iter().any(|e| e.contains("outcome")),
+            "outcome enum must be enforced; got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn test_validator_rejects_missing_required_field() {
+        let entry = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        let mut v = serde_json::to_value(AuditEventRecord::from_entry(&entry)).unwrap();
+        v.as_object_mut().unwrap().remove("correlation_id");
+        let s = root();
+        let errors = validator::validate(&s, &v, &s);
+        assert!(
+            errors.iter().any(|e| e.contains("correlation_id")),
+            "required fields must be enforced; got {errors:?}"
+        );
+    }
+}

--- a/backend/src/services/audit_service.rs
+++ b/backend/src/services/audit_service.rs
@@ -7,6 +7,7 @@ use std::net::IpAddr;
 use uuid::Uuid;
 
 use crate::error::{AppError, Result};
+use crate::services::audit_export::{self, Outcome};
 
 /// Audit action types
 #[derive(Debug, Clone, Copy)]
@@ -184,13 +185,126 @@ impl ResourceType {
 
 /// Audit log entry builder
 pub struct AuditEntry {
+    /// Client-minted event id (#2413). Passed explicitly to the INSERT so the
+    /// exported stream record and the DB row share one id — the SIEM ↔
+    /// admin-API join key — and so a record can be emitted even when the row
+    /// write fails.
+    event_id: Uuid,
     user_id: Option<Uuid>,
     action: AuditAction,
     resource_type: ResourceType,
     resource_id: Option<Uuid>,
+    /// Best-effort resource name for the export envelope (#2413); never stored
+    /// in the DB row.
+    resource_name: Option<String>,
     details: Option<serde_json::Value>,
     ip_address: Option<IpAddr>,
     correlation_id: String,
+    /// Best-effort actor display name for the export envelope (#2413); populated
+    /// where the handler already has it, never via a query-time join. Not stored
+    /// in the DB row (the admin API joins `users` at query time, #2392).
+    actor_name: Option<String>,
+    /// Optional explicit outcome for the export envelope (#2413). When unset the
+    /// outcome is derived from the action name. Not stored in the DB row.
+    outcome_override: Option<Outcome>,
+    /// Export-envelope actor-id override (#2413) for entries whose DB `user_id`
+    /// deliberately records a different principal (the subject-keyed password /
+    /// session events). Not stored in the DB row.
+    actor_id_override: Option<Uuid>,
+}
+
+/// Central sanitation for the free-form compatibility payload: the anti-spoof
+/// `actor` strip, normalization of legacy scalar payloads, and recursive
+/// redaction of known secret-bearing keys — the last line of defense before a
+/// `details` value reaches the DB row or the export stream. Size-bounding of
+/// the exported copy lives in [`crate::services::audit_export`]; the DB row
+/// always keeps the full (sanitized) payload.
+const AUDIT_LABEL_MAX_BYTES: usize = 4096;
+const AUDIT_REDACTED_VALUE: &str = "[REDACTED]";
+
+fn clamp_audit_label(value: impl Into<String>) -> String {
+    let mut value = value.into();
+    if value.len() <= AUDIT_LABEL_MAX_BYTES {
+        return value;
+    }
+    let mut end = AUDIT_LABEL_MAX_BYTES;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value.truncate(end);
+    value
+}
+
+fn audit_detail_key_is_sensitive(key: &str) -> bool {
+    let normalized = key.trim().to_ascii_lowercase().replace('-', "_");
+    matches!(
+        normalized.as_str(),
+        "authorization"
+            | "proxy_authorization"
+            | "cookie"
+            | "set_cookie"
+            | "password"
+            | "password_hash"
+            | "current_password"
+            | "new_password"
+            | "old_password"
+            | "secret"
+            | "client_secret"
+            | "credential"
+            | "credentials"
+            | "token"
+            | "access_token"
+            | "refresh_token"
+            | "id_token"
+            | "totp_token"
+            | "totp_secret"
+            | "api_key"
+            | "private_key"
+            | "saml_response"
+            | "upstream_password"
+    )
+}
+
+fn redact_audit_detail_secrets(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map {
+                if audit_detail_key_is_sensitive(key) {
+                    *child = serde_json::Value::String(AUDIT_REDACTED_VALUE.to_owned());
+                } else {
+                    redact_audit_detail_secrets(child);
+                }
+            }
+        }
+        serde_json::Value::Array(values) => {
+            for child in values {
+                redact_audit_detail_secrets(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn sanitize_audit_details(mut details: serde_json::Value) -> serde_json::Value {
+    if let serde_json::Value::Object(map) = &mut details {
+        if map.remove("actor").is_some() {
+            tracing::error!(
+                "AuditEntry::details received an 'actor' key from a caller; \
+                 stripping to prevent system-actor spoofing. Use \
+                 AuditEntry::system_actor() for system-initiated entries."
+            );
+        }
+    }
+
+    // The published envelope permits `details` as object|null. Preserve legacy
+    // scalar/array payloads under a stable object key instead of emitting a
+    // schema-invalid record.
+    if !details.is_object() && !details.is_null() {
+        details = serde_json::json!({ "value": details });
+    }
+
+    redact_audit_detail_secrets(&mut details);
+    details
 }
 
 impl AuditEntry {
@@ -208,15 +322,20 @@ impl AuditEntry {
     /// operation.
     pub fn new(action: AuditAction, resource_type: ResourceType) -> Self {
         Self {
+            event_id: Uuid::new_v4(),
             user_id: None,
             action,
             resource_type,
             resource_id: None,
+            resource_name: None,
             details: None,
             ip_address: None,
             correlation_id: crate::api::middleware::tracing::current_correlation_id()
                 .map(crate::api::middleware::tracing::CorrelationId::into_string)
                 .unwrap_or_else(|| Uuid::new_v4().to_string()),
+            actor_name: None,
+            outcome_override: None,
+            actor_id_override: None,
         }
     }
 
@@ -245,20 +364,7 @@ impl AuditEntry {
     /// method bypasses the user-input path and is the only sanctioned way
     /// to populate the field.
     pub fn details(mut self, details: serde_json::Value) -> Self {
-        let sanitized = match details {
-            serde_json::Value::Object(mut map) => {
-                if map.remove("actor").is_some() {
-                    tracing::error!(
-                        "AuditEntry::details received an 'actor' key from a caller; \
-                         stripping to prevent system-actor spoofing. Use \
-                         AuditEntry::system_actor() for system-initiated entries."
-                    );
-                }
-                serde_json::Value::Object(map)
-            }
-            other => other,
-        };
-        self.details = Some(sanitized);
+        self.details = Some(sanitize_audit_details(details));
         self
     }
 
@@ -273,10 +379,9 @@ impl AuditEntry {
     /// label is taken from a static / build-time string in the caller, not
     /// from request input.
     ///
-    /// If `.details(...)` was not called first, this seeds an Object with
-    /// just the actor key. If `.details(...)` was called with a non-Object
-    /// value, that value is replaced (the schema requires an Object for
-    /// `actor` to live in).
+    /// If `.details(...)` was not called first, this seeds an Object with just
+    /// the actor key. Legacy scalar/array payloads have already been normalized
+    /// under `details.value`, so they remain intact when this label is added.
     pub fn system_actor(mut self, label: &'static str) -> Self {
         let mut map = match self.details.take() {
             Some(serde_json::Value::Object(map)) => map,
@@ -293,6 +398,64 @@ impl AuditEntry {
     pub fn ip(mut self, ip_address: IpAddr) -> Self {
         self.ip_address = Some(ip_address);
         self
+    }
+
+    /// Attach a best-effort actor display name for the export envelope (#2413).
+    ///
+    /// Populate this where the handler already has the acting principal's name
+    /// in hand (login, token, repository, role handlers). It is emitted as
+    /// `actor.name` in the audit stream and is NOT written to the DB row — the
+    /// admin API still joins `users` at query time (#2392). Absent, `actor.name`
+    /// serializes to `null`.
+    pub fn actor_name(mut self, name: impl Into<String>) -> Self {
+        self.actor_name = Some(clamp_audit_label(name));
+        self
+    }
+
+    /// Attach a best-effort resource name for the export envelope (#2413).
+    ///
+    /// Emitted as `resource.name` in the audit stream; not stored in the DB row.
+    pub fn resource_name(mut self, name: impl Into<String>) -> Self {
+        self.resource_name = Some(clamp_audit_label(name));
+        self
+    }
+
+    /// Override the exported outcome (#2413). Unset, the outcome is derived from
+    /// the action name ([`AuditAction::outcome`](crate::services::audit_export)).
+    /// For future emitters that record one action with variable outcomes.
+    pub fn outcome(mut self, outcome: Outcome) -> Self {
+        self.outcome_override = Some(outcome);
+        self
+    }
+
+    /// Override the export envelope's `actor.id` (#2413) where the DB row's
+    /// `user_id` deliberately records a different principal — the subject-keyed
+    /// password / session events, whose column semantics predate the export and
+    /// must not change underneath existing consumers. Envelope-only: the DB
+    /// row, the admin API, and its `user_id` filter are unaffected. Unset,
+    /// `actor.id` is `user_id`.
+    pub fn actor_id(mut self, actor_id: Uuid) -> Self {
+        self.actor_id_override = Some(actor_id);
+        self
+    }
+
+    /// Attach a typed detail payload (#2413), serialized into the existing
+    /// `details` column through the same anti-spoof sanitization as
+    /// [`AuditEntry::details`]. The typed structs in
+    /// [`crate::services::audit_export`] anchor the published JSON Schema for
+    /// the representative security-lifecycle events.
+    ///
+    /// A serialization failure (not expected for the plain detail structs)
+    /// leaves `details` unchanged and logs at error level rather than dropping
+    /// the whole audit entry.
+    pub fn details_typed<T: serde::Serialize>(self, payload: T) -> Self {
+        match serde_json::to_value(payload) {
+            Ok(value) => self.details(value),
+            Err(e) => {
+                tracing::error!(error = %e, "failed to serialize typed audit details; leaving details unset");
+                self
+            }
+        }
     }
 
     /// Override the correlation ID (#2414: a string — caller-supplied header
@@ -337,16 +500,42 @@ impl AuditEntry {
         self.details.as_ref()
     }
 
-    // `ip_address` not yet used by a batched call site; kept symmetric so
-    // future system emitters (e.g. periodic lifecycle scheduler) can write
-    // an originating IP via the same accessor surface.
-    #[allow(dead_code)]
     pub(crate) fn ip_address(&self) -> Option<IpAddr> {
         self.ip_address
     }
 
     pub(crate) fn correlation_id(&self) -> &str {
         &self.correlation_id
+    }
+
+    /// The client-minted event id (#2413), shared with the DB row.
+    pub(crate) fn event_id(&self) -> Uuid {
+        self.event_id
+    }
+
+    /// Best-effort actor display name for the export envelope (#2413).
+    /// Named `_ref` to avoid colliding with the [`AuditEntry::actor_name`]
+    /// builder setter of the same base name.
+    pub(crate) fn actor_name_ref(&self) -> Option<&str> {
+        self.actor_name.as_deref()
+    }
+
+    /// Best-effort resource name for the export envelope (#2413).
+    /// Named `_ref` to avoid colliding with the [`AuditEntry::resource_name`]
+    /// builder setter of the same base name.
+    pub(crate) fn resource_name_ref(&self) -> Option<&str> {
+        self.resource_name.as_deref()
+    }
+
+    /// Explicit outcome override for the export envelope (#2413), if set.
+    pub(crate) fn outcome_override(&self) -> Option<Outcome> {
+        self.outcome_override
+    }
+
+    /// Export-envelope actor-id override (#2413), if set. Named `_override` to
+    /// avoid colliding with the [`AuditEntry::actor_id`] builder setter.
+    pub(crate) fn actor_id_override(&self) -> Option<Uuid> {
+        self.actor_id_override
     }
 }
 
@@ -362,17 +551,30 @@ impl AuditService {
 
     /// Log an audit entry.
     ///
+    /// Emits the structured export record (#2413) to the audit stream BEFORE
+    /// the row INSERT and regardless of its outcome: the stdout stream is the
+    /// SIEM-availability story, so a DB outage (or the fire-and-forget swallow
+    /// path) must not also lose the SIEM copy. The `id` is minted client-side
+    /// ([`AuditEntry::new`]) and passed explicitly to the INSERT so the exported
+    /// record and the DB row share one id. When the stream is off (the default)
+    /// the emit is a cheap no-op — the export record is never even constructed,
+    /// so existing deployments pay one sink check and nothing more.
+    ///
     /// Runtime (non-macro) query so the #2414 `correlation_id` type change
     /// (UUID -> TEXT) needs no offline `.sqlx` prepare, matching the pattern
-    /// [`AuditService::query`] already uses.
+    /// [`AuditService::query`] already uses; the #2413 change only adds the `id`
+    /// column to this INSERT's column list.
     pub async fn log(&self, entry: AuditEntry) -> Result<Uuid> {
-        let id: Uuid = sqlx::query_scalar(
+        audit_export::emit_entry(&entry);
+
+        let id = entry.event_id;
+        sqlx::query(
             r#"
-            INSERT INTO audit_log (user_id, action, resource_type, resource_id, details, ip_address, correlation_id)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING id
+            INSERT INTO audit_log (id, user_id, action, resource_type, resource_id, details, ip_address, correlation_id)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
             "#,
         )
+        .bind(id)
         .bind(entry.user_id)
         .bind(entry.action.as_str())
         .bind(entry.resource_type.as_str())
@@ -380,7 +582,7 @@ impl AuditService {
         .bind(entry.details)
         .bind(entry.ip_address.map(|ip| ip.to_string()))
         .bind(entry.correlation_id)
-        .fetch_one(&self.db)
+        .execute(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
@@ -571,11 +773,11 @@ pub async fn audit_admin_permission_denied(
     let entry = AuditEntry::new(AuditAction::PermissionDenied, resource_type)
         .user(user_id)
         .resource(user_id)
-        .details(serde_json::json!({
-            "path": path,
-            "method": method,
-            "reason": "admin_privileges_required",
-        }));
+        .details_typed(audit_export::details::AuthDetails::permission_denied(
+            path,
+            method,
+            "admin_privileges_required",
+        ));
     audit_fire_and_forget(db, entry).await;
 }
 
@@ -637,29 +839,33 @@ pub fn api_token_audit_entry(
     token_name: Option<&str>,
     surface: &str,
 ) -> AuditEntry {
+    // Typed payload (#2413): `TokenDetails` has no secret field, so the token
+    // secret cannot leak into the audit stream by construction, and the shape is
+    // pinned by the published schema.
     AuditEntry::new(action, ResourceType::ApiToken)
         .user(actor)
         .resource(token_id)
-        .details(serde_json::json!({
-            "token_id": token_id.to_string(),
-            "token_name": token_name,
-            "surface": surface,
-        }))
+        .details_typed(audit_export::details::TokenDetails::new(
+            token_id, token_name, surface,
+        ))
 }
 
 /// Build an audit entry for a self-service or admin password change (#386 /
 /// #1617 Phase 1).
 ///
 /// `subject` is the user whose password changed (recorded as `user_id` and the
-/// resource). `actor` is the principal that performed the change; it equals
-/// `subject` on a self-change and is the acting admin on an admin reset. The
-/// plaintext password and any hash are NEVER included. The acting principal is
-/// recorded under `actor_id` (not the reserved `actor` key, which
-/// [`AuditEntry::details`] strips as an anti-spoof measure). Pure builder —
-/// unit-testable without a database.
+/// resource — the established column semantics, unchanged by #2413). `actor` is
+/// the principal that performed the change; it equals `subject` on a
+/// self-change and is the acting admin on an admin reset. It is recorded under
+/// `details.actor_id` (not the reserved `actor` key, which
+/// [`AuditEntry::details`] strips as an anti-spoof measure) and exported as the
+/// envelope's `actor.id` via the envelope-only [`AuditEntry::actor_id`]
+/// override. The plaintext password and any hash are NEVER included. Pure
+/// builder — unit-testable without a database.
 pub fn password_change_audit_entry(subject: Uuid, actor: Uuid, by_admin: bool) -> AuditEntry {
     AuditEntry::new(AuditAction::PasswordChanged, ResourceType::User)
         .user(subject)
+        .actor_id(actor)
         .resource(subject)
         .details(serde_json::json!({
             "actor_id": actor.to_string(),
@@ -679,15 +885,18 @@ pub fn totp_audit_entry(action: AuditAction, subject: Uuid) -> AuditEntry {
 
 /// Build an audit entry for a mass session / refresh-token invalidation (#386).
 ///
-/// `subject` is the user whose sessions were invalidated; `actor` is the
-/// principal that triggered it (equals `subject` on a self-service change,
-/// the acting admin otherwise). `trigger` is a stable static label
-/// (`"totp_enable"` | `"totp_disable"` | `"password_change"` |
-/// `"password_reset"` | `"force_password_change"`). Recorded under `actor_id`
-/// (not the reserved `actor` key). Pure builder — unit-testable.
+/// `subject` is the user whose sessions were invalidated (recorded as
+/// `user_id` and the resource — the established column semantics, unchanged by
+/// #2413); `actor` is the principal that triggered it (equals `subject` on a
+/// self-service change, the acting admin otherwise), recorded under
+/// `details.actor_id` and exported as the envelope's `actor.id` via the
+/// envelope-only [`AuditEntry::actor_id`] override. `trigger` is a stable
+/// static label (`"totp_enable"` | `"totp_disable"` | `"password_change"` |
+/// `"password_reset"` | `"force_password_change"`). Pure builder.
 pub fn sessions_invalidated_audit_entry(subject: Uuid, actor: Uuid, trigger: &str) -> AuditEntry {
     AuditEntry::new(AuditAction::SessionsInvalidated, ResourceType::User)
         .user(subject)
+        .actor_id(actor)
         .resource(subject)
         .details(serde_json::json!({
             "actor_id": actor.to_string(),
@@ -966,14 +1175,42 @@ mod tests {
     }
 
     #[test]
-    fn test_audit_entry_details_passes_non_object_values_through() {
-        // Non-Object values cannot carry a key, so the strip is a no-op.
+    fn test_audit_entry_details_wraps_non_object_values() {
+        // The envelope contract requires an object/null details value.
         let entry = AuditEntry::new(AuditAction::SettingChanged, ResourceType::Setting)
             .details(serde_json::json!("a scalar string"));
-        assert_eq!(
-            entry.details,
-            Some(serde_json::Value::String("a scalar string".to_string()))
+        assert_eq!(entry.details.unwrap()["value"], "a scalar string");
+    }
+
+    #[test]
+    fn test_audit_entry_details_recursively_redacts_secret_keys() {
+        let entry = AuditEntry::new(AuditAction::SettingChanged, ResourceType::Setting).details(
+            serde_json::json!({
+                "password": "hunter2",
+                "nested": {
+                    "Authorization": "Bearer secret",
+                    "token_name": "safe metadata"
+                },
+                "items": [{"client-secret": "secret-value"}]
+            }),
         );
+        let details = entry.details.unwrap();
+        assert_eq!(details["password"], AUDIT_REDACTED_VALUE);
+        assert_eq!(details["nested"]["Authorization"], AUDIT_REDACTED_VALUE);
+        assert_eq!(details["nested"]["token_name"], "safe metadata");
+        assert_eq!(details["items"][0]["client-secret"], AUDIT_REDACTED_VALUE);
+    }
+
+    #[test]
+    fn test_audit_entry_details_keeps_oversized_payload_for_the_db_row() {
+        // Size-bounding applies only to the exported copy (see audit_export's
+        // `bounded_details_for_export`); the stored details must never lose
+        // data to an export concern.
+        let big = "x".repeat(70_000);
+        let entry = AuditEntry::new(AuditAction::SettingChanged, ResourceType::Setting)
+            .details(serde_json::json!({"value": big}));
+        let details = entry.details.unwrap();
+        assert_eq!(details["value"].as_str().unwrap().len(), 70_000);
     }
 
     #[test]
@@ -1059,10 +1296,7 @@ mod tests {
     }
 
     #[test]
-    fn test_audit_entry_system_actor_replaces_non_object_details() {
-        // If `.details(...)` was set to a scalar, `system_actor()` cannot
-        // attach a key in place; the documented behaviour is to seed a
-        // fresh Object so the schema is consistent.
+    fn test_audit_entry_system_actor_preserves_wrapped_scalar_details() {
         let entry = AuditEntry::new(AuditAction::ScanReaped, ResourceType::ScanResult)
             .details(serde_json::json!("scalar"))
             .system_actor("system:stuck_scan_janitor");
@@ -1070,8 +1304,9 @@ mod tests {
             .details
             .as_ref()
             .and_then(|v| v.as_object())
-            .expect("details replaced with Object");
-        assert_eq!(obj.len(), 1);
+            .expect("details normalized to Object");
+        assert_eq!(obj.len(), 2);
+        assert_eq!(obj.get("value"), Some(&serde_json::json!("scalar")));
         assert_eq!(
             obj.get("actor"),
             Some(&serde_json::Value::String(
@@ -1123,6 +1358,73 @@ mod tests {
         assert_eq!(entry.details, Some(details));
         assert_eq!(entry.ip_address, Some(ip));
         assert_eq!(entry.correlation_id, correlation_id);
+    }
+
+    // -----------------------------------------------------------------------
+    // #2413: export-envelope builder fields (event_id, actor_name,
+    // resource_name, outcome override, typed details).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_audit_entry_mints_unique_event_id() {
+        let a = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        let b = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        assert!(!a.event_id().is_nil());
+        assert_ne!(a.event_id(), b.event_id(), "each entry gets a fresh id");
+    }
+
+    #[test]
+    fn test_audit_entry_actor_and_resource_name_builders() {
+        let entry = AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .actor_name("alice")
+            .resource_name("maven-releases");
+        assert_eq!(entry.actor_name_ref(), Some("alice"));
+        assert_eq!(entry.resource_name_ref(), Some("maven-releases"));
+    }
+
+    #[test]
+    fn test_audit_entry_labels_are_bounded_on_utf8_boundary() {
+        let oversized = "é".repeat(AUDIT_LABEL_MAX_BYTES);
+        let entry = AuditEntry::new(AuditAction::RepositoryCreated, ResourceType::Repository)
+            .actor_name(&oversized)
+            .resource_name(&oversized);
+        for value in [
+            entry.actor_name_ref().unwrap(),
+            entry.resource_name_ref().unwrap(),
+        ] {
+            assert!(value.len() <= AUDIT_LABEL_MAX_BYTES);
+            assert!(value.is_char_boundary(value.len()));
+        }
+    }
+
+    #[test]
+    fn test_audit_entry_outcome_override_builder() {
+        let entry =
+            AuditEntry::new(AuditAction::Login, ResourceType::User).outcome(Outcome::Failure);
+        assert_eq!(entry.outcome_override(), Some(Outcome::Failure));
+        // Unset by default.
+        let plain = AuditEntry::new(AuditAction::Login, ResourceType::User);
+        assert_eq!(plain.outcome_override(), None);
+    }
+
+    #[test]
+    fn test_audit_entry_details_typed_serializes_and_sanitizes() {
+        #[derive(serde::Serialize)]
+        struct Payload {
+            key: &'static str,
+            actor: &'static str,
+        }
+        // The typed path routes through `details(...)`, so the reserved `actor`
+        // key is still stripped (anti-spoof).
+        let entry = AuditEntry::new(AuditAction::SettingChanged, ResourceType::Setting)
+            .details_typed(Payload {
+                key: "maven-releases",
+                actor: "spoof",
+            });
+        let details = entry.details_ref().expect("details present");
+        let obj = details.as_object().unwrap();
+        assert_eq!(obj.get("key").unwrap(), "maven-releases");
+        assert!(!obj.contains_key("actor"), "typed details still sanitized");
     }
 
     // -----------------------------------------------------------------------
@@ -1321,7 +1623,10 @@ mod tests {
         let subject = Uuid::new_v4();
         let actor = Uuid::new_v4();
         let entry = password_change_audit_entry(subject, actor, true);
+        // DB column semantics unchanged by #2413: `user_id` stays the subject;
+        // the initiator rides the envelope-only override and details.actor_id.
         assert_eq!(entry.user_id(), Some(subject));
+        assert_eq!(entry.actor_id_override(), Some(actor));
         let details = entry.details_ref().expect("details present");
         assert_eq!(details["actor_id"], actor.to_string());
         assert_eq!(details["by_admin"], true);
@@ -1353,7 +1658,9 @@ mod tests {
         let entry = sessions_invalidated_audit_entry(subject, actor, "password_change");
         assert_eq!(entry.action().as_str(), "SESSIONS_INVALIDATED");
         assert_eq!(entry.resource_type().as_str(), "user");
+        // DB column semantics unchanged by #2413 (see password-change test).
         assert_eq!(entry.user_id(), Some(subject));
+        assert_eq!(entry.actor_id_override(), Some(actor));
         assert_eq!(entry.resource_id(), Some(subject));
         let details = entry.details_ref().expect("details present");
         assert_eq!(details["actor_id"], actor.to_string());
@@ -1435,6 +1742,98 @@ mod tests {
             .bind(resource_id)
             .execute(&service.db)
             .await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #2413: the exported stream record shares the DB row's id (the SIEM ↔
+    // admin-API join key) and is emitted even when the DB write fails.
+    // -----------------------------------------------------------------------
+
+    /// The emitted record's `event_id` equals the `audit_log` row id, so a SIEM
+    /// can join a stream event back to `GET /api/v1/admin/audit`. Requires a DB.
+    #[tokio::test]
+    async fn test_log_emits_record_sharing_event_id_with_db_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::audit_export::test_sink;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (buffer, _guard) = test_sink::install();
+        let service = AuditService::new(pool);
+
+        let resource_id = Uuid::new_v4();
+        let corr = format!("emit-join-{}", Uuid::new_v4());
+        let entry = AuditEntry::new(AuditAction::RepositoryDeleted, ResourceType::Repository)
+            .resource(resource_id)
+            .correlation(&corr)
+            .actor_name("bob");
+        let id = service.log(entry).await.expect("log succeeds");
+
+        let mine: Vec<_> = buffer
+            .records()
+            .into_iter()
+            .filter(|r| r["correlation_id"] == corr)
+            .collect();
+        assert_eq!(mine.len(), 1, "exactly one stream record for this event");
+        assert_eq!(mine[0]["event_id"], id.to_string());
+        assert_eq!(mine[0]["actor"]["name"], "bob");
+
+        // The DB row carries the same id the record advertised.
+        let (rows, _) = service
+            .query(
+                None,
+                None,
+                Some("repository"),
+                Some(resource_id),
+                None,
+                None,
+                None,
+                0,
+                10,
+            )
+            .await
+            .expect("query succeeds");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].id, id);
+
+        let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+            .bind(resource_id)
+            .execute(&service.db)
+            .await;
+    }
+
+    /// A DB-write failure must not also lose the SIEM copy: emission happens
+    /// before the INSERT, so an unreachable pool still yields the stream record.
+    /// Needs no database (the pool is lazy and never connects).
+    #[tokio::test]
+    async fn test_log_emits_record_even_when_db_write_fails() {
+        use crate::services::audit_export::test_sink;
+        use sqlx::postgres::PgPoolOptions;
+
+        let (buffer, _guard) = test_sink::install();
+        // Lazy pool to an unreachable address: connect_lazy never blocks; the
+        // execute() inside log() is what fails.
+        let pool = PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_millis(250))
+            .connect_lazy("postgres://u:p@127.0.0.1:1/none")
+            .expect("lazy pool builds");
+        let service = AuditService::new(pool);
+
+        let corr = format!("db-down-{}", Uuid::new_v4());
+        let entry =
+            AuditEntry::new(AuditAction::LoginFailed, ResourceType::User).correlation(&corr);
+        let event_id = entry.event_id();
+        let result = service.log(entry).await;
+        assert!(result.is_err(), "write fails against an unreachable pool");
+
+        let mine: Vec<_> = buffer
+            .records()
+            .into_iter()
+            .filter(|r| r["correlation_id"] == corr)
+            .collect();
+        assert_eq!(mine.len(), 1, "record emitted despite DB failure");
+        assert_eq!(mine[0]["event_id"], event_id.to_string());
+        assert_eq!(mine[0]["outcome"], "failure");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/metrics_service.rs
+++ b/backend/src/services/metrics_service.rs
@@ -217,6 +217,14 @@ pub fn record_cleanup(cleanup_type: &str, items_removed: u64) {
         .increment(items_removed);
 }
 
+/// Record a structured audit-stream delivery failure. `reason` is a bounded
+/// internal label (`queue_full`, `writer_disconnected`, or `write_error`) so
+/// backpressure and broken stdout delivery are observable without logging back
+/// into the same potentially-blocked stream.
+pub fn record_audit_stream_failure(reason: &'static str) {
+    counter!("ak_audit_stream_failures_total", "reason" => reason).increment(1);
+}
+
 /// Record an email dispatch that was dropped by the per-event rate limiter.
 /// `reason` is the [`crate::services::email_rate_limiter::RateLimitDecision`]
 /// label (`"recipient"` or `"domain"`); the `"allowed"` decision does not

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -5,6 +5,8 @@ pub mod artifact_metadata;
 pub mod artifact_service;
 pub mod artifactory_client;
 pub mod artifactory_import;
+pub mod audit_export;
+pub mod audit_schema;
 pub mod audit_service;
 pub mod auth_config_service;
 pub mod auth_service;

--- a/backend/src/services/scan_result_service.rs
+++ b/backend/src/services/scan_result_service.rs
@@ -479,12 +479,20 @@ impl ScanResultService {
         // `get_by_correlation` query. The janitor runs outside any request
         // scope, so the ID is generated here rather than inherited.
         let sweep_correlation = crate::api::middleware::tracing::CorrelationId::generate();
+        let mut event_ids: Vec<Uuid> = Vec::with_capacity(reaped.len());
         let mut user_ids: Vec<Option<Uuid>> = Vec::with_capacity(reaped.len());
         let mut actions: Vec<String> = Vec::with_capacity(reaped.len());
         let mut resource_types: Vec<String> = Vec::with_capacity(reaped.len());
         let mut resource_ids: Vec<Option<Uuid>> = Vec::with_capacity(reaped.len());
         let mut details_blobs: Vec<serde_json::Value> = Vec::with_capacity(reaped.len());
         let mut correlation_ids: Vec<String> = Vec::with_capacity(reaped.len());
+        // Structured export records (#2413): built from the same builders as
+        // the DB rows so the emitted `event_id` matches the row id; emission
+        // happens after the sweep commits (below). Skipped entirely when the
+        // stream is off — no record construction on the default path.
+        let stream_on = crate::services::audit_export::stream_enabled();
+        let mut export_records: Vec<crate::services::audit_export::AuditEventRecord> =
+            Vec::with_capacity(if stream_on { reaped.len() } else { 0 });
         for row in &reaped {
             let entry = AuditEntry::new(AuditAction::ScanReaped, ResourceType::ScanResult)
                 .resource(row.id)
@@ -498,6 +506,12 @@ impl ScanResultService {
                 ))
                 .system_actor(STUCK_SCAN_AUDIT_ACTOR)
                 .correlation(sweep_correlation.as_str());
+            if stream_on {
+                export_records.push(crate::services::audit_export::AuditEventRecord::from_entry(
+                    &entry,
+                ));
+            }
+            event_ids.push(entry.event_id());
             user_ids.push(entry.user_id());
             actions.push(entry.action().as_str().to_string());
             resource_types.push(entry.resource_type().as_str().to_string());
@@ -531,14 +545,17 @@ impl ScanResultService {
         let audit_result = sqlx::query(
             r#"
             INSERT INTO audit_log
-                (user_id, action, resource_type, resource_id, details,
+                (id, user_id, action, resource_type, resource_id, details,
                  ip_address, correlation_id)
             SELECT * FROM UNNEST(
-                $1::uuid[], $2::text[], $3::text[], $4::uuid[],
-                $5::jsonb[], $6::text[], $7::text[]
+                $1::uuid[], $2::uuid[], $3::text[], $4::text[], $5::uuid[],
+                $6::jsonb[], $7::text[], $8::text[]
             )
             "#,
         )
+        // id: client-minted per row (#2413) so the DB row and the exported
+        // stream record share one id.
+        .bind(&event_ids)
         .bind(&user_ids)
         .bind(&actions)
         .bind(&resource_types)
@@ -579,6 +596,17 @@ impl ScanResultService {
         tx.commit()
             .await
             .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Emit the structured export records (#2413) AFTER the sweep commits: a
+        // failed commit means no reap happened, so nothing may be streamed (the
+        // re-run re-reaps under fresh event ids). If only the batched audit
+        // INSERT failed (savepoint rollback above), the records ARE still
+        // emitted — the same emit-even-on-DB-write-failure semantics as
+        // `AuditService::log()`: the stream is the SIEM-availability backstop
+        // for exactly that gap. Empty (no-op) when the stream is off.
+        for record in &export_records {
+            crate::services::audit_export::emit_audit_event(record);
+        }
 
         Ok(reaped.len() as u64)
     }
@@ -3953,6 +3981,59 @@ mod tests {
             );
 
             // Cleanup.
+            let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
+                .bind(stuck_id)
+                .execute(&pool)
+                .await;
+            cleanup_repo(&pool, repo_id).await;
+        }
+
+        /// #2413: a reap emits one structured export record per reaped row,
+        /// each carrying the system actor and an `event_id` equal to the
+        /// committed audit_log row id, and all sharing the sweep correlation.
+        #[tokio::test]
+        async fn cleanup_stuck_scans_emits_export_record_matching_row_id() {
+            use crate::services::audit_export::test_sink;
+            let _serial = CLEANUP_TEST_LOCK.lock().await;
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let (buffer, _guard) = test_sink::install();
+            let svc = ScanResultService::new(pool.clone());
+            let repo_id = insert_test_repo(&pool).await;
+            let (aid, _) = insert_test_artifact(&pool, repo_id, "export").await;
+            let stuck_id = insert_stuck_running_scan(&pool, aid, repo_id, 3600).await;
+
+            let reaped = svc
+                .cleanup_stuck_scans(Duration::from_secs(60))
+                .await
+                .expect("janitor returned Ok");
+            assert!(reaped >= 1);
+
+            // The committed row id for our scan.
+            let row_id: Uuid = sqlx::query_scalar(
+                "SELECT id FROM audit_log \
+                 WHERE resource_id = $1 AND action = 'SCAN_REAPED' LIMIT 1",
+            )
+            .bind(stuck_id)
+            .fetch_one(&pool)
+            .await
+            .expect("read audit row id");
+
+            // Exactly one emitted record targets this scan; it matches the row
+            // id, is a system actor, and shares the sweep correlation.
+            let mine: Vec<_> = buffer
+                .records()
+                .into_iter()
+                .filter(|r| r["resource"]["id"] == serde_json::json!(stuck_id.to_string()))
+                .collect();
+            assert_eq!(mine.len(), 1, "one export record per reaped row");
+            assert_eq!(mine[0]["event_id"], row_id.to_string());
+            assert_eq!(mine[0]["action"], "SCAN_REAPED");
+            assert_eq!(mine[0]["actor"]["type"], "system");
+            assert_eq!(mine[0]["actor"]["name"], STUCK_SCAN_AUDIT_ACTOR);
+            assert_eq!(mine[0]["outcome"], "success");
+
             let _ = sqlx::query("DELETE FROM audit_log WHERE resource_id = $1")
                 .bind(stuck_id)
                 .execute(&pool)

--- a/backend/src/telemetry.rs
+++ b/backend/src/telemetry.rs
@@ -8,11 +8,64 @@
 //! environment variable:
 //!   - `grpc` (default) -- gRPC over HTTP/2 using tonic
 //!   - `http/protobuf`  -- HTTP/1.1 with binary protobuf bodies using reqwest
+//!
+//! The diagnostics stdout format is selected via `LOG_FORMAT`:
+//!   - `pretty` (default) -- the human-readable multi-line `fmt` output
+//!   - `json` -- one JSON object per line, for structured stdout collection by a SIEM / log shipper (#2413 item 1)
 
 use opentelemetry::KeyValue;
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
 use opentelemetry_sdk::Resource;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer};
+
+/// Diagnostics stdout log format, selected via `LOG_FORMAT` (#2413 item 1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LogFormat {
+    /// Human-readable multi-line `fmt` output (default, unchanged behavior).
+    Pretty,
+    /// One JSON object per line for structured stdout collection.
+    Json,
+}
+
+impl LogFormat {
+    /// Parse a `LOG_FORMAT` value. Defaults to `pretty` for empty or
+    /// unrecognised values so an operator typo never silently drops
+    /// diagnostics to an unexpected shape.
+    fn from_value(val: &str) -> Self {
+        match val.trim().to_lowercase().as_str() {
+            "json" => Self::Json,
+            _ => Self::Pretty,
+        }
+    }
+
+    /// Read from `LOG_FORMAT`. Defaults to `pretty` when unset or unrecognised.
+    fn from_env() -> Self {
+        Self::from_value(&std::env::var("LOG_FORMAT").unwrap_or_default())
+    }
+
+    /// Canonical name, for the startup log line.
+    fn name(self) -> &'static str {
+        match self {
+            Self::Pretty => "pretty",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Build the diagnostics `fmt` layer in the configured format.
+///
+/// Boxed so both arms have the same type regardless of the concrete
+/// per-format layer. The workspace `tracing-subscriber` dependency already
+/// carries the `json` feature, so the JSON arm adds no new dependency.
+fn build_fmt_layer<S>(format: LogFormat) -> Box<dyn Layer<S> + Send + Sync>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    match format {
+        LogFormat::Pretty => tracing_subscriber::fmt::layer().boxed(),
+        LogFormat::Json => tracing_subscriber::fmt::layer().json().boxed(),
+    }
+}
 
 /// OTLP transport protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,15 +136,17 @@ pub fn init_tracing(otel_endpoint: Option<&str>, service_name: &str) -> Option<O
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         "artifact_keeper_backend=debug,tower_http=debug,sqlx::query=info".into()
     });
+    let log_format = LogFormat::from_env();
 
     match otel_endpoint {
         Some(endpoint) => {
             let protocol = OtlpProtocol::from_env();
-            let guard = init_with_otel(endpoint, service_name, env_filter, protocol);
+            let guard = init_with_otel(endpoint, service_name, env_filter, protocol, log_format);
             tracing::info!(
                 otel_endpoint = endpoint,
                 service_name,
                 protocol = protocol.name(),
+                log_format = log_format.name(),
                 "OpenTelemetry tracing enabled"
             );
             Some(guard)
@@ -99,7 +154,7 @@ pub fn init_tracing(otel_endpoint: Option<&str>, service_name: &str) -> Option<O
         None => {
             tracing_subscriber::registry()
                 .with(env_filter)
-                .with(tracing_subscriber::fmt::layer())
+                .with(build_fmt_layer(log_format))
                 .init();
             None
         }
@@ -125,6 +180,7 @@ fn init_with_otel(
     service_name: &str,
     env_filter: EnvFilter,
     protocol: OtlpProtocol,
+    log_format: LogFormat,
 ) -> OtelGuard {
     use opentelemetry::trace::TracerProvider;
     use opentelemetry_sdk::trace::{BatchSpanProcessor, SdkTracerProvider};
@@ -142,7 +198,7 @@ fn init_with_otel(
 
     tracing_subscriber::registry()
         .with(env_filter)
-        .with(tracing_subscriber::fmt::layer())
+        .with(build_fmt_layer(log_format))
         .with(otel_layer)
         .init();
 
@@ -268,6 +324,66 @@ mod tests {
         assert_eq!(OtlpProtocol::Grpc, OtlpProtocol::Grpc);
         assert_eq!(OtlpProtocol::HttpProtobuf, OtlpProtocol::HttpProtobuf);
         assert_ne!(OtlpProtocol::Grpc, OtlpProtocol::HttpProtobuf);
+    }
+
+    // ── LogFormat (#2413 item 1) ────────────────────────────────────────
+
+    #[test]
+    fn test_log_format_defaults_to_pretty_for_empty_string() {
+        assert_eq!(LogFormat::from_value(""), LogFormat::Pretty);
+    }
+
+    #[test]
+    fn test_log_format_accepts_json_variants() {
+        for val in ["json", "JSON", "Json", " json ", "json\n"] {
+            assert_eq!(
+                LogFormat::from_value(val),
+                LogFormat::Json,
+                "failed for {val:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_log_format_pretty_explicit() {
+        assert_eq!(LogFormat::from_value("pretty"), LogFormat::Pretty);
+        assert_eq!(LogFormat::from_value("PRETTY"), LogFormat::Pretty);
+    }
+
+    #[test]
+    fn test_log_format_unrecognised_falls_back_to_pretty() {
+        assert_eq!(LogFormat::from_value("logfmt"), LogFormat::Pretty);
+        assert_eq!(LogFormat::from_value("bogus"), LogFormat::Pretty);
+    }
+
+    #[test]
+    fn test_log_format_from_env_defaults_to_pretty_when_unset() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        std::env::remove_var("LOG_FORMAT");
+        assert_eq!(LogFormat::from_env(), LogFormat::Pretty);
+    }
+
+    #[test]
+    fn test_log_format_from_env_reads_json() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        std::env::set_var("LOG_FORMAT", "json");
+        let result = LogFormat::from_env();
+        std::env::remove_var("LOG_FORMAT");
+        assert_eq!(result, LogFormat::Json);
+    }
+
+    #[test]
+    fn test_log_format_name() {
+        assert_eq!(LogFormat::Pretty.name(), "pretty");
+        assert_eq!(LogFormat::Json.name(), "json");
+    }
+
+    #[test]
+    fn test_build_fmt_layer_builds_both_formats() {
+        // Both arms must type-check to the same boxed layer and construct
+        // without panicking against the registry subscriber type.
+        let _pretty = build_fmt_layer::<tracing_subscriber::Registry>(LogFormat::Pretty);
+        let _json = build_fmt_layer::<tracing_subscriber::Registry>(LogFormat::Json);
     }
 
     // ── build_otel_resource ─────────────────────────────────────────────

--- a/docker-compose.local-dev.yml
+++ b/docker-compose.local-dev.yml
@@ -199,6 +199,8 @@ services:
       JWT_SECRET: dev-secret-change-in-production
       ADMIN_PASSWORD: admin
       RUST_LOG: info,artifact_keeper=debug
+      LOG_FORMAT: ${LOG_FORMAT:-pretty}
+      AUDIT_STREAM: ${AUDIT_STREAM:-off}
       ENVIRONMENT: development
       CORS_ORIGINS: http://localhost:3000,http://localhost:8080
       TRIVY_URL: http://trivy:8090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,6 +220,8 @@ services:
       # Read it with: docker exec artifact-keeper-backend cat /data/storage/admin.password
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       RUST_LOG: ${RUST_LOG:-info,artifact_keeper=debug}
+      LOG_FORMAT: ${LOG_FORMAT:-pretty}
+      AUDIT_STREAM: ${AUDIT_STREAM:-off}
       ENVIRONMENT: ${ENVIRONMENT:-development}
       CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost,https://localhost}
       # Trusted reverse-proxy CIDRs (#2298 / #2023). Caddy terminates all

--- a/docs/audit-events.md
+++ b/docs/audit-events.md
@@ -1,0 +1,199 @@
+# Structured audit event stream
+
+Artifact Keeper can emit every recorded audit action as a self-contained,
+machine-readable log record so operators can ship the audit trail to a SIEM by
+collecting stdout — without polling the admin API (`GET /api/v1/admin/audit`) or
+reading Postgres directly. This is issue #2413.
+
+The emitted record is an instance of the committed JSON Schema at
+[`backend/schemas/audit-event.v1.schema.json`](../backend/schemas/audit-event.v1.schema.json).
+The line you collect *is* the schema instance — there is no message-text parsing
+and no nested JSON-string to unwrap.
+
+## Enabling
+
+Two independent knobs, both read from the environment before configuration
+loads (like the `OTEL_*` variables):
+
+| Variable | Values | Default | Effect |
+| --- | --- | --- | --- |
+| `AUDIT_STREAM` | `off`, `stdout` | `off` | Emit audit records as NDJSON on stdout. |
+| `LOG_FORMAT` | `pretty`, `json` | `pretty` | Format of the *diagnostics* log lines. |
+
+The audit stream is **opt-in**. When `AUDIT_STREAM=off` (the default) nothing is
+emitted and the code path short-circuits before the export record is even
+constructed — one sink check per audit event — so there is no overhead and no
+behavior change for existing deployments.
+
+For a fully structured stdout, pair `AUDIT_STREAM=stdout` with `LOG_FORMAT=json`.
+The two streams interleave on stdout. Audit records enter a bounded queue and a
+dedicated writer writes each complete line under the stdout lock, so stdout
+backpressure cannot stall request workers. Audit lines are
+distinguished from diagnostics by the top-level `"category": "audit"` marker —
+never by parsing message text. Operators who want full separation can route
+diagnostics to stderr at the container/runtime level; that is out of scope here.
+
+## Envelope
+
+Every record has this stable, versioned shape:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `schema_version` | integer | `1`. Bumped only on a breaking change. |
+| `category` | string | Always `"audit"`. The machine marker. |
+| `event_id` | uuid | Equals the `audit_log` row id — the SIEM ↔ admin-API join key. |
+| `timestamp` | date-time | Emit time (UTC, RFC 3339). Approximates the row's `created_at`; join on `event_id`. |
+| `action` | string | SCREAMING_SNAKE action name (`LOGIN`, `REPOSITORY_CREATED`, …). |
+| `outcome` | enum | `success` \| `failure` \| `denied`, derived from the action name. |
+| `actor` | object | `{ id, name, type }` — see below. |
+| `source_ip` | string \| null | Source IP when the emitter already captures one; otherwise `null`. |
+| `resource` | object | `{ type, id, name }` — the targeted resource. |
+| `correlation_id` | string | Joins to request logs and traces (#2414). |
+| `details` | object \| null | Typed for representative events (below); permissive otherwise. |
+
+`actor.type` is one of `system`, `user`, `anonymous`, or the reserved
+`service_account` (not yet emitted). `actor.name` is best-effort — it is
+populated only where the emitter already had the name in hand (there is no
+query-time join at emit time) and is `null` otherwise. Treat `actor.name` as
+informational: on failed-authentication events (`anonymous` actors) it can carry
+the *attempted* username — unauthenticated caller- or identity-provider-supplied
+input — so detection and access decisions should key on `actor.type` and
+`actor.id`, never on the name alone.
+
+For the password/session lifecycle events (`PASSWORD_CHANGED`,
+`SESSIONS_INVALIDATED`), the envelope's `actor` is the initiating principal
+(the acting admin on an admin reset), while the `audit_log` row's `user_id`
+column keeps its established subject-keyed semantics — the stream does not
+change what the admin API returns.
+
+`source_ip` is deliberately nullable. Most authentication, permission, and
+token emitters do not currently capture the request address, so those events
+generally emit `null`; existing emitters such as artifact operations populate
+it when that context is already available. Client attribution across the wider
+request surface needs a considered trust model and is separate from this export
+contract.
+
+## Examples
+
+Human login (request-scoped, `LOG_FORMAT=json` diagnostics elided):
+
+```json
+{"schema_version":1,"category":"audit","event_id":"7b6e...","timestamp":"2026-07-11T18:30:02.145Z","action":"LOGIN","outcome":"success","actor":{"id":"1f2c...","name":"alice","type":"user"},"source_ip":null,"resource":{"type":"user","id":"1f2c...","name":null},"correlation_id":"3d0f...","details":{"username":"alice"}}
+```
+
+Failed login for an unknown principal (anonymous actor, `failure` outcome):
+
+```json
+{"schema_version":1,"category":"audit","event_id":"...","timestamp":"...","action":"LOGIN_FAILED","outcome":"failure","actor":{"id":null,"name":null,"type":"anonymous"},"source_ip":null,"resource":{"type":"user","id":null,"name":null},"correlation_id":"...","details":{"username":"root"}}
+```
+
+Authorization denial (`denied` outcome):
+
+```json
+{"schema_version":1,"category":"audit","event_id":"...","timestamp":"...","action":"PERMISSION_DENIED","outcome":"denied","actor":{"id":"...","name":null,"type":"user"},"source_ip":null,"resource":{"type":"user","id":"...","name":null},"correlation_id":"...","details":{"path":"/api/v1/admin/users","method":"GET","reason":"admin_privileges_required"}}
+```
+
+API token created (typed `TokenDetails`; the secret is never present):
+
+```json
+{"schema_version":1,"category":"audit","event_id":"...","timestamp":"...","action":"API_TOKEN_CREATED","outcome":"success","actor":{"id":"...","name":null,"type":"user"},"source_ip":null,"resource":{"type":"api_token","id":"...","name":null},"correlation_id":"...","details":{"token_id":"...","token_name":"ci","surface":"profile"}}
+```
+
+System-initiated reaping of a stuck scan (`system` actor, one record per reaped
+row, all sharing the sweep's `correlation_id`):
+
+```json
+{"schema_version":1,"category":"audit","event_id":"...","timestamp":"...","action":"SCAN_REAPED","outcome":"success","actor":{"id":null,"name":"system:stuck_scan_janitor","type":"system"},"source_ip":null,"resource":{"type":"scan_result","id":"...","name":null},"correlation_id":"sweep-...","details":{"actor":"system:stuck_scan_janitor","scan_id":"...","reason":"stuck_running_janitor"}}
+```
+
+## Typed detail payloads
+
+The `details` object is typed for the representative security-lifecycle events;
+each shape is a `$def` in the schema. Actions not yet typed carry an ad-hoc
+object and remain schema-valid under the permissive `details` fallback — typing
+the remaining actions is an incremental follow-up.
+
+| Actions | `details` shape |
+| --- | --- |
+| `REPOSITORY_CREATED` / `_UPDATED` / `_DELETED` | `RepositoryDetails` (`actor_id`, `key`, `is_public`, structured format/policy fields) |
+| `ROLE_ASSIGNED` / `_REVOKED`, `REPOSITORY_PERMISSION_CHANGED` | `PermissionDetails` (`actor_id`, `role_id`, `grantee_id`, `repository_id?`) |
+| `API_TOKEN_CREATED` / `_REVOKED` | `TokenDetails` (`token_id`, `token_name?`, `surface`) |
+| `LOGIN_FAILED`, `PERMISSION_DENIED` | `AuthDetails` (`username?`, `path?`, `method?`, `reason?`, federated labels?) |
+| `ARTIFACT_UPLOADED` / `_DOWNLOADED` / `_DELETED` | `ArtifactDetails` (`repository_id`, `path`, `name`, `version?`, `size_bytes?`, `digest?`, `uploaded_by?`) |
+| `SETTING_CHANGED` | `SettingDetails` (`key`, `old_value?`, `new_value?`) |
+
+## Compatibility policy
+
+Within `schema_version: 1`:
+
+- **Additive fields are non-breaking.** New envelope or `details` fields may be
+  added. Consumers must ignore unknown fields.
+- **Enum values may be added.** New `action` and `actor.type` values may appear.
+  Consumers must tolerate unknown values (do not hard-fail on them).
+- **Breaking changes bump `schema_version`.** A rename or removal of an existing
+  field, or a type change, ships under a new integer version.
+
+A committed `--lib` test validates live emitted records against the committed
+schema, so a change to the Rust types that would break this contract fails CI.
+
+## Redaction guarantees
+
+Representative typed payloads contain no credential fields; `TokenDetails`, in
+particular, cannot carry the token secret. The compatibility path for legacy
+free-form details recursively replaces known secret-bearing keys (passwords,
+authorization/cookie fields, access/refresh tokens, API/private keys, SAML and
+TOTP material) with `[REDACTED]` before storage or export. Payloads over 64 KiB
+are replaced with a bounded truncation marker **in the exported record only** —
+the database row always keeps the full (redacted) payload, so the bound can
+never lose data from the authoritative trail; it exists to keep the export
+queue's worst-case memory finite. Free-text business fields can still
+contain operator-supplied sensitive text, so callers must not place secrets in
+names, reasons, or other descriptive values. The `details.actor` key is
+reserved for system emitters and is set only via a static label.
+
+## Retention
+
+The audit stream and the database audit trail are independent. `audit_log`
+retention is governed by the existing cleanup job; the SIEM owns long-term
+retention of the streamed copy. The stream is not a replacement for the DB audit
+trail — it is a delivery mechanism alongside it.
+
+## Delivery semantics
+
+- **At-most-once per process lifetime.** Records enter a bounded 4,096-record
+  in-process queue whose writer drains on a best-effort basis during graceful
+  shutdown, with no disk replay; durability and retry are the collector's job.
+  Queue saturation or writer failure increments
+  `ak_audit_stream_failures_total{reason=...}` rather than blocking the
+  originating request.
+- **Emitted even on DB-write failure.** The record is emitted *before* the row
+  INSERT and regardless of its outcome, so a database outage (or the
+  fire-and-forget swallow path) does not also lose the SIEM copy. In that case
+  the `event_id` will have no matching `audit_log` row until the DB recovers.
+- **Ordering.** The writer preserves queue order, but concurrent request tasks
+  may enqueue in either order. There is no cross-instance ordering guarantee;
+  join on `timestamp`, `event_id`, and `correlation_id`.
+
+### Collector examples
+
+OpenTelemetry Collector (filelog receiver over container stdout), keeping only
+audit lines:
+
+```yaml
+receivers:
+  filelog:
+    include: [/var/log/pods/*/artifact-keeper/*.log]
+    operators:
+      - type: json_parser
+      - type: filter
+        expr: 'body.category != "audit"'
+```
+
+Fluent Bit (parse JSON, keep `category == "audit"`):
+
+```ini
+[FILTER]
+    Name    grep
+    Match   kube.*artifact-keeper*
+    Regex   log \"category\":\"audit\"
+```


### PR DESCRIPTION
## Summary

Partially fixes #2413 by adding a vendor-neutral structured audit stream and published event contract.

This PR adds:

- `LOG_FORMAT=json` for one-record-per-line structured diagnostics;
- opt-in `AUDIT_STREAM=stdout` NDJSON audit records;
- a stable v1 envelope with event, actor, resource, correlation, outcome, and   nullable source-IP fields;
- typed details for representative security and lifecycle actions;
- recursive credential-field redaction and bounded non-blocking delivery;
- one shared event ID between the database row and exported record; and
- a committed JSON Schema plus drift/validation tests and operator docs.

The existing database-backed audit trail and admin query API remain in place. The stream is best-effort and at-most-once: queue-full, serialization, writer, and disconnected failures are counted without blocking request handling.

`source_ip` remains nullable. Most authentication, permission, and token emitters do not currently capture the request address; existing emitters such as artifact operations populate it when that context is already available. Wider request attribution needs a considered trust model and is outside this slice.

## Regression test (required for `fix/*` PRs)

- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [ ] Manually tested locally
- [x] No regressions in existing tests

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
