### PR TITLE
fix(helm): default chart apiVersion when an upstream index entry omits it

### DIFF
--- a/backend/src/formats/helm.rs
+++ b/backend/src/formats/helm.rs
@@ -319,10 +319,22 @@ pub struct HelmPathInfo {
     pub filename: Option<String>,
 }
 
+/// Default Helm chart apiVersion, used when an upstream index entry omits it.
+///
+/// Nexus-generated `index.yaml` drops `apiVersion` from every entry, which
+/// would otherwise fail deserialization of the whole index (serde is
+/// all-or-nothing) and leave a virtual repo unable to proxy Nexus-hosted
+/// charts. Helm treats a missing apiVersion as a legacy chart, so defaulting
+/// keeps parsing lenient while still emitting a valid index downstream.
+fn default_chart_api_version() -> String {
+    "v2".to_string()
+}
+
 /// Chart.yaml structure
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ChartYaml {
+    #[serde(default = "default_chart_api_version")]
     pub api_version: String,
     pub name: String,
     pub version: String,
@@ -1065,6 +1077,30 @@ version: "1.0.0"
         assert_eq!(parsed.chart.name, "test");
         assert_eq!(parsed.urls.len(), 1);
         assert_eq!(parsed.digest, "sha256:abc");
+    }
+
+    /// Nexus-generated index.yaml omits `apiVersion` from every entry. The
+    /// whole index must still parse (serde is all-or-nothing) with apiVersion
+    /// defaulted, otherwise a virtual repo cannot proxy Nexus-hosted charts.
+    #[test]
+    fn test_index_entry_without_api_version_defaults() {
+        let nexus_style = r#"
+apiVersion: v1
+generated: "2024-01-01T00:00:00Z"
+entries:
+  mychart:
+    - name: mychart
+      version: 1.2.3
+      created: "2024-01-01T00:00:00Z"
+      digest: sha256:deadbeef
+      urls:
+        - https://nexus.example/repository/helm/mychart-1.2.3.tgz
+"#;
+        let index: HelmIndex = serde_yaml::from_str(nexus_style).unwrap();
+        let entry = &index.entries["mychart"][0];
+        assert_eq!(entry.chart.api_version, "v2");
+        assert_eq!(entry.chart.version, "1.2.3");
+        assert_eq!(entry.urls.len(), 1);
     }
 
     // ---- decompression-bomb cap (issue #1806) ----


### PR DESCRIPTION
Closes #

## What

Make `ChartYaml.api_version` default when absent, so an upstream Helm `index.yaml` whose entries omit `apiVersion` parses successfully.

Fixes #2494.

## Why

`ChartYaml.api_version` is a required `String`. It is flattened into every `index.yaml` entry during deserialization. Sonatype Nexus emits its repository index **without** a per-entry `apiVersion`, so `serde` (all-or-nothing) fails the parse of the whole index on the first entry. A `helm` virtual repo with a Nexus-hosted remote member then serves an empty index, and chart downloads return `502 Failed to parse upstream index.yaml`.

Helm treats a missing `apiVersion` as a legacy (v1) chart rather than an error, so a proxy should tolerate it.

## How

- Add `#[serde(default = "default_chart_api_version")]` to `ChartYaml.api_version`, defaulting to `"v2"`.
- The field stays `String`, so validation (`extract_chart_yaml`'s `v1`/`v2` check), constructors, and existing tests are unchanged — no downstream churn.
- Entries without `apiVersion` now parse; the re-emitted index carries a valid `apiVersion`.

## Test

Added `test_index_entry_without_api_version_defaults`: parses a Nexus-style `index.yaml` whose entry omits `apiVersion` and asserts the whole index parses with the field defaulted.

```
cargo test --lib formats::helm::tests
# test result: ok. 44 passed; 0 failed
```

## Scope / risk

Single field attribute + one test. No API, schema, or signature changes. Deserialization becomes strictly more permissive (a previously-rejected index now parses); serialization is unchanged for entries that already carry `apiVersion`.
