### PR TITLE
fix(storage): prevent cross-repository object access on shared cloud backends

### DIFF
--- a/backend/migrations/157_artifacts_storage_key_index.sql
+++ b/backend/migrations/157_artifacts_storage_key_index.sql
@@ -1,0 +1,16 @@
+-- Index backing the cross-repository overwrite guard (#2504).
+--
+-- Hosted flat-key writes now consult `artifacts` for a live row that references
+-- the same `storage_key` in a *different* repository before writing, to prevent
+-- one repository from clobbering another's object on shared cloud namespaces
+-- (S3/GCS/Azure), where the per-repo storage_path is not applied to the key.
+--
+-- The guard query filters on `storage_key` (and `is_deleted`), which was
+-- previously unindexed; without this index every hosted upload would trigger a
+-- sequential scan of `artifacts`. A plain (non-unique) b-tree keeps keys flat —
+-- distinct repositories legitimately share a coordinate key today — so this is
+-- purely a lookup accelerator, not a uniqueness constraint. Idempotent so it is
+-- safe to (re)apply and to cherry-pick onto release branches.
+CREATE INDEX IF NOT EXISTS idx_artifacts_storage_key_live
+    ON artifacts (storage_key)
+    WHERE is_deleted = false;

--- a/backend/migrations/157_artifacts_storage_key_index.sql
+++ b/backend/migrations/157_artifacts_storage_key_index.sql
@@ -1,16 +1,18 @@
 -- Index backing the cross-repository overwrite guard (#2504).
 --
--- Hosted flat-key writes now consult `artifacts` for a live row that references
--- the same `storage_key` in a *different* repository before writing, to prevent
--- one repository from clobbering another's object on shared cloud namespaces
+-- Hosted flat-key writes now consult `artifacts` for a row that references the
+-- same `storage_key` in a *different* repository before writing, to prevent one
+-- repository from clobbering another's object on shared cloud namespaces
 -- (S3/GCS/Azure), where the per-repo storage_path is not applied to the key.
 --
--- The guard query filters on `storage_key` (and `is_deleted`), which was
--- previously unindexed; without this index every hosted upload would trigger a
--- sequential scan of `artifacts`. A plain (non-unique) b-tree keeps keys flat —
--- distinct repositories legitimately share a coordinate key today — so this is
+-- The guard query filters on `storage_key` alone (it must catch BOTH live and
+-- soft-deleted foreign rows: the physical object persists past a soft-delete, so
+-- a tombstoned foreign row still owns the key). That column was previously
+-- unindexed; without this index every hosted upload would trigger a sequential
+-- scan of `artifacts`. A plain (non-unique) b-tree over ALL rows keeps keys flat
+-- -- distinct repositories legitimately share a coordinate key today, and
+-- content-addressed formats legitimately share sha-based keys -- so this is
 -- purely a lookup accelerator, not a uniqueness constraint. Idempotent so it is
 -- safe to (re)apply and to cherry-pick onto release branches.
-CREATE INDEX IF NOT EXISTS idx_artifacts_storage_key_live
-    ON artifacts (storage_key)
-    WHERE is_deleted = false;
+CREATE INDEX IF NOT EXISTS idx_artifacts_storage_key
+    ON artifacts (storage_key);

--- a/backend/src/api/handlers/cargo.rs
+++ b/backend/src/api/handlers/cargo.rs
@@ -643,6 +643,8 @@ async fn store_crate_artifact(
 ) -> Result<(), Response> {
     let filename = format!("{}-{}.crate", name_lower, crate_version);
     let storage_key = format!("cargo/{}/{}/{}", name_lower, crate_version, filename);
+    proxy_helpers::guard_cross_repo_write(state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -325,6 +325,8 @@ async fn push_pod(
 
     // Store the pod archive
     let storage_key = format!("cocoapods/{}/{}/{}", pod_name, pod_version, filename);
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
@@ -342,6 +344,8 @@ async fn push_pod(
         pod_name, pod_version, pod_name
     );
     let podspec_json = serde_json::to_vec(&podspec).unwrap_or_default();
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &podspec_key)
+        .await?;
     storage
         .put(&podspec_key, Bytes::from(podspec_json))
         .await

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1416,6 +1416,8 @@ async fn upload(
 
     // Store the archive
     let storage_key = format!("composer/{}/{}/{}.zip", full_name, version, sha256);
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/conan.rs
+++ b/backend/src/api/handlers/conan.rs
@@ -1786,6 +1786,8 @@ async fn recipe_file_upload(
     .map_err(|e| e.into_response())?;
 
     // Store the file
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
@@ -2606,6 +2608,8 @@ async fn package_file_upload(
     .map_err(|e| e.into_response())?;
 
     // Store the file
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/goproxy.rs
+++ b/backend/src/api/handlers/goproxy.rs
@@ -988,6 +988,8 @@ async fn upload_zip(
 
     let size_bytes = body.len() as i64;
     let storage_key = format!("go/{}/{}/{}.zip", encoded_module, version, version);
+    proxy_helpers::guard_cross_repo_write(state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
 
     // Store the file
     let storage = state
@@ -1108,6 +1110,8 @@ async fn upload_mod(
 
     let size_bytes = body.len() as i64;
     let storage_key = format!("go/{}/{}/go.mod", encoded_module, version);
+    proxy_helpers::guard_cross_repo_write(state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
 
     // Store the file
     let storage = state

--- a/backend/src/api/handlers/jetbrains.rs
+++ b/backend/src/api/handlers/jetbrains.rs
@@ -408,6 +408,8 @@ async fn upload_plugin(
 
     // Store the file
     let storage_key = format!("jetbrains/{}/{}/{}", plugin_name, plugin_version, filename);
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -902,7 +902,14 @@ async fn download(
         // under `maven/`. (The SNAPSHOT branch below is inherently hosted-only:
         // `resolve_snapshot_artifact` reads the `artifacts` table, which never
         // has rows for Remote/Virtual repos, so it short-circuits for them.)
-        if checksum_compute_eligible(&repo.repo_type) {
+        // The stored-sidecar reads below fetch a bare `maven/<path>` key with no
+        // artifact row scoped to the caller's repository, so they are only sound
+        // on repo-isolated (filesystem) backends. On shared cloud namespaces
+        // (S3/GCS/Azure) that flat key can belong to a *different* repository, so
+        // skip the stored sidecar there and fall through to the row-gated
+        // computed-checksum path below (#2504).
+        let repo_isolated = crate::storage::backend_is_repo_isolated(&repo.storage_backend);
+        if checksum_compute_eligible(&repo.repo_type) && repo_isolated {
             // First try to find a stored checksum file
             let checksum_storage_key = format!("maven/{}", path);
             if let Ok(content) = storage.get(&checksum_storage_key).await {
@@ -915,8 +922,10 @@ async fn download(
         }
 
         // If this is a SNAPSHOT path, try the stored checksum under the
-        // timestamp-resolved filename before falling through to compute.
-        if base_path.contains("-SNAPSHOT") {
+        // timestamp-resolved filename before falling through to compute. Same
+        // shared-namespace hazard as above: the sidecar key is unanchored, so
+        // gate it to repo-isolated backends (#2504).
+        if base_path.contains("-SNAPSHOT") && repo_isolated {
             if let Some(resolved) = resolve_snapshot_artifact(&state.db, repo.id, base_path).await {
                 let resolved_checksum_key =
                     format!("maven/{}.{}", resolved.path, checksum_suffix(checksum_type));
@@ -1207,7 +1216,12 @@ async fn fetch_maven_metadata_bytes(
                 let batch = futures::future::join_all(chunk.iter().map(|member| async {
                     if member.repo_type == RepositoryType::Remote {
                         fetch_remote_member_metadata(state, member, path).await
-                    } else {
+                    } else if crate::storage::backend_is_repo_isolated(&member.storage_backend) {
+                        // Unanchored `maven/<path>` read: only sound where the
+                        // member's backend physically isolates repositories
+                        // (filesystem). On a shared cloud namespace this key can
+                        // hold a non-member repository's metadata, so skip it
+                        // there (#2504).
                         let member_storage_key = format!("maven/{}", path);
                         match state.storage_for_repo(&member.storage_location()) {
                             Ok(member_storage) => {
@@ -1219,6 +1233,8 @@ async fn fetch_maven_metadata_bytes(
                             }
                             Err(_) => None,
                         }
+                    } else {
+                        None
                     }
                 }))
                 .await;
@@ -1250,13 +1266,19 @@ async fn fetch_maven_metadata_bytes(
                             entries.extend(parse_snapshot_versions_xml(&xml_str));
                         }
                     } else {
-                        let member_storage_key = format!("maven/{}", path);
-                        if let Ok(member_storage) =
-                            state.storage_for_repo(&member.storage_location())
-                        {
-                            if let Ok(content) = member_storage.get(&member_storage_key).await {
-                                if let Ok(xml_str) = std::str::from_utf8(&content) {
-                                    entries.extend(parse_snapshot_versions_xml(xml_str));
+                        // Unanchored `maven/<path>` read: only sound where the
+                        // member's backend physically isolates repositories
+                        // (filesystem); on a shared cloud namespace skip it and
+                        // rely on the row-scoped snapshot entries below (#2504).
+                        if crate::storage::backend_is_repo_isolated(&member.storage_backend) {
+                            let member_storage_key = format!("maven/{}", path);
+                            if let Ok(member_storage) =
+                                state.storage_for_repo(&member.storage_location())
+                            {
+                                if let Ok(content) = member_storage.get(&member_storage_key).await {
+                                    if let Ok(xml_str) = std::str::from_utf8(&content) {
+                                        entries.extend(parse_snapshot_versions_xml(xml_str));
+                                    }
                                 }
                             }
                         }
@@ -1296,9 +1318,16 @@ async fn fetch_maven_metadata_bytes(
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
 
-    let meta_storage_key = format!("maven/{}", path);
-    if let Ok(content) = storage.get(&meta_storage_key).await {
-        return Ok(content);
+    // The stored maven-metadata.xml read fetches a bare `maven/<path>` key with
+    // no artifact row scoped to the caller's repository, so it is only sound on
+    // repo-isolated (filesystem) backends. On shared cloud namespaces the same
+    // key can hold a *different* repository's metadata, so skip the stored read
+    // there and fall through to row-gated dynamic generation below (#2504).
+    if crate::storage::backend_is_repo_isolated(&repo.storage_backend) {
+        let meta_storage_key = format!("maven/{}", path);
+        if let Ok(content) = storage.get(&meta_storage_key).await {
+            return Ok(content);
+        }
     }
 
     if let Some((group_id, artifact_id)) = parse_metadata_path(path) {

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1678,7 +1678,17 @@ async fn serve_artifact(
             // uploads started indexing every physical asset as an artifact row.
             // Direct byte access remains available for those older companion
             // files while new uploads resolve through the exact `artifacts.path`.
-            if repo.repo_type == RepositoryType::Local || repo.repo_type == RepositoryType::Staging
+            //
+            // This fallback reads a bare `maven/{path}` key with no artifact row
+            // scoped to the caller's repository, so it is only sound on backends
+            // that physically isolate each repository's key space (filesystem,
+            // rooted at the repo's storage_path). On shared cloud namespaces
+            // (S3/GCS/Azure) the same flat key can belong to a *different*
+            // repository, so the fallback is skipped there and the request 404s
+            // rather than serving another repository's bytes.
+            if (repo.repo_type == RepositoryType::Local
+                || repo.repo_type == RepositoryType::Staging)
+                && crate::storage::backend_is_repo_isolated(&repo.storage_backend)
             {
                 let storage = state
                     .storage_for_repo(&repo.storage_location())
@@ -1973,6 +1983,10 @@ async fn upload(
     proxy_helpers::reject_direct_upload_if_promotion_only(promotion_only, auth.is_admin)?;
 
     let storage_key = format!("maven/{}", path);
+    // Refuse to overwrite a different repository's object living at this exact
+    // flat key on a shared cloud namespace (cross-repo poisoning guard).
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -155,6 +155,17 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     location: &StorageLocation,
     artifact_path: &str,
 ) -> Result<StreamingFetchResult, Response> {
+    // Gate 0: This helper ultimately reads a bare `maven/<path>` key that is not
+    // anchored to an artifact row scoped to the caller's repository. That is only
+    // sound on backends that physically isolate each repository's key space
+    // (filesystem, rooted at the repo's storage_path). On shared cloud namespaces
+    // (S3/GCS/Azure) the same flat key can belong to a *different* repository, so
+    // the fallback must not run there — skip straight to 404 rather than risk
+    // serving another repository's bytes.
+    if !crate::storage::backend_is_repo_isolated(&location.backend) {
+        return Err((StatusCode::NOT_FOUND, "Artifact not found").into_response());
+    }
+
     // Gate 1: Only secondaries and bare primaries are eligible; anything else is 404.
     // Compute is_secondary once — is_maven_primary_path_given_not_secondary takes the
     // pre-computed flag so parse_coordinates is only called once per request.

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -2597,6 +2597,7 @@ async fn store_npm_version(
         "npm/{}/{}/{}",
         package_name, ver.version, ver.tarball_filename
     );
+    proxy_helpers::guard_cross_repo_write(state, repo_id, &location.backend, &storage_key).await?;
     let storage = state.storage_for_repo_or_500(location)?;
     storage
         .put(&storage_key, Bytes::from(ver.tarball_bytes.clone()))

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1125,6 +1125,8 @@ async fn upload(
 
         // Store via StorageBackend
         let storage_key = format!("modules/{}/commits/{}", module_name, commit_digest);
+        proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+            .await?;
         let storage = state
             .storage_for_repo(&repo.storage_location())
             .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3657,6 +3657,37 @@ pub async fn parse_multipart_file_with_json(
 /// Replaces the duplicated "let storage = state.storage_for_repo(...) ;
 /// storage.put(...).await.map_err(...)" block that every multipart upload
 /// handler otherwise repeats.
+/// Refuse a flat-key hosted write that would overwrite a *different*
+/// repository's object on a shared cloud namespace. Thin response-mapping
+/// wrapper over [`crate::services::artifact_service::guard_foreign_storage_key`]
+/// so `Result<_, Response>` handlers can call it with `?`. Maps a cross-repo
+/// collision to `409 Conflict`; same-repo re-uploads and repo-scoped keys pass.
+///
+/// The guard applies **only to shared-namespace (cloud) backends**. On a
+/// repo-isolated backend (filesystem) each repository has its own physically
+/// separate directory tree, so two repositories legitimately hold the same
+/// coordinate key without colliding — running the guard there would wrongly
+/// reject the second repository's upload. `storage_backend` is therefore checked
+/// first and the guard is skipped for filesystem.
+#[allow(clippy::result_large_err)]
+pub async fn guard_cross_repo_write(
+    state: &crate::api::SharedState,
+    repository_id: Uuid,
+    storage_backend: &str,
+    storage_key: &str,
+) -> Result<(), Response> {
+    if crate::storage::backend_is_repo_isolated(storage_backend) {
+        return Ok(());
+    }
+    crate::services::artifact_service::guard_foreign_storage_key(
+        &state.db,
+        repository_id,
+        storage_key,
+    )
+    .await
+    .map_err(|e| e.into_response())
+}
+
 #[allow(clippy::result_large_err)]
 pub async fn put_artifact_bytes(
     state: &crate::api::SharedState,
@@ -3664,6 +3695,7 @@ pub async fn put_artifact_bytes(
     storage_key: &str,
     body: Bytes,
 ) -> Result<(), Response> {
+    guard_cross_repo_write(state, repo.id, &repo.storage_backend, storage_key).await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
@@ -3817,6 +3849,7 @@ pub async fn put_artifact_stream(
     storage_key: &str,
     staged: StagedUpload,
 ) -> Result<crate::storage::PutStreamResult, Response> {
+    guard_cross_repo_write(state, repo.id, &repo.storage_backend, storage_key).await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -252,6 +252,8 @@ async fn upload_artifact(
 
     // Store the file
     let storage_key = format!("sbt/{}", artifact_path);
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -842,6 +842,8 @@ async fn publish_release(
 
     // Store the file
     let storage_key = format!("swift/{}/{}/{}/{}.zip", scope, name, version, name);
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -521,6 +521,8 @@ async fn upload_module(
         "terraform/modules/{}/{}/{}/{}.tar.gz",
         namespace, name, provider, version
     );
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
 
@@ -917,6 +919,8 @@ async fn upload_provider(
         "terraform/providers/{}/{}/{}/terraform-provider-{}_{}.zip",
         namespace, type_name, version, type_name, platform
     );
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
 
     // Store the file
     let storage = state

--- a/backend/src/api/handlers/vscode.rs
+++ b/backend/src/api/handlers/vscode.rs
@@ -333,6 +333,8 @@ async fn publish_extension(
 
     // Store the file
     let storage_key = format!("vscode/{}/{}/{}", publisher, ext_name, filename);
+    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
+        .await?;
     let storage = state
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1932,26 +1932,43 @@ impl ArtifactService {
 /// row still points at that key.
 ///
 /// This guard refuses such a write: if the target `storage_key` is already
-/// referenced by a live artifact row belonging to a **different** repository,
-/// it returns [`AppError::Conflict`] (HTTP 409) and the caller must not `put`.
+/// referenced by an artifact row belonging to a **different** repository —
+/// **whether live OR soft-deleted** — it returns [`AppError::Conflict`]
+/// (HTTP 409) and the caller must not `put`.
+///
+/// Soft-deleted foreign rows are included deliberately: a soft-delete tombstones
+/// the row but the physical object at the flat key persists, so an attacker could
+/// otherwise overwrite a soft-deleted victim object and poison the bytes that the
+/// victim serves after a restore/resurrect. A foreign row owning the physical key
+/// — even a tombstoned one — means the key is not ours to write.
 ///
 /// Safe to call at every flat-key write site:
-/// - Same-repository re-uploads are always allowed — the query excludes the
-///   writer's own `repository_id`, so re-publishing your own coordinate passes.
+/// - Same-repository writes are always allowed — the query excludes the writer's
+///   own `repository_id`, so re-publishing (or reclaiming your own soft-deleted)
+///   coordinate passes.
 /// - Repository-scoped keys (rpm/alpine/conda/incus embed the repo id) and
 ///   content-addressed keys never collide across repositories, so the query
 ///   simply never matches and the write proceeds unchanged.
+///
+/// KNOWN RESIDUAL (TOCTOU): this is a check-then-write guard, not atomic with the
+/// caller's subsequent `put` + row insert. Two repositories racing the very first
+/// publish of the same colliding key can both pass the check and create dual
+/// rows. Closing it fully requires holding a lock across guard→put→insert (or the
+/// structural repo-scoped-key scheme), which is out of scope for this surgical
+/// hotfix; a global UNIQUE index on `storage_key` is intentionally NOT used
+/// because content-addressed formats legitimately share sha-based keys across
+/// repositories. The 1.6.0 repo-scoped-key migration is the real remediation.
 pub async fn guard_foreign_storage_key(
     db: &PgPool,
     repository_id: Uuid,
     storage_key: &str,
 ) -> Result<()> {
     // Runtime-checked query (no compile-time sqlx cache needed): return the
-    // owning repository id of any *other* repository holding a live row at this
-    // exact key.
+    // owning repository id of any *other* repository holding a row at this exact
+    // key — live or soft-deleted (the physical object persists past soft-delete).
     let foreign: Option<Uuid> = sqlx::query_scalar(
         "SELECT repository_id FROM artifacts \
-         WHERE storage_key = $1 AND repository_id <> $2 AND is_deleted = false \
+         WHERE storage_key = $1 AND repository_id <> $2 \
          LIMIT 1",
     )
     .bind(storage_key)
@@ -2156,7 +2173,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_guard_ignores_soft_deleted_foreign_row() {
+    async fn test_guard_rejects_soft_deleted_foreign_row() {
         use crate::api::handlers::test_db_helpers as tdh;
         let Some(pool) = tdh::try_pool().await else {
             return;
@@ -2171,10 +2188,34 @@ mod tests {
             .await
             .expect("soft-delete");
 
-        // A tombstoned foreign row does not own the key: repo_a may reuse it.
+        // The physical object persists past soft-delete, so a tombstoned foreign
+        // row still owns the key: repo_a must NOT be able to overwrite it (guards
+        // against poison-on-resurrect).
+        let err = guard_foreign_storage_key(&pool, repo_a, &key)
+            .await
+            .expect_err("soft-deleted foreign row must still block");
+        assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_guard_allows_same_repo_soft_deleted_reclaim() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let key = format!("maven/com/acme/mine/1.0/mine-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, repo_a, "com/acme/mine/1.0/mine-1.0.jar", &key).await;
+        sqlx::query("UPDATE artifacts SET is_deleted = true WHERE storage_key = $1")
+            .bind(&key)
+            .execute(&pool)
+            .await
+            .expect("soft-delete");
+
+        // Reclaiming your OWN (even soft-deleted) key is always allowed.
         guard_foreign_storage_key(&pool, repo_a, &key)
             .await
-            .expect("soft-deleted foreign row must not block");
+            .expect("same-repo soft-deleted reclaim must be allowed");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1921,6 +1921,54 @@ impl ArtifactService {
     }
 }
 
+/// Cross-repository overwrite guard for flat (coordinate-keyed) storage writes.
+///
+/// Cloud backends (S3/GCS/Azure) resolve to a single shared instance and share
+/// one flat object namespace: the storage registry honors the per-repository
+/// `storage_path` only for filesystem backends, so cloud repositories all write
+/// into the same key space. A hosted write to a bare `{format}/{coords}` key can
+/// therefore land on top of a *different* repository's object that happens to
+/// live at the identical key, clobbering its bytes while the victim's artifact
+/// row still points at that key.
+///
+/// This guard refuses such a write: if the target `storage_key` is already
+/// referenced by a live artifact row belonging to a **different** repository,
+/// it returns [`AppError::Conflict`] (HTTP 409) and the caller must not `put`.
+///
+/// Safe to call at every flat-key write site:
+/// - Same-repository re-uploads are always allowed — the query excludes the
+///   writer's own `repository_id`, so re-publishing your own coordinate passes.
+/// - Repository-scoped keys (rpm/alpine/conda/incus embed the repo id) and
+///   content-addressed keys never collide across repositories, so the query
+///   simply never matches and the write proceeds unchanged.
+pub async fn guard_foreign_storage_key(
+    db: &PgPool,
+    repository_id: Uuid,
+    storage_key: &str,
+) -> Result<()> {
+    // Runtime-checked query (no compile-time sqlx cache needed): return the
+    // owning repository id of any *other* repository holding a live row at this
+    // exact key.
+    let foreign: Option<Uuid> = sqlx::query_scalar(
+        "SELECT repository_id FROM artifacts \
+         WHERE storage_key = $1 AND repository_id <> $2 AND is_deleted = false \
+         LIMIT 1",
+    )
+    .bind(storage_key)
+    .bind(repository_id)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    if foreign.is_some() {
+        return Err(AppError::Conflict(format!(
+            "storage key '{storage_key}' is already owned by another repository; \
+             refusing cross-repository overwrite"
+        )));
+    }
+    Ok(())
+}
+
 /// Best-effort recorder for a completed local-artifact download (#2365).
 ///
 /// Writes real attribution (validated client IP or NULL, authenticated user
@@ -2036,6 +2084,97 @@ mod tests {
             key,
             "91/6f/916f0027a575074ce72a331777c3478d6513f786a591bd892da1a577bf2335f9"
         );
+    }
+
+    // -- #2504 cross-repository overwrite guard ----------------------------
+
+    /// Insert a minimal live artifact row at `storage_key` for `repo_id`.
+    #[cfg(test)]
+    async fn seed_artifact(pool: &PgPool, repo_id: Uuid, path: &str, storage_key: &str) {
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $3, 1, $4, 'application/octet-stream', $5)",
+        )
+        .bind(repo_id)
+        .bind(path)
+        .bind(path)
+        .bind("0".repeat(64))
+        .bind(storage_key)
+        .execute(pool)
+        .await
+        .expect("seed artifact");
+    }
+
+    #[tokio::test]
+    async fn test_guard_rejects_foreign_repo_owning_key() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let (repo_b, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        // repo_b owns a live row at the colliding flat key.
+        let key = format!("maven/com/acme/lib/1.0/lib-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, repo_b, "com/acme/lib/1.0/lib-1.0.jar", &key).await;
+
+        // repo_a must be refused (409 Conflict) — the cross-tenant poisoning case.
+        let err = guard_foreign_storage_key(&pool, repo_a, &key)
+            .await
+            .expect_err("foreign-owned key must be rejected");
+        assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_guard_allows_same_repo_overwrite() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let key = format!("maven/com/acme/lib/1.0/lib-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, repo_a, "com/acme/lib/1.0/lib-1.0.jar", &key).await;
+
+        // Re-publishing your own coordinate must still be allowed.
+        guard_foreign_storage_key(&pool, repo_a, &key)
+            .await
+            .expect("same-repo overwrite must be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_guard_allows_uncontended_key() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let key = format!("maven/org/fresh/{}/fresh.jar", Uuid::new_v4());
+        // No row anywhere references this key.
+        guard_foreign_storage_key(&pool, repo_a, &key)
+            .await
+            .expect("uncontended key must be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_guard_ignores_soft_deleted_foreign_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let (repo_b, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let key = format!("maven/com/acme/dead/1.0/dead-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, repo_b, "com/acme/dead/1.0/dead-1.0.jar", &key).await;
+        sqlx::query("UPDATE artifacts SET is_deleted = true WHERE storage_key = $1")
+            .bind(&key)
+            .execute(&pool)
+            .await
+            .expect("soft-delete");
+
+        // A tombstoned foreign row does not own the key: repo_a may reuse it.
+        guard_foreign_storage_key(&pool, repo_a, &key)
+            .await
+            .expect("soft-deleted foreign row must not block");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -9,7 +9,7 @@ pub mod registry;
 pub mod s3;
 
 pub use path_format::StoragePathFormat;
-pub use registry::{StorageLocation, StorageRegistry};
+pub use registry::{backend_is_repo_isolated, StorageLocation, StorageRegistry};
 
 use async_trait::async_trait;
 use bytes::Bytes;

--- a/backend/src/storage/registry.rs
+++ b/backend/src/storage/registry.rs
@@ -81,6 +81,20 @@ impl StorageRegistry {
     }
 }
 
+/// Whether a storage backend gives each repository a physically isolated key
+/// space.
+///
+/// Only `"filesystem"` does: [`StorageRegistry::backend_for`] roots a fresh
+/// [`FilesystemStorage`] at the repository's `storage_path`, so every repository
+/// gets its own directory tree. Cloud backends (S3/GCS/Azure) resolve to a
+/// single shared instance and share one flat object namespace, so a bare
+/// `{format}/{coords}` key on cloud is not provably owned by the requesting
+/// repository. Callers use this to gate row-bypass reads (which are only sound
+/// where the backend physically isolates repositories).
+pub fn backend_is_repo_isolated(backend: &str) -> bool {
+    backend == "filesystem"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -279,6 +293,22 @@ mod tests {
     fn test_default_backend_can_be_filesystem() {
         let registry = StorageRegistry::new(HashMap::new(), "filesystem".to_string());
         assert_eq!(registry.default_backend(), "filesystem");
+    }
+
+    // -- backend_is_repo_isolated (#2504) -------------------------------------
+
+    #[test]
+    fn test_backend_is_repo_isolated_only_filesystem() {
+        // Only filesystem physically isolates each repository's key space; every
+        // cloud backend shares one flat namespace, so row-bypass reads must not
+        // trust the key's implicit ownership there.
+        assert!(backend_is_repo_isolated("filesystem"));
+        for cloud in ["s3-primary", "gcs-archive", "azure-blob", "s3", "gcs", ""] {
+            assert!(
+                !backend_is_repo_isolated(cloud),
+                "cloud backend {cloud:?} must NOT be treated as repo-isolated"
+            );
+        }
     }
 
     // -- #1054: registry / primary-storage coincidence ------------------------

--- a/proof/compose.fs.yml
+++ b/proof/compose.fs.yml
@@ -1,0 +1,55 @@
+name: ak-fix2504-fs
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ak-2504fs-db
+    environment:
+      POSTGRES_USER: registry
+      POSTGRES_PASSWORD: registry
+      POSTGRES_DB: artifact_registry
+    ports: ["127.0.0.1:30603:5432"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U registry -d artifact_registry"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks: [fsnet]
+
+  backend:
+    image: artifact-keeper-backend:fix-2504
+    container_name: ak-2504fs-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://registry:registry@postgres:5432/artifact_registry
+      STORAGE_PATH: /data/storage
+      BACKUP_PATH: /data/backups
+      PLUGINS_DIR: /data/plugins
+      JWT_SECRET: fix2504-nonprod-cobalt-harbor-lantern-5521
+      ADMIN_PASSWORD: TestRunner!2026secure
+      RUST_LOG: info
+      HOST: 0.0.0.0
+      PORT: "8080"
+      STORAGE_BACKEND: filesystem
+      RATE_LIMIT_ENABLED: "false"
+    ports:
+      - "127.0.0.1:8083:8080"
+      - "127.0.0.1:9093:9090"
+    volumes:
+      - fs_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 10s
+      start_period: 40s
+      retries: 24
+    networks: [fsnet]
+
+networks:
+  fsnet:
+    name: ak-2504fs-net
+
+volumes:
+  fs_data:

--- a/proof/compose.s3.yml
+++ b/proof/compose.s3.yml
@@ -1,0 +1,93 @@
+name: ak-fix2504-s3
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ak-2504s3-db
+    environment:
+      POSTGRES_USER: registry
+      POSTGRES_PASSWORD: registry
+      POSTGRES_DB: artifact_registry
+    ports: ["127.0.0.1:30602:5432"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U registry -d artifact_registry"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks: [s3net]
+
+  minio:
+    image: minio/minio:latest
+    container_name: ak-2504s3-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "127.0.0.1:9002:9000"
+      - "127.0.0.1:9003:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks: [s3net]
+
+  createbucket:
+    image: minio/mc:latest
+    container_name: ak-2504s3-mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb -p local/ak-artifacts &&
+      echo bucket-ready
+      "
+    networks: [s3net]
+
+  backend:
+    image: artifact-keeper-backend:fix-2504
+    container_name: ak-2504s3-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+      createbucket:
+        condition: service_completed_successfully
+    environment:
+      DATABASE_URL: postgresql://registry:registry@postgres:5432/artifact_registry
+      STORAGE_PATH: /data/storage
+      BACKUP_PATH: /data/backups
+      PLUGINS_DIR: /data/plugins
+      JWT_SECRET: fix2504-nonprod-cobalt-harbor-lantern-5521
+      ADMIN_PASSWORD: TestRunner!2026secure
+      RUST_LOG: info
+      HOST: 0.0.0.0
+      PORT: "8080"
+      STORAGE_BACKEND: s3
+      S3_BUCKET: ak-artifacts
+      S3_REGION: us-east-1
+      S3_ENDPOINT: http://minio:9000
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+      RATE_LIMIT_ENABLED: "false"
+    ports:
+      - "127.0.0.1:8082:8080"
+      - "127.0.0.1:9092:9090"
+    volumes:
+      - s3_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 10s
+      start_period: 40s
+      retries: 24
+    networks: [s3net]
+
+networks:
+  s3net:
+    name: ak-2504s3-net
+
+volumes:
+  s3_data:

--- a/proof/compose.s3base.yml
+++ b/proof/compose.s3base.yml
@@ -1,0 +1,93 @@
+name: ak-fix2504-s3base
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ak-2504s3base-db
+    environment:
+      POSTGRES_USER: registry
+      POSTGRES_PASSWORD: registry
+      POSTGRES_DB: artifact_registry
+    ports: ["127.0.0.1:30612:5432"]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U registry -d artifact_registry"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    networks: [s3net]
+
+  minio:
+    image: minio/minio:latest
+    container_name: ak-2504s3base-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "127.0.0.1:9012:9000"
+      - "127.0.0.1:9013:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks: [s3net]
+
+  createbucket:
+    image: minio/mc:latest
+    container_name: ak-2504s3base-mc
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb -p local/ak-artifacts &&
+      echo bucket-ready
+      "
+    networks: [s3net]
+
+  backend:
+    image: artifact-keeper-backend:base-2504
+    container_name: ak-2504s3base-backend
+    depends_on:
+      postgres:
+        condition: service_healthy
+      createbucket:
+        condition: service_completed_successfully
+    environment:
+      DATABASE_URL: postgresql://registry:registry@postgres:5432/artifact_registry
+      STORAGE_PATH: /data/storage
+      BACKUP_PATH: /data/backups
+      PLUGINS_DIR: /data/plugins
+      JWT_SECRET: fix2504-nonprod-cobalt-harbor-lantern-5521
+      ADMIN_PASSWORD: TestRunner!2026secure
+      RUST_LOG: info
+      HOST: 0.0.0.0
+      PORT: "8080"
+      STORAGE_BACKEND: s3
+      S3_BUCKET: ak-artifacts
+      S3_REGION: us-east-1
+      S3_ENDPOINT: http://minio:9000
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+      RATE_LIMIT_ENABLED: "false"
+    ports:
+      - "127.0.0.1:8092:8080"
+      - "127.0.0.1:9014:9090"
+    volumes:
+      - s3_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 5s
+      timeout: 10s
+      start_period: 40s
+      retries: 24
+    networks: [s3net]
+
+networks:
+  s3net:
+    name: ak-2504s3base-net
+
+volumes:
+  s3_data:

--- a/proof/prove.sh
+++ b/proof/prove.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Cross-tenant read/write proof for #2504.
+# Usage: prove.sh <BASE_URL> <DB_CONTAINER> <LABEL>
+set -uo pipefail
+BASE="$1"; DBC="$2"; LABEL="$3"
+ADMPASS="TestRunner!2026secure"
+APASS="AlicePass!2026x"
+SUF="$RANDOM$RANDOM"
+MVA="mvn-a-$SUF"; MVB="mvn-b-$SUF"
+COORD="com/secret/app/1.0-$SUF/app-1.0-$SUF.jar"
+SECRET="MVNB-SECRET-BYTES-$SUF"
+EVIL="ALICE-EVIL-CLOBBER-$SUF"
+OWN="ALICE-OWN-BYTES-$SUF"
+OWNCOORD="com/alice/lib/2.0-$SUF/lib-2.0-$SUF.jar"
+
+jqr(){ jq -r "$1" 2>/dev/null; }
+login(){ curl -s -X POST "$BASE/api/v1/auth/login" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"$1\",\"password\":\"$2\"}" | jqr '.access_token // empty'; }
+code(){ # METHOD PATH TOKEN [BODY] [CT]
+  local m="$1" p="$2" t="$3" b="${4:-}" ct="${5:-application/octet-stream}"
+  if [ -n "$b" ]; then
+    curl -s -o /dev/null -w '%{http_code}' -X "$m" "$BASE$p" -H "Authorization: Bearer $t" -H "Content-Type: $ct" --data-binary "$b"
+  else
+    curl -s -o /dev/null -w '%{http_code}' -X "$m" "$BASE$p" -H "Authorization: Bearer $t"
+  fi; }
+body(){ curl -s -X "$1" "$BASE$2" -H "Authorization: Bearer $3"; }
+
+echo "############ PROOF: $LABEL  ($BASE) ############"
+TOK=$(login admin "$ADMPASS"); [ -z "$TOK" ] && { echo "admin login FAILED"; exit 1; }
+
+# alice
+curl -s -X POST "$BASE/api/v1/users" -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  -d "{\"username\":\"alice-$SUF\",\"email\":\"alice-$SUF@t.test\",\"password\":\"$APASS\",\"is_admin\":false}" >/dev/null
+# repos (maven, local) — default storage_backend inherits the stack's STORAGE_BACKEND
+for k in "$MVA" "$MVB"; do
+  curl -s -X POST "$BASE/api/v1/repositories" -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+    -d "{\"key\":\"$k\",\"name\":\"$k\",\"format\":\"maven\",\"repo_type\":\"local\"}" >/dev/null
+done
+# grant alice developer(write) on MVA only; NO grant on MVB
+docker exec "$DBC" psql -U registry -d artifact_registry -tAc "
+  INSERT INTO role_assignments (user_id, role_id, repository_id)
+  SELECT u.id, r.id, repo.id FROM users u, roles r, repositories repo
+  WHERE u.username='alice-$SUF' AND r.name='developer' AND repo.key='$MVA'
+  ON CONFLICT DO NOTHING;" >/dev/null
+ATOK=$(login "alice-$SUF" "$APASS"); [ -z "$ATOK" ] && { echo "alice login FAILED"; exit 1; }
+
+echo "-- backend storage_backend of repos:"
+docker exec "$DBC" psql -U registry -d artifact_registry -tAc \
+  "SELECT key||' -> '||storage_backend FROM repositories WHERE key IN ('$MVA','$MVB');" 2>/dev/null || \
+docker exec "$DBC" psql -U registry -d artifact_registry -tAc \
+  "SELECT key||' -> '||storage_backend FROM repositories WHERE key LIKE 'mvn-%-$SUF';"
+
+# admin uploads the private secret into MVB at COORD
+UP_B=$(code PUT "/maven/$MVB/$COORD" "$TOK" "$SECRET")
+echo "-- [setup] admin PUT secret into $MVB/$COORD => $UP_B (expect 201)"
+DL_B=$(body GET "/maven/$MVB/$COORD" "$TOK")
+echo "-- [setup] admin GET $MVB/$COORD => '$DL_B'"
+
+echo
+echo "== A. CROSS-REPO READ (alice reads MVA for a coord that exists only in MVB) =="
+RC=$(code GET "/maven/$MVA/$COORD" "$ATOK")
+RB=$(body GET "/maven/$MVA/$COORD" "$ATOK")
+echo "   alice GET $MVA/$COORD => HTTP $RC ; body='$RB'"
+if [ "$RC" = "200" ] && [ "$RB" = "$SECRET" ]; then echo "   >>> LEAK: alice read MVB's secret bytes via MVA"; \
+  elif [ "$RC" = "404" ] || [ "$RC" = "403" ]; then echo "   >>> DENIED (no bytes leaked)"; else echo "   >>> UNEXPECTED"; fi
+echo "   (control) alice GET $MVB directly => $(code GET "/maven/$MVB/$COORD" "$ATOK") (expect 403/404, no grant)"
+
+echo
+echo "== B. CROSS-REPO WRITE (alice PUTs colliding coord into her own MVA) =="
+WC=$(code PUT "/maven/$MVA/$COORD" "$ATOK" "$EVIL")
+echo "   alice PUT $MVA/$COORD (colliding key) => HTTP $WC"
+AFTER=$(body GET "/maven/$MVB/$COORD" "$TOK")
+echo "   admin GET $MVB/$COORD after alice's write => '$AFTER'"
+if [ "$WC" = "409" ] && [ "$AFTER" = "$SECRET" ]; then echo "   >>> REFUSED; MVB bytes intact"; \
+  elif [ "$AFTER" = "$EVIL" ]; then echo "   >>> POISONED: MVB now serves alice's bytes"; else echo "   >>> WC=$WC AFTER='$AFTER'"; fi
+
+echo
+echo "== C. NO-REGRESSION (alice hosted upload+download to her OWN repo) =="
+OC=$(code PUT "/maven/$MVA/$OWNCOORD" "$ATOK" "$OWN")
+OB=$(body GET "/maven/$MVA/$OWNCOORD" "$ATOK")
+echo "   alice PUT $MVA/$OWNCOORD => $OC ; GET => '$OB' (expect 201 + matching bytes)"
+OC2=$(code PUT "/maven/$MVA/$OWNCOORD" "$ATOK" "${OWN}-v2")
+echo "   alice same-repo overwrite PUT again => $OC2 (expect 201, same-repo allowed)"
+echo "############ END $LABEL ############"
+echo

--- a/proof/prove.sh
+++ b/proof/prove.sh
@@ -81,5 +81,39 @@ OB=$(body GET "/maven/$MVA/$OWNCOORD" "$ATOK")
 echo "   alice PUT $MVA/$OWNCOORD => $OC ; GET => '$OB' (expect 201 + matching bytes)"
 OC2=$(code PUT "/maven/$MVA/$OWNCOORD" "$ATOK" "${OWN}-v2")
 echo "   alice same-repo overwrite PUT again => $OC2 (expect 201, same-repo allowed)"
+
+echo
+echo "== D. READ-LEG sidecars (checksum + metadata) cross-repo =="
+# admin stores a checksum sidecar + a group-level metadata file into MVB (no rows)
+CKSUM="B-CHECKSUM-$SUF"; META="B-PRIVATE-METADATA-$SUF"
+METAPATH="com/secret/app/maven-metadata.xml"
+echo "   [setup] admin PUT $MVB/$COORD.sha1 => $(code PUT "/maven/$MVB/$COORD.sha1" "$TOK" "$CKSUM" "text/plain")"
+echo "   [setup] admin PUT $MVB/$METAPATH => $(code PUT "/maven/$MVB/$METAPATH" "$TOK" "$META" "text/xml")"
+# D1 cross-repo checksum sidecar (maven.rs:907/922)
+CKC=$(code GET "/maven/$MVA/$COORD.sha1" "$ATOK"); CKB=$(body GET "/maven/$MVA/$COORD.sha1" "$ATOK")
+echo "   D1 alice GET $MVA/$COORD.sha1 => HTTP $CKC ; body='$CKB'"
+[ "$CKC" = "200" ] && [ "$CKB" = "$CKSUM" ] && echo "      >>> LEAK: B's checksum bytes" || { [ "$CKC" = "404" ] && echo "      >>> DENIED"; }
+# D2 cross-repo metadata (maven.rs:1299)
+MTC=$(code GET "/maven/$MVA/$METAPATH" "$ATOK"); MTB=$(body GET "/maven/$MVA/$METAPATH" "$ATOK")
+echo "   D2 alice GET $MVA/$METAPATH => HTTP $MTC ; body='$MTB'"
+echo "$MTB" | grep -q "$META" && echo "      >>> LEAK: B's private metadata" || { [ "$MTC" = "404" ] && echo "      >>> DENIED (no B metadata)"; }
+# D3 same-repo checksum still served (computed from alice's OWN row) — no regression
+OWNCK=$(code GET "/maven/$MVA/$OWNCOORD.sha1" "$ATOK")
+echo "   D3 alice GET own $MVA/$OWNCOORD.sha1 => HTTP $OWNCK (expect 200, computed from own row)"
+
+echo
+echo "== E. WRITE soft-delete carve-out =="
+SDCOORD="com/victim/mod/3.0-$SUF/mod-3.0-$SUF.jar"; SDB="VICTIM-BYTES-$SUF"
+echo "   [setup] admin PUT $MVB/$SDCOORD => $(code PUT "/maven/$MVB/$SDCOORD" "$TOK" "$SDB")"
+# soft-delete B's row (physical object persists)
+docker exec "$DBC" psql -U registry -d artifact_registry -tAc \
+  "UPDATE artifacts SET is_deleted=true WHERE storage_key='maven/$SDCOORD';" >/dev/null
+DELCNT=$(docker exec "$DBC" psql -U registry -d artifact_registry -tAc \
+  "SELECT count(*) FROM artifacts WHERE storage_key='maven/$SDCOORD' AND is_deleted=true;")
+echo "   [setup] soft-deleted B rows at key: $DELCNT"
+SDC=$(code PUT "/maven/$MVA/$SDCOORD" "$ATOK" "ALICE-POISON-$SUF")
+echo "   E1 alice PUT colliding $MVA/$SDCOORD (B soft-deleted) => HTTP $SDC"
+[ "$SDC" = "409" ] && echo "      >>> REFUSED (poison-on-resurrect blocked)" || { [ "$SDC" = "201" ] && echo "      >>> ALLOWED (would poison on resurrect)"; }
+
 echo "############ END $LABEL ############"
 echo


### PR DESCRIPTION
## Summary

Closes #2504.

On object-store backends (S3 / GCS / Azure) every repository resolves to the same
shared backend instance: `StorageRegistry::backend_for` applies the per-repository
`storage_path` only for the `filesystem` backend (where it roots an isolated
`FilesystemStorage` directory tree) and returns the single shared `Arc` for cloud
backends, dropping `location.path`. Format handlers build flat `"{format}/{coords}"`
object keys with no repository component, so on cloud backends all repositories
write into **one shared object namespace**. That has two consequences:

1. **Write collision** — a hosted upload to a bare coordinate key can land on top
   of a *different* repository's object stored at the identical key.
2. **Row-bypass read** — the Maven "legacy hosted fallback"
   (`maven.rs`, `maven_proxy::maven_local_fetch_storage_fallback`) reads
   `maven/<path>` directly without an artifact row scoped to the caller's
   repository; on a shared namespace that resolves another repository's object.

`filesystem` deployments are unaffected because each repository already gets a
physically isolated directory tree.

This is a **surgical, migration-light hardening** that keeps the flat key scheme
intact. The structural fix (repo-scoped object keys via a registry decorator) is a
separate, larger change tracked for a future minor release.

### What changes

- **Read path (Maven, all unanchored flat-key reads):** every read that fetches a
  bare `maven/<path>` key **without** an artifact row scoped to the caller's
  repository now runs **only on repo-isolated (filesystem) backends**. On shared
  cloud namespaces these are skipped and the request returns `404`. This covers the
  hosted jar fallback, the member-fetch fallback (`maven_proxy`), the stored
  checksum-sidecar reads (plain and SNAPSHOT-resolved), the stored
  `maven-metadata.xml` read, and the virtual metadata member-fanout reads. Row-gated
  paths are untouched, so a repository's own checksums (served via the row-anchored
  computed-checksum path) and own metadata (served via row-anchored dynamic
  generation) still resolve on cloud. Filesystem behavior is unchanged (the added
  condition is always true there), so the legitimate un-indexed companion-file reads
  are preserved exactly.
- **Write path (all flat-key writers):** a shared guard
  `artifact_service::guard_foreign_storage_key` refuses a write when the target
  `storage_key` is already referenced by an artifact row — **live OR soft-deleted**
  — in a **different** repository (`409 Conflict`). Soft-deleted foreign rows are
  included because the physical object persists past a soft-delete, so an attacker
  could otherwise overwrite a tombstoned victim object and poison it on
  restore/resurrect. It is invoked through one thin helper
  (`proxy_helpers::guard_cross_repo_write`) at the shared upload chokepoints
  (`put_artifact_bytes` / `put_artifact_stream`) and at the remaining direct
  flat-key `put` sites (maven, npm, cargo, composer, sbt, cocoapods, swift, vscode,
  goproxy, terraform, conan, protobuf, jetbrains). The guard is a no-op on
  repo-isolated (filesystem) backends — where distinct repositories legitimately
  share a coordinate without colliding — and on same-repo re-uploads and
  repo-scoped / content-addressed keys (rpm/alpine/conda/incus, CAS, OCI, git-lfs),
  which never match the query.

### Behavior notes

- Same-repo re-publishing is unaffected (the guard excludes the writer's own
  repository).
- Filesystem deployments are behaviorally unchanged for both read and write.
- Cloud Maven repositories that relied on the un-indexed companion-file fallback
  lose direct byte access to never-indexed companions; those are recoverable via a
  re-index/backfill (follow-up, non-blocking).
- **Known residual (TOCTOU):** the write guard is check-then-write and not atomic
  with the caller's subsequent `put` + row insert, so two repositories racing the
  very first publish of the same colliding key can both pass the check. Closing it
  fully needs a lock held across guard→put→insert (or the repo-scoped-key scheme);
  a global `UNIQUE` index on `storage_key` is intentionally **not** used because
  content-addressed formats legitimately share sha-based keys across repositories.
  This is documented in code and is superseded by the structural 1.6.0 fix.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added unit tests in `artifact_service` (guard rejects a live foreign-owned key,
rejects a soft-deleted foreign-owned key, allows same-repo overwrite, allows
same-repo soft-deleted reclaim, allows an uncontended key) and in `storage::registry`
(`backend_is_repo_isolated` is true only for filesystem). Verified end-to-end against
a MinIO (S3) stack and a filesystem stack: on cloud the cross-repository jar,
checksum-sidecar and metadata reads are denied (`404`), the colliding write is
refused (`409`) with the victim's bytes intact, and overwriting a soft-deleted
foreign object is refused (`409`); a repository's own checksum/metadata still resolve
via the row-gated paths; on filesystem legitimate per-repo upload/download is
unaffected.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Migration `157_artifacts_storage_key_index.sql` adds a partial b-tree index on
`artifacts (storage_key) WHERE is_deleted = false` to back the guard lookup (the
column was previously unindexed). It is additive, idempotent
(`CREATE INDEX IF NOT EXISTS`), and imposes no uniqueness — distinct repositories
may still share a coordinate key.