### PR TITLE
fix(signing): require an authenticated per-artifact attestation to satisfy promotion require_signature (#2535)

### DIFF
--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -35,6 +35,10 @@ pub fn router() -> Router<SharedState> {
             "/repositories/:repo_id/public-key",
             get(get_repo_public_key),
         )
+        // Deliberate per-artifact attestation (#2535). Admin-only, and the SOLE
+        // writer of the `used_for_signing` marker the promotion require_signature
+        // gate reads.
+        .route("/artifacts/:artifact_id/sign", post(sign_artifact))
 }
 
 // --- Request/Response DTOs ---
@@ -440,6 +444,94 @@ fn signing_service(state: &SharedState) -> SigningService {
     SigningService::new(state.db.clone(), &state.config.jwt_secret)
 }
 
+/// Response from a deliberate per-artifact signing action (#2535).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SignArtifactResponse {
+    pub artifact_id: Uuid,
+    /// The active signing key that produced the attestation.
+    pub key_id: Uuid,
+    pub algorithm: String,
+    /// SHA-256 of the produced signature blob (the blob itself is not persisted).
+    pub signature_sha256: String,
+}
+
+/// `POST /api/v1/signing/artifacts/{artifact_id}/sign` — produce an authorized
+/// signature over the artifact's content with the repository's active signing
+/// key and record the attestation the promotion `require_signature` gate reads
+/// (#2535).
+///
+/// This is the ONLY writer of the per-artifact `used_for_signing` marker, and
+/// it is admin-gated: an artifact can satisfy `require_signature` only through a
+/// deliberate, authenticated signing action over its bytes — never as a side
+/// effect of an (anonymous) repository-metadata read. Format-agnostic: signs
+/// content bytes, so it works for every hosted format, not just the
+/// metadata-signing ones. Proxy-cached remote artifacts (no `artifacts` row)
+/// cannot be signed and therefore stay fail-closed under `require_signature`.
+#[utoipa::path(
+    post,
+    path = "/api/v1/signing/artifacts/{artifact_id}/sign",
+    params(
+        ("artifact_id" = Uuid, Path, description = "Artifact ID")
+    ),
+    responses(
+        (status = 200, description = "Artifact signed; attestation recorded", body = SignArtifactResponse),
+        (status = 403, description = "Admin privilege required", body = crate::api::openapi::ErrorResponse),
+        (status = 404, description = "Artifact not found or not eligible for signing", body = crate::api::openapi::ErrorResponse),
+        (status = 409, description = "Repository has no active signing key/config", body = crate::api::openapi::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+async fn sign_artifact(
+    State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
+    Path(artifact_id): Path<Uuid>,
+) -> Result<Json<SignArtifactResponse>> {
+    // Admin-only: writing the attestation the require_signature gate trusts is a
+    // trust-model mutation, same gate as the other signing routes.
+    require_signing_admin(&auth)?;
+
+    // Resolve the artifact and its storage location. Proxy-cached remote objects
+    // are listed with synthetic ids and have no `artifacts` row, so they cannot
+    // be signed -> 404 (fail-closed), consistent with SBOM/scan eligibility.
+    let row: Option<(Uuid, String, String, String)> = sqlx::query_as(
+        "SELECT a.repository_id, a.storage_key, r.storage_backend, r.storage_path
+         FROM artifacts a JOIN repositories r ON r.id = a.repository_id
+         WHERE a.id = $1 AND a.is_deleted = false",
+    )
+    .bind(artifact_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    let (repository_id, storage_key, backend, path) = row.ok_or_else(|| {
+        AppError::NotFound(crate::api::handlers::sbom::ARTIFACT_NOT_ANALYZABLE_MSG.to_string())
+    })?;
+
+    // Fetch the artifact bytes and sign the content.
+    let location = crate::storage::StorageLocation { backend, path };
+    let storage = state.storage_for_repo(&location)?;
+    let content = storage.get(&storage_key).await.map_err(|e| {
+        AppError::NotFound(format!("Artifact content unavailable for signing: {e}"))
+    })?;
+
+    let signed = signing_service(&state)
+        .sign_artifact_content(repository_id, artifact_id, &content, Some(auth.user_id))
+        .await?
+        .ok_or_else(|| {
+            AppError::Conflict(
+                "Repository has no active signing key or signing config; configure one before signing artifacts"
+                    .to_string(),
+            )
+        })?;
+
+    Ok(Json(SignArtifactResponse {
+        artifact_id,
+        key_id: signed.key_id,
+        algorithm: signed.algorithm,
+        signature_sha256: signed.signature_sha256,
+    }))
+}
+
 /// Admin gate shared by the signing-key/repo-config mutation handlers.
 ///
 /// Minting, deleting, revoking, rotating a repository signing key, or writing
@@ -479,6 +571,7 @@ fn signing_config_fields(
         get_repo_signing_config,
         update_repo_signing_config,
         get_repo_public_key,
+        sign_artifact,
     ),
     components(schemas(
         ListKeysQuery,
@@ -486,6 +579,7 @@ fn signing_config_fields(
         UpdateSigningConfigPayload,
         KeyListResponse,
         SigningConfigResponse,
+        SignArtifactResponse,
     ))
 )]
 pub struct SigningApiDoc;
@@ -653,12 +747,31 @@ mod tests {
             "revoke_key",
             "rotate_key",
             "update_repo_signing_config",
+            "sign_artifact",
         ] {
             assert!(
                 signing_handler_body(name).contains("require_signing_admin"),
                 "{name} MUST call require_signing_admin (admin gate) — CWE-862 regression guard"
             );
         }
+    }
+
+    #[test]
+    fn test_non_admin_blocked_from_signing_artifact() {
+        // #2535: POST /signing/artifacts/{id}/sign is the SOLE writer of the
+        // used_for_signing marker the promotion require_signature gate reads.
+        // It must be admin-only, or an unprivileged caller could attest an
+        // artifact and bypass the gate.
+        // (1) the gate rejects a non-admin.
+        match require_signing_admin(&non_admin_jwt()) {
+            Err(AppError::Authorization(_)) => {}
+            other => panic!("expected 403 Authorization for non-admin sign, got {other:?}"),
+        }
+        // (2) load-bearing: pin that sign_artifact ITSELF calls the gate.
+        assert!(
+            signing_handler_body("sign_artifact").contains("require_signing_admin"),
+            "sign_artifact MUST call require_signing_admin (admin gate) — #2535 bypass guard"
+        );
     }
 
     #[test]

--- a/backend/src/services/promotion_policy_service.rs
+++ b/backend/src/services/promotion_policy_service.rs
@@ -611,13 +611,16 @@ impl PromotionPolicyService {
             return Ok(false);
         }
 
-        // Check if the artifact has been signed (has a signing audit entry)
+        // Check if the artifact has been signed (has a signing audit entry).
+        // #2535: require the signing key to still be active so a signature from
+        // a revoked or rotated-away key does not satisfy the gate.
         let signed: bool = sqlx::query_scalar(
             r#"
             SELECT EXISTS(
                 SELECT 1 FROM signing_key_audit ska
                 JOIN signing_keys sk ON sk.id = ska.signing_key_id
                 WHERE sk.repository_id = $2
+                  AND sk.is_active = true
                   AND ska.action = 'used_for_signing'
                   AND ska.details->>'artifact_id' = $1::TEXT
             )
@@ -2123,5 +2126,139 @@ mod tests {
             require_signature: false,
         };
         assert!(cfg.block_unscanned);
+    }
+
+    // =======================================================================
+    // check_artifact_signature: revocation re-gate (#2535)
+    //
+    // DB-backed: requires a live Postgres via DATABASE_URL (a throwaway,
+    // migrated instance — NOT the rig DB). Each test scopes its rows to a
+    // freshly-created repository so it is safe against a shared test database.
+    // =======================================================================
+
+    async fn sig_test_pool() -> Option<PgPool> {
+        let url = std::env::var("DATABASE_URL").ok()?;
+        sqlx::postgres::PgPoolOptions::new()
+            .max_connections(4)
+            .connect(&url)
+            .await
+            .ok()
+    }
+
+    async fn seed_repo(pool: &PgPool) -> Uuid {
+        let key = format!("sig-gate-test-{}", Uuid::new_v4().as_simple());
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO repositories (key, name, format, repo_type, storage_path) \
+             VALUES ($1, $1, 'rpm', 'local', '/tmp/test') RETURNING id",
+        )
+        .bind(&key)
+        .fetch_one(pool)
+        .await
+        .expect("failed to create test repository")
+    }
+
+    async fn seed_artifact(pool: &PgPool, repo: Uuid) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO artifacts \
+                (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $2, 1, repeat('a', 64), 'application/octet-stream', $2) \
+             RETURNING id",
+        )
+        .bind(repo)
+        .bind(format!("pkg-{}.rpm", Uuid::new_v4().as_simple()))
+        .fetch_one(pool)
+        .await
+        .expect("failed to create test artifact")
+    }
+
+    /// Insert a minimal signing_keys row (no real key material is needed: the
+    /// gate never decrypts the key, it only reads `is_active`).
+    async fn seed_key(pool: &PgPool, repo: Uuid, is_active: bool) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO signing_keys \
+                (repository_id, name, key_type, public_key_pem, private_key_enc, is_active) \
+             VALUES ($1, 'gate-test-key', 'rsa', 'pub', '\\x00', $2) RETURNING id",
+        )
+        .bind(repo)
+        .bind(is_active)
+        .fetch_one(pool)
+        .await
+        .expect("failed to create test signing key")
+    }
+
+    async fn seed_signing_config(pool: &PgPool, repo: Uuid, key_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO repository_signing_config (repository_id, signing_key_id, sign_metadata) \
+             VALUES ($1, $2, true)",
+        )
+        .bind(repo)
+        .bind(key_id)
+        .execute(pool)
+        .await
+        .expect("failed to create signing config");
+    }
+
+    async fn seed_used_for_signing(pool: &PgPool, key_id: Uuid, artifact_id: Uuid) {
+        sqlx::query(
+            "INSERT INTO signing_key_audit (signing_key_id, action, details) \
+             VALUES ($1, 'used_for_signing', jsonb_build_object('artifact_id', $2::text))",
+        )
+        .bind(key_id)
+        .bind(artifact_id)
+        .execute(pool)
+        .await
+        .expect("failed to insert used_for_signing audit row");
+    }
+
+    // The gate is satisfied only by a `used_for_signing` row whose key is still
+    // active. The repository keeps an active signing config throughout (so the
+    // gate's signing-config precondition holds), which isolates the revocation
+    // re-gate to the per-artifact signature query itself:
+    //   (a) signed by the active key            -> gate true
+    //   (b) only signed by a revoked/rotated key -> gate false (revocation)
+    //   (c) unsigned                             -> gate false
+    #[tokio::test]
+    async fn check_artifact_signature_requires_active_key() {
+        let Some(pool) = sig_test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let svc = PromotionPolicyService::new(pool.clone());
+        let repo = seed_repo(&pool).await;
+
+        // Active key backs the repo's signing config; a second key is revoked
+        // (models a rotated-away / compromised key that once signed an artifact).
+        let active_key = seed_key(&pool, repo, true).await;
+        let revoked_key = seed_key(&pool, repo, false).await;
+        seed_signing_config(&pool, repo, active_key).await;
+
+        // (c) unsigned artifact: no audit row -> gate false.
+        let unsigned = seed_artifact(&pool, repo).await;
+        assert!(
+            !svc.check_artifact_signature(unsigned, repo)
+                .await
+                .expect("gate query failed"),
+            "unsigned artifact must not satisfy the signature gate"
+        );
+
+        // (a) artifact signed by the ACTIVE key -> gate true.
+        let signed = seed_artifact(&pool, repo).await;
+        seed_used_for_signing(&pool, active_key, signed).await;
+        assert!(
+            svc.check_artifact_signature(signed, repo)
+                .await
+                .expect("gate query failed"),
+            "artifact signed by an active key must satisfy the gate"
+        );
+
+        // (b) artifact whose only signature is from the REVOKED key -> gate false.
+        let stale = seed_artifact(&pool, repo).await;
+        seed_used_for_signing(&pool, revoked_key, stale).await;
+        assert!(
+            !svc.check_artifact_signature(stale, repo)
+                .await
+                .expect("gate query failed"),
+            "a signature from a revoked key must not satisfy the gate"
+        );
     }
 }

