### PR TITLE
fix(debian): verify remote-proxy indices against the signed Release and reject flat-repo/mirrorlist upstreams

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -862,20 +862,56 @@ fn is_matching_packages_index(cache_path: &str, component: &str, arch: &str) -> 
     matches!(leaf, "Packages" | "Packages.gz" | "Packages.xz")
 }
 
+/// Ceiling on the *decompressed* size of a cached Packages index we will
+/// expand while resolving a pool `.deb`'s expected checksum (#2459 Tier B DoS
+/// guard). A signed Release can vouch for a small compressed index that passes
+/// Tier A (checksum + size ≤ the metadata cap) yet expands unbounded (>100x →
+/// multi-GiB) — capping the decode bounds worst-case memory. A stream that
+/// would exceed this is treated as "unresolvable" (returns `None`) so the pool
+/// download falls back to the Content-Length-gated cache commit; Tier B is
+/// best-effort and must never hard-fail the download.
+const MAX_DECOMPRESSED_INDEX_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Skip decompressing a cached *compressed* index whose body is already this
+/// large. A legitimately-published Packages index compresses far smaller
+/// (tens of MiB for the largest suites), so this bounds the work before the
+/// decoder even starts and cheaply rejects an oversized bomb payload.
+const MAX_COMPRESSED_INDEX_BYTES: usize = 32 * 1024 * 1024;
+
 /// Decompress a cached Packages index body into text based on the cache
-/// path's extension (`.gz` / `.xz` / plain). Returns `None` on a decode error.
+/// path's extension (`.gz` / `.xz` / plain). Returns `None` on a decode error
+/// or when the input would exceed the decompression-bomb caps
+/// ([`MAX_COMPRESSED_INDEX_BYTES`] / [`MAX_DECOMPRESSED_INDEX_BYTES`]).
 fn decompress_packages_index(cache_path: &str, bytes: &[u8]) -> Option<String> {
+    let compressed = cache_path.ends_with(".gz") || cache_path.ends_with(".xz");
+    if compressed && bytes.len() > MAX_COMPRESSED_INDEX_BYTES {
+        return None;
+    }
     if cache_path.ends_with(".gz") {
-        let mut s = String::new();
-        GzDecoder::new(bytes).read_to_string(&mut s).ok()?;
-        Some(s)
+        read_index_capped(GzDecoder::new(bytes))
     } else if cache_path.ends_with(".xz") {
-        let mut s = String::new();
-        XzDecoder::new(bytes).read_to_string(&mut s).ok()?;
-        Some(s)
+        read_index_capped(XzDecoder::new(bytes))
     } else {
         Some(String::from_utf8_lossy(bytes).into_owned())
     }
+}
+
+/// Read a decoder to completion, bounded at [`MAX_DECOMPRESSED_INDEX_BYTES`].
+/// Returns `None` on a decode error OR when the decompressed stream would
+/// exceed the cap (a decompression bomb), so the caller treats the index as
+/// unresolvable rather than expanding it into memory unbounded.
+fn read_index_capped<R: Read>(reader: R) -> Option<String> {
+    // Read one byte past the cap so a stream that exactly fills it but carries
+    // more data is still detected as over-limit.
+    let mut buf = Vec::new();
+    reader
+        .take(MAX_DECOMPRESSED_INDEX_BYTES + 1)
+        .read_to_end(&mut buf)
+        .ok()?;
+    if buf.len() as u64 > MAX_DECOMPRESSED_INDEX_BYTES {
+        return None;
+    }
+    String::from_utf8(buf).ok()
 }
 
 /// Tier B resolver: find the SHA-256 the cached Packages index records for a
@@ -3848,5 +3884,61 @@ mod virtual_dists_cap_tests {
             "main",
             "amd64"
         ));
