### PR TITLE
fix(service-accounts): exclude revoked tokens from token count

### DIFF
--- a/.sqlx/query-8ead7a7250a7087d4cc714cdf61fb2b6b3d81ab6bd6db12e3c7bd2d02eaf7295.json
+++ b/.sqlx/query-8ead7a7250a7087d4cc714cdf61fb2b6b3d81ab6bd6db12e3c7bd2d02eaf7295.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                u.id,\n                u.username,\n                u.display_name,\n                u.is_active,\n                COALESCE(t.cnt, 0) as \"token_count!: i64\",\n                u.created_at,\n                u.updated_at\n            FROM users u\n            LEFT JOIN (\n                SELECT user_id, COUNT(*) as cnt\n                FROM api_tokens\n                GROUP BY user_id\n            ) t ON t.user_id = u.id\n            WHERE u.is_service_account = true\n              AND ($1 OR u.is_active = true)\n            ORDER BY u.created_at DESC\n            ",
+  "query": "\n            SELECT\n                u.id,\n                u.username,\n                u.display_name,\n                u.is_active,\n                COALESCE(t.cnt, 0) as \"token_count!: i64\",\n                u.created_at,\n                u.updated_at\n            FROM users u\n            LEFT JOIN (\n                SELECT user_id, COUNT(*) as cnt\n                FROM api_tokens\n                WHERE revoked_at IS NULL\n                GROUP BY user_id\n            ) t ON t.user_id = u.id\n            WHERE u.is_service_account = true\n              AND ($1 OR u.is_active = true)\n            ORDER BY u.created_at DESC\n            ",
   "describe": {
     "columns": [
       {
@@ -54,5 +54,5 @@
       false
     ]
   },
-  "hash": "ac7d61d787276eeb27d7f479c527435a850650cf0885ed67037f09100b74277e"
+  "hash": "8ead7a7250a7087d4cc714cdf61fb2b6b3d81ab6bd6db12e3c7bd2d02eaf7295"
 }

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -2195,11 +2195,11 @@ mod audit_db_tests {
         );
 
         let _ = sqlx::query("DELETE FROM api_tokens WHERE id = ANY($1)")
-            .bind(&[old_token_id, replacement_token_id])
+            .bind([old_token_id, replacement_token_id])
             .execute(&pool)
             .await;
         let _ = sqlx::query("DELETE FROM users WHERE id = ANY($1)")
-            .bind(&[sa.id, admin_id])
+            .bind([sa.id, admin_id])
             .execute(&pool)
             .await;
     }

--- a/backend/src/api/handlers/service_accounts.rs
+++ b/backend/src/api/handlers/service_accounts.rs
@@ -2103,6 +2103,107 @@ mod audit_db_tests {
         .expect("audit_log count query")
     }
 
+    async fn mint_service_account_token(
+        state: SharedState,
+        auth: AuthExtension,
+        service_account_id: Uuid,
+        name: &str,
+    ) -> Uuid {
+        let body = json!({ "name": name, "scopes": ["read"] }).to_string();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{service_account_id}/tokens"))
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let (status, body_bytes) = tdh::send(build_app(state, auth), req).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "service-account mint failed: {}",
+            String::from_utf8_lossy(&body_bytes)
+        );
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        Uuid::parse_str(body["id"].as_str().unwrap()).unwrap()
+    }
+
+    async fn listed_token_count(
+        state: SharedState,
+        auth: AuthExtension,
+        service_account_id: Uuid,
+    ) -> i64 {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/")
+            .body(Body::empty())
+            .unwrap();
+        let (status, body_bytes) = tdh::send(build_app(state, auth), req).await;
+        assert_eq!(status, StatusCode::OK, "service-account list failed");
+
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        let service_account_id = service_account_id.to_string();
+        body["items"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|item| item["id"].as_str() == Some(service_account_id.as_str()))
+            .and_then(|item| item["token_count"].as_i64())
+            .expect("created service account must be present in list response")
+    }
+
+    /// Regression for artifact-keeper-web#554: revoking a service-account
+    /// token soft-deletes it, so the summary count must agree with the token
+    /// management endpoint, which only lists non-revoked tokens.
+    #[tokio::test]
+    async fn service_account_count_excludes_revoked_tokens() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (admin_id, admin_name) = tdh::create_user(&pool).await;
+        let state = tdh::build_state(pool.clone(), "/tmp");
+        let mut auth = tdh::make_auth(admin_id, &admin_name);
+        auth.is_admin = true;
+
+        let sa = ServiceAccountService::new(pool.clone())
+            .create(&format!("token-count-{}", Uuid::new_v4()), None)
+            .await
+            .expect("create service account");
+
+        let old_token_id =
+            mint_service_account_token(state.clone(), auth.clone(), sa.id, "old-token").await;
+        assert_eq!(
+            listed_token_count(state.clone(), auth.clone(), sa.id).await,
+            1,
+            "one freshly minted token must be counted"
+        );
+
+        let req = Request::builder()
+            .method(Method::DELETE)
+            .uri(format!("/{}/tokens/{old_token_id}", sa.id))
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = tdh::send(build_app(state.clone(), auth.clone()), req).await;
+        assert_eq!(status, StatusCode::NO_CONTENT, "token revoke failed");
+
+        let replacement_token_id =
+            mint_service_account_token(state.clone(), auth.clone(), sa.id, "replacement-token")
+                .await;
+        assert_eq!(
+            listed_token_count(state, auth, sa.id).await,
+            1,
+            "revoked token must not remain in the service-account token count"
+        );
+
+        let _ = sqlx::query("DELETE FROM api_tokens WHERE id = ANY($1)")
+            .bind(&[old_token_id, replacement_token_id])
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id = ANY($1)")
+            .bind(&[sa.id, admin_id])
+            .execute(&pool)
+            .await;
+    }
+
     /// `POST /service-accounts/:id/tokens` must emit `API_TOKEN_CREATED`, and
     /// the matching revoke must emit `API_TOKEN_REVOKED`, attributed to the
     /// acting admin.

--- a/backend/src/services/service_account_service.rs
+++ b/backend/src/services/service_account_service.rs
@@ -108,6 +108,7 @@ impl ServiceAccountService {
             LEFT JOIN (
                 SELECT user_id, COUNT(*) as cnt
                 FROM api_tokens
+                WHERE revoked_at IS NULL
                 GROUP BY user_id
             ) t ON t.user_id = u.id
             WHERE u.is_service_account = true


### PR DESCRIPTION
## Summary

The service-account list counted every `api_tokens` row, including tokens that had been soft-revoked. As a result, deleting a token and creating a replacement caused the displayed count to increase even though the revoked token was no longer returned by the token-management endpoint.

Filter the grouped token-count query with `revoked_at IS NULL` so the service-account summary count uses the same revoked-token semantics as the token list.

Expired tokens are intentionally still counted because the token-management endpoint continues to return them and marks them as expired. Changing the APIs to report only currently usable tokens would be a separate behavior change.

## Testing

- Added a Postgres-backed handler regression covering service-account creation, token minting, revocation, replacement-token minting, and the resulting summary count.
- Confirmed the regression fails against the original query with a count of 2 instead of 1.
- Confirmed the full backend test, lint, build, and integration suite passes with the fix, along with web build and E2E validation.
- Regenerated the SQLx offline metadata for the updated query.

Closes #2441.

Related frontend issue: [artifact-keeper/artifact-keeper-web#554](https://github.com/artifact-keeper/artifact-keeper-web/issues/554).
