### PR TITLE
fix: harden plugin callback SSRF guards (validator dispatch + config save)

### DIFF
--- a/backend/src/api/handlers/plugins.rs
+++ b/backend/src/api/handlers/plugins.rs
@@ -589,6 +589,13 @@ pub async fn update_plugin_config(
     // enforces this; this in-handler check is defense-in-depth.
     auth.require_admin()?;
 
+    // Reject dangerous callback destinations at write time (anti-SSRF,
+    // defense-in-depth). The config is stored as opaque JSON and later drives
+    // external webhook/validator callbacks, so validate any URL-bearing fields
+    // now — before they are persisted — so file://, gopher:// and internal /
+    // cloud-metadata targets never make it into a stored plugin config.
+    validate_plugin_config_urls(&payload.config)?;
+
     let plugin = sqlx::query!(
         r#"
         UPDATE plugins
@@ -609,6 +616,38 @@ pub async fn update_plugin_config(
         config: payload.config,
         schema: plugin.config_schema,
     }))
+}
+
+/// Validate the external-callback URL fields in a plugin config against the
+/// outbound-URL SSRF guard, rejecting the write if any is dangerous.
+///
+/// The plugin config is stored as opaque JSON but the classic `PluginService`
+/// dispatcher reads callback destinations from a fixed set of keys
+/// (`webhook_url`, `validator_url`, `url` at the top level, and per-hook
+/// `hooks.<name>.{url,validator_url}`). We validate exactly those so that
+/// non-http(s) schemes (`file://`, `gopher://`, ...) and internal / cloud-
+/// metadata / loopback / RFC1918 targets are rejected at save time. Fields
+/// that are absent or not strings are ignored (config remains free-form).
+fn validate_plugin_config_urls(config: &serde_json::Value) -> Result<()> {
+    // Top-level callback URL fields.
+    for key in ["webhook_url", "validator_url", "url"] {
+        if let Some(url) = config.get(key).and_then(|v| v.as_str()) {
+            crate::api::validation::validate_outbound_url(url, "Plugin callback URL")?;
+        }
+    }
+
+    // Per-hook callback URL fields: { "hooks": { "<name>": { "url"/"validator_url": ... } } }
+    if let Some(hooks) = config.get("hooks").and_then(|h| h.as_object()) {
+        for hook in hooks.values() {
+            for key in ["url", "validator_url"] {
+                if let Some(url) = hook.get(key).and_then(|v| v.as_str()) {
+                    crate::api::validation::validate_outbound_url(url, "Plugin callback URL")?;
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 // =========================================================================
@@ -1799,5 +1838,115 @@ mod tests {
             !router_body.contains("\"/:id/config\""),
             "plugin config route must NOT be in the auth-only router()"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Save-time SSRF validation of plugin config callback URLs (issue #2536)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn config_urls_reject_metadata_and_loopback() {
+        for url in [
+            "http://169.254.169.254/latest/meta-data",
+            "http://127.0.0.1:9090/",
+        ] {
+            let cfg = serde_json::json!({ "webhook_url": url });
+            assert!(
+                validate_plugin_config_urls(&cfg).is_err(),
+                "webhook_url `{url}` must be rejected at save time"
+            );
+            let cfg = serde_json::json!({ "validator_url": url });
+            assert!(
+                validate_plugin_config_urls(&cfg).is_err(),
+                "validator_url `{url}` must be rejected at save time"
+            );
+        }
+    }
+
+    #[test]
+    fn config_urls_reject_rfc1918() {
+        for url in [
+            "http://10.0.0.5/api",
+            "http://172.16.0.1/",
+            "http://192.168.1.1/",
+        ] {
+            let cfg = serde_json::json!({ "validator_url": url });
+            assert!(
+                validate_plugin_config_urls(&cfg).is_err(),
+                "validator_url `{url}` (RFC1918) must be rejected at save time"
+            );
+        }
+    }
+
+    #[test]
+    fn config_urls_reject_dangerous_schemes() {
+        for url in ["file:///etc/passwd", "gopher://127.0.0.1:6379/_INFO"] {
+            let cfg = serde_json::json!({ "webhook_url": url });
+            assert!(
+                validate_plugin_config_urls(&cfg).is_err(),
+                "webhook_url `{url}` (dangerous scheme) must be rejected at save time"
+            );
+        }
+    }
+
+    #[test]
+    fn config_urls_reject_encoded_internal_ips() {
+        // Decimal-encoded 127.0.0.1 and IPv6-encoded internal targets.
+        for url in [
+            "http://2130706433/",
+            "http://[::1]:9090/",
+            "http://[::ffff:169.254.169.254]/latest/meta-data",
+        ] {
+            let cfg = serde_json::json!({ "validator_url": url });
+            assert!(
+                validate_plugin_config_urls(&cfg).is_err(),
+                "validator_url `{url}` (encoded internal IP) must be rejected at save time"
+            );
+        }
+    }
+
+    #[test]
+    fn config_urls_reject_per_hook_targets() {
+        let cfg = serde_json::json!({
+            "hooks": {
+                "before_upload": { "url": "http://169.254.169.254/" }
+            }
+        });
+        assert!(
+            validate_plugin_config_urls(&cfg).is_err(),
+            "per-hook url pointing at metadata must be rejected"
+        );
+        let cfg = serde_json::json!({
+            "hooks": {
+                "before_upload": { "validator_url": "http://127.0.0.1:5432/" }
+            }
+        });
+        assert!(
+            validate_plugin_config_urls(&cfg).is_err(),
+            "per-hook validator_url pointing at loopback must be rejected"
+        );
+    }
+
+    #[test]
+    fn config_urls_allow_legit_external() {
+        let cfg = serde_json::json!({
+            "webhook_url": "https://hooks.example.com/ingest",
+            "validator_url": "https://validator.example.com/check",
+            "hooks": {
+                "before_upload": { "url": "https://cb.example.net/hook" }
+            },
+            "rules": { "max_size_bytes": 1048576 }
+        });
+        assert!(
+            validate_plugin_config_urls(&cfg).is_ok(),
+            "legit external callback URLs must pass save-time validation"
+        );
+    }
+
+    #[test]
+    fn config_urls_allow_config_without_url_fields() {
+        // Free-form config with no callback URLs is unaffected.
+        let cfg = serde_json::json!({ "rules": { "max_size_bytes": 1024 } });
+        assert!(validate_plugin_config_urls(&cfg).is_ok());
     }
 }

--- a/backend/src/services/plugin_service.rs
+++ b/backend/src/services/plugin_service.rs
@@ -880,6 +880,13 @@ impl PluginService {
         event: PluginEventType,
         artifact_info: &ArtifactInfo,
     ) -> Result<()> {
+        // Re-validate URL before dispatch (anti-SSRF), mirroring the guard on
+        // the webhook path in `execute_webhook_hook`. The shared client's DNS
+        // resolver only covers hostnames (not literal IPs) and only fires on
+        // redirect hops, so this string-level check is what actually blocks
+        // literal-IP metadata / loopback / RFC1918 targets on the initial POST.
+        crate::api::validation::validate_outbound_url(url, "Plugin validator URL")?;
+
         let payload = WebhookPayload {
             event: event.as_str().to_string(),
             timestamp: Utc::now().to_rfc3339(),
@@ -1831,5 +1838,115 @@ mod tests {
         let event = PluginEventType::BeforeUpload;
         let event2 = event; // Copy
         assert_eq!(event, event2);
+    }
+
+    // -----------------------------------------------------------------------
+    // SSRF guard on the validator callback path (issue #2536)
+    //
+    // `call_validator_url` validates the target with `validate_outbound_url`
+    // before dispatch, mirroring `execute_webhook_hook`. These tests prove the
+    // guard is actually wired into `call_validator_url` (not just present in
+    // the sibling webhook path): the validation runs before any DB / network
+    // access, so a lazily-created pool never connects for the blocked cases.
+    // -----------------------------------------------------------------------
+
+    fn ssrf_test_plugin() -> Plugin {
+        use crate::models::plugin::{PluginSourceType, PluginStatus};
+        Plugin {
+            id: Uuid::new_v4(),
+            name: "test-plugin".to_string(),
+            version: "1.0.0".to_string(),
+            display_name: "Test Plugin".to_string(),
+            description: None,
+            author: None,
+            homepage: None,
+            license: None,
+            status: PluginStatus::Active,
+            plugin_type: PluginType::Webhook,
+            source_type: PluginSourceType::Core,
+            source_url: None,
+            source_ref: None,
+            wasm_path: None,
+            manifest: None,
+            capabilities: None,
+            resource_limits: None,
+            config: None,
+            config_schema: None,
+            error_message: None,
+            installed_at: Utc::now(),
+            enabled_at: None,
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn ssrf_test_artifact_info() -> ArtifactInfo {
+        ArtifactInfo {
+            id: Uuid::new_v4(),
+            repository_id: Uuid::new_v4(),
+            path: "com/example/test.jar".to_string(),
+            name: "test.jar".to_string(),
+            version: Some("1.0.0".to_string()),
+            size_bytes: 1024,
+            checksum_sha256: "abc123".to_string(),
+            content_type: "application/java-archive".to_string(),
+            uploaded_by: None,
+        }
+    }
+
+    async fn assert_validator_url_blocked(url: &str) {
+        // Lazy pool: never connects because the SSRF guard rejects before any
+        // DB/network access, so no live Postgres is needed for these cases.
+        let pool = PgPool::connect_lazy("postgres://registry:registry@127.0.0.1:1/none")
+            .expect("lazy pool");
+        let svc = PluginService::new(pool);
+        let plugin = ssrf_test_plugin();
+        let info = ssrf_test_artifact_info();
+        let res = svc
+            .call_validator_url(url, &plugin, PluginEventType::BeforeUpload, &info)
+            .await;
+        assert!(res.is_err(), "expected `{url}` to be blocked by SSRF guard");
+        let msg = format!("{:?}", res.unwrap_err());
+        assert!(
+            msg.contains("Plugin validator URL"),
+            "`{url}` was not rejected by the outbound-URL guard: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_validator_url_blocks_metadata_and_loopback() {
+        assert_validator_url_blocked("http://169.254.169.254/latest/meta-data").await;
+        assert_validator_url_blocked("http://127.0.0.1:9090/").await;
+    }
+
+    #[tokio::test]
+    async fn call_validator_url_blocks_rfc1918() {
+        assert_validator_url_blocked("http://10.0.0.5/api").await;
+        assert_validator_url_blocked("http://172.16.0.1/api").await;
+        assert_validator_url_blocked("http://192.168.1.1/api").await;
+    }
+
+    #[tokio::test]
+    async fn call_validator_url_blocks_dangerous_schemes() {
+        assert_validator_url_blocked("file:///etc/passwd").await;
+        assert_validator_url_blocked("gopher://127.0.0.1:6379/_INFO").await;
+    }
+
+    #[tokio::test]
+    async fn call_validator_url_blocks_encoded_internal_ips() {
+        // Decimal-encoded 127.0.0.1 (WHATWG host parser normalizes it).
+        assert_validator_url_blocked("http://2130706433/").await;
+        // IPv6 loopback and IPv4-mapped metadata literal.
+        assert_validator_url_blocked("http://[::1]:9090/").await;
+        assert_validator_url_blocked("http://[::ffff:169.254.169.254]/latest/meta-data").await;
+    }
+
+    #[test]
+    fn validator_url_guard_allows_legit_external() {
+        // The guard used by `call_validator_url` accepts ordinary public URLs.
+        assert!(crate::api::validation::validate_outbound_url(
+            "https://validator.example.com/check",
+            "Plugin validator URL"
+        )
+        .is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Hardens the plugin callback path against SSRF by making the two outbound-URL
guards symmetric and adding save-time validation for stored callback URLs.

The classic `PluginService` webhook/validator dispatcher has an asymmetric guard:
`execute_webhook_hook` re-validates its target with
`validate_outbound_url(&webhook_url, ...)` before POSTing, but the sibling
`call_validator_url` POSTed straight to the configured URL with no check. The
shared client's SSRF DNS resolver only covers hostnames (literal IPs bypass it)
and only fires on redirect hops, so a literal-IP `validator_url`
(`169.254.169.254`, `127.0.0.1:9090`, RFC1918, decimal/IPv6-encoded internal
IPs) would connect unchecked on the initial request. Separately,
`update_plugin_config` stored the config as opaque JSON with no URL validation,
so `file://` / `gopher://` and internal/metadata targets could be persisted.

Changes (minimal, in the surrounding style):

- `services/plugin_service.rs::call_validator_url` — add
  `validate_outbound_url(url, "Plugin validator URL")?` at the top, mirroring the
  webhook path. This string-level check is what actually blocks literal-IP
  metadata / loopback / RFC1918 targets on the initial POST.
- `api/handlers/plugins.rs::update_plugin_config` — validate the callback URL
  fields (`webhook_url`, `validator_url`, `url`, and per-hook
  `hooks.<name>.{url,validator_url}`) with the same outbound-URL guard before the
  config is persisted, rejecting dangerous schemes and internal targets at write
  time (defense-in-depth). Config without URL fields is unaffected.

Note: the classic `PluginService` that dispatches these callbacks is not
currently constructed (only `WasmPluginService` runs), so this is latent
defense-in-depth before the callback engine is ever wired in. Both guards are
implemented and tested now so the surface is closed ahead of enablement.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New unit tests:
- `call_validator_url` rejects cloud-metadata, loopback, RFC1918, `file://` /
  `gopher://`, and decimal/IPv6-encoded internal IPs; a legit external URL
  passes the guard.
- `update_plugin_config`'s save-time validation rejects the same set (top-level
  and per-hook fields) and allows legit external URLs / URL-less config.

Verified on an isolated instance: config-save returns `400 VALIDATION_ERROR`
for `http://169.254.169.254/...` and `file:///etc/passwd`
("Plugin callback URL must use http or https"), while a legit
`https://validator.example.com/check` passes validation and proceeds to the
normal handler path. Full workspace `--lib` suite: 13177 passed, 0 failures.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2536
