### PR TITLE
fix(grpc): enforce per-method action scopes in the gRPC auth interceptor

### DIFF
--- a/backend/src/grpc/auth_interceptor.rs
+++ b/backend/src/grpc/auth_interceptor.rs
@@ -5,12 +5,65 @@
 //! interceptor enforces authorization by requiring the `is_admin` claim. All
 //! current gRPC services (SBOM, CVE History, Security Policy) are admin-only
 //! operations, matching the HTTP layer's `admin_middleware` behaviour.
+//!
+//! On top of the admin floor, the interceptor also stamps the authenticated
+//! principal's action-scope ceiling (`Claims.scopes`) into the request
+//! extensions as a [`GrpcPrincipal`]. Per-method authorization is then enforced
+//! by each service method calling [`authorize_grpc_scope`] as its first line,
+//! mirroring the REST layer's `AuthExtension::has_scope` / `require_scope`
+//! (`api/middleware/auth.rs`). A method-agnostic tonic `Request<()>` interceptor
+//! cannot see the gRPC method path, so the required scope must be selected
+//! per-method at the handler, not in the interceptor.
 
 use jsonwebtoken::{decode, Algorithm, DecodingKey, Validation};
 use sqlx::PgPool;
 use tonic::{Request, Status};
 
 use crate::services::auth_service::Claims;
+
+/// Authenticated principal stamped into the gRPC request extensions by the
+/// interceptor. Carries the live `is_admin` role and the token's action-scope
+/// ceiling so per-method authorization ([`authorize_grpc_scope`]) can mirror the
+/// REST `AuthExtension` without re-decoding the JWT.
+#[derive(Clone, Debug)]
+pub struct GrpcPrincipal {
+    /// Live server-side admin role (re-derived from the DB when a pool is wired).
+    pub is_admin: bool,
+    /// Action-scope ceiling copied from `Claims.scopes`. `None` = interactive/full
+    /// token (no scope restriction); `Some(list)` = allowlist evaluated by
+    /// `token_service::scopes_grant_access` (exact match | `*` | `admin`).
+    pub scopes: Option<Vec<String>>,
+}
+
+/// Per-method scope authorizer for the gRPC plane. Mirrors REST's
+/// `AuthExtension::has_scope` / `require_scope`: `None` scopes (interactive/full
+/// token) pass everything; `Some(list)` delegates to the canonical
+/// `token_service::scopes_grant_access` (exact | `*` | `admin`) so the two planes
+/// share one wildcard policy and cannot drift.
+///
+/// A missing principal fails closed (`Unauthenticated`) — this only happens if a
+/// method runs without the interceptor having stamped the extension.
+#[allow(clippy::result_large_err)]
+pub fn authorize_grpc_scope<T>(req: &Request<T>, required: &str) -> Result<(), Status> {
+    let principal = req
+        .extensions()
+        .get::<GrpcPrincipal>()
+        .ok_or_else(|| Status::unauthenticated("missing authenticated principal"))?;
+
+    let allowed = match &principal.scopes {
+        None => true,
+        Some(scopes) => crate::services::token_service::scopes_grant_access(scopes, required),
+    };
+
+    if allowed {
+        Ok(())
+    } else {
+        Err(Status::permission_denied(format!(
+            "Token does not have required scope: {}",
+            required
+        )))
+    }
+}
 
 /// gRPC auth interceptor that validates JWT Bearer tokens and enforces admin authorization.
 #[derive(Clone)]
@@ -128,6 +181,15 @@ impl AuthInterceptor {
         if self.require_admin && !token_data.claims.is_admin {
             return Err(Status::permission_denied("Admin access required"));
         }
+
+        // Stamp the authenticated principal (live is_admin + the token's
+        // action-scope ceiling) so each service method can enforce its required
+        // scope via `authorize_grpc_scope`, mirroring REST's `has_scope`.
+        let mut req = req;
+        req.extensions_mut().insert(GrpcPrincipal {
+            is_admin: token_data.claims.is_admin,
+            scopes: token_data.claims.scopes.clone(),
+        });
 
         Ok(req)
     }
