### PR TITLE
fix(apt): add support for .ddeb debug packages

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -463,10 +463,12 @@ struct DebInfo {
     package_type: String,
 }
 
-/// Parse `{name}_{version}_{arch}.deb` or `.udeb` from a filename.
+/// Parse `{name}_{version}_{arch}.deb`, `.udeb`, or `.ddeb` from a filename.
 fn parse_deb_filename(filename: &str) -> Option<DebInfo> {
     let package_type = if filename.ends_with(".udeb") {
         "udeb"
+    } else if filename.ends_with(".ddeb") {
+        "ddeb"
     } else {
         "deb"
     };
@@ -3413,6 +3415,15 @@ mod tests {
         assert_eq!(info.version, "1.200");
         assert_eq!(info.arch, "amd64");
         assert_eq!(info.package_type, "udeb");
+    }
+
+    #[test]
+    fn test_parse_deb_filename_ddeb() {
+        let info = parse_deb_filename("systemd-dbgsym_256_amd64.ddeb").unwrap();
+        assert_eq!(info.name, "systemd-dbgsym");
+        assert_eq!(info.version, "256");
+        assert_eq!(info.arch, "amd64");
+        assert_eq!(info.package_type, "ddeb");
     }
 
     #[test]

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -331,7 +331,11 @@ impl DebianHandler {
         }
 
         // Pool package
-        if path.starts_with("pool/") || path.ends_with(".deb") || path.ends_with(".udeb") {
+        if path.starts_with("pool/")
+            || path.ends_with(".deb")
+            || path.ends_with(".udeb")
+            || path.ends_with(".ddeb")
+        {
             let filename = path.rsplit('/').next().unwrap_or(path);
             let info = Self::parse_deb_filename(filename)?;
 
@@ -365,6 +369,7 @@ impl DebianHandler {
         let name = filename
             .strip_suffix(".deb")
             .or_else(|| filename.strip_suffix(".udeb"))
+            .or_else(|| filename.strip_suffix(".ddeb"))
             .ok_or_else(|| {
                 AppError::Validation(format!("Invalid Debian package filename: {}", filename))
             })?;
@@ -965,6 +970,15 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_deb_filename_ddeb() {
+        let (pkg, ver, arch) =
+            DebianHandler::parse_deb_filename("systemd-dbgsym_256_amd64.ddeb").unwrap();
+        assert_eq!(pkg, "systemd-dbgsym");
+        assert_eq!(ver, "256");
+        assert_eq!(arch, "amd64");
+    }
+
+    #[test]
     fn test_parse_deb_filename_epoch_in_version() {
         // Debian allows epoch: "1:1.0-1" but _ separates fields
         let (pkg, ver, arch) =
@@ -1063,6 +1077,13 @@ mod tests {
     #[test]
     fn test_parse_path_direct_udeb_file() {
         let info = DebianHandler::parse_path("base_1.0_amd64.udeb").unwrap();
+        assert!(matches!(info.operation, DebianOperation::Package));
+        assert_eq!(info.package, Some("base".to_string()));
+    }
+
+    #[test]
+    fn test_parse_path_direct_ddeb_file() {
+        let info = DebianHandler::parse_path("base_1.0_amd64.ddeb").unwrap();
         assert!(matches!(info.operation, DebianOperation::Package));
         assert_eq!(info.package, Some("base".to_string()));
     }

--- a/backend/src/services/cache_classifier.rs
+++ b/backend/src/services/cache_classifier.rs
@@ -388,7 +388,7 @@ fn classify_cargo(lower: &str) -> Mutability {
 /// - **pool/**: The Debian Repository Format spec mandates "A repository must
 ///   not include different packages (different content) with the same package
 ///   name, version, and architecture." The path encodes name+version+arch, so
-///   content is pinned. Covers `.deb`, `.udeb`, `.dsc`, `.orig.tar.*`,
+///   content is pinned. Covers `.deb`, `.udeb`, `.ddeb`, `.dsc`, `.orig.tar.*`,
 ///   `.debian.tar.*`.
 /// - **dists/**: Release, InRelease, Packages, Sources, Translation, Contents,
 ///   dep11, etc. are rewritten in place by upstream on each publish.


### PR DESCRIPTION
Resolves: #2526.

## Summary

Debian debug packages (`.ddeb`) were not recognised by the filename parser, path dispatching, or immutable-classification comment. Now treated identically to `.udeb` throughout the pipeline: `parse_deb_filename`, `DebianHandler::parse_path`, and the pool/ classifier documentation.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
