### PR TITLE
feat(npm): enforce scope policy on tarball + direct-remote paths and add glob name patterns (#2424)

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -673,6 +673,139 @@ fn empty_audits_quick_response() -> Response {
     build_json_metadata_response(body.to_string())
 }
 
+// ---------------------------------------------------------------------------
+// npm /-/ meta+audit namespace — scope-policy filtering (#2424)
+//
+// The advisory/audit/search endpoints proxy to upstream. On a scope-restricted
+// Remote repository they must not leak metadata (advisories, audit reports,
+// search hits) for out-of-scope package names. These pure helpers filter the
+// package-name-bearing request/response shapes against the repo's policy;
+// callers only invoke them when `policy.is_active()`, so unset-policy repos are
+// byte-identical (allow-all) and never touch this code path.
+// ---------------------------------------------------------------------------
+
+/// Filter a JSON object whose keys are npm package names, keeping only entries
+/// the policy allows. Returns the filtered map and whether any entry survived.
+/// Shared by the bulk-advisories request/response (`{name: [...]}`) and the
+/// quick-audit `requires` / `dependencies` sub-maps.
+fn filter_pkg_name_map(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    policy: &NpmScopePolicy,
+) -> (serde_json::Map<String, serde_json::Value>, bool) {
+    let filtered: serde_json::Map<String, serde_json::Value> = obj
+        .iter()
+        .filter(|(name, _)| policy.allows(name))
+        .map(|(name, val)| (name.clone(), val.clone()))
+        .collect();
+    let kept = !filtered.is_empty();
+    (filtered, kept)
+}
+
+/// Filter the bulk-advisories request body (`{name: [versions]}`) against the
+/// policy. Returns the re-serialised body and whether any in-scope package
+/// remained. `None` when the body is not the expected object shape — the caller
+/// fails closed (empty response) under an active policy.
+fn filter_bulk_advisory_request(body: &[u8], policy: &NpmScopePolicy) -> Option<(Bytes, bool)> {
+    let value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let obj = value.as_object()?;
+    let (filtered, kept) = filter_pkg_name_map(obj, policy);
+    let bytes = serde_json::to_vec(&serde_json::Value::Object(filtered)).ok()?;
+    Some((Bytes::from(bytes), kept))
+}
+
+/// Filter a bulk-advisories response (`{name: [advisories]}`) against the
+/// policy — defence in depth in case upstream returns advisories for names that
+/// were not requested. Parse failure yields an empty object (fail-closed).
+fn filter_bulk_advisory_response(bytes: &[u8], policy: &NpmScopePolicy) -> String {
+    match serde_json::from_slice::<serde_json::Value>(bytes) {
+        Ok(serde_json::Value::Object(obj)) => {
+            let (filtered, _) = filter_pkg_name_map(&obj, policy);
+            serde_json::Value::Object(filtered).to_string()
+        }
+        _ => serde_json::Value::Object(serde_json::Map::new()).to_string(),
+    }
+}
+
+/// Filter the quick-audit request body: drop out-of-scope names from the
+/// `requires` and `dependencies` maps so upstream is never asked about them.
+/// Returns the re-serialised body and whether any in-scope dependency remained.
+/// `None` when the body is not an object (caller fails closed).
+fn filter_quick_audit_request(body: &[u8], policy: &NpmScopePolicy) -> Option<(Bytes, bool)> {
+    let mut value: serde_json::Value = serde_json::from_slice(body).ok()?;
+    let obj = value.as_object_mut()?;
+    let mut kept = false;
+    for key in ["requires", "dependencies"] {
+        // Compute the filtered sub-map first (borrow ends before the insert).
+        let filtered = obj
+            .get(key)
+            .and_then(|v| v.as_object())
+            .map(|sub| filter_pkg_name_map(sub, policy));
+        if let Some((fmap, k)) = filtered {
+            kept = kept || k;
+            obj.insert(key.to_string(), serde_json::Value::Object(fmap));
+        }
+    }
+    let bytes = serde_json::to_vec(&value).ok()?;
+    Some((Bytes::from(bytes), kept))
+}
+
+/// Filter a quick-audit response: keep only `advisories` whose `module_name`
+/// the policy allows. Returns the re-serialised body; `None` when the body is
+/// not an object (caller falls back to the empty audit report).
+fn filter_quick_audit_response(bytes: &[u8], policy: &NpmScopePolicy) -> Option<String> {
+    let mut value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let obj = value.as_object_mut()?;
+    // Compute the filtered advisories map first so the immutable borrow of
+    // `obj` ends before the mutable `insert`.
+    let filtered = obj
+        .get("advisories")
+        .and_then(|v| v.as_object())
+        .map(|adv| {
+            adv.iter()
+                .filter(|(_, entry)| {
+                    entry
+                        .get("module_name")
+                        .and_then(|m| m.as_str())
+                        .map(|name| policy.allows(name))
+                        // An advisory with no module_name cannot be scoped: drop it.
+                        .unwrap_or(false)
+                })
+                .map(|(id, entry)| (id.clone(), entry.clone()))
+                .collect::<serde_json::Map<String, serde_json::Value>>()
+        });
+    if let Some(fmap) = filtered {
+        obj.insert("advisories".to_string(), serde_json::Value::Object(fmap));
+    }
+    Some(value.to_string())
+}
+
+/// Best-effort defensive filter of an npm `/-/` meta response against the scope
+/// policy (#2424). Handles the search shape
+/// (`{"objects":[{"package":{"name":...}}], "total":N, ...}`) — dropping
+/// out-of-scope hits and correcting `total`. Other shapes carry no arbitrary
+/// package-name listing and are returned unchanged. `None` on parse failure so
+/// the caller serves the upstream body verbatim.
+fn filter_meta_response(bytes: &[u8], policy: &NpmScopePolicy) -> Option<Bytes> {
+    let mut value: serde_json::Value = serde_json::from_slice(bytes).ok()?;
+    let obj = value.as_object_mut()?;
+    let mut new_total: Option<usize> = None;
+    if let Some(objects) = obj.get_mut("objects").and_then(|v| v.as_array_mut()) {
+        objects.retain(|entry| {
+            entry
+                .get("package")
+                .and_then(|p| p.get("name"))
+                .and_then(|n| n.as_str())
+                .map(|name| policy.allows(name))
+                .unwrap_or(false)
+        });
+        new_total = Some(objects.len());
+    }
+    if let Some(total) = new_total {
+        obj.insert("total".to_string(), serde_json::json!(total));
+    }
+    serde_json::to_vec(&value).ok().map(Bytes::from)
+}
+
 /// Forward an npm audit POST request to the configured upstream registry.
 ///
 /// Used by Remote repos to proxy advisory and audit calls to npmjs.org (or
@@ -681,13 +814,17 @@ fn empty_audits_quick_response() -> Response {
 /// transport failure (timeout, DNS, TLS, etc.) the helper returns an empty
 /// well-formed response so the audit degrades gracefully instead of failing
 /// the client command. See issue #1400.
-#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
-async fn proxy_npm_audit_post(
+/// POST an npm audit body upstream and return the raw 2xx JSON bytes plus the
+/// upstream content-type. Returns `None` on a non-success status or any
+/// transport/read error, mirroring the empty-fallback semantics of
+/// [`proxy_npm_audit_post`]. Split out so the scope-policy path (#2424) can
+/// post-filter the response before serving it.
+#[allow(clippy::disallowed_methods)] // the exempt call is marked inline below (#1608)
+async fn npm_audit_upstream_json(
     upstream_url: &str,
     path: &str,
     body: Bytes,
-    empty_fallback: fn() -> Response,
-) -> Response {
+) -> Option<(String, Bytes)> {
     let base = upstream_url.trim_end_matches('/');
     let url = format!("{}{}", base, path);
     let client = crate::services::http_client::default_client();
@@ -696,46 +833,8 @@ async fn proxy_npm_audit_post(
         .header(CONTENT_TYPE, "application/json")
         .body(body);
 
-    match req.send().await {
-        Ok(resp) => {
-            let status = resp.status();
-            let content_type = resp
-                .headers()
-                .get(CONTENT_TYPE)
-                .and_then(|v| v.to_str().ok())
-                .unwrap_or("application/json")
-                .to_string();
-            // STREAMING-EXEMPT: capped metadata read (upstream npm audit advisory JSON, not an artifact blob); bounded to <=16 MiB via axum::body::to_bytes so a hostile/broken upstream cannot OOM us; over-cap degrades to empty advisories; tracked under #1608
-            match axum::body::to_bytes(Body::from_stream(resp.bytes_stream()), 16 * 1024 * 1024)
-                .await
-            {
-                Ok(bytes) => {
-                    if !status.is_success() {
-                        debug!(
-                            target: "npm_audit",
-                            upstream = %url,
-                            status = %status,
-                            "npm audit upstream returned non-success; serving empty advisories"
-                        );
-                        return empty_fallback();
-                    }
-                    Response::builder()
-                        .status(StatusCode::OK)
-                        .header(CONTENT_TYPE, content_type)
-                        .body(Body::from(bytes))
-                        .unwrap_or_else(|_| empty_fallback())
-                }
-                Err(err) => {
-                    debug!(
-                        target: "npm_audit",
-                        upstream = %url,
-                        error = %err,
-                        "failed to read npm audit upstream body; serving empty advisories"
-                    );
-                    empty_fallback()
-                }
-            }
-        }
+    let resp = match req.send().await {
+        Ok(r) => r,
         Err(err) => {
             debug!(
                 target: "npm_audit",
@@ -743,8 +842,63 @@ async fn proxy_npm_audit_post(
                 error = %err,
                 "failed to reach npm audit upstream; serving empty advisories"
             );
-            empty_fallback()
+            return None;
         }
+    };
+    let status = resp.status();
+    let content_type = resp
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+    // STREAMING-EXEMPT: capped metadata read (upstream npm audit advisory JSON, not an artifact blob); bounded to <=16 MiB via axum::body::to_bytes so a hostile/broken upstream cannot OOM us; over-cap degrades to empty advisories; tracked under #1608
+    match axum::body::to_bytes(Body::from_stream(resp.bytes_stream()), 16 * 1024 * 1024).await {
+        Ok(bytes) => {
+            if !status.is_success() {
+                debug!(
+                    target: "npm_audit",
+                    upstream = %url,
+                    status = %status,
+                    "npm audit upstream returned non-success; serving empty advisories"
+                );
+                return None;
+            }
+            Some((content_type, bytes))
+        }
+        Err(err) => {
+            debug!(
+                target: "npm_audit",
+                upstream = %url,
+                error = %err,
+                "failed to read npm audit upstream body; serving empty advisories"
+            );
+            None
+        }
+    }
+}
+
+/// Forward an npm audit POST request to the configured upstream registry.
+///
+/// Used by Remote repos to proxy advisory and audit calls to npmjs.org (or
+/// whichever upstream is configured) so `npm audit` works for cached/mirrored
+/// dependencies. The full client body is forwarded verbatim. On any upstream
+/// transport failure (timeout, DNS, TLS, etc.) the helper returns an empty
+/// well-formed response so the audit degrades gracefully instead of failing
+/// the client command. See issue #1400.
+async fn proxy_npm_audit_post(
+    upstream_url: &str,
+    path: &str,
+    body: Bytes,
+    empty_fallback: fn() -> Response,
+) -> Response {
+    match npm_audit_upstream_json(upstream_url, path, body).await {
+        Some((content_type, bytes)) => Response::builder()
+            .status(StatusCode::OK)
+            .header(CONTENT_TYPE, content_type)
+            .body(Body::from(bytes))
+            .unwrap_or_else(|_| empty_fallback()),
+        None => empty_fallback(),
     }
 }
 
@@ -757,14 +911,23 @@ async fn proxy_npm_audit_post(
 /// Returns the upstream status + body verbatim. On any transport error (DNS,
 /// TLS, timeout) returns `None` so the caller can fall through to the local
 /// fallback.
-#[allow(clippy::disallowed_methods)] // clippy allow is fn-scoped (tail expr); the exempt call is marked inline below (#1608)
-async fn proxy_npm_meta_get(upstream_url: &str, meta_path: &str) -> Option<Response> {
+#[allow(clippy::disallowed_methods)] // the exempt call is marked inline below (#1608)
+async fn npm_meta_upstream_bytes(
+    upstream_url: &str,
+    meta_path: &str,
+    query: Option<&str>,
+) -> Option<(StatusCode, String, Bytes)> {
     let base = upstream_url.trim_end_matches('/');
     // Reconstruct the `/-/<rest>` meta path. axum 0.7 wildcard captures do NOT
     // include a leading slash (`*rest` on `/-/ping` yields `ping`, not `/ping`),
     // so prepend `/-/` and strip any stray leading slash to be robust either way.
     let path_with_dash = format!("/-/{}", meta_path.trim_start_matches('/'));
-    let url = format!("{}{}", base, path_with_dash);
+    // The wildcard capture also drops the query string, so the search term never
+    // reached upstream (`-/v1/search` 400'd with no `text`). Re-append it here.
+    let url = match query {
+        Some(q) if !q.is_empty() => format!("{}{}?{}", base, path_with_dash, q),
+        _ => format!("{}{}", base, path_with_dash),
+    };
     let client = crate::services::http_client::default_client();
 
     let resp = match client.get(&url).send().await {
@@ -790,15 +953,7 @@ async fn proxy_npm_meta_get(upstream_url: &str, meta_path: &str) -> Option<Respo
 
     // STREAMING-EXEMPT: capped metadata read (upstream npm registry packument/meta JSON, not an artifact blob); bounded to <=16 MiB via axum::body::to_bytes so a hostile/broken upstream cannot OOM us; over-cap falls through to local fallback; tracked under #1608
     match axum::body::to_bytes(Body::from_stream(resp.bytes_stream()), 16 * 1024 * 1024).await {
-        Ok(bytes) => Some(
-            Response::builder()
-                .status(status)
-                .header(CONTENT_TYPE, content_type)
-                .body(Body::from(bytes))
-                .unwrap_or_else(|_| {
-                    (StatusCode::INTERNAL_SERVER_ERROR, "upstream error").into_response()
-                }),
-        ),
+        Ok(bytes) => Some((status, content_type, bytes)),
         Err(err) => {
             debug!(
                 target: "npm_meta",
@@ -809,6 +964,36 @@ async fn proxy_npm_meta_get(upstream_url: &str, meta_path: &str) -> Option<Respo
             None
         }
     }
+}
+
+/// Forward a GET request to the upstream registry at the given meta path,
+/// carrying the original query string. When the repository's scope `policy` is
+/// active (#2424), defensively filter package names out of the response (npm
+/// search results) so a scope-restricted repo does not list out-of-scope
+/// packages. Returns `None` on any transport error so the caller can fall
+/// through to the local fallback.
+async fn proxy_npm_meta_get(
+    upstream_url: &str,
+    meta_path: &str,
+    query: Option<&str>,
+    policy: &NpmScopePolicy,
+) -> Option<Response> {
+    let (status, content_type, bytes) =
+        npm_meta_upstream_bytes(upstream_url, meta_path, query).await?;
+    let bytes = if policy.is_active() {
+        filter_meta_response(&bytes, policy).unwrap_or(bytes)
+    } else {
+        bytes
+    };
+    Some(
+        Response::builder()
+            .status(status)
+            .header(CONTENT_TYPE, content_type)
+            .body(Body::from(bytes))
+            .unwrap_or_else(|_| {
+                (StatusCode::INTERNAL_SERVER_ERROR, "upstream error").into_response()
+            }),
+    )
 }
 
 /// Handler for `GET /npm/{repo_key}/-/*rest`.
@@ -834,20 +1019,27 @@ async fn npm_meta_get(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, rest)): Path<(String, String)>,
+    raw_query: axum::extract::RawQuery,
 ) -> Result<Response, Response> {
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;
+    let query = raw_query.0;
 
-    // Remote: proxy the whole request to upstream verbatim.
+    // Remote: proxy the whole request to upstream, filtered by this repo's own
+    // scope policy (#2424) so search cannot list out-of-scope packages.
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
-            if let Some(resp) = proxy_npm_meta_get(upstream_url, &rest).await {
+            let policy = fetch_npm_scope_policy(&state.db, repo.id).await;
+            if let Some(resp) =
+                proxy_npm_meta_get(upstream_url, &rest, query.as_deref(), &policy).await
+            {
                 return Ok(resp);
             }
         }
         // Upstream misconfigured or unreachable — fall through to local stub.
     }
 
-    // Virtual: try the first Remote member whose upstream is reachable.
+    // Virtual: try the first Remote member whose upstream is reachable, applying
+    // that member's scope policy (parity with the metadata/packument loops).
     if repo.repo_type == RepositoryType::Virtual {
         let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
         for member in &members {
@@ -857,7 +1049,10 @@ async fn npm_meta_get(
             let Some(ref upstream_url) = member.upstream_url else {
                 continue;
             };
-            if let Some(resp) = proxy_npm_meta_get(upstream_url, &rest).await {
+            let policy = fetch_npm_scope_policy(&state.db, member.id).await;
+            if let Some(resp) =
+                proxy_npm_meta_get(upstream_url, &rest, query.as_deref(), &policy).await
+            {
                 return Ok(resp);
             }
         }
@@ -907,17 +1102,39 @@ async fn security_advisories_bulk(
     Path(repo_key): Path<String>,
     body: Bytes,
 ) -> Result<Response, Response> {
+    const PATH: &str = "/-/npm/v1/security/advisories/bulk";
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;
 
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
-            return Ok(proxy_npm_audit_post(
-                upstream_url,
-                "/-/npm/v1/security/advisories/bulk",
-                body,
-                empty_advisories_bulk_response,
-            )
-            .await);
+            let policy = fetch_npm_scope_policy(&state.db, repo.id).await;
+            // Unset/inactive policy: verbatim proxy (byte-identical, #1400).
+            if !policy.is_active() {
+                return Ok(proxy_npm_audit_post(
+                    upstream_url,
+                    PATH,
+                    body,
+                    empty_advisories_bulk_response,
+                )
+                .await);
+            }
+            // Active policy (#2424): drop out-of-scope package names from the
+            // request so upstream is never queried about them, then filter the
+            // response as defence in depth. Unparseable body ⇒ fail closed.
+            let Some((filtered_body, kept)) = filter_bulk_advisory_request(&body, &policy) else {
+                return Ok(empty_advisories_bulk_response());
+            };
+            if !kept {
+                return Ok(empty_advisories_bulk_response());
+            }
+            return Ok(
+                match npm_audit_upstream_json(upstream_url, PATH, filtered_body).await {
+                    Some((_ct, bytes)) => {
+                        build_json_metadata_response(filter_bulk_advisory_response(&bytes, &policy))
+                    }
+                    None => empty_advisories_bulk_response(),
+                },
+            );
         }
     }
 
@@ -934,17 +1151,40 @@ async fn security_audits_quick(
     Path(repo_key): Path<String>,
     body: Bytes,
 ) -> Result<Response, Response> {
+    const PATH: &str = "/-/npm/v1/security/audits/quick";
     let repo = resolve_npm_repo(&state.db, &repo_key).await?;
 
     if repo.repo_type == RepositoryType::Remote {
         if let Some(ref upstream_url) = repo.upstream_url {
-            return Ok(proxy_npm_audit_post(
-                upstream_url,
-                "/-/npm/v1/security/audits/quick",
-                body,
-                empty_audits_quick_response,
-            )
-            .await);
+            let policy = fetch_npm_scope_policy(&state.db, repo.id).await;
+            // Unset/inactive policy: verbatim proxy (byte-identical, #1400).
+            if !policy.is_active() {
+                return Ok(proxy_npm_audit_post(
+                    upstream_url,
+                    PATH,
+                    body,
+                    empty_audits_quick_response,
+                )
+                .await);
+            }
+            // Active policy (#2424): strip out-of-scope names from the request's
+            // requires/dependencies, then filter the response's advisories by
+            // module_name. Unparseable body ⇒ fail closed.
+            let Some((filtered_body, kept)) = filter_quick_audit_request(&body, &policy) else {
+                return Ok(empty_audits_quick_response());
+            };
+            if !kept {
+                return Ok(empty_audits_quick_response());
+            }
+            return Ok(
+                match npm_audit_upstream_json(upstream_url, PATH, filtered_body).await {
+                    Some((_ct, bytes)) => match filter_quick_audit_response(&bytes, &policy) {
+                        Some(filtered) => build_json_metadata_response(filtered),
+                        None => empty_audits_quick_response(),
+                    },
+                    None => empty_audits_quick_response(),
+                },
+            );
         }
     }
 
@@ -3335,6 +3575,113 @@ mod tests {
         assert!(p.allows("@types/node"));
         assert!(!p.allows("@other/x"));
         assert!(!p.allows("lodash"));
+    }
+
+    // -----------------------------------------------------------------------
+    // npm /-/ meta+audit namespace filtering (#2424)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn bulk_advisory_request_drops_out_of_scope_names() {
+        let p = policy_with_patterns(&["@types"], Some(false), &["lodash*"]);
+        let body = br#"{"@types/node":["18.0.0"],"lodash":["4.17.4"],"express":["4.16.0"]}"#;
+        let (filtered, kept) = filter_bulk_advisory_request(body, &p).expect("parses");
+        assert!(kept);
+        let v: serde_json::Value = serde_json::from_slice(&filtered).unwrap();
+        let obj = v.as_object().unwrap();
+        assert!(obj.contains_key("@types/node"));
+        assert!(obj.contains_key("lodash"));
+        assert!(!obj.contains_key("express"));
+    }
+
+    #[test]
+    fn bulk_advisory_request_all_out_of_scope_keeps_nothing() {
+        let p = policy_with_patterns(&["@types"], Some(false), &[]);
+        let body = br#"{"express":["4.16.0"],"react":["18.0.0"]}"#;
+        let (_filtered, kept) = filter_bulk_advisory_request(body, &p).expect("parses");
+        assert!(!kept);
+    }
+
+    #[test]
+    fn bulk_advisory_request_unparseable_is_none() {
+        let p = policy_with_patterns(&["@types"], Some(false), &[]);
+        assert!(filter_bulk_advisory_request(b"not-json", &p).is_none());
+    }
+
+    #[test]
+    fn bulk_advisory_response_filters_names() {
+        let p = policy_with_patterns(&[], Some(false), &["lodash*"]);
+        let body = br#"{"lodash":[{"id":1}],"express":[{"id":2}]}"#;
+        let out = filter_bulk_advisory_response(body, &p);
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert!(v.get("lodash").is_some());
+        assert!(v.get("express").is_none());
+    }
+
+    #[test]
+    fn quick_audit_request_filters_requires_and_dependencies() {
+        let p = policy_with_patterns(&[], Some(false), &["lodash*"]);
+        let body = br#"{"name":"app","version":"1.0.0",
+            "requires":{"lodash":"^4.17.0","express":"^4.16.0"},
+            "dependencies":{"lodash":{"version":"4.17.4"},"express":{"version":"4.16.0"}}}"#;
+        let (filtered, kept) = filter_quick_audit_request(body, &p).expect("parses");
+        assert!(kept);
+        let v: serde_json::Value = serde_json::from_slice(&filtered).unwrap();
+        assert!(v["requires"].get("lodash").is_some());
+        assert!(v["requires"].get("express").is_none());
+        assert!(v["dependencies"].get("lodash").is_some());
+        assert!(v["dependencies"].get("express").is_none());
+        // Untouched top-level fields survive.
+        assert_eq!(v["name"], "app");
+    }
+
+    #[test]
+    fn quick_audit_response_filters_advisories_by_module_name() {
+        let p = policy_with_patterns(&[], Some(false), &["lodash*"]);
+        let body = br#"{"actions":[],"advisories":{
+            "1065":{"module_name":"lodash","severity":"high"},
+            "1755":{"module_name":"express","severity":"low"},
+            "9999":{"severity":"low"}
+        },"muted":[],"metadata":{}}"#;
+        let out = filter_quick_audit_response(body, &p).expect("object");
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        let adv = v["advisories"].as_object().unwrap();
+        assert!(adv.contains_key("1065")); // lodash in scope
+        assert!(!adv.contains_key("1755")); // express out of scope
+        assert!(!adv.contains_key("9999")); // no module_name -> dropped (fail-closed)
+    }
+
+    #[test]
+    fn meta_search_response_filters_objects_and_total() {
+        let p = policy_with_patterns(&[], Some(false), &["lodash*"]);
+        let body = br#"{"objects":[
+            {"package":{"name":"lodash","version":"4.17.21"}},
+            {"package":{"name":"express","version":"4.18.0"}},
+            {"package":{"name":"lodash.merge","version":"4.6.2"}}
+        ],"total":3,"time":"now"}"#;
+        let out = filter_meta_response(body, &p).expect("parses");
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        let objs = v["objects"].as_array().unwrap();
+        assert_eq!(objs.len(), 2);
+        assert_eq!(v["total"], 2);
+        let names: Vec<&str> = objs
+            .iter()
+            .map(|o| o["package"]["name"].as_str().unwrap())
+            .collect();
+        assert!(names.contains(&"lodash"));
+        assert!(names.contains(&"lodash.merge"));
+        assert!(!names.contains(&"express"));
+    }
+
+    #[test]
+    fn meta_response_non_search_shape_is_unchanged_bytes() {
+        // A ping/whoami-style object with no `objects` array is returned as
+        // re-serialised JSON with the same logical content.
+        let p = policy_with_patterns(&[], Some(false), &["lodash*"]);
+        let body = br#"{"ok":true}"#;
+        let out = filter_meta_response(body, &p).expect("parses");
+        let v: serde_json::Value = serde_json::from_slice(&out).unwrap();
+        assert_eq!(v["ok"], true);
     }
 
     #[test]

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1220,6 +1220,14 @@ async fn fetch_npm_artifacts(
 pub(crate) const NPM_ALLOWED_SCOPES_KEY: &str = "npm_allowed_scopes";
 /// `repository_config` key holding the unscoped-package toggle ("true"/"false").
 pub(crate) const NPM_ALLOW_UNSCOPED_KEY: &str = "npm_allow_unscoped";
+/// `repository_config` key holding the JSON array of allowed npm name globs
+/// (#2424). Additive to `npm_allowed_scopes`: an unset key has no effect, so
+/// repositories configured before #2424 behave byte-identically.
+pub(crate) const NPM_ALLOWED_NAME_PATTERNS_KEY: &str = "npm_allowed_name_patterns";
+
+/// Maximum length of a single npm name glob pattern (matches the npm package
+/// name length cap; keeps a stored pattern from growing unbounded).
+pub(crate) const NPM_NAME_PATTERN_MAX_LEN: usize = 214;
 
 /// Parsed shape of an npm package name for scope-policy evaluation.
 #[derive(Debug, PartialEq, Eq)]
@@ -1284,13 +1292,32 @@ pub(crate) struct NpmScopePolicy {
     /// repository. `None` = not configured; treated as "deny" once the
     /// policy is otherwise active (fail-closed) and "allow" otherwise.
     pub(crate) allow_unscoped: Option<bool>,
+    /// Allowed full-package-name glob patterns (`*`/`?`), case-folded to
+    /// lowercase (#2424). Additive to `allowed_scopes`: a name is allowed if
+    /// its scope is in `allowed_scopes` OR any of these globs matches the full
+    /// package name. Empty = no pattern restriction (default, unchanged).
+    pub(crate) allowed_name_patterns: Vec<String>,
 }
 
 impl NpmScopePolicy {
-    /// A policy participates in filtering iff an allow-list is present or
-    /// unscoped resolution was explicitly switched off.
+    /// A policy participates in filtering iff an allow-list is present, a name
+    /// pattern list is present (#2424), or unscoped resolution was explicitly
+    /// switched off.
     pub(crate) fn is_active(&self) -> bool {
-        !self.allowed_scopes.is_empty() || self.allow_unscoped == Some(false)
+        !self.allowed_scopes.is_empty()
+            || !self.allowed_name_patterns.is_empty()
+            || self.allow_unscoped == Some(false)
+    }
+
+    /// Whether any configured name glob matches `package_name` (case-folded).
+    fn pattern_matches(&self, package_name: &str) -> bool {
+        if self.allowed_name_patterns.is_empty() {
+            return false;
+        }
+        let name = package_name.to_ascii_lowercase();
+        self.allowed_name_patterns
+            .iter()
+            .any(|pattern| crate::util::glob::glob_match(&pattern.to_ascii_lowercase(), &name))
     }
 
     /// Whether `package_name` may be resolved through the repository this
@@ -1302,13 +1329,21 @@ impl NpmScopePolicy {
         }
         match npm_name_shape(package_name) {
             NpmNameShape::Scoped(scope) => {
-                self.allowed_scopes.is_empty()
+                // Preserve the #2327 semantics: when neither a scope allow-list
+                // nor a name-pattern allow-list is configured (the policy is
+                // active only because `allow_unscoped == Some(false)`), every
+                // scoped name is still allowed. Otherwise a scoped name passes
+                // iff its scope is allow-listed OR a name glob matches.
+                (self.allowed_scopes.is_empty() && self.allowed_name_patterns.is_empty())
                     || self
                         .allowed_scopes
                         .iter()
                         .any(|allowed| allowed == &scope.to_ascii_lowercase())
+                    || self.pattern_matches(package_name)
             }
-            NpmNameShape::Unscoped => self.allow_unscoped == Some(true),
+            NpmNameShape::Unscoped => {
+                self.allow_unscoped == Some(true) || self.pattern_matches(package_name)
+            }
             NpmNameShape::Invalid => false,
         }
     }
@@ -1330,11 +1365,12 @@ async fn fetch_npm_scope_policies(
     }
     let rows: Vec<(uuid::Uuid, String, String)> = sqlx::query_as(
         "SELECT repository_id, key, value FROM repository_config \
-         WHERE repository_id = ANY($1) AND key IN ($2, $3)",
+         WHERE repository_id = ANY($1) AND key IN ($2, $3, $4)",
     )
     .bind(repo_ids)
     .bind(NPM_ALLOWED_SCOPES_KEY)
     .bind(NPM_ALLOW_UNSCOPED_KEY)
+    .bind(NPM_ALLOWED_NAME_PATTERNS_KEY)
     .fetch_all(db)
     .await
     .unwrap_or_default();
@@ -1349,6 +1385,14 @@ async fn fetch_npm_scope_policies(
                 .collect();
         } else if key == NPM_ALLOW_UNSCOPED_KEY {
             policy.allow_unscoped = value.parse::<bool>().ok();
+        } else if key == NPM_ALLOWED_NAME_PATTERNS_KEY {
+            // Malformed JSON => empty (unrestricted by this key), consistent
+            // with the `npm_allowed_scopes` parse above (#2424).
+            policy.allowed_name_patterns = serde_json::from_str::<Vec<String>>(&value)
+                .unwrap_or_default()
+                .into_iter()
+                .map(|s| s.to_ascii_lowercase())
+                .collect();
         }
     }
     policies
@@ -1396,6 +1440,15 @@ async fn get_package_metadata(
     // artifacts do not contain enough information to reconstruct the full
     // package metadata that npm clients expect.
     if repo.repo_type == RepositoryType::Remote {
+        // Enforce the repository's own npm scope policy on the direct-remote
+        // path (#2424). Pointing a client straight at the member key would
+        // otherwise bypass the filter the virtual metadata loops apply. An
+        // out-of-scope name returns 404 (parity with the virtual "skipped by
+        // policy => not found" behaviour; avoids confirming the name exists).
+        let policy = fetch_npm_scope_policy(&state.db, repo.id).await;
+        if !policy.allows(package_name) {
+            return Err(AppError::NotFound("Package not found".to_string()).into_response());
+        }
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let encoded_name = encode_package_name_for_upstream(package_name);
@@ -1621,6 +1674,12 @@ async fn fetch_remote_packument(
     package_name: &str,
     base_url: &str,
 ) -> Result<serde_json::Value, Response> {
+    // Enforce the repository's own npm scope policy on the direct-remote
+    // packument path (#2424); an out-of-scope name returns 404.
+    let policy = fetch_npm_scope_policy(&state.db, repo.id).await;
+    if !policy.allows(package_name) {
+        return Err(AppError::NotFound("Package not found".to_string()).into_response());
+    }
     let upstream_url = repo
         .upstream_url
         .as_deref()
@@ -2143,6 +2202,14 @@ async fn serve_tarball(
     // already fetched). The proxy cache stores content under its own storage
     // key which the regular artifact storage cannot resolve.
     if repo.repo_type == RepositoryType::Remote {
+        // Enforce the repository's own npm scope policy on the direct-remote
+        // tarball path (#2424). A pinned-lockfile tarball GET for an
+        // out-of-scope name would otherwise stream straight through; an
+        // out-of-scope name now returns 404.
+        let policy = fetch_npm_scope_policy(&state.db, repo.id).await;
+        if !policy.allows(package_name) {
+            return Err(AppError::NotFound("Tarball not found".to_string()).into_response());
+        }
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
@@ -2227,6 +2294,26 @@ async fn serve_tarball(
             state.proxy_service.as_deref()
         };
 
+        // #2424: apply the per-member npm scope policy to the direct-tarball
+        // path, exactly as the metadata/packument loops already do. Metadata
+        // filtering alone does not cover a client that already knows the exact
+        // tarball URL (a pinned lockfile), which would otherwise stream an
+        // out-of-scope `@scope/pkg` straight through a Remote member. Fetch the
+        // members once, drop Remote members the policy excludes, and resolve
+        // over the pre-filtered list via `resolve_virtual_download_from_members`
+        // — the established pre-filtered-member seam (cf. maven.rs) — so the
+        // shared generic `resolve_virtual_download` helper is left untouched and
+        // no other format (maven/hex/...) is affected. Non-Remote members are
+        // always eligible, preserving the `virtual_non_remote_owns_name`
+        // shadowing guard and the local-only primitive above.
+        let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
+        let member_ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
+        let scope_policies = fetch_npm_scope_policies(&state.db, &member_ids).await;
+        let members: Vec<_> = members
+            .into_iter()
+            .filter(|m| npm_member_eligible(&m.repo_type, scope_policies.get(&m.id), package_name))
+            .collect();
+
         // #2066: enforce each gated Remote member's download age gate before
         // resolving the virtual tarball. Virtual metadata is already filtered
         // per-member (see the metadata branch), so an ordinary `npm install`
@@ -2238,7 +2325,6 @@ async fn serve_tarball(
         // shared `resolve_virtual_download` helper is left untouched so no
         // other format (maven/hex/...) is affected.
         if let Some(proxy) = proxy_for_virtual {
-            let members = proxy_helpers::fetch_virtual_members(&state.db, repo.id).await?;
             for member in &members {
                 if member.repo_type != RepositoryType::Remote {
                     continue;
@@ -2279,10 +2365,9 @@ async fn serve_tarball(
             }
         }
 
-        let result = proxy_helpers::resolve_virtual_download(
-            &state.db,
+        let result = proxy_helpers::resolve_virtual_download_from_members(
+            members,
             proxy_for_virtual,
-            repo.id,
             &upstream_path,
             |member_id, location| {
                 let db = db.clone();
@@ -3083,6 +3168,19 @@ mod tests {
         NpmScopePolicy {
             allowed_scopes: scopes.iter().map(|s| s.to_string()).collect(),
             allow_unscoped,
+            allowed_name_patterns: Vec::new(),
+        }
+    }
+
+    fn policy_with_patterns(
+        scopes: &[&str],
+        allow_unscoped: Option<bool>,
+        patterns: &[&str],
+    ) -> NpmScopePolicy {
+        NpmScopePolicy {
+            allowed_scopes: scopes.iter().map(|s| s.to_string()).collect(),
+            allow_unscoped,
+            allowed_name_patterns: patterns.iter().map(|s| s.to_string()).collect(),
         }
     }
 
@@ -3173,6 +3271,70 @@ mod tests {
         assert!(!p.allows("@types"));
         assert!(!p.allows("@/x"));
         assert!(!p.allows(""));
+    }
+
+    // -----------------------------------------------------------------------
+    // npm name-glob patterns (#2424)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn glob_patterns_activate_and_allow_scoped_names() {
+        // Patterns-only policy (no scope list, unscoped unset) is active.
+        let p = policy_with_patterns(&[], None, &["@acme/*"]);
+        assert!(p.is_active());
+        assert!(p.allows("@acme/foo"));
+        assert!(p.allows("@acme/bar-baz"));
+        // A scoped name outside the glob is denied even though allowed_scopes
+        // is empty (the glob restriction is what makes the policy active).
+        assert!(!p.allows("@evil/foo"));
+    }
+
+    #[test]
+    fn glob_patterns_allow_unscoped_names() {
+        let p = policy_with_patterns(&[], Some(false), &["internal-*"]);
+        assert!(p.is_active());
+        assert!(p.allows("internal-utils"));
+        assert!(!p.allows("lodash"));
+        // allow_unscoped=false but the glob still admits matching unscoped names.
+        assert!(p.allows("internal-tools"));
+    }
+
+    #[test]
+    fn glob_patterns_or_compose_with_exact_scopes() {
+        // Exact scope @acme + pattern internal-* + unscoped denied: mirrors the
+        // on-box verification policy.
+        let p = policy_with_patterns(&["@acme"], Some(false), &["internal-*"]);
+        assert!(p.is_active());
+        assert!(p.allows("@acme/foo")); // exact scope
+        assert!(p.allows("internal-utils")); // pattern (unscoped)
+        assert!(!p.allows("other-pkg")); // neither, unscoped denied
+        assert!(!p.allows("@evil/pkg")); // neither, scope not allowed
+    }
+
+    #[test]
+    fn glob_patterns_are_case_insensitive() {
+        let p = policy_with_patterns(&[], None, &["@acme/*"]);
+        assert!(p.allows("@ACME/Foo"));
+        // Constructed with mixed-case pattern (loader lowercases, but be safe).
+        let p2 = policy_with_patterns(&[], None, &["@Acme/*"]);
+        assert!(p2.allows("@acme/foo"));
+    }
+
+    #[test]
+    fn glob_patterns_invalid_names_fail_closed() {
+        let p = policy_with_patterns(&[], None, &["@acme/*"]);
+        assert!(!p.allows("@acme")); // malformed (no package part)
+        assert!(!p.allows(""));
+    }
+
+    #[test]
+    fn glob_patterns_do_not_affect_existing_scope_only_policies() {
+        // A policy with only exact scopes behaves byte-identically: no patterns
+        // means pattern_matches never fires.
+        let p = policy(&["@types"], Some(false));
+        assert!(p.allows("@types/node"));
+        assert!(!p.allows("@other/x"));
+        assert!(!p.allows("lodash"));
     }
 
     #[test]
@@ -3279,6 +3441,28 @@ mod tests {
         let flipped = fetch_npm_scope_policy(&pool, repo_id).await;
         assert_eq!(flipped.allow_unscoped, Some(true));
         assert!(flipped.allows("lodash"));
+
+        // #2424: the new name-pattern key parses into a lowercased Vec and
+        // composes with the scope list; malformed JSON degrades to empty
+        // (unrestricted by that key), consistent with the scope-list parse.
+        upsert(NPM_ALLOWED_NAME_PATTERNS_KEY, "not-json").await;
+        let bad_patterns = fetch_npm_scope_policy(&pool, repo_id).await;
+        assert!(bad_patterns.allowed_name_patterns.is_empty());
+        upsert(
+            NPM_ALLOWED_NAME_PATTERNS_KEY,
+            "[\"@Acme/*\",\"internal-*\"]",
+        )
+        .await;
+        upsert(NPM_ALLOW_UNSCOPED_KEY, "false").await;
+        let with_patterns = fetch_npm_scope_policy(&pool, repo_id).await;
+        assert_eq!(
+            with_patterns.allowed_name_patterns,
+            vec!["@acme/*", "internal-*"]
+        );
+        assert!(with_patterns.is_active());
+        assert!(with_patterns.allows("@acme/thing"));
+        assert!(with_patterns.allows("internal-utils"));
+        assert!(!with_patterns.allows("random-pkg"));
 
         // Cleanup.
         let _ = sqlx::query("DELETE FROM repository_config WHERE repository_id = $1")

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -571,6 +571,19 @@ pub struct CreateRepositoryRequest {
     /// Custom Description field for Debian/APT Release files.
     /// Stored in `repository_config` under `apt_description`.
     pub apt_description: Option<String>,
+    /// Allowed npm `@scope` literals for this npm Remote repository (#2424).
+    /// Only meaningful for npm-format Remote repositories; validated and stored
+    /// in `repository_config` under `npm_allowed_scopes`. Omit to leave the
+    /// repository unrestricted by scope.
+    pub npm_allowed_scopes: Option<Vec<String>>,
+    /// Whether unscoped npm package names may resolve through this npm Remote
+    /// repository (#2424). Stored under `npm_allow_unscoped`.
+    pub npm_allow_unscoped: Option<bool>,
+    /// Allowed npm full-name glob patterns (`*`/`?`) for this npm Remote
+    /// repository (#2424). Additive to `npm_allowed_scopes`; stored under
+    /// `npm_allowed_name_patterns`. A name is allowed if its scope is allowed
+    /// OR any glob matches (e.g. `@acme/*`, `internal-*`).
+    pub npm_allowed_name_patterns: Option<Vec<String>>,
 }
 
 impl CreateRepositoryRequest {
@@ -659,6 +672,16 @@ pub struct UpdateRepositoryRequest {
     /// string to remove (omits the field entirely from the Release file).
     /// Stored in `repository_config` under `apt_description`.
     pub apt_description: Option<String>,
+    /// Update the allowed npm `@scope` literals for this npm Remote repository
+    /// (#2424). When provided, replaces the stored `npm_allowed_scopes` list.
+    pub npm_allowed_scopes: Option<Vec<String>>,
+    /// Update whether unscoped npm package names may resolve through this npm
+    /// Remote repository (#2424). Stored under `npm_allow_unscoped`.
+    pub npm_allow_unscoped: Option<bool>,
+    /// Update the allowed npm full-name glob patterns for this npm Remote
+    /// repository (#2424). When provided, replaces the stored
+    /// `npm_allowed_name_patterns` list.
+    pub npm_allowed_name_patterns: Option<Vec<String>>,
 }
 
 impl UpdateRepositoryRequest {
@@ -721,6 +744,18 @@ pub struct RepositoryResponse {
     /// Release file when `None` or empty.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub apt_description: Option<String>,
+    /// Allowed npm `@scope` literals (#2424), read back from
+    /// `repository_config`. Omitted for non-npm repositories or when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npm_allowed_scopes: Option<Vec<String>>,
+    /// Whether unscoped npm names may resolve through this npm Remote
+    /// repository (#2424). Omitted when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npm_allow_unscoped: Option<bool>,
+    /// Allowed npm full-name glob patterns (#2424), read back from
+    /// `repository_config`. Omitted for non-npm repositories or when unset.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npm_allowed_name_patterns: Option<Vec<String>>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -763,6 +798,9 @@ fn repo_to_response(
         apt_label: None,
         apt_release_version: None,
         apt_description: None,
+        npm_allowed_scopes: None,
+        npm_allow_unscoped: None,
+        npm_allowed_name_patterns: None,
         created_at: repo.created_at,
         updated_at: repo.updated_at,
     }
@@ -1203,6 +1241,180 @@ fn is_npm_scope_policy_configurable(
     Ok(())
 }
 
+/// Normalise + validate an npm scope allow-list: trim, lowercase (matching is
+/// case-insensitive), sort/dedupe, and require each entry to be a well-formed
+/// `@scope` literal. Shared by the dedicated PUT endpoint and the create/update
+/// repository handlers (#2327/#2424).
+fn normalize_npm_scopes(raw: &[String]) -> Result<Vec<String>> {
+    let mut allowed_scopes: Vec<String> =
+        raw.iter().map(|s| s.trim().to_ascii_lowercase()).collect();
+    allowed_scopes.sort();
+    allowed_scopes.dedup();
+    for scope in &allowed_scopes {
+        if !crate::api::handlers::npm::is_valid_npm_scope(scope) {
+            return Err(AppError::Validation(format!(
+                "Invalid npm scope '{}': scopes must start with '@' followed by \
+                 lowercase letters, digits, '-', '_' or '.' (not leading '.'/'_')",
+                scope
+            )));
+        }
+    }
+    Ok(allowed_scopes)
+}
+
+/// Normalise + validate an npm name-glob allow-list (#2424): trim, lowercase,
+/// sort/dedupe, and reject empty patterns, over-long patterns, path separators
+/// (`\`, `..`) and characters outside the npm package-name + glob alphabet.
+/// The forward slash is retained so scope wildcards (`@acme/*`) are expressible.
+fn normalize_npm_name_patterns(raw: &[String]) -> Result<Vec<String>> {
+    let mut patterns: Vec<String> = Vec::with_capacity(raw.len());
+    for p in raw {
+        let trimmed = p.trim().to_ascii_lowercase();
+        if trimmed.is_empty() {
+            return Err(AppError::Validation(
+                "npm name pattern must not be empty".to_string(),
+            ));
+        }
+        if trimmed.len() > crate::api::handlers::npm::NPM_NAME_PATTERN_MAX_LEN {
+            return Err(AppError::Validation(format!(
+                "npm name pattern '{}' exceeds {} characters",
+                trimmed,
+                crate::api::handlers::npm::NPM_NAME_PATTERN_MAX_LEN
+            )));
+        }
+        if trimmed.contains('\\') || trimmed.contains("..") {
+            return Err(AppError::Validation(format!(
+                "npm name pattern '{}' must not contain path separators or '..'",
+                trimmed
+            )));
+        }
+        if !trimmed.chars().all(|c| {
+            c.is_ascii_lowercase()
+                || c.is_ascii_digit()
+                || matches!(c, '@' | '/' | '-' | '_' | '.' | '*' | '?')
+        }) {
+            return Err(AppError::Validation(format!(
+                "npm name pattern '{}' contains invalid characters",
+                trimmed
+            )));
+        }
+        patterns.push(trimmed);
+    }
+    patterns.sort();
+    patterns.dedup();
+    Ok(patterns)
+}
+
+/// Validate every provided npm scope-policy field up-front (no persistence).
+/// Returns an error before any repository row is created so a bad glob cannot
+/// leave an orphaned repository behind — mirrors the apt_* up-front validation.
+fn validate_npm_scope_policy_fields(
+    repo_type: &RepositoryType,
+    format: &RepositoryFormat,
+    allowed_scopes: Option<&[String]>,
+    allow_unscoped: Option<bool>,
+    allowed_name_patterns: Option<&[String]>,
+) -> Result<()> {
+    if allowed_scopes.is_none() && allow_unscoped.is_none() && allowed_name_patterns.is_none() {
+        return Ok(());
+    }
+    is_npm_scope_policy_configurable(repo_type, format)?;
+    if let Some(scopes) = allowed_scopes {
+        normalize_npm_scopes(scopes)?;
+    }
+    if let Some(patterns) = allowed_name_patterns {
+        normalize_npm_name_patterns(patterns)?;
+    }
+    Ok(())
+}
+
+/// Persist any provided npm scope-policy fields to `repository_config`
+/// (#2327/#2424). Validation runs first (via the normalise helpers) so a bad
+/// value never leaves a partial write; only keys whose argument is `Some` are
+/// written, so omitted fields are left unchanged. Shared by the dedicated PUT
+/// endpoint and the create/update repository handlers (no copy-paste).
+async fn apply_npm_scope_policy_config(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    allowed_scopes: Option<&[String]>,
+    allow_unscoped: Option<bool>,
+    allowed_name_patterns: Option<&[String]>,
+) -> Result<()> {
+    // Validate + serialise everything before the first upsert.
+    let scopes_json = match allowed_scopes {
+        Some(scopes) => Some(
+            serde_json::to_string(&normalize_npm_scopes(scopes)?).map_err(|e| {
+                AppError::Internal(format!("Failed to serialize scope list: {}", e))
+            })?,
+        ),
+        None => None,
+    };
+    let patterns_json = match allowed_name_patterns {
+        Some(patterns) => Some(
+            serde_json::to_string(&normalize_npm_name_patterns(patterns)?).map_err(|e| {
+                AppError::Internal(format!("Failed to serialize name pattern list: {}", e))
+            })?,
+        ),
+        None => None,
+    };
+
+    if let Some(json) = scopes_json {
+        upsert_repo_config(
+            db,
+            repo_id,
+            crate::api::handlers::npm::NPM_ALLOWED_SCOPES_KEY,
+            &json,
+        )
+        .await?;
+    }
+    if let Some(unscoped) = allow_unscoped {
+        upsert_repo_config(
+            db,
+            repo_id,
+            crate::api::handlers::npm::NPM_ALLOW_UNSCOPED_KEY,
+            if unscoped { "true" } else { "false" },
+        )
+        .await?;
+    }
+    if let Some(json) = patterns_json {
+        upsert_repo_config(
+            db,
+            repo_id,
+            crate::api::handlers::npm::NPM_ALLOWED_NAME_PATTERNS_KEY,
+            &json,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+/// Populate `RepositoryResponse` npm scope-policy fields from
+/// `repository_config` (#2424) so create/get/update echo the stored policy.
+/// A no-op for non-npm-Remote repositories and for repositories with no stored
+/// policy (fields stay `None` and are skipped in the serialised JSON).
+async fn with_npm_scope_policy(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    repo_type: &RepositoryType,
+    format: &RepositoryFormat,
+    mut response: RepositoryResponse,
+) -> RepositoryResponse {
+    if repo_type != &RepositoryType::Remote || format != &RepositoryFormat::Npm {
+        return response;
+    }
+    let policy = crate::api::handlers::npm::fetch_npm_scope_policy(db, repo_id).await;
+    if !policy.allowed_scopes.is_empty() {
+        response.npm_allowed_scopes = Some(policy.allowed_scopes);
+    }
+    if let Some(unscoped) = policy.allow_unscoped {
+        response.npm_allow_unscoped = Some(unscoped);
+    }
+    if !policy.allowed_name_patterns.is_empty() {
+        response.npm_allowed_name_patterns = Some(policy.allowed_name_patterns);
+    }
+    response
+}
+
 /// Set the npm scope policy for a Remote repository (#2327).
 ///
 /// Mirrors the auth + repo-access pattern of `set_cache_ttl`: candidate
@@ -1256,47 +1468,19 @@ pub async fn set_npm_scope_policy(
 
     is_npm_scope_policy_configurable(&repo.repo_type, &repo.format)?;
 
-    // Normalise and validate the allow-list: lowercase (matching is
-    // case-insensitive), dedupe, and require each entry to be a well-formed
-    // `@scope` literal.
-    let mut allowed_scopes: Vec<String> = payload
-        .allowed_scopes
-        .iter()
-        .map(|s| s.trim().to_ascii_lowercase())
-        .collect();
-    allowed_scopes.sort();
-    allowed_scopes.dedup();
-    for scope in &allowed_scopes {
-        if !crate::api::handlers::npm::is_valid_npm_scope(scope) {
-            return Err(AppError::Validation(format!(
-                "Invalid npm scope '{}': scopes must start with '@' followed by \
-                 lowercase letters, digits, '-', '_' or '.' (not leading '.'/'_')",
-                scope
-            )));
-        }
-    }
-
-    let scopes_json = serde_json::to_string(&allowed_scopes)
-        .map_err(|e| AppError::Internal(format!("Failed to serialize scope list: {}", e)))?;
-    upsert_repo_config(
+    // Normalise + validate + persist via the shared helper (#2424) so this
+    // endpoint and the create/update repo handlers stay in lock-step.
+    apply_npm_scope_policy_config(
         &state.db,
         repo.id,
-        crate::api::handlers::npm::NPM_ALLOWED_SCOPES_KEY,
-        &scopes_json,
-    )
-    .await?;
-    upsert_repo_config(
-        &state.db,
-        repo.id,
-        crate::api::handlers::npm::NPM_ALLOW_UNSCOPED_KEY,
-        if payload.allow_unscoped {
-            "true"
-        } else {
-            "false"
-        },
+        Some(&payload.allowed_scopes),
+        Some(payload.allow_unscoped),
+        None,
     )
     .await?;
 
+    // Recompute the normalised scopes for the response (same shared validator).
+    let allowed_scopes = normalize_npm_scopes(&payload.allowed_scopes)?;
     let active = !allowed_scopes.is_empty() || !payload.allow_unscoped;
     Ok(Json(NpmScopePolicyResponse {
         repository_key: key,
@@ -1932,6 +2116,19 @@ pub async fn create_repository(
         }
     }
 
+    // npm scope policy (#2424): validate up-front — before the repository row is
+    // created — so a rejected value (wrong repo type/format or a bad glob)
+    // cannot leave an orphaned repository behind, mirroring the apt_* guard
+    // above. Persistence happens after `service.create(...)`, once `repo.id`
+    // exists.
+    validate_npm_scope_policy_fields(
+        &repo_type,
+        &format,
+        payload.npm_allowed_scopes.as_deref(),
+        payload.npm_allow_unscoped,
+        payload.npm_allowed_name_patterns.as_deref(),
+    )?;
+
     // Resolve storage backend: use the requested one or fall back to the default.
     let storage_backend = match &payload.storage_backend {
         None => state.config.storage_backend.clone(),
@@ -2030,6 +2227,22 @@ pub async fn create_repository(
         if !ua.is_empty() {
             upsert_repo_config(&state.db, repo.id, CUSTOM_USER_AGENT_KEY, ua).await?;
         }
+    }
+
+    // Persist npm scope policy (#2424). Validation already ran up-front; the
+    // shared helper re-validates and writes only the provided keys.
+    if payload.npm_allowed_scopes.is_some()
+        || payload.npm_allow_unscoped.is_some()
+        || payload.npm_allowed_name_patterns.is_some()
+    {
+        apply_npm_scope_policy_config(
+            &state.db,
+            repo.id,
+            payload.npm_allowed_scopes.as_deref(),
+            payload.npm_allow_unscoped,
+            payload.npm_allowed_name_patterns.as_deref(),
+        )
+        .await?;
     }
 
     // Persist apt_* Release metadata. Validation already ran up-front (before
@@ -2139,6 +2352,9 @@ pub async fn create_repository(
     )
     .await;
 
+    let repo_id = repo.id;
+    let repo_type_out = repo.repo_type.clone();
+    let repo_format_out = repo.format.clone();
     let mut response = repo_to_response(repo, 0);
     if let Some(ref at) = payload.upstream_auth_type {
         response.upstream_auth_type = Some(at.clone());
@@ -2154,6 +2370,10 @@ pub async fn create_repository(
     response.apt_label = trimmed_nonempty(payload.apt_label);
     response.apt_release_version = trimmed_nonempty(payload.apt_release_version);
     response.apt_description = trimmed_nonempty(payload.apt_description);
+    // Echo the npm scope policy that was persisted (#2424) so the create
+    // response round-trips with a subsequent GET.
+    let response =
+        with_npm_scope_policy(&state.db, repo_id, &repo_type_out, &repo_format_out, response).await;
     Ok(Json(response))
 }
 
@@ -2184,6 +2404,8 @@ pub async fn get_repository(
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
 
     let repo_id = repo.id;
+    let repo_type = repo.repo_type.clone();
+    let repo_format = repo.format.clone();
     let is_apt_hosted =
         repo.repo_type.is_hosted() && matches!(repo.format, RepositoryFormat::Debian);
     let mut response = repo_to_response(repo, storage_used);
@@ -2196,6 +2418,8 @@ pub async fn get_repository(
     } else {
         response
     };
+    let response =
+        with_npm_scope_policy(&state.db, repo_id, &repo_type, &repo_format, response).await;
     Ok(Json(response))
 }
 
@@ -2299,6 +2523,23 @@ pub async fn update_repository(
 
     if let Some(ref index_path) = payload.pypi_upstream_index_path {
         upsert_repo_config(&state.db, repo.id, "pypi_upstream_index_path", index_path).await?;
+    }
+
+    // npm scope policy (#2424): validate the target is an npm Remote repo, then
+    // persist only the provided keys via the shared helper.
+    if payload.npm_allowed_scopes.is_some()
+        || payload.npm_allow_unscoped.is_some()
+        || payload.npm_allowed_name_patterns.is_some()
+    {
+        is_npm_scope_policy_configurable(&repo.repo_type, &repo.format)?;
+        apply_npm_scope_policy_config(
+            &state.db,
+            repo.id,
+            payload.npm_allowed_scopes.as_deref(),
+            payload.npm_allow_unscoped,
+            payload.npm_allowed_name_patterns.as_deref(),
+        )
+        .await?;
     }
 
     if let Some(enabled) = payload.quarantine_enabled {
@@ -2502,6 +2743,8 @@ pub async fn update_repository(
     .await;
 
     let repo_id = repo.id;
+    let repo_type = repo.repo_type.clone();
+    let repo_format = repo.format.clone();
     let is_apt_hosted =
         repo.repo_type.is_hosted() && matches!(repo.format, RepositoryFormat::Debian);
     let response = repo_to_response(repo, storage_used);
@@ -2518,6 +2761,8 @@ pub async fn update_repository(
     } else {
         response
     };
+    let response =
+        with_npm_scope_policy(&state.db, repo_id, &repo_type, &repo_format, response).await;
     Ok(Json(response))
 }
 
@@ -6855,6 +7100,96 @@ mod tests {
         );
     }
 
+    // -----------------------------------------------------------------------
+    // npm scope-policy create/update validation (#2424)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn normalize_npm_scopes_folds_sorts_dedupes() {
+        let out = normalize_npm_scopes(&[
+            "@Types".to_string(),
+            "  @acme ".to_string(),
+            "@types".to_string(),
+        ])
+        .expect("valid scopes");
+        assert_eq!(out, vec!["@acme", "@types"]);
+    }
+
+    #[test]
+    fn normalize_npm_scopes_rejects_bad_literal() {
+        assert!(normalize_npm_scopes(&["types".to_string()]).is_err());
+        assert!(normalize_npm_scopes(&["@sc/ope".to_string()]).is_err());
+    }
+
+    #[test]
+    fn normalize_npm_name_patterns_accepts_globs_and_scope_slash() {
+        let out = normalize_npm_name_patterns(&[
+            "@Acme/*".to_string(),
+            "internal-*".to_string(),
+            "@acme/*".to_string(),
+        ])
+        .expect("valid patterns");
+        // Lowercased, sorted, deduped; the scope `/` is preserved.
+        assert_eq!(out, vec!["@acme/*", "internal-*"]);
+    }
+
+    #[test]
+    fn normalize_npm_name_patterns_rejects_empty_and_path_sep() {
+        assert!(normalize_npm_name_patterns(&["   ".to_string()]).is_err());
+        assert!(normalize_npm_name_patterns(&["..\\evil".to_string()]).is_err());
+        assert!(normalize_npm_name_patterns(&["a/../b".to_string()]).is_err());
+        assert!(normalize_npm_name_patterns(&["bad space".to_string()]).is_err());
+        let too_long = "a".repeat(crate::api::handlers::npm::NPM_NAME_PATTERN_MAX_LEN + 1);
+        assert!(normalize_npm_name_patterns(&[too_long]).is_err());
+    }
+
+    #[test]
+    fn validate_npm_scope_policy_fields_gates_repo_type_and_format() {
+        // No fields => always OK regardless of repo type/format.
+        assert!(validate_npm_scope_policy_fields(
+            &RepositoryType::Local,
+            &RepositoryFormat::Generic,
+            None,
+            None,
+            None,
+        )
+        .is_ok());
+        // A field present on a non-remote or non-npm repo => rejected.
+        assert!(validate_npm_scope_policy_fields(
+            &RepositoryType::Local,
+            &RepositoryFormat::Npm,
+            Some(&["@acme".to_string()]),
+            None,
+            None,
+        )
+        .is_err());
+        assert!(validate_npm_scope_policy_fields(
+            &RepositoryType::Remote,
+            &RepositoryFormat::Maven,
+            None,
+            Some(false),
+            None,
+        )
+        .is_err());
+        // npm Remote with a valid glob => OK; with a bad glob => rejected.
+        assert!(validate_npm_scope_policy_fields(
+            &RepositoryType::Remote,
+            &RepositoryFormat::Npm,
+            Some(&["@acme".to_string()]),
+            Some(false),
+            Some(&["internal-*".to_string()]),
+        )
+        .is_ok());
+        assert!(validate_npm_scope_policy_fields(
+            &RepositoryType::Remote,
+            &RepositoryFormat::Npm,
+            None,
+            None,
+            Some(&["".to_string()]),
+        )
+        .is_err());
+    }
+
     #[test]
     fn download_filename_handles_flat_path() {
         assert_eq!(download_filename("plainfile.bin"), "plainfile.bin");
@@ -8232,6 +8567,9 @@ mod tests {
             apt_label: None,
             apt_release_version: None,
             apt_description: None,
+            npm_allowed_scopes: None,
+            npm_allow_unscoped: None,
+            npm_allowed_name_patterns: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -9564,6 +9902,9 @@ mod tests {
             apt_label: None,
             apt_release_version: None,
             apt_description: None,
+            npm_allowed_scopes: None,
+            npm_allow_unscoped: None,
+            npm_allowed_name_patterns: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -15629,6 +15970,9 @@ mod tests {
             apt_label: None,
             apt_release_version: None,
             apt_description: None,
+            npm_allowed_scopes: None,
+            npm_allow_unscoped: None,
+            npm_allowed_name_patterns: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2372,8 +2372,14 @@ pub async fn create_repository(
     response.apt_description = trimmed_nonempty(payload.apt_description);
     // Echo the npm scope policy that was persisted (#2424) so the create
     // response round-trips with a subsequent GET.
-    let response =
-        with_npm_scope_policy(&state.db, repo_id, &repo_type_out, &repo_format_out, response).await;
+    let response = with_npm_scope_policy(
+        &state.db,
+        repo_id,
+        &repo_type_out,
+        &repo_format_out,
+        response,
+    )
+    .await;
     Ok(Json(response))
 }
 

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -17,6 +17,7 @@ pub mod models;
 pub mod services;
 pub mod storage;
 pub mod telemetry;
+pub mod util;
 
 pub use config::Config;
 pub use error::{AppError, Result};

--- a/backend/src/services/curation_service.rs
+++ b/backend/src/services/curation_service.rs
@@ -27,7 +27,7 @@ impl CurationService {
     /// Check if a package name matches a glob pattern.
     /// Supports `*` (any chars) and `?` (single char).
     pub fn pattern_matches(pattern: &str, name: &str) -> bool {
-        glob_match(pattern, name)
+        crate::util::glob::glob_match(pattern, name)
     }
 
     /// Check if a version satisfies a constraint string.
@@ -469,42 +469,6 @@ impl CurationService {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Simple glob matching: `*` matches any sequence, `?` matches one char.
-fn glob_match(pattern: &str, text: &str) -> bool {
-    let p = pattern.chars().collect::<Vec<_>>();
-    let t = text.chars().collect::<Vec<_>>();
-    glob_match_inner(&p, &t, 0, 0)
-}
-
-fn glob_match_inner(pattern: &[char], text: &[char], pi: usize, ti: usize) -> bool {
-    if pi == pattern.len() && ti == text.len() {
-        return true;
-    }
-    if pi == pattern.len() {
-        return false;
-    }
-
-    if pattern[pi] == '*' {
-        // Try matching * against 0..n characters
-        for skip in 0..=(text.len() - ti) {
-            if glob_match_inner(pattern, text, pi + 1, ti + skip) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    if ti == text.len() {
-        return false;
-    }
-
-    if pattern[pi] == '?' || pattern[pi] == text[ti] {
-        return glob_match_inner(pattern, text, pi + 1, ti + 1);
-    }
-
-    false
-}
 
 /// Compare two version strings. Returns -1, 0, or 1.
 /// Splits on `.` and `-`, compares segments numerically when possible.

--- a/backend/src/util/glob.rs
+++ b/backend/src/util/glob.rs
@@ -1,0 +1,71 @@
+//! Shared glob matching used by several allow-list / pattern features.
+//!
+//! Extracted from `curation_service` so callers that need the same `*` / `?`
+//! semantics (curation package rules, npm scope-policy name patterns #2424)
+//! share a single implementation rather than copy-pasting it.
+
+/// Simple glob matching: `*` matches any sequence of characters (including the
+/// empty sequence) and `?` matches exactly one character. All other characters
+/// match literally. Callers that need case-insensitive matching should fold the
+/// case of both `pattern` and `text` before calling.
+pub fn glob_match(pattern: &str, text: &str) -> bool {
+    let p = pattern.chars().collect::<Vec<_>>();
+    let t = text.chars().collect::<Vec<_>>();
+    glob_match_inner(&p, &t, 0, 0)
+}
+
+fn glob_match_inner(pattern: &[char], text: &[char], pi: usize, ti: usize) -> bool {
+    if pi == pattern.len() && ti == text.len() {
+        return true;
+    }
+    if pi == pattern.len() {
+        return false;
+    }
+
+    if pattern[pi] == '*' {
+        // Try matching * against 0..n characters
+        for skip in 0..=(text.len() - ti) {
+            if glob_match_inner(pattern, text, pi + 1, ti + skip) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if ti == text.len() {
+        return false;
+    }
+
+    if pattern[pi] == '?' || pattern[pi] == text[ti] {
+        return glob_match_inner(pattern, text, pi + 1, ti + 1);
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::glob_match;
+
+    #[test]
+    fn star_matches_any_sequence() {
+        assert!(glob_match("*", "anything"));
+        assert!(glob_match("*", ""));
+        assert!(glob_match("@acme/*", "@acme/foo"));
+        assert!(!glob_match("@acme/*", "@evil/foo"));
+        assert!(glob_match("internal-*", "internal-utils"));
+        assert!(!glob_match("internal-*", "lodash"));
+    }
+
+    #[test]
+    fn question_mark_matches_single_char() {
+        assert!(glob_match("lib?", "liba"));
+        assert!(!glob_match("lib?", "libab"));
+    }
+
+    #[test]
+    fn literal_match() {
+        assert!(glob_match("lodash", "lodash"));
+        assert!(!glob_match("lodash", "lodashx"));
+    }
+}

--- a/backend/src/util/mod.rs
+++ b/backend/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! Small, dependency-free utilities shared across the backend.
+
+pub mod glob;


### PR DESCRIPTION
## Summary

Extends the per-repository npm scope allow-list (#2327) so it is enforced
consistently across **every** npm resolution path, adds glob name-pattern
support, and lets the policy be configured at repository create/update time.

Before this change the scope policy was consulted only on the two virtual
metadata loops (abbreviated/full metadata and packument). Three other seams
resolved packages without consulting it:

1. **Virtual tarball downloads** — the direct-tarball path resolved through a
   Remote member without applying the per-member scope filter, so a client with
   an exact tarball URL (e.g. a pinned lockfile) could pull a package the
   metadata loops would have filtered out. The member list is now pre-filtered
   by the policy and resolved through the established
   `resolve_virtual_download_from_members` seam (as maven already does); the
   generic `resolve_virtual_download` helper is left untouched, so no other
   format is affected. The #2066 download age-gate and the
   `virtual_non_remote_owns_name` shadowing guard are preserved.
2. **Direct-remote metadata / packument / tarball** — requests addressed
   straight at a Remote repository key never read that repository's own policy.
   Each branch (`get_package_metadata`, `fetch_remote_packument`, and the
   `serve_tarball` Remote branch) now loads the policy and returns **404 Not
   Found** for a package the policy disallows (parity with the "skipped by
   policy ⇒ not found" behaviour of the virtual loops).
3. **Exact-match only** — the policy matched only exact `@scope` literals. A new
   additive `npm_allowed_name_patterns` config key adds `*`/`?` glob matching on
   the full package name (e.g. `@acme/*`, `internal-*`). A name is allowed if
   its scope is in the exact-scope list **OR** any glob matches. The shared glob
   implementation was extracted from `curation_service` into
   `crate::util::glob` and is called from both sites (no copy-paste).

4. **`/-/` meta + audit namespace** — the advisory/audit/search endpoints
   proxied to upstream with no scope check, leaking metadata for out-of-scope
   packages on a scope-restricted repo. Now filtered against the repo's policy
   when active (unset policy = allow-all, byte-identical):
   - `POST /-/npm/v1/security/advisories/bulk` — out-of-scope package names are
     dropped from the request (upstream is never queried about them) and from
     the response (defence in depth).
   - `POST /-/npm/v1/security/audits/quick` — out-of-scope names are stripped
     from the request `requires`/`dependencies`; the response `advisories` are
     filtered by `module_name`.
   - `GET /-/*rest` (e.g. `/-/v1/search`) — search results are filtered so a
     scope-restricted repo never lists out-of-scope packages. This path also
     fixes a pre-existing query-strip bug: the axum `*rest` wildcard dropped the
     query string, so `-/v1/search` reached upstream with no `text` and 400'd;
     the original query is now re-appended.

Additionally, the npm scope policy can now be set when a repository is created
or updated: `CreateRepositoryRequest` / `UpdateRepositoryRequest` /
`RepositoryResponse` carry optional `npm_allowed_scopes`, `npm_allow_unscoped`
and `npm_allowed_name_patterns` fields. Create/update share a single
validate-and-persist helper (also used by the existing dedicated
`PUT /npm-scope-policy` endpoint), with up-front validation so a bad value
cannot leave an orphaned repository behind.

**Additive & backwards-compatible:** all state remains `repository_config` KV
rows — **no DB migration**. The new `npm_allowed_name_patterns` key defaults to
empty, so a repository configured before this change (scopes only, or no policy)
behaves byte-identically. A repository with no policy remains allow-all.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is a `feat/*` enhancement (milestone 1.6.0); it ships with unit
  coverage of the new matching, loader, and create/update validation logic.

## Test Checklist
- [x] Unit tests added/updated — glob util; `allows()`/`is_active()` glob
  composition (exact-scope OR pattern, unscoped, fail-closed, case-fold);
  loader parses the new key (malformed ⇒ empty); create/update
  normalise+validate (bad glob / path-sep / empty ⇒ 400; non-npm/non-remote
  ⇒ 400).
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — isolated instance; full before/after matrix
  across all four seams plus regression cases (see below).
- [x] No regressions in existing tests — full `--lib` suite green; existing
  #2327 scope-only and #2066 age-gate tests unchanged.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations — N/A (no new endpoints;
  fields added to existing `CreateRepositoryRequest`/`UpdateRepositoryRequest`/
  `RepositoryResponse`).
- [x] Request/response types have `#[derive(ToSchema)]` — the extended structs
  already derive `ToSchema`; new fields surface in the OpenAPI spec.
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no migration (all state is
  `repository_config` KV).
- [ ] N/A - no API changes

## Verification (isolated instance)

Policy on a scoped npm Remote member: `allowed_scopes=[@types]`,
`allowed_name_patterns=[react*]`, `allow_unscoped=false`. An unrestricted Remote
(`mem-open`) and its virtual parent provide the "before" baseline (no policy =
allow-all).

| Path | Case | mem-open (before) | scoped (after) |
|---|---|---|---|
| Direct-remote metadata | out-of-scope `@babel/core` | 200 | **404** |
| Direct-remote packument | out-of-scope `express@5.1.0` | 200 | **404** |
| Direct-remote tarball | out-of-scope `@babel/core` tgz | 200 | **404** |
| Virtual tarball | out-of-scope `@babel/core` tgz | 200 | **404** |

`/-/` meta + audit namespace (policy: scopes `@types`, pattern `lodash*`,
unscoped denied). Out-of-scope `express` (has real advisories) vs in-scope
`lodash` (has real advisories):

| Endpoint | Case | open (before) | scoped (after) |
|---|---|---|---|
| `POST …/advisories/bulk` | response keys | `[express, lodash]` | **`[lodash]`** |
| `POST …/audits/quick` | advisory `module_name`s | `[express, lodash]` | **`[lodash]`** |
| `GET /-/v1/search?text=lodash` | HTTP | 200 (12824 hits) | 200, **all hits in-scope** |
| `GET /-/v1/search` (query-strip) | was 400 (no `text`) | — | **200** (query re-appended) |

In-scope still works: `lodash` advisory + audit still returned on the scoped
repo; `@types/node` bulk request is accepted (not filtered — it simply has no
upstream advisories).

In-scope / glob / regression (patched instance):

- In-scope `@types/node` — metadata, packument, direct-remote tarball, virtual
  tarball all **200**.
- Glob `react*` — `react` metadata **200**, virtual `react` tarball **200**.
- Exact-scope-only repo (no patterns, #2327 shape) unchanged: `@types/node`
  **200**, `@babel/core` **404**, unscoped `react` **404** (fail-closed).
- No-policy repo = allow-all: `@babel/core` **200**, `express` **200**.
- Create-time config round-trips on `GET`; bad glob ⇒ **400**; policy on a
  non-npm repo ⇒ **400**.

## Follow-up (web repo)

The UI control for editing scopes + glob patterns on the repository create/edit
form belongs in `artifact-keeper-web`. File a paired web issue once the OpenAPI
fields land and the SDK is regenerated; the SDK regen must precede the web work.

Closes #2424