+    }
+
+    fn gzip(bytes: &[u8]) -> Vec<u8> {
+        let mut enc = GzBuilder::new().write(Vec::new(), Compression::default());
+        enc.write_all(bytes).unwrap();
+        enc.finish().unwrap()
+    }
+
+    fn xz(bytes: &[u8]) -> Vec<u8> {
+        let mut enc = xz2::write::XzEncoder::new(Vec::new(), 6);
+        enc.write_all(bytes).unwrap();
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn test_decompress_packages_index_honest_gz_and_xz() {
+        let body = b"Package: hello\nFilename: pool/main/h/hello/hello_1.0_amd64.deb\nSHA256: abc\nSize: 10\n";
+        assert_eq!(
+            decompress_packages_index("dists/x/main/binary-amd64/Packages.gz", &gzip(body)),
+            Some(String::from_utf8(body.to_vec()).unwrap())
+        );
+        assert_eq!(
+            decompress_packages_index("dists/x/main/binary-amd64/Packages.xz", &xz(body)),
+            Some(String::from_utf8(body.to_vec()).unwrap())
+        );
+        // Plain (uncompressed) passes through unchanged.
+        assert_eq!(
+            decompress_packages_index("dists/x/main/binary-amd64/Packages", body),
+            Some(String::from_utf8(body.to_vec()).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_decompress_packages_index_bomb_hits_cap_returns_none() {
+        // A highly-compressible payload that expands past the decompressed cap.
+        // ~200 MiB of zeros compresses to a few hundred KiB but must NOT be
+        // expanded into memory — the cap returns None (unresolvable), no OOM.
+        let bomb = vec![0u8; (MAX_DECOMPRESSED_INDEX_BYTES as usize) + (16 * 1024 * 1024)];
+        let gz = gzip(&bomb);
+        assert!(
+            gz.len() <= MAX_COMPRESSED_INDEX_BYTES,
+            "test bomb should slip past the compressed-size pre-check to exercise the decode cap"
+        );
+        assert_eq!(
+            decompress_packages_index("dists/x/main/binary-amd64/Packages.gz", &gz),
+            None
+        );
+    }
+
+    #[test]
+    fn test_decompress_packages_index_oversized_compressed_skipped() {
+        let too_big = vec![7u8; MAX_COMPRESSED_INDEX_BYTES + 1];
+        assert_eq!(
+            decompress_packages_index("dists/x/main/binary-amd64/Packages.gz", &too_big),
+            None
+        );
     }
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -17,7 +17,8 @@
 //!   POST /debian/{repo_key}/upload                                                  - Upload .deb (raw body)
 
 use std::collections::BTreeSet;
-use std::io::{self, Write};
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
 
 use axum::body::Body;
 use axum::extract::{Path, State};
@@ -28,11 +29,13 @@ use axum::routing::{get, post};
 use axum::Extension;
 use axum::Router;
 use bytes::Bytes;
+use flate2::read::GzDecoder;
 use flate2::Compression;
 use flate2::GzBuilder;
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tracing::info;
+use xz2::read::XzDecoder;
 
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
@@ -584,6 +587,18 @@ impl<'a> DebianProxy<'a> {
             )
             .await
             .map_err(map_proxy_err)?;
+        // #2459 Tier A: reject an index the signed Release does not vouch for.
+        enforce_dists_integrity(
+            proxy,
+            repo.id,
+            self.repo_key,
+            upstream_url,
+            self.distribution,
+            &upstream_path,
+            suffix,
+            &content,
+        )
+        .await?;
         Err(build_dists_response(content, upstream_ct, content_type))
     }
 
@@ -678,6 +693,222 @@ fn remote_member_upstream(member: &crate::models::repository::Repository) -> Opt
         return None;
     }
     member.upstream_url.as_deref()
+}
+
+// ---------------------------------------------------------------------------
+// Remote-proxy integrity verification (#2459)
+//
+// Tier A (mandatory): every dists index proxied from a Remote upstream is
+// checked against the checksum table of the repo's signed Release/InRelease
+// before it is served or persisted. A mismatch means the upstream (or a MITM)
+// answered a signed-Release-covered path with content the signature does not
+// vouch for, so the fetch is rejected with 502 and the poisoned cache entry
+// is evicted.
+//
+// Tier B (best-effort): a pool `.deb` download is gated on the SHA-256 the
+// cached Packages index records for its `Filename`, so a mismatching body is
+// still streamed to the client (which verifies it itself) but never written
+// to the proxy cache. Both tiers apply to `repo_type == Remote` only.
+// ---------------------------------------------------------------------------
+
+/// Outcome of checking a proxied dists index against the signed Release.
+#[derive(Debug, PartialEq, Eq)]
+enum IndexVerification {
+    /// The path is covered by the signed Release (or is a by-hash path) and
+    /// the fetched content matched.
+    Verified,
+    /// The signed Release does not cover this path; nothing to enforce.
+    NotCovered,
+    /// The content did not match the signed Release entry (or by-hash digest).
+    Mismatch,
+}
+
+/// If `path` is a `by-hash/SHA256/<hex>` index variant, return the embedded
+/// digest. Such paths are content-addressed, so the digest in the path is the
+/// integrity claim apt selected from the (already-verified) signed Release.
+fn by_hash_sha256(path: &str) -> Option<&str> {
+    let idx = path.find("by-hash/SHA256/")?;
+    let tail = &path[idx + "by-hash/SHA256/".len()..];
+    let hex = tail.split('/').next()?;
+    if hex.is_empty() {
+        None
+    } else {
+        Some(hex)
+    }
+}
+
+/// Verify a fetched dists index (`dist_relative_path`, relative to
+/// `dists/{distribution}/`) against the signed Release checksum table. Pure so
+/// the match / sha-mismatch / size-mismatch / by-hash / not-covered branches
+/// are unit-testable without a runtime or storage.
+fn verify_index_against_release(
+    release_checksums: &HashMap<String, (String, u64)>,
+    dist_relative_path: &str,
+    content: &[u8],
+) -> IndexVerification {
+    let actual_sha = hex::encode(Sha256::digest(content));
+    let actual_size = content.len() as u64;
+
+    if let Some(expected) = by_hash_sha256(dist_relative_path) {
+        return if actual_sha.eq_ignore_ascii_case(expected) {
+            IndexVerification::Verified
+        } else {
+            IndexVerification::Mismatch
+        };
+    }
+
+    match release_checksums.get(dist_relative_path) {
+        Some((sha, size)) => {
+            if actual_sha.eq_ignore_ascii_case(sha) && actual_size == *size {
+                IndexVerification::Verified
+            } else {
+                IndexVerification::Mismatch
+            }
+        }
+        None => IndexVerification::NotCovered,
+    }
+}
+
+/// Load and parse the SHA256 checksum table from the repo's signed Release,
+/// preferring `InRelease` and falling back to `Release`. Best-effort: returns
+/// `None` when neither can be loaded or neither carries a SHA256 section (in
+/// which case the caller serves the fetch unchanged, mirroring apt, which
+/// itself refuses unsigned indices downstream).
+async fn load_release_checksums(
+    proxy: &ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    distribution: &str,
+) -> Option<HashMap<String, (String, u64)>> {
+    let pseudo_repo = proxy_helpers::build_remote_repo(repo_id, repo_key, upstream_url);
+    for name in ["InRelease", "Release"] {
+        let path = format!("dists/{}/{}", distribution, name);
+        if let Ok((bytes, _ct, _changed)) = proxy
+            .fetch_dists_with_revalidation(
+                &pseudo_repo,
+                &path,
+                distribution,
+                DEFAULT_DISTS_INDEX_TTL_SECS,
+            )
+            .await
+        {
+            let text = String::from_utf8_lossy(&bytes);
+            let table = crate::formats::debian::parse_release_checksums(&text);
+            if !table.is_empty() {
+                return Some(table);
+            }
+        }
+    }
+    None
+}
+
+/// Tier A guard: verify a freshly-proxied dists index against the signed
+/// Release and, on a checksum/size mismatch, evict the just-written cache
+/// entry and return a 502. `dist_relative_path` is the tail of `upstream_path`
+/// beneath `dists/{distribution}/`.
+#[allow(clippy::too_many_arguments)]
+async fn enforce_dists_integrity(
+    proxy: &ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    distribution: &str,
+    upstream_path: &str,
+    dist_relative_path: &str,
+    content: &[u8],
+) -> Result<(), Response> {
+    let Some(table) =
+        load_release_checksums(proxy, repo_id, repo_key, upstream_url, distribution).await
+    else {
+        return Ok(());
+    };
+    if verify_index_against_release(&table, dist_relative_path, content)
+        == IndexVerification::Mismatch
+    {
+        // Evict the poisoned entry so a later read cannot serve it.
+        let _ = proxy.invalidate_cache_by_key(repo_key, upstream_path).await;
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            "Upstream index failed integrity verification against the signed Release",
+        )
+            .into_response());
+    }
+    Ok(())
+}
+
+/// Resolve the expected SHA-256 for a pool artifact from a parsed Packages
+/// `Filename` -> (sha, size) map. The Packages `Filename` field carries the
+/// full pool-relative path, so a direct lookup suffices. Pure (map lookup).
+fn resolve_pool_deb_checksum(
+    packages: &HashMap<String, (String, u64)>,
+    artifact_path: &str,
+) -> Option<String> {
+    packages.get(artifact_path).map(|(sha, _)| sha.clone())
+}
+
+/// True when `cache_path` names a cached Packages index for `component` and
+/// `arch` (any distribution / compression). Pure so the shape match is
+/// unit-testable. Used to narrow the cached-index scan at pool download time.
+fn is_matching_packages_index(cache_path: &str, component: &str, arch: &str) -> bool {
+    if !cache_path.starts_with("dists/") {
+        return false;
+    }
+    let needle = format!("/{}/binary-{}/Packages", component, arch);
+    if !cache_path.contains(&needle) {
+        return false;
+    }
+    let leaf = cache_path.rsplit('/').next().unwrap_or("");
+    matches!(leaf, "Packages" | "Packages.gz" | "Packages.xz")
+}
+
+/// Decompress a cached Packages index body into text based on the cache
+/// path's extension (`.gz` / `.xz` / plain). Returns `None` on a decode error.
+fn decompress_packages_index(cache_path: &str, bytes: &[u8]) -> Option<String> {
+    if cache_path.ends_with(".gz") {
+        let mut s = String::new();
+        GzDecoder::new(bytes).read_to_string(&mut s).ok()?;
+        Some(s)
+    } else if cache_path.ends_with(".xz") {
+        let mut s = String::new();
+        XzDecoder::new(bytes).read_to_string(&mut s).ok()?;
+        Some(s)
+    } else {
+        Some(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+/// Tier B resolver: find the SHA-256 the cached Packages index records for a
+/// pool artifact, so the streamed `.deb` download can gate its cache commit on
+/// it. Best-effort: `None` when no cached Packages index covers the file
+/// (which leaves the download's cache behaviour unchanged from before #2459).
+async fn resolve_pool_expected_checksum(
+    proxy: &ProxyService,
+    repo_key: &str,
+    component: &str,
+    artifact_path: &str,
+) -> Option<String> {
+    let filename = artifact_path.rsplit('/').next()?;
+    let (_, _, arch) = DebianHandler::parse_deb_filename(filename).ok()?;
+    for cache_path in proxy.list_cached_paths(repo_key).await {
+        if !is_matching_packages_index(&cache_path, component, &arch) {
+            continue;
+        }
+        let Ok(Some((bytes, _))) = proxy
+            .get_cached_artifact_by_path(repo_key, &cache_path)
+            .await
+        else {
+            continue;
+        };
+        let Some(text) = decompress_packages_index(&cache_path, &bytes) else {
+            continue;
+        };
+        let map = crate::formats::debian::parse_packages_index(&text);
+        if let Some(sha) = resolve_pool_deb_checksum(&map, artifact_path) {
+            return Some(sha);
+        }
+    }
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -1406,6 +1637,18 @@ async fn dists_proxy_catchall(
         )
         .await
         .map_err(map_proxy_err)?;
+    // #2459 Tier A: reject an index the signed Release does not vouch for.
+    enforce_dists_integrity(
+        proxy,
+        repo.id,
+        &repo_key,
+        upstream_url,
+        &distribution,
+        &upstream_path,
+        &dists_path,
+        &content,
+    )
+    .await?;
 
     let content_type = upstream_ct.unwrap_or_else(|| content_type_for_dists_path(&dists_path));
 
@@ -1490,15 +1733,38 @@ async fn pool_download(
                     // (apt clients don't care; the registration just
                     // gives downstream proxies a meaningful Content-Type
                     // when upstream omits it).
-                    return proxy_helpers::proxy_fetch_streaming(
+                    //
+                    // #2459 Tier B: gate the proxy-cache commit on the
+                    // SHA-256 the cached Packages index records for this
+                    // `Filename`. A body that does not match is still
+                    // streamed to the client (which verifies it itself)
+                    // but never persisted, so a mismatching upstream cannot
+                    // poison the cache. The body STAYS streamed — it is
+                    // never buffered (#1608). `None` (no covering Packages
+                    // index cached) preserves the prior cache behaviour.
+                    let expected_checksum = resolve_pool_expected_checksum(
+                        proxy,
+                        &repo_key,
+                        &component,
+                        &artifact_path,
+                    )
+                    .await;
+                    let result = proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
                         proxy,
                         repo.id,
                         &repo_key,
                         upstream_url,
                         &upstream_path,
-                        DEBIAN_BINARY_CONTENT_TYPE,
+                        &upstream_path,
+                        expected_checksum,
+                        RepositoryFormat::Debian,
                     )
-                    .await;
+                    .await?;
+                    return proxy_helpers::stream_fetch_result(
+                        result,
+                        DEBIAN_BINARY_CONTENT_TYPE,
+                        None,
+                    );
                 }
             }
 
@@ -3461,5 +3727,126 @@ mod virtual_dists_cap_tests {
             "a 404 member must fall through to Ok(None), got {:?}",
             out.map(|o| o.map(|r| r.status())),
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2459 remote-proxy integrity verification (pure helpers)
+    // -----------------------------------------------------------------------
+
+    fn release_table(path: &str, sha: &str, size: u64) -> HashMap<String, (String, u64)> {
+        let mut m = HashMap::new();
+        m.insert(path.to_string(), (sha.to_string(), size));
+        m
+    }
+
+    #[test]
+    fn test_verify_index_against_release_ok_on_match() {
+        let content = b"Packages index body";
+        let sha = hex::encode(Sha256::digest(content));
+        let table = release_table("main/binary-amd64/Packages", &sha, content.len() as u64);
+        assert_eq!(
+            verify_index_against_release(&table, "main/binary-amd64/Packages", content),
+            IndexVerification::Verified
+        );
+    }
+
+    #[test]
+    fn test_verify_index_against_release_err_on_sha_mismatch() {
+        let content = b"poisoned body";
+        // Correct size, wrong sha.
+        let table = release_table(
+            "main/binary-amd64/Packages",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            content.len() as u64,
+        );
+        assert_eq!(
+            verify_index_against_release(&table, "main/binary-amd64/Packages", content),
+            IndexVerification::Mismatch
+        );
+    }
+
+    #[test]
+    fn test_verify_index_against_release_err_on_size_mismatch() {
+        let content = b"body";
+        let sha = hex::encode(Sha256::digest(content));
+        // Correct sha, wrong size.
+        let table = release_table("main/binary-amd64/Packages", &sha, 999_999);
+        assert_eq!(
+            verify_index_against_release(&table, "main/binary-amd64/Packages", content),
+            IndexVerification::Mismatch
+        );
+    }
+
+    #[test]
+    fn test_verify_index_against_release_not_covered() {
+        let table = release_table("main/binary-amd64/Packages", "abc", 3);
+        assert_eq!(
+            verify_index_against_release(&table, "main/i18n/Translation-en", b"anything"),
+            IndexVerification::NotCovered
+        );
+    }
+
+    #[test]
+    fn test_verify_index_against_release_by_hash() {
+        let content = b"by-hash body";
+        let sha = hex::encode(Sha256::digest(content));
+        let path = format!("main/binary-amd64/by-hash/SHA256/{}", sha);
+        let empty = HashMap::new();
+        assert_eq!(
+            verify_index_against_release(&empty, &path, content),
+            IndexVerification::Verified
+        );
+        // Wrong bytes for the claimed by-hash digest -> mismatch.
+        assert_eq!(
+            verify_index_against_release(&empty, &path, b"tampered"),
+            IndexVerification::Mismatch
+        );
+    }
+
+    #[test]
+    fn test_resolve_pool_deb_checksum_hit_and_miss() {
+        let mut map = HashMap::new();
+        map.insert(
+            "pool/main/n/nginx/nginx_1.24.0-1_amd64.deb".to_string(),
+            ("deadbeef".to_string(), 512u64),
+        );
+        assert_eq!(
+            resolve_pool_deb_checksum(&map, "pool/main/n/nginx/nginx_1.24.0-1_amd64.deb"),
+            Some("deadbeef".to_string())
+        );
+        assert_eq!(
+            resolve_pool_deb_checksum(&map, "pool/main/c/curl/curl_8.0.1-1_amd64.deb"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_is_matching_packages_index() {
+        assert!(is_matching_packages_index(
+            "dists/bookworm/main/binary-amd64/Packages.gz",
+            "main",
+            "amd64"
+        ));
+        assert!(is_matching_packages_index(
+            "dists/jammy/main/binary-amd64/Packages",
+            "main",
+            "amd64"
+        ));
+        // Wrong component / arch / not a Packages leaf.
+        assert!(!is_matching_packages_index(
+            "dists/bookworm/contrib/binary-amd64/Packages.gz",
+            "main",
+            "amd64"
+        ));
+        assert!(!is_matching_packages_index(
+            "dists/bookworm/main/binary-arm64/Packages.gz",
+            "main",
+            "amd64"
+        ));
+        assert!(!is_matching_packages_index(
+            "dists/bookworm/main/binary-amd64/Release",
+            "main",
+            "amd64"
+        ));
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -8248,23 +8248,32 @@ mod tests {
 
     const STREAMING_CALL_TOKEN: &str = "proxy_helpers::proxy_fetch_streaming(";
 
+    /// The digest-gated streaming sibling: same streaming/tee semantics as
+    /// `proxy_fetch_streaming` (no buffering), plus a cache commit gated on
+    /// an expected SHA-256. The debian pool `.deb` download moved to this
+    /// helper in #2459 (Tier B cache-poisoning protection), so its pin
+    /// asserts this token instead — a revert to either the buffered
+    /// `proxy_fetch` OR the unverified streaming helper must fail the pin.
+    const VERIFIED_STREAMING_CALL_TOKEN: &str =
+        "proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(";
+
     /// One pin test per handler. Kept as separate `#[test]` functions
     /// (rather than a single loop) so a CI failure points directly at
     /// the regressing handler. The macro keeps the surface area small
     /// and stops the five near-identical functions from tripping the
     /// 3% duplication gate.
     macro_rules! streaming_pin_test {
-        ($name:ident, $module_file:literal, $what:literal) => {
+        ($name:ident, $module_file:literal, $token:expr, $what:literal) => {
             #[test]
             fn $name() {
                 let src = include_str!($module_file);
                 assert!(
-                    src.contains(STREAMING_CALL_TOKEN),
+                    src.contains($token),
                     "{} handler MUST call `{}` for {} (#1183). A revert \
                      to the buffered `proxy_fetch` helper would re-introduce \
                      the OOM regression closed by #895/#1181.",
                     $module_file,
-                    STREAMING_CALL_TOKEN,
+                    $token,
                     $what,
                 );
             }
@@ -8274,27 +8283,32 @@ mod tests {
     streaming_pin_test!(
         test_maven_remote_fetch_uses_streaming_helper_1183,
         "maven.rs",
+        STREAMING_CALL_TOKEN,
         "the remote catch-all download"
     );
     streaming_pin_test!(
         test_goproxy_remote_fetch_uses_streaming_helper_1183,
         "goproxy.rs",
+        STREAMING_CALL_TOKEN,
         "the remote `@v/<ver>.zip` download"
     );
     streaming_pin_test!(
         test_gitlfs_remote_fetch_uses_streaming_helper_1183,
         "gitlfs.rs",
+        STREAMING_CALL_TOKEN,
         "the remote LFS blob download (large binaries)"
     );
     streaming_pin_test!(
         test_alpine_remote_fetch_uses_streaming_helper_1183,
         "alpine.rs",
+        STREAMING_CALL_TOKEN,
         "the remote `.apk` download"
     );
     streaming_pin_test!(
         test_debian_remote_fetch_uses_streaming_helper_1183,
         "debian.rs",
-        "the remote pool `.deb` download"
+        VERIFIED_STREAMING_CALL_TOKEN,
+        "the remote pool `.deb` download (digest-gated cache commit, #2459)"
     );
 
     // -------------------------------------------------------------------

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -595,6 +595,92 @@ pub fn generate_release(
     release
 }
 
+/// Parse the `SHA256:` checksum section of a signed `Release`/`InRelease`
+/// document into a map of dist-relative path -> (sha256_hex, size).
+///
+/// Only the SHA256 section is honoured; the weaker `MD5Sum:` / `SHA1:`
+/// sections are ignored so they can never become a source of truth. A
+/// clearsigned `InRelease` wrapper is handled transparently: the PGP armor
+/// lines and the `Hash:` header do not match a checksum-entry shape, and the
+/// trailing signature block terminates the section like any other top-level
+/// field. Malformed or empty input yields an empty map.
+pub fn parse_release_checksums(release_text: &str) -> HashMap<String, (String, u64)> {
+    let mut out = HashMap::new();
+    let mut in_sha256 = false;
+    for line in release_text.lines() {
+        // Indented continuation lines inside the active section are entries.
+        if in_sha256 && (line.starts_with(' ') || line.starts_with('\t')) {
+            if let Some(h) = parse_release_hash_line(line) {
+                out.insert(h.path, (h.hash, h.size));
+            }
+            continue;
+        }
+        // A non-indented line is a field header; it switches sections.
+        in_sha256 = line.trim_end().eq_ignore_ascii_case("SHA256:");
+    }
+    out
+}
+
+/// Parse a single indented `Release` hash entry (`<hash> <size> <path>`) into
+/// a [`ReleaseHash`]. Returns `None` when the line does not carry exactly the
+/// three whitespace-separated fields or the size is not a number.
+fn parse_release_hash_line(line: &str) -> Option<ReleaseHash> {
+    let mut it = line.split_whitespace();
+    let hash = it.next()?.to_string();
+    let size = it.next()?.parse::<u64>().ok()?;
+    let path = it.next()?.to_string();
+    if it.next().is_some() || hash.is_empty() || path.is_empty() {
+        return None;
+    }
+    Some(ReleaseHash { hash, size, path })
+}
+
+/// Parse a `Packages` index into a map of `Filename` -> (sha256_hex, size).
+///
+/// Stanzas are separated by blank lines; a stanza missing any of `Filename`,
+/// `SHA256`, or `Size` (or with a non-numeric size) is skipped. Malformed or
+/// empty input yields an empty map.
+pub fn parse_packages_index(packages_text: &str) -> HashMap<String, (String, u64)> {
+    let mut out = HashMap::new();
+    let mut filename: Option<String> = None;
+    let mut sha256: Option<String> = None;
+    let mut size: Option<u64> = None;
+    for line in packages_text.lines() {
+        if line.trim().is_empty() {
+            insert_package_stanza(&mut out, &mut filename, &mut sha256, &mut size);
+            continue;
+        }
+        if let Some(v) = line.strip_prefix("Filename:") {
+            filename = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("SHA256:") {
+            sha256 = Some(v.trim().to_string());
+        } else if let Some(v) = line.strip_prefix("Size:") {
+            size = v.trim().parse::<u64>().ok();
+        }
+    }
+    insert_package_stanza(&mut out, &mut filename, &mut sha256, &mut size);
+    out
+}
+
+/// Flush a completed `Packages` stanza into `out`, resetting the accumulators.
+/// A stanza that did not collect all three required fields is discarded.
+fn insert_package_stanza(
+    out: &mut HashMap<String, (String, u64)>,
+    filename: &mut Option<String>,
+    sha256: &mut Option<String>,
+    size: &mut Option<u64>,
+) {
+    if let (Some(f), Some(s), Some(z)) = (filename.take(), sha256.take(), size.take()) {
+        if !f.is_empty() && !s.is_empty() {
+            out.insert(f, (s, z));
+        }
+    } else {
+        filename.take();
+        sha256.take();
+        size.take();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1256,5 +1342,117 @@ Source: full-pkg-src
     #[test]
     fn test_debian_handler_default() {
         let _handler = DebianHandler;
+    }
+
+    // ========================================================================
+    // parse_release_checksums tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_release_checksums_sha256_only() {
+        let release = "\
+Origin: Debian
+Suite: bookworm
+Date: Sat, 10 Jun 2023 10:00:00 UTC
+MD5Sum:
+ d41d8cd98f00b204e9800998ecf8427e 1024 main/binary-amd64/Packages
+SHA1:
+ da39a3ee5e6b4b0d3255bfef95601890afd80709 1024 main/binary-amd64/Packages
+SHA256:
+ aaa111 1024 main/binary-amd64/Packages
+ bbb222 512 main/binary-amd64/Packages.gz
+";
+        let table = parse_release_checksums(release);
+        assert_eq!(table.len(), 2);
+        assert_eq!(
+            table.get("main/binary-amd64/Packages"),
+            Some(&("aaa111".to_string(), 1024))
+        );
+        assert_eq!(
+            table.get("main/binary-amd64/Packages.gz"),
+            Some(&("bbb222".to_string(), 512))
+        );
+    }
+
+    #[test]
+    fn test_parse_release_checksums_inrelease_clearsigned() {
+        let inrelease = "\
+-----BEGIN PGP SIGNED MESSAGE-----
+Hash: SHA512
+
+Origin: Debian
+Suite: bookworm
+SHA256:
+ cafe01 4096 main/binary-amd64/Packages.xz
+-----BEGIN PGP SIGNATURE-----
+
+iQwertyBase64SignatureBytesabcdef==
+-----END PGP SIGNATURE-----
+";
+        let table = parse_release_checksums(inrelease);
+        assert_eq!(
+            table.get("main/binary-amd64/Packages.xz"),
+            Some(&("cafe01".to_string(), 4096))
+        );
+        // The base64 signature line must not be mistaken for an entry.
+        assert_eq!(table.len(), 1);
+    }
+
+    #[test]
+    fn test_parse_release_checksums_empty_and_malformed() {
+        assert!(parse_release_checksums("").is_empty());
+        assert!(parse_release_checksums("Suite: bookworm\nDate: today\n").is_empty());
+        // SHA256 header but a malformed (2-field) entry -> skipped.
+        assert!(parse_release_checksums("SHA256:\n deadbeef 1024\n").is_empty());
+    }
+
+    // ========================================================================
+    // parse_packages_index tests
+    // ========================================================================
+
+    #[test]
+    fn test_parse_packages_index_multi_stanza() {
+        let packages = "\
+Package: nginx
+Version: 1.24.0-1
+Architecture: amd64
+Filename: pool/main/n/nginx/nginx_1.24.0-1_amd64.deb
+Size: 512000
+MD5sum: 0123456789abcdef0123456789abcdef
+SHA256: 1111aaaa
+
+Package: curl
+Version: 8.0.1-1
+Architecture: amd64
+Filename: pool/main/c/curl/curl_8.0.1-1_amd64.deb
+Size: 250000
+SHA256: 2222bbbb
+";
+        let map = parse_packages_index(packages);
+        assert_eq!(map.len(), 2);
+        assert_eq!(
+            map.get("pool/main/n/nginx/nginx_1.24.0-1_amd64.deb"),
+            Some(&("1111aaaa".to_string(), 512000))
+        );
+        assert_eq!(
+            map.get("pool/main/c/curl/curl_8.0.1-1_amd64.deb"),
+            Some(&("2222bbbb".to_string(), 250000))
+        );
+    }
+
+    #[test]
+    fn test_parse_packages_index_partial_stanza_skipped() {
+        // Missing SHA256 -> stanza dropped.
+        let packages = "\
+Package: broken
+Filename: pool/main/b/broken/broken_1_amd64.deb
+Size: 100
+";
+        assert!(parse_packages_index(packages).is_empty());
+    }
+
+    #[test]
+    fn test_parse_packages_index_empty() {
+        assert!(parse_packages_index("").is_empty());
     }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -116,6 +116,15 @@ pub(crate) fn validate_remote_upstream(
                             .to_string(),
                     ));
                 }
+                if *format == RepositoryFormat::Debian && is_debian_flat_or_mirrorlist(url) {
+                    return Err(AppError::Validation(
+                        "Debian remote upstream must be a concrete archive root (apt expands \
+                         `dists/<suite>/...` beneath it), not a flat repository, mirrorlist, or \
+                         `mirror://` URL. Point it at the archive root (e.g. \
+                         http://deb.debian.org/debian)."
+                            .to_string(),
+                    ));
+                }
             }
         }
     } else if let Some(url) = upstream_url {
@@ -128,6 +137,43 @@ pub(crate) fn validate_remote_upstream(
 fn is_mirrorlist_or_metalink(url: &str) -> bool {
     let lower = url.to_ascii_lowercase();
     lower.contains("mirrorlist") || lower.contains("metalink")
+}
+
+/// Heuristic: a Debian remote upstream that is a flat repository, a
+/// mirrorlist, or the apt `mirror://` method rather than a concrete archive
+/// root. apt expands `dists/<suite>/...` beneath a proper archive root
+/// (e.g. `http://deb.debian.org/debian`), which this must NOT reject; it
+/// rejects the shapes the remote-proxy trust model cannot verify against a
+/// signed Release:
+///   * the apt mirror method (`mirror://`, `mirror+http(s)://`) and any
+///     mirrorlist/metalink naming,
+///   * a baseurl aimed straight at a dists index file (`.../Packages`,
+///     `.../Release`, `.../InRelease`, `.../Release.gpg`) — the flat-repo /
+///     misconfiguration shape, and
+///   * an explicit flat-repo distribution component (`deb <url> ./`).
+fn is_debian_flat_or_mirrorlist(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    if lower.starts_with("mirror://")
+        || lower.starts_with("mirror+http://")
+        || lower.starts_with("mirror+https://")
+    {
+        return true;
+    }
+    if lower.contains("mirrorlist") || lower.contains("metalink") {
+        return true;
+    }
+    let path = lower.split(['?', '#']).next().unwrap_or(&lower);
+    // Explicit flat-repo component (`deb <url> ./`).
+    if path.ends_with("/./") || path.ends_with(" ./") || path.ends_with("/.") {
+        return true;
+    }
+    let trimmed = path.trim_end_matches('/');
+    trimmed.ends_with("/packages")
+        || trimmed.ends_with("/packages.gz")
+        || trimmed.ends_with("/packages.xz")
+        || trimmed.ends_with("/inrelease")
+        || trimmed.ends_with("/release")
+        || trimmed.ends_with("/release.gpg")
 }
 
 /// Derive a format key string from a RepositoryFormat enum.
@@ -1791,6 +1837,40 @@ mod tests {
             validate_remote_upstream(&RepositoryType::Remote, &base, &RepositoryFormat::Rpm)
                 .is_ok()
         );
+    }
+
+    #[test]
+    fn test_debian_remote_rejects_flat_repo_and_mirrorlist() {
+        let mirror = Some("mirror://mirrors.ubuntu.com/mirrors.txt".to_string());
+        let mirrorlist = Some("https://mirrors.example.org/mirrorlist?dist=bookworm".to_string());
+        let flat_index = Some(
+            "http://apt.example.com/debian/dists/stable/main/binary-amd64/Packages".to_string(),
+        );
+        let flat_component = Some("http://apt.example.com/flat/ ./".to_string());
+        // A well-formed archive root (apt expands `dists/<suite>/...` beneath).
+        let base = Some("http://deb.debian.org/debian".to_string());
+        let ubuntu = Some("http://archive.ubuntu.com/ubuntu".to_string());
+
+        for bad in [&mirror, &mirrorlist, &flat_index, &flat_component] {
+            assert!(
+                validate_remote_upstream(&RepositoryType::Remote, bad, &RepositoryFormat::Debian)
+                    .is_err(),
+                "expected rejection for {:?}",
+                bad
+            );
+        }
+        assert!(validate_remote_upstream(
+            &RepositoryType::Remote,
+            &base,
+            &RepositoryFormat::Debian
+        )
+        .is_ok());
+        assert!(validate_remote_upstream(
+            &RepositoryType::Remote,
+            &ubuntu,
+            &RepositoryFormat::Debian
+        )
+        .is_ok());
     }
 
     // -----------------------------------------------------------------------

--- a/scripts/e2e-syspkg/test-debian.sh
+++ b/scripts/e2e-syspkg/test-debian.sh
@@ -123,5 +123,46 @@ INSTALLED_CONTENT=$(cat "/opt/$PKG_NAME/test-file.txt" 2>/dev/null) || fail "Ins
 echo "$INSTALLED_CONTENT" | grep -q "$TEST_VERSION" || fail "Version mismatch in installed file"
 log "Installed file content verified"
 
+# ---------------------------------------------------------------------------
+# Remote-proxy variant (#2459 regression guard): a Remote debian repo whose
+# upstream is the signed hosted repo above must still serve apt metadata and
+# packages through the proxy. This exercises the Tier A signed-Release
+# integrity check (which must pass for honest, matching content) and the
+# Tier B pool-download cache-key gating without breaking a well-formed remote.
+# ---------------------------------------------------------------------------
+REMOTE_KEY="e2e-debian-remote-$(date +%s)"
+UPSTREAM_URL="$BACKEND_URL/debian/$REPO_KEY"
+log "Creating Remote debian repo $REMOTE_KEY -> $UPSTREAM_URL"
+REMOTE_CODE=$(curl -s -o /tmp/remote-repo.json -w "%{http_code}" -X POST \
+    "$BACKEND_URL/api/v1/repositories" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "{\"key\":\"$REMOTE_KEY\",\"name\":\"E2E $REMOTE_KEY\",\"format\":\"debian\",\"repo_type\":\"remote\",\"upstream_url\":\"$UPSTREAM_URL\",\"is_public\":true}")
+[ "$REMOTE_CODE" = "200" ] || [ "$REMOTE_CODE" = "201" ] \
+    || fail "Failed to create remote debian repo (HTTP $REMOTE_CODE): $(cat /tmp/remote-repo.json)"
+log "Remote repo created ($REMOTE_CODE)"
+
+log "Adding apt source for the remote proxy (signed-by same key)..."
+echo "deb [signed-by=/etc/apt/keyrings/e2e-registry.gpg] $BACKEND_URL/debian/$REMOTE_KEY stable main" \
+    > /etc/apt/sources.list.d/e2e-remote.list
+# Isolate to the remote source so the fetch is provably through the proxy.
+mv /etc/apt/sources.list.d/e2e-registry.list /tmp/e2e-registry.list.bak
+
+log "apt-get update through the remote proxy..."
+apt-get update 2>&1 | tail -10
+apt-cache show "$PKG_NAME" 2>&1 | grep -q "Package: $PKG_NAME" \
+    || fail "remote proxy did not serve a verified Packages index for $PKG_NAME"
+
+log "Downloading $PKG_NAME through the remote pool proxy..."
+REMOTE_DL_DIR="$(mktemp -d)"
+( cd "$REMOTE_DL_DIR" && apt-get download "$PKG_NAME" ) 2>&1 || fail "apt-get download via remote proxy failed"
+[ -n "$(find "$REMOTE_DL_DIR" -name '*.deb' | head -1)" ] \
+    || fail "remote pool proxy produced no .deb"
+log "Remote-proxy Packages + pool download verified"
+
+# Restore the hosted source for any later stages.
+mv /tmp/e2e-registry.list.bak /etc/apt/sources.list.d/e2e-registry.list
+rm -rf "$REMOTE_DL_DIR"
+
 echo ""
 echo "=== Debian/APT E2E test PASSED ==="


### PR DESCRIPTION
## Summary

Debian remote-proxy hardening (P1) — brings the Debian proxy path to
parity with the RPM Phase-1 trust model. Two upstream-trust gaps are
closed for `repo_type == Remote` repositories only; hosted/local/virtual
metadata generation is untouched.

**1. Signed-Release integrity verification (Tier A, mandatory).**
Every `dists/` index proxied from a Remote upstream is now checked against
the SHA-256 checksum table of the repository's signed `Release`/`InRelease`
before it is served or persisted. The signed Release is loaded via the
existing revalidation path and its `SHA256:` section parsed (the weaker
`MD5Sum`/`SHA1` sections are ignored). If a fetched index the Release
vouches for does not match on SHA-256 *or* size, the proxy returns **502**
and evicts the just-written cache entry instead of serving/caching it.
`.gz`/`.xz` and by-hash index variants are handled (the Release entry is
per-compression; by-hash paths are content-addressed and verified against
the digest embedded in the path). When no signed Release can be loaded the
fetch is served unchanged — mirroring apt, which itself refuses unsigned
indices downstream.

**2. Pool `.deb` cache-poisoning protection (Tier B, best-effort).**
A pool `.deb` download now gates its proxy-cache commit on the SHA-256 the
cached `Packages` index records for that `Filename`. A body that does not
match is still streamed to the client (which verifies it independently) but
is never written to the proxy cache, so a mismatching upstream cannot poison
the shared cache. The `.deb` stays fully streamed — it is never buffered
(preserves the streaming-download invariant). When no cached `Packages`
index covers the file the download behaves exactly as before.

The cached `Packages` index is decompressed under bounded memory when the expected checksum is resolved: the decompressed size is capped (128 MiB) and an oversized compressed body (>32 MiB) is skipped, so a signed Release that vouches for a small compressed index which expands unbounded (a decompression bomb) cannot exhaust memory. Over-limit input is treated as unresolvable and the download falls back to the Content-Length-gated cache commit.

**3. Flat-repo / mirrorlist upstream rejection.**
`validate_remote_upstream` now rejects Debian flat-repository, mirrorlist,
and apt `mirror://` upstreams at repository-create time (400), the same way
it already rejects RPM mirrorlist/metalink baseurls. A normal archive root
such as `http://deb.debian.org/debian` (apt expands `dists/<suite>/...`
beneath it) is still accepted.

The connect-time SSRF IP check on Debian upstream fetches is already
inherited from the shared `UpstreamClient` (fail-closed SSRF DNS resolver);
this PR does not change it. Cloud-metadata / loopback / link-local addresses
remain hard-blocked regardless of any private-IP relaxation.

Scope-out (tracked separately): metadata filtering (#2460), metadata
generation (#2461), local signing (#2462).

Closes #2459

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New/updated tests:
- `formats::debian`: `parse_release_checksums` (SHA256-only, InRelease
  clearsigned wrapper, empty/malformed) and `parse_packages_index`
  (multi-stanza, partial-stanza-skipped, empty).
- `api::handlers::debian`: `verify_index_against_release`
  (match / SHA mismatch / size mismatch / by-hash / not-covered),
  the pool `resolve_pool_deb_checksum` resolver (hit/miss), `is_matching_packages_index`, and the bounded
  `decompress_packages_index` (honest gz/xz/plain resolve; a decompression
  bomb and an oversized compressed body return None with no OOM).
- `services::repository_service`:
  `test_debian_remote_rejects_flat_repo_and_mirrorlist` (mirror://,
  mirrorlist, flat Packages index, `./` component rejected; concrete
  archive roots accepted), mirroring the RPM test.
- E2E: `scripts/e2e-syspkg/test-debian.sh` gains a Remote-proxy variant
  (create a Remote debian repo over the signed hosted repo → `apt update`
  + package download through the proxy still succeed).

Manual validation on an isolated pool instance:
- Honest Remote `Packages` → 200; a validly-Release-listed `Packages`
  served with wrong bytes → 502, and the poisoned entry is not persisted
  in the proxy cache.
- A pool `.deb` whose bytes mismatch the `Packages` SHA-256 → streamed
  (200) but not written to the proxy cache; the honest `.deb` is cached
  (legit path intact).
- Flat-repo / mirrorlist / `mirror://` upstream → 400 at repo create;
  `http://deb.debian.org/debian` and `http://archive.ubuntu.com/ubuntu`
  accepted.

## API Changes
- [x] N/A - no API changes
