### PR TITLE
fix(saml): bind consumed assertion to signature and reject multi-assertion (XSW)

### DIFF
--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -265,6 +265,14 @@ struct SamlResponseParser {
     assertion: SamlAssertion,
     current_element: String,
     in_assertion: bool,
+    /// Depth of the current `<ds:Signature>` subtree. The enveloped signature is
+    /// a CHILD of `<saml:Assertion>`, but the enveloped-signature transform
+    /// removes the entire `<ds:Signature>` element before the digest is computed,
+    /// so nothing inside it is covered by the signature. A depth counter (not a
+    /// bool) keeps nested/decoy `<Signature>` elements from underflowing the
+    /// guard. Claim harvesting is suppressed while this is `> 0` so an attacker
+    /// cannot splice a claim into an unsigned `<ds:Object>` and have it consumed.
+    in_signature_depth: u32,
     current_attr_name: Option<String>,
     current_attr_values: Vec<String>,
     /// Number of `<saml:Assertion>` elements seen. AK only ever consumes a
@@ -307,6 +315,7 @@ impl SamlResponseParser {
             },
             current_element: String::new(),
             in_assertion: false,
+            in_signature_depth: 0,
             current_attr_name: None,
             current_attr_values: Vec::new(),
             assertion_count: 0,
@@ -321,6 +330,15 @@ impl SamlResponseParser {
         // Start of a new element: reset the leaf-text accumulator so each
         // element's text is committed fresh on its own `End`.
         self.current_text.clear();
+
+        // Enter a `<ds:Signature>` subtree (namespace-agnostic local name). The
+        // signature transform strips this element before the digest, so anything
+        // inside it is unsigned and must not be harvested as a claim. Tracked
+        // regardless of `in_assertion` — guarding a response-level Signature too
+        // is harmless.
+        if name == "Signature" {
+            self.in_signature_depth += 1;
+        }
 
         match name.as_str() {
             "Response" => self.handle_response_start(e),
@@ -374,28 +392,35 @@ impl SamlResponseParser {
                 self.in_assertion = false;
                 self.response.assertion = Some(self.assertion.clone());
             }
+            // Leave the `<ds:Signature>` subtree (namespace-agnostic local name).
+            // `saturating_sub` keeps a stray/decoy `</Signature>` from underflowing
+            // the guard below `0`.
+            "Signature" => {
+                self.in_signature_depth = self.in_signature_depth.saturating_sub(1);
+            }
             // Text commits happen here (on `End`) from the accumulator. Every
-            // assertion-scoped claim is gated on `self.in_assertion` so a claim
+            // assertion-scoped claim is gated on `self.claims_active()` so a claim
             // element spliced outside the verified `<Assertion>` subtree (e.g. a
-            // sibling of `<Assertion>` under `<Response>`) is never consumed.
+            // sibling of `<Assertion>` under `<Response>`) — or inside the
+            // transform-removed `<ds:Signature>` subtree — is never consumed.
             "Issuer" => {
                 let text = std::mem::take(&mut self.current_text);
                 self.handle_issuer_text(text);
             }
             "NameID" => {
-                if self.in_assertion && !self.current_text.is_empty() {
+                if self.claims_active() && !self.current_text.is_empty() {
                     self.assertion.name_id = std::mem::take(&mut self.current_text);
                 }
             }
             "Audience" => {
-                if self.in_assertion && !self.current_text.is_empty() {
+                if self.claims_active() && !self.current_text.is_empty() {
                     self.assertion
                         .audiences
                         .push(std::mem::take(&mut self.current_text));
                 }
             }
             "AttributeValue" => {
-                if self.in_assertion && !self.current_text.is_empty() {
+                if self.claims_active() && !self.current_text.is_empty() {
                     self.current_attr_values
                         .push(std::mem::take(&mut self.current_text));
                 }
@@ -407,7 +432,7 @@ impl SamlResponseParser {
             }
             "Attribute" => {
                 if let Some(attr_name) = self.current_attr_name.take() {
-                    if self.in_assertion {
+                    if self.claims_active() {
                         self.assertion
                             .attributes
                             .insert(attr_name, self.current_attr_values.clone());
@@ -435,8 +460,17 @@ impl SamlResponseParser {
     /// `<SubjectConfirmationData>` carries the `Recipient` attribute — the ACS
     /// URL the IdP asserts this assertion was minted for. Captured here and
     /// bound against the SP's own ACS URL in `validate_response`.
+    /// A claim may be consumed only inside the signed `<Assertion>` subtree AND
+    /// outside any `<ds:Signature>` subtree. The enveloped signature (a child of
+    /// the assertion) is transform-removed before the digest, so its contents are
+    /// unsigned even though `in_assertion` is still true there — this excludes an
+    /// in-`<ds:Signature>` `<ds:Object>` claim-injection path.
+    fn claims_active(&self) -> bool {
+        self.in_assertion && self.in_signature_depth == 0
+    }
+
     fn handle_subject_confirmation_data(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if self.in_assertion {
+        if self.claims_active() {
             if let Some(recipient) = get_xml_attr(e, "Recipient") {
                 self.assertion.recipient = Some(recipient);
             }
@@ -458,7 +492,7 @@ impl SamlResponseParser {
     }
 
     fn handle_name_id_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if self.in_assertion {
+        if self.claims_active() {
             if let Some(format) = get_xml_attr(e, "Format") {
                 self.assertion.name_id_format = Some(format);
             }
@@ -466,7 +500,7 @@ impl SamlResponseParser {
     }
 
     fn handle_conditions_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if self.in_assertion {
+        if self.claims_active() {
             for (key, value) in collect_xml_attrs(e) {
                 match key.as_str() {
                     "NotBefore" => self.assertion.not_before = Some(value),
@@ -478,7 +512,7 @@ impl SamlResponseParser {
     }
 
     fn handle_authn_statement(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if self.in_assertion {
+        if self.claims_active() {
             if let Some(session_index) = get_xml_attr(e, "SessionIndex") {
                 self.assertion.session_index = Some(session_index);
             }
@@ -486,7 +520,7 @@ impl SamlResponseParser {
     }
 
     fn handle_attribute_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if self.in_assertion {
+        if self.claims_active() {
             if let Some(name) = get_xml_attr(e, "Name") {
                 self.current_attr_name = Some(name);
                 self.current_attr_values.clear();
@@ -3464,6 +3498,101 @@ mod tests {
             groups,
             &vec!["developers".to_string(), "ak-admins".to_string()]
         );
+    }
+
+    /// The enveloped `<ds:Signature>` is a CHILD of `<saml:Assertion>`, but the
+    /// signature transform removes it before the digest — so anything spliced into
+    /// a `<ds:Object>` inside it is unsigned. A `groups` attribute injected there
+    /// must NOT be harvested as a claim even though it is nominally "in assertion".
+    #[test]
+    fn test_parser_attribute_in_ds_signature_object_not_consumed() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <ds:Signature>
+                    <ds:SignedInfo/>
+                    <ds:SignatureValue>abc</ds:SignatureValue>
+                    <ds:Object>
+                        <saml:AttributeStatement>
+                            <saml:Attribute Name="groups">
+                                <saml:AttributeValue>ak-admins</saml:AttributeValue>
+                            </saml:Attribute>
+                        </saml:AttributeStatement>
+                    </ds:Object>
+                </ds:Signature>
+                <saml:Subject>
+                    <saml:NameID>alice@example.com</saml:NameID>
+                </saml:Subject>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        // The injected in-Signature groups attribute is NOT consumed.
+        assert!(!assertion.attributes.contains_key("groups"));
+        // The genuine, out-of-Signature NameID is still recorded.
+        assert_eq!(assertion.name_id, "alice@example.com");
+    }
+
+    /// A `<saml:NameID>` spliced inside the `<ds:Signature>` subtree is ignored;
+    /// the assertion's own NameID (outside the Signature) is what is recorded.
+    #[test]
+    fn test_parser_nameid_in_ds_signature_not_consumed() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <ds:Signature>
+                    <ds:Object>
+                        <saml:Subject>
+                            <saml:NameID>attacker@evil.com</saml:NameID>
+                        </saml:Subject>
+                    </ds:Object>
+                </ds:Signature>
+                <saml:Subject>
+                    <saml:NameID>alice@example.com</saml:NameID>
+                </saml:Subject>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert_eq!(assertion.name_id, "alice@example.com");
+    }
+
+    /// The depth counter decrements on `</ds:Signature>`: a claim placed AFTER the
+    /// Signature closes, but still inside the assertion, IS consumed (proves the
+    /// guard does not over-suppress legitimate post-Signature claims).
+    #[test]
+    fn test_parser_claims_after_signature_end_still_consumed() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <ds:Signature>
+                    <ds:SignedInfo/>
+                    <ds:SignatureValue>abc</ds:SignatureValue>
+                </ds:Signature>
+                <saml:Subject>
+                    <saml:NameID>alice@example.com</saml:NameID>
+                </saml:Subject>
+                <saml:AttributeStatement>
+                    <saml:Attribute Name="groups">
+                        <saml:AttributeValue>ak-admins</saml:AttributeValue>
+                    </saml:Attribute>
+                </saml:AttributeStatement>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert_eq!(assertion.name_id, "alice@example.com");
+        let groups = assertion.attributes.get("groups").unwrap();
+        assert_eq!(groups, &vec!["ak-admins".to_string()]);
     }
 
     #[test]

--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -4,6 +4,7 @@
 //! Okta, Azure AD, ADFS, Shibboleth, etc.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use quick_xml::escape::unescape;
@@ -230,6 +231,34 @@ fn acs_urls_match(expected: &str, asserted: &str) -> bool {
     expected.trim_end_matches('/') == asserted.trim_end_matches('/')
 }
 
+/// Decide whether the assertion AK will actually consume is cryptographically
+/// covered by a verified XML-DSig signature — the core defense against XML
+/// Signature Wrapping (XSW).
+///
+/// `signed_ids` is the set of `ID` strings whose digest `bergshamra` actually
+/// verified on the `VerifyResult::Valid` path (each `<Reference URI>` with its
+/// leading `#` stripped; empty and `cid:` URIs excluded — see
+/// [`SamlService::validate_response`]). We accept the consumed assertion when
+/// either:
+///   * the signature directly covers the assertion element (`assertion_id` is
+///     signed) — AK's own assertion-level signing posture; or
+///   * the signature covers the enclosing `<Response>` (`response_id` is
+///     signed) — the Response-level signing that ADFS / Azure AD emit.
+///
+/// Both forms are legitimate, so we must not collapse to assertion-only signing
+/// or we would break those IdPs. An empty `signed_ids` (nothing verified)
+/// always returns `false`, so an unsigned or unbound assertion can never be
+/// consumed. Binding is by ID *string* (not tree position): `bergshamra`
+/// rejects documents with duplicate IDs on the `Valid` path, so a signed ID is
+/// unambiguous.
+fn consumed_assertion_is_signed(
+    assertion_id: &str,
+    response_id: &str,
+    signed_ids: &HashSet<String>,
+) -> bool {
+    signed_ids.contains(assertion_id) || signed_ids.contains(response_id)
+}
+
 /// Mutable state used while walking a SAML response XML document.
 struct SamlResponseParser {
     response: SamlResponse,
@@ -238,6 +267,12 @@ struct SamlResponseParser {
     in_assertion: bool,
     current_attr_name: Option<String>,
     current_attr_values: Vec<String>,
+    /// Number of `<saml:Assertion>` elements seen. AK only ever consumes a
+    /// single assertion (`response.assertion: Option<..>`, last-wins), so a
+    /// Response carrying more than one is rejected at parse time — this removes
+    /// the "second assertion to smuggle" precondition for XML Signature
+    /// Wrapping and applies even on the no-certificate dev path.
+    assertion_count: usize,
 }
 
 impl SamlResponseParser {
@@ -268,6 +303,7 @@ impl SamlResponseParser {
             in_assertion: false,
             current_attr_name: None,
             current_attr_values: Vec::new(),
+            assertion_count: 0,
         }
     }
 
@@ -366,6 +402,7 @@ impl SamlResponseParser {
 
     fn handle_assertion_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
         self.in_assertion = true;
+        self.assertion_count += 1;
         if let Some(id) = get_xml_attr(e, "ID") {
             self.assertion.id = id;
         }
@@ -636,6 +673,22 @@ impl SamlService {
             buf.clear();
         }
 
+        // Structural XML Signature Wrapping (XSW) defense: reject any Response
+        // carrying more than one `<saml:Assertion>`. AK only ever consumes a
+        // single assertion, and the parser is last-wins, so a second assertion
+        // exists only to smuggle attacker-controlled claims (e.g. an admin
+        // group) past a signature that covers a different, benign assertion.
+        // Enforced unconditionally at parse time so it also guards the no-cert
+        // dev path where `validate_response` skips signature verification.
+        if parser.assertion_count > 1 {
+            return Err(AppError::Authentication(format!(
+                "SAML response contains {} assertions; only a single assertion is \
+                 supported (multi-assertion responses are rejected to prevent XML \
+                 signature wrapping)",
+                parser.assertion_count
+            )));
+        }
+
         Ok(parser.finish())
     }
 
@@ -742,8 +795,45 @@ impl SamlService {
             ctx.trusted_keys_only = true;
 
             match bergshamra::verify(&ctx, xml) {
-                Ok(bergshamra::VerifyResult::Valid { .. }) => {
-                    tracing::debug!("SAML response signature verified successfully");
+                Ok(bergshamra::VerifyResult::Valid { references, .. }) => {
+                    // The signature is cryptographically valid, but that alone
+                    // does not say *which* element it covers. Build the set of
+                    // IDs whose digest was actually verified and require the
+                    // assertion AK will consume to be among them (or the
+                    // enclosing Response, for Response-level signers). Without
+                    // this, an XSW attacker can present a valid signature over a
+                    // benign assertion while the parser consumes a different,
+                    // unsigned one — the core of the escalation. `bergshamra`
+                    // parses its own tree, so bind by ID *string* (safe: the
+                    // `Valid` path rejects duplicate IDs document-wide).
+                    let signed_ids: HashSet<String> = references
+                        .iter()
+                        .filter(|r| r.digest_verified)
+                        .filter_map(|r| {
+                            let id = r.uri.strip_prefix('#').unwrap_or(&r.uri);
+                            if id.is_empty() || id.starts_with("cid:") {
+                                None
+                            } else {
+                                Some(id.to_string())
+                            }
+                        })
+                        .collect();
+
+                    let assertion_id = response
+                        .assertion
+                        .as_ref()
+                        .map(|a| a.id.as_str())
+                        .unwrap_or("");
+                    if !consumed_assertion_is_signed(assertion_id, &response.id, &signed_ids) {
+                        return Err(AppError::Authentication(
+                            "SAML signature does not cover the consumed assertion \
+                             (possible XML signature wrapping)"
+                                .into(),
+                        ));
+                    }
+                    tracing::debug!(
+                        "SAML response signature verified and bound to the consumed assertion"
+                    );
                 }
                 Ok(bergshamra::VerifyResult::Invalid { reason }) => {
                     return Err(AppError::Authentication(format!(
@@ -1580,6 +1670,157 @@ mod tests {
         let response = service.parse_saml_response(xml).unwrap();
         assert_eq!(response.id, "_resp1");
         assert!(response.status_code.contains("Success"));
+    }
+
+    // =======================================================================
+    // XML Signature Wrapping (XSW) structural defense (#2449)
+    // =======================================================================
+
+    /// A `<Response>` carrying a single `<Assertion>` parses successfully and
+    /// that assertion is the one consumed.
+    #[tokio::test]
+    async fn test_parse_saml_response_single_assertion_ok() {
+        let service = make_test_saml_service();
+        let xml = sample_saml_response_xml();
+
+        let response = service.parse_saml_response(&xml).unwrap();
+        let assertion = response.assertion.expect("single assertion consumed");
+        assert_eq!(assertion.id, "_assertion789");
+    }
+
+    /// A `<Response>` carrying more than one `<Assertion>` is rejected at parse
+    /// time (the XSW precondition: a second, unsigned assertion smuggled in to
+    /// be consumed in place of the signed one). AK only ever consumes a single
+    /// assertion, so this is safe and unconditional.
+    #[tokio::test]
+    async fn test_parse_saml_response_rejects_multiple_assertions() {
+        let service = make_test_saml_service();
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_resp_multi" Version="2.0">
+    <saml:Issuer>https://idp.example.com</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:Assertion ID="_signed_benign" Version="2.0">
+        <saml:Issuer>https://idp.example.com</saml:Issuer>
+        <saml:Subject>
+            <saml:NameID>benign@example.com</saml:NameID>
+        </saml:Subject>
+        <saml:AttributeStatement>
+            <saml:Attribute Name="groups">
+                <saml:AttributeValue>Developers</saml:AttributeValue>
+            </saml:Attribute>
+        </saml:AttributeStatement>
+    </saml:Assertion>
+    <saml:Assertion ID="_unsigned_evil" Version="2.0">
+        <saml:Issuer>https://idp.example.com</saml:Issuer>
+        <saml:Subject>
+            <saml:NameID>attacker@example.com</saml:NameID>
+        </saml:Subject>
+        <saml:AttributeStatement>
+            <saml:Attribute Name="groups">
+                <saml:AttributeValue>ak-admins</saml:AttributeValue>
+            </saml:Attribute>
+        </saml:AttributeStatement>
+    </saml:Assertion>
+</samlp:Response>"#;
+
+        let result = service.parse_saml_response(xml);
+        assert!(
+            result.is_err(),
+            "a multi-assertion response must be rejected at parse time"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("single assertion") || err.contains("2 assertions"),
+            "rejection must name the multi-assertion cause, got: {err}"
+        );
+    }
+
+    /// A duplicate-ID variant (two assertions sharing the signed ID) is also a
+    /// multi-assertion response, so it is rejected by the same structural check
+    /// (defense-in-depth ahead of bergshamra's own duplicate-ID rejection).
+    #[tokio::test]
+    async fn test_parse_saml_response_rejects_duplicate_id_assertions() {
+        let service = make_test_saml_service();
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                ID="_resp_dup" Version="2.0">
+    <saml:Issuer>https://idp.example.com</saml:Issuer>
+    <samlp:Status>
+        <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+    <saml:Assertion ID="_shared" Version="2.0">
+        <saml:Issuer>https://idp.example.com</saml:Issuer>
+        <saml:Subject><saml:NameID>benign@example.com</saml:NameID></saml:Subject>
+    </saml:Assertion>
+    <saml:Assertion ID="_shared" Version="2.0">
+        <saml:Issuer>https://idp.example.com</saml:Issuer>
+        <saml:Subject><saml:NameID>attacker@example.com</saml:NameID></saml:Subject>
+    </saml:Assertion>
+</samlp:Response>"#;
+
+        assert!(
+            service.parse_saml_response(xml).is_err(),
+            "a duplicate-ID (two-assertion) response must be rejected at parse time"
+        );
+    }
+
+    /// The pure signature-binding helper: the consumed assertion is accepted
+    /// only when its ID (assertion-level signing) or the Response ID
+    /// (Response-level signing) is in the verified set.
+    #[test]
+    fn test_consumed_assertion_is_signed_assertion_level() {
+        let signed: HashSet<String> = ["_assertion789".to_string()].into_iter().collect();
+        assert!(consumed_assertion_is_signed(
+            "_assertion789",
+            "_resp1",
+            &signed
+        ));
+    }
+
+    #[test]
+    fn test_consumed_assertion_is_signed_response_level() {
+        // ADFS / Azure AD sign the enclosing <Response>, not the assertion.
+        let signed: HashSet<String> = ["_resp1".to_string()].into_iter().collect();
+        assert!(consumed_assertion_is_signed(
+            "_assertion789",
+            "_resp1",
+            &signed
+        ));
+    }
+
+    #[test]
+    fn test_consumed_assertion_is_signed_neither_covered() {
+        // The signature covers some *other* element (classic XSW) → reject.
+        let signed: HashSet<String> = ["_some_other_elem".to_string()].into_iter().collect();
+        assert!(!consumed_assertion_is_signed(
+            "_assertion789",
+            "_resp1",
+            &signed
+        ));
+    }
+
+    #[test]
+    fn test_consumed_assertion_is_signed_empty_set() {
+        // Nothing verified (e.g. all references were empty/cid:) → reject.
+        let signed: HashSet<String> = HashSet::new();
+        assert!(!consumed_assertion_is_signed(
+            "_assertion789",
+            "_resp1",
+            &signed
+        ));
+    }
+
+    #[test]
+    fn test_consumed_assertion_is_signed_empty_ids_never_match() {
+        // Empty/cid: URIs are excluded from `signed_ids` upstream, so an empty
+        // assertion/response id can never be satisfied by a stray empty entry.
+        let signed: HashSet<String> = ["_assertion789".to_string()].into_iter().collect();
+        assert!(!consumed_assertion_is_signed("", "", &signed));
     }
 
     // =======================================================================

--- a/backend/src/services/saml_service.rs
+++ b/backend/src/services/saml_service.rs
@@ -273,6 +273,12 @@ struct SamlResponseParser {
     /// the "second assertion to smuggle" precondition for XML Signature
     /// Wrapping and applies even on the no-certificate dev path.
     assertion_count: usize,
+    /// Text accumulated for the current leaf element, committed on its `End`.
+    /// Accumulating (rather than last-wins on each `Text` event) canonicalises
+    /// a signed value an attacker split across two text nodes with an
+    /// intervening comment — `foo<!--c-->bar` yields `foobar`, matching the
+    /// exclusive-c14n#(no-comments) view under which the signature was verified.
+    current_text: String,
 }
 
 impl SamlResponseParser {
@@ -304,6 +310,7 @@ impl SamlResponseParser {
             current_attr_name: None,
             current_attr_values: Vec::new(),
             assertion_count: 0,
+            current_text: String::new(),
         }
     }
 
@@ -311,6 +318,9 @@ impl SamlResponseParser {
     fn handle_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
         let name = String::from_utf8_lossy(e.local_name().as_ref()).to_string();
         self.current_element = name.clone();
+        // Start of a new element: reset the leaf-text accumulator so each
+        // element's text is committed fresh on its own `End`.
+        self.current_text.clear();
 
         match name.as_str() {
             "Response" => self.handle_response_start(e),
@@ -348,14 +358,12 @@ impl SamlResponseParser {
             return;
         }
 
-        match self.current_element.as_str() {
-            "Issuer" => self.handle_issuer_text(text),
-            "NameID" => self.assertion.name_id = text,
-            "Audience" => self.assertion.audiences.push(text),
-            "AttributeValue" => self.current_attr_values.push(text),
-            "StatusMessage" => self.response.status_message = Some(text),
-            _ => {}
-        }
+        // Accumulate rather than commit here: a comment splitting a signed value
+        // into two text nodes (`foo<!--c-->bar`) arrives as two `Text` events
+        // with no intervening `Start`, so both segments concatenate into the
+        // canonical value. The accumulated text is committed on the element's
+        // `End`. Comments are `Event::Comment` and never reach this method.
+        self.current_text.push_str(&text);
     }
 
     /// Handle an `Event::End` element.
@@ -366,13 +374,46 @@ impl SamlResponseParser {
                 self.in_assertion = false;
                 self.response.assertion = Some(self.assertion.clone());
             }
+            // Text commits happen here (on `End`) from the accumulator. Every
+            // assertion-scoped claim is gated on `self.in_assertion` so a claim
+            // element spliced outside the verified `<Assertion>` subtree (e.g. a
+            // sibling of `<Assertion>` under `<Response>`) is never consumed.
+            "Issuer" => {
+                let text = std::mem::take(&mut self.current_text);
+                self.handle_issuer_text(text);
+            }
+            "NameID" => {
+                if self.in_assertion && !self.current_text.is_empty() {
+                    self.assertion.name_id = std::mem::take(&mut self.current_text);
+                }
+            }
+            "Audience" => {
+                if self.in_assertion && !self.current_text.is_empty() {
+                    self.assertion
+                        .audiences
+                        .push(std::mem::take(&mut self.current_text));
+                }
+            }
+            "AttributeValue" => {
+                if self.in_assertion && !self.current_text.is_empty() {
+                    self.current_attr_values
+                        .push(std::mem::take(&mut self.current_text));
+                }
+            }
+            "StatusMessage" => {
+                if !self.current_text.is_empty() {
+                    self.response.status_message = Some(std::mem::take(&mut self.current_text));
+                }
+            }
             "Attribute" => {
                 if let Some(attr_name) = self.current_attr_name.take() {
-                    self.assertion
-                        .attributes
-                        .insert(attr_name, self.current_attr_values.clone());
-                    self.current_attr_values.clear();
+                    if self.in_assertion {
+                        self.assertion
+                            .attributes
+                            .insert(attr_name, self.current_attr_values.clone());
+                    }
                 }
+                self.current_attr_values.clear();
             }
             _ => {}
         }
@@ -395,8 +436,10 @@ impl SamlResponseParser {
     /// URL the IdP asserts this assertion was minted for. Captured here and
     /// bound against the SP's own ACS URL in `validate_response`.
     fn handle_subject_confirmation_data(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if let Some(recipient) = get_xml_attr(e, "Recipient") {
-            self.assertion.recipient = Some(recipient);
+        if self.in_assertion {
+            if let Some(recipient) = get_xml_attr(e, "Recipient") {
+                self.assertion.recipient = Some(recipient);
+            }
         }
     }
 
@@ -415,31 +458,39 @@ impl SamlResponseParser {
     }
 
     fn handle_name_id_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if let Some(format) = get_xml_attr(e, "Format") {
-            self.assertion.name_id_format = Some(format);
+        if self.in_assertion {
+            if let Some(format) = get_xml_attr(e, "Format") {
+                self.assertion.name_id_format = Some(format);
+            }
         }
     }
 
     fn handle_conditions_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        for (key, value) in collect_xml_attrs(e) {
-            match key.as_str() {
-                "NotBefore" => self.assertion.not_before = Some(value),
-                "NotOnOrAfter" => self.assertion.not_on_or_after = Some(value),
-                _ => {}
+        if self.in_assertion {
+            for (key, value) in collect_xml_attrs(e) {
+                match key.as_str() {
+                    "NotBefore" => self.assertion.not_before = Some(value),
+                    "NotOnOrAfter" => self.assertion.not_on_or_after = Some(value),
+                    _ => {}
+                }
             }
         }
     }
 
     fn handle_authn_statement(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if let Some(session_index) = get_xml_attr(e, "SessionIndex") {
-            self.assertion.session_index = Some(session_index);
+        if self.in_assertion {
+            if let Some(session_index) = get_xml_attr(e, "SessionIndex") {
+                self.assertion.session_index = Some(session_index);
+            }
         }
     }
 
     fn handle_attribute_start(&mut self, e: &quick_xml::events::BytesStart<'_>) {
-        if let Some(name) = get_xml_attr(e, "Name") {
-            self.current_attr_name = Some(name);
-            self.current_attr_values.clear();
+        if self.in_assertion {
+            if let Some(name) = get_xml_attr(e, "Name") {
+                self.current_attr_name = Some(name);
+                self.current_attr_values.clear();
+            }
         }
     }
 
@@ -3222,12 +3273,16 @@ mod tests {
         let start = BytesStart::from_content(r#"Attribute Name="groups""#, 9);
         parser.handle_start(&start);
 
-        // Simulate AttributeValue text nodes
-        parser.current_element = "AttributeValue".to_string();
-        let text1 = quick_xml::events::BytesText::new("GroupA");
-        parser.handle_text(&text1);
-        let text2 = quick_xml::events::BytesText::new("GroupB");
-        parser.handle_text(&text2);
+        // Simulate two `<AttributeValue>` children: each value is accumulated
+        // between its Start and End and committed on End.
+        let av_start = BytesStart::from_content("AttributeValue", 14);
+        let av_end = BytesEnd::new("AttributeValue");
+        parser.handle_start(&av_start);
+        parser.handle_text(&quick_xml::events::BytesText::new("GroupA"));
+        parser.handle_end(&av_end);
+        parser.handle_start(&av_start);
+        parser.handle_text(&quick_xml::events::BytesText::new("GroupB"));
+        parser.handle_end(&av_end);
 
         // Close the Attribute element
         let end = BytesEnd::new("Attribute");
@@ -3262,6 +3317,153 @@ mod tests {
         let response = parser.finish();
         assert!(response.assertion.is_some());
         assert_eq!(response.assertion.as_ref().unwrap().id, "_test_end");
+    }
+
+    // --- Subtree-scoping (claims confined to the verified `<Assertion>`) ---
+
+    /// A `<saml:Attribute Name="groups">` spliced as a sibling of the assertion
+    /// (BEFORE it, directly under `<Response>`) must not be consumed: it is not
+    /// within the assertion the signature covers.
+    #[test]
+    fn test_parser_attribute_before_assertion_not_consumed() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     ID="_r1" Version="2.0">
+            <saml:Attribute Name="groups">
+                <saml:AttributeValue>ak-admins</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Assertion ID="_a1" Version="2.0">
+                <saml:Subject>
+                    <saml:NameID>alice@example.com</saml:NameID>
+                </saml:Subject>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert!(
+            !assertion.attributes.contains_key("groups"),
+            "attribute spliced before the assertion must not be consumed"
+        );
+        assert_eq!(assertion.name_id, "alice@example.com");
+    }
+
+    /// Control: the same splice AFTER the assertion (still a `<Response>` child)
+    /// is likewise outside the assertion subtree and must not be consumed.
+    #[test]
+    fn test_parser_attribute_after_assertion_not_consumed() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <saml:Subject>
+                    <saml:NameID>alice@example.com</saml:NameID>
+                </saml:Subject>
+            </saml:Assertion>
+            <saml:Attribute Name="groups">
+                <saml:AttributeValue>ak-admins</saml:AttributeValue>
+            </saml:Attribute>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert!(
+            !assertion.attributes.contains_key("groups"),
+            "attribute spliced after the assertion must not be consumed"
+        );
+    }
+
+    /// A `<saml:NameID>` under `<Response>` before the assertion must not win
+    /// over the assertion's own NameID.
+    #[test]
+    fn test_parser_name_id_before_assertion_ignored() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     ID="_r1" Version="2.0">
+            <saml:NameID>attacker@evil.com</saml:NameID>
+            <saml:Assertion ID="_a1" Version="2.0">
+                <saml:Subject>
+                    <saml:NameID>victim@example.com</saml:NameID>
+                </saml:Subject>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert_eq!(assertion.name_id, "victim@example.com");
+    }
+
+    // --- Comment-split signed values canonicalise by concatenation ---
+
+    /// A comment splitting the NameID text (`foo<!--x-->bar`) yields the whole
+    /// value `foobar`, matching the exclusive-c14n#(no-comments) signed view.
+    #[test]
+    fn test_parser_name_id_comment_split_concatenates() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <saml:Subject>
+                    <saml:NameID>foo<!--x-->bar</saml:NameID>
+                </saml:Subject>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert_eq!(assertion.name_id, "foobar");
+    }
+
+    /// The same for an `<AttributeValue>`: `ak-<!--x-->admins` is the single
+    /// value `ak-admins`, not the trailing `admins` segment.
+    #[test]
+    fn test_parser_attribute_value_comment_split_concatenates() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <saml:AttributeStatement>
+                    <saml:Attribute Name="groups">
+                        <saml:AttributeValue>ak-<!--x-->admins</saml:AttributeValue>
+                    </saml:Attribute>
+                </saml:AttributeStatement>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        let groups = assertion.attributes.get("groups").unwrap();
+        assert_eq!(groups, &vec!["ak-admins".to_string()]);
+    }
+
+    /// Sanity: NameID and a groups attribute genuinely inside the assertion are
+    /// still recorded (subtree scoping does not drop legitimate claims).
+    #[test]
+    fn test_parser_in_assertion_claims_still_recorded() {
+        let xml = r#"<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol"
+                                     xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion"
+                                     ID="_r1" Version="2.0">
+            <saml:Assertion ID="_a1" Version="2.0">
+                <saml:Subject>
+                    <saml:NameID>alice@example.com</saml:NameID>
+                </saml:Subject>
+                <saml:AttributeStatement>
+                    <saml:Attribute Name="groups">
+                        <saml:AttributeValue>developers</saml:AttributeValue>
+                        <saml:AttributeValue>ak-admins</saml:AttributeValue>
+                    </saml:Attribute>
+                </saml:AttributeStatement>
+            </saml:Assertion>
+        </samlp:Response>"#;
+
+        let response = parse_xml_fragment(xml);
+        let assertion = response.assertion.as_ref().unwrap();
+        assert_eq!(assertion.name_id, "alice@example.com");
+        let groups = assertion.attributes.get("groups").unwrap();
+        assert_eq!(
+            groups,
+            &vec!["developers".to_string(), "ak-admins".to_string()]
+        );
     }
 
     #[test]

--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -460,6 +460,88 @@ impl SamlResponseSpec {
     pub fn signed_b64(&self) -> String {
         base64_standard(sign_saml_document(&self.to_unsigned_xml()).as_bytes())
     }
+
+    /// Build the XML Signature Wrapping (XSW) attack payload (#2449) and
+    /// base64-encode it for the `SAMLResponse` form field.
+    ///
+    /// The legitimate, single signed assertion in `self` is signed normally,
+    /// then a SECOND, UNSIGNED `<saml:Assertion>` is spliced in immediately
+    /// before the closing `</samlp:Response>`. That injected assertion carries
+    /// attacker-controlled `attacker_groups` (e.g. the provider `admin_group`)
+    /// and the given `attacker_name_id`. Because the historical parser was
+    /// last-wins over `<Assertion>`, the *unsigned* assertion is the one that
+    /// would be consumed while the signature still verifies over the benign
+    /// one — the escalation. When `dup_id` is set, the injected assertion
+    /// reuses the signed assertion's ID (the duplicate-ID XSW variant).
+    pub fn xsw_wrapped_b64(
+        &self,
+        attacker_name_id: &str,
+        attacker_groups: &[&str],
+        dup_id: bool,
+    ) -> String {
+        let signed = sign_saml_document(&self.to_unsigned_xml());
+
+        // Recover the signed assertion's ID so the dup-ID variant can reuse it.
+        let signed_assertion_id = signed
+            .split("<saml:Assertion ID=\"")
+            .nth(1)
+            .and_then(|s| s.split('"').next())
+            .unwrap_or("_signed")
+            .to_string();
+        let injected_id = if dup_id {
+            signed_assertion_id
+        } else {
+            format!("_xsw{}", Uuid::new_v4().as_simple())
+        };
+
+        let now = chrono::Utc::now();
+        let issue_instant = now.format("%Y-%m-%dT%H:%M:%SZ");
+        let not_before = (now - chrono::Duration::minutes(5)).format("%Y-%m-%dT%H:%M:%SZ");
+        let not_on_or_after = (now + chrono::Duration::minutes(5)).format("%Y-%m-%dT%H:%M:%SZ");
+        let group_values = attacker_groups
+            .iter()
+            .map(|g| {
+                format!(
+                    "<saml:AttributeValue>{}</saml:AttributeValue>",
+                    xml_escape(g)
+                )
+            })
+            .collect::<String>();
+
+        let injected = format!(
+            r##"<saml:Assertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="{injected_id}" Version="2.0" IssueInstant="{issue_instant}">
+        <saml:Issuer>{issuer}</saml:Issuer>
+        <saml:Subject>
+            <saml:NameID Format="urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress">{name_id}</saml:NameID>
+            <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
+                <saml:SubjectConfirmationData NotOnOrAfter="{not_on_or_after}"/>
+            </saml:SubjectConfirmation>
+        </saml:Subject>
+        <saml:Conditions NotBefore="{not_before}" NotOnOrAfter="{not_on_or_after}">
+            <saml:AudienceRestriction>
+                <saml:Audience>{audience}</saml:Audience>
+            </saml:AudienceRestriction>
+        </saml:Conditions>
+        <saml:AuthnStatement AuthnInstant="{issue_instant}"/>
+        <saml:AttributeStatement>
+            <saml:Attribute Name="email">
+                <saml:AttributeValue>{name_id}@attacker.test</saml:AttributeValue>
+            </saml:Attribute>
+            <saml:Attribute Name="groups">{group_values}</saml:Attribute>
+        </saml:AttributeStatement>
+    </saml:Assertion>"##,
+            issuer = xml_escape(&self.issuer),
+            audience = xml_escape(&self.audience),
+            name_id = xml_escape(attacker_name_id),
+        );
+
+        let wrapped = signed.replacen(
+            "</samlp:Response>",
+            &format!("{injected}\n</samlp:Response>"),
+            1,
+        );
+        base64_standard(wrapped.as_bytes())
+    }
 }
 
 /// Base64 (standard alphabet, padded) — the encoding `saml_acs` decodes the

--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -621,6 +621,43 @@ impl SamlResponseSpec {
         );
         base64_standard(wrapped.as_bytes())
     }
+
+    /// In-`<ds:Signature>` `<ds:Object>` claim-injection variant (#2453 layer-3):
+    /// the assertion is signed normally with NO groups of its own, then a
+    /// `<saml:Attribute Name="groups">` carrying `attacker_groups` is spliced
+    /// into a `<ds:Object>` INSIDE the assertion's own `<ds:Signature>` — AFTER
+    /// signing. The enveloped-signature transform removes the entire
+    /// `<ds:Signature>` element before the digest is computed, and the injected
+    /// `<ds:Object>` is not referenced by any `<ds:Reference>`, so it is not
+    /// covered by the signature and verification still passes. Because the
+    /// `<ds:Signature>` is a CHILD of `<saml:Assertion>`, a parser that scopes
+    /// claims to the assertion subtree but does NOT exclude the transform-removed
+    /// `<ds:Signature>` subtree would harvest the injected groups as an
+    /// in-assertion claim.
+    ///
+    /// Pair with `SamlResponseSpec { groups: vec![], .. }` so the signed
+    /// assertion carries no groups attribute of its own.
+    pub fn ds_object_groups_injection_b64(&self, attacker_groups: &[&str]) -> String {
+        let signed = sign_saml_document(&self.to_unsigned_xml());
+        let values = attacker_groups
+            .iter()
+            .map(|g| {
+                format!(
+                    "<saml:AttributeValue>{}</saml:AttributeValue>",
+                    xml_escape(g)
+                )
+            })
+            .collect::<String>();
+        let injected = format!(
+            r#"<ds:Object><saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="groups">{values}</saml:Attribute></ds:Object>"#
+        );
+        // Splice the `<ds:Object>` just before the enveloped signature closes,
+        // inside the assertion's own `<ds:Signature>`. Adding a sibling of
+        // `<ds:SignedInfo>` does not change `<ds:SignedInfo>`, so the
+        // `<ds:SignatureValue>` still verifies.
+        let wrapped = signed.replacen("</ds:Signature>", &format!("{injected}</ds:Signature>"), 1);
+        base64_standard(wrapped.as_bytes())
+    }
 }
 
 /// Base64 (standard alphabet, padded) — the encoding `saml_acs` decodes the

--- a/backend/tests/common/sso_support.rs
+++ b/backend/tests/common/sso_support.rs
@@ -396,6 +396,16 @@ impl SamlResponseSpec {
                 )
             })
             .collect::<String>();
+        // Emit the `groups` attribute only when there are groups. A spec with
+        // `groups: vec![]` produces a signed assertion carrying NO groups
+        // attribute — the precondition for the attribute-injection variant,
+        // where an attacker splices a `groups` attribute outside the signed
+        // subtree.
+        let groups_attribute = if self.groups.is_empty() {
+            String::new()
+        } else {
+            format!(r#"<saml:Attribute Name="groups">{group_values}</saml:Attribute>"#)
+        };
 
         format!(
             r##"<?xml version="1.0" encoding="UTF-8"?>
@@ -443,7 +453,7 @@ impl SamlResponseSpec {
             <saml:Attribute Name="displayName">
                 <saml:AttributeValue>{display_name}</saml:AttributeValue>
             </saml:Attribute>
-            <saml:Attribute Name="groups">{group_values}</saml:Attribute>
+            {groups_attribute}
         </saml:AttributeStatement>
     </saml:Assertion>
 </samlp:Response>"##,
@@ -538,6 +548,75 @@ impl SamlResponseSpec {
         let wrapped = signed.replacen(
             "</samlp:Response>",
             &format!("{injected}\n</samlp:Response>"),
+            1,
+        );
+        base64_standard(wrapped.as_bytes())
+    }
+
+    /// Attribute-injection XSW variant (#2453 layer-2): the assertion is signed
+    /// normally, then a `<saml:Attribute Name="groups">` carrying
+    /// `attacker_groups` is spliced in as a child of `<samlp:Response>` —
+    /// OUTSIDE the signed `<saml:Assertion>` subtree — either before or after
+    /// the assertion. The assertion's digest is unchanged, so the signature
+    /// still verifies; a parser that harvests claims whole-document (rather than
+    /// scoping to the signed assertion) would consume the injected groups.
+    ///
+    /// Pair with `SamlResponseSpec { groups: vec![], .. }` so the signed
+    /// assertion carries no groups attribute of its own.
+    pub fn attribute_xsw_b64(&self, attacker_groups: &[&str], before_assertion: bool) -> String {
+        let signed = sign_saml_document(&self.to_unsigned_xml());
+        let values = attacker_groups
+            .iter()
+            .map(|g| {
+                format!(
+                    "<saml:AttributeValue>{}</saml:AttributeValue>",
+                    xml_escape(g)
+                )
+            })
+            .collect::<String>();
+        let injected = format!(
+            r#"<saml:Attribute xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Name="groups">{values}</saml:Attribute>"#
+        );
+        let wrapped = if before_assertion {
+            signed.replacen(
+                "<saml:Assertion ",
+                &format!("{injected}\n    <saml:Assertion "),
+                1,
+            )
+        } else {
+            signed.replacen(
+                "</saml:Assertion>",
+                &format!("</saml:Assertion>\n    {injected}"),
+                1,
+            )
+        };
+        base64_standard(wrapped.as_bytes())
+    }
+
+    /// Comment-splitting variant (#2453 layer-2 / Case-5): the assertion is
+    /// signed normally, then an XML comment is injected INTO the signed NameID
+    /// text, splitting it before its last `-`-delimited segment
+    /// (`victim-prefix-<!--c-->suffix`). Because the signature uses
+    /// exclusive-c14n#(no-comments), the comment is stripped before digesting
+    /// and the signature still verifies; a last-wins parser would keep only the
+    /// trailing text node (`suffix`), whereas the canonical value is the full
+    /// concatenation.
+    pub fn nameid_comment_b64(&self) -> String {
+        let signed = sign_saml_document(&self.to_unsigned_xml());
+        let escaped = xml_escape(&self.name_id);
+        // Split before the last `-`-delimited segment; fall back to the midpoint
+        // (on a char boundary) when there is no `-`.
+        let split = escaped.rfind('-').map(|i| i + 1).unwrap_or_else(|| {
+            let mut m = escaped.len() / 2;
+            while m < escaped.len() && !escaped.is_char_boundary(m) {
+                m += 1;
+            }
+            m
+        });
+        let (first_half, second_half) = escaped.split_at(split);
+        let wrapped = signed.replacen(
+            &format!("{escaped}</saml:NameID>"),
+            &format!("{first_half}<!--c-->{second_half}</saml:NameID>"),
             1,
         );
         base64_standard(wrapped.as_bytes())

--- a/backend/tests/sso_saml_acs_e2e_tests.rs
+++ b/backend/tests/sso_saml_acs_e2e_tests.rs
@@ -648,3 +648,97 @@ async fn test_saml_login_then_acs_full_flow() {
     delete_saml_user(&pool, &name_id).await;
     delete_saml_provider(&pool, provider_id).await;
 }
+
+/// XML Signature Wrapping (XSW) escalation (#2449): a response with the legit,
+/// benign, single signed assertion PLUS an appended UNSIGNED second assertion
+/// whose `groups` include the provider `admin_group`. Pre-fix the last-wins
+/// parser consumed the unsigned assertion (307 + admin). Post-fix the parser
+/// rejects any multi-assertion response outright → 401, and NO user (admin or
+/// otherwise) is provisioned for the attacker NameID.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn test_saml_acs_xsw_dual_assertion_rejected() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let provider_id = create_saml_provider(
+        &pool,
+        SamlProviderOpts {
+            admin_group: Some("ak-admins".to_string()),
+            ..SamlProviderOpts::default()
+        },
+    )
+    .await;
+
+    // Benign, correctly-signed assertion for a normal user (non-admin groups).
+    let victim = format!("saml-xsw-victim-{}", Uuid::new_v4().as_simple());
+    let attacker = format!("saml-xsw-attacker-{}", Uuid::new_v4().as_simple());
+    let request_id = seed_session(&pool, provider_id).await;
+    let spec = happy_spec(&request_id, &victim);
+
+    // Splice an UNSIGNED assertion (attacker NameID, groups=[ak-admins]) after
+    // the signed one.
+    let payload = spec.xsw_wrapped_b64(&attacker, &["ak-admins", "Developers"], false);
+    let resp = post_acs(build_state(pool.clone()), provider_id, &payload).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "an XSW dual-assertion response must be rejected (was 307 + admin escalation)"
+    );
+
+    // Neither the smuggled attacker identity nor the wrapped victim may be
+    // provisioned, and specifically no admin user is created.
+    assert!(
+        get_saml_user(&pool, &attacker).await.is_none(),
+        "the smuggled (unsigned) assertion must NOT provision a user — this is the escalation"
+    );
+    assert!(
+        get_saml_user(&pool, &victim).await.is_none(),
+        "the wrapped response must be rejected wholesale; no user provisioned"
+    );
+
+    delete_saml_user(&pool, &attacker).await;
+    delete_saml_user(&pool, &victim).await;
+    delete_saml_provider(&pool, provider_id).await;
+}
+
+/// Duplicate-ID XSW variant (#2449): two assertions sharing the signed
+/// assertion's ID — the second unsigned one carrying the admin group. Rejected
+/// (multi-assertion) → 401, no admin user provisioned.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn test_saml_acs_xsw_duplicate_id_rejected() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let provider_id = create_saml_provider(
+        &pool,
+        SamlProviderOpts {
+            admin_group: Some("ak-admins".to_string()),
+            ..SamlProviderOpts::default()
+        },
+    )
+    .await;
+
+    let victim = format!("saml-xswdup-victim-{}", Uuid::new_v4().as_simple());
+    let attacker = format!("saml-xswdup-attacker-{}", Uuid::new_v4().as_simple());
+    let request_id = seed_session(&pool, provider_id).await;
+    let spec = happy_spec(&request_id, &victim);
+
+    // dup_id = true → the injected unsigned assertion reuses the signed ID.
+    let payload = spec.xsw_wrapped_b64(&attacker, &["ak-admins"], true);
+    let resp = post_acs(build_state(pool.clone()), provider_id, &payload).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "a duplicate-ID XSW response must be rejected"
+    );
+    assert!(get_saml_user(&pool, &attacker).await.is_none());
+    assert!(get_saml_user(&pool, &victim).await.is_none());
+
+    delete_saml_user(&pool, &attacker).await;
+    delete_saml_user(&pool, &victim).await;
+    delete_saml_provider(&pool, provider_id).await;
+}

--- a/backend/tests/sso_saml_acs_e2e_tests.rs
+++ b/backend/tests/sso_saml_acs_e2e_tests.rs
@@ -742,3 +742,133 @@ async fn test_saml_acs_xsw_duplicate_id_rejected() {
     delete_saml_user(&pool, &victim).await;
     delete_saml_provider(&pool, provider_id).await;
 }
+
+/// Attribute-injection XSW variant (#2453 layer-2): the assertion is validly
+/// signed but carries NO groups attribute; a `<saml:Attribute Name="groups">`
+/// with the provider admin group is spliced in as a `<samlp:Response>` child
+/// BEFORE the signed `<saml:Assertion>`. The splice is outside the signed
+/// subtree so the signature still verifies (single assertion → no multi-assert
+/// reject), but claims are now scoped to the verified assertion, so the injected
+/// group must NOT grant admin. Login succeeds (307) as a non-admin.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn test_saml_acs_xsw_attribute_before_assertion_not_admin() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let provider_id = create_saml_provider(
+        &pool,
+        SamlProviderOpts {
+            admin_group: Some("ak-admins".to_string()),
+            ..SamlProviderOpts::default()
+        },
+    )
+    .await;
+
+    let name_id = format!("saml-attrxsw-{}", Uuid::new_v4().as_simple());
+    let request_id = seed_session(&pool, provider_id).await;
+    let mut spec = happy_spec(&request_id, &name_id);
+    spec.groups = vec![]; // signed assertion carries no groups attribute
+
+    let payload = spec.attribute_xsw_b64(&["ak-admins"], true);
+    let resp = post_acs(build_state(pool.clone()), provider_id, &payload).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "a valid signature with an out-of-subtree attribute must still authenticate"
+    );
+    let (_, _, _, is_admin) = get_saml_user(&pool, &name_id)
+        .await
+        .expect("the signed subject must still provision");
+    assert!(
+        !is_admin,
+        "a groups attribute spliced BEFORE the signed assertion must NOT grant admin"
+    );
+
+    delete_saml_user(&pool, &name_id).await;
+    delete_saml_provider(&pool, provider_id).await;
+}
+
+/// Control for the attribute-injection variant: the same `groups` attribute
+/// spliced AFTER `</saml:Assertion>` (still a `<Response>` child, still outside
+/// the signed subtree) likewise must not grant admin.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn test_saml_acs_xsw_attribute_after_assertion_not_admin() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let provider_id = create_saml_provider(
+        &pool,
+        SamlProviderOpts {
+            admin_group: Some("ak-admins".to_string()),
+            ..SamlProviderOpts::default()
+        },
+    )
+    .await;
+
+    let name_id = format!("saml-attrxsw-after-{}", Uuid::new_v4().as_simple());
+    let request_id = seed_session(&pool, provider_id).await;
+    let mut spec = happy_spec(&request_id, &name_id);
+    spec.groups = vec![];
+
+    let payload = spec.attribute_xsw_b64(&["ak-admins"], false);
+    let resp = post_acs(build_state(pool.clone()), provider_id, &payload).await;
+
+    assert_eq!(resp.status(), StatusCode::TEMPORARY_REDIRECT);
+    let (_, _, _, is_admin) = get_saml_user(&pool, &name_id)
+        .await
+        .expect("the signed subject must still provision");
+    assert!(
+        !is_admin,
+        "a groups attribute spliced AFTER the signed assertion must NOT grant admin"
+    );
+
+    delete_saml_user(&pool, &name_id).await;
+    delete_saml_provider(&pool, provider_id).await;
+}
+
+/// Comment-split NameID variant (#2453 layer-2 / Case-5): the signed NameID text
+/// is split by an XML comment (`victim-prefix-<!--c-->suffix`). exc-c14n#
+/// (no-comments) strips the comment before digesting, so the signature stays
+/// valid. The parser now accumulates leaf text across the comment, so the
+/// provisioned `external_id` is the FULL signed NameID — not the trailing
+/// segment a last-wins parser would have stored.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn test_saml_acs_comment_split_nameid_uses_full_value() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let provider_id = create_saml_provider(&pool, SamlProviderOpts::default()).await;
+
+    let name_id = format!("victim-prefix-suffix-{}", Uuid::new_v4().as_simple());
+    let request_id = seed_session(&pool, provider_id).await;
+    let spec = happy_spec(&request_id, &name_id);
+
+    let payload = spec.nameid_comment_b64();
+    let resp = post_acs(build_state(pool.clone()), provider_id, &payload).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "a comment-split (but validly signed) NameID must authenticate"
+    );
+
+    // The provisioned user is keyed on the FULL NameID value.
+    assert!(
+        get_saml_user(&pool, &name_id).await.is_some(),
+        "the provisioned external_id must equal the full signed NameID"
+    );
+    // A last-wins parser would have stored only the trailing text node; assert
+    // no user exists under that truncated value.
+    let truncated = name_id.rsplit('-').next().unwrap();
+    assert!(
+        get_saml_user(&pool, truncated).await.is_none(),
+        "no user may be provisioned under the truncated (trailing-segment) NameID"
+    );
+
+    delete_saml_user(&pool, &name_id).await;
+    delete_saml_provider(&pool, provider_id).await;
+}

--- a/backend/tests/sso_saml_acs_e2e_tests.rs
+++ b/backend/tests/sso_saml_acs_e2e_tests.rs
@@ -829,6 +829,56 @@ async fn test_saml_acs_xsw_attribute_after_assertion_not_admin() {
     delete_saml_provider(&pool, provider_id).await;
 }
 
+/// In-`<ds:Signature>` `<ds:Object>` injection variant (#2453 layer-3): the
+/// assertion is validly signed but carries NO groups attribute; a
+/// `<saml:Attribute Name="groups">` with the provider admin group is spliced
+/// into a `<ds:Object>` INSIDE the assertion's enveloped `<ds:Signature>` after
+/// signing. The signature transform removes the whole `<ds:Signature>` before
+/// digesting, so the injection is unsigned and the signature still verifies —
+/// but the `<ds:Signature>` is a child of the assertion, so a parser that scopes
+/// claims to the assertion subtree WITHOUT excluding the Signature subtree would
+/// harvest the injected group. Login must succeed (307) as a NON-admin.
+#[tokio::test]
+#[ignore = "requires DATABASE_URL"]
+async fn test_saml_acs_ds_object_groups_injection_not_admin() {
+    let Some(pool) = try_pool().await else {
+        return;
+    };
+    let provider_id = create_saml_provider(
+        &pool,
+        SamlProviderOpts {
+            admin_group: Some("ak-admins".to_string()),
+            ..SamlProviderOpts::default()
+        },
+    )
+    .await;
+
+    let name_id = format!("saml-dsobjxsw-{}", Uuid::new_v4().as_simple());
+    let request_id = seed_session(&pool, provider_id).await;
+    let mut spec = happy_spec(&request_id, &name_id);
+    spec.groups = vec![]; // signed assertion carries no groups attribute
+
+    let payload = spec.ds_object_groups_injection_b64(&["ak-admins"]);
+    let resp = post_acs(build_state(pool.clone()), provider_id, &payload).await;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "a valid signature with an in-<ds:Signature> <ds:Object> attribute must still authenticate"
+    );
+    let (_, _, _, is_admin) = get_saml_user(&pool, &name_id)
+        .await
+        .expect("the signed subject must still provision");
+    assert!(
+        !is_admin,
+        "a groups attribute spliced into a <ds:Object> inside the assertion's \
+         <ds:Signature> must NOT grant admin"
+    );
+
+    delete_saml_user(&pool, &name_id).await;
+    delete_saml_provider(&pool, provider_id).await;
+}
+
 /// Comment-split NameID variant (#2453 layer-2 / Case-5): the signed NameID text
 /// is split by an XML comment (`victim-prefix-<!--c-->suffix`). exc-c14n#
 /// (no-comments) strips the comment before digesting, so the signature stays


### PR DESCRIPTION
## Summary

Closes #2449.

The SAML ACS path accepted a `<samlp:Response>` in which the assertion that was
actually consumed was not the assertion that had been cryptographically signed.
Two independent gaps combined to allow a forged administrator login:

1. **Last-wins, unbounded assertion parsing.** `SamlResponseParser::handle_end`
   overwrote `response.assertion` on *every* `</Assertion>` and placed no limit
   on the number of assertions, so an attacker could append a second,
   attacker-controlled `<saml:Assertion>` (e.g. `groups=[admin_group]`) after a
   legitimately signed one and have *that* one consumed.
2. **Discarded signature scope.** `validate_response` matched
   `bergshamra::verify` → `VerifyResult::Valid { references, .. }` but dropped
   `references`, so a valid signature over *any* element was treated as a valid
   signature over the consumed assertion.

Both are addressed with a minimal, defense-in-depth change confined to the SAML
service:

- **Structural (parse time, unconditional):** a `<Response>` carrying more than
  one `<saml:Assertion>` is now rejected. Artifact Keeper only ever consumes a
  single assertion (`assertion: Option<..>`), so this is behaviour-preserving
  for every legitimate IdP and removes the "second assertion to smuggle"
  precondition — including on the no-certificate development path where signature
  verification is skipped.
- **Cryptographic binding:** on the `Valid` arm, the set of reference IDs whose
  digest was actually verified is now computed (each `<Reference URI>` with a
  leading `#` stripped; empty and `cid:` URIs excluded), and the consumed
  assertion is required to be covered — either the assertion's own ID
  (assertion-level signing, AK's posture) **or** the enclosing Response ID
  (Response-level signing, as ADFS / Azure AD emit). Both remain accepted so
  those IdPs continue to work. The decision is factored into a small pure helper
  (`consumed_assertion_is_signed`) for unit testing.

Dual-signing IdPs are unaffected (multiple `<Signature>` elements are still
allowed; only multiple `<Assertion>` elements are rejected).

## Defense-in-depth hardening (follow-up commit)

A re-review of the parser found two same-class ways a claim could still be
consumed from outside the cryptographically-verified assertion. Both are closed
with a minimal follow-up that keeps the load-bearing invariants above unchanged:

- **Claim extraction is now confined to the verified `<Assertion>` element.**
  Every assertion-level write in `SamlResponseParser` (NameID, Audience,
  Attribute/AttributeValue, NameID `Format`, `Conditions`, `SessionIndex`,
  `SubjectConfirmationData` `Recipient`) is gated on the existing `in_assertion`
  flag. Because the unconditional multi-assertion reject plus the
  signed-id binding already guarantee the single consumed `<Assertion>` is the
  signed one, gating claim writes on `in_assertion` scopes all consumed claims
  to that verified subtree by construction — a claim element placed elsewhere in
  the document (e.g. as a sibling of the assertion under `<Response>`) is never
  read.
- **Comment-split signed values canonicalise by concatenation.** Leaf text is
  accumulated across `Text` events and committed on the element's `End` instead
  of last-wins per event. A value the IdP signed but that is split by an XML
  comment now reconstructs whole, matching the `exclusive-c14n#`(no-comments)
  form under which the digest was verified, rather than yielding only a trailing
  fragment.
- **Claim extraction now also excludes the enveloped `<ds:Signature>` subtree.**
  The enveloped `<ds:Signature>` is a child of `<saml:Assertion>`, but the
  enveloped-signature transform removes the entire `<ds:Signature>` element
  before the digest is computed, so nothing inside it is covered by the
  signature. Scoping claims to the assertion subtree alone therefore still left
  a same-class path: a claim spliced into an unreferenced `<ds:Object>` inside
  `<ds:Signature>` was nominally "in assertion" yet unsigned. `SamlResponseParser`
  now tracks a `<ds:Signature>` nesting depth (a saturating counter, so
  nested/decoy `<Signature>` elements cannot underflow the guard) and suppresses
  every claim write while inside that subtree (`claims_active()` =
  `in_assertion && signature_depth == 0`). No legitimate SAML claim lives inside
  `<ds:Signature>` — the real `<Subject>`/`<AttributeStatement>` sit outside it —
  so this has no false-positive risk and normal signed assertions are unaffected.

Invariants preserved: single-assertion reject, signed-id binding
(`consumed_assertion_is_signed`), and `extract_user_info` are untouched;
in-subtree signed groups still drive admin mapping and multi-value attributes
still yield distinct entries.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added:
- Unit (`backend/src/services/saml_service.rs`): a two-`<Assertion>` response is
  rejected at parse time; a single-assertion response parses and is consumed; a
  duplicate-ID two-assertion response is rejected; and five cases for the pure
  `consumed_assertion_is_signed` helper (assertion-ID covered → accept,
  Response-ID covered → accept, neither → reject, empty set → reject, empty IDs
  never match).
- End-to-end (`backend/tests/sso_saml_acs_e2e_tests.rs` +
  `backend/tests/common/sso_support.rs`): a new `xsw_wrapped_b64` helper splices
  an unsigned second assertion (`groups=[admin_group]`) after the signed one; the
  dual-assertion and duplicate-ID variants both now return `401` and provision no
  user. The existing happy-path, invalid-signature, replay/unsolicited,
  Destination/Recipient binding, admin-group mapping, audit, and full login→ACS
  flow tests remain green.
- Follow-up (subtree scoping): pure-parser unit tests that an out-of-subtree
  `groups` attribute (before or after the assertion) and a Response-level
  `<NameID>` are not consumed, and that a comment-split NameID/AttributeValue
  concatenates; plus ACS e2e tests (`attribute_xsw_b64`, `nameid_comment_b64`
  helpers) asserting an out-of-subtree `groups` attribute yields a non-admin
  login and a comment-split signed NameID provisions under the full value.
- Follow-up (`<ds:Signature>` subtree exclusion): pure-parser unit tests that a
  `groups` attribute and a `<NameID>` spliced into a `<ds:Object>` inside the
  assertion's `<ds:Signature>` are not consumed, and that a claim placed after
  `</ds:Signature>` but still inside the assertion *is* consumed (the depth
  counter decrements correctly and does not over-suppress); plus an ACS e2e test
  (`ds_object_groups_injection_b64` helper) asserting that a `groups` attribute
  spliced into a `<ds:Object>` within the assertion's `<ds:Signature>` still
  authenticates (`307`) but provisions a non-admin user.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
