### PR TITLE
fix(api): bound and stream the remote-instance proxy to prevent resource exhaustion

### DIFF
--- a/backend/src/api/handlers/remote_instances.rs
+++ b/backend/src/api/handlers/remote_instances.rs
@@ -11,7 +11,17 @@ use axum::{
     routing::{delete, get},
     Json, Router,
 };
+use bytes::Bytes;
+use futures::Stream;
+use once_cell::sync::Lazy;
 use serde::Deserialize;
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use utoipa::{OpenApi, ToSchema};
 use uuid::Uuid;
 
@@ -40,6 +50,116 @@ pub fn proxy_body_limit_bytes() -> usize {
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .unwrap_or(DEFAULT_PROXY_BODY_LIMIT_BYTES)
+}
+
+/// Default overall (headers + full body transfer) time budget for a single
+/// proxied request, in seconds. Distinct from the client's idle read-timeout:
+/// the read-timeout only bounds *inactivity*, so a cooperative-slow upstream
+/// that dribbles bytes just often enough to reset the idle timer would never be
+/// aborted. This absolute deadline bounds the whole relay regardless of per-read
+/// activity. Generous by default because the proxy can forward large management
+/// payloads; env-tunable via `REMOTE_PROXY_TOTAL_TIMEOUT_SECS` so an operator who
+/// proxies genuinely large/slow downloads can raise it.
+const DEFAULT_PROXY_TOTAL_TIMEOUT_SECS: u64 = 300;
+
+/// Default cap on concurrent in-flight proxy requests **per user**. Each stalled
+/// relay pins a backend task plus an upstream and a downstream socket, so an
+/// unbounded number would let a single user exhaust the process file-descriptor
+/// limit. A per-user cap keeps one user from starving others. Env-tunable via
+/// `REMOTE_PROXY_MAX_INFLIGHT_PER_USER`.
+const DEFAULT_PROXY_MAX_INFLIGHT_PER_USER: usize = 16;
+
+/// Resolve the overall per-request time budget for a proxied relay.
+fn proxy_total_timeout() -> Duration {
+    let secs = std::env::var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_PROXY_TOTAL_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// Resolve the per-user concurrent-proxy cap.
+fn proxy_max_inflight_per_user() -> usize {
+    std::env::var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_PROXY_MAX_INFLIGHT_PER_USER)
+}
+
+/// Per-user semaphores bounding concurrent in-flight proxy requests. Entries are
+/// created lazily on first use; the set of distinct users is bounded, so the map
+/// does not grow without limit in practice.
+static PROXY_INFLIGHT: Lazy<Mutex<HashMap<Uuid, Arc<Semaphore>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Try to acquire an in-flight slot for `user_id` from `map`, creating that
+/// user's semaphore with `cap` permits on first use. Returns `None` when the
+/// user is already at the cap (caller maps that to 429). Split from
+/// [`acquire_proxy_permit`] so the capacity logic is unit-testable without
+/// touching the process-global map or environment.
+fn acquire_proxy_permit_from(
+    map: &Mutex<HashMap<Uuid, Arc<Semaphore>>>,
+    user_id: Uuid,
+    cap: usize,
+) -> Option<OwnedSemaphorePermit> {
+    let sem = {
+        let mut guard = map.lock().unwrap_or_else(|e| e.into_inner());
+        guard
+            .entry(user_id)
+            .or_insert_with(|| Arc::new(Semaphore::new(cap)))
+            .clone()
+    };
+    sem.try_acquire_owned().ok()
+}
+
+/// Acquire an in-flight proxy slot for `user_id`, or `None` if the per-user cap
+/// is reached. The returned permit must be held for the whole relay (it is moved
+/// into the response body so it is released only when streaming finishes or the
+/// body is dropped).
+fn acquire_proxy_permit(user_id: Uuid) -> Option<OwnedSemaphorePermit> {
+    acquire_proxy_permit_from(&PROXY_INFLIGHT, user_id, proxy_max_inflight_per_user())
+}
+
+/// Response body wrapper for a proxied relay that (a) enforces an absolute
+/// total-time deadline over the whole body transfer — terminating the stream
+/// even when the upstream trickles bytes just under the idle read-timeout or
+/// stalls entirely (the timer wakes the task at the deadline regardless of
+/// upstream activity) — and (b) holds the per-user concurrency permit until the
+/// body finishes, so a slot is released only when the relay actually completes.
+struct GuardedProxyBody {
+    inner: Pin<Box<dyn Stream<Item = reqwest::Result<Bytes>> + Send>>,
+    deadline: Pin<Box<tokio::time::Sleep>>,
+    // Held for the lifetime of the streamed body; released on drop.
+    _permit: OwnedSemaphorePermit,
+}
+
+impl Stream for GuardedProxyBody {
+    type Item = reqwest::Result<Bytes>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Check the absolute deadline first so it fires even if `inner` is
+        // stalled: polling the Sleep registers its timer waker, which wakes this
+        // task at the deadline independent of any upstream chunk arriving.
+        if self.deadline.as_mut().poll(cx).is_ready() {
+            return Poll::Ready(None);
+        }
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+/// Build a small static `Response` with the given status and plain-text message.
+fn proxy_status_response(status: axum::http::StatusCode, msg: &'static str) -> Response {
+    let mut builder = Response::builder()
+        .status(status)
+        .header("content-type", "text/plain; charset=utf-8");
+    if status == axum::http::StatusCode::TOO_MANY_REQUESTS {
+        builder = builder.header("retry-after", "1");
+    }
+    builder
+        .body(Body::from(msg))
+        .expect("static proxy status response is always valid")
 }
 
 /// Build the router for `/api/v1/instances`.
@@ -179,7 +299,15 @@ fn build_target_url(base: &str, path: &str) -> String {
 /// the unbounded-memory (OOM) vector for arbitrarily large or endless upstream
 /// responses while preserving correctness for any size (large legitimate
 /// proxied downloads keep working with no artificial ceiling).
-fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
+///
+/// The stream is wrapped in a [`GuardedProxyBody`] that enforces the overall
+/// `deadline` (total-timeout) over the whole body transfer and holds the
+/// concurrency `permit` until streaming finishes.
+fn reqwest_to_axum(
+    resp: reqwest::Response,
+    deadline: tokio::time::Instant,
+    permit: OwnedSemaphorePermit,
+) -> Result<Response> {
     let status = axum::http::StatusCode::from_u16(resp.status().as_u16())
         .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
     let content_type = resp.headers().get("content-type").cloned();
@@ -187,6 +315,12 @@ fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
     // upstreams (Body::from_stream yields a chunked response) rather than
     // fabricate one.
     let content_length = resp.headers().get("content-length").cloned();
+
+    let body = GuardedProxyBody {
+        inner: Box::pin(resp.bytes_stream()),
+        deadline: Box::pin(tokio::time::sleep_until(deadline)),
+        _permit: permit,
+    };
 
     let mut builder = Response::builder().status(status);
     if let Some(ct) = content_type {
@@ -196,7 +330,7 @@ fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
         builder = builder.header("content-length", cl);
     }
     builder
-        .body(Body::from_stream(resp.bytes_stream()))
+        .body(Body::from_stream(body))
         .map_err(|e| AppError::Internal(format!("Failed to build response: {e}")))
 }
 
@@ -204,8 +338,14 @@ fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
 /// the decrypted remote URL + API key, forwards the request to the remote
 /// instance and streams the response back. `body` is `Some` only for verbs
 /// that carry a request body (POST/PUT); it is attached zero-copy via
-/// [`reqwest::Body::from`] with a JSON content-type. The proxy client sets a
-/// connect/read timeout so an endless upstream cannot pin a worker task.
+/// [`reqwest::Body::from`] with a JSON content-type.
+///
+/// Three layers bound resource use so a hostile/slow upstream cannot exhaust the
+/// backend: the proxy client's idle connect/read timeout (bounds inactivity), an
+/// overall total-time budget applied to both the header phase and the streamed
+/// body via [`GuardedProxyBody`] (bounds a cooperative trickle that never idles),
+/// and a per-user concurrency cap (bounds file-descriptor/socket exhaustion;
+/// over the cap → 429).
 async fn send_proxy_request(
     state: &SharedState,
     auth: &AuthExtension,
@@ -215,8 +355,25 @@ async fn send_proxy_request(
     body: Option<axum::body::Bytes>,
 ) -> Result<Response> {
     validate_proxy_path(path)?;
+
+    // Bound concurrent in-flight proxy relays per user. The permit is held for
+    // the whole relay (moved into the response body below) and released only
+    // when streaming completes or the body is dropped.
+    let permit = match acquire_proxy_permit(auth.user_id) {
+        Some(permit) => permit,
+        None => {
+            return Ok(proxy_status_response(
+                axum::http::StatusCode::TOO_MANY_REQUESTS,
+                "Too many concurrent proxy requests for this user; retry shortly",
+            ));
+        }
+    };
+
     let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
     let target = build_target_url(&url, path);
+
+    // Absolute deadline for the entire relay (headers + full body transfer).
+    let deadline = tokio::time::Instant::now() + proxy_total_timeout();
 
     let mut req = crate::services::http_client::proxy_client()
         .request(method, &target)
@@ -227,12 +384,20 @@ async fn send_proxy_request(
             .body(reqwest::Body::from(body));
     }
 
-    let resp = req
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Proxy request failed: {e}")))?;
+    // Bound the header/connect phase by the same total budget; the body phase is
+    // bounded by GuardedProxyBody using the shared deadline.
+    let resp = match tokio::time::timeout_at(deadline, req.send()).await {
+        Ok(Ok(resp)) => resp,
+        Ok(Err(e)) => return Err(AppError::Internal(format!("Proxy request failed: {e}"))),
+        Err(_elapsed) => {
+            return Ok(proxy_status_response(
+                axum::http::StatusCode::GATEWAY_TIMEOUT,
+                "Upstream proxy request exceeded the total time budget",
+            ));
+        }
+    };
 
-    reqwest_to_axum(resp)
+    reqwest_to_axum(resp, deadline, permit)
 }
 
 // ---------------------------------------------------------------------------
@@ -540,10 +705,21 @@ mod tests {
         reqwest::Response::from(builder.body(body).unwrap())
     }
 
+    /// A far-future deadline and a fresh permit for exercising `reqwest_to_axum`
+    /// without a total-timeout firing. Must be called inside a tokio runtime.
+    fn test_deadline_and_permit() -> (tokio::time::Instant, OwnedSemaphorePermit) {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+        let permit = Arc::new(Semaphore::new(1))
+            .try_acquire_owned()
+            .expect("permit available");
+        (deadline, permit)
+    }
+
     #[tokio::test]
     async fn test_reqwest_to_axum_forwards_status_and_content_type() {
         let resp = mock_reqwest_response(201, Some("application/json"), b"{\"ok\":true}".to_vec());
-        let axum_resp = reqwest_to_axum(resp).expect("conversion should succeed");
+        let (deadline, permit) = test_deadline_and_permit();
+        let axum_resp = reqwest_to_axum(resp, deadline, permit).expect("conversion should succeed");
 
         assert_eq!(axum_resp.status().as_u16(), 201);
         assert_eq!(
@@ -565,7 +741,8 @@ mod tests {
     #[tokio::test]
     async fn test_reqwest_to_axum_forwards_error_status_without_content_type() {
         let resp = mock_reqwest_response(502, None, b"upstream error".to_vec());
-        let axum_resp = reqwest_to_axum(resp).expect("conversion should succeed");
+        let (deadline, permit) = test_deadline_and_permit();
+        let axum_resp = reqwest_to_axum(resp, deadline, permit).expect("conversion should succeed");
 
         assert_eq!(axum_resp.status().as_u16(), 502);
         assert!(axum_resp.headers().get("content-type").is_none());
@@ -580,7 +757,8 @@ mod tests {
         let size = 16 * 1024 * 1024;
         let payload = vec![0xABu8; size];
         let resp = mock_reqwest_response(200, Some("application/octet-stream"), payload.clone());
-        let axum_resp = reqwest_to_axum(resp).expect("conversion should succeed");
+        let (deadline, permit) = test_deadline_and_permit();
+        let axum_resp = reqwest_to_axum(resp, deadline, permit).expect("conversion should succeed");
 
         assert_eq!(axum_resp.status().as_u16(), 200);
         // content-length forwarded from the upstream when present.
@@ -627,5 +805,112 @@ mod tests {
             Some(v) => std::env::set_var("REMOTE_PROXY_BODY_LIMIT_BYTES", v),
             None => std::env::remove_var("REMOTE_PROXY_BODY_LIMIT_BYTES"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // total-timeout + per-user concurrency knobs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_proxy_total_timeout_default_and_override() {
+        let saved = std::env::var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS").ok();
+
+        std::env::remove_var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS");
+        assert_eq!(proxy_total_timeout(), Duration::from_secs(300));
+
+        std::env::set_var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS", "15");
+        assert_eq!(proxy_total_timeout(), Duration::from_secs(15));
+
+        // Zero / non-numeric fall back to the default (never a 0-length budget).
+        std::env::set_var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS", "0");
+        assert_eq!(proxy_total_timeout(), Duration::from_secs(300));
+        std::env::set_var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS", "nope");
+        assert_eq!(proxy_total_timeout(), Duration::from_secs(300));
+
+        match saved {
+            Some(v) => std::env::set_var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS", v),
+            None => std::env::remove_var("REMOTE_PROXY_TOTAL_TIMEOUT_SECS"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_max_inflight_default_and_override() {
+        let saved = std::env::var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER").ok();
+
+        std::env::remove_var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER");
+        assert_eq!(proxy_max_inflight_per_user(), 16);
+
+        std::env::set_var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER", "3");
+        assert_eq!(proxy_max_inflight_per_user(), 3);
+
+        // Zero / non-numeric fall back to the default (never an unusable 0 cap).
+        std::env::set_var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER", "0");
+        assert_eq!(proxy_max_inflight_per_user(), 16);
+        std::env::set_var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER", "x");
+        assert_eq!(proxy_max_inflight_per_user(), 16);
+
+        match saved {
+            Some(v) => std::env::set_var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER", v),
+            None => std::env::remove_var("REMOTE_PROXY_MAX_INFLIGHT_PER_USER"),
+        }
+    }
+
+    #[test]
+    fn test_proxy_permit_caps_and_releases_per_user() {
+        // Uses a local map + explicit cap so it is deterministic and does not
+        // touch the process-global state or environment.
+        let map = Mutex::new(HashMap::new());
+        let user = Uuid::new_v4();
+
+        let p1 = acquire_proxy_permit_from(&map, user, 2);
+        let p2 = acquire_proxy_permit_from(&map, user, 2);
+        let p3 = acquire_proxy_permit_from(&map, user, 2);
+        assert!(
+            p1.is_some() && p2.is_some(),
+            "up to the cap must be admitted"
+        );
+        assert!(p3.is_none(), "over the cap must be refused (caller -> 429)");
+
+        // A different user has an independent slot allowance.
+        let other = acquire_proxy_permit_from(&map, Uuid::new_v4(), 2);
+        assert!(
+            other.is_some(),
+            "cap is per-user; one user cannot starve another"
+        );
+
+        // Releasing a permit frees a slot for the same user.
+        drop(p2);
+        assert!(
+            acquire_proxy_permit_from(&map, user, 2).is_some(),
+            "releasing an in-flight slot admits the next request"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_guarded_body_aborts_stalled_stream_at_deadline() {
+        // A stream that never yields a chunk (endless/stalled upstream). The
+        // absolute deadline must terminate the body rather than hang forever.
+        let pending = futures::stream::pending::<reqwest::Result<Bytes>>();
+        let permit = Arc::new(Semaphore::new(1))
+            .try_acquire_owned()
+            .expect("permit available");
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(150);
+        let body = GuardedProxyBody {
+            inner: Box::pin(pending),
+            deadline: Box::pin(tokio::time::sleep_until(deadline)),
+            _permit: permit,
+        };
+
+        let start = tokio::time::Instant::now();
+        // Test-only: drain the guarded body; it must end at the deadline.
+        #[allow(clippy::disallowed_methods)]
+        let bytes = axum::body::to_bytes(Body::from_stream(body), usize::MAX)
+            .await
+            .expect("guarded body terminates cleanly");
+        assert!(bytes.is_empty(), "stalled stream yields no bytes");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "must abort at the ~150ms deadline, not hang"
+        );
     }
 }

--- a/backend/src/api/handlers/remote_instances.rs
+++ b/backend/src/api/handlers/remote_instances.rs
@@ -22,6 +22,26 @@ use crate::services::remote_instance_service::{RemoteInstanceResponse, RemoteIns
 
 use crate::api::validation::validate_outbound_url;
 
+/// Default request-body limit (bytes) for the remote-instance proxy surface:
+/// 32 MiB. The global body limit is disabled (`routes.rs`), so without a
+/// route-scoped limit this management proxy would buffer an unbounded request
+/// body. This is a control-plane management surface (allow-listed to `api/` /
+/// `health` calls), not a bulk data plane, so a modest ceiling is appropriate.
+const DEFAULT_PROXY_BODY_LIMIT_BYTES: usize = 32 * 1024 * 1024;
+
+/// Resolve the request-body limit for the remote-instance proxy nest.
+///
+/// Defaults to [`DEFAULT_PROXY_BODY_LIMIT_BYTES`] (32 MiB) and is env-tunable
+/// via `REMOTE_PROXY_BODY_LIMIT_BYTES` so an operator who genuinely proxies
+/// larger management payloads can raise it without a code change (avoids a
+/// silent 413 regression).
+pub fn proxy_body_limit_bytes() -> usize {
+    std::env::var("REMOTE_PROXY_BODY_LIMIT_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(DEFAULT_PROXY_BODY_LIMIT_BYTES)
+}
+
 /// Build the router for `/api/v1/instances`.
 pub fn router() -> Router<SharedState> {
     Router::new()
@@ -151,24 +171,68 @@ fn build_target_url(base: &str, path: &str) -> String {
 
 /// Convert a reqwest response into an axum response, forwarding status and
 /// content-type.
-async fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
+///
+/// The upstream body is *streamed* straight through to the client via
+/// [`Body::from_stream`] rather than being buffered into memory first. This
+/// path is a pure pass-through — it performs no checksum verification and no
+/// cache-tee, so nothing here needs the whole body resident. Streaming removes
+/// the unbounded-memory (OOM) vector for arbitrarily large or endless upstream
+/// responses while preserving correctness for any size (large legitimate
+/// proxied downloads keep working with no artificial ceiling).
+fn reqwest_to_axum(resp: reqwest::Response) -> Result<Response> {
     let status = axum::http::StatusCode::from_u16(resp.status().as_u16())
         .unwrap_or(axum::http::StatusCode::INTERNAL_SERVER_ERROR);
     let content_type = resp.headers().get("content-type").cloned();
-    #[allow(clippy::disallowed_methods)]
-    // STREAMING-EXEMPT: capped-metadata read (upstream index/advisory/packument, not an artifact blob); bounded response buffered; tracked under #1608
-    let body = resp
-        .bytes()
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to read proxy response: {e}")))?;
+    // Forward the upstream content-length when present; omit it for chunked
+    // upstreams (Body::from_stream yields a chunked response) rather than
+    // fabricate one.
+    let content_length = resp.headers().get("content-length").cloned();
 
     let mut builder = Response::builder().status(status);
     if let Some(ct) = content_type {
         builder = builder.header("content-type", ct);
     }
+    if let Some(cl) = content_length {
+        builder = builder.header("content-length", cl);
+    }
     builder
-        .body(Body::from(body))
+        .body(Body::from_stream(resp.bytes_stream()))
         .map_err(|e| AppError::Internal(format!("Failed to build response: {e}")))
+}
+
+/// Shared proxy dispatch for all four verbs. Validates the sub-path, resolves
+/// the decrypted remote URL + API key, forwards the request to the remote
+/// instance and streams the response back. `body` is `Some` only for verbs
+/// that carry a request body (POST/PUT); it is attached zero-copy via
+/// [`reqwest::Body::from`] with a JSON content-type. The proxy client sets a
+/// connect/read timeout so an endless upstream cannot pin a worker task.
+async fn send_proxy_request(
+    state: &SharedState,
+    auth: &AuthExtension,
+    id: Uuid,
+    path: &str,
+    method: reqwest::Method,
+    body: Option<axum::body::Bytes>,
+) -> Result<Response> {
+    validate_proxy_path(path)?;
+    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
+    let target = build_target_url(&url, path);
+
+    let mut req = crate::services::http_client::proxy_client()
+        .request(method, &target)
+        .bearer_auth(&api_key);
+    if let Some(body) = body {
+        req = req
+            .header("content-type", "application/json")
+            .body(reqwest::Body::from(body));
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| AppError::Internal(format!("Proxy request failed: {e}")))?;
+
+    reqwest_to_axum(resp)
 }
 
 // ---------------------------------------------------------------------------
@@ -195,18 +259,7 @@ async fn proxy_get(
     Extension(auth): Extension<AuthExtension>,
     Path((id, path)): Path<(Uuid, String)>,
 ) -> Result<Response> {
-    validate_proxy_path(&path)?;
-    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
-    let target = build_target_url(&url, &path);
-
-    let resp = crate::services::http_client::default_client()
-        .get(&target)
-        .bearer_auth(&api_key)
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Proxy request failed: {e}")))?;
-
-    reqwest_to_axum(resp).await
+    send_proxy_request(&state, &auth, id, &path, reqwest::Method::GET, None).await
 }
 
 /// Proxy a POST request to a remote instance
@@ -231,20 +284,7 @@ async fn proxy_post(
     Path((id, path)): Path<(Uuid, String)>,
     body: axum::body::Bytes,
 ) -> Result<Response> {
-    validate_proxy_path(&path)?;
-    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
-    let target = build_target_url(&url, &path);
-
-    let resp = crate::services::http_client::default_client()
-        .post(&target)
-        .bearer_auth(&api_key)
-        .header("content-type", "application/json")
-        .body(body.to_vec())
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Proxy request failed: {e}")))?;
-
-    reqwest_to_axum(resp).await
+    send_proxy_request(&state, &auth, id, &path, reqwest::Method::POST, Some(body)).await
 }
 
 /// Proxy a PUT request to a remote instance
@@ -269,20 +309,7 @@ async fn proxy_put(
     Path((id, path)): Path<(Uuid, String)>,
     body: axum::body::Bytes,
 ) -> Result<Response> {
-    validate_proxy_path(&path)?;
-    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
-    let target = build_target_url(&url, &path);
-
-    let resp = crate::services::http_client::default_client()
-        .put(&target)
-        .bearer_auth(&api_key)
-        .header("content-type", "application/json")
-        .body(body.to_vec())
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Proxy request failed: {e}")))?;
-
-    reqwest_to_axum(resp).await
+    send_proxy_request(&state, &auth, id, &path, reqwest::Method::PUT, Some(body)).await
 }
 
 /// Proxy a DELETE request to a remote instance
@@ -305,18 +332,7 @@ async fn proxy_delete(
     Extension(auth): Extension<AuthExtension>,
     Path((id, path)): Path<(Uuid, String)>,
 ) -> Result<Response> {
-    validate_proxy_path(&path)?;
-    let (url, api_key) = RemoteInstanceService::get_decrypted(&state.db, id, auth.user_id).await?;
-    let target = build_target_url(&url, &path);
-
-    let resp = crate::services::http_client::default_client()
-        .delete(&target)
-        .bearer_auth(&api_key)
-        .send()
-        .await
-        .map_err(|e| AppError::Internal(format!("Proxy request failed: {e}")))?;
-
-    reqwest_to_axum(resp).await
+    send_proxy_request(&state, &auth, id, &path, reqwest::Method::DELETE, None).await
 }
 
 #[derive(OpenApi)]
@@ -503,5 +519,113 @@ mod tests {
     fn test_build_target_url_preserves_path_slashes() {
         let url = build_target_url("http://example.com", "a/b/c/d/e");
         assert_eq!(url, "http://example.com/a/b/c/d/e");
+    }
+
+    // -----------------------------------------------------------------------
+    // reqwest_to_axum — streaming pass-through
+    // -----------------------------------------------------------------------
+
+    /// Build a mock `reqwest::Response` from an in-memory `http::Response`
+    /// (no network), so the conversion can be exercised offline.
+    fn mock_reqwest_response(
+        status: u16,
+        content_type: Option<&str>,
+        body: Vec<u8>,
+    ) -> reqwest::Response {
+        let mut builder = http::response::Builder::new().status(status);
+        if let Some(ct) = content_type {
+            builder = builder.header("content-type", ct);
+        }
+        builder = builder.header("content-length", body.len().to_string());
+        reqwest::Response::from(builder.body(body).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_to_axum_forwards_status_and_content_type() {
+        let resp = mock_reqwest_response(201, Some("application/json"), b"{\"ok\":true}".to_vec());
+        let axum_resp = reqwest_to_axum(resp).expect("conversion should succeed");
+
+        assert_eq!(axum_resp.status().as_u16(), 201);
+        assert_eq!(
+            axum_resp
+                .headers()
+                .get("content-type")
+                .and_then(|v| v.to_str().ok()),
+            Some("application/json")
+        );
+
+        // Test-only: drain the streamed body to assert its full contents.
+        #[allow(clippy::disallowed_methods)]
+        let bytes = axum::body::to_bytes(axum_resp.into_body(), usize::MAX)
+            .await
+            .expect("body readable");
+        assert_eq!(&bytes[..], b"{\"ok\":true}");
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_to_axum_forwards_error_status_without_content_type() {
+        let resp = mock_reqwest_response(502, None, b"upstream error".to_vec());
+        let axum_resp = reqwest_to_axum(resp).expect("conversion should succeed");
+
+        assert_eq!(axum_resp.status().as_u16(), 502);
+        assert!(axum_resp.headers().get("content-type").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_reqwest_to_axum_streams_large_body_without_buffering() {
+        // A large (16 MiB) upstream body must pass through intact. The handler
+        // wraps it in a streaming body (`Body::from_stream`) rather than a
+        // pre-buffered `Bytes`, so it never holds the whole payload before the
+        // client starts receiving it.
+        let size = 16 * 1024 * 1024;
+        let payload = vec![0xABu8; size];
+        let resp = mock_reqwest_response(200, Some("application/octet-stream"), payload.clone());
+        let axum_resp = reqwest_to_axum(resp).expect("conversion should succeed");
+
+        assert_eq!(axum_resp.status().as_u16(), 200);
+        // content-length forwarded from the upstream when present.
+        assert_eq!(
+            axum_resp
+                .headers()
+                .get("content-length")
+                .and_then(|v| v.to_str().ok()),
+            Some(size.to_string().as_str())
+        );
+
+        // Test-only: drain the streamed body to assert its full contents.
+        #[allow(clippy::disallowed_methods)]
+        let bytes = axum::body::to_bytes(axum_resp.into_body(), usize::MAX)
+            .await
+            .expect("body readable");
+        assert_eq!(bytes.len(), size);
+        assert_eq!(&bytes[..], &payload[..]);
+    }
+
+    // -----------------------------------------------------------------------
+    // proxy_body_limit_bytes — env-tunable request-body ceiling
+    // -----------------------------------------------------------------------
+
+    // Default + env override are checked in one test: both mutate the same
+    // process-global env var, so keeping them serial avoids a parallel-run race.
+    #[test]
+    fn test_proxy_body_limit_default_and_env_override() {
+        let saved = std::env::var("REMOTE_PROXY_BODY_LIMIT_BYTES").ok();
+
+        // Default (no override) is 32 MiB.
+        std::env::remove_var("REMOTE_PROXY_BODY_LIMIT_BYTES");
+        assert_eq!(proxy_body_limit_bytes(), 32 * 1024 * 1024);
+
+        // A valid numeric override is honored.
+        std::env::set_var("REMOTE_PROXY_BODY_LIMIT_BYTES", "1048576");
+        assert_eq!(proxy_body_limit_bytes(), 1_048_576);
+
+        // A non-numeric value falls back to the default.
+        std::env::set_var("REMOTE_PROXY_BODY_LIMIT_BYTES", "not-a-number");
+        assert_eq!(proxy_body_limit_bytes(), 32 * 1024 * 1024);
+
+        match saved {
+            Some(v) => std::env::set_var("REMOTE_PROXY_BODY_LIMIT_BYTES", v),
+            None => std::env::remove_var("REMOTE_PROXY_BODY_LIMIT_BYTES"),
+        }
     }
 }

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -893,13 +893,22 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 admin_middleware,
             )),
         )
-        // Remote instance management & proxy routes with auth middleware
+        // Remote instance management & proxy routes with auth middleware.
+        // The global body limit is disabled above, so apply a route-scoped
+        // request-body limit here (default 32 MiB, env-tunable via
+        // REMOTE_PROXY_BODY_LIMIT_BYTES) to bound the proxy request path. The
+        // limit is on the REQUEST body only — proxied response downloads stream
+        // through with no ceiling.
         .nest(
             "/instances",
-            handlers::remote_instances::router().layer(middleware::from_fn_with_state(
-                auth_service.clone(),
-                auth_middleware,
-            )),
+            handlers::remote_instances::router()
+                .layer(DefaultBodyLimit::max(
+                    handlers::remote_instances::proxy_body_limit_bytes(),
+                ))
+                .layer(middleware::from_fn_with_state(
+                    auth_service.clone(),
+                    auth_middleware,
+                )),
         )
         // Service account management routes with auth middleware
         .nest(

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -216,6 +216,39 @@ pub fn default_client() -> reqwest::Client {
         .expect("failed to build default HTTP client")
 }
 
+/// Default connect timeout (seconds) for the remote-instance proxy client.
+const DEFAULT_PROXY_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Default read-inactivity timeout (seconds) for the remote-instance proxy
+/// client.
+const DEFAULT_PROXY_READ_TIMEOUT_SECS: u64 = 30;
+
+/// Build a [`reqwest::Client`] for the **remote-instance management proxy**
+/// (`/api/v1/instances/:id/proxy/*`).
+///
+/// Same SSRF trust class, redirect policy and plaintext/HTTP semantics as
+/// [`default_client`] — the proxy target is user-influenceable, so it stays
+/// fail-closed and is deliberately NOT switched to [`large_object_client_builder`],
+/// which would force `https_only` and change the existing behavior. The only
+/// addition is a `connect_timeout` plus a `read_timeout` that bounds inactivity
+/// while reading the upstream response, so a slow-loris / endless upstream
+/// cannot pin a worker task indefinitely. Both are env-tunable via
+/// `REMOTE_PROXY_CONNECT_TIMEOUT_SECS` and `REMOTE_PROXY_READ_TIMEOUT_SECS`.
+pub fn proxy_client() -> reqwest::Client {
+    let connect_secs = std::env::var("REMOTE_PROXY_CONNECT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_PROXY_CONNECT_TIMEOUT_SECS);
+    let read_secs = std::env::var("REMOTE_PROXY_READ_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_PROXY_READ_TIMEOUT_SECS);
+    base_client_builder()
+        .connect_timeout(Duration::from_secs(connect_secs))
+        .read_timeout(Duration::from_secs(read_secs))
+        .build()
+        .expect("failed to build remote-instance proxy HTTP client")
+}
+
 /// Redirect policy that re-runs the SSRF allow-list on every hop. An
 /// upstream returning `302 Location: http://[::ffff:127.0.0.1]/` would
 /// otherwise defeat the entry-point validator. Caps at


### PR DESCRIPTION
## Summary

The remote-instance management proxy (`/api/v1/instances/:id/proxy/*`) was a pure
pass-through that buffered **both** directions fully in memory with no framework
body limit, so a large or endless payload could exhaust backend memory or pin a
worker. This surface was never brought under the `#1608` streaming-enforcement work
(relates to #2517 / PF-005). This PR hardens it with a minimal, behavior-preserving
change.

Closes #2515

### What changed
- **Stream upstream responses instead of buffering them.** `reqwest_to_axum` now
  forwards the upstream body via `Body::from_stream(resp.bytes_stream())` rather than
  reading it into a single `Bytes` first. This path does **no checksum verification and
  no cache-tee** — it only forwards status + content-type (+ content-length when the
  upstream provides one) — so nothing here needs the whole body resident. Large
  legitimate proxied downloads keep working at **any size** with no artificial ceiling;
  the memory no longer scales with response size. The stale, inaccurate
  `STREAMING-EXEMPT … bounded response buffered` comment (no cap was ever applied) is
  removed.
- **Drop the request-body copy.** `proxy_post` / `proxy_put` attach the request body
  to reqwest zero-copy via `reqwest::Body::from(body)` instead of `body.to_vec()`.
- **Route-scoped request-body limit.** The global body limit is disabled for the
  registry upload paths, so the `/instances` nest had none. It now carries a
  `DefaultBodyLimit` (default **32 MiB**, env-tunable via
  `REMOTE_PROXY_BODY_LIMIT_BYTES`). This is a control-plane management surface
  (allow-listed to `api/` / `health` calls), not a bulk data plane, so a modest ceiling
  is appropriate; operators who genuinely proxy larger management payloads can raise it
  without a code change (avoids a silent 413 regression). **The limit is on the REQUEST
  body only — response downloads still stream with no ceiling.**
- **Read/connect timeout on the proxy client.** Added `proxy_client()`, which reuses
  `base_client_builder()` (identical SSRF trust class, redirect policy and plaintext
  behavior as `default_client` — deliberately **not** `large_object_client_builder`,
  which would force `https_only`) and adds a `connect_timeout` + `read_timeout`
  (env-tunable) so a slow-loris / endless upstream is bounded instead of pinning a
  worker task.
- **Overall (total) per-request timeout.** The idle read-timeout only bounds
  *inactivity*, so a cooperative-slow upstream that dribbles bytes just under the
  read-timeout is never aborted. A `GuardedProxyBody` now enforces an absolute deadline
  over the whole relay (header phase via `timeout_at`, body phase via the wrapped
  stream — the deadline fires even when the upstream stalls entirely), env-tunable via
  `REMOTE_PROXY_TOTAL_TIMEOUT_SECS` (default **300 s**). Header-phase overrun returns
  **504**; a mid-body overrun terminates the stream and releases the backend task + both
  sockets. 300 s is generous for the management payloads this proxy forwards; operators
  who genuinely proxy larger/slower downloads can raise it (the deliberate
  default/tradeoff — a legit download must complete within the budget).
- **Per-user concurrent-proxy cap.** Each in-flight relay pins a task + an upstream and
  a downstream socket, so an unbounded number lets one user reach the process
  file-descriptor limit. A per-user semaphore (`REMOTE_PROXY_MAX_INFLIGHT_PER_USER`,
  default **16**) bounds in-flight proxy requests; over the cap returns **429** with
  `Retry-After`. Per-user (not global) so one user cannot starve others. The permit is
  held for the whole relay (moved into `GuardedProxyBody`) and released only when
  streaming finishes or the body is dropped.

The four proxy verb handlers were collapsed onto a single `send_proxy_request` helper
(they were near-identical), which also keeps the changed file under the duplication gate.

**Not weakened:** this is a pure passthrough — there is no integrity check on this path
to lose by streaming (unlike the cache-tee'd package-format proxy). **SSRF controls are
untouched:** `validate_outbound_url` (create) and `validate_proxy_path` (per-request)
and the `default_client`/`base_client_builder` SSRF DNS + redirect trust class are
unchanged.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added unit tests in `remote_instances.rs`:
- `reqwest_to_axum` forwards status + content-type and returns a **streaming** body
  (drives it with a 16 MiB fixture; asserts full contents pass through and the handler
  builds a stream rather than a pre-buffered `Bytes`), plus error-status forwarding.
- `proxy_body_limit_bytes()` / `proxy_total_timeout()` / `proxy_max_inflight_per_user()`
  default + env override / fallback behavior.
- Per-user concurrency cap admits up to the cap, refuses over it (→ 429), is independent
  per user, and frees a slot on release.
- `GuardedProxyBody` aborts a fully stalled stream at the deadline (no hang).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification on an isolated stack against a test upstream:
- Large proxied GET (512 MiB) streams through; backend RSS stayed flat (~44→~50 MiB
  for the whole transfer) instead of climbing with body size.
- Oversized request body (~38 MiB) → **413**; ~19 MiB body → **200** forwarded.
- Status/content-type/body forwarding intact (200 `application/json`, 404 passthrough,
  POST echo 200).
- Stalling upstream aborted at the read timeout (~5 s) instead of hanging.
- **Trickle (1 byte / 2 s, idle read-timeout=60 s so it never fires) aborted at the
  total-timeout (~15 s), not held indefinitely.**
- **Per-user cap=3: 6 concurrent long proxy GETs → 3 served, 3 × 429.**
- **No regression under the new bounds:** 512 MiB legit download completed full-body in
  ~0.2 s (well within budget); request-body 413 held; idle read-timeout still fired
  (~5 s) with a generous 300 s total budget.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (no new routes/types; no schema change)