@@ -375,6 +437,101 @@ mod tests {
             .bind(low_id)
             .execute(&pool)
             .await;
+    }
+
+    // -----------------------------------------------------------------------
+    // authorize_grpc_scope: per-method scope enforcement (mirror of REST
+    // AuthExtension::has_scope). Pure, no DB.
+    // -----------------------------------------------------------------------
+
+    fn request_with_principal(scopes: Option<Vec<String>>) -> Request<()> {
+        let mut req = Request::new(());
+        req.extensions_mut().insert(GrpcPrincipal {
+            is_admin: true,
+            scopes,
+        });
+        req
+    }
+
+    #[test]
+    fn test_authorize_scope_none_passes_everything() {
+        // Interactive / full token (scopes = None) mirrors REST: allowed on any scope.
+        let req = request_with_principal(None);
+        assert!(authorize_grpc_scope(&req, "read:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "write:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "delete:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "write:repositories").is_ok());
+    }
+
+    #[test]
+    fn test_authorize_scope_read_only_denied_on_writes() {
+        let req = request_with_principal(Some(vec!["read:artifacts".to_string()]));
+        assert!(authorize_grpc_scope(&req, "read:artifacts").is_ok());
+
+        for required in ["write:artifacts", "delete:artifacts", "write:repositories"] {
+            let err = authorize_grpc_scope(&req, required).unwrap_err();
+            assert_eq!(err.code(), tonic::Code::PermissionDenied);
+            assert!(err.message().contains(required));
+        }
+    }
+
+    #[test]
+    fn test_authorize_scope_wildcard_passes_everything() {
+        let req = request_with_principal(Some(vec!["*".to_string()]));
+        assert!(authorize_grpc_scope(&req, "read:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "delete:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "write:repositories").is_ok());
+    }
+
+    #[test]
+    fn test_authorize_scope_admin_wildcard_passes_everything() {
+        let req = request_with_principal(Some(vec!["admin".to_string()]));
+        assert!(authorize_grpc_scope(&req, "read:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "delete:artifacts").is_ok());
+        assert!(authorize_grpc_scope(&req, "write:repositories").is_ok());
+    }
+
+    #[test]
+    fn test_authorize_scope_missing_principal_fails_closed() {
+        let req = Request::new(());
+        let err = authorize_grpc_scope(&req, "read:artifacts").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[test]
+    fn test_intercept_stamps_principal_scopes() {
+        // The interceptor must copy Claims.scopes into the stamped principal so
+        // per-method enforcement sees the token's ceiling.
+        let mut claims = test_claims(Uuid::new_v4(), true, "access", None);
+        claims.scopes = Some(vec!["read:artifacts".to_string()]);
+        let token = encode(
+            &Header::default(),
+            &claims,
+            &EncodingKey::from_secret(b"secret"),
+        )
+        .unwrap();
+        let interceptor = AuthInterceptor::new("secret", None);
+        let req = interceptor
+            .intercept(request_with_token(&token))
+            .expect("admin token should pass");
+        let principal = req
+            .extensions()
+            .get::<GrpcPrincipal>()
+            .expect("principal stamped");
+        assert!(principal.is_admin);
+        assert_eq!(
+            principal.scopes,
+            Some(vec!["read:artifacts".to_string()]),
+            "the token's scope ceiling must be carried into the request"
+        );
+        // And it enforces: read passes, write denied.
+        assert!(authorize_grpc_scope(&req, "read:artifacts").is_ok());
+        assert_eq!(
+            authorize_grpc_scope(&req, "write:artifacts")
+                .unwrap_err()
+                .code(),
+            tonic::Code::PermissionDenied
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/backend/src/grpc/sbom_server.rs
+++ b/backend/src/grpc/sbom_server.rs
@@ -1,5 +1,6 @@
 //! gRPC server implementations for SBOM services.
 
+use crate::grpc::auth_interceptor::authorize_grpc_scope;
 use crate::models::access_scope::AccessScope;
 use crate::models::sbom::{CveStatus, SbomFormat};
 use crate::services::sbom_service::{DependencyInfo, SbomService};
@@ -7,6 +8,47 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use tonic::{Request, Response, Status};
 use uuid::Uuid;
+
+// === Per-method action-scope map ===
+//
+// Every gRPC service method below authorizes the caller's token action-scope
+// ceiling against the required scope in this map via `authorize_grpc_scope`,
+// exactly as the REST handlers do via `AuthExtension::require_scope`
+// (api/middleware/auth.rs). The interceptor already enforces authentication and
+// the admin floor; this adds the same per-scope ceiling REST enforces, so a
+// scoped token is constrained identically on both planes. A full/interactive
+// token (`scopes = None`) and admin-minted `*`/`admin` tokens pass everywhere.
+//
+// SBOM & CVE data are artifact-security metadata -> `*:artifacts`; license
+// policy is repository-level config -> `*:repositories`.
+//
+// | Service.Method                          | Required scope       |
+// |-----------------------------------------|----------------------|
+// | SbomService.generate_sbom               | write:artifacts      |
+// | SbomService.get_sbom                    | read:artifacts       |
+// | SbomService.get_sbom_by_artifact        | read:artifacts       |
+// | SbomService.list_sboms_for_artifact     | read:artifacts       |
+// | SbomService.get_sbom_components         | read:artifacts       |
+// | SbomService.convert_sbom                | read:artifacts       |
+// | SbomService.delete_sbom                 | delete:artifacts     |
+// | SbomService.regenerate_sbom             | write:artifacts      |
+// | SbomService.check_license_compliance    | read:artifacts       |
+// | CveHistoryService.get_cve_history       | read:artifacts       |
+// | CveHistoryService.update_cve_status     | write:artifacts      |
+// | CveHistoryService.get_cve_trends        | read:artifacts       |
+// | CveHistoryService.trigger_retroactive_scan | write:artifacts   |
+// | SecurityPolicyService.get_license_policy   | read:repositories |
+// | SecurityPolicyService.list_license_policies| read:repositories |
+// | SecurityPolicyService.upsert_license_policy| write:repositories|
+// | SecurityPolicyService.delete_license_policy| delete:repositories|
+mod scope {
+    pub const READ_ARTIFACTS: &str = "read:artifacts";
+    pub const WRITE_ARTIFACTS: &str = "write:artifacts";
+    pub const DELETE_ARTIFACTS: &str = "delete:artifacts";
+    pub const READ_REPOSITORIES: &str = "read:repositories";
+    pub const WRITE_REPOSITORIES: &str = "write:repositories";
+    pub const DELETE_REPOSITORIES: &str = "delete:repositories";
+}
 
 use super::generated::{
     cve_history_service_server::CveHistoryService as CveHistoryServiceTrait,
@@ -41,6 +83,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<GenerateSbomRequest>,
     ) -> Result<Response<SbomDocument>, Status> {
+        authorize_grpc_scope(&request, scope::WRITE_ARTIFACTS)?;
         let req = request.into_inner();
 
         let artifact_id = parse_uuid(&req.artifact_id)?;
@@ -64,6 +107,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<GetSbomRequest>,
     ) -> Result<Response<SbomDocument>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let id = parse_uuid(&req.id)?;
 
@@ -81,6 +125,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<GetSbomByArtifactRequest>,
     ) -> Result<Response<SbomDocument>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let artifact_id = parse_uuid(&req.artifact_id)?;
         let format = proto_to_sbom_format(req.format());
@@ -99,6 +144,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<ListSbomsRequest>,
     ) -> Result<Response<ListSbomsResponse>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let artifact_id = parse_uuid(&req.artifact_id)?;
 
@@ -137,6 +183,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<GetSbomComponentsRequest>,
     ) -> Result<Response<GetSbomComponentsResponse>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let sbom_id = parse_uuid(&req.sbom_id)?;
 
@@ -178,6 +225,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<ConvertSbomRequest>,
     ) -> Result<Response<SbomDocument>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let sbom_id = parse_uuid(&req.sbom_id)?;
         let target_format = proto_to_sbom_format(req.target_format());
@@ -195,6 +243,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<DeleteSbomRequest>,
     ) -> Result<Response<DeleteSbomResponse>, Status> {
+        authorize_grpc_scope(&request, scope::DELETE_ARTIFACTS)?;
         let req = request.into_inner();
         let id = parse_uuid(&req.id)?;
 
@@ -210,6 +259,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<RegenerateSbomRequest>,
     ) -> Result<Response<SbomDocument>, Status> {
+        authorize_grpc_scope(&request, scope::WRITE_ARTIFACTS)?;
         let req = request.into_inner();
         let artifact_id = parse_uuid(&req.artifact_id)?;
         let format = proto_to_sbom_format(req.format());
@@ -241,6 +291,7 @@ impl SbomServiceTrait for SbomGrpcServer {
         &self,
         request: Request<CheckLicenseComplianceRequest>,
     ) -> Result<Response<LicenseComplianceResponse>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let repo_id = if req.repository_id.is_empty() {
             None
@@ -286,6 +337,7 @@ impl CveHistoryServiceTrait for CveHistoryGrpcServer {
         &self,
         request: Request<GetCveHistoryRequest>,
     ) -> Result<Response<GetCveHistoryResponse>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let artifact_id = parse_uuid(&req.artifact_id)?;
 
@@ -307,6 +359,7 @@ impl CveHistoryServiceTrait for CveHistoryGrpcServer {
         &self,
         request: Request<UpdateCveStatusRequest>,
     ) -> Result<Response<CveHistoryEntry>, Status> {
+        authorize_grpc_scope(&request, scope::WRITE_ARTIFACTS)?;
         let req = request.into_inner();
         let id = parse_uuid(&req.id)?;
         let status = proto_to_cve_status(req.status());
@@ -327,6 +380,7 @@ impl CveHistoryServiceTrait for CveHistoryGrpcServer {
         &self,
         request: Request<GetCveTrendsRequest>,
     ) -> Result<Response<CveTrendsResponse>, Status> {
+        authorize_grpc_scope(&request, scope::READ_ARTIFACTS)?;
         let req = request.into_inner();
         let repo_id = if req.repository_id.is_empty() {
             None
@@ -372,6 +426,7 @@ impl CveHistoryServiceTrait for CveHistoryGrpcServer {
         &self,
         request: Request<RetroactiveScanRequest>,
     ) -> Result<Response<RetroactiveScanResponse>, Status> {
+        authorize_grpc_scope(&request, scope::WRITE_ARTIFACTS)?;
         let _req = request.into_inner();
 
         Err(Status::unimplemented("Retroactive scan queuing is not yet implemented. This feature is planned for a future release."))
@@ -395,6 +450,7 @@ impl SecurityPolicyServiceTrait for SecurityPolicyGrpcServer {
         &self,
         request: Request<GetLicensePolicyRequest>,
     ) -> Result<Response<LicensePolicy>, Status> {
+        authorize_grpc_scope(&request, scope::READ_REPOSITORIES)?;
         let req = request.into_inner();
         let repo_id = if req.repository_id.is_empty() {
             None
@@ -416,6 +472,7 @@ impl SecurityPolicyServiceTrait for SecurityPolicyGrpcServer {
         &self,
         request: Request<UpsertLicensePolicyRequest>,
     ) -> Result<Response<LicensePolicy>, Status> {
+        authorize_grpc_scope(&request, scope::WRITE_REPOSITORIES)?;
         let req = request.into_inner();
         let policy = req
             .policy
@@ -465,6 +522,7 @@ impl SecurityPolicyServiceTrait for SecurityPolicyGrpcServer {
         &self,
         request: Request<DeleteLicensePolicyRequest>,
     ) -> Result<Response<DeleteLicensePolicyResponse>, Status> {
+        authorize_grpc_scope(&request, scope::DELETE_REPOSITORIES)?;
         let req = request.into_inner();
         let id = parse_uuid(&req.id)?;
 
@@ -481,6 +539,7 @@ impl SecurityPolicyServiceTrait for SecurityPolicyGrpcServer {
         &self,
         request: Request<ListLicensePoliciesRequest>,
     ) -> Result<Response<ListLicensePoliciesResponse>, Status> {
+        authorize_grpc_scope(&request, scope::READ_REPOSITORIES)?;
         let req = request.into_inner();
 
         let policies: Vec<crate::models::sbom::LicensePolicy> = if req.repository_id.is_empty() {
@@ -648,6 +707,49 @@ fn model_policy_action_to_proto(
 mod tests {
     use super::*;
     use chrono::{TimeZone, Utc};
+
+    // -----------------------------------------------------------------------
+    // Fail-open guard: every gRPC service-trait method in this file must call
+    // `authorize_grpc_scope` as part of its body. All `async fn`s in this file
+    // are service-trait implementations (the conversion helpers are sync), so a
+    // future method that forgets the scope check fails THIS test, not open.
+    // Mirrors the source-grep handler-dir gate pattern (#1316).
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_every_grpc_method_enforces_scope() {
+        let src = include_str!("sbom_server.rs");
+        // Collect each `async fn <name>(` and the slice of source until the next
+        // `async fn ` (or EOF), then assert that slice contains the authorizer.
+        let marker = "async fn ";
+        let positions: Vec<usize> = src.match_indices(marker).map(|(i, _)| i).collect();
+        assert!(
+            positions.len() >= 17,
+            "expected >=17 gRPC service methods, found {} — did the parser break?",
+            positions.len()
+        );
+        for (idx, &start) in positions.iter().enumerate() {
+            let end = positions.get(idx + 1).copied().unwrap_or(src.len());
+            let body = &src[start..end];
+            // Method name for a clear failure message.
+            let name: String = body[marker.len()..]
+                .chars()
+                .take_while(|c| c.is_alphanumeric() || *c == '_')
+                .collect();
+            // Skip the reference to `async fn` that appears inside this very test
+            // string literal (the include_str! self-reference), if any.
+            if name.is_empty() {
+                continue;
+            }
+            assert!(
+                body.contains("authorize_grpc_scope("),
+                "gRPC method `{}` is missing an `authorize_grpc_scope(...)` call \
+                 (fail-open risk): add the per-method scope check per the map at \
+                 the top of sbom_server.rs",
+                name
+            );
+        }
+    }
 
     // -----------------------------------------------------------------------
     // parse_uuid


### PR DESCRIPTION
## Summary

The gRPC auth interceptor authorized requests on the `is_admin` claim alone and
never consulted the token's action-scope ceiling (`Claims.scopes`). The REST layer
already enforces that ceiling via `AuthExtension::has_scope` / `require_scope`
(`api/middleware/auth.rs`), so a scoped token was constrained on REST but not on
the equivalent gRPC methods — a parity gap on the SBOM / CVE-history / license-policy
surface.

This PR closes the gap while keeping the interceptor as the single authentication
point:

- `grpc/auth_interceptor.rs`: after the existing authentication and `require_admin`
  floor, the interceptor now stamps a `GrpcPrincipal { is_admin, scopes }` into the
  request extensions. A shared `authorize_grpc_scope(&request, required)` helper reads
  that principal and delegates to the canonical `token_service::scopes_grant_access`
  — the exact `*` / `admin` wildcard + exact-match policy REST uses — so the two planes
  share one evaluator and cannot drift. `scopes = None` (interactive/full tokens) passes
  everything, matching `has_scope`.
- `grpc/sbom_server.rs`: each service method now calls `authorize_grpc_scope(...)` as
  its first line, driven by a documented method→scope `const` map at the top of the
  file (SBOM/CVE methods → `*:artifacts`; license-policy methods → `*:repositories`,
  mirroring the REST read/write/delete classification).

A method-agnostic tonic `Request<()>` interceptor cannot see the gRPC method path, so
the required scope is selected per-method at the handler rather than in the interceptor.

**Intended behavior change:** service accounts / automation that drive gRPC *writes*
(`GenerateSbom`, `DeleteSbom`, `RegenerateSbom`, `UpdateCveStatus`,
`TriggerRetroactiveScan`, `UpsertLicensePolicy`, `DeleteLicensePolicy`) using a JWT
whose scopes are narrower than the method requires are now correctly denied
(`PermissionDenied`), exactly as on REST. Operators driving those calls should mint
tokens with an appropriate write scope (or `*` / `admin`, or use an interactive token
with `scopes = None`). This is not a change to anonymous/unauthenticated access — the
JWT authentication and admin floor are untouched.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Tests added (`grpc/auth_interceptor.rs`, `grpc/sbom_server.rs`):
- `authorize_grpc_scope` branch coverage: `None` passes all scopes; `["read:artifacts"]`
  passes reads and is denied (`PermissionDenied`) on `write:*` / `delete:*`; `["*"]` and
  `["admin"]` pass all; missing principal fails closed (`Unauthenticated`).
- `test_intercept_stamps_principal_scopes`: the interceptor carries `Claims.scopes` into
  the stamped principal and it enforces (read allowed, write denied).
- `test_every_grpc_method_enforces_scope`: source-grep gate asserting every gRPC
  service-trait method contains an `authorize_grpc_scope(` call, so a future method that
  forgets the check fails the build rather than failing open.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2432
