### PR TITLE
fix(authz): enforce cross-repo authorization on security scan reads and SBOM writes (#2439)

### DIFF
--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::artifacts::check_artifact_visibility;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -351,6 +352,13 @@ async fn generate_sbom(
     Extension(auth): Extension<AuthExtension>,
     Json(body): Json<GenerateSbomRequest>,
 ) -> Result<Json<SbomResponse>> {
+    // Cross-repo authorization (#2439): generating/regenerating an SBOM is a
+    // write against a specific artifact. A member who can see the artifact's
+    // repository is legitimately allowed to do this, so gate on the canonical
+    // artifact-visibility check (token scope + admin bypass + private-repo
+    // membership, existence-hiding 404) BEFORE any write lands.
+    check_artifact_visibility(&Some(auth.clone()), body.artifact_id, &state.db).await?;
+
     let service = SbomService::new(state.db.clone());
     let format = SbomFormat::parse(&body.format)
         .ok_or_else(|| AppError::Validation(format!("Unknown format: {}", body.format)))?;
@@ -999,6 +1007,7 @@ async fn get_cve_history_by_cve(
     request_body = UpdateCveStatusRequest,
     responses(
         (status = 200, description = "Updated CVE entry", body = crate::models::sbom::CveHistoryEntry),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 422, description = "Validation error", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
@@ -1009,6 +1018,23 @@ async fn update_cve_status(
     Path(id): Path<Uuid>,
     Json(body): Json<UpdateCveStatusRequest>,
 ) -> Result<Json<crate::models::sbom::CveHistoryEntry>> {
+    // Cross-repo authorization (#2439): mutating vulnerability triage state
+    // (accept/dismiss a CVE) is an administrative security decision, not a
+    // per-repo-member action — mirror the sibling
+    // `update_cve_status_by_artifact_cve` (#2321 G3) and the finding
+    // acknowledge/revoke writes (which all `require_admin`). Gate on global
+    // admin BEFORE any validation or lookup, and record the RBAC-deny so an
+    // unauthorized attempt is audited rather than silently 403'd.
+    crate::services::audit_service::enforce_admin_audited(
+        auth.is_admin,
+        state.db.clone(),
+        auth.user_id,
+        crate::services::audit_service::ResourceType::ScanResult,
+        "/api/v1/sbom/cve/status/{id}",
+        "POST",
+    )
+    .await?;
+
     let service = SbomService::new(state.db.clone());
     let status = CveStatus::parse(&body.status)
         .ok_or_else(|| AppError::Validation(format!("Unknown status: {}", body.status)))?;
@@ -1609,20 +1635,58 @@ fn require_repo_access(
     Ok(())
 }
 
-/// Resolve `artifact_id → repository_id` and apply [`require_repo_access`].
+/// Full per-repo authorization for the SBOM repo-scoped read/write routes.
+///
+/// Combines the pure token-scope decision ([`require_repo_access`]) with a
+/// private-repo membership check (`user_can_access_repo`) — i.e. the same
+/// semantics as [`check_artifact_visibility`]. Before #2439 the `ensure_*`
+/// wrappers ran token-scope ONLY, so any unrestricted JWT/token (which
+/// `can_access_repo` always accepts) could read a private repo's SBOM/CVE
+/// data. Admins bypass the membership check; public repos pass for everyone.
+///
+/// `repo` carries `(repository_id, is_public)`; `None` means the resource row
+/// does not exist (or is soft-deleted) and yields the existence-hiding 404
+/// `missing_msg`. Membership denials also 404 (never 403) so a non-member
+/// cannot enumerate resource ids by status code.
+async fn require_repo_visibility(
+    db: &sqlx::PgPool,
+    auth: &AuthExtension,
+    repo: Option<(Uuid, bool)>,
+    missing_msg: &'static str,
+) -> Result<()> {
+    // Token-scope + existence (the pure, unit-tested decision).
+    require_repo_access(auth, repo.map(|(id, _)| id), missing_msg)?;
+    let (repo_id, is_public) = repo.expect("require_repo_access rejects None repo");
+    if !is_public && !auth.is_admin {
+        let repo_service = crate::services::repository_service::RepositoryService::new(db.clone());
+        if !repo_service
+            .user_can_access_repo(repo_id, auth.user_id)
+            .await?
+        {
+            return Err(AppError::NotFound(missing_msg.into()));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve `artifact_id → (repository_id, is_public)` and apply
+/// [`require_repo_visibility`].
 async fn ensure_artifact_repo_access(
     db: &sqlx::PgPool,
     auth: &AuthExtension,
     artifact_id: Uuid,
 ) -> Result<()> {
-    let repo_id: Option<Uuid> =
-        sqlx::query_scalar("SELECT repository_id FROM artifacts WHERE id = $1 AND NOT is_deleted")
-            .bind(artifact_id)
-            .fetch_optional(db)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
+    let repo: Option<(Uuid, bool)> = sqlx::query_as(
+        "SELECT r.id, r.is_public FROM artifacts a \
+         JOIN repositories r ON r.id = a.repository_id \
+         WHERE a.id = $1 AND NOT a.is_deleted",
+    )
+    .bind(artifact_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
 
-    require_repo_access(auth, repo_id, ARTIFACT_NOT_ANALYZABLE_MSG)
+    require_repo_visibility(db, auth, repo, ARTIFACT_NOT_ANALYZABLE_MSG).await
 }
 
 /// Like [`ensure_artifact_repo_access`] but resolves through `sbom_documents`
@@ -1632,14 +1696,17 @@ async fn ensure_sbom_repo_access(
     auth: &AuthExtension,
     sbom_id: Uuid,
 ) -> Result<()> {
-    let repo_id: Option<Uuid> =
-        sqlx::query_scalar("SELECT repository_id FROM sbom_documents WHERE id = $1")
-            .bind(sbom_id)
-            .fetch_optional(db)
-            .await
-            .map_err(|e| AppError::Database(e.to_string()))?;
+    let repo: Option<(Uuid, bool)> = sqlx::query_as(
+        "SELECT r.id, r.is_public FROM sbom_documents s \
+         JOIN repositories r ON r.id = s.repository_id \
+         WHERE s.id = $1",
+    )
+    .bind(sbom_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
 
-    require_repo_access(auth, repo_id, "SBOM not found")
+    require_repo_visibility(db, auth, repo, "SBOM not found").await
 }
 
 #[derive(OpenApi)]
@@ -3260,5 +3327,230 @@ mod tests {
                 other
             ),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #2439 cross-repo authorization for the SBOM routes.
+    //
+    // (a) generate_sbom (WRITE): a member of the artifact's repo may generate;
+    //     a non-member gets an existence-hiding 404 and NO sbom_documents row
+    //     is written; public repos + admins pass.
+    // (b) update_cve_status (WRITE): admin-only (mirrors the sibling
+    //     update_cve_status_by_artifact_cve / finding-acknowledge gate); a
+    //     non-admin member is 403'd before any lookup or write.
+    // (c) require_repo_access upgrade via ensure_artifact_repo_access: token
+    //     scope alone no longer suffices for a private repo — a non-member
+    //     unrestricted JWT is denied; members + admins + public repos pass.
+    // -----------------------------------------------------------------------
+
+    #[cfg(test)]
+    async fn set_repo_public(pool: &sqlx::PgPool, repo_id: Uuid, public: bool) {
+        sqlx::query("UPDATE repositories SET is_public = $1 WHERE id = $2")
+            .bind(public)
+            .bind(repo_id)
+            .execute(pool)
+            .await
+            .expect("set is_public");
+    }
+
+    #[cfg(test)]
+    async fn sbom_row_count(pool: &sqlx::PgPool, artifact_id: Uuid) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .fetch_one(pool)
+            .await
+            .expect("count sbom rows")
+    }
+
+    #[tokio::test]
+    async fn test_generate_sbom_non_member_404_and_no_write_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = super::generate_sbom(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(outsider, &outname)),
+            axum::Json(GenerateSbomRequest {
+                artifact_id,
+                format: "cyclonedx".to_string(),
+                force_regenerate: false,
+            }),
+        )
+        .await;
+        let count = sbom_row_count(&fx.pool, artifact_id).await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "non-member must get 404, got {:?}",
+            res.err()
+        );
+        assert_eq!(count, 0, "no SBOM row must be written on a denied generate");
+    }
+
+    #[tokio::test]
+    async fn test_generate_sbom_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        // fixture user is auto-granted repo access (member).
+        let res = super::generate_sbom(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            axum::Json(GenerateSbomRequest {
+                artifact_id,
+                format: "cyclonedx".to_string(),
+                force_regenerate: false,
+            }),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+        assert!(
+            res.is_ok(),
+            "member must be able to generate: {:?}",
+            res.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generate_sbom_public_repo_non_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        set_repo_public(&fx.pool, fx.repo_id, true).await;
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = super::generate_sbom(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(outsider, &outname)),
+            axum::Json(GenerateSbomRequest {
+                artifact_id,
+                format: "cyclonedx".to_string(),
+                force_regenerate: false,
+            }),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            res.is_ok(),
+            "public-repo generate allowed for any authed user"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_cve_status_non_admin_denied_no_write_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        seed_finding_for_handler(&fx.pool, artifact_id, fx.repo_id, "CVE-2024-7788", "high").await;
+        // A legitimate repo member is still denied: the CVE-triage write is
+        // gated on GLOBAL admin (mirrors update_cve_status_by_artifact_cve).
+        let res = super::update_cve_status(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            axum::extract::Path(Uuid::new_v4()),
+            axum::Json(UpdateCveStatusRequest {
+                status: "acknowledged".to_string(),
+                reason: None,
+            }),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::Authorization(_))),
+            "non-admin CVE-status write must be 403, got {:?}",
+            res.err()
+        );
+    }
+
+    // --- require_repo_access upgrade (ensure_artifact_repo_access) ---------
+
+    #[tokio::test]
+    async fn test_ensure_artifact_repo_access_non_member_private_denied_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        // Unrestricted JWT (allowed_repo_ids = Admin scope) — passes the old
+        // token-scope-only gate but must now fail on private-repo membership.
+        let auth = tdh::make_auth(outsider, &outname);
+        let res = super::ensure_artifact_repo_access(&fx.pool, &auth, artifact_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "non-member unrestricted token must be denied on a private repo, got {:?}",
+            res.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ensure_artifact_repo_access_member_allowed_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let res = super::ensure_artifact_repo_access(&fx.pool, &auth, artifact_id).await;
+        fx.teardown().await;
+        assert!(res.is_ok(), "member must pass: {:?}", res.err());
+    }
+
+    #[tokio::test]
+    async fn test_ensure_artifact_repo_access_admin_allowed_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let (admin_id, admin_name) = tdh::create_user(&fx.pool).await;
+        let auth = tdh::admin_auth(admin_id, &admin_name);
+        let res = super::ensure_artifact_repo_access(&fx.pool, &auth, artifact_id).await;
+        tdh::cleanup_user(&fx.pool, admin_id).await;
+        fx.teardown().await;
+        assert!(res.is_ok(), "admin bypass must pass: {:?}", res.err());
+    }
+
+    #[tokio::test]
+    async fn test_ensure_artifact_repo_access_public_repo_non_member_allowed_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        set_repo_public(&fx.pool, fx.repo_id, true).await;
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let auth = tdh::make_auth(outsider, &outname);
+        let res = super::ensure_artifact_repo_access(&fx.pool, &auth, artifact_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            res.is_ok(),
+            "public repo must be accessible to any authed user"
+        );
     }
 }

--- a/backend/src/api/handlers/sbom.rs
+++ b/backend/src/api/handlers/sbom.rs
@@ -693,10 +693,18 @@ async fn get_sbom_components(
 )]
 async fn convert_sbom(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Json(body): Json<ConvertSbomRequest>,
 ) -> Result<Json<SbomContentResponse>> {
+    // Cross-repo authorization (#2439): converting reads the SBOM's full
+    // component inventory and persists convert rows, so resolve the SBOM's
+    // owning repository and apply the same membership gate as the other
+    // by-id SBOM routes (existence-hiding 404) BEFORE any read or write.
+    // Member-visibility is the correct level: a member converting an SBOM
+    // they can already see is legitimate.
+    ensure_sbom_repo_access(&state.db, &auth, id).await?;
+
     let service = SbomService::new(state.db.clone());
     let target_format = SbomFormat::parse(&body.target_format)
         .ok_or_else(|| AppError::Validation(format!("Unknown format: {}", body.target_format)))?;
@@ -3551,6 +3559,139 @@ mod tests {
         assert!(
             res.is_ok(),
             "public repo must be accessible to any authed user"
+        );
+    }
+
+    // --- convert_sbom cross-repo authorization (#2439 residual) -----------
+
+    /// Seed one `sbom_documents` row for (artifact, repo, format). Returns id.
+    #[cfg(test)]
+    async fn seed_sbom_for_handler(
+        pool: &sqlx::PgPool,
+        artifact_id: Uuid,
+        repo_id: Uuid,
+        format: &str,
+    ) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO sbom_documents (artifact_id, repository_id, format, format_version, \
+                 content, content_hash) \
+             VALUES ($1, $2, $3, '1.5', '{}'::jsonb, $4) RETURNING id",
+        )
+        .bind(artifact_id)
+        .bind(repo_id)
+        .bind(format)
+        .bind(format!("hash-{}", Uuid::new_v4()))
+        .fetch_one(pool)
+        .await
+        .expect("seed sbom_document")
+    }
+
+    #[cfg(test)]
+    async fn sbom_format_count(pool: &sqlx::PgPool, artifact_id: Uuid, format: &str) -> i64 {
+        sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sbom_documents WHERE artifact_id = $1 AND format = $2",
+        )
+        .bind(artifact_id)
+        .bind(format)
+        .fetch_one(pool)
+        .await
+        .expect("count sbom by format")
+    }
+
+    #[tokio::test]
+    async fn test_convert_sbom_non_member_404_and_no_write_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let sbom_id = seed_sbom_for_handler(&fx.pool, artifact_id, fx.repo_id, "cyclonedx").await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = super::convert_sbom(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(outsider, &outname)),
+            axum::extract::Path(sbom_id),
+            axum::Json(ConvertSbomRequest {
+                target_format: "spdx".to_string(),
+            }),
+        )
+        .await;
+        let spdx_rows = sbom_format_count(&fx.pool, artifact_id, "spdx").await;
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "non-member convert must be an existence-hiding 404, got {:?}",
+            res.err()
+        );
+        assert_eq!(
+            spdx_rows, 0,
+            "denied convert must not persist a converted SBOM row"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_convert_sbom_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let sbom_id = seed_sbom_for_handler(&fx.pool, artifact_id, fx.repo_id, "cyclonedx").await;
+        // fixture user is auto-granted repo access (member).
+        let res = super::convert_sbom(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            axum::extract::Path(sbom_id),
+            axum::Json(ConvertSbomRequest {
+                target_format: "spdx".to_string(),
+            }),
+        )
+        .await;
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        fx.teardown().await;
+        assert!(
+            res.is_ok(),
+            "member must be able to convert: {:?}",
+            res.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_convert_sbom_public_repo_non_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        set_repo_public(&fx.pool, fx.repo_id, true).await;
+        let artifact_id = seed_artifact_for_handler(&fx.pool, fx.repo_id).await;
+        let sbom_id = seed_sbom_for_handler(&fx.pool, artifact_id, fx.repo_id, "cyclonedx").await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = super::convert_sbom(
+            axum::extract::State(fx.state.clone()),
+            axum::Extension(tdh::make_auth(outsider, &outname)),
+            axum::extract::Path(sbom_id),
+            axum::Json(ConvertSbomRequest {
+                target_format: "spdx".to_string(),
+            }),
+        )
+        .await;
+        let _ = sqlx::query("DELETE FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .execute(&fx.pool)
+            .await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            res.is_ok(),
+            "public-repo convert allowed for any authed user"
         );
     }
 }

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -10,6 +10,7 @@ use sqlx::PgPool;
 use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
