### PR TITLE
fix(analytics): record a download exactly once on every local-serve path (#2260)

### DIFF
--- a/backend/src/api/handlers/admin.rs
+++ b/backend/src/api/handlers/admin.rs
@@ -1934,11 +1934,13 @@ mod tests {
             client_ip: Some("203.0.113.10".parse().unwrap()),
             user_id: Some(user_id),
             user_agent: Some("admin-dl-test/1.0".to_string()),
+            is_head: false,
         };
         let ctx_anon = crate::api::middleware::download_telemetry::DownloadContext {
             client_ip: Some("203.0.113.11".parse().unwrap()),
             user_id: None,
             user_agent: None,
+            is_head: false,
         };
         crate::services::artifact_service::record_download(&pool, artifact_id, &ctx_authed).await;
         crate::services::artifact_service::record_download(&pool, artifact_id, &ctx_anon).await;

--- a/backend/src/api/handlers/ansible.rs
+++ b/backend/src/api/handlers/ansible.rs
@@ -369,6 +369,7 @@ async fn download_collection(
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
                     &repo,
+                    &ctx,
                     proxy_helpers::DownloadResponseOpts {
                         upstream_path: &upstream_path,
                         virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(filename),

--- a/backend/src/api/handlers/cran.rs
+++ b/backend/src/api/handlers/cran.rs
@@ -208,6 +208,7 @@ async fn download_package(
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
                     &repo,
+                    &ctx,
                     proxy_helpers::DownloadResponseOpts {
                         upstream_path: &upstream_path,
                         virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(&filename),

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -239,6 +239,7 @@ async fn download_tarball(
             if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                 &state,
                 &repo,
+                &ctx,
                 proxy_helpers::DownloadResponseOpts {
                     upstream_path: &upstream_path,
                     virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(filename),

--- a/backend/src/api/handlers/huggingface.rs
+++ b/backend/src/api/handlers/huggingface.rs
@@ -254,6 +254,7 @@ async fn download_file(
             if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                 &state,
                 &repo,
+                &ctx,
                 proxy_helpers::DownloadResponseOpts {
                     upstream_path: &upstream_path,
                     virtual_lookup: proxy_helpers::VirtualLookup::ExactPath(&artifact_path),

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -723,7 +723,9 @@ async fn streams_images(
 
 async fn download_image(
     State(state): State<SharedState>,
+    method: axum::http::Method,
     headers: HeaderMap,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
     AxumPath((repo_key, product, version, filename)): AxumPath<(String, String, String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_incus_repo(&state.db, &repo_key).await?;
@@ -756,6 +758,15 @@ async fn download_image(
     crate::services::quarantine_service::check_artifact_download(&state.db, artifact_id)
         .await
         .map_err(|e| e.into_response())?;
+
+    // Record the download exactly once for a real GET (#2260). A HEAD request
+    // returns identical headers but serves no body — axum routes HEAD to this
+    // GET handler — so it must NOT write a download row (guard against the
+    // HEAD over-count in §5). Inline-awaited so the row is committed before the
+    // response is built.
+    if method != axum::http::Method::HEAD {
+        crate::services::artifact_service::record_download(&state.db, artifact_id, &ctx).await;
+    }
 
     // Pull the artifact through the repo's configured StorageBackend via
     // `get_stream`. Pre-#1471 the upload path wrote to local disk on the

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -261,6 +261,7 @@ async fn resolve_snapshot_artifact(
 
     use sqlx::Row;
     Some(ResolvedSnapshot {
+        id: row.get("id"),
         storage_key: row.get("storage_key"),
         checksum_sha256: row.get("checksum_sha256"),
         path: row.get("path"),
@@ -268,6 +269,7 @@ async fn resolve_snapshot_artifact(
 }
 
 struct ResolvedSnapshot {
+    id: uuid::Uuid,
     storage_key: String,
     checksum_sha256: String,
     path: String,
@@ -386,6 +388,9 @@ async fn maven_local_fetch_snapshot(
         body: stream,
         content_type: Some(ct),
         content_length: None,
+        // Local snapshot artifact resolved: surface its id so a virtual
+        // maven-snapshot member download is recorded exactly once (#2260).
+        artifact_id: Some(resolved.id),
     })
 }
 

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -282,6 +282,8 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
         body: stream,
         content_type: None,
         content_length: None,
+        // Remote proxy-cache stream: not our artifact row (#1278), unrecorded.
+        artifact_id: None,
     })
 }
 

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2118,6 +2118,9 @@ async fn npm_local_fetch(
         body,
         content_type: Some(artifact.content_type.clone()),
         content_length: Some(artifact.size_bytes as u64),
+        // Local artifact resolved: surface its id so a virtual npm-member
+        // download is recorded exactly once at the streaming resolver (#2260).
+        artifact_id: Some(artifact.id),
     })
 }
 

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -6681,12 +6681,50 @@ async fn handle_head_manifest(
     )
 }
 
+/// Record one download-statistics row for a local Docker/OCI manifest pull
+/// (#2260). The manifest's `artifacts` row is resolved by its content-addressed
+/// storage key, so a manifest addressable under both a tag-keyed and a
+/// digest-keyed path still counts once per GET. Best-effort: a lookup miss or a
+/// stats failure never affects the pull.
+async fn record_oci_manifest_download(
+    state: &SharedState,
+    repo_id: Uuid,
+    manifest_digest: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
+) {
+    let manifest_key = manifest_storage_key(manifest_digest);
+    match sqlx::query_scalar::<_, Uuid>(
+        "SELECT id FROM artifacts \
+         WHERE repository_id = $1 AND storage_key = $2 AND is_deleted = false \
+         LIMIT 1",
+    )
+    .bind(repo_id)
+    .bind(&manifest_key)
+    .fetch_optional(&state.db)
+    .await
+    {
+        Ok(Some(artifact_id)) => {
+            crate::services::artifact_service::record_download(&state.db, artifact_id, ctx).await;
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(
+                %repo_id,
+                manifest_digest = %manifest_digest,
+                error = %e,
+                "failed to resolve manifest artifact for download statistics"
+            );
+        }
+    }
+}
+
 async fn handle_get_manifest(
     state: &SharedState,
     headers: &HeaderMap,
     base_url: &str,
     image_name: &str,
     reference: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Response {
     let scope = pull_scope(image_name);
     let is_anon = is_anonymous_token(headers);
@@ -6779,6 +6817,15 @@ async fn handle_get_manifest(
         .await
         {
             tracing::debug!(repo = %repo.key, image = %repo.image, reference = %reference, digest = %manifest_digest, "GET manifest: served from local storage (tag row or content-addressable digest)");
+            // #2260: count a Docker/OCI pull exactly ONCE, here on the local
+            // manifest GET — NOT per blob. A `docker pull` fetches one manifest
+            // plus N (often shared/deduplicated) blobs; counting blob GETs would
+            // wildly over-report. Recording against the manifest's `artifacts`
+            // row (resolved by its content-addressed storage key) attributes one
+            // download per pull. Best-effort + inline-awaited; a HEAD manifest
+            // is a separate handler and is never counted. Remote/virtual
+            // pass-through manifests resolve no local row and stay unrecorded.
+            record_oci_manifest_download(state, repo.id, &manifest_digest, ctx).await;
             return build_local_manifest_response(&manifest_digest, &content_type, data, true);
         }
         if let Some(manifest_digest) = tag_row_digest {
@@ -8176,12 +8223,14 @@ async fn handle_delete_manifest(
 // Catch-all handlers
 // ---------------------------------------------------------------------------
 
+#[allow(clippy::too_many_arguments)]
 async fn catch_all(
     State(state): State<SharedState>,
     method: Method,
     uri: axum::http::Uri,
     headers: HeaderMap,
     base_url: RequestBaseUrl,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
     query: Query<std::collections::HashMap<String, String>>,
     body: Body,
 ) -> Response {
@@ -8260,7 +8309,7 @@ async fn catch_all(
         }
         ("GET", "manifests") => {
             let r = require_ref!(reference, "NAME_INVALID", "reference required");
-            handle_get_manifest(&state, &headers, base_url, &image_name, &r).await
+            handle_get_manifest(&state, &headers, base_url, &image_name, &r, &ctx).await
         }
         ("PUT", "manifests") => {
             let r = require_ref!(reference, "NAME_INVALID", "reference required");

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -1915,6 +1915,7 @@ fn is_quarantine_block_response(resp: &Response) -> bool {
 /// `path` must address an **immutable** artifact. The Pass-1 cache probe is
 /// upstream-free only for immutable content; mutable indexes/metadata must go
 /// through [`resolve_virtual_metadata`] / the metadata-merge helpers instead.
+#[allow(clippy::too_many_arguments)]
 pub async fn resolve_virtual_download_streaming<F, Fut>(
     state: &AppState,
     proxy_service: Option<&ProxyService>,
@@ -1922,6 +1923,7 @@ pub async fn resolve_virtual_download_streaming<F, Fut>(
     path: &str,
     default_content_type: &str,
     content_disposition_filename: Option<&str>,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
     local_fetch: F,
 ) -> Result<Response, Response>
 where
@@ -1949,7 +1951,13 @@ where
     // Borrow `local_fetch` so the per-member `probe` closure copies the
     // reference instead of moving the `Fn` into each `async move` future.
     let local_fetch = &local_fetch;
-    let outcome = resolve_members_two_phase::<Response, Response, _, _, _, _>(
+    // The winning hit carries the resolved LOCAL artifact id (`Some`) so a
+    // local-member serve can be recorded exactly once at winner-determination
+    // (#2260). Remote pass-through / proxy-cache hits carry `None` and stay
+    // unrecorded (#1278). Recording in the probe would over-count members that
+    // are probed but lose to a higher-priority upstream candidate in Pass 2, so
+    // the id is threaded to the outcome instead.
+    let outcome = resolve_members_two_phase::<(Response, Option<Uuid>), Response, _, _, _, _>(
         &members,
         |member| async move {
             match virtual_member_fetch_strategy(
@@ -1957,11 +1965,18 @@ where
                 proxy_service.is_some(),
                 member.upstream_url.is_some(),
             ) {
-                VirtualMemberFetchStrategy::Local => classify_streaming_local(
-                    local_fetch(member.id, member.storage_location()).await,
-                    default_content_type,
-                    content_disposition_filename,
-                ),
+                VirtualMemberFetchStrategy::Local => {
+                    let fetched = local_fetch(member.id, member.storage_location()).await;
+                    // Capture the local artifact id before `fetched` is consumed
+                    // into a Response by `classify_streaming_local`.
+                    let artifact_id = fetched.as_ref().ok().and_then(|r| r.artifact_id);
+                    let (class, hit) = classify_streaming_local(
+                        fetched,
+                        default_content_type,
+                        content_disposition_filename,
+                    );
+                    (class, hit.map(|resp| (resp, artifact_id)))
+                }
                 VirtualMemberFetchStrategy::Proxy => match proxy_service {
                     Some(proxy) => {
                         // #1555: a fresh proxy-cache hit on a redirect-capable
@@ -1970,13 +1985,15 @@ where
                         if let Some(redirect) =
                             try_member_cache_redirect(state, proxy, member, path).await
                         {
-                            (MemberCacheClass::DefiniteHit, Some(redirect))
+                            // Remote proxy-cache serve: not our artifact (#1278).
+                            (MemberCacheClass::DefiniteHit, Some((redirect, None)))
                         } else {
-                            classify_streaming_cache_probe(
+                            let (class, hit) = classify_streaming_cache_probe(
                                 proxy.streaming_cached_artifact_by_path(member, path).await,
                                 default_content_type,
                                 content_disposition_filename,
-                            )
+                            );
+                            (class, hit.map(|resp| (resp, None)))
                         }
                     }
                     None => (MemberCacheClass::DefiniteMiss, None),
@@ -1986,7 +2003,8 @@ where
         },
         |member| async move {
             match proxy_service {
-                Some(proxy) => classify_streaming_upstream(
+                // Remote upstream serve: not our artifact (#1278), so `None`.
+                Some(proxy) => match classify_streaming_upstream(
                     proxy_fetch_streaming_member(
                         proxy,
                         member,
@@ -1995,7 +2013,13 @@ where
                         content_disposition_filename,
                     )
                     .await,
-                ),
+                ) {
+                    MemberResolveOutcome::Hit(resp) => MemberResolveOutcome::Hit((resp, None)),
+                    MemberResolveOutcome::Quarantine(resp) => {
+                        MemberResolveOutcome::Quarantine(resp)
+                    }
+                    MemberResolveOutcome::Miss => MemberResolveOutcome::Miss,
+                },
                 None => MemberResolveOutcome::Miss,
             }
         },
@@ -2003,7 +2027,16 @@ where
     .await;
 
     match outcome {
-        Some(MemberResolveOutcome::Hit(response)) => Ok(response),
+        Some(MemberResolveOutcome::Hit((response, artifact_id))) => {
+            // Record the local-member winner exactly once (#2260). Inline-awaited
+            // so the row is committed before the response is returned; a Remote
+            // pass-through winner has `artifact_id == None` and stays unrecorded.
+            if let Some(artifact_id) = artifact_id {
+                crate::services::artifact_service::record_download(&state.db, artifact_id, ctx)
+                    .await;
+            }
+            Ok(response)
+        }
         Some(MemberResolveOutcome::Quarantine(response)) => Err(response),
         _ => Err((
             StatusCode::NOT_FOUND,
@@ -2510,6 +2543,9 @@ async fn read_local_stream(
         body,
         content_type: Some(artifact.content_type.clone()),
         content_length: Some(artifact.size_bytes as u64),
+        // Local artifact row resolved: surface its id so the virtual-member
+        // streaming resolver can record the download exactly once (#2260).
+        artifact_id: Some(artifact.id),
     })
 }
 
@@ -2634,6 +2670,7 @@ pub async fn local_fetch_or_redirect_by_suffix(
     repo_id: Uuid,
     location: &StorageLocation,
     path_suffix: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let reversed_pattern = reverse_suffix_for_like(path_suffix);
     let path: String = sqlx::query_scalar(
@@ -2650,7 +2687,7 @@ pub async fn local_fetch_or_redirect_by_suffix(
     .map_err(|e| internal_error("Database", e))?
     .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
 
-    local_fetch_or_redirect(db, state, repo_id, location, &path).await
+    local_fetch_or_redirect(db, state, repo_id, location, &path, ctx).await
 }
 
 /// Build the reversed-+-escaped LIKE prefix for a path-suffix query
@@ -2687,6 +2724,7 @@ pub async fn local_fetch_or_redirect(
     repo_id: Uuid,
     location: &StorageLocation,
     artifact_path: &str,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let (artifact, storage) = local_lookup_artifact(
         db,
@@ -2696,6 +2734,24 @@ pub async fn local_fetch_or_redirect(
         LocalLookup::Path(artifact_path),
     )
     .await?;
+
+    // #2260: this is THE single central recording point for a local-artifact
+    // presigned redirect. A 302 is counted at redirect-issue time because the
+    // client's subsequent S3/CloudFront GET is invisible to us; the streaming
+    // fallback below serves the same local artifact, so it is counted here too.
+    // Recording once, before the response is built, means no local-serve path
+    // through this helper can silently under-report — and any handler that
+    // later adopts it (e.g. Maven presigned redirects, #1945) inherits the
+    // count and MUST NOT add its own second record call. Inline-awaited (never
+    // spawned) so the row is committed before the response is returned.
+    //
+    // A proxy-cache row (a Remote member's cached upstream object, keyed under
+    // `proxy-cache/`) is NOT our artifact, so it stays unrecorded (#1278;
+    // accounting for those is #2270/#2218, out of scope). This helper also
+    // serves those for redirect-capable virtual members, so gate on the key.
+    if !ProxyService::is_proxy_cache_key(&artifact.storage_key) {
+        crate::services::artifact_service::record_download(db, artifact.id, ctx).await;
+    }
 
     // Try presigned redirect before reading content into memory
     if state.config.presigned_downloads_enabled {
@@ -3309,6 +3365,7 @@ pub async fn virtual_non_remote_owns_maven_gav(
 pub async fn try_remote_or_virtual_download(
     state: &crate::api::SharedState,
     repo: &RepoInfo,
+    ctx: &crate::api::middleware::download_telemetry::DownloadContext,
     opts: DownloadResponseOpts<'_>,
 ) -> Result<Option<Response>, Response> {
     if classify_remote_or_virtual(&repo.repo_type) == RemoteOrVirtualAction::Remote {
@@ -3366,6 +3423,7 @@ pub async fn try_remote_or_virtual_download(
                     opts.upstream_path,
                     opts.default_content_type,
                     opts.content_disposition_filename,
+                    ctx,
                     move |member_id, location| {
                         let db = db.clone();
                         let state = state_arc.clone();
@@ -3388,6 +3446,7 @@ pub async fn try_remote_or_virtual_download(
                     opts.upstream_path,
                     opts.default_content_type,
                     opts.content_disposition_filename,
+                    ctx,
                     move |member_id, location| {
                         let db = db.clone();
                         let state = state_arc.clone();
@@ -4772,6 +4831,7 @@ mod tests {
             body: Box::pin(futures::stream::empty()),
             content_type: None,
             content_length: Some(0),
+            artifact_id: None,
         }
     }
 
@@ -7746,9 +7806,18 @@ mod tests {
             content_disposition_filename: None,
             suppress_upstream_proxy: false,
         };
-        let result = try_remote_or_virtual_download(&state, &repo, opts)
-            .await
-            .expect("ok");
+        let result = try_remote_or_virtual_download(
+            &state,
+            &repo,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                client_ip: None,
+                user_id: None,
+                user_agent: None,
+            },
+            opts,
+        )
+        .await
+        .expect("ok");
         assert!(result.is_none(), "hosted repo must propagate to caller");
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
@@ -7785,9 +7854,18 @@ mod tests {
             content_disposition_filename: None,
             suppress_upstream_proxy: false,
         };
-        let result = try_remote_or_virtual_download(&state, &repo, opts)
-            .await
-            .expect("ok");
+        let result = try_remote_or_virtual_download(
+            &state,
+            &repo,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                client_ip: None,
+                user_id: None,
+                user_agent: None,
+            },
+            opts,
+        )
+        .await
+        .expect("ok");
         assert!(result.is_none(), "no proxy service → Ok(None)");
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
@@ -7823,9 +7901,18 @@ mod tests {
             content_disposition_filename: None,
             suppress_upstream_proxy: false,
         };
-        let result = try_remote_or_virtual_download(&state, &repo, opts)
-            .await
-            .expect("ok");
+        let result = try_remote_or_virtual_download(
+            &state,
+            &repo,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                client_ip: None,
+                user_id: None,
+                user_agent: None,
+            },
+            opts,
+        )
+        .await
+        .expect("ok");
         assert!(result.is_none(), "no upstream URL: Ok(None)");
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
@@ -8005,6 +8092,7 @@ mod tests {
             body: empty_body(),
             content_type: Some("application/java-archive".to_string()),
             content_length: None,
+            artifact_id: None,
         };
         let response = build_streaming_response(result, "application/octet-stream")
             .expect("response build must succeed");
@@ -8024,6 +8112,7 @@ mod tests {
             body: empty_body(),
             content_type: None,
             content_length: None,
+            artifact_id: None,
         };
         let response =
             build_streaming_response(result, "text/xml").expect("response build must succeed");
@@ -8045,6 +8134,7 @@ mod tests {
             body: empty_body(),
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(12345),
+            artifact_id: None,
         };
         let response = build_streaming_response(result, "application/octet-stream").unwrap();
         assert_eq!(
@@ -8067,6 +8157,7 @@ mod tests {
             body: empty_body(),
             content_type: Some("application/octet-stream".to_string()),
             content_length: None,
+            artifact_id: None,
         };
         let response = build_streaming_response(result, "application/octet-stream").unwrap();
         assert!(
@@ -8083,6 +8174,7 @@ mod tests {
             body: empty_body(),
             content_type: None,
             content_length: None,
+            artifact_id: None,
         };
         let response = build_streaming_response(result, "application/octet-stream").unwrap();
         assert_eq!(response.status(), StatusCode::OK);
@@ -8098,6 +8190,7 @@ mod tests {
             body: empty_body(),
             content_type: None,
             content_length: None,
+            artifact_id: None,
         };
         let response = build_streaming_response(result, weird).unwrap();
         assert_eq!(
@@ -8118,6 +8211,7 @@ mod tests {
             body: empty_body(),
             content_type: Some("application/zip".to_string()),
             content_length: Some(1234),
+            artifact_id: None,
         };
         let response = stream_fetch_result(result, "application/octet-stream", Some("pkg.whl"))
             .expect("stream_fetch_result must build a response");
@@ -8145,6 +8239,7 @@ mod tests {
             body: empty_body(),
             content_type: None,
             content_length: None,
+            artifact_id: None,
         };
         let response = stream_fetch_result(result, "application/octet-stream", None)
             .expect("stream_fetch_result must build a response");
@@ -8627,6 +8722,11 @@ mod tests {
             "pkg/pkg-1.0.0-py3-none-any.whl",
             "application/octet-stream",
             None,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                client_ip: None,
+                user_id: None,
+                user_agent: None,
+            },
             // Remote member must redirect before reaching any local fetch.
             |_id, _loc| async {
                 panic!("local_fetch must NOT run: the redirect fast path should win");
@@ -8886,6 +8986,11 @@ mod tests {
             "pkg/pkg-1.0.0-py3-none-any.whl",
             "application/octet-stream",
             None,
+            &crate::api::middleware::download_telemetry::DownloadContext {
+                client_ip: None,
+                user_id: None,
+                user_agent: None,
+            },
             |_id, _loc| async {
                 panic!("local_fetch must NOT run: the held entry must 409 before any fallback");
                 #[allow(unreachable_code)]
@@ -8970,9 +9075,25 @@ mod tests {
         .expect("seed proxy-cache artifact row");
 
         let location = repo_info.storage_location();
-        let result =
-            super::local_fetch_or_redirect(&fx.pool, &state, fx.repo_id, &location, artifact_path)
-                .await;
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+        };
+        let result = super::local_fetch_or_redirect(
+            &fx.pool,
+            &state,
+            fx.repo_id,
+            &location,
+            artifact_path,
+            &ctx,
+        )
+        .await;
+
+        // #2260/#1278: a proxy-cache-keyed row is a Remote member's cached
+        // upstream object, NOT our artifact, so serving it here must record
+        // ZERO download-statistics rows.
+        let recorded = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
 
         // Clean up before asserting so a panic still leaves the DB clean.
         fx.teardown().await;
@@ -8986,6 +9107,200 @@ mod tests {
         assert!(
             resp.headers().get("location").is_none(),
             "filesystem backend must NOT emit a redirect Location header (#1555)"
+        );
+        assert_eq!(
+            recorded, 0,
+            "a proxy-cache serve must NOT be counted (#1278; out of scope for #2260)"
+        );
+    }
+
+    /// Count `download_statistics` rows attributed to any artifact in `repo_id`.
+    /// Shared by the #2260 count-once tests so the assertion query is defined
+    /// once (jscpd).
+    async fn download_stats_count_for_repo(pool: &PgPool, repo_id: Uuid) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM download_statistics ds \
+             JOIN artifacts a ON a.id = ds.artifact_id \
+             WHERE a.repository_id = $1",
+        )
+        .bind(repo_id)
+        .fetch_one(pool)
+        .await
+        .expect("count download_statistics rows")
+    }
+
+    /// #2260: a HOSTED (non-proxy-cache) local artifact served through
+    /// `local_fetch_or_redirect` on a filesystem backend (streaming fallback,
+    /// no presign) records exactly ONE download-statistics row — and a second
+    /// serve records a second, so the append-only `COUNT(*)` metric tracks real
+    /// downloads one-for-one.
+    #[tokio::test]
+    async fn test_local_fetch_or_redirect_hosted_records_once_2260() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = tdh::build_state(fx.pool.clone(), &storage_path);
+        let repo_info =
+            tdh::make_repo_info(fx.repo_id, &fx.repo_key, &fx.storage_dir, "local", None);
+
+        let body: &[u8] = b"hosted-bytes";
+        let artifact_path = "pkg/pkg-1.0.0.bin";
+        // A hosted artifact is content-addressed (NOT a proxy-cache/ key).
+        let storage_key = format!("{}/{}", fx.repo_key, artifact_path);
+        super::put_artifact_bytes(&state, &repo_info, &storage_key, Bytes::from_static(body))
+            .await
+            .expect("seed hosted payload on disk");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(fx.repo_id)
+        .bind(artifact_path)
+        .bind("pkg")
+        .bind("1.0.0")
+        .bind(body.len() as i64)
+        .bind("test-pkg")
+        .bind("application/octet-stream")
+        .bind(&storage_key)
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed hosted artifact row");
+
+        let location = repo_info.storage_location();
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+        };
+
+        super::local_fetch_or_redirect(
+            &fx.pool,
+            &state,
+            fx.repo_id,
+            &location,
+            artifact_path,
+            &ctx,
+        )
+        .await
+        .expect("first hosted fetch must succeed");
+        let after_one = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+
+        super::local_fetch_or_redirect(
+            &fx.pool,
+            &state,
+            fx.repo_id,
+            &location,
+            artifact_path,
+            &ctx,
+        )
+        .await
+        .expect("second hosted fetch must succeed");
+        let after_two = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+
+        fx.teardown().await;
+
+        assert_eq!(after_one, 1, "one hosted serve must record exactly one row");
+        assert_eq!(
+            after_two, 2,
+            "a second serve records a second row (append-only COUNT tracks downloads 1:1)"
+        );
+    }
+
+    /// #2260 (G5): a virtual repo whose winning member is a LOCAL artifact,
+    /// resolved through `resolve_virtual_download_streaming`, records exactly
+    /// ONE download-statistics row attributed to that member's artifact — the
+    /// gap that left ansible/cran/hex/rubygems/huggingface/rpm/puppet/npm
+    /// virtual-member downloads uncounted.
+    #[tokio::test]
+    async fn test_resolve_virtual_download_streaming_records_local_member_once_2260() {
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (virtual_id, _vkey, _vdir) = db_helpers::create_repo(&pool, "virtual", "generic").await;
+        let (member_id, member_key, mdir) =
+            db_helpers::create_repo(&pool, "local", "generic").await;
+        db_helpers::link_member(&pool, virtual_id, member_id, 0).await;
+
+        let storage_path = mdir.to_str().unwrap().to_string();
+        let state = db_helpers::build_state(pool.clone(), &storage_path);
+        let member_info = crate::api::handlers::test_db_helpers::make_repo_info(
+            member_id,
+            &member_key,
+            &mdir,
+            "local",
+            None,
+        );
+
+        let body: &[u8] = b"virtual-local-member-bytes";
+        let path = "pkg/pkg-2.0.0.bin";
+        let storage_key = format!("{}/{}", member_key, path);
+        put_artifact_bytes(&state, &member_info, &storage_key, Bytes::from_static(body))
+            .await
+            .expect("seed member payload on disk");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(member_id)
+        .bind(path)
+        .bind("pkg")
+        .bind("2.0.0")
+        .bind(body.len() as i64)
+        .bind("test-vpkg")
+        .bind("application/octet-stream")
+        .bind(&storage_key)
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .expect("seed member artifact row");
+
+        let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+        };
+        let db = pool.clone();
+        let state_arc = state.clone();
+        let p = path.to_string();
+        // proxy_service = None so only the Local member can win.
+        let result = resolve_virtual_download_streaming(
+            &state,
+            None,
+            virtual_id,
+            path,
+            "application/octet-stream",
+            None,
+            &ctx,
+            move |mid, loc| {
+                let db = db.clone();
+                let st = state_arc.clone();
+                let p = p.clone();
+                async move { local_fetch_by_path(&db, &st, mid, &loc, &p).await }
+            },
+        )
+        .await;
+
+        let recorded = download_stats_count_for_repo(&pool, member_id).await;
+
+        db_helpers::cleanup(&pool, member_id, user_id).await;
+        db_helpers::cleanup(&pool, virtual_id, user_id).await;
+
+        assert!(
+            result.is_ok(),
+            "local virtual member must resolve and serve the artifact"
+        );
+        assert_eq!(
+            recorded, 1,
+            "a virtual-member local resolve must record exactly one download"
         );
     }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -7547,6 +7547,7 @@ mod tests {
             client_ip: Some("203.0.113.77".parse().unwrap()),
             user_id: Some(user_id),
             user_agent: Some("serve-local-test/1.0".to_string()),
+            is_head: false,
         };
         let resp = serve_local_artifact(
             &state,
@@ -7813,6 +7814,7 @@ mod tests {
                 client_ip: None,
                 user_id: None,
                 user_agent: None,
+                is_head: false,
             },
             opts,
         )
@@ -7861,6 +7863,7 @@ mod tests {
                 client_ip: None,
                 user_id: None,
                 user_agent: None,
+                is_head: false,
             },
             opts,
         )
@@ -7908,6 +7911,7 @@ mod tests {
                 client_ip: None,
                 user_id: None,
                 user_agent: None,
+                is_head: false,
             },
             opts,
         )
@@ -8726,6 +8730,7 @@ mod tests {
                 client_ip: None,
                 user_id: None,
                 user_agent: None,
+                is_head: false,
             },
             // Remote member must redirect before reaching any local fetch.
             |_id, _loc| async {
@@ -8990,6 +8995,7 @@ mod tests {
                 client_ip: None,
                 user_id: None,
                 user_agent: None,
+                is_head: false,
             },
             |_id, _loc| async {
                 panic!("local_fetch must NOT run: the held entry must 409 before any fallback");
@@ -9079,6 +9085,7 @@ mod tests {
             client_ip: None,
             user_id: None,
             user_agent: None,
+            is_head: false,
         };
         let result = super::local_fetch_or_redirect(
             &fx.pool,
@@ -9177,6 +9184,7 @@ mod tests {
             client_ip: None,
             user_id: None,
             user_agent: None,
+            is_head: false,
         };
 
         super::local_fetch_or_redirect(
@@ -9209,6 +9217,102 @@ mod tests {
         assert_eq!(
             after_two, 2,
             "a second serve records a second row (append-only COUNT tracks downloads 1:1)"
+        );
+    }
+
+    /// #2260 §5: a HEAD request served through the shared local-serve choke
+    /// point records ZERO download-statistics rows, while a GET on the same
+    /// artifact records exactly one. axum's `get()` auto-dispatches HEAD to the
+    /// GET handler for the format routes (pypi/npm/rubygems/rpm/cran/hex/puppet/
+    /// ansible/huggingface/maven), so the `DownloadContext.is_head` flag — set
+    /// from the request method — must suppress the recorder even though the
+    /// helper runs. Guards against the HEAD over-count QA caught on the format
+    /// download routes.
+    #[tokio::test]
+    async fn test_local_fetch_or_redirect_head_does_not_count_2260() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(fx) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+
+        let storage_path = fx.storage_dir.to_str().unwrap().to_string();
+        let state = tdh::build_state(fx.pool.clone(), &storage_path);
+        let repo_info =
+            tdh::make_repo_info(fx.repo_id, &fx.repo_key, &fx.storage_dir, "local", None);
+
+        let body: &[u8] = b"head-guard-bytes";
+        let artifact_path = "pkg/pkg-3.0.0.bin";
+        let storage_key = format!("{}/{}", fx.repo_key, artifact_path);
+        super::put_artifact_bytes(&state, &repo_info, &storage_key, Bytes::from_static(body))
+            .await
+            .expect("seed hosted payload on disk");
+        sqlx::query(
+            "INSERT INTO artifacts ( \
+                 repository_id, path, name, version, size_bytes, \
+                 checksum_sha256, content_type, storage_key, uploaded_by \
+             ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+        )
+        .bind(fx.repo_id)
+        .bind(artifact_path)
+        .bind("pkg")
+        .bind("3.0.0")
+        .bind(body.len() as i64)
+        .bind("test-pkg3")
+        .bind("application/octet-stream")
+        .bind(&storage_key)
+        .bind(fx.user_id)
+        .execute(&fx.pool)
+        .await
+        .expect("seed hosted artifact row");
+
+        let location = repo_info.storage_location();
+        // A HEAD-flagged context (as the extractor builds it for a HEAD request).
+        let head_ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+            is_head: true,
+        };
+        super::local_fetch_or_redirect(
+            &fx.pool,
+            &state,
+            fx.repo_id,
+            &location,
+            artifact_path,
+            &head_ctx,
+        )
+        .await
+        .expect("HEAD serve must still succeed");
+        let after_head = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+
+        // A GET (is_head == false) on the same artifact must record one row.
+        let get_ctx = crate::api::middleware::download_telemetry::DownloadContext {
+            client_ip: None,
+            user_id: None,
+            user_agent: None,
+            is_head: false,
+        };
+        super::local_fetch_or_redirect(
+            &fx.pool,
+            &state,
+            fx.repo_id,
+            &location,
+            artifact_path,
+            &get_ctx,
+        )
+        .await
+        .expect("GET serve must succeed");
+        let after_get = download_stats_count_for_repo(&fx.pool, fx.repo_id).await;
+
+        fx.teardown().await;
+
+        assert_eq!(
+            after_head, 0,
+            "a HEAD must NOT record a download row (#2260 §5)"
+        );
+        assert_eq!(
+            after_get, 1,
+            "a GET on the same artifact records exactly one"
         );
     }
 
@@ -9267,6 +9371,7 @@ mod tests {
             client_ip: None,
             user_id: None,
             user_agent: None,
+            is_head: false,
         };
         let db = pool.clone();
         let state_arc = state.clone();

--- a/backend/src/api/handlers/puppet.rs
+++ b/backend/src/api/handlers/puppet.rs
@@ -288,6 +288,7 @@ async fn download_module(
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
                     &repo,
+                    &ctx,
                     proxy_helpers::DownloadResponseOpts {
                         upstream_path: &upstream_path,
                         virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(filename),

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -1673,6 +1673,7 @@ async fn serve_file(
                         member.id,
                         &member.storage_location(),
                         filename,
+                        ctx,
                     )
                     .await
                     {
@@ -4210,6 +4211,7 @@ mod tests {
             body: futures::stream::once(async move { Ok(Bytes::from_static(content)) }).boxed(),
             content_type: None,
             content_length: len,
+            artifact_id: None,
         }
     }
 
@@ -4323,6 +4325,7 @@ mod tests {
             body: futures::stream::once(async move { Ok(Bytes::from_static(content)) }).boxed(),
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(content.len() as u64),
+            artifact_id: None,
         }
     }
 
@@ -4724,6 +4727,7 @@ mod tests {
                 .boxed(),
             content_type: Some("application/octet-stream".to_string()),
             content_length,
+            artifact_id: None,
         }
     }
 
@@ -7200,6 +7204,7 @@ mod tests {
             body: Box::pin(stream),
             content_type: Some("application/zip".to_string()),
             content_length: Some(data_len),
+            artifact_id: None,
         };
 
         let response = build_streaming_file_response("numpy-1.0-py3-none-any.whl", result);

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -5142,6 +5142,13 @@ fn download_filename(path: &str) -> &str {
 ///
 /// Stats recording must never block or fail the download itself, so errors
 /// are logged at `warn` and swallowed rather than propagated.
+/// Test-only shim preserving the historical `record_redirect_download`
+/// entrypoint. Redirect and streaming downloads now share the single canonical
+/// recorder (`artifact_service::record_download`) so there is exactly one
+/// `download_statistics` INSERT in the codebase (#2260); this delegates to it
+/// and keeps the existing redirect-recording behavior tests exercising that one
+/// path (writes a row; swallows a DB error without failing the download).
+#[cfg(test)]
 async fn record_redirect_download(
     db: &sqlx::PgPool,
     artifact_id: Uuid,
@@ -5149,25 +5156,12 @@ async fn record_redirect_download(
     ip_address: Option<&str>,
     user_agent: Option<&str>,
 ) {
-    if let Err(e) = sqlx::query(
-        r#"
-        INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent)
-        VALUES ($1, $2, $3, $4)
-        "#,
-    )
-    .bind(artifact_id)
-    .bind(user_id)
-    .bind(ip_address)
-    .bind(user_agent)
-    .execute(db)
-    .await
-    {
-        tracing::warn!(
-            %artifact_id,
-            error = %e,
-            "failed to record download statistics for redirect download"
-        );
-    }
+    let ctx = crate::api::middleware::download_telemetry::DownloadContext {
+        client_ip: ip_address.and_then(|s| s.parse().ok()),
+        user_id,
+        user_agent: user_agent.map(str::to_string),
+    };
+    crate::services::artifact_service::record_download(db, artifact_id, &ctx).await;
 }
 
 /// Outcome of parsing an HTTP `Range` request header against a known total
@@ -5563,18 +5557,20 @@ pub async fn download_artifact(
                 .await?
             {
                 // Record download analytics (best-effort; must not block the
-                // redirect). This previously inserted into an events table
-                // that does not exist in the schema — and discarded the
-                // error — so every presigned/redirect download was silently
-                // missing from download statistics (#2260, bug 1).
-                record_redirect_download(
-                    &state.db,
-                    artifact.id,
-                    auth.as_ref().map(|a| a.user_id),
-                    client_ip_str.as_deref(),
-                    user_agent.as_deref(),
-                )
-                .await;
+                // redirect). A presigned 302 is counted at redirect-issue time
+                // because the client's subsequent S3/CloudFront GET is invisible
+                // to us. Recording goes through the single canonical recorder
+                // (`artifact_service::record_download`) so redirect and streaming
+                // downloads share one behavior and one INSERT (#2260). A HEAD
+                // request issues no real download, so it is not counted (§5).
+                if !is_head {
+                    crate::services::artifact_service::record_download(
+                        &state.db,
+                        artifact.id,
+                        &dl_ctx,
+                    )
+                    .await;
+                }
 
                 tracing::info!(
                     repo = %key,
@@ -5597,6 +5593,8 @@ pub async fn download_artifact(
             auth.map(|a| a.user_id),
             client_ip_str.clone(),
             user_agent.as_deref(),
+            // #2260 §5: a HEAD serves no body, so it must not count.
+            !is_head,
         )
         .await;
 
@@ -5717,7 +5715,7 @@ pub async fn download_artifact(
             // no local `artifacts` row and stays unrecorded (#1278). No
             // double-count: the direct-row path records in `download_stream`
             // and cannot reach this arm.
-            if owns_locally {
+            if owns_locally && !is_head {
                 if let Some(artifact_id) =
                     proxy_helpers::virtual_local_winner_artifact_id(&state.db, repo.id, &path).await
                 {

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -5160,6 +5160,7 @@ async fn record_redirect_download(
         client_ip: ip_address.and_then(|s| s.parse().ok()),
         user_id,
         user_agent: user_agent.map(str::to_string),
+        is_head: false,
     };
     crate::services::artifact_service::record_download(db, artifact_id, &ctx).await;
 }

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -766,6 +766,7 @@ async fn download_package(
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
                     &repo,
+                    &ctx,
                     proxy_helpers::DownloadResponseOpts {
                         upstream_path: &upstream_path,
                         virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(filename),

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -240,6 +240,7 @@ async fn download_gem(
                 if let Some(resp) = proxy_helpers::try_remote_or_virtual_download(
                     &state,
                     &repo,
+                    &ctx,
                     proxy_helpers::DownloadResponseOpts {
                         upstream_path: &upstream_path,
                         virtual_lookup: proxy_helpers::VirtualLookup::PathSuffix(filename),

--- a/backend/src/api/middleware/download_telemetry.rs
+++ b/backend/src/api/middleware/download_telemetry.rs
@@ -41,6 +41,13 @@ pub struct DownloadContext {
     pub user_id: Option<Uuid>,
     /// The request's `User-Agent` header, when present and valid UTF-8.
     pub user_agent: Option<String>,
+    /// True when the request method is `HEAD`. axum's `get(handler)` auto-
+    /// dispatches `HEAD` to the same GET handler, which then runs its full
+    /// serve path (including the shared recorders) even though no body is
+    /// returned. Recording keys off this flag so a `HEAD` — a metadata probe
+    /// that serves no bytes — never writes a `download_statistics` row
+    /// (#2260 §5). Synthesized (non-request) contexts leave this `false`.
+    pub is_head: bool,
 }
 
 impl DownloadContext {
@@ -59,6 +66,9 @@ impl DownloadContext {
                 .get(header::USER_AGENT)
                 .and_then(|v| v.to_str().ok())
                 .map(str::to_string),
+            // Method-agnostic constructor: callers that care about HEAD set the
+            // flag from the request method (see the `FromRequestParts` impl).
+            is_head: false,
         }
     }
 }
@@ -83,12 +93,16 @@ impl FromRequestParts<SharedState> for DownloadContext {
             .get::<Option<AuthExtension>>()
             .and_then(|opt| opt.as_ref())
             .or_else(|| parts.extensions.get::<AuthExtension>());
-        Ok(Self::from_parts_inner(
+        let mut ctx = Self::from_parts_inner(
             &parts.headers,
             peer,
             auth,
             &state.config.rate_limit_trusted_proxy_cidrs,
-        ))
+        );
+        // A HEAD served through an axum `get()` route runs the GET handler and
+        // its recorders; flag it so `record_download` skips the write (#2260).
+        ctx.is_head = parts.method == axum::http::Method::HEAD;
+        Ok(ctx)
     }
 }
 

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1457,6 +1457,7 @@ impl ArtifactService {
         user_id: Option<Uuid>,
         ip_address: Option<String>,
         user_agent: Option<&str>,
+        count_download: bool,
     ) -> Result<(Artifact, BoxStream<'static, Result<Bytes>>)> {
         let (artifact, artifact_info) = self.prepare_download(repository_id, path).await?;
 
@@ -1465,14 +1466,20 @@ impl ArtifactService {
         // matching the buffered `get` path's NotFound contract.
         let body = self.storage.get_stream(&artifact.storage_key).await?;
 
-        self.finish_download(
-            artifact.id,
-            &artifact_info,
-            user_id,
-            ip_address.as_deref(),
-            user_agent,
-        )
-        .await;
+        // `count_download` is false for a HEAD request: it returns identical
+        // headers but serves no body, so it must not write a download-statistics
+        // row (or fire the AfterDownload epilogue) — that would over-count the
+        // metric (#2260 §5). A real GET counts exactly once here.
+        if count_download {
+            self.finish_download(
+                artifact.id,
+                &artifact_info,
+                user_id,
+                ip_address.as_deref(),
+                user_agent,
+            )
+            .await;
+        }
 
         Ok((artifact, body))
     }

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1364,6 +1364,7 @@ impl ArtifactService {
             client_ip: ip_address.and_then(|s| s.parse().ok()),
             user_id,
             user_agent: user_agent.map(str::to_string),
+            is_head: false,
         };
         record_download(&self.db, artifact_id, &ctx).await;
 
@@ -1938,6 +1939,16 @@ impl ArtifactService {
 /// Call this only after a **local** artifact row has been resolved; remote
 /// pass-through proxy fetches are not our artifacts and stay unrecorded.
 pub async fn record_download(db: &PgPool, artifact_id: Uuid, ctx: &DownloadContext) {
+    // A HEAD request serves no body — it must never write a download row
+    // (#2260 §5). This is the single choke point every serving path funnels
+    // through (hosted stream, presigned redirect, virtual-member local resolve,
+    // per-format serve_local_artifact / direct recorders), so guarding here
+    // makes "one row == one real body served" hold for the axum `get()`-
+    // registered format routes that auto-dispatch HEAD to their GET handler,
+    // mirroring the explicit guards on the generic / OCI / incus paths.
+    if ctx.is_head {
+        return;
+    }
     if let Err(e) = sqlx::query(
         "INSERT INTO download_statistics (artifact_id, user_id, ip_address, user_agent) \
          VALUES ($1, $2, $3, $4)",

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -119,6 +119,13 @@ pub struct StreamingFetchResult {
     /// without a length advertised, in which case the outbound response
     /// uses chunked transfer encoding.
     pub content_length: Option<u64>,
+    /// The `artifacts.id` this result was resolved from when it was served
+    /// from a **local** artifact row (hosted / virtual-member local hit).
+    /// `None` for remote pass-through / proxy-cache streams, which are not
+    /// our artifacts and stay unrecorded (#1278). Download-statistics
+    /// recording keys off this field so a local-member serve is counted
+    /// exactly once, at the shared local-serve choke point (#2260).
+    pub artifact_id: Option<Uuid>,
 }
 
 impl From<StreamHandle> for StreamingFetchResult {
@@ -130,6 +137,8 @@ impl From<StreamHandle> for StreamingFetchResult {
             body: handle.body,
             content_type: handle.headers.content_type,
             content_length: handle.headers.content_length,
+            // Remote/cache stream: not a local artifact row, so unrecorded.
+            artifact_id: None,
         }
     }
 }
@@ -2978,6 +2987,8 @@ impl ProxyService {
                 body,
                 content_type: metadata.content_type.clone(),
                 content_length: Some(metadata.size_bytes as u64),
+                // Proxy-cache stream: not our artifact row (#1278), unrecorded.
+                artifact_id: None,
             })),
             Err(AppError::NotFound(_)) => {
                 tracing::debug!(
@@ -9347,6 +9358,7 @@ mod tests {
             body: dummy,
             content_type: Some("application/octet-stream".to_string()),
             content_length: Some(12345),
+            artifact_id: None,
         };
         assert_eq!(r.content_length, Some(12345));
         assert_eq!(r.content_type.as_deref(), Some("application/octet-stream"));


### PR DESCRIPTION
## Summary

Closes #2260.

Download statistics (`download_statistics`, an append-only table where
`COUNT(*)` is the metric) were recorded per-handler rather than at a shared
local-serve choke point. Because recording was attached to individual serving
code paths, several local-serve routes returned real artifact bytes (or a 302 to
them) without ever writing a row, so the reported download count silently
under-reported. A metadata `HEAD` on the generic path had the opposite bug: it
wrote a row though no body was served.

This change moves recording into the shared `proxy_helpers` local-serve
primitives so a local artifact is counted **exactly once** wherever it is served,
and adds a `HEAD` guard so counts are complete without being inflated.

### What changed
- **Central redirect recording.** `local_fetch_or_redirect` /
  `local_fetch_or_redirect_by_suffix` now record the download at
  **redirect-issue time** (the client's subsequent presigned S3/CloudFront GET is
  invisible to us, so redirect-issue is the only correct count point) and equally
  on the streaming fallback. This is the single place a local-artifact redirect is
  counted; a proxy-cache-keyed row (a Remote member's cached upstream object) is
  gated out and stays unrecorded.
- **Virtual-member local winner.** `resolve_virtual_download_streaming` records
  the winning member's download once, and only when the winner is a **local**
  artifact. The resolved `artifacts.id` is surfaced on `StreamingFetchResult`
  (`read_local_stream`, plus the npm and maven-snapshot local callbacks) and
  threaded to winner-determination — recording in the two-phase probe would
  over-count members that are probed but then lose to a higher-priority upstream
  candidate. `try_remote_or_virtual_download` threads the `DownloadContext` its
  format-handler callers already hold (ansible/cran/hex/rubygems/huggingface/
  rpm/puppet).
- **Confirmed gaps closed.** incus image GET, PyPI virtual-member download, and
  the redirect/virtual helpers now count.
- **OCI/Docker.** A pull is counted **once per pull, on the manifest GET** in
  `oci_v2.rs` — never per blob (a pull is one manifest + N shared/deduplicated
  blobs; counting blobs would wildly over-report). `HEAD` manifest is a separate
  handler and is never counted.
- **HEAD guard.** The generic download path threads `count_download = !is_head`
  into `download_stream`, and the presigned-redirect and virtual-local-winner
  arms skip recording on `HEAD`. incus guards the same way (axum routes `HEAD` to
  the `GET` handler).
- **One recorder.** The generic redirect path now uses the single canonical
  recorder `artifact_service::record_download`; the duplicate INSERT in
  `record_redirect_download` is collapsed (kept only as a test shim), so there is
  exactly one `download_statistics` INSERT in the codebase.

Remote pass-through / proxy-cache serves stay intentionally unrecorded (#1278;
their accounting is #2270/#2218, out of scope). No DB migration.

### Coordination note (maven presigned redirect, #1945)
This PR owns the **central redirect-recording point**. When #1945 switches Maven
downloads to `local_fetch_or_redirect`, they inherit the count automatically and
**must NOT add a second `record_download` call** — doing so would double-count
every Maven presigned redirect.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New/updated tests assert the exact-count invariant:
- `test_local_fetch_or_redirect_hosted_records_once_2260` — a hosted local serve
  records exactly one row (and two on a second serve; append-only `COUNT` tracks
  downloads 1:1).
- `test_local_fetch_or_redirect_proxy_cache_key_streams_on_filesystem_1555` —
  extended to assert a proxy-cache serve records **zero** rows (#1278).
- `test_resolve_virtual_download_streaming_records_local_member_once_2260` — a
  virtual repo whose winning member is a local artifact records exactly one row.
- The redirect-recording behavior tests now exercise the single canonical
  recorder (writes a row; swallows a DB error without failing the download).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual end-to-end verification (isolated instance, DB `COUNT(*)` before/after):
| Path | GET | HEAD | Notes |
|---|---|---|---|
| hosted stream | +1 | +0 | |
| docker pull (manifest GET) | +1 | +0 | config+layer blob GETs +0; a 2nd pull +1 |
| generic virtual-member local | +1 | +0 | no double-count |
| rpm virtual-member local (streaming resolver) | +1 | — | |
| cran virtual-member local (streaming resolver) | +1 | — | |
| incus image | +1 | +0 | |
| proxy-cache serve | +0 | — | unit-tested (#1278) |

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
