### PR TITLE
fix(authz): validate principal type/id correspondence on permission writes (#2503)

### DIFF
--- a/backend/src/api/handlers/groups.rs
+++ b/backend/src/api/handlers/groups.rs
@@ -1724,14 +1724,86 @@ mod tests {
             "admin must read any group"
         );
 
+        // #2503 (finding 2): a *direct* service_account-typed grant on a group
+        // must surface that group in the SA's list_groups (not just group-mediated
+        // repo access). The SA is a non-member of `other`, so only the grant can
+        // make it visible; `visible_groups_predicate`'s
+        // `principal_type IN ('user','service_account')` arm is what carries it.
+        let sa_id = Uuid::new_v4();
+        let sa_username = format!("ph-grp-sa-{sa_id}");
+        sqlx::query(
+            r#"INSERT INTO users
+                 (id, username, email, password_hash, auth_provider,
+                  is_admin, is_active, is_service_account)
+               VALUES ($1, $2, $3, 'unused', 'local', false, true, true)"#,
+        )
+        .bind(sa_id)
+        .bind(&sa_username)
+        .bind(format!("{sa_username}@test.local"))
+        .execute(&pool)
+        .await
+        .expect("seed service account");
+        let grant_id = Uuid::new_v4();
+        sqlx::query(
+            r#"INSERT INTO permissions
+                 (id, principal_type, principal_id, target_type, target_id, actions)
+               VALUES ($1, 'service_account', $2, 'group', $3, ARRAY['read'])"#,
+        )
+        .bind(grant_id)
+        .bind(sa_id)
+        .bind(other)
+        .execute(&pool)
+        .await
+        .expect("seed direct SA->group grant");
+
+        let sa_auth = AuthExtension {
+            is_service_account: true,
+            is_api_token: true,
+            ..tdh::make_auth(sa_id, &sa_username)
+        };
+        let sa_listed = list_groups(
+            State(state.clone()),
+            Extension(Some(sa_auth.clone())),
+            Query(list_q()),
+        )
+        .await
+        .expect("SA list ok")
+        .0;
+        let sa_names: Vec<&str> = sa_listed.items.iter().map(|g| g.name.as_str()).collect();
+        assert!(
+            sa_names.contains(&other_name.as_str()),
+            "a direct service_account grant on a group must surface it in list_groups: {sa_names:?}"
+        );
+        assert!(
+            !sa_names.contains(&mine_name.as_str()),
+            "SA must NOT see a group it neither belongs to nor holds a grant on: {sa_names:?}"
+        );
+        // get_group over the same direct grant also resolves (not a NotFound leak-avoider).
+        assert!(
+            get_group(
+                State(state.clone()),
+                Extension(Some(sa_auth)),
+                Path(other),
+                Query(get_q()),
+            )
+            .await
+            .is_ok(),
+            "direct SA grant must also make get_group succeed"
+        );
+
         // cleanup (user_group_members cascades on group/user delete).
+        let _ = sqlx::query("DELETE FROM permissions WHERE id = $1")
+            .bind(grant_id)
+            .execute(&pool)
+            .await;
         let _ = sqlx::query("DELETE FROM groups WHERE id IN ($1, $2)")
             .bind(mine)
             .bind(other)
             .execute(&pool)
             .await;
-        let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+        let _ = sqlx::query("DELETE FROM users WHERE id IN ($1, $2)")
             .bind(user_id)
+            .bind(sa_id)
             .execute(&pool)
             .await;
     }