+use crate::api::handlers::artifacts::check_artifact_visibility;
 use crate::api::handlers::repositories::{require_repo_write_access, require_visible};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
@@ -137,7 +138,7 @@ pub struct TriggerScanResponse {
     pub scan_result_ids: Vec<Uuid>,
 }
 
-#[derive(Debug, Deserialize, IntoParams)]
+#[derive(Debug, Default, Deserialize, IntoParams)]
 pub struct ListScansQuery {
     pub repository_id: Option<Uuid>,
     pub artifact_id: Option<Uuid>,
@@ -343,7 +344,7 @@ async fn enrich_scans(db: &PgPool, scans: Vec<ScanResult>) -> Result<Vec<ScanRes
         .collect())
 }
 
-#[derive(Debug, Deserialize, IntoParams)]
+#[derive(Debug, Default, Deserialize, IntoParams)]
 pub struct ListFindingsQuery {
     pub page: Option<i64>,
     pub per_page: Option<i64>,
@@ -722,9 +723,38 @@ async fn trigger_scan(
 )]
 async fn list_scans(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListScansQuery>,
 ) -> Result<Json<ScanListResponse>> {
+    // Cross-repo authorization (#2439): this global scan list is
+    // artifact/repo-scoped data. Gate on whichever filter the caller
+    // supplied so a non-member cannot enumerate another repo's scans:
+    //   - artifact_id → canonical artifact-visibility gate;
+    //   - repository_id → canonical repo-visibility gate;
+    //   - neither → an unfiltered listing would expose every repo's scans,
+    //     so restrict it to admins (non-admins must scope by repo/artifact).
+    // Existence-hiding NotFound (never Forbidden) for the scoped branches.
+    let auth = Some(auth);
+    match (query.artifact_id, query.repository_id) {
+        (Some(artifact_id), _) => {
+            check_artifact_visibility(&auth, artifact_id, &state.db).await?;
+        }
+        (None, Some(repository_id)) => {
+            let repo_service = RepositoryService::new(state.db.clone());
+            let repo = repo_service.get_by_id(repository_id).await?;
+            require_visible(&repo, &auth, &repo_service).await?;
+        }
+        (None, None) => {
+            if !auth.as_ref().is_some_and(|a| a.is_admin) {
+                return Err(AppError::Authorization(
+                    "Listing all scans requires admin; scope the request with \
+                     repository_id or artifact_id"
+                        .to_string(),
+                ));
+            }
+        }
+    }
+
     let svc = ScanResultService::new(state.db.clone());
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
@@ -760,11 +790,16 @@ async fn list_scans(
 )]
 async fn get_scan(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<ScanResponse>> {
     let svc = ScanResultService::new(state.db.clone());
     let s = svc.get_scan(id).await?;
+
+    // Cross-repo authorization (#2439): resolve the scan's owning artifact,
+    // then apply the canonical visibility gate (existence-hiding 404) before
+    // returning any scan detail.
+    check_artifact_visibility(&Some(auth), s.artifact_id, &state.db).await?;
 
     let mut items = enrich_scans(&state.db, vec![s]).await?;
     Ok(Json(items.remove(0)))
@@ -791,7 +826,7 @@ async fn get_scan(
 )]
 async fn list_findings(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(scan_id): Path<Uuid>,
     Query(query): Query<ListFindingsQuery>,
 ) -> Result<Json<FindingListResponse>> {
@@ -802,7 +837,12 @@ async fn list_findings(
     // an empty envelope, contradicting the 404 documented in the OpenAPI
     // annotation above. Clients can't distinguish "unknown scan" from "real
     // scan with zero findings" without this pre-check.
-    svc.get_scan(scan_id).await?;
+    let scan = svc.get_scan(scan_id).await?;
+
+    // Cross-repo authorization (#2439): resolve the scan's owning artifact and
+    // apply the canonical visibility gate (existence-hiding 404) before
+    // returning any CVE finding for it.
+    check_artifact_visibility(&Some(auth), scan.artifact_id, &state.db).await?;
 
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(50).min(200);
@@ -1137,10 +1177,14 @@ async fn update_repo_security(
 )]
 async fn list_artifact_scans(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(artifact_id): Path<Uuid>,
     Query(query): Query<ListScansQuery>,
 ) -> Result<Json<ScanListResponse>> {
+    // Cross-repo authorization (#2439): apply the canonical artifact-visibility
+    // gate (existence-hiding 404) before listing any scan for this artifact.
+    check_artifact_visibility(&Some(auth), artifact_id, &state.db).await?;
+
     let svc = ScanResultService::new(state.db.clone());
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
@@ -2649,5 +2693,388 @@ mod tests {
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert_eq!(json["total"], 42);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cross-repo scan/finding-read authorization (#2439).
+    //
+    // The global (non repo-nested) scan read routes -- `list_scans`,
+    // `get_scan`, `list_findings`, `list_artifact_scans` -- query
+    // artifact/repo-scoped data with NO per-repo authorization before this
+    // fix, leaking CVE/supply-chain data to any authenticated non-member.
+    // Each now runs the canonical `check_artifact_visibility` / `require_visible`
+    // gate. These DB-backed tests call the handlers directly (matching the
+    // `trigger_scan` sibling) and no-op when `DATABASE_URL` is unset.
+    // -----------------------------------------------------------------------
+
+    /// Insert an `artifacts` row owned by `repo_id` and return its id.
+    #[cfg(test)]
+    async fn seed_artifact_row(pool: &sqlx::PgPool, repo_id: Uuid) -> Uuid {
+        let id = Uuid::new_v4();
+        let path = format!("{}/{}", repo_id, id);
+        sqlx::query(
+            "INSERT INTO artifacts (id, repository_id, name, path, version, size_bytes, \
+             checksum_sha256, content_type, storage_key, is_deleted) \
+             VALUES ($1, $2, $3, $4, '1.0.0', 1024, $5, 'application/octet-stream', $4, false)",
+        )
+        .bind(id)
+        .bind(repo_id)
+        .bind(format!("scan-art-{}", id))
+        .bind(&path)
+        .bind(format!("sha256-scan-{}", id))
+        .execute(pool)
+        .await
+        .expect("seed artifact row");
+        id
+    }
+
+    /// Insert a completed `scan_results` row + one `scan_findings` row for
+    /// `(repo_id, artifact_id)`. Returns `(scan_id, finding_id)`.
+    #[cfg(test)]
+    async fn seed_scan_with_finding(
+        pool: &sqlx::PgPool,
+        repo_id: Uuid,
+        artifact_id: Uuid,
+    ) -> (Uuid, Uuid) {
+        let scan_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO scan_results (id, artifact_id, repository_id, scan_type, status, \
+             findings_count, started_at, completed_at) \
+             VALUES ($1, $2, $3, 'dependency', 'completed', 1, NOW(), NOW())",
+        )
+        .bind(scan_id)
+        .bind(artifact_id)
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("seed scan_result");
+        let finding_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO scan_findings (scan_result_id, artifact_id, severity, title, cve_id, \
+             source, is_acknowledged) \
+             VALUES ($1, $2, 'critical', 'seed finding', 'CVE-2024-9999', 'trivy', false) \
+             RETURNING id",
+        )
+        .bind(scan_id)
+        .bind(artifact_id)
+        .fetch_one(pool)
+        .await
+        .expect("seed scan_finding");
+        (scan_id, finding_id)
+    }
+
+    #[cfg(test)]
+    async fn teardown_scans(pool: &sqlx::PgPool, repo_id: Uuid) {
+        let _ = sqlx::query(
+            "DELETE FROM scan_findings WHERE scan_result_id IN \
+             (SELECT id FROM scan_results WHERE repository_id = $1)",
+        )
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+        let _ = sqlx::query("DELETE FROM scan_results WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+    }
+
+    #[cfg(test)]
+    async fn set_public(pool: &sqlx::PgPool, repo_id: Uuid, public: bool) {
+        sqlx::query("UPDATE repositories SET is_public = $1 WHERE id = $2")
+            .bind(public)
+            .bind(repo_id)
+            .execute(pool)
+            .await
+            .expect("set is_public");
+    }
+
+    /// A denial (404) message must not leak any scan/finding metadata field.
+    #[cfg(test)]
+    fn assert_no_scan_leak(err: &AppError) {
+        let msg = format!("{:?}", err);
+        for needle in ["repository_id", "cve", "CVE-", "severity", "critical"] {
+            assert!(
+                !msg.contains(needle),
+                "denial message must not leak `{needle}`: {msg}"
+            );
+        }
+    }
+
+    // --- get_scan ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_scan_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        // fixture user is auto-granted repo access (a member).
+        let res = get_scan(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            Path(scan_id),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
+        assert!(res.is_ok(), "member must see the scan, got {:?}", res.err());
+    }
+
+    #[tokio::test]
+    async fn test_get_scan_non_member_404_no_leak_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = get_scan(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(scan_id),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        match res {
+            Err(ref e @ AppError::NotFound(_)) => assert_no_scan_leak(e),
+            other => panic!("non-member must get 404, got {:?}", other.err()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_scan_admin_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (admin_id, admin_name) = tdh::create_user(&fx.pool).await;
+        let res = get_scan(
+            State(fx.state.clone()),
+            Extension(tdh::admin_auth(admin_id, &admin_name)),
+            Path(scan_id),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, admin_id).await;
+        fx.teardown().await;
+        assert!(res.is_ok(), "admin bypass must see the scan");
+    }
+
+    #[tokio::test]
+    async fn test_get_scan_public_repo_non_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        set_public(&fx.pool, fx.repo_id, true).await;
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = get_scan(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(scan_id),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            res.is_ok(),
+            "public-repo scan is visible to any authed user"
+        );
+    }
+
+    // --- list_findings ----------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_findings_non_member_404_no_leak_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = list_findings(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(scan_id),
+            Query(ListFindingsQuery::default()),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        match res {
+            Err(ref e @ AppError::NotFound(_)) => assert_no_scan_leak(e),
+            other => panic!("non-member must get 404, got {:?}", other.err()),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_list_findings_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let res = list_findings(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            Path(scan_id),
+            Query(ListFindingsQuery::default()),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
+        let body = res.expect("member sees findings");
+        assert_eq!(body.0.total, 1);
+    }
+
+    // --- list_artifact_scans ---------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_artifact_scans_non_member_404_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (_s, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = list_artifact_scans(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(art),
+            Query(ListScansQuery::default()),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "non-member must get 404 on artifact scans, got {:?}",
+            res.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_artifact_scans_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (_s, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let res = list_artifact_scans(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            Path(art),
+            Query(ListScansQuery::default()),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
+        let body = res.expect("member sees artifact scans");
+        assert_eq!(body.0.total, 1);
+    }
+
+    // --- list_scans (filtered + unfiltered) -------------------------------
+
+    #[tokio::test]
+    async fn test_list_scans_artifact_filter_non_member_404_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (_s, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+        let res = list_scans(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Query(ListScansQuery {
+                artifact_id: Some(art),
+                ..Default::default()
+            }),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::NotFound(_))),
+            "non-member filtering by hidden artifact must 404, got {:?}",
+            res.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_scans_repo_filter_member_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (_s, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let res = list_scans(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            Query(ListScansQuery {
+                repository_id: Some(fx.repo_id),
+                ..Default::default()
+            }),
+        )
+        .await;
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        fx.teardown().await;
+        assert!(res.is_ok(), "member filtering by own repo must 200");
+    }
+
+    #[tokio::test]
+    async fn test_list_scans_unfiltered_non_admin_denied_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let res = list_scans(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(fx.user_id, &fx.username)),
+            Query(ListScansQuery::default()),
+        )
+        .await;
+        fx.teardown().await;
+        assert!(
+            matches!(res, Err(AppError::Authorization(_))),
+            "unfiltered global scan list must be admin-only, got {:?}",
+            res.err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_scans_unfiltered_admin_ok_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let (admin_id, admin_name) = tdh::create_user(&fx.pool).await;
+        let res = list_scans(
+            State(fx.state.clone()),
+            Extension(tdh::admin_auth(admin_id, &admin_name)),
+            Query(ListScansQuery::default()),
+        )
+        .await;
+        tdh::cleanup_user(&fx.pool, admin_id).await;
+        fx.teardown().await;
+        assert!(res.is_ok(), "admin may list all scans unfiltered");
     }
 }

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -21,6 +21,24 @@ use crate::services::repository_service::RepositoryService;
 use crate::services::scan_config_service::{ScanConfigService, UpsertScanConfigRequest};
 use crate::services::scan_result_service::ScanResultService;
 
+/// Canonical 404 body for the scan-by-id read routes. Both "this scan id does
+/// not exist" (from `ScanResultService::get_scan`) and "the scan exists but the
+/// caller may not see its repository" (from `check_artifact_visibility`) must
+/// return this SAME message so the response is not a boolean existence oracle
+/// for hidden scans. Kept identical to the string `get_scan` emits for a truly
+/// absent id. (#2439 residual.)
+const SCAN_NOT_FOUND_MSG: &str = "Scan result not found";
+
+/// Normalize a cross-repo-visibility `NotFound` (which carries an
+/// artifact-flavored message) to the canonical scan-not-found body, so a
+/// no-access scan is indistinguishable from an absent one.
+fn unify_scan_not_found(e: AppError) -> AppError {
+    match e {
+        AppError::NotFound(_) => AppError::NotFound(SCAN_NOT_FOUND_MSG.to_string()),
+        other => other,
+    }
+}
+
 /// Create security routes
 pub fn router() -> Router<SharedState> {
     Router::new()
@@ -798,8 +816,11 @@ async fn get_scan(
 
     // Cross-repo authorization (#2439): resolve the scan's owning artifact,
     // then apply the canonical visibility gate (existence-hiding 404) before
-    // returning any scan detail.
-    check_artifact_visibility(&Some(auth), s.artifact_id, &state.db).await?;
+    // returning any scan detail. Normalize the no-access 404 body to the same
+    // message an absent id produces so it is not an existence oracle.
+    check_artifact_visibility(&Some(auth), s.artifact_id, &state.db)
+        .await
+        .map_err(unify_scan_not_found)?;
 
     let mut items = enrich_scans(&state.db, vec![s]).await?;
     Ok(Json(items.remove(0)))
@@ -841,8 +862,11 @@ async fn list_findings(
 
     // Cross-repo authorization (#2439): resolve the scan's owning artifact and
     // apply the canonical visibility gate (existence-hiding 404) before
-    // returning any CVE finding for it.
-    check_artifact_visibility(&Some(auth), scan.artifact_id, &state.db).await?;
+    // returning any CVE finding for it. Normalize the no-access 404 body to the
+    // same message an absent id produces so it is not an existence oracle.
+    check_artifact_visibility(&Some(auth), scan.artifact_id, &state.db)
+        .await
+        .map_err(unify_scan_not_found)?;
 
     let page = query.page.unwrap_or(1);
     let per_page = query.per_page.unwrap_or(50).min(200);
@@ -3076,5 +3100,96 @@ mod tests {
         tdh::cleanup_user(&fx.pool, admin_id).await;
         fx.teardown().await;
         assert!(res.is_ok(), "admin may list all scans unfiltered");
+    }
+
+    // --- 404-body uniformity: hidden-exists vs truly-absent (#2439 residual) --
+    //
+    // A hidden-but-existing scan (no-access) and a nonexistent scan id must
+    // return the SAME 404 body, else the status/message is a boolean existence
+    // oracle. Extract the NotFound message in both cases and assert equality.
+
+    #[cfg(test)]
+    fn not_found_msg<T>(res: &Result<T>) -> String {
+        match res {
+            Err(AppError::NotFound(m)) => m.clone(),
+            Err(other) => panic!("expected NotFound, got {:?}", other),
+            Ok(_) => panic!("expected NotFound, got Ok"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_scan_404_body_uniform_hidden_vs_absent_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+
+        // hidden-but-existing scan, seen by a non-member.
+        let hidden = get_scan(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(scan_id),
+        )
+        .await;
+        // truly-absent scan id.
+        let absent = get_scan(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(Uuid::new_v4()),
+        )
+        .await;
+
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+
+        let hm = not_found_msg(&hidden);
+        let am = not_found_msg(&absent);
+        assert_eq!(
+            hm, am,
+            "hidden and absent get_scan 404 bodies must be identical (no oracle)"
+        );
+        assert_eq!(hm, SCAN_NOT_FOUND_MSG, "canonical scan-not-found message");
+    }
+
+    #[tokio::test]
+    async fn test_list_findings_404_body_uniform_hidden_vs_absent_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let art = seed_artifact_row(&fx.pool, fx.repo_id).await;
+        let (scan_id, _f) = seed_scan_with_finding(&fx.pool, fx.repo_id, art).await;
+        let (outsider, outname) = tdh::create_user(&fx.pool).await;
+
+        let hidden = list_findings(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(scan_id),
+            Query(ListFindingsQuery::default()),
+        )
+        .await;
+        let absent = list_findings(
+            State(fx.state.clone()),
+            Extension(tdh::make_auth(outsider, &outname)),
+            Path(Uuid::new_v4()),
+            Query(ListFindingsQuery::default()),
+        )
+        .await;
+
+        teardown_scans(&fx.pool, fx.repo_id).await;
+        tdh::cleanup_user(&fx.pool, outsider).await;
+        fx.teardown().await;
+
+        let hm = not_found_msg(&hidden);
+        let am = not_found_msg(&absent);
+        assert_eq!(
+            hm, am,
+            "hidden and absent list_findings 404 bodies must be identical (no oracle)"
+        );
+        assert_eq!(hm, SCAN_NOT_FOUND_MSG, "canonical scan-not-found message");
     }
 }

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -1049,6 +1049,85 @@ mod scan_sbom_leak_2439 {
             "member generate must write an sbom row"
         );
 
+        // --- convert_sbom (#2439 residual): non-member 404 + no convert row;
+        //     member 200. Use the SBOM the member just generated. ------------
+        let sbom_id: Uuid =
+            sqlx::query_scalar("SELECT id FROM sbom_documents WHERE artifact_id = $1 LIMIT 1")
+                .bind(artifact_id)
+                .fetch_one(&pool)
+                .await
+                .expect("member-generated sbom must exist");
+
+        let (status, body) = send(
+            sb(),
+            post_json(
+                &format!("/{sbom_id}/convert"),
+                "{\"target_format\":\"spdx\"}",
+            ),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "non-member convert must 404");
+        assert_no_leak(&body);
+        let spdx_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sbom_documents WHERE artifact_id = $1 AND format = 'spdx'",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            spdx_rows, 0,
+            "denied convert must not persist a convert row"
+        );
+
+        let (status, _body) = send(
+            sb(),
+            post_json(
+                &format!("/{sbom_id}/convert"),
+                "{\"target_format\":\"spdx\"}",
+            ),
+            auth_for(user_a),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "member convert must 200");
+
+        // --- 404-body uniformity: a hidden-but-existing scan and an absent
+        //     scan id must return the SAME body (no existence oracle). --------
+        let (hs, hidden_body) =
+            send(sec(), get(&format!("/scans/{scan_id}")), auth_for(user_b)).await;
+        let (as_, absent_body) = send(
+            sec(),
+            get(&format!("/scans/{}", Uuid::new_v4())),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(hs, StatusCode::NOT_FOUND);
+        assert_eq!(as_, StatusCode::NOT_FOUND);
+        assert_eq!(
+            hidden_body, absent_body,
+            "hidden vs absent get_scan 404 bodies must be byte-identical"
+        );
+
+        let (hs, hidden_fbody) = send(
+            sec(),
+            get(&format!("/scans/{scan_id}/findings")),
+            auth_for(user_b),
+        )
+        .await;
+        let (as_, absent_fbody) = send(
+            sec(),
+            get(&format!("/scans/{}/findings", Uuid::new_v4())),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(hs, StatusCode::NOT_FOUND);
+        assert_eq!(as_, StatusCode::NOT_FOUND);
+        assert_eq!(
+            hidden_fbody, absent_fbody,
+            "hidden vs absent list_findings 404 bodies must be byte-identical"
+        );
+
         cleanup(&pool, repo_id, &[user_a, user_b]).await;
     }
 }

--- a/backend/tests/security_regression_tests.rs
+++ b/backend/tests/security_regression_tests.rs
@@ -710,3 +710,345 @@ mod qc_metadata_leak_2437 {
         cleanup(&pool, repo_id, &[user_a, user_b]).await;
     }
 }
+
+// ---------------------------------------------------------------------------
+// #2439  Cross-repo authorization: ungated /security scan+finding reads and
+//        /sbom generate/cve-status writes.
+// ---------------------------------------------------------------------------
+// Class:  Broken object-level authorization on artifact/repo-scoped
+//         security-scan reads and SBOM/CVE writes.
+// Seam:   the `/security/scans*` + `/security/artifacts/:id/scans` read
+//         handlers and the `/sbom` generate + `/sbom/cve/status/:id` write
+//         handlers, exercised end-to-end over the real routers against a live
+//         DB (the external HTTP vantage), not a helper.
+// What:   `GET /scans?artifact_id=<X>`, `/scans/:id`, `/scans/:id/findings`,
+//         `/artifacts/:id/scans` returned CVE/scan data for ANY authenticated
+//         caller with no check they can see the artifact's (private) repo;
+//         `POST /sbom {artifact_id:<X>}` let any authed caller write an SBOM
+//         attestation on another tenant's artifact; `POST /sbom/cve/status/:id`
+//         let any authed caller mutate CVE triage state.
+// Asserts: a non-member (tenant B) gets an existence-hiding 404 on the reads
+//         and the SBOM generate (with NO sbom_documents row written), a 403 on
+//         the CVE-status write, while the repo member (tenant A / owner) still
+//         gets 200 on reads + generate.
+//
+// DB-gated; run with:
+//   DATABASE_URL="postgresql://.../artifact_registry" \
+//     cargo test --test security_regression_tests -- --ignored
+// ---------------------------------------------------------------------------
+mod scan_sbom_leak_2439 {
+    // streaming-invariant: test file exempt — buffering a 404/200 response body
+    // in an assertion is not an artifact path (#1608).
+    #![allow(clippy::disallowed_methods)]
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use axum::Extension;
+    use sqlx::PgPool;
+    use tower::ServiceExt;
+    use uuid::Uuid;
+
+    use artifact_keeper_backend::api::handlers::{sbom, security};
+    use artifact_keeper_backend::api::middleware::auth::AuthExtension;
+    use artifact_keeper_backend::api::{AppState, SharedState};
+    use artifact_keeper_backend::config::Config;
+    use artifact_keeper_backend::models::access_scope::AccessScope;
+
+    use super::common;
+
+    fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+        let config = Config {
+            database_url: std::env::var("DATABASE_URL").unwrap_or_default(),
+            storage_path: storage_path.into(),
+            jwt_secret: "test-secret-at-least-32-bytes-long-for-testing".into(),
+            ..Default::default()
+        };
+        let storage: Arc<dyn artifact_keeper_backend::storage::StorageBackend> = Arc::new(
+            artifact_keeper_backend::storage::filesystem::FilesystemStorage::new(storage_path),
+        );
+        let registry = Arc::new(artifact_keeper_backend::storage::StorageRegistry::new(
+            HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        Arc::new(AppState::new(config, pool, storage, registry))
+    }
+
+    fn auth_for(user_id: Uuid) -> AuthExtension {
+        AuthExtension {
+            user_id,
+            username: format!("u-{}", &user_id.to_string()[..8]),
+            email: "u@test.local".to_string(),
+            is_admin: false,
+            is_api_token: false,
+            is_service_account: false,
+            scopes: None,
+            allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
+        }
+    }
+
+    async fn create_private_repo(pool: &PgPool) -> (Uuid, String) {
+        let id = Uuid::new_v4();
+        let key = format!("sc2439-{}", &id.to_string()[..8]);
+        let dir = std::env::temp_dir().join(&key);
+        std::fs::create_dir_all(&dir).expect("create storage dir");
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local', 'rpm'::repository_format, false)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(dir.to_string_lossy().as_ref())
+        .execute(pool)
+        .await
+        .expect("insert private repo");
+        (id, dir.to_string_lossy().to_string())
+    }
+
+    async fn seed_artifact(pool: &PgPool, repo_id: Uuid) -> Uuid {
+        let path = format!("sc2439/{}", Uuid::new_v4());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by) \
+             VALUES ($1, $2, 'sc2439', '1.0', 1, 'deadbeef', 'application/octet-stream', $3, NULL) \
+             RETURNING id",
+        )
+        .bind(repo_id)
+        .bind(&path)
+        .bind(&path)
+        .fetch_one(pool)
+        .await
+        .expect("seed artifact")
+    }
+
+    /// Seed a completed scan + one finding for (repo, artifact). Returns scan id.
+    async fn seed_scan(pool: &PgPool, repo_id: Uuid, artifact_id: Uuid) -> Uuid {
+        let scan_id: Uuid = sqlx::query_scalar(
+            "INSERT INTO scan_results (artifact_id, repository_id, scan_type, status, \
+                 findings_count, started_at, completed_at) \
+             VALUES ($1, $2, 'dependency', 'completed', 1, NOW(), NOW()) RETURNING id",
+        )
+        .bind(artifact_id)
+        .bind(repo_id)
+        .fetch_one(pool)
+        .await
+        .expect("seed scan_result");
+        sqlx::query(
+            "INSERT INTO scan_findings (scan_result_id, artifact_id, severity, title, cve_id, \
+                 source, is_acknowledged) \
+             VALUES ($1, $2, 'critical', 'seed', 'CVE-2024-1212', 'trivy', false)",
+        )
+        .bind(scan_id)
+        .bind(artifact_id)
+        .execute(pool)
+        .await
+        .expect("seed scan_finding");
+        scan_id
+    }
+
+    async fn grant_member(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+             SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+             ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .execute(pool)
+        .await
+        .expect("grant developer role");
+    }
+
+    async fn send(
+        app: axum::Router,
+        req: Request<Body>,
+        auth: AuthExtension,
+    ) -> (StatusCode, String) {
+        let resp = app.layer(Extension(auth)).oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, String::from_utf8_lossy(&bytes).to_string())
+    }
+
+    fn get(uri: &str) -> Request<Body> {
+        Request::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    fn post_json(uri: &str, body: &str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap()
+    }
+
+    fn assert_no_leak(body: &str) {
+        for needle in ["repository_id", "cve", "CVE-", "severity", "critical"] {
+            assert!(
+                !body.contains(needle),
+                "cross-tenant denial body must not leak `{needle}`: {body}"
+            );
+        }
+    }
+
+    async fn cleanup(pool: &PgPool, repo_id: Uuid, users: &[Uuid]) {
+        let _ = sqlx::query(
+            "DELETE FROM scan_findings WHERE scan_result_id IN \
+             (SELECT id FROM scan_results WHERE repository_id = $1)",
+        )
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+        for tbl in [
+            "scan_results",
+            "sbom_documents",
+            "role_assignments",
+            "artifacts",
+        ] {
+            let _ = sqlx::query(&format!("DELETE FROM {tbl} WHERE repository_id = $1"))
+                .bind(repo_id)
+                .execute(pool)
+                .await;
+        }
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        for u in users {
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(u)
+                .execute(pool)
+                .await;
+        }
+    }
+
+    async fn sbom_count(pool: &PgPool, artifact_id: Uuid) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM sbom_documents WHERE artifact_id = $1")
+            .bind(artifact_id)
+            .fetch_one(pool)
+            .await
+            .expect("count sboms")
+    }
+
+    #[tokio::test]
+    #[ignore = "requires DATABASE_URL pointed at a Postgres with migrations applied"]
+    async fn regression_2439_cross_repo_scan_sbom_bola() {
+        let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+            .await
+            .unwrap();
+
+        // Tenant A owns a private repo + artifact + scan/finding; tenant B has
+        // no membership on it.
+        let user_a = common::insert_active_user(&pool, "sc2439-a").await;
+        let user_b = common::insert_active_user(&pool, "sc2439-b").await;
+        let (repo_id, storage) = create_private_repo(&pool).await;
+        let artifact_id = seed_artifact(&pool, repo_id).await;
+        let scan_id = seed_scan(&pool, repo_id, artifact_id).await;
+        grant_member(&pool, repo_id, user_a).await;
+
+        let state = build_state(pool.clone(), &storage);
+        let sec = || security::router().with_state(state.clone());
+        let sb = || sbom::router().with_state(state.clone());
+
+        // --- Non-member (tenant B) reads: existence-hiding 404, no leak. ----
+        let (status, body) = send(
+            sec(),
+            get(&format!("/scans?artifact_id={artifact_id}")),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "list_scans artifact filter");
+        assert_no_leak(&body);
+
+        let (status, body) = send(sec(), get(&format!("/scans/{scan_id}")), auth_for(user_b)).await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "get_scan");
+        assert_no_leak(&body);
+
+        let (status, body) = send(
+            sec(),
+            get(&format!("/scans/{scan_id}/findings")),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "list_findings");
+        assert_no_leak(&body);
+
+        let (status, body) = send(
+            sec(),
+            get(&format!("/artifacts/{artifact_id}/scans")),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "list_artifact_scans");
+        assert_no_leak(&body);
+
+        // --- Non-member SBOM generate (WRITE): 404 and NO row written. ------
+        let (status, body) = send(
+            sb(),
+            post_json(
+                "/",
+                &format!("{{\"artifact_id\":\"{artifact_id}\",\"format\":\"cyclonedx\"}}"),
+            ),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "generate_sbom non-member");
+        assert_no_leak(&body);
+        assert_eq!(
+            sbom_count(&pool, artifact_id).await,
+            0,
+            "denied generate must not write an sbom_documents row"
+        );
+
+        // --- Non-member CVE-status write: admin-only -> 403. ----------------
+        let (status, _body) = send(
+            sb(),
+            post_json(
+                &format!("/cve/status/{}", Uuid::new_v4()),
+                "{\"status\":\"acknowledged\"}",
+            ),
+            auth_for(user_b),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "CVE-status write is admin-only (mirrors update_cve_status_by_artifact_cve)"
+        );
+
+        // --- Owner (tenant A member) legitimate use is intact. --------------
+        let (status, _body) =
+            send(sec(), get(&format!("/scans/{scan_id}")), auth_for(user_a)).await;
+        assert_eq!(status, StatusCode::OK, "member get_scan must still 200");
+
+        let (status, _body) = send(
+            sec(),
+            get(&format!("/artifacts/{artifact_id}/scans")),
+            auth_for(user_a),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "member list_artifact_scans 200");
+
+        let (status, _body) = send(
+            sb(),
+            post_json(
+                "/",
+                &format!("{{\"artifact_id\":\"{artifact_id}\",\"format\":\"cyclonedx\"}}"),
+            ),
+            auth_for(user_a),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "member generate_sbom must 200");
+        assert!(
+            sbom_count(&pool, artifact_id).await >= 1,
+            "member generate must write an sbom row"
+        );
+
+        cleanup(&pool, repo_id, &[user_a, user_b]).await;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2439.

Several artifact/repository-scoped security and SBOM routes queried
cross-tenant data (or accepted cross-tenant writes) without running the
per-repository authorization gate, so any authenticated caller — including a
non-member of a private repository — could read another tenant's scan/CVE
data or write against their artifacts. This applies the two canonical gates
already used by the repo-nested twins:

- artifact-level `check_artifact_visibility` (`artifacts.rs`)
- repo-level `require_visible` (`repositories.rs`)

Both enforce token scope + admin bypass + private-repo membership
(`user_can_access_repo`) and hide existence with `NotFound` (never
`Forbidden`).

Routes hardened:

- `GET /security/scans` (`list_scans`) — gates on the supplied `artifact_id`
  (artifact-visibility) or `repository_id` (repo-visibility); an unfiltered
  global listing is restricted to admins (a non-admin must scope by
  repo/artifact rather than receive every repo's scans).
- `GET /security/scans/:id` (`get_scan`) — resolves the scan's artifact, then
  gates.
- `GET /security/scans/:id/findings` (`list_findings`) — resolves the scan's
  artifact, then gates.
- `GET /security/artifacts/:artifact_id/scans` (`list_artifact_scans`) — gates
  on the path artifact.
- `POST /sbom` (`generate_sbom`, WRITE) — gates on the body `artifact_id`
  before any write; repo members may generate (member-visibility is the
  correct level for this write).
- `POST /sbom/cve/status/:id` (`update_cve_status`, WRITE) — CVE-triage state
  is an administrative decision; gated on global admin with an audited
  RBAC-deny, **mirroring the sibling `update_cve_status_by_artifact_cve`
  (#2321 G3)** and the finding acknowledge/revoke handlers, which are all
  admin-only.

Weak-gate upgrade: the shared `sbom.rs` `require_repo_access` path previously
checked token scope only (`can_access_repo`), which any unrestricted JWT/token
satisfies, still leaking private-repo data. The two resolver wrappers
(`ensure_artifact_repo_access` / `ensure_sbom_repo_access`) now additionally
enforce private-repo membership via a small shared `require_repo_visibility`
helper, closing `get_sbom` / `get_sbom_by_artifact` / `delete_sbom` /
`get_sbom_components` / `list_sboms` / `get_cve_history_by_artifact` /
`update_cve_status_by_artifact_cve` in one place. The pure, unit-tested
`require_repo_access` token-scope decision is preserved as the first layer.

Public repositories stay public, admins and members are unaffected, the
already-correct repo-nested twins (`list_repo_scans`, `list_artifacts`) are not
double-gated, and denials return existence-hiding 404 (403 only for the
admin-gated CVE-status write).

Follow-up (re-review): two residuals from the same class are also closed here:

- `POST /sbom/:id/convert` (`convert_sbom`) was ungated — it read the full
  component inventory and persisted a converted SBOM row for any authenticated
  caller. It now routes through the same upgraded `ensure_sbom_repo_access`
  membership gate (member-visibility; existence-hiding 404). A module sweep
  confirmed every other by-id SBOM route already routes through the upgraded
  gate; `get_cve_trends` returns aggregate counts only (no inventory /
  `repository_id`) and is out of this class.
- `GET /security/scans/:id` and `/scans/:id/findings` previously returned
  "Artifact not found" for a hidden-but-existing scan vs "Scan result not
  found" for an absent id — a boolean existence oracle. Both now return the
  single canonical `Scan result not found` body (matching the already-uniform
  `GET /sbom/:id`), so a no-access scan is indistinguishable from an absent one.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Added ~20 DB-backed unit tests (member→200, non-member→404 with no leaked
`repository_id`/`cve`/`severity`, admin→200, public-repo→200, writes denied +
no row written) plus an end-to-end cross-tenant BOLA case in
`security_regression_tests.rs` (`regression_2439_cross_repo_scan_sbom_bola`).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (authorization added to existing routes; the
      `update_cve_status` OpenAPI responses now document the 403 branch)