### PR TITLE
ci(docker-publish): verify scanner-adapter at its own version, not the AK release tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1130,6 +1130,11 @@ jobs:
     needs: [merge-backend, merge-openscap, merge-scanner-adapter]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
+      # Needed to read docker/scanner-adapter/VERSION — the adapter is
+      # independently versioned, so its published tag is NOT the AK release tag.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - name: Probe ghcr.io manifests for expected semver tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1162,11 +1167,25 @@ jobs:
           # currently suspended (its build/merge jobs are gated `if: false`),
           # so it is intentionally absent here — re-add the
           # `${BACKEND_IMAGE}:${VERSION}-alpine` entry when those jobs return.
+          #
+          # backend/openscap publish the AK release semver (git tag). The
+          # scanner-adapter is INDEPENDENTLY versioned (source of truth:
+          # docker/scanner-adapter/VERSION) and never publishes a tag at the AK
+          # release version, so it must be verified at its OWN version — see
+          # merge-scanner-adapter.
           EXPECTED=(
             "${BACKEND_IMAGE}:${VERSION}"
             "${OPENSCAP_IMAGE}:${VERSION}"
-            "${SCANNER_ADAPTER_IMAGE}:${VERSION}"
           )
+
+          # merge-scanner-adapter only publishes the adapter's semver tag on
+          # clean (non-prerelease) v-tags. Mirror that gate so prerelease cuts
+          # don't flag a tag the publish step intentionally skipped.
+          SCANNER_VERSION="$(cat docker/scanner-adapter/VERSION)"
+          case "${GITHUB_REF}" in
+            *-*) echo "Prerelease tag ${GITHUB_REF}; skipping scanner-adapter semver check (not published)." ;;
+            *)   EXPECTED+=("${SCANNER_ADAPTER_IMAGE}:${SCANNER_VERSION}") ;;
+          esac
 
           missing=()
           for entry in "${EXPECTED[@]}"; do


### PR DESCRIPTION
## Problem

The `Docker Publish` workflow's **Verify Published Tags** job (`verify-published`) fails on every release cut. It builds an `EXPECTED` tag list at the AK release version and includes `scanner-adapter:<AK version>` (e.g. `scanner-adapter:1.5.7`).

But the scanner-adapter is **independently versioned** — its source of truth is `docker/scanner-adapter/VERSION` (currently `1.2.0`), decoupled from AK's git tag. `merge-scanner-adapter` publishes the adapter using *that* file's value, never at the AK release version. So a tag at `scanner-adapter:<AK version>` never exists and the job reports a false failure. This has been red-herring-failing v1.5.4 through v1.5.7.

## Fix

In `verify-published`, verify the scanner-adapter at **its own version** instead of the AK release version:

- Added a `Checkout` step so `docker/scanner-adapter/VERSION` is available.
- Removed `${SCANNER_ADAPTER_IMAGE}:${VERSION}` from the AK-version `EXPECTED` list.
- Added `${SCANNER_ADAPTER_IMAGE}:${SCANNER_VERSION}` where `SCANNER_VERSION` is read from the VERSION file — mirroring `merge-scanner-adapter`.
- Gated the scanner-adapter check on clean (non-prerelease) v-tags, matching `merge-scanner-adapter`'s own `publish` gate, so prerelease cuts don't flag a tag the publish step intentionally skips.

Backend and openscap continue to be verified at the AK release version — that verification is unchanged. No image verification is weakened; scanner-adapter is now verified at the version it is actually published with.

Closes #2428