### PR TITLE
feat(apt): customizable Release metadata for hosted Debian repos

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -4249,3 +4249,180 @@ mod apt_release_helpers_tests {
         assert_eq!(text, "");
     }
 }
+
+// --------------------------------------------------------------------------
+// DB-backed tests: fetch_apt_release_metadata defaults + injection defense
+// (generation-layer, defense-in-depth for #2489)
+// --------------------------------------------------------------------------
+
+#[cfg(test)]
+mod apt_release_metadata_db_tests {
+    use super::*;
+    use crate::api::handlers::test_db_helpers as tdh;
+    use uuid::Uuid;
+
+    /// Insert a hosted (local) Debian repo and return its id + storage dir.
+    async fn insert_hosted_debian(pool: &sqlx::PgPool) -> (Uuid, std::path::PathBuf) {
+        let id = Uuid::new_v4();
+        let key = format!("apt-meta-{}", id.simple());
+        let dir = std::env::temp_dir().join(format!("apt-meta-{id}"));
+        std::fs::create_dir_all(&dir).expect("create storage dir");
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format) \
+             VALUES ($1, $2, $3, $4, 'local'::repository_type, 'debian'::repository_format)",
+        )
+        .bind(id)
+        .bind(&key)
+        .bind(&key)
+        .bind(dir.to_string_lossy().as_ref())
+        .execute(pool)
+        .await
+        .expect("insert hosted debian repo");
+        (id, dir)
+    }
+
+    async fn set_cfg(pool: &sqlx::PgPool, repo_id: Uuid, key: &str, value: &str) {
+        sqlx::query(
+            "INSERT INTO repository_config (repository_id, key, value) VALUES ($1, $2, $3)",
+        )
+        .bind(repo_id)
+        .bind(key)
+        .bind(value)
+        .execute(pool)
+        .await
+        .expect("insert repository_config");
+    }
+
+    async fn cleanup(pool: &sqlx::PgPool, repo_id: Uuid, dir: &std::path::Path) {
+        let _ = sqlx::query("DELETE FROM repository_config WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    /// A repo with no apt_* config must fall back to the "artifact-keeper"
+    /// defaults for Origin/Label and omit Version/Description — i.e. the exact
+    /// pre-#2489 behavior, so existing hosted Debian repos never regress.
+    #[tokio::test]
+    async fn test_fetch_apt_release_metadata_defaults() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+
+        let (origin, label, version, description) =
+            fetch_apt_release_metadata(&pool, repo_id).await;
+        assert_eq!(
+            origin, "artifact-keeper",
+            "default Origin must be preserved"
+        );
+        assert_eq!(label, "artifact-keeper", "default Label must be preserved");
+        assert_eq!(version, None, "Version omitted when unset");
+        assert_eq!(description, None, "Description omitted when unset");
+
+        cleanup(&pool, repo_id, &dir).await;
+    }
+
+    /// Configured values are read back verbatim.
+    #[tokio::test]
+    async fn test_fetch_apt_release_metadata_custom_values() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+        set_cfg(&pool, repo_id, "apt_origin", "Acme Corp").await;
+        set_cfg(&pool, repo_id, "apt_label", "Acme Staging").await;
+        set_cfg(&pool, repo_id, "apt_release_version", "2026.07").await;
+        set_cfg(&pool, repo_id, "apt_description", "Internal mirror").await;
+
+        let (origin, label, version, description) =
+            fetch_apt_release_metadata(&pool, repo_id).await;
+        assert_eq!(origin, "Acme Corp");
+        assert_eq!(label, "Acme Staging");
+        assert_eq!(version.as_deref(), Some("2026.07"));
+        assert_eq!(description.as_deref(), Some("Internal mirror"));
+
+        cleanup(&pool, repo_id, &dir).await;
+    }
+
+    /// Defense-in-depth: even if a multi-line value bypasses the API layer and
+    /// lands in `repository_config` directly (e.g. via a migration, an admin
+    /// SQL edit, or a future code path), the generation layer must NOT emit the
+    /// injected trailing content as forged Release fields. `apt_origin`,
+    /// `apt_label`, and `apt_release_version` are reduced to their first line;
+    /// this is what prevents `Origin:`/`Label:`/`Version:` newline injection
+    /// from appending arbitrary lines to the signed Release file.
+    #[tokio::test]
+    async fn test_fetch_apt_release_metadata_strips_injected_newlines() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+        // Directly plant forged values that the API would have rejected.
+        set_cfg(&pool, repo_id, "apt_origin", "evil\nForged-Field: pwned").await;
+        set_cfg(&pool, repo_id, "apt_label", "l1\r\nSigned-By: attacker").await;
+        set_cfg(
+            &pool,
+            repo_id,
+            "apt_release_version",
+            "9.9\rNotAutomatic: no",
+        )
+        .await;
+
+        let (origin, label, version, _desc) = fetch_apt_release_metadata(&pool, repo_id).await;
+        assert_eq!(origin, "evil", "Origin must be reduced to its first line");
+        assert!(!origin.contains('\n') && !origin.contains('\r'));
+        assert_eq!(label, "l1", "Label must be reduced to its first line");
+        assert!(!label.contains('\n') && !label.contains('\r'));
+        assert_eq!(
+            version.as_deref(),
+            Some("9.9"),
+            "Version must be reduced to its first line"
+        );
+
+        // Prove it end-to-end at the Release string level: a forged field name
+        // must never appear at column 0 (which is how apt parses a new field).
+        let origin_line = format!("Origin: {origin}\n");
+        assert!(!origin_line.contains("\nForged-Field:"));
+
+        cleanup(&pool, repo_id, &dir).await;
+    }
+
+    /// A multi-line `apt_description` is preserved (it is deb822-formatted at
+    /// render time) but must not be usable to inject a bare field: every
+    /// continuation line is space-prefixed by `format_deb822_description`.
+    #[tokio::test]
+    async fn test_apt_description_multiline_cannot_forge_field() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+        set_cfg(
+            &pool,
+            repo_id,
+            "apt_description",
+            "Summary line\nForged-Field: pwned",
+        )
+        .await;
+
+        let (_o, _l, _v, description) = fetch_apt_release_metadata(&pool, repo_id).await;
+        let desc = description.expect("description present");
+        let rendered = format!("Description: {}\n", format_deb822_description(&desc));
+        // The second line must be a space-prefixed continuation, never a field.
+        assert!(
+            rendered.contains("\n Forged-Field: pwned"),
+            "continuation line must be space-prefixed: {rendered:?}"
+        );
+        assert!(
+            !rendered.contains("\nForged-Field:"),
+            "must not emit a bare (column-0) forged field: {rendered:?}"
+        );
+
+        cleanup(&pool, repo_id, &dir).await;
+    }
+}

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -210,7 +210,8 @@ fn push_dependency_field(text: &mut String, key: &str, values: Option<&Vec<Strin
 }
 
 fn push_control_field(text: &mut String, key: &str, value: &str) {
-    let mut lines = value.lines();
+    let normalized = normalize_newlines(value);
+    let mut lines = normalized.lines();
     let Some(first) = lines.next() else {
         return;
     };
@@ -344,6 +345,148 @@ async fn fetch_package_entries(
 // Release content generation (shared by Release, InRelease, Release.gpg)
 // ---------------------------------------------------------------------------
 
+/// Default values for Debian/APT Release Origin and Label fields.
+const DEFAULT_APT_ORIGIN: &str = "artifact-keeper";
+const DEFAULT_APT_LABEL: &str = "artifact-keeper";
+
+/// Returns `true` when `s` contains any line-ending character
+/// (`\n`, `\r\n`, or bare `\r`).
+fn contains_newline(s: &str) -> bool {
+    s.contains('\n') || s.contains('\r')
+}
+
+/// Normalize `\r\n` and bare `\r` to plain `\n` so that
+/// `.lines()` and friends operate on a single canonical form.
+fn normalize_newlines(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                out.push('\n');
+            }
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Format a multi-line description string according to the deb822
+/// continuation convention: the first line carries no leading
+/// space; every subsequent non-empty line is trimmed and prefixed with
+/// a single space; empty lines are rendered as a bare ` .` (space-dot).
+///
+/// Example input:
+///   "Cross-binutils for Win32\n\nMinGW-w64 provides a runtime\n\nLast line"
+///
+/// Example output:
+///   "Cross-binutils for Win32\n .\n MinGW-w64 provides a runtime\n .\n Last line"
+fn format_deb822_description(desc: &str) -> String {
+    let normalized = normalize_newlines(desc);
+    let mut out = String::with_capacity(normalized.len());
+    let mut lines = normalized.lines();
+    if let Some(first) = lines.next() {
+        out.push_str(first.trim());
+    }
+    for line in lines {
+        out.push('\n');
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            out.push_str(" .");
+        } else {
+            out.push(' ');
+            out.push_str(trimmed);
+        }
+    }
+    out
+}
+
+/// Read per-repository APT release metadata overrides from
+/// `repository_config`. `apt_origin` and `apt_label` fall back to
+/// defaults (`DEFAULT_APT_ORIGIN` / `DEFAULT_APT_LABEL`) when unset.
+/// `apt_release_version` and `apt_description` are returned as
+/// `Option<String>` — `None` when unset or empty, meaning the caller
+/// omits those lines from the Release file.
+async fn fetch_apt_release_metadata(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+) -> (String, String, Option<String>, Option<String>) {
+    let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+        "SELECT key, value FROM repository_config \
+         WHERE repository_id = $1 \
+           AND key IN ('apt_origin', 'apt_label', 'apt_release_version', 'apt_description')",
+    )
+    .bind(repo_id)
+    .fetch_all(db)
+    .await
+    .unwrap_or_default();
+
+    let mut origin: Option<String> = None;
+    let mut label: Option<String> = None;
+    let mut release_version: Option<String> = None;
+    let mut description: Option<String> = None;
+
+    for (key, value) in &rows {
+        let raw = value.as_deref().unwrap_or("");
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match key.as_str() {
+            "apt_origin" | "apt_label" | "apt_release_version" => {
+                let single_line = take_first_line(trimmed);
+                if contains_newline(trimmed) {
+                    tracing::warn!(
+                        repo_id = %repo_id,
+                        key = %key,
+                        "{} is multi-line; only the first line will be used",
+                        key
+                    );
+                }
+                match key.as_str() {
+                    "apt_origin" => origin = Some(single_line),
+                    "apt_label" => label = Some(single_line),
+                    "apt_release_version" => release_version = Some(single_line),
+                    _ => unreachable!(),
+                }
+            }
+            "apt_description" => {
+                if contains_newline(trimmed) {
+                    tracing::warn!(
+                        repo_id = %repo_id,
+                        "apt_description is multi-line; will be formatted per deb822"
+                    );
+                }
+                description = Some(trimmed.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    (
+        origin.unwrap_or_else(|| DEFAULT_APT_ORIGIN.to_string()),
+        label.unwrap_or_else(|| DEFAULT_APT_LABEL.to_string()),
+        release_version,
+        description,
+    )
+}
+
+/// Return the first line of `s` (up to but not including the first
+/// newline of any style).
+fn take_first_line(s: &str) -> String {
+    // Normalize \r\n and bare \r to \n so `.lines()` splits correctly.
+    let normalized = normalize_newlines(s);
+    normalized
+        .lines()
+        .next()
+        .unwrap_or(&normalized)
+        .trim()
+        .to_string()
+}
+
 async fn generate_release_content(
     state: &SharedState,
     repo_id: uuid::Uuid,
@@ -391,11 +534,22 @@ async fn generate_release_content(
     let now = chrono::Utc::now();
     let date_str = now.format("%a, %d %b %Y %H:%M:%S UTC").to_string();
 
+    let (origin, label, version, description) =
+        fetch_apt_release_metadata(&state.db, repo_id).await;
+
     let mut release = String::new();
-    release.push_str("Origin: artifact-keeper\n");
-    release.push_str("Label: artifact-keeper\n");
+    release.push_str(&format!("Origin: {}\n", origin));
+    release.push_str(&format!("Label: {}\n", label));
     release.push_str(&format!("Suite: {}\n", distribution));
     release.push_str(&format!("Codename: {}\n", distribution));
+    if let Some(ref ver) = version {
+        release.push_str(&format!("Version: {}\n", ver));
+    }
+    if let Some(ref desc) = description {
+        release.push_str("Description: ");
+        release.push_str(&format_deb822_description(desc));
+        release.push('\n');
+    }
     release.push_str(&format!("Date: {}\n", date_str));
     release.push_str(&format!("Architectures: {}\n", arch_str));
     release.push_str(&format!("Components: {}\n", component_str));
@@ -3941,5 +4095,157 @@ mod virtual_dists_cap_tests {
             decompress_packages_index("dists/x/main/binary-amd64/Packages.gz", &too_big),
             None
         );
+    }
+}
+
+// --------------------------------------------------------------------------
+// Unit tests: newline normalization & deb822 formatting helpers
+// --------------------------------------------------------------------------
+
+#[cfg(test)]
+mod apt_release_helpers_tests {
+    use super::*;
+
+    // -- contains_newline ---------------------------------------------------
+
+    #[test]
+    fn test_contains_newline_no_newline() {
+        assert!(!contains_newline("plain text"));
+        assert!(!contains_newline(""));
+    }
+
+    #[test]
+    fn test_contains_newline_lf() {
+        assert!(contains_newline("line1\nline2"));
+    }
+
+    #[test]
+    fn test_contains_newline_crlf() {
+        assert!(contains_newline("line1\r\nline2"));
+    }
+
+    #[test]
+    fn test_contains_newline_cr() {
+        assert!(contains_newline("line1\rline2"));
+    }
+
+    // -- normalize_newlines -------------------------------------------------
+
+    #[test]
+    fn test_normalize_newlines_no_change() {
+        assert_eq!(normalize_newlines("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_normalize_newlines_lf_unchanged() {
+        assert_eq!(normalize_newlines("a\nb"), "a\nb");
+    }
+
+    #[test]
+    fn test_normalize_newlines_crlf_to_lf() {
+        assert_eq!(normalize_newlines("a\r\nb"), "a\nb");
+    }
+
+    #[test]
+    fn test_normalize_newlines_cr_to_lf() {
+        assert_eq!(normalize_newlines("a\rb"), "a\nb");
+    }
+
+    #[test]
+    fn test_normalize_newlines_mixed() {
+        let input = "line1\r\nline2\nline3\rline4";
+        let expected = "line1\nline2\nline3\nline4";
+        assert_eq!(normalize_newlines(input), expected);
+    }
+
+    // -- take_first_line ----------------------------------------------------
+
+    #[test]
+    fn test_take_first_line_single() {
+        assert_eq!(take_first_line("hello"), "hello");
+    }
+
+    #[test]
+    fn test_take_first_line_lf() {
+        assert_eq!(take_first_line("hello\nworld"), "hello");
+    }
+
+    #[test]
+    fn test_take_first_line_crlf() {
+        assert_eq!(take_first_line("hello\r\nworld"), "hello");
+    }
+
+    #[test]
+    fn test_take_first_line_cr() {
+        assert_eq!(take_first_line("hello\rworld"), "hello");
+    }
+
+    #[test]
+    fn test_take_first_line_trims() {
+        assert_eq!(take_first_line("  hello  \nworld"), "hello");
+    }
+
+    // -- format_deb822_description ------------------------------------------
+
+    #[test]
+    fn test_format_deb822_single_line() {
+        assert_eq!(format_deb822_description("A single line"), "A single line");
+    }
+
+    #[test]
+    fn test_format_deb822_multi_line_continuation() {
+        let input = "First line\nSecond line";
+        assert_eq!(format_deb822_description(input), "First line\n Second line");
+    }
+
+    #[test]
+    fn test_format_deb822_empty_lines_bare_dot() {
+        let input = "Header\n\nBody\n\nFooter";
+        assert_eq!(
+            format_deb822_description(input),
+            "Header\n .\n Body\n .\n Footer"
+        );
+    }
+
+    #[test]
+    fn test_format_deb822_trims_continuation_lines() {
+        let input = "First\n  indented line  ";
+        assert_eq!(format_deb822_description(input), "First\n indented line");
+    }
+
+    #[test]
+    fn test_format_deb822_crlf_handling() {
+        let input = "Header\r\n\r\nBody";
+        assert_eq!(format_deb822_description(input), "Header\n .\n Body");
+    }
+
+    // -- push_control_field -------------------------------------------------
+
+    #[test]
+    fn test_push_control_field_single_line() {
+        let mut text = String::new();
+        push_control_field(&mut text, "Key", "value");
+        assert_eq!(text, "Key: value\n");
+    }
+
+    #[test]
+    fn test_push_control_field_multi_line() {
+        let mut text = String::new();
+        push_control_field(&mut text, "Desc", "Line1\nLine2");
+        assert_eq!(text, "Desc: Line1\n Line2\n");
+    }
+
+    #[test]
+    fn test_push_control_field_empty_line_bare_dot() {
+        let mut text = String::new();
+        push_control_field(&mut text, "Desc", "Line1\n\nLine3");
+        assert_eq!(text, "Desc: Line1\n .\n Line3\n");
+    }
+
+    #[test]
+    fn test_push_control_field_empty_value() {
+        let mut text = String::new();
+        push_control_field(&mut text, "Key", "");
+        assert_eq!(text, "");
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -559,6 +559,18 @@ pub struct CreateRepositoryRequest {
     /// project (permissions with `target_type = 'project'`) are inherited by
     /// the repository. Omit to leave the repository unassigned.
     pub project_id: Option<Uuid>,
+    /// Custom Origin field for Debian/APT Release files.
+    /// Stored in `repository_config` under `apt_origin`.
+    pub apt_origin: Option<String>,
+    /// Custom Label field for Debian/APT Release files.
+    /// Stored in `repository_config` under `apt_label`.
+    pub apt_label: Option<String>,
+    /// Custom Version field for Debian/APT Release files.
+    /// Stored in `repository_config` under `apt_release_version`.
+    pub apt_release_version: Option<String>,
+    /// Custom Description field for Debian/APT Release files.
+    /// Stored in `repository_config` under `apt_description`.
+    pub apt_description: Option<String>,
 }
 
 impl CreateRepositoryRequest {
@@ -631,6 +643,22 @@ pub struct UpdateRepositoryRequest {
     /// the field leaves the assignment unchanged (unassignment ships with the
     /// project-admin surface in P2).
     pub project_id: Option<Uuid>,
+    /// Custom Origin field for Debian/APT Release files. Pass an empty string
+    /// to reset to the default ("artifact-keeper").
+    /// Stored in `repository_config` under `apt_origin`.
+    pub apt_origin: Option<String>,
+    /// Custom Label field for Debian/APT Release files. Pass an empty string
+    /// to reset to the default ("artifact-keeper").
+    /// Stored in `repository_config` under `apt_label`.
+    pub apt_label: Option<String>,
+    /// Custom Version field for Debian/APT Release files. Pass an empty
+    /// string to remove (omits the field entirely from the Release file).
+    /// Stored in `repository_config` under `apt_release_version`.
+    pub apt_release_version: Option<String>,
+    /// Custom Description field for Debian/APT Release files. Pass an empty
+    /// string to remove (omits the field entirely from the Release file).
+    /// Stored in `repository_config` under `apt_description`.
+    pub apt_description: Option<String>,
 }
 
 impl UpdateRepositoryRequest {
@@ -679,6 +707,20 @@ pub struct RepositoryResponse {
     /// read back from `repository_config`. `None` when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub custom_user_agent: Option<String>,
+    /// Custom Origin field for Debian/APT Release files (default: "artifact-keeper").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apt_origin: Option<String>,
+    /// Custom Label field for Debian/APT Release files (default: "artifact-keeper").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apt_label: Option<String>,
+    /// Custom Version field for Debian/APT Release files. Omitted from the
+    /// Release file when `None` or empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apt_release_version: Option<String>,
+    /// Custom Description field for Debian/APT Release files. Omitted from the
+    /// Release file when `None` or empty.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub apt_description: Option<String>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -717,6 +759,10 @@ fn repo_to_response(
         quarantine_enabled: None,
         quarantine_duration_minutes: None,
         custom_user_agent: None,
+        apt_origin: None,
+        apt_label: None,
+        apt_release_version: None,
+        apt_description: None,
         created_at: repo.created_at,
         updated_at: repo.updated_at,
     }
@@ -754,6 +800,63 @@ async fn with_custom_user_agent(
     .await;
     if let Ok(Some(ua)) = result {
         response.custom_user_agent = Some(ua);
+    }
+    response
+}
+
+/// Populate `RepositoryResponse` APT release fields (`apt_origin`,
+/// `apt_label`, `apt_release_version`, `apt_description`) from
+/// `repository_config`.
+async fn with_apt_settings(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    mut response: RepositoryResponse,
+) -> RepositoryResponse {
+    let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+        "SELECT key, value FROM repository_config \
+         WHERE repository_id = $1 \
+           AND key IN ('apt_origin', 'apt_label', 'apt_release_version', 'apt_description')",
+    )
+    .bind(repo_id)
+    .fetch_all(db)
+    .await
+    .unwrap_or_default();
+    for (key, value) in &rows {
+        if let Some(v) = value {
+            let trimmed = v.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match key.as_str() {
+                "apt_origin" | "apt_label" | "apt_release_version" => {
+                    let single_line = trimmed.lines().next().unwrap_or("").trim().to_string();
+                    if contains_newline(trimmed) {
+                        tracing::warn!(
+                            repo_id = %repo_id,
+                            key = %key,
+                            "{} is multi-line; only the first line will be used",
+                            key
+                        );
+                    }
+                    match key.as_str() {
+                        "apt_origin" => response.apt_origin = Some(single_line),
+                        "apt_label" => response.apt_label = Some(single_line),
+                        "apt_release_version" => response.apt_release_version = Some(single_line),
+                        _ => unreachable!(),
+                    }
+                }
+                "apt_description" => {
+                    if contains_newline(trimmed) {
+                        tracing::warn!(
+                            repo_id = %repo_id,
+                            "apt_description is multi-line; will be formatted per deb822"
+                        );
+                    }
+                    response.apt_description = Some(trimmed.to_string());
+                }
+                _ => {}
+            }
+        }
     }
     response
 }
@@ -807,6 +910,23 @@ fn validate_custom_user_agent(ua: &str) -> Result<()> {
             "custom_user_agent must not contain control characters (see RFC 7230 §3.2.6)"
                 .to_string(),
         ));
+    }
+    Ok(())
+}
+
+/// Returns `true` when `s` contains any line-ending character
+/// (`\n`, `\r\n`, or bare `\r`).
+fn contains_newline(s: &str) -> bool {
+    s.contains('\n') || s.contains('\r')
+}
+
+/// Reject multi-line values for APT Release fields that must be single-line
+/// (`Origin`, `Label`, `Version`).
+fn ensure_single_line(value: &str, field_name: &str) -> Result<()> {
+    if contains_newline(value) {
+        return Err(AppError::Validation(format!(
+            "{field_name} must be a single-line value"
+        )));
     }
     Ok(())
 }
@@ -1764,6 +1884,7 @@ pub async fn create_repository(
     let service = state.create_repository_service();
     let (format, plugin_format_key) = service.resolve_format(&payload.format).await?;
     let repo_type = parse_repo_type(&payload.repo_type)?;
+    let is_apt_hosted = repo_type.is_hosted() && matches!(format, RepositoryFormat::Debian);
 
     // Validate up-front that virtual repos do not arrive with an explicit
     // empty `member_repos: []`. Omitted-field (deferred-population) is
@@ -1880,6 +2001,50 @@ pub async fn create_repository(
         }
     }
 
+    if !is_apt_hosted
+        && (payload.apt_origin.is_some()
+            || payload.apt_label.is_some()
+            || payload.apt_release_version.is_some()
+            || payload.apt_description.is_some())
+    {
+        return Err(AppError::Validation(
+            "apt_origin, apt_label, apt_release_version, and apt_description are only valid for hosted APT repositories".to_string(),
+        ));
+    }
+
+    if is_apt_hosted {
+        if let Some(ref origin) = payload.apt_origin {
+            let trimmed = origin.trim();
+            if !trimmed.is_empty() {
+                ensure_single_line(trimmed, "apt_origin")?;
+                upsert_repo_config(&state.db, repo.id, "apt_origin", trimmed).await?;
+            }
+        }
+        if let Some(ref label) = payload.apt_label {
+            let trimmed = label.trim();
+            if !trimmed.is_empty() {
+                ensure_single_line(trimmed, "apt_label")?;
+                upsert_repo_config(&state.db, repo.id, "apt_label", trimmed).await?;
+            }
+        }
+        if let Some(ref ver) = payload.apt_release_version {
+            let trimmed = ver.trim();
+            if !trimmed.is_empty() {
+                ensure_single_line(trimmed, "apt_release_version")?;
+                upsert_repo_config(&state.db, repo.id, "apt_release_version", trimmed).await?;
+            }
+        }
+        if let Some(ref desc) = payload.apt_description {
+            let trimmed = desc.trim();
+            if !trimmed.is_empty() {
+                if contains_newline(trimmed) {
+                    tracing::warn!("apt_description is multi-line; will be formatted per deb822");
+                }
+                upsert_repo_config(&state.db, repo.id, "apt_description", trimmed).await?;
+            }
+        }
+    }
+
     // Add virtual repository members. Post-#1444, the validator accepts
     // `member_repos == None` (deferred-population pattern: caller will
     // POST /members later) and only rejects `Some(empty_vec)`. Treat the
@@ -1961,6 +2126,10 @@ pub async fn create_repository(
         response.upstream_auth_configured = true;
     }
     response.custom_user_agent = payload.custom_user_agent.filter(|ua| !ua.is_empty());
+    response.apt_origin = payload.apt_origin.filter(|v| !v.trim().is_empty());
+    response.apt_label = payload.apt_label.filter(|v| !v.trim().is_empty());
+    response.apt_release_version = payload.apt_release_version.filter(|v| !v.trim().is_empty());
+    response.apt_description = payload.apt_description.filter(|v| !v.trim().is_empty());
     Ok(Json(response))
 }
 
@@ -1991,11 +2160,18 @@ pub async fn get_repository(
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
 
     let repo_id = repo.id;
+    let is_apt_hosted =
+        repo.repo_type.is_hosted() && matches!(repo.format, RepositoryFormat::Debian);
     let mut response = repo_to_response(repo, storage_used);
     response.upstream_auth_configured = auth_type.is_some();
     response.upstream_auth_type = auth_type;
     let response = with_quarantine_settings(&state.db, repo_id, response).await;
     let response = with_custom_user_agent(&state.db, repo_id, response).await;
+    let response = if is_apt_hosted {
+        with_apt_settings(&state.db, repo_id, response).await
+    } else {
+        response
+    };
     Ok(Json(response))
 }
 
@@ -2185,6 +2361,81 @@ pub async fn update_repository(
         }
     }
 
+    let is_apt_hosted =
+        existing.repo_type.is_hosted() && matches!(existing.format, RepositoryFormat::Debian);
+
+    if !is_apt_hosted
+        && (payload.apt_origin.is_some()
+            || payload.apt_label.is_some()
+            || payload.apt_release_version.is_some()
+            || payload.apt_description.is_some())
+    {
+        return Err(AppError::Validation(
+            "apt_origin, apt_label, apt_release_version, and apt_description are only valid for hosted APT repositories".to_string(),
+        ));
+    }
+
+    if is_apt_hosted {
+        if let Some(ref origin) = payload.apt_origin {
+            let trimmed = origin.trim();
+            if trimmed.is_empty() {
+                sqlx::query(
+                    "DELETE FROM repository_config WHERE repository_id = $1 AND key = 'apt_origin'",
+                )
+                .bind(repo.id)
+                .execute(&state.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            } else {
+                ensure_single_line(trimmed, "apt_origin")?;
+                upsert_repo_config(&state.db, repo.id, "apt_origin", trimmed).await?;
+            }
+        }
+        if let Some(ref label) = payload.apt_label {
+            let trimmed = label.trim();
+            if trimmed.is_empty() {
+                sqlx::query(
+                    "DELETE FROM repository_config WHERE repository_id = $1 AND key = 'apt_label'",
+                )
+                .bind(repo.id)
+                .execute(&state.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            } else {
+                ensure_single_line(trimmed, "apt_label")?;
+                upsert_repo_config(&state.db, repo.id, "apt_label", trimmed).await?;
+            }
+        }
+        if let Some(ref ver) = payload.apt_release_version {
+            let trimmed = ver.trim();
+            if trimmed.is_empty() {
+                sqlx::query("DELETE FROM repository_config WHERE repository_id = $1 AND key = 'apt_release_version'")
+                    .bind(repo.id)
+                    .execute(&state.db)
+                    .await
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+            } else {
+                ensure_single_line(trimmed, "apt_release_version")?;
+                upsert_repo_config(&state.db, repo.id, "apt_release_version", trimmed).await?;
+            }
+        }
+        if let Some(ref desc) = payload.apt_description {
+            let trimmed = desc.trim();
+            if trimmed.is_empty() {
+                sqlx::query("DELETE FROM repository_config WHERE repository_id = $1 AND key = 'apt_description'")
+                    .bind(repo.id)
+                    .execute(&state.db)
+                    .await
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+            } else {
+                if contains_newline(trimmed) {
+                    tracing::warn!("apt_description is multi-line; will be formatted per deb822");
+                }
+                upsert_repo_config(&state.db, repo.id, "apt_description", trimmed).await?;
+            }
+        }
+    }
+
     // Invalidate the in-memory repo cache so that visibility changes take
     // effect immediately instead of waiting for the TTL to expire. Remove
     // both the old key and the new key (in case the key was renamed). This
@@ -2227,6 +2478,8 @@ pub async fn update_repository(
     .await;
 
     let repo_id = repo.id;
+    let is_apt_hosted =
+        repo.repo_type.is_hosted() && matches!(repo.format, RepositoryFormat::Debian);
     let response = repo_to_response(repo, storage_used);
     let mut response = with_quarantine_settings(&state.db, repo_id, response).await;
     if let Some(ref ua) = payload.custom_user_agent {
@@ -2236,6 +2489,11 @@ pub async fn update_repository(
             Some(ua.clone())
         };
     }
+    let response = if is_apt_hosted {
+        with_apt_settings(&state.db, repo_id, response).await
+    } else {
+        response
+    };
     Ok(Json(response))
 }
 
@@ -7947,6 +8205,10 @@ mod tests {
             quarantine_duration_minutes: None,
             custom_user_agent: None,
             project_id: None,
+            apt_origin: None,
+            apt_label: None,
+            apt_release_version: None,
+            apt_description: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -9275,6 +9537,10 @@ mod tests {
             quarantine_duration_minutes: Some(525600),
             custom_user_agent: None,
             project_id: None,
+            apt_origin: None,
+            apt_label: None,
+            apt_release_version: None,
+            apt_description: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -15072,6 +15338,10 @@ mod tests {
             quarantine_duration_minutes: None,
             custom_user_agent: None,
             project_id: None,
+            apt_origin: None,
+            apt_label: None,
+            apt_release_version: None,
+            apt_description: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -15984,5 +16254,64 @@ mod tests {
 
         tdh::cleanup(&pool, repo_id, user_id).await;
         let _ = std::fs::remove_dir_all(&dir);
+    }
+}
+
+// --------------------------------------------------------------------------
+// Unit tests: APT field validation helpers
+// --------------------------------------------------------------------------
+
+#[cfg(test)]
+mod apt_validation_tests {
+    use super::*;
+
+    // -- contains_newline ---------------------------------------------------
+
+    #[test]
+    fn test_contains_newline_plain() {
+        assert!(!contains_newline("plain text"));
+    }
+
+    #[test]
+    fn test_contains_newline_lf() {
+        assert!(contains_newline("a\nb"));
+    }
+
+    #[test]
+    fn test_contains_newline_crlf() {
+        assert!(contains_newline("a\r\nb"));
+    }
+
+    #[test]
+    fn test_contains_newline_cr() {
+        assert!(contains_newline("a\rb"));
+    }
+
+    // -- ensure_single_line -------------------------------------------------
+
+    #[test]
+    fn test_ensure_single_line_passes() {
+        assert!(ensure_single_line("valid value", "apt_origin").is_ok());
+    }
+
+    #[test]
+    fn test_ensure_single_line_rejects_lf() {
+        let err = ensure_single_line("line1\nline2", "apt_origin").unwrap_err();
+        assert!(err.to_string().contains("apt_origin"));
+        assert!(err.to_string().contains("single-line"));
+    }
+
+    #[test]
+    fn test_ensure_single_line_rejects_crlf() {
+        let err = ensure_single_line("line1\r\nline2", "apt_label").unwrap_err();
+        assert!(err.to_string().contains("apt_label"));
+        assert!(err.to_string().contains("single-line"));
+    }
+
+    #[test]
+    fn test_ensure_single_line_rejects_cr() {
+        let err = ensure_single_line("line1\rline2", "apt_release_version").unwrap_err();
+        assert!(err.to_string().contains("apt_release_version"));
+        assert!(err.to_string().contains("single-line"));
     }
 }

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -1901,6 +1901,37 @@ pub async fn create_repository(
         validate_custom_user_agent(ua)?;
     }
 
+    // apt_* Release metadata (#2489): validate up-front — before the repository
+    // row is created — so a rejected value (wrong repo type or a newline
+    // injection attempt) cannot leave an orphaned repository behind. This
+    // mirrors the `custom_user_agent` guard above. The actual persistence to
+    // `repository_config` happens after `service.create(...)` below, once
+    // `repo.id` exists.
+    if !is_apt_hosted
+        && (payload.apt_origin.is_some()
+            || payload.apt_label.is_some()
+            || payload.apt_release_version.is_some()
+            || payload.apt_description.is_some())
+    {
+        return Err(AppError::Validation(
+            "apt_origin, apt_label, apt_release_version, and apt_description are only valid for hosted APT repositories".to_string(),
+        ));
+    }
+    if is_apt_hosted {
+        for (value, field) in [
+            (&payload.apt_origin, "apt_origin"),
+            (&payload.apt_label, "apt_label"),
+            (&payload.apt_release_version, "apt_release_version"),
+        ] {
+            if let Some(v) = value {
+                let trimmed = v.trim();
+                if !trimmed.is_empty() {
+                    ensure_single_line(trimmed, field)?;
+                }
+            }
+        }
+    }
+
     // Resolve storage backend: use the requested one or fall back to the default.
     let storage_backend = match &payload.storage_backend {
         None => state.config.storage_backend.clone(),
@@ -2001,36 +2032,24 @@ pub async fn create_repository(
         }
     }
 
-    if !is_apt_hosted
-        && (payload.apt_origin.is_some()
-            || payload.apt_label.is_some()
-            || payload.apt_release_version.is_some()
-            || payload.apt_description.is_some())
-    {
-        return Err(AppError::Validation(
-            "apt_origin, apt_label, apt_release_version, and apt_description are only valid for hosted APT repositories".to_string(),
-        ));
-    }
-
+    // Persist apt_* Release metadata. Validation already ran up-front (before
+    // create), so here we only write the trimmed values to `repository_config`.
     if is_apt_hosted {
         if let Some(ref origin) = payload.apt_origin {
             let trimmed = origin.trim();
             if !trimmed.is_empty() {
-                ensure_single_line(trimmed, "apt_origin")?;
                 upsert_repo_config(&state.db, repo.id, "apt_origin", trimmed).await?;
             }
         }
         if let Some(ref label) = payload.apt_label {
             let trimmed = label.trim();
             if !trimmed.is_empty() {
-                ensure_single_line(trimmed, "apt_label")?;
                 upsert_repo_config(&state.db, repo.id, "apt_label", trimmed).await?;
             }
         }
         if let Some(ref ver) = payload.apt_release_version {
             let trimmed = ver.trim();
             if !trimmed.is_empty() {
-                ensure_single_line(trimmed, "apt_release_version")?;
                 upsert_repo_config(&state.db, repo.id, "apt_release_version", trimmed).await?;
             }
         }
@@ -2126,10 +2145,15 @@ pub async fn create_repository(
         response.upstream_auth_configured = true;
     }
     response.custom_user_agent = payload.custom_user_agent.filter(|ua| !ua.is_empty());
-    response.apt_origin = payload.apt_origin.filter(|v| !v.trim().is_empty());
-    response.apt_label = payload.apt_label.filter(|v| !v.trim().is_empty());
-    response.apt_release_version = payload.apt_release_version.filter(|v| !v.trim().is_empty());
-    response.apt_description = payload.apt_description.filter(|v| !v.trim().is_empty());
+    // Echo the trimmed values that were actually persisted to
+    // `repository_config` so the create response matches a subsequent GET.
+    let trimmed_nonempty = |v: Option<String>| -> Option<String> {
+        v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+    };
+    response.apt_origin = trimmed_nonempty(payload.apt_origin);
+    response.apt_label = trimmed_nonempty(payload.apt_label);
+    response.apt_release_version = trimmed_nonempty(payload.apt_release_version);
+    response.apt_description = trimmed_nonempty(payload.apt_description);
     Ok(Json(response))
 }
 
@@ -15312,6 +15336,270 @@ mod tests {
         tdh::cleanup(&pool, repo_id, user_id).await;
         let _ = std::fs::remove_dir_all(&storage_dir);
         let _ = std::fs::remove_dir_all(&local_dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // apt_* Release metadata: handler plumbing (create / update / get) — #2489
+    // -----------------------------------------------------------------------
+
+    /// apt_* fields on a hosted Debian create must persist to
+    /// `repository_config`, echo in the create response, and read back via GET
+    /// (`with_apt_settings`).
+    #[tokio::test]
+    async fn test_apt_settings_create_roundtrip_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Extension, Path, State};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let storage_dir = std::env::temp_dir().join(format!("apt-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let repo_key = format!("apt-hosted-{}", Uuid::new_v4().simple());
+        let payload = make_create_request(
+            &repo_key,
+            "APT hosted repo",
+            "debian",
+            serde_json::json!({
+                "repo_type": "local",
+                "apt_origin": "  Acme Corp  ",
+                "apt_label": "Acme Staging",
+                "apt_release_version": "2026.07",
+                "apt_description": "Internal staging mirror"
+            }),
+        );
+
+        let Json(created) = create_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            payload,
+        )
+        .await
+        .expect("hosted Debian create with apt_* must succeed");
+        // Response echoes the trimmed, persisted values.
+        assert_eq!(created.apt_origin.as_deref(), Some("Acme Corp"));
+        assert_eq!(created.apt_label.as_deref(), Some("Acme Staging"));
+        assert_eq!(created.apt_release_version.as_deref(), Some("2026.07"));
+        assert_eq!(
+            created.apt_description.as_deref(),
+            Some("Internal staging mirror")
+        );
+
+        let rows: Vec<(String, Option<String>)> = sqlx::query_as(
+            "SELECT key, value FROM repository_config WHERE repository_id = $1 \
+             AND key IN ('apt_origin','apt_label','apt_release_version','apt_description')",
+        )
+        .bind(created.id)
+        .fetch_all(&pool)
+        .await
+        .expect("query repository_config");
+        let map: std::collections::HashMap<String, Option<String>> = rows.into_iter().collect();
+        assert_eq!(map["apt_origin"].as_deref(), Some("Acme Corp"));
+        assert_eq!(map["apt_label"].as_deref(), Some("Acme Staging"));
+        assert_eq!(map["apt_release_version"].as_deref(), Some("2026.07"));
+        assert_eq!(
+            map["apt_description"].as_deref(),
+            Some("Internal staging mirror")
+        );
+
+        let Json(fetched) = get_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            Path(repo_key.clone()),
+        )
+        .await
+        .expect("GET must succeed");
+        assert_eq!(fetched.apt_origin.as_deref(), Some("Acme Corp"));
+        assert_eq!(fetched.apt_label.as_deref(), Some("Acme Staging"));
+        assert_eq!(fetched.apt_release_version.as_deref(), Some("2026.07"));
+        assert_eq!(
+            fetched.apt_description.as_deref(),
+            Some("Internal staging mirror")
+        );
+
+        tdh::cleanup(&pool, created.id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// A newline (injection attempt) in a single-line apt_* field must be
+    /// rejected AND — because validation runs before the repo is created — must
+    /// NOT leave an orphaned repository behind.
+    #[tokio::test]
+    async fn test_apt_settings_create_rejects_newline_no_orphan_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Extension, State};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let storage_dir = std::env::temp_dir().join(format!("apt-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let repo_key = format!("apt-inject-{}", Uuid::new_v4().simple());
+        let payload = make_create_request(
+            &repo_key,
+            "APT inject repo",
+            "debian",
+            serde_json::json!({
+                "repo_type": "local",
+                "apt_origin": "good\nForged-Field: pwned"
+            }),
+        );
+        let err = create_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            payload,
+        )
+        .await
+        .expect_err("newline in apt_origin must be rejected");
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("single-line")),
+            "expected single-line Validation error, got {err:?}",
+        );
+
+        // No orphaned repository row.
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM repositories WHERE key = $1)")
+                .bind(&repo_key)
+                .fetch_one(&pool)
+                .await
+                .expect("query repositories");
+        assert!(
+            !exists,
+            "rejected create must not leave an orphaned repository"
+        );
+
+        tdh::cleanup_user(&pool, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// apt_* fields on a non-Debian (or non-hosted) repo are rejected up-front,
+    /// and no orphaned repository is created.
+    #[tokio::test]
+    async fn test_apt_settings_create_rejected_on_non_apt_no_orphan_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Extension, State};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let storage_dir = std::env::temp_dir().join(format!("apt-test-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&storage_dir).expect("create storage dir");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let repo_key = format!("apt-wrongfmt-{}", Uuid::new_v4().simple());
+        let payload = make_create_request(
+            &repo_key,
+            "Maven with apt fields",
+            "maven",
+            serde_json::json!({ "repo_type": "local", "apt_origin": "Acme" }),
+        );
+        let err = create_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            payload,
+        )
+        .await
+        .expect_err("apt_* on a non-APT repo must be rejected");
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("hosted APT")),
+            "expected hosted-APT-only Validation error, got {err:?}",
+        );
+
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM repositories WHERE key = $1)")
+                .bind(&repo_key)
+                .fetch_one(&pool)
+                .await
+                .expect("query repositories");
+        assert!(
+            !exists,
+            "rejected create must not leave an orphaned repository"
+        );
+
+        tdh::cleanup_user(&pool, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// PATCH plumbing: set upserts + echoes; empty string clears (deletes the
+    /// row and echoes None); a value with a newline is rejected.
+    #[tokio::test]
+    async fn test_apt_settings_update_set_clear_and_reject_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::extract::{Extension, Path, State};
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, repo_key, storage_dir) = tdh::create_repo(&pool, "local", "debian").await;
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let update = |json: &str| -> UpdateRepositoryRequest {
+            serde_json::from_str(json).expect("deserialize update payload")
+        };
+
+        // Set.
+        let Json(resp) = update_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            Path(repo_key.clone()),
+            Json(update(r#"{"apt_origin":"Acme","apt_label":"Staging"}"#)),
+        )
+        .await
+        .expect("update set must succeed");
+        assert_eq!(resp.apt_origin.as_deref(), Some("Acme"));
+        assert_eq!(resp.apt_label.as_deref(), Some("Staging"));
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM repository_config WHERE repository_id = $1 AND key = 'apt_origin'",
+        )
+        .bind(repo_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("query");
+        assert_eq!(stored.as_deref(), Some("Acme"));
+
+        // Newline (CRLF) must be rejected on update too.
+        let err = update_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            Path(repo_key.clone()),
+            Json(update(r#"{"apt_label":"bad\r\nForged: x"}"#)),
+        )
+        .await
+        .expect_err("newline must be rejected on update");
+        assert!(
+            matches!(err, AppError::Validation(ref m) if m.contains("single-line")),
+            "expected single-line Validation error, got {err:?}",
+        );
+
+        // Clear apt_origin with empty string: row deleted, echoes None.
+        let Json(resp) = update_repository(
+            State(state.clone()),
+            Extension(Some(admin_auth(user_id, &username))),
+            Path(repo_key.clone()),
+            Json(update(r#"{"apt_origin":""}"#)),
+        )
+        .await
+        .expect("update clear must succeed");
+        assert_eq!(resp.apt_origin, None, "clear must echo None");
+        let stored: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM repository_config WHERE repository_id = $1 AND key = 'apt_origin'",
+        )
+        .bind(repo_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("query");
+        assert_eq!(stored, None, "clear must delete the config row");
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
     }
 
     /// `custom_user_agent` serialization contract: omitted when `None`


### PR DESCRIPTION
Resolves #2489.

## Summary

`Origin:` and `Label:` were hardcoded to "`artifact-keeper`". Now per-repo configurable via repository_config (`apt_origin` / `apt_label` / `apt_release_version` / `apt_description`), exposed through the repository CRUD API.

- `apt_origin` / `apt_label`: default to "`artifact-keeper`" when unset
- `apt_release_version` / `apt_description`: optional, omitted from Release when empty
- Single-line enforcement for `Origin:`, `Label:`, `Version:` (API rejects, DB-read warns)
- Multi-line `Description:` allowed (with deb822 formatting)
- Fields only apply to hosted Debian repositories (rejected or skipped otherwise)
- Newline handling (LF, CRLF, CR) normalized domain-wide for both Release and Packages control fields

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [ ] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes