### PR TITLE
fix: make OCI /v2/token registry refresh tokens reusable (non-rotating)

### DIFF
--- a/.sqlx/query-3df6ff59a318b1b8577d2d46c1f0db76221914ab34473cc60ce025ca31cc70c3.json
+++ b/.sqlx/query-3df6ff59a318b1b8577d2d46c1f0db76221914ab34473cc60ce025ca31cc70c3.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT revoked_at\n                FROM refresh_token_jti\n                WHERE jti = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "revoked_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "3df6ff59a318b1b8577d2d46c1f0db76221914ab34473cc60ce025ca31cc70c3"
+}

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -3660,18 +3660,23 @@ fn offline_access_type_from_query(offline_token: Option<&str>) -> Option<String>
     }
 }
 
-/// Exchange a refresh token for a fresh access token plus the rotated
-/// replacement refresh token (rotation is mandatory — see the comment on
-/// the response construction below). Per
-/// [the Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
+/// Exchange a (reusable) offline refresh token for a fresh access token.
+/// Per [the Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
 /// the refresh-grant request body is just `grant_type=refresh_token` +
 /// `refresh_token=…` with no credentials — the refresh token itself
-/// authenticates.
+/// authenticates — and the SAME offline token is presented every time the
+/// access token expires. This path therefore uses
+/// `auth_service::mint_access_from_registry_refresh` (non-rotating; #2477)
+/// rather than the interactive `refresh_tokens` rotation used by
+/// `POST /api/v1/auth/refresh`, whose single-use + replay-family-revocation
+/// semantics treated the daemon's expected reuse as an attack and revoked
+/// the family, failing every subsequent pull.
 ///