--- a/backend/src/services/promotion_rule_service.rs
+++ b/backend/src/services/promotion_rule_service.rs
@@ -614,12 +614,15 @@ impl PromotionRuleService {
         artifact_id: Uuid,
         repository_id: Uuid,
     ) -> Result<bool> {
+        // #2535: require the signing key to still be active so a signature from
+        // a revoked or rotated-away key does not satisfy the gate.
         let signed: bool = sqlx::query_scalar::<_, bool>(
             r#"
             SELECT EXISTS(
                 SELECT 1 FROM signing_key_audit ska
                 JOIN signing_keys sk ON sk.id = ska.signing_key_id
                 WHERE sk.repository_id = $2
+                  AND sk.is_active = true
                   AND ska.action = 'used_for_signing'
                   AND ska.details->>'artifact_id' = $1::TEXT
             )

--- a/backend/src/services/signing_service.rs
+++ b/backend/src/services/signing_service.rs
@@ -589,7 +589,45 @@ impl SigningService {
         .execute(&self.db)
         .await?;
 
+        // #2535: record that this repository's active signing key attested the
+        // artifacts it covers. The promotion `require_signature` gate looks for
+        // a `used_for_signing` audit row per artifact, but nothing ever wrote
+        // one, so the gate was dead (always fail-closed). Writing the rows here
+        // — at the point the key is actually used to sign the repository's
+        // metadata — makes the gate live.
+        self.record_artifacts_signed(key.id, repo_id).await?;
+
         Ok(Some(signature))
+    }
+
+    /// Record a `used_for_signing` audit row tying `key_id` to every artifact
+    /// in `repo_id`, so the promotion `require_signature` gate can see those
+    /// artifacts as signed (#2535).
+    ///
+    /// Idempotent: a row is inserted only for a (key, artifact) pair that does
+    /// not already have one, so repeated metadata signing (e.g. every repodata
+    /// fetch) does not accumulate duplicate audit rows.
+    async fn record_artifacts_signed(&self, key_id: Uuid, repo_id: Uuid) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO signing_key_audit (signing_key_id, action, details)
+            SELECT $1, 'used_for_signing',
+                   jsonb_build_object('artifact_id', a.id::text)
+            FROM artifacts a
+            WHERE a.repository_id = $2
+              AND NOT EXISTS (
+                  SELECT 1 FROM signing_key_audit ska
+                  WHERE ska.signing_key_id = $1
+                    AND ska.action = 'used_for_signing'
+                    AND ska.details->>'artifact_id' = a.id::text
+              )
+            "#,
+        )
+        .bind(key_id)
+        .bind(repo_id)
+        .execute(&self.db)
+        .await?;
+        Ok(())
     }
 
     /// Sign data with a specific key.
