### PR TITLE
fix(migration): treat absent 73/74/75 checksum rows as no-op in v1.1.9 divergence repair (#2456)

### DIFF
--- a/backend/src/migration_repair.rs
+++ b/backend/src/migration_repair.rs
@@ -194,7 +194,15 @@ pub async fn repair_release_1_1_9_divergence(db: &PgPool) -> Result<()> {
         return Ok(());
     }
 
-    let row: Option<(Vec<u8>, Vec<u8>, Vec<u8>)> = sqlx::query_as(
+    // This is a FROM-less SELECT of three scalar sub-queries, so PostgreSQL
+    // always returns exactly one row. When a migration row (73/74/75) is
+    // absent, its sub-query yields SQL NULL rather than a missing row, so
+    // `fetch_optional` returns `Some((NULL, NULL, NULL))` - never `None`.
+    // Decode into `Option<Vec<u8>>` columns so an absent row surfaces as
+    // `None` instead of failing to decode a NULL into `Vec<u8>` (which would
+    // abort startup and cause a restart loop; see #2456).
+    type ChecksumRow = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>);
+    let row: Option<ChecksumRow> = sqlx::query_as(
         "SELECT \
              (SELECT checksum FROM _sqlx_migrations WHERE version = 73), \
              (SELECT checksum FROM _sqlx_migrations WHERE version = 74), \
@@ -204,7 +212,9 @@ pub async fn repair_release_1_1_9_divergence(db: &PgPool) -> Result<()> {
     .await
     .map_err(|e| AppError::Database(e.to_string()))?;
 
-    let Some((stored_73, stored_74, stored_75)) = row else {
+    // All three diverged v1.1.9 rows must be present; any NULL means this is
+    // not the v1.1.9 -> main upgrade we recover, so no-op.
+    let Some((Some(stored_73), Some(stored_74), Some(stored_75))) = row else {
         return Ok(());
     };
 
@@ -387,27 +397,51 @@ mod tests {
         }
     }
 
+    /// Create a fresh isolation schema (named `<prefix>_<uuid>`) and return a
+    /// pool whose connections are pinned to it, together with the resolved
+    /// `DATABASE_URL` and schema name (both needed for `drop_isolation_schema`
+    /// cleanup). Returns `None` when `DATABASE_URL` is unset or the database
+    /// is unreachable, so the DB-backed tests skip silently (local `cargo test
+    /// --lib` without a Postgres just no-ops).
+    async fn setup_isolated_pool(prefix: &str) -> Option<(String, String, PgPool)> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        let bootstrap = PgPool::connect(&url).await.ok()?;
+        let schema = format!("{prefix}_{}", uuid::Uuid::new_v4().simple());
+        create_isolation_schema(&bootstrap, &schema).await;
+        drop(bootstrap);
+        let pool = schema_isolated_pool(&url, &schema).await;
+        Some((url, schema, pool))
+    }
+
+    /// Stand up the `_sqlx_migrations` table in the same shape sqlx creates
+    /// it, so the tests can seed migration rows the repair function inspects.
+    async fn create_sqlx_migrations_table(pool: &PgPool) {
+        sqlx::query(
+            "CREATE TABLE _sqlx_migrations ( \
+                 version BIGINT PRIMARY KEY, \
+                 description TEXT NOT NULL, \
+                 installed_on TIMESTAMPTZ NOT NULL DEFAULT NOW(), \
+                 success BOOLEAN NOT NULL, \
+                 checksum BYTEA NOT NULL, \
+                 execution_time BIGINT NOT NULL \
+             )",
+        )
+        .execute(pool)
+        .await
+        .expect("create _sqlx_migrations");
+    }
+
     /// DB-backed regression test for the v1.1.9 -> main upgrade path.
     /// Requires `DATABASE_URL` (the CI coverage job sets this; local
     /// `cargo test --lib` skips silently when the var is missing).
     #[tokio::test]
     async fn repair_release_1_1_9_divergence_rewrites_checksums_and_applies_schema() {
-        let url = match std::env::var("DATABASE_URL") {
-            Ok(v) => v,
-            Err(_) => return,
-        };
         // Use a schema-isolated pool: install the repair scenario into
         // a fresh test schema so we don't disturb the migrator's
         // production state on shared CI databases.
-        let bootstrap = match PgPool::connect(&url).await {
-            Ok(p) => p,
-            Err(_) => return,
+        let Some((url, schema, pool)) = setup_isolated_pool("issue1277").await else {
+            return;
         };
-
-        let schema = format!("issue1277_{}", uuid::Uuid::new_v4().simple());
-        create_isolation_schema(&bootstrap, &schema).await;
-        drop(bootstrap);
-        let pool = schema_isolated_pool(&url, &schema).await;
 
         // Minimal `users` and `artifacts` skeleton matching the columns
         // the repair function touches. Real installs always have these
@@ -434,22 +468,9 @@ mod tests {
         .await
         .expect("create artifacts");
 
-        // Stand up the _sqlx_migrations table in the same shape sqlx
-        // creates it, then seed the three rows with the v1.1.9
-        // checksums to simulate a freshly-upgraded customer.
-        sqlx::query(
-            "CREATE TABLE _sqlx_migrations ( \
-                 version BIGINT PRIMARY KEY, \
-                 description TEXT NOT NULL, \
-                 installed_on TIMESTAMPTZ NOT NULL DEFAULT NOW(), \
-                 success BOOLEAN NOT NULL, \
-                 checksum BYTEA NOT NULL, \
-                 execution_time BIGINT NOT NULL \
-             )",
-        )
-        .execute(&pool)
-        .await
-        .expect("create _sqlx_migrations");
+        // Stand up the _sqlx_migrations table, then seed the three rows
+        // with the v1.1.9 checksums to simulate a freshly-upgraded customer.
+        create_sqlx_migrations_table(&pool).await;
         for (version, label, checksum) in [
             (
                 73i64,
@@ -577,36 +598,14 @@ mod tests {
     /// install that already migrated past slot 75.
     #[tokio::test]
     async fn repair_release_1_1_9_divergence_no_op_when_checksums_differ() {
-        let url = match std::env::var("DATABASE_URL") {
-            Ok(v) => v,
-            Err(_) => return,
+        let Some((url, schema, pool)) = setup_isolated_pool("issue1277_noop").await else {
+            return;
         };
-        let bootstrap = match PgPool::connect(&url).await {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-
-        let schema = format!("issue1277_noop_{}", uuid::Uuid::new_v4().simple());
-        create_isolation_schema(&bootstrap, &schema).await;
-        drop(bootstrap);
-        let pool = schema_isolated_pool(&url, &schema).await;
 
         // Seed _sqlx_migrations with NOT-v1.1.9 checksums (e.g. fresh
         // main install where rows 73-75 were applied from main's own
         // files). The function must not touch this DB.
-        sqlx::query(
-            "CREATE TABLE _sqlx_migrations ( \
-                 version BIGINT PRIMARY KEY, \
-                 description TEXT NOT NULL, \
-                 installed_on TIMESTAMPTZ NOT NULL DEFAULT NOW(), \
-                 success BOOLEAN NOT NULL, \
-                 checksum BYTEA NOT NULL, \
-                 execution_time BIGINT NOT NULL \
-             )",
-        )
-        .execute(&pool)
-        .await
-        .expect("create _sqlx_migrations");
+        create_sqlx_migrations_table(&pool).await;
 
         let bogus_checksum = vec![0xaau8; 48];
         for version in [73i64, 74, 75] {
@@ -660,24 +659,79 @@ mod tests {
     /// table does not exist (fresh install).
     #[tokio::test]
     async fn repair_release_1_1_9_divergence_no_op_on_fresh_install() {
-        let url = match std::env::var("DATABASE_URL") {
-            Ok(v) => v,
-            Err(_) => return,
+        let Some((url, schema, pool)) = setup_isolated_pool("issue1277_fresh").await else {
+            return;
         };
-        let bootstrap = match PgPool::connect(&url).await {
-            Ok(p) => p,
-            Err(_) => return,
-        };
-
-        let schema = format!("issue1277_fresh_{}", uuid::Uuid::new_v4().simple());
-        create_isolation_schema(&bootstrap, &schema).await;
-        drop(bootstrap);
-        let pool = schema_isolated_pool(&url, &schema).await;
 
         // No _sqlx_migrations table at all. The repair must early-return.
         repair_release_1_1_9_divergence(&pool)
             .await
             .expect("repair must succeed (as no-op) on fresh install");
+
+        drop(pool);
+        drop_isolation_schema(&url, &schema).await;
+    }
+
+    /// The repair must be a strict no-op when the `_sqlx_migrations` table
+    /// exists but rows 73/74/75 are absent - the reporter's 1.1.0-rc.8 ->
+    /// 1.2.0 case (#2456). The detection query is a FROM-less SELECT of
+    /// three scalar sub-queries, so it always returns exactly one row whose
+    /// columns are NULL when the rows are missing. Before the fix this NULL
+    /// failed to decode into `Vec<u8>` ("unexpected null; try decoding as an
+    /// `Option`") and aborted startup into a restart loop; after the fix the
+    /// columns decode into `Option<Vec<u8>>` and the missing rows are treated
+    /// as a clean no-op, leaving the schema untouched.
+    #[tokio::test]
+    async fn repair_release_1_1_9_divergence_no_op_when_rows_absent() {
+        let Some((url, schema, pool)) = setup_isolated_pool("issue2456_absent").await else {
+            return;
+        };
+
+        // Stand up the _sqlx_migrations table but seed NO rows for versions
+        // 73/74/75. Seed a lower row (72) so the table is non-empty and
+        // realistic for a pre-73 (1.1.0-rc.8) database.
+        create_sqlx_migrations_table(&pool).await;
+        sqlx::query(
+            "INSERT INTO _sqlx_migrations \
+                 (version, description, success, checksum, execution_time) \
+                 VALUES (72, 'pre_v1_1_9_baseline', true, $1, 0)",
+        )
+        .bind(vec![0x11u8; 48])
+        .execute(&pool)
+        .await
+        .expect("seed baseline row 72");
+
+        // Must be a clean no-op (pre-fix: Err with the "unexpected null"
+        // decode failure that aborted startup).
+        repair_release_1_1_9_divergence(&pool)
+            .await
+            .expect("repair must be a no-op when rows 73/74/75 are absent");
+
+        // Schema must be untouched: the repair's account-lockout columns and
+        // password_history table must NOT have been created.
+        let users_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+             WHERE table_schema = current_schema() AND table_name = 'users')",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("users exists check");
+        assert!(
+            !users_exists,
+            "no-op path must not create the users table / lockout columns"
+        );
+
+        let ph_exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS (SELECT 1 FROM information_schema.tables \
+             WHERE table_schema = current_schema() AND table_name = 'password_history')",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("password_history exists check");
+        assert!(
+            !ph_exists,
+            "no-op path must not create the password_history table"
+        );
 
         drop(pool);
         drop_isolation_schema(&url, &schema).await;


### PR DESCRIPTION
## Summary

Closes #2456.

The pre-migration recovery step for the v1.1.9 -> v1.2.0 migration-slot
divergence (`repair_release_1_1_9_divergence`, issue #1277) aborts startup on
databases that never applied migration slots 73/74/75 — for example a
`1.1.0-rc.8` install upgrading to a newer release. Affected backends crash on
boot with:

```
Error: Database("error occurred while decoding column 0: unexpected null; try decoding as an `Option`")
```

and enter a restart loop.

### Root cause

The detection query is a `FROM`-less `SELECT` of three scalar sub-queries:

```sql
SELECT (SELECT checksum FROM _sqlx_migrations WHERE version = 73),
       (SELECT checksum FROM _sqlx_migrations WHERE version = 74),
       (SELECT checksum FROM _sqlx_migrations WHERE version = 75)
```

A `FROM`-less scalar-subquery select always returns exactly one row. When rows
73/74/75 are absent, each sub-query yields SQL `NULL`, so `fetch_optional`
returns `Some((NULL, NULL, NULL))` — never `None`. The result was decoded into
the non-optional tuple `(Vec<u8>, Vec<u8>, Vec<u8>)`, and decoding a `NULL`
into `Vec<u8>` fails. The intended "rows absent -> no-op" guard
(`let Some(..) = row else { return Ok(()) }`) never fires for this case because
the row is present with NULL columns. The error is `?`-propagated at startup,
so the process exits before the normal `sqlx` migrator can run.

`_sqlx_migrations.checksum` is `BYTEA NOT NULL`; the NULL comes from the absent
row via the scalar sub-query, not from nullable column data — so this is a
decode-target fix, not a schema/migration change.

### Fix

Decode the three columns into `Option<Vec<u8>>` and only proceed when all
three are present, treating any missing row as "this is not the v1.1.9 upgrade
we recover" (a clean no-op):

```rust
type ChecksumRow = (Option<Vec<u8>>, Option<Vec<u8>>, Option<Vec<u8>>);
let row: Option<ChecksumRow> = sqlx::query_as(/* unchanged query */)...;
let Some((Some(stored_73), Some(stored_74), Some(stored_75))) = row else {
    return Ok(());
};
```

The query text, the checksum comparison against the hard-coded v1.1.9
SHA-384s, and the schema/checksum-rewrite path are all unchanged, so the real
v1.1.9 -> main upgrade (rows present with the v1.1.9 checksums) still triggers
the repair exactly as before.

No migration, no schema change, no change to startup ordering. Blast radius is
the decode type + destructure pattern in one function.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`repair_release_1_1_9_divergence_no_op_when_rows_absent` seeds the
`_sqlx_migrations` table with a lower row (72) but no rows for 73/74/75, then
asserts the repair is a clean no-op that leaves the schema untouched. It fails
on `main` with the "unexpected null" decode error and passes here. The three
existing DB-backed tests (happy-path apply, no-op-on-differing-checksums,
no-op-on-fresh-install) continue to pass unchanged. The repeated per-test
pool/table setup was extracted into two shared helpers
(`setup_isolated_pool`, `create_sqlx_migrations_table`) to keep the module
under the duplication gate.

Verified end-to-end: a Postgres migrated to version 72 (rows 73/74/75 and
their schema absent) crash-loops the pre-fix binary at boot with the exact
decode error, while the patched binary runs the repair as a no-op, lets the
migrator apply 73..N cleanly, and reaches a healthy `/health`.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