-/// `auth_service::refresh_tokens` filters `is_active = true` and consults
-/// `is_token_invalidated`, so any of (a) deactivated user, (b) password
-/// change since issue, (c) TOTP enable/disable since issue, will surface
-/// here as a 401.
+/// `mint_access_from_registry_refresh` still filters `is_active = true`,
+/// consults the credential-change watermark, and honors explicit
+/// `refresh_token_jti.revoked_at`, so any of (a) deactivated user,
+/// (b) password change since issue, (c) TOTP enable/disable since issue,
+/// (d) logout/admin family revocation, will surface here as a 401.
 async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response {
     let refresh = match form.refresh_token.as_deref() {
         Some(s) if !s.is_empty() => s,
@@ -3684,7 +3689,10 @@ async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response
         }
     };
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
-    let (_user, tokens) = match auth_service.refresh_tokens(refresh).await {
+    let (_user, tokens) = match auth_service
+        .mint_access_from_registry_refresh(refresh)
+        .await
+    {
         Ok(pair) => pair,
         Err(_) => {
             return oci_error(
@@ -3699,14 +3707,11 @@ async fn handle_refresh_grant(state: &SharedState, form: &TokenForm) -> Response
     // suppression already prevented one being issued for an API-token
     // session.
     //
-    // The rotated refresh token is ALWAYS returned here, regardless of
-    // `access_type`. `auth_service::refresh_tokens` performs mandatory
-    // single-use rotation (#1174): the presented refresh token was just
-    // marked consumed and a replacement minted. Gating the replacement on
-    // `access_type=offline` (as the first-issuance path correctly does)
-    // would discard the only live refresh token — the client would retry
-    // with the consumed one, trip replay detection, and get its whole
-    // token family revoked.
+    // A refresh token is ALWAYS returned here, regardless of `access_type`,
+    // and it is the PRESENTED token unchanged
+    // (`mint_access_from_registry_refresh` does not rotate, #2477). Docker
+    // clients replace their stored offline token with whatever this field
+    // carries, so echoing the same token keeps their credential live.
     let resp = TokenResponse {
         token: tokens.access_token.clone(),
         access_token: tokens.access_token.clone(),
@@ -4042,15 +4047,44 @@ async fn token(
         );
     }
 
+    // Emit a REUSABLE, registry-marked offline refresh token (#2477/#2487)
+    // only when the client asked for one AND did not authenticate via an API
+    // token (see `offline_refresh_token` for the suppression rationale, which
+    // still governs the decision here). It is minted FRESH with
+    // `REGISTRY_REFRESH_TOKEN_TYPE` rather than echoing the web-shaped refresh
+    // token from `authenticate`, so it is usable only on this `/v2/token`
+    // path and can never be replayed against the interactive
+    // `/api/v1/auth/refresh` endpoint. Interactive auth is always
+    // unrestricted, so the offline token inherits no repo/scope ceiling here.
+    let refresh_token = if offline_refresh_token(
+        access_type.as_deref(),
+        authenticated_via_api_token,
+        &tokens.refresh_token,
+    )
+    .is_some()
+    {
+        match auth_service
+            .generate_registry_offline_token(&user, None, None)
+            .await
+        {
+            Ok(rt) => Some(rt),
+            Err(_) => {
+                return oci_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "INTERNAL_ERROR",
+                    "failed to generate tokens",
+                )
+            }
+        }
+    } else {
+        None
+    };
+
     let resp = TokenResponse {
         token: tokens.access_token.clone(),
         access_token: tokens.access_token.clone(),
         expires_in: tokens.expires_in,
-        refresh_token: offline_refresh_token(
-            access_type.as_deref(),
-            authenticated_via_api_token,
-            &tokens.refresh_token,
-        ),
+        refresh_token,
         issued_at: chrono::Utc::now().to_rfc3339(),
     };
 
@@ -22472,13 +22506,13 @@ mod token_refresh_grant_tests {
     }
 
     /// Refresh-grant default (no `access_type`) → new access token AND the
-    /// rotated refresh token. `auth_service::refresh_tokens` consumes the
-    /// presented refresh token unconditionally (#1174), so the response must
-    /// always hand back the replacement — omitting it would strand the
-    /// client with a consumed token and trip replay detection on its next
-    /// refresh (see `refresh_grant_rotated_token_can_refresh_again`).
+    /// PRESENTED refresh token echoed back unchanged. The registry offline
+    /// token is reusable per the Distribution OAuth2 spec (#2477):
+    /// `mint_access_from_registry_refresh` neither consumes nor rotates it,
+    /// and the handler must return it so Docker clients that overwrite their
+    /// stored credential with the response field keep a live token.
     #[tokio::test]
-    async fn refresh_grant_default_returns_rotated_refresh_token() {
+    async fn refresh_grant_returns_presented_refresh_token_unrotated() {
         let Some((pool, user_id, username, state, _)) = setup().await else {
             return;
         };
@@ -22507,24 +22541,21 @@ mod token_refresh_grant_tests {
         assert!(body["access_token"]
             .as_str()
             .is_some_and(|s| !s.is_empty() && s != "anonymous"));
-        let rotated = body["refresh_token"]
-            .as_str()
-            .expect("refresh-grant must return the rotated refresh token");
-        assert_ne!(
-            rotated, refresh,
-            "returned refresh token must be the rotated replacement, not the consumed original"
+        assert_eq!(
+            body["refresh_token"].as_str(),
+            Some(refresh.as_str()),
+            "refresh-grant must echo the presented (reusable) refresh token unchanged"
         );
     }
 
-    /// Two-call regression for the rotation/DoS bug: refresh, then refresh
-    /// AGAIN with the token returned by the first refresh. Because
-    /// `auth_service::refresh_tokens` consumes the presented token and mints
-    /// a replacement, the handler must return that replacement — a client
-    /// that only ever sees the original would replay it, trip
-    /// `revoke_all_refresh_token_families`, and lose its whole session. The
-    /// second call succeeding proves the client was handed a live token.
+    /// The #2477 regression test: the SAME offline refresh token presented
+    /// twice must succeed BOTH times. Docker daemons re-POST the stored
+    /// token on every access-token expiry; before the fix the second
+    /// presentation went through `auth_service::refresh_tokens`, tripped
+    /// replay detection, revoked the whole token family, and every
+    /// subsequent pull failed with `invalid username or password`.
     #[tokio::test]
-    async fn refresh_grant_rotated_token_can_refresh_again() {
+    async fn refresh_grant_same_token_twice_succeeds_no_family_revocation() {
         let Some((pool, user_id, username, state, _)) = setup().await else {
             return;
         };
@@ -22544,47 +22575,52 @@ mod token_refresh_grant_tests {
             .expect("issued refresh")
             .to_string();
 
-        // First refresh (default, no access_type) — must return the rotated
-        // refresh token.
-        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
-        let resp = app
-            .clone()
-            .oneshot(form_post("/token", body))
-            .await
-            .unwrap();
-        let first_status = resp.status();
-        let json = read_body(resp).await;
-        let rotated = json["refresh_token"].as_str().map(str::to_string);
+        let mut statuses = Vec::new();
+        let mut last_json = serde_json::Value::Null;
+        for _ in 0..3 {
+            let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+            let resp = app
+                .clone()
+                .oneshot(form_post("/token", body))
+                .await
+                .unwrap();
+            statuses.push(resp.status());
+            last_json = read_body(resp).await;
+        }
 
-        // Second refresh with whatever the first refresh handed back.
-        let Some(rotated) = rotated else {
-            cleanup(&pool, user_id).await;
-            panic!("first refresh-grant response did not include a refresh token: {json}");
-        };
-        let body = format!("grant_type=refresh_token&refresh_token={rotated}");
-        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
-        let second_status = resp.status();
-        let json = read_body(resp).await;
+        // The family must not have been revoked by the reuse: no row for
+        // this user may carry `revoked_at`.
+        let revoked: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM refresh_token_jti \
+             WHERE user_id = $1 AND revoked_at IS NOT NULL",
+        )
+        .bind(user_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count revoked rows");
+        let _ = sqlx::query("DELETE FROM refresh_token_jti WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await;
         cleanup(&pool, user_id).await;
 
-        assert_eq!(first_status, StatusCode::OK);
-        assert_eq!(
-            second_status,
-            StatusCode::OK,
-            "second refresh with the rotated token must succeed (no family revocation): {json}"
+        assert!(
+            statuses.iter().all(|s| *s == StatusCode::OK),
+            "every reuse of the offline token must succeed, got {statuses:?}: {last_json}"
         );
-        assert!(json["access_token"]
+        assert!(last_json["access_token"]
             .as_str()
             .is_some_and(|s| !s.is_empty() && s != "anonymous"));
-        assert!(
-            json["refresh_token"].as_str().is_some(),
-            "second refresh must also return a rotated refresh token: {json}"
+        assert_eq!(
+            revoked, 0,
+            "reusing the registry offline token must NOT revoke the token family"
         );
     }
 
-    /// Refresh-grant + `access_type=offline` rotates the refresh token.
+    /// Refresh-grant + `access_type=offline` also echoes the presented
+    /// token (the offline flag changes nothing on this path).
     #[tokio::test]
-    async fn refresh_grant_offline_rotates_refresh_token() {
+    async fn refresh_grant_offline_echoes_presented_refresh_token() {
         let Some((pool, user_id, username, state, _)) = setup().await else {
             return;
         };
@@ -22611,9 +22647,66 @@ mod token_refresh_grant_tests {
         cleanup(&pool, user_id).await;
         assert_eq!(status, StatusCode::OK);
         assert!(body["access_token"].as_str().is_some_and(|s| !s.is_empty()));
-        assert!(
-            body["refresh_token"].as_str().is_some(),
-            "offline refresh-grant should mint a new refresh: {body}"
+        assert_eq!(
+            body["refresh_token"].as_str(),
+            Some(refresh.as_str()),
+            "offline refresh-grant must echo the presented refresh token: {body}"
+        );
+    }
+
+    /// Explicit revocation still bounds the reusable token: after
+    /// `revoke_all_refresh_token_families` (logout / kill-all-sessions /
+    /// deactivation sweep) the refresh-grant must return 401 even though
+    /// this path never revokes on reuse.
+    #[tokio::test]
+    async fn refresh_grant_after_family_revocation_returns_401() {
+        let Some((pool, user_id, username, state, auth_service)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        let body = format!(
+            "grant_type=password&username={username}&password=real-test-password&access_type=offline"
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let json = read_body(resp).await;
+        let refresh = json["refresh_token"]
+            .as_str()
+            .expect("issued refresh")
+            .to_string();
+
+        // Reusable before revocation (control).
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let pre_status = resp.status();
+
+        auth_service
+            .revoke_all_refresh_token_families(user_id)
+            .await
+            .expect("revoke families");
+
+        let body = format!("grant_type=refresh_token&refresh_token={refresh}");
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let post_status = resp.status();
+        let _ = sqlx::query("DELETE FROM refresh_token_jti WHERE user_id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await;
+        cleanup(&pool, user_id).await;
+
+        assert_eq!(pre_status, StatusCode::OK, "control reuse must succeed");
+        assert_eq!(
+            post_status,
+            StatusCode::UNAUTHORIZED,
+            "explicitly revoked offline token must be rejected"
         );
     }
 
@@ -22834,6 +22927,62 @@ mod token_refresh_grant_tests {
             status,
             StatusCode::UNAUTHORIZED,
             "deactivated user must not mint fresh tokens via refresh-grant"
+        );
+    }
+
+    /// #2487 (probe #5): a web-session refresh token (bare `token_type
+    /// "refresh"`, minted by `authenticate` for the interactive login flow)
+    /// presented to `/v2/token grant_type=refresh_token` must be rejected —
+    /// the registry path requires the registry marker, so it cannot be used
+    /// as a replay oracle for the web single-use rotation family. Also covers
+    /// an already-CONSUMED web token (rotated once on the web path first).
+    #[tokio::test]
+    async fn refresh_grant_rejects_web_session_refresh_token() {
+        let Some((pool, user_id, username, state, auth_service)) = setup().await else {
+            return;
+        };
+        let app = router().with_state(state);
+
+        // Interactive login mints a web-session refresh token.
+        let (_user, web) = auth_service
+            .authenticate(&username, "real-test-password")
+            .await
+            .expect("interactive authenticate");
+
+        // Fresh web token → /v2/token → 401.
+        let body = format!(
+            "grant_type=refresh_token&refresh_token={}",
+            web.refresh_token
+        );
+        let resp = app
+            .clone()
+            .oneshot(form_post("/token", body))
+            .await
+            .unwrap();
+        let fresh_status = resp.status();
+
+        // Consume it on the web path, then replay the original at /v2/token.
+        auth_service
+            .refresh_tokens(&web.refresh_token)
+            .await
+            .expect("web rotation consumes the token");
+        let body = format!(
+            "grant_type=refresh_token&refresh_token={}",
+            web.refresh_token
+        );
+        let resp = app.oneshot(form_post("/token", body)).await.unwrap();
+        let consumed_status = resp.status();
+
+        cleanup(&pool, user_id).await;
+        assert_eq!(
+            fresh_status,
+            StatusCode::UNAUTHORIZED,
+            "a web-session refresh token must not mint via the /v2/token registry path"
+        );
+        assert_eq!(
+            consumed_status,
+            StatusCode::UNAUTHORIZED,
+            "an already-consumed web refresh token must not be revived via /v2/token"
         );
     }
 }

--- a/backend/src/services/auth_service.rs
+++ b/backend/src/services/auth_service.rs
@@ -79,6 +79,21 @@ pub struct RoleMapping {
     pub roles: Vec<String>,
 }
 
+/// `token_type` marker for OCI registry offline refresh tokens (#2487).
+///
+/// The Docker `/v2/token` offline token is byte-identical in shape to a
+/// web-session refresh token except for this discriminator. It exists so the
+/// two refresh classes are mutually exclusive across endpoints:
+///   * `mint_access_from_registry_refresh` (the reusable, non-rotating
+///     `/v2/token` path) REQUIRES this marker and rejects a bare `"refresh"`
+///     web token — otherwise the non-consuming path would be a replay oracle
+///     that revives already-rotated/consumed web tokens, bypassing single-use
+///     rotation + replay-family-revocation.
+///   * `refresh_tokens` (the interactive `/api/v1/auth/refresh` path) keeps
+///     its `token_type != "refresh"` guard, so a registry token carrying this
+///     marker is rejected there too.
+pub(crate) const REGISTRY_REFRESH_TOKEN_TYPE: &str = "registry_refresh";
+
 /// Result of API token validation: the user plus the token's constraints.
 #[derive(Debug, Clone)]
 pub struct ApiTokenValidation {
@@ -1251,6 +1266,26 @@ impl AuthService {
         allowed_repo_ids: Option<Vec<Uuid>>,
         scopes: Option<Vec<String>>,
     ) -> Result<TokenPair> {
+        // Web/interactive refresh tokens carry the bare "refresh" type. The
+        // registry offline path uses `generate_registry_offline_token`
+        // (REGISTRY_REFRESH_TOKEN_TYPE) instead so the two token classes are
+        // never interchangeable across the two refresh endpoints (#2487).
+        self.generate_token_pair_typed(user, family_id, allowed_repo_ids, scopes, "refresh")
+    }
+
+    /// Core token-pair minter. `refresh_token_type` stamps the refresh JWT's
+    /// `token_type` claim: `"refresh"` for the interactive web-session path
+    /// (single-use rotation via [`refresh_tokens`]) or
+    /// [`REGISTRY_REFRESH_TOKEN_TYPE`] for the reusable, non-rotating OCI
+    /// registry path (#2487). The access claims are identical either way.
+    fn generate_token_pair_typed(
+        &self,
+        user: &User,
+        family_id: Uuid,
+        allowed_repo_ids: Option<Vec<Uuid>>,
+        scopes: Option<Vec<String>>,
+        refresh_token_type: &str,
+    ) -> Result<TokenPair> {
         let now = Utc::now();
         // Capture the millisecond instant once so access and refresh tokens
         // share the exact same `iat_ms` ordering anchor.
@@ -1284,7 +1319,7 @@ impl AuthService {
             iat: now.timestamp(),
             iat_ms: Some(now_ms),
             exp: refresh_exp.timestamp(),
-            token_type: "refresh".to_string(),
+            token_type: refresh_token_type.to_string(),
             jti: Some(refresh_jti),
             family_id: Some(family_id),
             scan_pull_repo: None,
@@ -1623,6 +1658,154 @@ impl AuthService {
         )?;
         self.persist_refresh_jti_from_pair(&tokens, user.id).await?;
         Ok((user, tokens))
+    }
+
+    /// Non-rotating refresh for the OCI registry flow (`/v2/token` with
+    /// `grant_type=refresh_token`, #2477).
+    ///
+    /// Per the [Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/),
+    /// the offline token is a long-lived **reusable** credential: the Docker
+    /// daemon stores it once and presents the SAME token every time its
+    /// short-lived access token expires. Running that flow through
+    /// [`AuthService::refresh_tokens`] (single-use rotation +
+    /// replay-family-revocation per RFC 9700 §2.2.2) mis-classified the
+    /// second presentation as a replay, revoked the whole family, and broke
+    /// every subsequent pull with `invalid username or password` (#2477).
+    /// Rotation is an interactive web-session semantic
+    /// (`POST /api/v1/auth/refresh`); the registry grant uses this dedicated
+    /// path instead.
+    ///
+    /// The reusable token remains fully bounded:
+    ///   * signature + expiry via [`decode_token`](Self::decode_token) and
+    ///     the [`REGISTRY_REFRESH_TOKEN_TYPE`] discriminator check — a
+    ///     web-session refresh token (bare `token_type == "refresh"`, even one
+    ///     already consumed/rotated) is rejected here (#2487), so this
+    ///     non-consuming path can never be used as a replay oracle for the
+    ///     interactive single-use rotation family;
+    ///   * the replica-safe credential-change watermark (password change,
+    ///     TOTP toggle, privilege change since issuance) via
+    ///     [`is_token_invalidated_replica_safe`] → 401;
+    ///   * explicit revocation: `refresh_token_jti.revoked_at` on the
+    ///     presented `jti` (logout, deactivation sweep, admin family
+    ///     revocation) → 401;
+    ///   * account state: `users.is_active = true` via
+    ///     [`load_active_user`](Self::load_active_user) → 401.
+    ///
+    /// It does NOT consume the `jti` and does NOT revoke the family on
+    /// reuse. The minted access token preserves the presenting token's
+    /// `allowed_repo_ids` and action-scope ceiling so a refresh can never
+    /// widen the grant (#2430). The returned `TokenPair.refresh_token` is
+    /// the presented token, unchanged.
+    pub async fn mint_access_from_registry_refresh(
+        &self,
+        refresh_token: &str,
+    ) -> Result<(User, TokenPair)> {
+        let token_data = self.decode_token(refresh_token)?;
+
+        // REQUIRE the registry marker. A bare web-session refresh token
+        // (`token_type == "refresh"`) must NOT be accepted on this
+        // non-consuming path, or it would bypass the single-use rotation +
+        // replay-family-revocation that contains web token theft (#2487).
+        if token_data.claims.token_type != REGISTRY_REFRESH_TOKEN_TYPE {
+            return Err(AppError::Authentication("Invalid token type".to_string()));
+        }
+
+        if is_token_invalidated_replica_safe(
+            &self.db,
+            token_data.claims.sub,
+            token_data.claims.effective_iat_ms(),
+        )
+        .await?
+        {
+            return Err(AppError::Authentication(
+                "Token invalidated by credential change".to_string(),
+            ));
+        }
+
+        // Honor explicit revocation WITHOUT consuming the row: reuse is
+        // expected on this path, so `consumed_at` is neither set nor checked
+        // here. Tokens minted before the jti table existed have no row and
+        // fall through to the watermark + is_active bounds above/below.
+        if let Some(jti) = token_data.claims.jti {
+            let row = sqlx::query!(
+                r#"
+                SELECT revoked_at
+                FROM refresh_token_jti
+                WHERE jti = $1
+                "#,
+                jti
+            )
+            .fetch_optional(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+            if row.is_some_and(|r| r.revoked_at.is_some()) {
+                tracing::warn!(
+                    user_id = %token_data.claims.sub,
+                    jti = %jti,
+                    "Registry refresh token rejected: revoked",
+                );
+                return Err(AppError::Authentication(
+                    "Refresh token has been revoked".to_string(),
+                ));
+            }
+        }
+
+        let user = self.load_active_user(token_data.claims.sub).await?;
+
+        // Mint a fresh short-lived access token under the presenting token's
+        // repo allow-list and action-scope ceiling (#2430). The refresh JWT
+        // that `generate_tokens_with_family_and_scope` also mints is
+        // discarded here — never returned to any caller and never persisted
+        // to `refresh_token_jti` — so this path cannot spawn additional
+        // refresh credentials: the client keeps exactly the token it
+        // presented.
+        let minted = self.generate_tokens_with_family_and_scope(
+            &user,
+            token_data.claims.family_id.unwrap_or_else(Uuid::new_v4),
+            token_data.claims.allowed_repo_ids.clone(),
+            token_data.claims.scopes.clone(),
+        )?;
+
+        Ok((
+            user,
+            TokenPair {
+                access_token: minted.access_token,
+                refresh_token: refresh_token.to_string(),
+                expires_in: minted.expires_in,
+            },
+        ))
+    }
+
+    /// Mint a reusable OCI registry offline refresh token (#2477/#2487).
+    ///
+    /// Stamps the refresh JWT with [`REGISTRY_REFRESH_TOKEN_TYPE`] so it is
+    /// accepted ONLY by [`mint_access_from_registry_refresh`] (the
+    /// non-rotating `/v2/token` path) and rejected by [`refresh_tokens`] (the
+    /// interactive `/api/v1/auth/refresh` path). Persists the `jti` so
+    /// logout / deactivation / admin family-revocation still bound it exactly
+    /// like a web-session token. `allowed_repo_ids` / `scopes` carry the
+    /// presenting credential's ceiling forward (#2430).
+    ///
+    /// Returns the bare refresh-token string; the access token minted
+    /// alongside it is discarded (the OCI handler returns its own access
+    /// token from the password/credential grant), so this never spawns an
+    /// extra usable access credential.
+    pub async fn generate_registry_offline_token(
+        &self,
+        user: &User,
+        allowed_repo_ids: Option<Vec<Uuid>>,
+        scopes: Option<Vec<String>>,
+    ) -> Result<String> {
+        let pair = self.generate_token_pair_typed(
+            user,
+            Uuid::new_v4(),
+            allowed_repo_ids,
+            scopes,
+            REGISTRY_REFRESH_TOKEN_TYPE,
+        )?;
+        self.persist_refresh_jti_from_pair(&pair, user.id).await?;
+        Ok(pair.refresh_token)
     }
 
     /// Fetch a user row by id, rejecting deactivated accounts. Shared by the
@@ -6881,6 +7064,417 @@ mod tests {
         // carried on refresh tokens, so they are out of scope for this check.)
         assert_eq!(rotated.scopes, ceiling);
 
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #2477: non-rotating registry refresh (OCI /v2/token refresh grant).
+    // The interactive-rotation guarantees are covered separately above
+    // (`test_refresh_token_replay_revokes_family`,
+    // `test_refresh_token_legitimate_rotation_succeeds`) and are unchanged.
+    // -----------------------------------------------------------------------
+
+    /// Runtime (non-macro) row check so the test compiles without a `.sqlx`
+    /// cache entry. Returns `(consumed, revoked)` counts for the user's rows.
+    async fn jti_counts(pool: &sqlx::PgPool, user_id: Uuid) -> (i64, i64) {
+        let consumed: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM refresh_token_jti \
+             WHERE user_id = $1 AND consumed_at IS NOT NULL",
+        )
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("count consumed");
+        let revoked: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM refresh_token_jti \
+             WHERE user_id = $1 AND revoked_at IS NOT NULL",
+        )
+        .bind(user_id)
+        .fetch_one(pool)
+        .await
+        .expect("count revoked");
+        (consumed, revoked)
+    }
+
+    /// #2477 regression: the SAME offline token presented repeatedly must
+    /// keep minting access tokens — no single-use consumption, no
+    /// replay-family-revocation — and the presented refresh token comes
+    /// back unchanged.
+    #[tokio::test]
+    async fn test_registry_refresh_is_reusable_and_does_not_consume_jti() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let service = AuthService::new(pool.clone(), make_test_config());
+
+        let username = format!("regref_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        let offline = service
+            .generate_registry_offline_token(&user, None, None)
+            .await
+            .expect("mint registry offline token");
+
+        for attempt in 1..=3 {
+            let (_, minted) = service
+                .mint_access_from_registry_refresh(&offline)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!("registry refresh attempt {attempt} must succeed, got {e:?}")
+                });
+            assert_eq!(
+                minted.refresh_token, offline,
+                "presented refresh token must be returned unchanged"
+            );
+            assert!(!minted.access_token.is_empty());
+        }
+
+        let (consumed, revoked) = jti_counts(&pool, user_id).await;
+        assert_eq!(consumed, 0, "registry refresh must NOT consume the jti");
+        assert_eq!(
+            revoked, 0,
+            "registry refresh reuse must NOT revoke the token family"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Explicit revocation (logout / kill-all-sessions / admin sweep) still
+    /// bounds the reusable registry token.
+    #[tokio::test]
+    async fn test_registry_refresh_rejects_explicitly_revoked_token() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let service = AuthService::new(pool.clone(), make_test_config());
+
+        let username = format!("regrev_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        let offline = service
+            .generate_registry_offline_token(&user, None, None)
+            .await
+            .expect("mint registry offline token");
+
+        // Control: reusable before revocation.
+        assert!(
+            service
+                .mint_access_from_registry_refresh(&offline)
+                .await
+                .is_ok(),
+            "control registry refresh must succeed before revocation"
+        );
+
+        service
+            .revoke_all_refresh_token_families(user_id)
+            .await
+            .expect("revoke families");
+
+        let err = service
+            .mint_access_from_registry_refresh(&offline)
+            .await
+            .expect_err("revoked registry token must be rejected");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "expected Authentication error, got {err:?}"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Deactivated account: `load_active_user` filters `is_active = true`
+    /// with a direct DB read, so the reusable token dies with the account
+    /// even if the watermark cache is warm.
+    #[tokio::test]
+    async fn test_registry_refresh_rejects_deactivated_user() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let service = AuthService::new(pool.clone(), make_test_config());
+
+        let username = format!("regdeact_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        let offline = service
+            .generate_registry_offline_token(&user, None, None)
+            .await
+            .expect("mint registry offline token");
+
+        sqlx::query("UPDATE users SET is_active = false WHERE id = $1")
+            .bind(user_id)
+            .execute(&pool)
+            .await
+            .expect("deactivate user");
+
+        let err = service
+            .mint_access_from_registry_refresh(&offline)
+            .await
+            .expect_err("deactivated user's registry token must be rejected");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "expected Authentication error, got {err:?}"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// Credential-change watermark: a registry token minted BEFORE a
+    /// password change / TOTP toggle must be rejected, same as the
+    /// interactive path. Sleep first so the second-granularity comparison
+    /// is unambiguous (mirrors `refresh_grant_after_totp_toggle_returns_401`
+    /// in oci_v2.rs).
+    #[tokio::test]
+    async fn test_registry_refresh_rejects_pre_credential_change_token() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let service = AuthService::new(pool.clone(), make_test_config());
+
+        let username = format!("regwm_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        let offline = service
+            .generate_registry_offline_token(&user, None, None)
+            .await
+            .expect("mint registry offline token");
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        invalidate_user_tokens(user_id);
+
+        let err = service
+            .mint_access_from_registry_refresh(&offline)
+            .await
+            .expect_err("pre-credential-change registry token must be rejected");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "expected Authentication error, got {err:?}"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// #2430 ceiling: the access token minted by the registry refresh must
+    /// carry the presenting refresh token's action-scope ceiling (and its
+    /// repo allow-list, which is deliberately access-token-only and thus
+    /// `None` on every refresh claim) — reuse must never widen the grant.
+    #[tokio::test]
+    async fn test_registry_refresh_preserves_scope_ceiling() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let cfg = make_test_config();
+        let service = AuthService::new(pool.clone(), cfg.clone());
+
+        let username = format!("regscope_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        let ceiling = Some(vec!["read:artifacts".to_string()]);
+        let offline = service
+            .generate_registry_offline_token(&user, None, ceiling.clone())
+            .await
+            .expect("mint scoped registry offline token");
+
+        let (_, minted) = service
+            .mint_access_from_registry_refresh(&offline)
+            .await
+            .expect("registry refresh of a scoped token");
+
+        let decoding_key = DecodingKey::from_secret(cfg.jwt_secret.as_bytes());
+        let claims = decode::<Claims>(
+            &minted.access_token,
+            &decoding_key,
+            &Validation::new(Algorithm::HS256),
+        )
+        .expect("minted access token should decode")
+        .claims;
+        assert_eq!(
+            claims.scopes, ceiling,
+            "registry refresh must preserve the action-scope ceiling (#2430)"
+        );
+        assert_eq!(
+            claims.allowed_repo_ids, None,
+            "repo allow-list mirrors the presenting refresh claims (access-token-only field)"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// #2487 (probe #5, family confusion): a bare web-session refresh token
+    /// must NOT be accepted on the non-consuming registry path — otherwise
+    /// that path is a replay oracle that revives web tokens, bypassing
+    /// single-use rotation + replay-family-revocation. Covers a fresh web
+    /// token AND an already-consumed/rotated one.
+    #[tokio::test]
+    async fn test_web_refresh_token_rejected_on_registry_path() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let service = AuthService::new(pool.clone(), make_test_config());
+
+        let username = format!("webconf_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        // A fresh web-session refresh token (token_type "refresh").
+        let web = service.generate_tokens(&user).expect("mint web pair");
+        service
+            .persist_refresh_jti_from_pair(&web, user_id)
+            .await
+            .expect("persist web jti");
+
+        let err = service
+            .mint_access_from_registry_refresh(&web.refresh_token)
+            .await
+            .expect_err("web refresh token must be rejected on the registry path");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "expected Authentication error, got {err:?}"
+        );
+
+        // Rotate it once on the web path (consumes the jti), then replay the
+        // ORIGINAL consumed token against the registry path: still 401. This
+        // is the replay-oracle repro — pre-#2487 the non-consuming path would
+        // have minted access from a token the web path had already retired.
+        let (_, _rotated) = service
+            .refresh_tokens(&web.refresh_token)
+            .await
+            .expect("web rotation consumes the token");
+        let err = service
+            .mint_access_from_registry_refresh(&web.refresh_token)
+            .await
+            .expect_err("consumed web refresh token must still be rejected on the registry path");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "expected Authentication error, got {err:?}"
+        );
+
+        // Cleanup.
+        let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query!("DELETE FROM users WHERE id = $1", user_id)
+            .execute(&pool)
+            .await;
+    }
+
+    /// #2487: the inverse — a registry offline token (marked) must NOT be
+    /// usable on the interactive web `/api/v1/auth/refresh` path
+    /// (`refresh_tokens`), which requires the bare `"refresh"` type.
+    #[tokio::test]
+    async fn test_registry_token_rejected_on_web_refresh_path() {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(v) => v,
+            Err(_) => return,
+        };
+        let pool = match sqlx::PgPool::connect(&url).await {
+            Ok(p) => p,
+            Err(_) => return,
+        };
+        let service = AuthService::new(pool.clone(), make_test_config());
+
+        let username = format!("regconf_{}", &Uuid::new_v4().to_string()[..8]);
+        let user_id = insert_test_user(&pool, &username).await;
+        let mut user = make_test_user();
+        user.id = user_id;
+        user.username = username;
+
+        let offline = service
+            .generate_registry_offline_token(&user, None, None)
+            .await
+            .expect("mint registry offline token");
+
+        let err = service
+            .refresh_tokens(&offline)
+            .await
+            .expect_err("registry offline token must be rejected on the web refresh path");
+        assert!(
+            matches!(err, AppError::Authentication(_)),
+            "expected Authentication error, got {err:?}"
+        );
+
+        // Cleanup.
         let _ = sqlx::query!("DELETE FROM refresh_token_jti WHERE user_id = $1", user_id)
             .execute(&pool)
             .await;


### PR DESCRIPTION
## Summary

Closes #2477

Docker remote/proxy pulls started failing with `invalid username or password` after the first token refresh. Root cause: the OCI `/v2/token` `grant_type=refresh_token` handler (`handle_refresh_grant`) ran the registry offline token through `auth_service::refresh_tokens`, which implements **interactive web-session** semantics — single-use rotation plus replay-family-revocation (RFC 9700 §2.2.2). Per the [Docker Distribution OAuth2 spec](https://distribution.github.io/distribution/spec/auth/oauth/), the offline token is a long-lived **reusable** credential: the Docker daemon stores it once and presents the SAME token every time its short-lived access token expires. The second presentation was classified as a replay, the whole token family was revoked, and every subsequent pull 401'd until re-login.

This PR adds a dedicated non-rotating registry refresh path, `AuthService::mint_access_from_registry_refresh`, and points `handle_refresh_grant` at it:

- Validates the presented offline token (signature, expiry, and the registry-token discriminator — see below).
- Keeps ALL revocation bounds: the replica-safe credential-change watermark (password change / TOTP toggle / privilege change since issuance), explicit `refresh_token_jti.revoked_at` (logout, kill-all-sessions, admin sweep), and `users.is_active` — each rejects with 401.
- Does NOT consume the `jti` and does NOT revoke the family on reuse; the response echoes the presented refresh token unchanged.
- The minted access token preserves the presenting token's `allowed_repo_ids` and action-scope ceiling (#2430) — reuse can never widen the grant.

**Token-class separation (audience discriminator).** The registry offline token is otherwise byte-identical to a web-session refresh token, which would make the non-consuming registry path a replay oracle for ALL refresh tokens (a web-session refresh token — even an already-rotated/consumed one — could be presented to `/v2/token` to keep minting access, bypassing single-use rotation + replay-family-revocation). To prevent this, registry offline tokens are minted (`AuthService::generate_registry_offline_token`) with a distinct `token_type` marker (`registry_refresh`), and:

- `mint_access_from_registry_refresh` (the `/v2/token` path) REQUIRES the marker → a bare `token_type:"refresh"` web token is rejected with 401.
- `refresh_tokens` (the web `/api/v1/auth/refresh` path) keeps its existing `token_type != "refresh"` guard → a `registry_refresh`-marked token is rejected with 401.

Net: registry tokens work only on `/v2/token` (non-rotating, reusable); web tokens work only on `/api/v1/auth/refresh` (single-use + replay-protected). No cross-endpoint confusion. Backward-compat: existing unmarked web refresh tokens still work on `/auth/refresh`; docker clients simply re-login to obtain a marked registry token.

The interactive web-session endpoint (`POST /api/v1/auth/refresh` → `auth_service::refresh_tokens`) is **unchanged** and keeps single-use rotation + replay-family-revocation; `handle_refresh_grant` was the only other caller. The existing guard tests (`test_refresh_token_replay_revokes_family`, `test_refresh_token_legitimate_rotation_succeeds`, `test_logout_revokes_refresh_token_family`) continue to pin that behavior.

Verified end-to-end on an isolated stack: a Docker remote repository proxying `registry-1.docker.io`, `docker login`, then repeated `docker pull` runs across access-token expiry all succeed with no `refresh_token_replay` / family-revocation events in the logs; after `revoke_all_refresh_token_families` (logout/deactivation path) the same grant returns 401.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Key regression tests (fail on `main`, pass here):
- `oci_v2::token_refresh_grant_tests::refresh_grant_same_token_twice_succeeds_no_family_revocation` — the exact #2477 failure mode: the same offline token presented repeatedly must succeed every time and must not revoke the family.
- `oci_v2::token_refresh_grant_tests::refresh_grant_returns_presented_refresh_token_unrotated` / `refresh_grant_offline_echoes_presented_refresh_token`
- `auth_service::tests::test_registry_refresh_is_reusable_and_does_not_consume_jti`

Bounds coverage (new):
- `test_registry_refresh_rejects_explicitly_revoked_token`
- `test_registry_refresh_rejects_deactivated_user`
- `test_registry_refresh_rejects_pre_credential_change_token`
- `test_registry_refresh_preserves_scope_ceiling` (#2430 ceiling)
- `oci_v2::token_refresh_grant_tests::refresh_grant_after_family_revocation_returns_401`

Token-class separation (audience discriminator — closes the auth red-team's probe #5 replay-oracle):
- `auth_service::tests::test_web_refresh_token_rejected_on_registry_path` — fresh AND already-consumed web token → registry path → 401.
- `auth_service::tests::test_registry_token_rejected_on_web_refresh_path` — registry token → web `refresh_tokens` → 401.
- `oci_v2::token_refresh_grant_tests::refresh_grant_rejects_web_session_refresh_token` — HTTP-level: web-session refresh token (fresh + consumed) → `/v2/token` → 401.

Pre-existing negative tests (`refresh_grant_after_totp_toggle_returns_401`, `refresh_grant_deactivated_user_returns_401`, `refresh_grant_invalid_token_returns_401`) pass unchanged against the new path.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No wire-format change: the `/v2/token` refresh-grant response keeps the same fields; the `refresh_token` field now carries the presented token instead of a rotated replacement, which is what Distribution-spec clients expect. `.sqlx` cache regenerated for the one new query (`cargo sqlx prepare --workspace -- --all-targets`).