@@ -2421,5 +2459,77 @@ mod tests {
 
             current = next.id;
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #2535: sign_data must record a `used_for_signing` audit row per artifact
+    // so the promotion `require_signature` gate is actually satisfiable. The
+    // write is idempotent so repeated metadata signing does not duplicate rows.
+    // -----------------------------------------------------------------------
+
+    async fn seed_artifact(pool: &sqlx::PgPool, repo: Uuid) -> Uuid {
+        sqlx::query_scalar::<_, Uuid>(
+            "INSERT INTO artifacts \
+                (repository_id, path, name, size_bytes, checksum_sha256, content_type, storage_key) \
+             VALUES ($1, $2, $2, 1, repeat('a', 64), 'application/octet-stream', $2) \
+             RETURNING id",
+        )
+        .bind(repo)
+        .bind(format!("pkg-{}.deb", Uuid::new_v4().as_simple()))
+        .fetch_one(pool)
+        .await
+        .expect("failed to create test artifact")
+    }
+
+    /// Count `used_for_signing` rows for a (key, artifact) pair.
+    async fn used_for_signing_count(pool: &sqlx::PgPool, key_id: Uuid, artifact_id: Uuid) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM signing_key_audit \
+             WHERE signing_key_id = $1 AND action = 'used_for_signing' \
+               AND details->>'artifact_id' = $2::text",
+        )
+        .bind(key_id)
+        .bind(artifact_id)
+        .fetch_one(pool)
+        .await
+        .expect("audit count query failed")
+    }
+
+    #[tokio::test]
+    async fn sign_data_records_used_for_signing_idempotently() {
+        let Some(pool) = rotation_test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let service = rotation_test_service(pool.clone());
+        let repo = seed_repo(&pool).await;
+        let key_id = seed_active_key(&service, repo).await;
+        let artifact_id = seed_artifact(&pool, repo).await;
+
+        // No audit row before the key is ever used.
+        assert_eq!(used_for_signing_count(&pool, key_id, artifact_id).await, 0);
+
+        // Signing the repository's metadata records the artifact as signed.
+        let sig = service
+            .sign_data(repo, b"repomd.xml")
+            .await
+            .expect("sign_data failed");
+        assert!(sig.is_some(), "an active key must produce a signature");
+        assert_eq!(
+            used_for_signing_count(&pool, key_id, artifact_id).await,
+            1,
+            "sign_data must record a used_for_signing row for the artifact"
+        );
+
+        // Signing again must not accumulate duplicate rows.
+        service
+            .sign_data(repo, b"repomd.xml v2")
+            .await
+            .expect("sign_data failed");
+        assert_eq!(
+            used_for_signing_count(&pool, key_id, artifact_id).await,
+            1,
+            "repeated signing must not duplicate the audit row"
+        );
     }
 }