--- a/backend/src/api/handlers/permissions.rs
+++ b/backend/src/api/handlers/permissions.rs
@@ -271,6 +271,17 @@ pub async fn create_permission(
     let payload: CreatePermissionRequest = serde_json::from_slice(&body)
         .map_err(|e| AppError::Validation(format!("Invalid permission payload: {}", e)))?;
 
+    // #2503 (defense-in-depth): validate that `principal_id` actually names a
+    // principal of the declared `principal_type`. Since #2433 widened grant
+    // matching to include `service_account`, a mistyped grant (e.g.
+    // `principal_type = 'service_account'` naming a real user id) would resolve
+    // against the wrong principal. Reject the mismatch with a 400 before the
+    // INSERT instead of persisting an effective, misattributed grant.
+    state
+        .permission_service
+        .validate_principal(&payload.principal_type, payload.principal_id)
+        .await?;
+
     let permission: CreatedPermissionRow = sqlx::query_as(
         r#"
         INSERT INTO permissions (principal_type, principal_id, target_type, target_id, actions)
@@ -406,6 +417,13 @@ pub async fn update_permission(
 
     let payload: CreatePermissionRequest = serde_json::from_slice(&body)
         .map_err(|e| AppError::Validation(format!("Invalid permission payload: {}", e)))?;
+
+    // #2503 (defense-in-depth): mirror the create-path check so an update cannot
+    // reintroduce a type/id mismatch (e.g. `service_account` naming a user id).
+    state
+        .permission_service
+        .validate_principal(&payload.principal_type, payload.principal_id)
+        .await?;
 
     let permission: CreatedPermissionRow = sqlx::query_as(
         r#"

--- a/backend/src/api/handlers/projects.rs
+++ b/backend/src/api/handlers/projects.rs
@@ -484,6 +484,19 @@ pub async fn add_project_member(
         .map_err(|e| AppError::Validation(format!("Invalid member payload: {}", e)))?;
 
     validate_member_grant(&payload.principal_type, &payload.actions)?;
+    // #2503 (defense-in-depth): `validate_member_grant` only enforces the
+    // project-member *type allowlist* (user|group) and non-empty actions — it
+    // never checks that `principal_id` actually names a principal of that type.
+    // Without this, a mistyped grant (e.g. `principal_type = 'user'` naming a
+    // service-account id) is upserted here and, because project grants are
+    // inherited by every repository in the project and the resolver matches
+    // `principal_type IN ('user','service_account')`, becomes effective for the
+    // mistyped principal — the same class POST /permissions rejects. Reuse the
+    // identical write-time correspondence check so this parallel writer agrees.
+    state
+        .permission_service
+        .validate_principal(&payload.principal_type, payload.principal_id)
+        .await?;
     require_project_exists(&state, id).await?;
 
     let row: ProjectMemberRow = sqlx::query_as(
@@ -889,6 +902,91 @@ mod tests {
             cleanup_project(&pool, project_id).await;
             tdh::cleanup(&pool, repo_id, member_id).await;
             tdh::cleanup(&pool, repo_id, outsider_id).await;
+        }
+
+        /// #2503: `add_project_member` must reject a mistyped grant (a `user`-typed
+        /// grant naming a service-account id) with a 400, exactly as
+        /// `POST /permissions` does — otherwise the mistyped grant is upserted and,
+        /// being inherited by the project's repositories, makes the SA effective.
+        /// A well-typed member is still accepted, and no stray grant is written.
+        #[tokio::test]
+        async fn test_add_project_member_rejects_mistyped_principal() {
+            use axum::extract::{Path, State};
+            use axum::Extension;
+
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let dir = std::env::temp_dir().join(format!("prj-mt-{}", Uuid::new_v4()));
+            let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+            let (admin_id, admin_name) = tdh::create_user(&pool).await;
+            let admin = AuthExtension {
+                is_admin: true,
+                ..tdh::make_auth(admin_id, &admin_name)
+            };
+            let (user_id, _) = tdh::create_user(&pool).await;
+            let sa_id = Uuid::new_v4();
+            let sa_name = format!("prj-mt-sa-{sa_id}");
+            sqlx::query(
+                r#"INSERT INTO users
+                     (id, username, email, password_hash, auth_provider,
+                      is_admin, is_active, is_service_account)
+                   VALUES ($1, $2, $3, 'unused', 'local', false, true, true)"#,
+            )
+            .bind(sa_id)
+            .bind(&sa_name)
+            .bind(format!("{sa_name}@test.local"))
+            .execute(&pool)
+            .await
+            .expect("seed service account");
+            let (repo_id, _, _) = tdh::create_repo(&pool, "local", "generic").await;
+            let project_id = create_project_row(&pool, "mistype").await;
+            assign_repo_to_project(&pool, repo_id, project_id).await;
+
+            let call = |auth: AuthExtension, ptype: &str, pid: Uuid| {
+                let state = state.clone();
+                let body = axum::body::Bytes::from(
+                    serde_json::to_vec(&serde_json::json!({
+                        "principal_type": ptype,
+                        "principal_id": pid,
+                        "actions": ["read", "write"],
+                    }))
+                    .unwrap(),
+                );
+                async move {
+                    add_project_member(State(state), Extension(Some(auth)), Path(project_id), body)
+                        .await
+                }
+            };
+
+            // Exploit: a `user`-typed grant naming a service-account id -> 400.
+            let mistyped = call(admin.clone(), "user", sa_id).await;
+            assert!(
+                matches!(mistyped, Err(AppError::Validation(_))),
+                "mistyped project-member grant (user id = SA) must be a 400, got {mistyped:?}"
+            );
+
+            // Resolve-time: the rejected grant was never written, so the SA has no
+            // inherited access to the project's private repository.
+            let svc = crate::services::repository_service::RepositoryService::new(pool.clone());
+            assert!(
+                !svc.user_can_access_repo(repo_id, sa_id).await.unwrap(),
+                "a rejected mistyped grant must not make the SA effective on the project repo"
+            );
+
+            // Legit: a well-typed user member is still accepted (200).
+            assert!(
+                call(admin, "user", user_id).await.is_ok(),
+                "a valid user member must still be accepted"
+            );
+
+            cleanup_project(&pool, project_id).await;
+            tdh::cleanup(&pool, repo_id, user_id).await;
+            let _ = sqlx::query("DELETE FROM users WHERE id IN ($1, $2)")
+                .bind(admin_id)
+                .bind(sa_id)
+                .execute(&pool)
+                .await;
         }
 
         /// (2) Cross-project isolation: a grant on project B conveys nothing
@@ -1307,8 +1405,16 @@ mod tests {
             let key = format!("prj-http-mem-{}", Uuid::new_v4().simple());
             let (_, created) = create_via_api(&state, &key).await;
             let id = created["id"].as_str().expect("project id").to_string();
-            let user_id = Uuid::new_v4();
+            // #2503: project-member grants are now validated for principal
+            // type/id correspondence, so the grantees must be real principals.
+            let (user_id, _) = tdh::create_user(&pool).await;
             let group_id = Uuid::new_v4();
+            sqlx::query("INSERT INTO groups (id, name) VALUES ($1, $2)")
+                .bind(group_id)
+                .bind(format!("prj-http-mem-grp-{group_id}"))
+                .execute(&pool)
+                .await
+                .expect("seed group");
 
             // Grant a user -> 200 with the row echoed.
             let (status, bytes) = tdh::send(
@@ -1432,6 +1538,14 @@ mod tests {
             assert_eq!(status, StatusCode::BAD_REQUEST);
 
             cleanup_project_rows(&pool, &key).await;
+            let _ = sqlx::query("DELETE FROM groups WHERE id = $1")
+                .bind(group_id)
+                .execute(&pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                .bind(user_id)
+                .execute(&pool)
+                .await;
         }
 
         #[tokio::test]

--- a/backend/src/services/permission_service.rs
+++ b/backend/src/services/permission_service.rs
@@ -86,6 +86,26 @@ impl RulesCacheEntry {
     }
 }
 
+/// SQL that checks whether a principal of `principal_type` exists with `id = $1`,
+/// or `None` when the principal type is not recognised.
+///
+/// Service accounts are stored in the `users` table with `is_service_account =
+/// true`; human users have it `false`; groups live in the `groups` table. This
+/// mapping is the single source of truth for the write-time type/id
+/// correspondence check performed by [`PermissionService::validate_principal`].
+fn principal_existence_query(principal_type: &str) -> Option<&'static str> {
+    match principal_type {
+        "user" => {
+            Some("SELECT EXISTS(SELECT 1 FROM users WHERE id = $1 AND is_service_account = false)")
+        }
+        "service_account" => {
+            Some("SELECT EXISTS(SELECT 1 FROM users WHERE id = $1 AND is_service_account = true)")
+        }
+        "group" => Some("SELECT EXISTS(SELECT 1 FROM groups WHERE id = $1)"),
+        _ => None,
+    }
+}
+
 /// Service that evaluates permission rules stored in the `permissions` table.
 ///
 /// The service resolves both direct user grants and group-based grants in a
@@ -240,6 +260,37 @@ impl PermissionService {
                 poisoned.into_inner().clear();
             }
         }
+    }
+
+    /// Validate that `principal_id` names an existing principal of the declared
+    /// `principal_type` before a grant is written.
+    ///
+    /// #2503 (defense-in-depth): since #2433 widened grant matching to include
+    /// `service_account`, a mistyped grant — e.g. `principal_type =
+    /// 'service_account'` naming a real *user* id — becomes effective. Principal
+    /// ids are globally-unique UUIDs drawn from distinct tables (`users` for both
+    /// `user` and `service_account`, disambiguated by `is_service_account`;
+    /// `groups` for `group`), so a type/id mismatch is always an authoring error.
+    /// Reject it at write time with a 400 rather than persisting a grant that
+    /// resolves against the wrong principal.
+    pub async fn validate_principal(&self, principal_type: &str, principal_id: Uuid) -> Result<()> {
+        let query = principal_existence_query(principal_type).ok_or_else(|| {
+            AppError::Validation(format!(
+                "Invalid principal_type '{principal_type}': expected one of user, \
+                 service_account, group"
+            ))
+        })?;
+        let exists: bool = sqlx::query_scalar(query)
+            .bind(principal_id)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        if !exists {
+            return Err(AppError::Validation(format!(
+                "principal_id {principal_id} does not exist as a {principal_type}"
+            )));
+        }
+        Ok(())
     }
 
     /// Resolve the full set of granted actions for a user on a specific target.
@@ -771,6 +822,144 @@ mod tests {
             body.contains("(principal_type IN ('user', 'service_account') AND principal_id = $1)"),
             "direct-principal arm must accept service_account without relaxing the id match"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2503: principal type/id correspondence check for grant writes.
+    //
+    // `validate_principal` needs a DB, but the type->table mapping it relies on
+    // is a pure function. Pin that mapping here without a database: it is the
+    // single source of truth deciding which table a grant's principal_id must
+    // exist in, so a regression (e.g. dropping the is_service_account guard, or
+    // accepting an unknown type) is what would let a mistyped grant slip through.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_principal_existence_query_user_excludes_service_accounts() {
+        let q = principal_existence_query("user").expect("user is a valid principal type");
+        assert!(
+            q.contains("FROM users"),
+            "user check must target the users table"
+        );
+        assert!(
+            q.contains("is_service_account = false"),
+            "user check must exclude service-account rows so a SA id cannot pose as a user"
+        );
+    }
+
+    #[test]
+    fn test_principal_existence_query_service_account_requires_flag() {
+        let q = principal_existence_query("service_account")
+            .expect("service_account is a valid principal type");
+        assert!(
+            q.contains("FROM users"),
+            "service_account check must target the users table"
+        );
+        assert!(
+            q.contains("is_service_account = true"),
+            "service_account check must require the flag so a human user id cannot pose as a SA"
+        );
+    }
+
+    #[test]
+    fn test_principal_existence_query_group_targets_groups_table() {
+        let q = principal_existence_query("group").expect("group is a valid principal type");
+        assert!(
+            q.contains("FROM groups"),
+            "group check must target the groups table"
+        );
+    }
+
+    #[test]
+    fn test_principal_existence_query_rejects_unknown_type() {
+        assert!(principal_existence_query("").is_none());
+        assert!(principal_existence_query("admin").is_none());
+        assert!(principal_existence_query("User").is_none());
+        assert!(principal_existence_query("serviceaccount").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_validate_principal_unknown_type_is_400_without_db() {
+        // The unknown-type arm rejects before any query, so a doomed lazy pool
+        // is fine: we must get a Validation (400), not a Database (500) error.
+        let service = lazy_service();
+        let err = service
+            .validate_principal("root", Uuid::new_v4())
+            .await
+            .expect_err("unknown principal_type must be rejected");
+        assert!(
+            matches!(err, AppError::Validation(_)),
+            "unknown principal_type must be a 400 Validation, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_principal_type_id_correspondence_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let service = PermissionService::new(pool.clone());
+
+        // A human user and a service account (both live in `users`).
+        let (user_id, _uname) = tdh::create_user(&pool).await;
+        let sa_id = Uuid::new_v4();
+        let sa_name = format!("ph-perm-sa-{sa_id}");
+        sqlx::query(
+            r#"INSERT INTO users
+                 (id, username, email, password_hash, auth_provider,
+                  is_admin, is_active, is_service_account)
+               VALUES ($1, $2, $3, 'unused', 'local', false, true, true)"#,
+        )
+        .bind(sa_id)
+        .bind(&sa_name)
+        .bind(format!("{sa_name}@test.local"))
+        .execute(&pool)
+        .await
+        .expect("seed service account");
+        let group_id = Uuid::new_v4();
+        sqlx::query("INSERT INTO groups (id, name) VALUES ($1, $2)")
+            .bind(group_id)
+            .bind(format!("ph-perm-grp-{group_id}"))
+            .execute(&pool)
+            .await
+            .expect("seed group");
+
+        // Each type with a matching id is accepted.
+        assert!(service.validate_principal("user", user_id).await.is_ok());
+        assert!(service
+            .validate_principal("service_account", sa_id)
+            .await
+            .is_ok());
+        assert!(service.validate_principal("group", group_id).await.is_ok());
+
+        // Mistyped grants (the #2503 case) are rejected with a 400.
+        let mistyped = service
+            .validate_principal("service_account", user_id)
+            .await
+            .expect_err("a user id declared as service_account must be rejected");
+        assert!(
+            matches!(mistyped, AppError::Validation(_)),
+            "type/id mismatch must be a 400, got {mistyped:?}"
+        );
+        assert!(service.validate_principal("user", sa_id).await.is_err(),);
+        assert!(service.validate_principal("group", user_id).await.is_err());
+        // A well-typed but non-existent id is also rejected.
+        assert!(service
+            .validate_principal("user", Uuid::new_v4())
+            .await
+            .is_err());
+
+        let _ = sqlx::query("DELETE FROM groups WHERE id = $1")
+            .bind(group_id)
+            .execute(&pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM users WHERE id IN ($1, $2)")
+            .bind(user_id)
+            .bind(sa_id)
+            .execute(&pool)
+            .await;
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-ups from the #2433 / PR #2499 review (both hardening, non-blocking):

1. **Write-time principal type/id correspondence check.** `create_permission`
   (and `update_permission`) persisted a grant without verifying that
   `principal_id` names an existing principal of the declared `principal_type`.
   Since #2433 widened grant matching to `principal_type IN ('user',
   'service_account')`, a mistyped grant — e.g. `principal_type =
   'service_account'` naming a real *user* id — became effective against the
   wrong principal. Principal ids are globally-unique UUIDs drawn from distinct
   tables (`users`, disambiguated by `is_service_account`, for both `user` and
   `service_account`; `groups` for `group`), so a type/id mismatch is always an
   authoring error. The new `PermissionService::validate_principal` rejects it
   with a `400 VALIDATION_ERROR` before the write. Applied to both the create
   and update paths so an update cannot reintroduce a mismatch.

2. **Direct service-account grant on `target_type='group'` visibility.** A
   regression test now pins that a *direct* `service_account`-typed grant on a
   group surfaces that group in the grant-holder's `list_groups`/`get_group`.
   The `visible_groups_predicate` widening from #2499 already carries this arm
   (`principal_type IN ('user','service_account')`, keyed by the caller's own
   id); this change adds a DB-backed handler-level test so the behaviour is
   locked against future narrowing.

3. **Third permissions writer: `add_project_member`.**
   `POST /api/v1/projects/{id}/members` (`api/handlers/projects.rs`) is a third
   runtime writer into `permissions`. It ran only `validate_member_grant` (a
   type-string allowlist: `user|group` + non-empty actions) and skipped the
   type/id-correspondence check, so a mistyped grant (`principal_type = 'user'`
   naming a service-account id) was upserted with `200` and — because project
   grants are inherited by every repository in the project — made the SA
   effective on the project's private repos. It now calls the same
   `validate_principal` before the INSERT (the type allowlist is retained).

An audit of every `INSERT/UPDATE INTO permissions` confirms these three
(`create_permission`, `update_permission`, `add_project_member`) are the only
production writers that accept a client-supplied `principal_type`/`principal_id`;
all other production writers hardcode `principal_type` with a trusted
self/creator id, and the remainder are `#[cfg(test)]`.

Note: the three writers live in the handler layer
(`api/handlers/{permissions,projects}.rs`); the reusable check is added to
`services/permission_service.rs` (the type→table mapping is the single source of
truth) and called from each handler.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Verification

Isolated instance (patched image, throwaway DB):

- Mistyped `service_account` grant naming a user id → `400` (`principal_id ...
  does not exist as a service_account`).
- Mistyped `user` grant naming an SA id → `400`.
- Unknown `principal_type` → `400`.
- Well-typed but non-existent id → `400`.
- Valid `user` / `service_account` / `group` grants (each with a matching id) →
  `200`.
- Direct `service_account` grant on a group → that group appears in the SA's
  `GET /api/v1/groups` (and only that group; scoping preserved).
- `POST /projects/{id}/members {principal_type:"user", principal_id:<SA id>}` →
  `400` (was `200`); mistyped `group`/nonexistent ids → `400`; valid `user`/
  `group` members → `200`.
- Resolve-time: with the mistyped grant blocked, the SA is denied on the
  project's private repo (`GET /repositories/{key}/artifacts` → `404`, i.e. no
  inherited access). Positive control: injecting the same grant directly into
  `permissions` (as the pre-fix writer would) flips the SA to `200`, and
  removing it returns `404` — confirming the blocked grant is exactly what
  conferred access.

`cargo fmt`, `cargo clippy --all-targets -D warnings`, and the lib test suite
(incl. the new DB-backed tests) pass; jscpd on changed files is under threshold.

Closes #2503