### PR TITLE
chore(release): v1.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.3] - 2026-07-12
+
+Security hotfix: closes a systemic cross-repository authorization gap where artifact/repository-scoped routes returned (and in some cases mutated) another repository's data for any authenticated non-member. Found by red-team; the HIGH-impact subset (vulnerability/SBOM data) is fixed here, with the remaining medium/low routes tracked for the next feature release (#2443).
+
+### Security
+
+- **Cross-repo vulnerability & SBOM authorization enforced** (#2439): the security-scan reads (`GET /security/scans`, `/security/scans/{id}`, `/security/scans/{id}/findings`, `/security/artifacts/{id}/scans`), the SBOM reads (`GET /sbom/{id}`, `/sbom/{id}/components`, `/sbom?artifact_id=`, `/sbom/by-artifact/{id}`, `POST /sbom/{id}/convert`), and the SBOM writes (`POST /sbom` generate, `POST /sbom/cve/status/{id}`) now enforce the canonical repository-visibility gate — token repo-scope + admin bypass + private-repository membership — returning an existence-hiding 404 to non-members. Previously any authenticated user could read another repository's CVE findings and SBOM inventory, and generate/convert SBOMs on artifacts in repositories they could not see. The `require_repo_access` helper was upgraded to check membership (not just token scope), and the scan-not-found responses were unified to remove an existence oracle. CVE-status writes remain admin-gated (#2321). Public repositories stay public; members and admins are unaffected.
+- **Cross-repo quality-check metadata authorization enforced** (#2437): the artifact-scoped quality-check routes (`GET /quality/checks`, `/quality/checks/{id}`, `/quality/checks/{id}/issues`, `/quality/health/artifacts/{id}`) now apply the same repository-visibility gate, so quality-check results/scores no longer leak across repositories.
+
+### Added
+
+- **Admin quality-checks list-all endpoint** (#2419): `GET /api/v1/admin/quality-checks` (admin-only, paginated, filterable by `repository_id`/`artifact_id`/`status`) backs the admin quality-checks view. The artifact-scoped `GET /api/v1/quality/checks` contract (400 without `artifact_id`) is unchanged.
+
+
+
 ## [1.5.2] - 2026-07-12
 
 Security hotfix: closes a token-exchange privilege-escalation where a scope-restricted API token could be exchanged (via docker-login `/v2/token` or Conan `users/authenticate`) into an unrestricted JWT — a read-only token could gain write/delete. Also completes the GHSA-vvc3 write-scope enforcement on the eight remaining format publish handlers.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
 
 [[package]]
 name = "artifact-keeper-backend"
-version = "1.5.2"
+version = "1.5.3"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["backend"]
 
 [workspace.package]
-version = "1.5.2"
+version = "1.5.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yourorg/artifact-keeper"

--- a/backend/src/api/openapi.rs
+++ b/backend/src/api/openapi.rs
@@ -24,7 +24,7 @@ registries are intentionally more permissive for client compatibility: in additi
 HTTP **Basic** auth with the API token supplied in the *password* field (any username), matching the \
 `pip` netrc / Artifactory-style `token:<api_token>` convention used by package managers that cannot send a \
 Bearer header. This Basic-with-token fallback applies to format endpoints only, never to `/api/v1/*`.",
-        version = "1.5.2",
+        version = "1.5.3",
         license(name = "MIT", url = "https://opensource.org/licenses/MIT"),
         contact(name = "Artifact Keeper", url = "https://artifactkeeper.com")
     ),


### PR DESCRIPTION
Security hotfix **v1.5.3**. Bumps 1.5.2 → 1.5.3 + CHANGELOG.

Closes the systemic cross-repo authorization gap: **#2439** (HIGH — vulnerability-scan/SBOM reads + SBOM/CVE writes) + **#2437** (MEDIUM — quality-check metadata), plus **#2419** (admin quality-checks list-all). All validated through the full loop (unit + e2e + pool + red-team class-closed + positive controls). Remaining MED/LOW routes tracked in #2443 (1.6.0).

Release-mechanics PR — labeled `no-issue-required`.