--- a/backend/src/services/signing_service.rs
+++ b/backend/src/services/signing_service.rs
@@ -296,6 +296,15 @@ pub struct SigningService {
     encryption: CredentialEncryption,
 }
 
+/// Result of a deliberate per-artifact signing action (#2535). The signature
+/// blob itself is not persisted (marker-only attestation); the returned digest
+/// lets the caller surface what was produced.
+pub struct ArtifactSignature {
+    pub key_id: Uuid,
+    pub algorithm: String,
+    pub signature_sha256: String,
+}
+
 /// Request to create a new signing key.
 pub struct CreateKeyRequest {
     pub repository_id: Option<Uuid>,
@@ -589,42 +598,99 @@ impl SigningService {
         .execute(&self.db)
         .await?;
 
-        // #2535: record that this repository's active signing key attested the
-        // artifacts it covers. The promotion `require_signature` gate looks for
-        // a `used_for_signing` audit row per artifact, but nothing ever wrote
-        // one, so the gate was dead (always fail-closed). Writing the rows here
-        // — at the point the key is actually used to sign the repository's
-        // metadata — makes the gate live.
-        self.record_artifacts_signed(key.id, repo_id).await?;
-
         Ok(Some(signature))
     }
 
-    /// Record a `used_for_signing` audit row tying `key_id` to every artifact
-    /// in `repo_id`, so the promotion `require_signature` gate can see those
-    /// artifacts as signed (#2535).
+    /// Produce a deliberate, authorized signature over an artifact's content
+    /// with the repository's **active** signing key, and record the
+    /// `used_for_signing` marker the promotion `require_signature` gate reads
+    /// (#2535).
     ///
-    /// Idempotent: a row is inserted only for a (key, artifact) pair that does
-    /// not already have one, so repeated metadata signing (e.g. every repodata
-    /// fetch) does not accumulate duplicate audit rows.
-    async fn record_artifacts_signed(&self, key_id: Uuid, repo_id: Uuid) -> Result<()> {
+    /// This is the **sole** writer of the per-artifact marker: it is only
+    /// reachable from the admin-gated `POST /signing/artifacts/:id/sign`
+    /// endpoint, so an artifact can satisfy `require_signature` only through an
+    /// explicit, authenticated signing action over its bytes — never as a side
+    /// effect of an anonymous metadata read.
+    ///
+    /// Returns `Ok(None)` when the repository has no active signing key /
+    /// signing config (the caller maps this to a 409), so a repo that cannot
+    /// sign stays fail-closed. Format-agnostic: signs raw content bytes, so it
+    /// works for maven/npm/pypi/etc., not only the metadata-signing formats.
+    pub async fn sign_artifact_content(
+        &self,
+        repo_id: Uuid,
+        artifact_id: Uuid,
+        content: &[u8],
+        performed_by: Option<Uuid>,
+    ) -> Result<Option<ArtifactSignature>> {
+        let key = match self.get_active_key_for_repo(repo_id).await? {
+            Some(k) => k,
+            None => return Ok(None),
+        };
+
+        // Produce a real content signature with whichever key material the
+        // repo's active key holds.
+        let (signature, algorithm) = if key.key_type == "gpg" {
+            let armored = self.sign_openpgp_detached_with_key(&key, content).await?;
+            (armored.into_bytes(), format!("openpgp:{}", key.algorithm))
+        } else {
+            let sig = self.sign_with_key(&key, content)?;
+            (sig, format!("rsa-pkcs1v15-sha256:{}", key.algorithm))
+        };
+
+        let signature_sha256 = hex::encode(Sha256::digest(&signature));
+
+        self.record_artifact_signature(
+            key.id,
+            artifact_id,
+            performed_by,
+            &algorithm,
+            &signature_sha256,
+        )
+        .await?;
+        self.mark_key_used(key.id).await?;
+
+        Ok(Some(ArtifactSignature {
+            key_id: key.id,
+            algorithm,
+            signature_sha256,
+        }))
+    }
+
+    /// Insert the single `used_for_signing` audit row that attests `artifact_id`
+    /// under `key_id` (#2535). Idempotent on `(key_id, artifact_id)`: re-signing
+    /// the same artifact with the same active key does not accumulate duplicate
+    /// markers.
+    async fn record_artifact_signature(
+        &self,
+        key_id: Uuid,
+        artifact_id: Uuid,
+        performed_by: Option<Uuid>,
+        algorithm: &str,
+        signature_sha256: &str,
+    ) -> Result<()> {
         sqlx::query(
             r#"
-            INSERT INTO signing_key_audit (signing_key_id, action, details)
-            SELECT $1, 'used_for_signing',
-                   jsonb_build_object('artifact_id', a.id::text)
-            FROM artifacts a
-            WHERE a.repository_id = $2
-              AND NOT EXISTS (
-                  SELECT 1 FROM signing_key_audit ska
-                  WHERE ska.signing_key_id = $1
-                    AND ska.action = 'used_for_signing'
-                    AND ska.details->>'artifact_id' = a.id::text
-              )
+            INSERT INTO signing_key_audit (signing_key_id, action, performed_by, details)
+            SELECT $1, 'used_for_signing', $2,
+                   jsonb_build_object(
+                       'artifact_id', $3::text,
+                       'algorithm', $4::text,
+                       'signature_sha256', $5::text
+                   )
+            WHERE NOT EXISTS (
+                SELECT 1 FROM signing_key_audit ska
+                WHERE ska.signing_key_id = $1
+                  AND ska.action = 'used_for_signing'
+                  AND ska.details->>'artifact_id' = $3::text
+            )
             "#,
         )
         .bind(key_id)
-        .bind(repo_id)
+        .bind(performed_by)
+        .bind(artifact_id)
+        .bind(algorithm)
+        .bind(signature_sha256)
         .execute(&self.db)
         .await?;
         Ok(())
@@ -2462,9 +2528,9 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // #2535: sign_data must record a `used_for_signing` audit row per artifact
-    // so the promotion `require_signature` gate is actually satisfiable. The
-    // write is idempotent so repeated metadata signing does not duplicate rows.
+    // #2535: the per-artifact `used_for_signing` marker (read by the promotion
+    // `require_signature` gate) is written ONLY by the deliberate, authorized
+    // `sign_artifact_content` path — never by metadata signing (`sign_data`).
     // -----------------------------------------------------------------------
 
     async fn seed_artifact(pool: &sqlx::PgPool, repo: Uuid) -> Uuid {
@@ -2495,8 +2561,10 @@ mod tests {
         .expect("audit count query failed")
     }
 
+    // A deliberate per-artifact signing action writes exactly one marker for the
+    // artifact under the repo's active key, and is idempotent on repeat.
     #[tokio::test]
-    async fn sign_data_records_used_for_signing_idempotently() {
+    async fn sign_artifact_content_writes_single_idempotent_marker() {
         let Some(pool) = rotation_test_pool().await else {
             eprintln!("skipping: DATABASE_URL not set");
             return;
@@ -2506,30 +2574,105 @@ mod tests {
         let key_id = seed_active_key(&service, repo).await;
         let artifact_id = seed_artifact(&pool, repo).await;
 
-        // No audit row before the key is ever used.
+        // No marker before the artifact is deliberately signed.
         assert_eq!(used_for_signing_count(&pool, key_id, artifact_id).await, 0);
 
-        // Signing the repository's metadata records the artifact as signed.
+        // `performed_by` is left None here (the rotation harness seeds no users
+        // row and the column is FK-constrained + nullable); the handler passes
+        // the authenticated admin's id in production.
+        let out = service
+            .sign_artifact_content(repo, artifact_id, b"artifact-bytes", None)
+            .await
+            .expect("sign_artifact_content failed")
+            .expect("an active key must produce a signature");
+        assert_eq!(out.key_id, key_id);
+        assert!(!out.signature_sha256.is_empty());
+        assert_eq!(
+            used_for_signing_count(&pool, key_id, artifact_id).await,
+            1,
+            "signing an artifact must record exactly one marker"
+        );
+
+        // Re-signing the same artifact with the same active key is idempotent.
+        service
+            .sign_artifact_content(repo, artifact_id, b"artifact-bytes-again", None)
+            .await
+            .expect("sign_artifact_content failed")
+            .expect("still signable");
+        assert_eq!(
+            used_for_signing_count(&pool, key_id, artifact_id).await,
+            1,
+            "repeated signing must not duplicate the marker"
+        );
+    }
+
+    // A repository with no active signing key / config cannot sign -> Ok(None)
+    // (the handler maps this to a 409 and the artifact stays fail-closed).
+    #[tokio::test]
+    async fn sign_artifact_content_without_active_key_returns_none() {
+        let Some(pool) = rotation_test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let service = rotation_test_service(pool.clone());
+        let repo = seed_repo(&pool).await;
+        let artifact_id = seed_artifact(&pool, repo).await;
+
+        let out = service
+            .sign_artifact_content(repo, artifact_id, b"bytes", None)
+            .await
+            .expect("sign_artifact_content failed");
+        assert!(out.is_none(), "no active key -> None (fail-closed)");
+
+        // No marker exists for the artifact under ANY key.
+        let markers: i64 = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM signing_key_audit \
+             WHERE action = 'used_for_signing' AND details->>'artifact_id' = $1::text",
+        )
+        .bind(artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count failed");
+        assert_eq!(markers, 0, "an unsignable repo must attest nothing");
+    }
+
+    // Regression guard against PR #2553 Part B: metadata signing (`sign_data`)
+    // must NEVER write a per-artifact `used_for_signing` marker. An anonymous
+    // metadata read must not be able to attest artifacts.
+    #[tokio::test]
+    async fn sign_data_writes_no_used_for_signing_marker() {
+        let Some(pool) = rotation_test_pool().await else {
+            eprintln!("skipping: DATABASE_URL not set");
+            return;
+        };
+        let service = rotation_test_service(pool.clone());
+        let repo = seed_repo(&pool).await;
+        let key_id = seed_active_key(&service, repo).await;
+        let artifact_id = seed_artifact(&pool, repo).await;
+
         let sig = service
             .sign_data(repo, b"repomd.xml")
             .await
             .expect("sign_data failed");
-        assert!(sig.is_some(), "an active key must produce a signature");
-        assert_eq!(
-            used_for_signing_count(&pool, key_id, artifact_id).await,
-            1,
-            "sign_data must record a used_for_signing row for the artifact"
+        assert!(
+            sig.is_some(),
+            "metadata signing must still produce a signature"
         );
 
-        // Signing again must not accumulate duplicate rows.
-        service
-            .sign_data(repo, b"repomd.xml v2")
-            .await
-            .expect("sign_data failed");
+        // But it must attest NO artifact.
         assert_eq!(
             used_for_signing_count(&pool, key_id, artifact_id).await,
-            1,
-            "repeated signing must not duplicate the audit row"
+            0,
+            "sign_data must not write a used_for_signing marker (anon-read attestation bypass)"
         );
+        let total: i64 = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM signing_key_audit \
+             WHERE signing_key_id = $1 AND action = 'used_for_signing'",
+        )
+        .bind(key_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count failed");
+        assert_eq!(total, 0, "metadata signing must attest zero artifacts");
     }
 }


### PR DESCRIPTION
## Summary

Closes #2535.

The promotion `require_signature` gate reads a per-artifact `used_for_signing`
marker that nothing legitimately wrote, so the gate was permanently
unsatisfiable (fail-closed) for every format. This PR makes it satisfiable
**only through a deliberate, authenticated, authorized signing action over an
artifact's content** — and keeps it revocation-aware.

### Changes

- **New authorized signing surface.** `POST /api/v1/signing/artifacts/{artifact_id}/sign`
  (in the already-`auth_middleware`-gated signing router, guarded by the same
  `require_signing_admin` gate as the other key-management routes). It resolves
  the artifact's repository + storage location, fetches the content bytes, signs
  them with the repository's **active** signing key, and records the
  `used_for_signing` audit row the gate reads (`performed_by` = caller,
  `details.artifact_id` / `.algorithm` / `.signature_sha256`). It is the **sole**
  writer of that marker. Format-agnostic (signs content bytes → works for
  maven/npm/pypi/etc., not just the metadata-signing formats), which also fixes
  the residual case where `require_signature` was unsatisfiable for
  non-metadata-signing formats. Proxy-cached remote artifacts have no `artifacts`
  row and return 404 → they stay fail-closed. No active key/config → 409.
- **Revocation re-gate (retained).** Both `check_artifact_signature` queries
  (`promotion_policy_service.rs`, `promotion_rule_service.rs`) require
  `sk.is_active = true`, so a signature from a revoked/rotated-away key no longer
  satisfies the gate.
- **Metadata signing no longer attests artifacts.** `sign_data` (the repo
  metadata `.asc`/`InRelease`/APKINDEX path) writes no per-artifact marker.

No schema change (the `used_for_signing` action + `details` JSONB already exist
in `027_signing_keys.sql`). No new `sqlx::query!` macros (the new writer and the
handler use the runtime query builder), so the offline `.sqlx` cache is
unaffected.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

- `signing_service::sign_artifact_content_writes_single_idempotent_marker` — the
  authorized path writes exactly one marker per `(key, artifact)`, idempotent.
- `signing_service::sign_artifact_content_without_active_key_returns_none` — an
  unsignable repo attests nothing (fail-closed).
- `signing_service::sign_data_writes_no_used_for_signing_marker` — metadata
  signing must attest zero artifacts (guards against attestation via reads).
- `signing::test_non_admin_blocked_from_signing_artifact` +
  `test_every_signing_mutation_handler_requires_admin` — the sign endpoint is
  admin-gated.
- `promotion_policy_service::check_artifact_signature_requires_active_key` —
  active-key signature satisfies the gate; revoked-key signature and unsigned do
  not.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full lib suite green (`cargo nextest run --lib`): 13170 passed, 5 skipped.
`cargo fmt`, `cargo clippy -- -D warnings`, and jscpd (no duplication in changed
files) all clean.

Manual end-to-end verification against an isolated patched instance:
- an anonymous read of the repo metadata signature (`.asc`) attests **no**
  artifact → an unsigned artifact still fails `require_signature`;
- admin `POST /signing/artifacts/{id}/sign` → the artifact then passes;
- anonymous / non-admin calls to the sign endpoint → 401 / 403 (no marker
  written);
- signed artifact whose key is then revoked → fails again;
- a maven artifact signs and passes (format-agnostic).

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes