### PR TITLE
fix(ingestion): bound archive decompression during upload/serve metadata extraction

### DIFF
--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -492,40 +492,19 @@ use crate::formats::cocoapods::PodSpec;
 /// Scans the archive entries for any file ending in `.podspec.json` and
 /// deserializes it into a PodSpec.
 fn extract_podspec_from_archive(data: &[u8]) -> Result<PodSpec, String> {
-    use flate2::read::GzDecoder;
-    use std::io::Read;
-    use tar::Archive;
+    // Bound the gzip/tar decompression: total-byte budget + entry-count cap +
+    // per-metadata-entry cap so a crafted pod archive cannot inflate unbounded
+    // during metadata parsing (#2556).
+    let contents = crate::util::bounded_archive::read_metadata_from_tar_gz(data, |path| {
+        path.to_string_lossy().ends_with(".podspec.json")
+    })
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "No .podspec.json found in archive".to_string())?;
 
-    let gz = GzDecoder::new(data);
-    let mut archive = Archive::new(gz);
+    let podspec: PodSpec =
+        serde_json::from_slice(&contents).map_err(|e| format!("Invalid podspec JSON: {}", e))?;
 
-    let entries = archive
-        .entries()
-        .map_err(|e| format!("Failed to read archive: {}", e))?;
-
-    for entry in entries {
-        let mut entry = entry.map_err(|e| format!("Failed to read entry: {}", e))?;
-
-        let path = entry
-            .path()
-            .map_err(|e| format!("Failed to read path: {}", e))?
-            .to_string_lossy()
-            .to_string();
-
-        if path.ends_with(".podspec.json") {
-            let mut contents = Vec::new();
-            entry
-                .read_to_end(&mut contents)
-                .map_err(|e| format!("Failed to read podspec: {}", e))?;
-
-            let podspec: PodSpec = serde_json::from_slice(&contents)
-                .map_err(|e| format!("Invalid podspec JSON: {}", e))?;
-
-            return Ok(podspec);
-        }
-    }
-
-    Err("No .podspec.json found in archive".to_string())
+    Ok(podspec)
 }
 
 #[cfg(test)]

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -2591,8 +2591,12 @@ fn validate_conda_package(content: &[u8], filename: &str) -> Result<(), String> 
             return Err("Invalid .conda package: missing info-*.tar.zst archive".to_string());
         }
     } else if filename.ends_with(".tar.bz2") {
-        // Validate .tar.bz2 v1 structure
-        let decoder = bzip2::read::BzDecoder::new(std::io::Cursor::new(content));
+        // Validate .tar.bz2 v1 structure. Wrap the bzip2 stream in the shared
+        // total-byte budget (#2556) so a crafted v1 package cannot inflate
+        // unbounded while we walk it looking for info/index.json.
+        let decoder = crate::util::bounded_archive::budgeted(bzip2::read::BzDecoder::new(
+            std::io::Cursor::new(content),
+        ));
         let mut archive = tar::Archive::new(decoder);
 
         let entries = archive
@@ -2736,14 +2740,19 @@ fn extract_conda_v2_metadata(content: &[u8]) -> Option<serde_json::Value> {
     let cursor = std::io::Cursor::new(content);
     let mut archive = zip::ZipArchive::new(cursor).ok()?;
 
-    // First try metadata.json at the root of the ZIP
-    if let Ok(mut file) = archive.by_name("metadata.json") {
-        let mut buf = String::new();
-        std::io::Read::read_to_string(&mut file, &mut buf).ok()?;
-        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&buf) {
-            // metadata.json may only have name/version; look for index.json in info tar
-            if val.get("depends").is_some() {
-                return Some(val);
+    // First try metadata.json at the root of the ZIP. Cap the entry read so a
+    // crafted zip entry cannot buffer unbounded (#2556).
+    if let Ok(file) = archive.by_name("metadata.json") {
+        if let Ok(buf) = crate::util::bounded_archive::read_capped(
+            file,
+            crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES,
+            "conda metadata.json",
+        ) {
+            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(&buf) {
+                // metadata.json may only have name/version; look for index.json in info tar
+                if val.get("depends").is_some() {
+                    return Some(val);
+                }
             }
         }
     }
@@ -2755,10 +2764,18 @@ fn extract_conda_v2_metadata(content: &[u8]) -> Option<serde_json::Value> {
 
     for (idx, name) in &file_names {
         if name.starts_with("info-") && name.ends_with(".tar.zst") {
-            let mut file = archive.by_index(*idx).ok()?;
-            let mut compressed = Vec::new();
-            std::io::Read::read_to_end(&mut file, &mut compressed).ok()?;
-            drop(file);
+            let file = archive.by_index(*idx).ok()?;
+            // Cap the read of the compressed inner archive so a crafted zip
+            // entry cannot buffer unbounded before we even reach zstd (#2556).
+            // The info tar carries only small metadata files, so the per-entry
+            // cap is generous; the actual package payload lives in pkg-*.tar.zst
+            // which we never read here.
+            let compressed = crate::util::bounded_archive::read_capped(
+                file,
+                crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES,
+                "conda info-*.tar.zst",
+            )
+            .ok()?;
 
             // Decompress the zstd tar with size limit
             let decompressed = limited_decode_zstd(&compressed, MAX_DECOMPRESSED_METADATA_SIZE)?;
@@ -2773,9 +2790,14 @@ fn extract_conda_v2_metadata(content: &[u8]) -> Option<serde_json::Value> {
                 let mut entry = entry.ok()?;
                 let path = entry.path().ok()?.to_string_lossy().to_string();
                 if path == "info/index.json" || path.ends_with("/index.json") {
-                    let mut buf = String::new();
-                    std::io::Read::read_to_string(&mut entry, &mut buf).ok()?;
-                    return serde_json::from_str(&buf).ok();
+                    // Cap the inner index.json read too (#2556).
+                    let buf = crate::util::bounded_archive::read_capped(
+                        &mut entry,
+                        crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES,
+                        "conda info/index.json",
+                    )
+                    .ok()?;
+                    return serde_json::from_slice(&buf).ok();
                 }
             }
         }
@@ -2788,25 +2810,14 @@ fn extract_conda_v2_metadata(content: &[u8]) -> Option<serde_json::Value> {
 ///
 /// The package is a bzip2-compressed tar containing `info/index.json`.
 fn extract_conda_v1_metadata(content: &[u8]) -> Option<serde_json::Value> {
-    let decoder = bzip2::read::BzDecoder::new(std::io::Cursor::new(content));
-    let mut archive = tar::Archive::new(decoder);
-
-    let mut entries_checked = 0;
-    for entry in archive.entries().ok()? {
-        entries_checked += 1;
-        if entries_checked > MAX_TAR_ENTRIES {
-            break;
-        }
-        let mut entry = entry.ok()?;
-        let path = entry.path().ok()?.to_string_lossy().to_string();
-        if path == "info/index.json" {
-            let mut buf = String::new();
-            std::io::Read::read_to_string(&mut entry, &mut buf).ok()?;
-            return serde_json::from_str(&buf).ok();
-        }
-    }
-
-    None
+    // Route through the shared bounded bz2/tar extractor: total-byte budget +
+    // entry-count cap + per-metadata-entry cap (#2556) close the v1 gap (which
+    // previously had only an entry-count cap and no total-byte cap).
+    let bytes = crate::util::bounded_archive::read_metadata_from_tar_bz2(content, |path| {
+        path == std::path::Path::new("info/index.json")
+    })
+    .ok()??;
+    serde_json::from_slice(&bytes).ok()
 }
 
 // ---------------------------------------------------------------------------
@@ -4503,6 +4514,39 @@ mod tests {
             "Valid .tar.bz2 package should pass: {:?}",
             result
         );
+    }
+
+    /// #2556: a v1 `.tar.bz2` whose `info/index.json` inflates past the
+    /// per-metadata-entry cap must not buffer unbounded during extraction; it
+    /// returns None (bounded) rather than exhausting memory. The compressed bz2
+    /// stays tiny, proving the cap bounds the decompressed size.
+    #[test]
+    fn test_extract_conda_v1_oversized_index_bounded_2556() {
+        let pad = "A".repeat(
+            (crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES + 1024) as usize,
+        );
+        let huge = serde_json::json!({
+            "name": "p", "version": "1", "build": "0", "pad": pad,
+        });
+        let package = build_test_conda_v1_package(&huge);
+        assert!(package.len() < 256 * 1024, "compressed bz2 stays tiny");
+        assert!(
+            extract_conda_v1_metadata(&package).is_none(),
+            "oversized v1 index must be bounded (None)"
+        );
+    }
+
+    /// #2556 regression: a normal v1 package still extracts its metadata after
+    /// the hardening.
+    #[test]
+    fn test_extract_conda_v1_normal_still_parses_2556() {
+        let index = serde_json::json!({
+            "name": "numpy", "version": "1.2.3", "build": "0", "depends": [],
+        });
+        let package = build_test_conda_v1_package(&index);
+        let meta = extract_conda_v1_metadata(&package).expect("normal v1 parses");
+        assert_eq!(meta.get("name").and_then(|v| v.as_str()), Some("numpy"));
+        assert_eq!(meta.get("version").and_then(|v| v.as_str()), Some("1.2.3"));
     }
 
     /// Regression (#1782): the uploaded filename must match the embedded

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -956,35 +956,24 @@ fn build_versions_response(
 ///
 /// We parse the metadata.config to extract the name and version fields.
 fn extract_name_version_from_tarball(data: &[u8]) -> Result<(String, String), String> {
-    let mut archive = tar::Archive::new(data);
+    // Bound the (plain) tar walk: entry-count cap + per-metadata-entry cap so a
+    // crafted tarball cannot buffer an unbounded metadata.config during parsing
+    // (#2556).
+    let content = crate::util::bounded_archive::read_metadata_from_tar(data, |path| {
+        path == std::path::Path::new("metadata.config")
+    })
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "metadata.config not found in tarball".to_string())?;
 
-    let entries = archive
-        .entries()
-        .map_err(|e| format!("Failed to read tarball entries: {}", e))?;
+    let content =
+        String::from_utf8(content).map_err(|e| format!("Failed to read metadata.config: {}", e))?;
 
-    for entry_result in entries {
-        let mut entry = entry_result.map_err(|e| format!("Failed to read tar entry: {}", e))?;
-        let path = entry
-            .path()
-            .map_err(|e| format!("Failed to read entry path: {}", e))?
-            .to_string_lossy()
-            .to_string();
+    let name = extract_erlang_term_value(&content, "name")
+        .ok_or_else(|| "Missing 'name' in metadata.config".to_string())?;
+    let version = extract_erlang_term_value(&content, "version")
+        .ok_or_else(|| "Missing 'version' in metadata.config".to_string())?;
 
-        if path == "metadata.config" {
-            let mut content = String::new();
-            std::io::Read::read_to_string(&mut entry, &mut content)
-                .map_err(|e| format!("Failed to read metadata.config: {}", e))?;
-
-            let name = extract_erlang_term_value(&content, "name")
-                .ok_or_else(|| "Missing 'name' in metadata.config".to_string())?;
-            let version = extract_erlang_term_value(&content, "version")
-                .ok_or_else(|| "Missing 'version' in metadata.config".to_string())?;
-
-            return Ok((name, version));
-        }
-    }
-
-    Err("metadata.config not found in tarball".to_string())
+    Ok((name, version))
 }
 
 /// Extract a string value from Erlang term format metadata.

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -11,7 +11,6 @@
 //!   GET  /nuget/{repo_key}/v3/flatcontainer/{id}/{version}/{id}.{version}.nupkg — Download
 //!   PUT  /nuget/{repo_key}/api/v2/package                                     — Push package
 
-use std::io::Read;
 use std::sync::Arc;
 
 use axum::body::Body;
@@ -1073,21 +1072,17 @@ struct NuspecInfo {
 fn parse_nuspec_from_reader<R: std::io::Read + std::io::Seek>(
     reader: R,
 ) -> Result<NuspecInfo, String> {
-    let mut archive =
-        zip::ZipArchive::new(reader).map_err(|e| format!("Invalid ZIP archive: {}", e))?;
-
-    // Find the .nuspec file inside the archive.
-    let mut nuspec_xml = String::new();
-    for i in 0..archive.len() {
-        let mut file = archive
-            .by_index(i)
-            .map_err(|e| format!("Cannot read ZIP entry: {}", e))?;
-        if file.name().ends_with(".nuspec") {
-            file.read_to_string(&mut nuspec_xml)
-                .map_err(|e| format!("Cannot read .nuspec: {}", e))?;
-            break;
-        }
-    }
+    // Bound the decompression: entry-count cap + per-metadata-entry cap so a
+    // crafted .nupkg cannot inflate the .nuspec unbounded during metadata
+    // parsing (#2556). Zip is random-access, so unmatched entries are never
+    // inflated.
+    let nuspec_bytes = crate::util::bounded_archive::read_metadata_from_zip(reader, |name| {
+        name.ends_with(".nuspec")
+    })
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "No .nuspec file found in package".to_string())?;
+    let nuspec_xml =
+        String::from_utf8(nuspec_bytes).map_err(|e| format!("Cannot read .nuspec: {}", e))?;
 
     if nuspec_xml.is_empty() {
         return Err("No .nuspec file found in package".to_string());
@@ -1480,6 +1475,32 @@ mod tests {
         assert_eq!(nuspec.version, "1.2.3");
         assert_eq!(nuspec.description, "A test package");
         assert_eq!(nuspec.authors, "Test Author");
+    }
+
+    #[test]
+    fn test_parse_nuspec_oversized_entry_rejected_2556() {
+        // A .nuspec entry that inflates past the per-metadata-entry cap is a
+        // decompression bomb and must be rejected (bounded memory), while the
+        // compressed .nupkg stays tiny (highly repetitive deflate payload).
+        let buf = Vec::new();
+        let cursor = std::io::Cursor::new(buf);
+        let mut zip = zip::ZipWriter::new(cursor);
+        let options = zip::write::SimpleFileOptions::default();
+        zip.start_file("Big.nuspec", options).unwrap();
+        let oversized = vec![
+            b'A';
+            (crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES + 1024)
+                as usize
+        ];
+        std::io::Write::write_all(&mut zip, &oversized).unwrap();
+        let cursor = zip.finish().unwrap();
+        assert!(
+            cursor.get_ref().len() < 128 * 1024,
+            "compressed nupkg is tiny"
+        );
+
+        let result = parse_nuspec_from_nupkg(cursor.get_ref());
+        assert!(result.is_err(), "oversized .nuspec must be rejected");
     }
 
     #[test]

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -15,7 +15,7 @@
 //!   POST /:repo_key/buf.registry.module.v1.GraphService/GetGraph
 //!   POST /:repo_key/buf.registry.module.v1.ResourceService/GetResources
 
-use std::io::{Read, Write};
+use std::io::Write;
 
 use axum::body::Body;
 use axum::extract::{DefaultBodyLimit, Path, State};
@@ -554,10 +554,20 @@ fn build_bundle(files: &[UploadFile]) -> Result<Vec<u8>, Response> {
 
 #[allow(clippy::result_large_err)]
 fn extract_files_from_bundle(data: &[u8]) -> Result<Vec<DownloadFile>, Response> {
+    use crate::util::bounded_archive::{
+        budgeted, read_capped, MAX_INGEST_ARCHIVE_ENTRIES, MAX_INGEST_METADATA_ENTRY_BYTES,
+    };
+
+    // This extractor reads EVERY entry into memory and base64-encodes it (~1.33x
+    // amplification on top of decompression), so it is the worst in-memory site.
+    // Wrap the gzip stream in the shared total-byte budget (#2556) so a crafted
+    // bundle aborts mid-inflate, and enforce the entry-count + per-entry caps so
+    // worst-case buffered memory is deterministic.
     let gz_decoder = GzDecoder::new(data);
-    let mut archive = tar::Archive::new(gz_decoder);
+    let mut archive = tar::Archive::new(budgeted(gz_decoder));
 
     let mut files = Vec::new();
+    let mut entries_seen: u64 = 0;
 
     for entry_result in archive.entries().map_err(|e| {
         connect_error(
@@ -574,6 +584,18 @@ fn extract_files_from_bundle(data: &[u8]) -> Result<Vec<DownloadFile>, Response>
             )
         })?;
 
+        entries_seen += 1;
+        if entries_seen > MAX_INGEST_ARCHIVE_ENTRIES {
+            return Err(connect_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_argument",
+                &format!(
+                    "Bundle contains too many entries (> {}); refusing suspected decompression bomb",
+                    MAX_INGEST_ARCHIVE_ENTRIES
+                ),
+            ));
+        }
+
         let path = entry
             .path()
             .map_err(|e| {
@@ -586,14 +608,10 @@ fn extract_files_from_bundle(data: &[u8]) -> Result<Vec<DownloadFile>, Response>
             .to_string_lossy()
             .to_string();
 
-        let mut content_bytes = Vec::new();
-        entry.read_to_end(&mut content_bytes).map_err(|e| {
-            connect_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "internal",
-                &format!("Failed to read entry content: {}", e),
-            )
-        })?;
+        let content_bytes =
+            read_capped(&mut entry, MAX_INGEST_METADATA_ENTRY_BYTES, "bundle entry").map_err(
+                |e| connect_error(StatusCode::BAD_REQUEST, "invalid_argument", &e.to_string()),
+            )?;
 
         let encoded = base64::engine::general_purpose::STANDARD.encode(&content_bytes);
 
@@ -2127,6 +2145,29 @@ mod tests {
         let extracted = extract_files_from_bundle(&bundle).unwrap();
         assert_eq!(extracted.len(), 1);
         assert_eq!(extracted[0].path, "single.proto");
+    }
+
+    /// #2556: a bundle entry that inflates past the per-entry cap (the worst
+    /// in-memory site: every entry is read + base64-encoded) is rejected with a
+    /// bounded error instead of buffering unbounded. The compressed bundle stays
+    /// tiny (highly repetitive), proving the cap bounds the decompressed size.
+    #[test]
+    fn test_extract_bundle_oversized_entry_rejected_2556() {
+        let oversized = vec![
+            b'A';
+            (crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES + 1024)
+                as usize
+        ];
+        let files = vec![UploadFile {
+            path: "bomb.proto".to_string(),
+            content: base64::engine::general_purpose::STANDARD.encode(&oversized),
+        }];
+        let bundle = build_bundle(&files).unwrap();
+        assert!(bundle.len() < 256 * 1024, "compressed bundle stays tiny");
+        assert!(
+            extract_files_from_bundle(&bundle).is_err(),
+            "oversized bundle entry must be rejected"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -964,39 +964,24 @@ async fn proxy_pub_meta_get(
 fn extract_pubspec_from_reader<R: std::io::Read>(
     reader: R,
 ) -> Result<crate::formats::r#pub::PubSpec, String> {
-    use flate2::read::GzDecoder;
-    use std::io::Read;
-    use tar::Archive;
+    // Bound the gzip/tar decompression: total-byte budget + entry-count cap +
+    // per-metadata-entry cap so a crafted package cannot inflate unbounded
+    // during metadata parsing (#2556).
+    let contents = crate::util::bounded_archive::read_metadata_from_tar_gz(reader, |path| {
+        path.file_name()
+            .map(|n| n == "pubspec.yaml")
+            .unwrap_or(false)
+    })
+    .map_err(|e| e.to_string())?
+    .ok_or_else(|| "pubspec.yaml not found in archive".to_string())?;
 
-    let decoder = GzDecoder::new(reader);
-    let mut archive = Archive::new(decoder);
+    let contents =
+        String::from_utf8(contents).map_err(|e| format!("Failed to read pubspec.yaml: {}", e))?;
 
-    let entries = archive
-        .entries()
-        .map_err(|e| format!("Failed to read archive: {}", e))?;
+    let pubspec: crate::formats::r#pub::PubSpec = serde_yaml::from_str(&contents)
+        .map_err(|e| format!("Failed to parse pubspec.yaml: {}", e))?;
 
-    for entry in entries {
-        let mut entry = entry.map_err(|e| format!("Failed to read archive entry: {}", e))?;
-        let path = entry
-            .path()
-            .map_err(|e| format!("Failed to read entry path: {}", e))?
-            .to_string_lossy()
-            .to_string();
-
-        if path == "pubspec.yaml" || path.ends_with("/pubspec.yaml") {
-            let mut contents = String::new();
-            entry
-                .read_to_string(&mut contents)
-                .map_err(|e| format!("Failed to read pubspec.yaml: {}", e))?;
-
-            let pubspec: crate::formats::r#pub::PubSpec = serde_yaml::from_str(&contents)
-                .map_err(|e| format!("Failed to parse pubspec.yaml: {}", e))?;
-
-            return Ok(pubspec);
-        }
-    }
-
-    Err("pubspec.yaml not found in archive".to_string())
+    Ok(pubspec)
 }
 
 /// Extract pubspec.yaml from a staged tar.gz archive on disk. The blocking

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2316,33 +2316,25 @@ async fn serve_metadata(
 }
 
 fn extract_metadata_from_wheel(content: &[u8]) -> Option<String> {
+    // Bound the zip decompression (#2556): a crafted wheel served via PEP 658
+    // `.metadata` cannot inflate the METADATA entry unbounded. On a cap breach
+    // this returns None -> a bounded "Metadata not available" response instead
+    // of an unbounded inflate.
     let cursor = std::io::Cursor::new(content);
-    let mut archive = zip::ZipArchive::new(cursor).ok()?;
-    for i in 0..archive.len() {
-        let mut file = archive.by_index(i).ok()?;
-        if file.name().contains(".dist-info/") && file.name().ends_with("METADATA") {
-            let mut text = String::new();
-            std::io::Read::read_to_string(&mut file, &mut text).ok()?;
-            return Some(text);
-        }
-    }
-    None
+    let bytes = crate::util::bounded_archive::read_metadata_from_zip(cursor, |name| {
+        name.contains(".dist-info/") && name.ends_with("METADATA")
+    })
+    .ok()??;
+    String::from_utf8(bytes).ok()
 }
 
 fn extract_metadata_from_sdist(content: &[u8]) -> Option<String> {
-    use flate2::read::GzDecoder;
-    let gz = GzDecoder::new(content);
-    let mut archive = tar::Archive::new(gz);
-    for entry in archive.entries().ok()? {
-        let mut entry = entry.ok()?;
-        let path = entry.path().ok()?.to_path_buf();
-        if path.ends_with("PKG-INFO") {
-            let mut text = String::new();
-            std::io::Read::read_to_string(&mut entry, &mut text).ok()?;
-            return Some(text);
-        }
-    }
-    None
+    // Bound the gzip/tar decompression (#2556) for the served sdist PKG-INFO.
+    let bytes = crate::util::bounded_archive::read_metadata_from_tar_gz(content, |path| {
+        path.ends_with("PKG-INFO")
+    })
+    .ok()??;
+    String::from_utf8(bytes).ok()
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -431,7 +431,10 @@ async fn query_local_member_specs(
 /// Decompress gzipped upstream spec data and parse as a JSON array of spec tuples.
 #[allow(clippy::result_large_err)]
 fn parse_upstream_specs(bytes: &[u8]) -> Result<Vec<serde_json::Value>, Response> {
-    let mut decoder = GzDecoder::new(bytes);
+    // Wrap the upstream gzip stream in the shared total-byte budget (#2556) so a
+    // malicious/compromised upstream index cannot inflate unbounded during a
+    // virtual/remote proxy fetch.
+    let mut decoder = crate::util::bounded_archive::budgeted(GzDecoder::new(bytes));
     let mut decompressed = Vec::new();
     decoder.read_to_end(&mut decompressed).map_err(|_| {
         (

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -84,6 +84,17 @@ fn extract_manifest_from_zip(zip_bytes: &[u8]) -> Option<String> {
         }
     };
 
+    // Defence-in-depth entry-count cap (#2556): the per-entry byte cap already
+    // bounds memory, but reject entry-count bombs before walking the archive.
+    if archive.len() as u64 > crate::util::bounded_archive::MAX_INGEST_ARCHIVE_ENTRIES {
+        tracing::debug!(
+            entries = archive.len(),
+            cap = crate::util::bounded_archive::MAX_INGEST_ARCHIVE_ENTRIES,
+            "swift manifest extraction: too many zip entries"
+        );
+        return None;
+    }
+
     // Pass 1: top-level Package.swift wins. This is the layout produced by
     // `swift package archive-source` and most CI helpers.
     // Pass 2: any `<single-prefix>/Package.swift` (one directory deep).

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -96,31 +96,23 @@ impl ComposerHandler {
     }
 
     /// Parse composer.json from a package archive to extract metadata.
+    ///
+    /// The uploaded zip's `composer.json` is read through the shared bounded
+    /// extractor (#2556): the entry-count cap + per-metadata-entry cap bound the
+    /// read so a crafted package cannot inflate the entry unbounded during
+    /// metadata parsing (previously an unbounded `read_to_string`).
     pub fn parse_composer_json(content: &[u8]) -> Result<ComposerJson> {
-        // Try to read as zip and find composer.json
-        let reader = std::io::Cursor::new(content);
-        let mut archive = zip::ZipArchive::new(reader)
-            .map_err(|e| AppError::Validation(format!("Invalid zip archive: {}", e)))?;
+        let bytes = crate::util::bounded_archive::read_metadata_from_zip(
+            std::io::Cursor::new(content),
+            |name| name.ends_with("composer.json"),
+        )?
+        .ok_or_else(|| AppError::Validation("composer.json not found in archive".to_string()))?;
 
-        for i in 0..archive.len() {
-            let mut file = archive
-                .by_index(i)
-                .map_err(|e| AppError::Validation(format!("Invalid zip entry: {}", e)))?;
+        let content = String::from_utf8(bytes)
+            .map_err(|e| AppError::Validation(format!("Failed to read composer.json: {}", e)))?;
 
-            if file.name().ends_with("composer.json") {
-                let mut content = String::new();
-                std::io::Read::read_to_string(&mut file, &mut content).map_err(|e| {
-                    AppError::Validation(format!("Failed to read composer.json: {}", e))
-                })?;
-
-                return serde_json::from_str(&content)
-                    .map_err(|e| AppError::Validation(format!("Invalid composer.json: {}", e)));
-            }
-        }
-
-        Err(AppError::Validation(
-            "composer.json not found in archive".to_string(),
-        ))
+        serde_json::from_str(&content)
+            .map_err(|e| AppError::Validation(format!("Invalid composer.json: {}", e)))
     }
 }
 
@@ -393,6 +385,43 @@ mod tests {
     fn test_parse_composer_json_empty() {
         let result = ComposerHandler::parse_composer_json(b"");
         assert!(result.is_err());
+    }
+
+    /// Build a composer package zip carrying `composer.json` with `body`.
+    fn composer_zip(body: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut w = zip::ZipWriter::new(&mut cursor);
+            let opts: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            w.start_file("vendor/pkg/composer.json", opts).unwrap();
+            w.write_all(body).unwrap();
+            w.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    #[test]
+    fn test_parse_composer_json_normal_2556() {
+        let zip = composer_zip(br#"{"name":"vendor/pkg","version":"1.2.3"}"#);
+        let parsed = ComposerHandler::parse_composer_json(&zip).expect("normal package parses");
+        assert_eq!(parsed.name, "vendor/pkg");
+    }
+
+    /// #2556: a `composer.json` entry that inflates past the 8 MiB per-metadata
+    /// cap is rejected (bounded memory), while the compressed zip stays tiny.
+    #[test]
+    fn test_parse_composer_json_bomb_rejected_2556() {
+        let mut body = br#"{"name":"vendor/bomb","description":""#.to_vec();
+        body.extend(std::iter::repeat(b'A').take(9 * 1024 * 1024));
+        body.extend_from_slice(br#""}"#);
+        let zip = composer_zip(&body);
+        assert!(zip.len() < 256 * 1024, "compressed composer zip stays tiny");
+        assert!(
+            ComposerHandler::parse_composer_json(&zip).is_err(),
+            "oversized composer.json must be rejected"
+        );
     }
 
     // ---- ComposerJson serde ----

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -10,7 +10,6 @@ use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::Read;
-use tar::Archive;
 use xz2::read::XzDecoder;
 use zstd::stream::read::Decoder as ZstdDecoder;
 
@@ -207,9 +206,17 @@ impl DebianHandler {
         ))
     }
 
-    /// Parse control.tar(.gz) to extract control file
+    /// Parse control.tar(.gz) to extract control file.
+    ///
+    /// The decompressor is selected from the ar member extension and then routed
+    /// through the shared bounded extractor (#2556): the total-byte budget on
+    /// the DECODED stream aborts a gz/xz/bz2/zstd `control.tar` bomb mid-inflate
+    /// (previously the `read_to_string` on `control` inflated unbounded and only
+    /// returned 400 *after* buffering), and the entry-count + per-entry caps
+    /// bound the walk. xz/zstd amplify hardest, so the decoded-stream budget is
+    /// the primary defence.
     fn parse_control_tar(data: &[u8], member_name: &str) -> Result<DebControl> {
-        let reader: Box<dyn Read + '_> = if member_name.ends_with(".gz") {
+        let decoder: Box<dyn Read + '_> = if member_name.ends_with(".gz") {
             Box::new(GzDecoder::new(data))
         } else if member_name.ends_with(".xz") {
             Box::new(XzDecoder::new(data))
@@ -223,32 +230,18 @@ impl DebianHandler {
             Box::new(data)
         };
 
-        let mut archive = Archive::new(reader);
+        let content =
+            crate::util::bounded_archive::read_metadata_from_decoded_tar(decoder, |path| {
+                path.ends_with("control")
+            })?
+            .ok_or_else(|| {
+                AppError::Validation("control file not found in control.tar".to_string())
+            })?;
 
-        for entry in archive
-            .entries()
-            .map_err(|e| AppError::Validation(format!("Invalid control.tar: {}", e)))?
-        {
-            let mut entry =
-                entry.map_err(|e| AppError::Validation(format!("Invalid tar entry: {}", e)))?;
+        let content = String::from_utf8(content)
+            .map_err(|e| AppError::Validation(format!("Failed to read control file: {}", e)))?;
 
-            let path = entry
-                .path()
-                .map_err(|e| AppError::Validation(format!("Invalid path: {}", e)))?;
-
-            if path.ends_with("control") {
-                let mut content = String::new();
-                entry.read_to_string(&mut content).map_err(|e| {
-                    AppError::Validation(format!("Failed to read control file: {}", e))
-                })?;
-
-                return Self::parse_control(&content);
-            }
-        }
-
-        Err(AppError::Validation(
-            "control file not found in control.tar".to_string(),
-        ))
+        Self::parse_control(&content)
     }
 
     /// Parse Debian control file format
@@ -1191,6 +1184,68 @@ Source: full-pkg-src
         assert_eq!(control.package, "xz-pkg");
         assert_eq!(control.version, "1.0-1");
         assert_eq!(control.architecture, "amd64");
+    }
+
+    /// Build a `control.tar` whose `control` entry itself inflates past the
+    /// 8 MiB per-metadata cap (repeated bytes, so it compresses to a tiny
+    /// "bomb"). The pre-target *total-byte* budget path is covered by the fast
+    /// `bounded_archive` module tests.
+    fn control_tar_bomb(control_prefix: &str) -> Vec<u8> {
+        let mut control = control_prefix.as_bytes().to_vec();
+        // Comment lines keep it a valid-ish control file while blowing past the
+        // 8 MiB per-metadata cap.
+        control.extend(std::iter::repeat(b'#').take(9 * 1024 * 1024));
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut h = tar::Header::new_gnu();
+        h.set_size(control.len() as u64);
+        h.set_mode(0o644);
+        h.set_cksum();
+        builder
+            .append_data(&mut h, "./control", &control[..])
+            .unwrap();
+        builder.finish().unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    /// #2556: a `control.tar.xz` whose `control` inflates past the per-metadata
+    /// cap is rejected mid-inflate (previously unbounded xz `read_to_string`).
+    #[test]
+    fn test_extract_control_xz_bomb_rejected_2556() {
+        use std::io::Write;
+        let tar_bytes = control_tar_bomb("Package: p\nVersion: 1\n");
+        let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 1);
+        encoder.write_all(&tar_bytes).unwrap();
+        let xz = encoder.finish().unwrap();
+        assert!(xz.len() < 1024 * 1024, "xz bomb compresses tiny");
+        let deb = deb_with_control_member("control.tar.xz", &xz);
+        assert!(
+            DebianHandler::extract_control(&deb).is_err(),
+            "xz control bomb must be rejected"
+        );
+    }
+
+    /// #2556: a `control.tar.zst` bomb is likewise rejected.
+    #[test]
+    fn test_extract_control_zst_bomb_rejected_2556() {
+        let tar_bytes = control_tar_bomb("Package: p\nVersion: 1\n");
+        let zst = zstd::encode_all(std::io::Cursor::new(tar_bytes), 1).unwrap();
+        assert!(zst.len() < 1024 * 1024, "zstd bomb compresses tiny");
+        let deb = deb_with_control_member("control.tar.zst", &zst);
+        assert!(
+            DebianHandler::extract_control(&deb).is_err(),
+            "zstd control bomb must be rejected"
+        );
+    }
+
+    /// #2556 regression: a normal `.deb` still parses its control after the
+    /// hardening.
+    #[test]
+    fn test_extract_control_normal_after_hardening_2556() {
+        let control = "Package: normalpkg\nVersion: 2.3.4\nArchitecture: amd64\n";
+        let deb = deb_with_control_member("control.tar", &control_tar(control));
+        let parsed = DebianHandler::extract_control(&deb).expect("normal .deb parses");
+        assert_eq!(parsed.package, "normalpkg");
+        assert_eq!(parsed.version, "2.3.4");
     }
 
     // ========================================================================

--- a/backend/src/formats/helm.rs
+++ b/backend/src/formats/helm.rs
@@ -162,39 +162,41 @@ impl HelmHandler {
     /// the Chart.yaml entry is read (capped by `read_capped_entry_to_string`),
     /// so peak memory is a single metadata entry rather than the full artifact.
     pub fn extract_chart_yaml_from_reader<R: Read>(reader: R) -> Result<ChartYaml> {
-        let gz = GzDecoder::new(reader);
-        let mut archive = Archive::new(gz);
+        let content = Self::find_capped_chart_entry(reader, "Chart.yaml")?.ok_or_else(|| {
+            AppError::Validation("Chart.yaml not found in chart package".to_string())
+        })?;
 
-        for entry in archive
-            .entries()
-            .map_err(|e| AppError::Validation(format!("Invalid chart package: {}", e)))?
-        {
-            let mut entry =
-                entry.map_err(|e| AppError::Validation(format!("Invalid chart entry: {}", e)))?;
-
-            let path = entry
-                .path()
-                .map_err(|e| AppError::Validation(format!("Invalid path in chart: {}", e)))?;
-
-            // Chart.yaml is typically in <chartname>/Chart.yaml
-            if path.ends_with("Chart.yaml") {
-                let content = read_capped_entry_to_string(&mut entry, "Chart.yaml")?;
-
-                return serde_yaml::from_str(&content)
-                    .map_err(|e| AppError::Validation(format!("Invalid Chart.yaml: {}", e)));
-            }
-        }
-
-        Err(AppError::Validation(
-            "Chart.yaml not found in chart package".to_string(),
-        ))
+        serde_yaml::from_str(&content)
+            .map_err(|e| AppError::Validation(format!("Invalid Chart.yaml: {}", e)))
     }
 
     /// Extract values.yaml from chart package (optional)
     pub fn extract_values_yaml(content: &[u8]) -> Result<Option<serde_yaml::Value>> {
-        let gz = GzDecoder::new(content);
-        let mut archive = Archive::new(gz);
+        match Self::find_capped_chart_entry(content, "values.yaml")? {
+            Some(content) => {
+                let values: serde_yaml::Value = serde_yaml::from_str(&content)
+                    .map_err(|e| AppError::Validation(format!("Invalid values.yaml: {}", e)))?;
+                Ok(Some(values))
+            }
+            None => Ok(None),
+        }
+    }
 
+    /// Locate a metadata entry (`Chart.yaml` / `values.yaml`) inside a chart
+    /// `.tgz`, returning its capped contents (`None` when absent).
+    ///
+    /// The gzip stream is wrapped in the shared total-byte budget (#2556) so a
+    /// bomb that inflates *before* the target entry — or an archive that never
+    /// contains it — aborts mid-inflate instead of decompressing unbounded, and
+    /// the entry-count cap bounds entry-count bombs. The matched entry is still
+    /// read through the existing per-entry `MAX_METADATA_ENTRY_BYTES` cap.
+    fn find_capped_chart_entry<R: Read>(reader: R, filename: &str) -> Result<Option<String>> {
+        use crate::util::bounded_archive::{budgeted, MAX_INGEST_ARCHIVE_ENTRIES};
+
+        let gz = GzDecoder::new(reader);
+        let mut archive = Archive::new(budgeted(gz));
+
+        let mut entries_seen: u64 = 0;
         for entry in archive
             .entries()
             .map_err(|e| AppError::Validation(format!("Invalid chart package: {}", e)))?
@@ -202,18 +204,22 @@ impl HelmHandler {
             let mut entry =
                 entry.map_err(|e| AppError::Validation(format!("Invalid chart entry: {}", e)))?;
 
+            entries_seen += 1;
+            if entries_seen > MAX_INGEST_ARCHIVE_ENTRIES {
+                return Err(AppError::Validation(format!(
+                    "Chart package contains too many entries (> {}); refusing suspected decompression bomb",
+                    MAX_INGEST_ARCHIVE_ENTRIES
+                )));
+            }
+
             let path = entry
                 .path()
                 .map_err(|e| AppError::Validation(format!("Invalid path in chart: {}", e)))?;
 
-            // values.yaml is typically in <chartname>/values.yaml
-            if path.ends_with("values.yaml") {
-                let content = read_capped_entry_to_string(&mut entry, "values.yaml")?;
-
-                let values: serde_yaml::Value = serde_yaml::from_str(&content)
-                    .map_err(|e| AppError::Validation(format!("Invalid values.yaml: {}", e)))?;
-
-                return Ok(Some(values));
+            // Chart.yaml / values.yaml is typically in <chartname>/<filename>.
+            if path.ends_with(filename) {
+                let content = read_capped_entry_to_string(&mut entry, filename)?;
+                return Ok(Some(content));
             }
         }
 
@@ -1171,5 +1177,94 @@ entries:
             }
             other => panic!("expected Validation error, got {other:?}"),
         }
+    }
+
+    /// Build a `.tgz` containing multiple named entries (each a regular file).
+    fn build_multi_tgz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        use flate2::{write::GzEncoder, Compression};
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            for (path, body) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(body.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder.append_data(&mut header, path, *body).unwrap();
+            }
+            builder.finish().unwrap();
+        }
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::best());
+        std::io::Write::write_all(&mut encoder, &tar_buf).unwrap();
+        encoder.finish().unwrap()
+    }
+
+    /// #2556: a chart whose entries inflate past the total-byte budget *before*
+    /// Chart.yaml is reached must be rejected mid-inflate, not decompressed
+    /// unbounded. Drive it through the shared `_limited` seam with a tiny budget
+    /// so the fixture stays small.
+    #[test]
+    fn test_extract_chart_yaml_pre_target_inflation_rejected_2556() {
+        use crate::util::bounded_archive::read_metadata_from_tar_gz_limited;
+        let filler = vec![0u8; 1024 * 1024];
+        let tgz = build_multi_tgz(&[
+            ("chart/big.bin", &filler[..]),
+            ("chart/Chart.yaml", b"apiVersion: v2\nname: n\nversion: 1"),
+        ]);
+        // Tiny total budget: the 1 MiB filler entry (walked before Chart.yaml)
+        // trips the budget.
+        let out = read_metadata_from_tar_gz_limited(
+            &tgz[..],
+            |p| p.ends_with("Chart.yaml"),
+            4096,
+            10_000,
+            4 * 1024 * 1024,
+        );
+        assert!(out.is_err(), "pre-target inflation past budget must reject");
+    }
+
+    /// #2556: the real extractor rejects a many-entry chart via the entry-count
+    /// cap. Build far more than the cap would allow at test scale by asserting
+    /// the shared cap is enforced through the seam.
+    #[test]
+    fn test_extract_chart_yaml_entry_count_cap_2556() {
+        use crate::util::bounded_archive::read_metadata_from_tar_gz_limited;
+        let mut entries: Vec<(String, Vec<u8>)> = (0..40)
+            .map(|i| (format!("chart/f{i}"), vec![b'a']))
+            .collect();
+        entries.push((
+            "chart/Chart.yaml".to_string(),
+            b"apiVersion: v2\nname: n\nversion: 1".to_vec(),
+        ));
+        let refs: Vec<(&str, &[u8])> = entries
+            .iter()
+            .map(|(n, d)| (n.as_str(), d.as_slice()))
+            .collect();
+        let tgz = build_multi_tgz(&refs);
+        let out = read_metadata_from_tar_gz_limited(
+            &tgz[..],
+            |p| p.ends_with("Chart.yaml"),
+            64 * 1024 * 1024,
+            10,
+            4 * 1024 * 1024,
+        );
+        assert!(out.is_err(), "entry-count breach must reject");
+    }
+
+    /// Regression: a normal chart still parses through the hardened path.
+    #[test]
+    fn test_extract_chart_yaml_normal_after_hardening_2556() {
+        let tgz = build_multi_tgz(&[
+            ("nginx/values.yaml", b"replicaCount: 1\n"),
+            (
+                "nginx/Chart.yaml",
+                b"apiVersion: v2\nname: nginx\nversion: 9.9.9\n",
+            ),
+        ]);
+        let chart = HelmHandler::extract_chart_yaml(&tgz).unwrap();
+        assert_eq!(chart.name, "nginx");
+        assert_eq!(chart.version, "9.9.9");
+        let values = HelmHandler::extract_values_yaml(&tgz).unwrap();
+        assert!(values.is_some());
     }
 }

--- a/backend/src/formats/incus.rs
+++ b/backend/src/formats/incus.rs
@@ -150,22 +150,19 @@ impl IncusHandler {
             Box::new(GzDecoder::new(full_reader))
         };
 
-        let mut archive = tar::Archive::new(decompressor);
-        let entries = archive.entries().ok()?;
-
-        for entry in entries {
-            let mut entry = entry.ok()?;
-            let path = entry.path().ok()?;
-            let path_str = path.to_string_lossy();
-
-            if path_str == "metadata.yaml" || path_str == "./metadata.yaml" {
-                let mut yaml_content = String::new();
-                entry.read_to_string(&mut yaml_content).ok()?;
-                return Self::parse_metadata_yaml(&yaml_content);
-            }
-        }
-
-        None
+        // Route the (magic-byte-dispatched) decompressor through the shared
+        // bounded extractor (#2556): the total-byte budget on the DECODED stream
+        // aborts an xz/zstd/gzip bomb mid-inflate, and the entry-count +
+        // per-entry caps bound the walk. A cap breach yields Err -> None here, so
+        // a bomb is bounded (RSS flat) rather than ballooning to hundreds of MiB.
+        let bytes =
+            crate::util::bounded_archive::read_metadata_from_decoded_tar(decompressor, |path| {
+                let s = path.to_string_lossy();
+                s == "metadata.yaml" || s == "./metadata.yaml"
+            })
+            .ok()??;
+        let yaml_content = String::from_utf8(bytes).ok()?;
+        Self::parse_metadata_yaml(&yaml_content)
     }
 
     /// Parse the metadata.yaml content.
@@ -518,6 +515,102 @@ properties:
         assert_eq!(meta.architecture, Some("aarch64".to_string()));
         assert_eq!(meta.os, Some("Debian".to_string()));
         assert_eq!(meta.release, Some("bookworm".to_string()));
+    }
+
+    /// Build an image tar carrying `metadata.yaml`, optionally preceded by a
+    /// huge (highly compressible) filler entry so decoders must inflate past the
+    /// budget before reaching the metadata (the pre-target-inflation bomb).
+    fn image_tar(yaml: &[u8], filler_bytes: usize) -> Vec<u8> {
+        let mut tar_buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_buf);
+            if filler_bytes > 0 {
+                let filler = vec![0u8; filler_bytes];
+                let mut h = tar::Header::new_gnu();
+                h.set_size(filler.len() as u64);
+                h.set_mode(0o644);
+                h.set_cksum();
+                builder.append_data(&mut h, "big.bin", &filler[..]).unwrap();
+            }
+            let mut header = tar::Header::new_gnu();
+            header.set_size(yaml.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "metadata.yaml", yaml)
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        tar_buf
+    }
+
+    /// #2556: incus image bombs across all three codecs (gzip / xz / zstd) are
+    /// bounded (extraction returns None, RSS flat) rather than ballooning. Here
+    /// the `metadata.yaml` entry itself inflates past the 8 MiB per-metadata cap;
+    /// the pre-target *total-byte* budget path is covered by the fast
+    /// `bounded_archive` module tests (`xz_/zst_..._total_budget_breach`).
+    #[test]
+    fn test_incus_metadata_bombs_bounded_all_codecs_2556() {
+        use std::io::Write;
+        // 9 MiB metadata.yaml (> 8 MiB per-metadata cap); repeated bytes so all
+        // three codecs compress it to a tiny "bomb".
+        let mut yaml = b"architecture: x86_64\nproperties:\n  os: Ubuntu\n".to_vec();
+        yaml.extend(std::iter::repeat(b'#').take(9 * 1024 * 1024));
+        let raw = image_tar(&yaml, 0);
+
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+        gz.write_all(&raw).unwrap();
+        let gz = gz.finish().unwrap();
+        assert!(gz.len() < 1024 * 1024, "gzip bomb compresses tiny");
+        assert!(
+            IncusHandler::extract_metadata(&gz).is_none(),
+            "gzip bomb bounded"
+        );
+
+        let mut xz = xz2::write::XzEncoder::new(Vec::new(), 1);
+        xz.write_all(&raw).unwrap();
+        let xz = xz.finish().unwrap();
+        assert!(xz.len() < 1024 * 1024, "xz bomb compresses tiny");
+        assert!(
+            IncusHandler::extract_metadata(&xz).is_none(),
+            "xz bomb bounded"
+        );
+
+        let zst = zstd::encode_all(std::io::Cursor::new(&raw[..]), 1).unwrap();
+        assert!(zst.len() < 1024 * 1024, "zstd bomb compresses tiny");
+        assert!(
+            IncusHandler::extract_metadata(&zst).is_none(),
+            "zstd bomb bounded"
+        );
+    }
+
+    #[test]
+    fn test_incus_metadata_normal_all_codecs_2556() {
+        use std::io::Write;
+        let yaml = b"architecture: x86_64\nproperties:\n  os: Ubuntu\n  release: noble\n";
+
+        let raw = image_tar(yaml, 0);
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gz.write_all(&raw).unwrap();
+        let gz = gz.finish().unwrap();
+        assert_eq!(
+            IncusHandler::extract_metadata(&gz).unwrap().os,
+            Some("Ubuntu".to_string())
+        );
+
+        let mut xz = xz2::write::XzEncoder::new(Vec::new(), 6);
+        xz.write_all(&image_tar(yaml, 0)).unwrap();
+        let xz = xz.finish().unwrap();
+        assert_eq!(
+            IncusHandler::extract_metadata(&xz).unwrap().release,
+            Some("noble".to_string())
+        );
+
+        let zst = zstd::encode_all(std::io::Cursor::new(image_tar(yaml, 0)), 3).unwrap();
+        assert_eq!(
+            IncusHandler::extract_metadata(&zst).unwrap().os,
+            Some("Ubuntu".to_string())
+        );
     }
 
     #[tokio::test]

--- a/backend/src/formats/rubygems.rs
+++ b/backend/src/formats/rubygems.rs
@@ -5,10 +5,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use flate2::read::GzDecoder;
 use serde::{Deserialize, Serialize};
-use std::io::Read;
-use tar::Archive;
 
 use crate::error::{AppError, Result};
 use crate::formats::FormatHandler;
@@ -231,39 +228,27 @@ impl RubygemsHandler {
 
     /// Extract gemspec from .gem file
     /// .gem files are tar archives containing metadata.gz and data.tar.gz
+    ///
+    /// The outer `.gem` is a plain tar; the `metadata.gz` entry is read bounded
+    /// by the entry-count + per-entry caps, then gzip-decompressed bounded by the
+    /// per-metadata-entry cap so a gem bomb aborts mid-inflate (#2556).
+    /// Previously the `read_to_end(metadata.gz)` and the `GzDecoder`
+    /// `read_to_string` were both unbounded.
     pub fn extract_gemspec(content: &[u8]) -> Result<GemSpec> {
-        let mut archive = Archive::new(content);
+        let compressed = crate::util::bounded_archive::read_metadata_from_tar(content, |path| {
+            path.to_string_lossy() == "metadata.gz"
+        })?
+        .ok_or_else(|| AppError::Validation("metadata.gz not found in gem file".to_string()))?;
 
-        for entry in archive
-            .entries()
-            .map_err(|e| AppError::Validation(format!("Invalid gem file: {}", e)))?
-        {
-            let mut entry =
-                entry.map_err(|e| AppError::Validation(format!("Invalid gem entry: {}", e)))?;
+        let yaml = crate::util::bounded_archive::decompress_gz_capped(
+            &compressed[..],
+            crate::util::bounded_archive::MAX_INGEST_METADATA_ENTRY_BYTES,
+            "gem metadata",
+        )?;
+        let yaml_content = String::from_utf8(yaml)
+            .map_err(|e| AppError::Validation(format!("Failed to decompress metadata: {}", e)))?;
 
-            let path = entry
-                .path()
-                .map_err(|e| AppError::Validation(format!("Invalid path in gem: {}", e)))?;
-
-            if path.to_string_lossy() == "metadata.gz" {
-                let mut compressed = Vec::new();
-                entry.read_to_end(&mut compressed).map_err(|e| {
-                    AppError::Validation(format!("Failed to read metadata.gz: {}", e))
-                })?;
-
-                let mut decoder = GzDecoder::new(&compressed[..]);
-                let mut yaml_content = String::new();
-                decoder.read_to_string(&mut yaml_content).map_err(|e| {
-                    AppError::Validation(format!("Failed to decompress metadata: {}", e))
-                })?;
-
-                return Self::parse_gemspec_yaml(&yaml_content);
-            }
-        }
-
-        Err(AppError::Validation(
-            "metadata.gz not found in gem file".to_string(),
-        ))
+        Self::parse_gemspec_yaml(&yaml_content)
     }
 
     /// Parse gemspec YAML content
@@ -1129,5 +1114,51 @@ summary: A summary
         assert!(!is_valid_rubygems_name(".rails"));
         assert!(!is_valid_rubygems_name("rails space"));
         assert!(!is_valid_rubygems_name("rails/slash"));
+    }
+
+    /// Build a `.gem` (plain tar) whose `metadata.gz` holds `yaml` gzip-encoded.
+    fn gem_with_metadata(yaml: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+        gz.write_all(yaml).unwrap();
+        let metadata_gz = gz.finish().unwrap();
+
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_size(metadata_gz.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "metadata.gz", &metadata_gz[..])
+            .unwrap();
+        builder.finish().unwrap();
+        builder.into_inner().unwrap()
+    }
+
+    /// #2556 regression: a normal `.gem` still parses its gemspec.
+    #[test]
+    fn test_extract_gemspec_normal_2556() {
+        let gem = gem_with_metadata(
+            b"--- !ruby/object:Gem::Specification\nname: rails\nversion: 7.1.0\n",
+        );
+        let spec = RubygemsHandler::extract_gemspec(&gem).expect("normal gem parses");
+        assert_eq!(spec.name, "rails");
+    }
+
+    /// #2556: a `.gem` whose `metadata.gz` inflates past the per-metadata cap is
+    /// rejected mid-inflate (previously `read_to_end` + `read_to_string` were
+    /// both unbounded). The compressed gem stays tiny.
+    #[test]
+    fn test_extract_gemspec_bomb_rejected_2556() {
+        // ~9 MiB inflated gemspec YAML (> 8 MiB per-metadata cap), gzip of
+        // repeated bytes compresses tiny.
+        let mut yaml = b"--- !ruby/object:Gem::Specification\nname: bomb\nversion: 1\n".to_vec();
+        yaml.extend(std::iter::repeat(b'#').take(9 * 1024 * 1024));
+        let gem = gem_with_metadata(&yaml);
+        assert!(gem.len() < 256 * 1024, "compressed gem stays tiny");
+        assert!(
+            RubygemsHandler::extract_gemspec(&gem).is_err(),
+            "gem metadata bomb must be rejected"
+        );
     }
 }

--- a/backend/src/services/artifact_metadata.rs
+++ b/backend/src/services/artifact_metadata.rs
@@ -113,30 +113,18 @@ fn extract_npm_metadata(artifact_data: &[u8]) -> Option<serde_json::Value> {
 }
 
 fn extract_npm_metadata_reader<R: std::io::Read>(reader: R) -> Option<serde_json::Value> {
-    use std::io::Read;
-    let gz = flate2::read::GzDecoder::new(reader);
-    let mut tar = tar::Archive::new(gz);
-    let entries = tar.entries().ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path().ok()?;
-        let name = path.to_string_lossy();
-        // Most npm tarballs use the `package/` prefix, but some publish
-        // tools put the actual package name first or omit the prefix
-        // entirely. Match any path ending in `/package.json` or the bare
-        // `package.json` at the root.
-        if name == "package.json" || name.ends_with("/package.json") {
-            // Drop the moved entry — re-iterate is messy with `tar`'s
-            // Read-once entries iterator, so capture the bytes here.
-            drop(name);
-            drop(path);
-            let mut buf = String::new();
-            let mut e = entry;
-            e.read_to_string(&mut buf).ok()?;
-            let pkg: serde_json::Value = serde_json::from_str(&buf).ok()?;
-            return Some(serde_json::json!({ "version_data": pkg }));
-        }
-    }
-    None
+    // Bound the gzip/tar decompression on this migration-worker reprocessing
+    // path (#2556). Most npm tarballs use the `package/` prefix, but some
+    // publish tools put the actual package name first or omit the prefix — match
+    // any path whose file name is `package.json`.
+    let bytes = crate::util::bounded_archive::read_metadata_from_tar_gz(reader, |path| {
+        path.file_name()
+            .map(|n| n == "package.json")
+            .unwrap_or(false)
+    })
+    .ok()??;
+    let pkg: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    Some(serde_json::json!({ "version_data": pkg }))
 }
 
 /// Extract helm chart metadata from a `.tgz` tarball.
@@ -151,39 +139,30 @@ fn extract_helm_metadata(artifact_data: &[u8]) -> Option<serde_json::Value> {
 }
 
 fn extract_helm_metadata_reader<R: std::io::Read>(reader: R) -> Option<serde_json::Value> {
-    use std::io::Read;
-    let gz = flate2::read::GzDecoder::new(reader);
-    let mut tar = tar::Archive::new(gz);
-    let entries = tar.entries().ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path().ok()?;
-        let name = path.to_string_lossy();
-        if name == "Chart.yaml" || name.ends_with("/Chart.yaml") {
-            drop(name);
-            drop(path);
-            let mut buf = String::new();
-            let mut e = entry;
-            e.read_to_string(&mut buf).ok()?;
-            let chart: serde_json::Value = serde_yaml::from_str(&buf).ok()?;
-            let description = chart
-                .get("description")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let app_version = chart
-                .get("appVersion")
-                .and_then(|v| v.as_str())
-                .map(String::from);
-            let mut wrapper = serde_json::json!({ "chart": chart });
-            if let Some(d) = description {
-                wrapper["description"] = serde_json::Value::String(d);
-            }
-            if let Some(a) = app_version {
-                wrapper["appVersion"] = serde_json::Value::String(a);
-            }
-            return Some(wrapper);
-        }
+    // Bound the gzip/tar decompression on this migration-worker reprocessing
+    // path (#2556).
+    let bytes = crate::util::bounded_archive::read_metadata_from_tar_gz(reader, |path| {
+        path.file_name().map(|n| n == "Chart.yaml").unwrap_or(false)
+    })
+    .ok()??;
+    let buf = String::from_utf8(bytes).ok()?;
+    let chart: serde_json::Value = serde_yaml::from_str(&buf).ok()?;
+    let description = chart
+        .get("description")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let app_version = chart
+        .get("appVersion")
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    let mut wrapper = serde_json::json!({ "chart": chart });
+    if let Some(d) = description {
+        wrapper["description"] = serde_json::Value::String(d);
     }
-    None
+    if let Some(a) = app_version {
+        wrapper["appVersion"] = serde_json::Value::String(a);
+    }
+    Some(wrapper)
 }
 
 fn fallback(filename: &str) -> ParsedArtifact {

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -963,11 +963,10 @@ async fn run_curation_sync_cycle(
                         // STREAMING-EXEMPT: capped-metadata (upstream repo index) buffered for gz-decode; not an artifact blob (#1608)
                         let bytes = resp.bytes().await?;
                         let xml = if primary_path.ends_with(".gz") {
-                            use std::io::Read;
-                            let mut decoder = flate2::read::GzDecoder::new(&bytes[..]);
-                            let mut s = String::new();
-                            decoder.read_to_string(&mut s)?;
-                            s
+                            // Bound the upstream-index decompression (#2556): a
+                            // malicious/compromised upstream mirror cannot inflate
+                            // primary.xml.gz unbounded during sync.
+                            decompress_upstream_index_gz(&bytes)?
                         } else {
                             String::from_utf8_lossy(&bytes).to_string()
                         };
@@ -995,10 +994,10 @@ async fn run_curation_sync_cycle(
                         #[allow(clippy::disallowed_methods)]
                         // STREAMING-EXEMPT: capped-metadata (upstream repo index) buffered for gz-decode; not an artifact blob (#1608)
                         let bytes = resp.bytes().await?;
-                        use std::io::Read;
-                        let mut decoder = flate2::read::GzDecoder::new(&bytes[..]);
-                        let mut content = String::new();
-                        decoder.read_to_string(&mut content)?;
+                        // Bound the upstream-index decompression (#2556): a
+                        // malicious/compromised upstream mirror cannot inflate
+                        // Packages.gz unbounded during sync.
+                        let content = decompress_upstream_index_gz(&bytes)?;
                         curation_sync::parse_deb_packages_index(&content, "main")
                     }
                     _ => {
@@ -1089,6 +1088,30 @@ async fn run_curation_sync_cycle(
 }
 
 /// Extract the primary.xml href from repomd.xml content.
+/// Decompress a gzip-compressed upstream repo index (RPM `primary.xml.gz`,
+/// Debian `Packages.gz`) during proxy-sync, bounded by the shared total-byte
+/// budget (#2556) so a malicious/compromised upstream mirror cannot inflate the
+/// index unbounded. This is the egress analogue of the rubygems
+/// `parse_upstream_specs` upload-side hardening. A budget breach surfaces as an
+/// `io::Error`, which propagates up the sync path (the sync fails, bounded).
+fn decompress_upstream_index_gz(bytes: &[u8]) -> std::io::Result<String> {
+    decompress_upstream_index_gz_limited(
+        bytes,
+        crate::util::bounded_archive::max_ingest_decompressed_bytes(),
+    )
+}
+
+/// `_limited` seam for [`decompress_upstream_index_gz`] — lets tests drive a
+/// tiny budget against a tiny gzip-bomb fixture.
+fn decompress_upstream_index_gz_limited(bytes: &[u8], budget: u64) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut decoder =
+        crate::util::bounded_archive::budgeted_to(flate2::read::GzDecoder::new(bytes), budget);
+    let mut s = String::new();
+    decoder.read_to_string(&mut s)?;
+    Ok(s)
+}
+
 fn extract_primary_href(repomd: &str) -> Option<String> {
     // Look for: <data type="primary"><location href="repodata/...-primary.xml.gz"/>
     for data_block in repomd.split("<data type=\"primary\">").skip(1) {
@@ -1106,6 +1129,38 @@ fn extract_primary_href(repomd: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // #2556 — bounded upstream-index decompression
+    // -----------------------------------------------------------------------
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        use std::io::Write;
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn test_upstream_index_gz_normal_decompresses() {
+        let index = b"Package: nginx\nVersion: 1.24.0-1\n\nPackage: curl\nVersion: 8.0\n";
+        let gz = gzip(index);
+        let out = decompress_upstream_index_gz(&gz).expect("legit index decompresses");
+        assert_eq!(out.as_bytes(), index);
+    }
+
+    #[test]
+    fn test_upstream_index_gz_bomb_is_bounded() {
+        // A tiny gzip that inflates past a small budget → aborts mid-inflate
+        // with an io error rather than ballooning (a compromised upstream
+        // mirror serving primary.xml.gz / Packages.gz cannot exhaust memory).
+        let bomb = gzip(&vec![0u8; 4 * 1024 * 1024]);
+        assert!(bomb.len() < 64 * 1024, "gzip of zeros compresses tiny");
+        assert!(
+            decompress_upstream_index_gz_limited(&bomb, 4096).is_err(),
+            "upstream index bomb past budget must be bounded/rejected"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // compute_next_run

--- a/backend/src/util/bounded_archive.rs
+++ b/backend/src/util/bounded_archive.rs
@@ -150,7 +150,15 @@ fn map_archive_err(context: &str, err: &io::Error) -> AppError {
 /// the entry-count cap. A budget breach surfaces as an [`io::Error`] during the
 /// walk, which the caller maps to its own validation error.
 pub fn budgeted<R: Read>(reader: R) -> impl Read {
-    BudgetReader::new(reader, max_ingest_decompressed_bytes())
+    budgeted_to(reader, max_ingest_decompressed_bytes())
+}
+
+/// Like [`budgeted`] but with an explicit byte budget. Callers that decompress a
+/// *whole* stream (not a tar walk) — e.g. an upstream repo index — use this to
+/// pick a budget appropriate to the payload, and unit tests use it to drive a
+/// tiny budget against a tiny fixture.
+pub fn budgeted_to<R: Read>(reader: R, budget: u64) -> impl Read {
+    BudgetReader::new(reader, budget)
 }
 
 /// Read at most `cap` bytes from `reader`, rejecting input that exceeds `cap`.

--- a/backend/src/util/bounded_archive.rs
+++ b/backend/src/util/bounded_archive.rs
@@ -1,0 +1,602 @@
+//! Bounded archive decompression for ingestion/serve metadata extraction.
+//!
+//! Every format that needs package coordinates (name/version/description)
+//! decompresses the uploaded or served archive *inside the request handler* to
+//! read a single small metadata file (`Chart.yaml`, `.nuspec`, `pubspec.yaml`,
+//! `METADATA`, `.podspec.json`, `metadata.config`, …). Those extractors never
+//! touch the scanner's bounded extractors (`unpack_*_limited`, #2514) nor the
+//! Debian-index cap (#2482), so historically they decoded a gzip/zip/bz2 stream
+//! with **no cap on total decompressed bytes**, walked tar entries with **no
+//! entry-count cap**, and read the target entry with **no per-entry cap** — a
+//! decompression-bomb / unbounded-memory surface at upload and serve time.
+//!
+//! This module consolidates the proven bounding primitives into three shared
+//! helpers so every ingestion metadata extractor gets the same three caps with
+//! one implementation:
+//!
+//! 1. a **total decompressed-byte budget** on the decoded stream (default
+//!    128 MiB, env [`MAX_INGEST_DECOMPRESSED_BYTES_ENV`]) — the core mechanism;
+//!    it defeats both the *pre-target-inflation* bomb (huge entries walked
+//!    before the metadata file) and the *entry-count* bomb (the walk hits the
+//!    byte budget and stops),
+//! 2. a **10 000 entry-count cap** ([`MAX_INGEST_ARCHIVE_ENTRIES`]) —
+//!    defence-in-depth against inode/entry-count bombs with a clearer error,
+//! 3. an **8 MiB per-metadata-entry cap** ([`MAX_INGEST_METADATA_ENTRY_BYTES`])
+//!    — a metadata file larger than this is itself a bomb.
+//!
+//! Reference implementations reused here (do not re-derive):
+//! - the scanner's `positive_env_or` env-override idiom and `copy_entry_bounded`
+//!   running-budget check (#2514),
+//! - the Debian index `.take()` byte budget (#2482),
+//! - `api/handlers/conda.rs::limited_decode_zstd` streaming cap,
+//! - **`api/handlers/swift.rs::extract_manifest_from_zip`** — already correctly
+//!   bounded (`size()` pre-check + `.take(N + 1)` per entry, random-access zip
+//!   so unmatched entries are never inflated); this module generalises exactly
+//!   that pattern to the other formats.
+//!
+//! All caps sit far above real packages — metadata files are KB-scale, so a
+//! legitimate large chart/wheel/nupkg/pod/gem reads only a few KB before the
+//! match and never approaches a cap. A cap breach is surfaced as
+//! [`AppError::Validation`] (HTTP 400) so ingestion **rejects** the bomb rather
+//! than silently truncating or hanging.
+
+use std::io::{self, Read, Seek};
+use std::path::Path;
+
+use crate::error::{AppError, Result};
+
+/// Total decompressed bytes any single ingestion metadata-extraction may
+/// consume before it is rejected as a suspected decompression bomb. 128 MiB
+/// matches the Debian #2482 index cap; it is generous for real charts/wheels/
+/// nupkgs (whose metadata files are KB) — the cap only bites on bombs or on
+/// pre-target inflation.
+pub const DEFAULT_MAX_INGEST_DECOMPRESSED_BYTES: u64 = 128 * 1024 * 1024;
+
+/// Env var overriding [`DEFAULT_MAX_INGEST_DECOMPRESSED_BYTES`]. Value is a
+/// plain decimal byte count; blank/zero/non-numeric falls back to the default.
+/// Named to mirror the scanner's `MAX_SCAN_EXTRACTED_BYTES` so operators tune
+/// ingestion and scan caps with the same idiom.
+pub const MAX_INGEST_DECOMPRESSED_BYTES_ENV: &str = "MAX_INGEST_DECOMPRESSED_BYTES";
+
+/// Maximum tar/zip entries walked while searching for the metadata file.
+/// 10 000 matches conda's `MAX_TAR_ENTRIES`; bounds inode/entry-count bombs.
+pub const MAX_INGEST_ARCHIVE_ENTRIES: u64 = 10_000;
+
+/// Maximum bytes read for the single matched metadata entry (`Chart.yaml` /
+/// `.nuspec` / `pubspec.yaml` / `METADATA` / …). 8 MiB is ≥ helm's prior 4 MiB
+/// per-entry cap; a metadata file larger than this is itself a bomb.
+pub const MAX_INGEST_METADATA_ENTRY_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Parse a positive-integer environment override, falling back to `default`
+/// when the variable is unset, blank, non-numeric, or zero (a zero cap would
+/// reject every upload, so it is treated as "unset"). Mirrors the scanner's
+/// `positive_env_or` so the parse/filter logic reads identically.
+pub fn positive_env_or(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .filter(|&v| v > 0)
+        .unwrap_or(default)
+}
+
+/// Effective total decompressed-byte ceiling, honouring
+/// [`MAX_INGEST_DECOMPRESSED_BYTES_ENV`] over the default.
+pub fn max_ingest_decompressed_bytes() -> u64 {
+    positive_env_or(
+        MAX_INGEST_DECOMPRESSED_BYTES_ENV,
+        DEFAULT_MAX_INGEST_DECOMPRESSED_BYTES,
+    )
+}
+
+/// A `Read` wrapper enforcing a hard cumulative-byte budget on a *decoded*
+/// stream. Once `budget` bytes have been read it probes for one more byte: a
+/// genuine EOF exactly at the budget passes, but any further data trips an
+/// [`io::ErrorKind::InvalidData`] error carrying [`BOMB_SENTINEL`]. This makes a
+/// decompression bomb abort *mid-inflate* (the budget is on the stream, not on
+/// a buffered result), and — unlike a bare `.take()` — surfaces an explicit
+/// error instead of silently truncating the archive.
+struct BudgetReader<R> {
+    inner: R,
+    remaining: u64,
+}
+
+/// Marker embedded in the budget-breach `io::Error` so the tar/zip boundary can
+/// translate it into a clear "decompression bomb" validation error.
+const BOMB_SENTINEL: &str = "ingest decompression budget exceeded";
+
+impl<R: Read> BudgetReader<R> {
+    fn new(inner: R, budget: u64) -> Self {
+        Self {
+            inner,
+            remaining: budget,
+        }
+    }
+}
+
+impl<R: Read> Read for BudgetReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.remaining == 0 {
+            // Budget spent: distinguish a clean EOF from further inflation.
+            let mut probe = [0u8; 1];
+            return match self.inner.read(&mut probe)? {
+                0 => Ok(0),
+                _ => Err(io::Error::new(io::ErrorKind::InvalidData, BOMB_SENTINEL)),
+            };
+        }
+        let cap = std::cmp::min(buf.len() as u64, self.remaining) as usize;
+        let n = self.inner.read(&mut buf[..cap])?;
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
+
+/// Translate a low-level archive `io::Error` into an [`AppError::Validation`],
+/// mapping a budget breach to an explicit decompression-bomb message.
+fn map_archive_err(context: &str, err: &io::Error) -> AppError {
+    if err.to_string().contains(BOMB_SENTINEL) {
+        AppError::Validation(
+            "Archive expands beyond the decompression budget; refusing suspected decompression bomb"
+                .to_string(),
+        )
+    } else {
+        AppError::Validation(format!("{}: {}", context, err))
+    }
+}
+
+/// Wrap a *decoded* stream in the shared total-byte budget so a decompression
+/// bomb aborts mid-inflate. Use when a caller must drive its own tar/zip walk
+/// (e.g. to keep a format-specific per-entry cap or message) but still wants the
+/// module's total-byte defence; pair it with [`MAX_INGEST_ARCHIVE_ENTRIES`] for
+/// the entry-count cap. A budget breach surfaces as an [`io::Error`] during the
+/// walk, which the caller maps to its own validation error.
+pub fn budgeted<R: Read>(reader: R) -> impl Read {
+    BudgetReader::new(reader, max_ingest_decompressed_bytes())
+}
+
+/// Read at most `cap` bytes from `reader`, rejecting input that exceeds `cap`.
+///
+/// Reads `cap + 1` bytes so an exactly-at-cap breach is detected rather than
+/// silently truncated (mirrors swift's `.take(N + 1)` re-check). Used both for
+/// the matched metadata entry inside the tar/zip walkers and directly by
+/// callers that read a single already-located archive entry (conda zip-entry
+/// reads, pypi wheel `METADATA`).
+pub fn read_capped<R: Read>(reader: R, cap: u64, what: &str) -> Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    reader
+        .take(cap + 1)
+        .read_to_end(&mut buf)
+        .map_err(|e| AppError::Validation(format!("Failed to read {}: {}", what, e)))?;
+    if buf.len() as u64 > cap {
+        return Err(AppError::Validation(format!(
+            "{} exceeds the maximum allowed size of {} bytes",
+            what, cap
+        )));
+    }
+    Ok(buf)
+}
+
+/// Walk an already-budget-wrapped tar stream, returning the first entry whose
+/// path satisfies `matches`. Enforces the entry-count cap and reads the matched
+/// entry through the per-entry cap. The total-byte budget is enforced by the
+/// [`BudgetReader`] the caller wrapped `archive_reader` in, so *skipped* entries
+/// (which tar must still inflate to reach the next header) also count against
+/// the budget — defeating the pre-target-inflation bomb.
+fn read_tar_entries<R: Read>(
+    archive_reader: R,
+    matches: impl Fn(&Path) -> bool,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    let mut archive = tar::Archive::new(archive_reader);
+
+    let entries = archive
+        .entries()
+        .map_err(|e| map_archive_err("Invalid archive", &e))?;
+
+    let mut entries_seen: u64 = 0;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| map_archive_err("Invalid archive entry", &e))?;
+
+        entries_seen += 1;
+        if entries_seen > max_entries {
+            return Err(AppError::Validation(format!(
+                "Archive contains too many entries (> {}); refusing suspected decompression bomb",
+                max_entries
+            )));
+        }
+
+        let path = entry
+            .path()
+            .map_err(|e| map_archive_err("Invalid entry path", &e))?
+            .to_path_buf();
+
+        if matches(&path) {
+            let bytes = read_capped(&mut entry, max_entry, "archive metadata entry")?;
+            return Ok(Some(bytes));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Read the first matching metadata entry from a gzip-compressed tar stream,
+/// bounded by the total-byte budget, entry-count cap, and per-entry cap.
+/// `matches` selects the target entry by its path (e.g. `pubspec.yaml`,
+/// `.podspec.json`). Returns `Ok(None)` when no entry matches (not a bomb) and
+/// `Err` when any cap is breached.
+pub fn read_metadata_from_tar_gz<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_tar_gz_limited(
+        reader,
+        matches,
+        max_ingest_decompressed_bytes(),
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_tar_gz`] — lets unit tests drive
+/// tiny caps against tiny fixtures instead of building 128 MiB.
+pub fn read_metadata_from_tar_gz_limited<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+    max_total: u64,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    let decoder = flate2::read::GzDecoder::new(reader);
+    read_tar_entries(
+        BudgetReader::new(decoder, max_total),
+        matches,
+        max_entries,
+        max_entry,
+    )
+}
+
+/// Read the first matching metadata entry from a bzip2-compressed tar stream
+/// (conda v1 `.tar.bz2`), with the same three caps as the gzip variant.
+pub fn read_metadata_from_tar_bz2<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_tar_bz2_limited(
+        reader,
+        matches,
+        max_ingest_decompressed_bytes(),
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_tar_bz2`].
+pub fn read_metadata_from_tar_bz2_limited<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+    max_total: u64,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    let decoder = bzip2::read::BzDecoder::new(reader);
+    read_tar_entries(
+        BudgetReader::new(decoder, max_total),
+        matches,
+        max_entries,
+        max_entry,
+    )
+}
+
+/// Read the first matching metadata entry from a *plain* (uncompressed) tar
+/// stream (hex outer tarball). No decoder, but the same entry-count and
+/// per-entry caps apply; the total-byte budget bounds the walk (a plain tar
+/// still has low amplification, but the entry-count and per-entry caps bound
+/// worst-case memory to a single entry).
+pub fn read_metadata_from_tar<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_tar_limited(
+        reader,
+        matches,
+        max_ingest_decompressed_bytes(),
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_tar`].
+pub fn read_metadata_from_tar_limited<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+    max_total: u64,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    read_tar_entries(
+        BudgetReader::new(reader, max_total),
+        matches,
+        max_entries,
+        max_entry,
+    )
+}
+
+/// Read the first matching metadata entry from a ZIP archive (`.nupkg`, `.whl`,
+/// `.conda` v2). Zip is random-access, so unmatched entries are never inflated
+/// and no total-stream budget is needed; instead an entry-count cap is checked
+/// up front and the matched entry is read through a header-size pre-check plus
+/// the per-entry `.take()` cap — exactly swift's `extract_manifest_from_zip`
+/// pattern. `matches` selects the target entry by its name.
+pub fn read_metadata_from_zip<R: Read + Seek>(
+    reader: R,
+    matches: impl Fn(&str) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_zip_limited(
+        reader,
+        matches,
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_zip`].
+pub fn read_metadata_from_zip_limited<R: Read + Seek>(
+    reader: R,
+    matches: impl Fn(&str) -> bool,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    let mut archive = zip::ZipArchive::new(reader)
+        .map_err(|e| AppError::Validation(format!("Invalid ZIP archive: {}", e)))?;
+
+    if archive.len() as u64 > max_entries {
+        return Err(AppError::Validation(format!(
+            "ZIP archive contains too many entries (> {}); refusing suspected decompression bomb",
+            max_entries
+        )));
+    }
+
+    for i in 0..archive.len() {
+        let mut file = archive
+            .by_index(i)
+            .map_err(|e| AppError::Validation(format!("Cannot read ZIP entry: {}", e)))?;
+        if !file.is_file() {
+            continue;
+        }
+        if !matches(file.name()) {
+            continue;
+        }
+        // Header size is a hint (the central directory may lie); reject an
+        // oversized entry up front, then re-check with the `.take()` read.
+        if file.size() > max_entry {
+            return Err(AppError::Validation(format!(
+                "ZIP metadata entry exceeds the maximum allowed size of {} bytes",
+                max_entry
+            )));
+        }
+        let bytes = read_capped(&mut file, max_entry, "ZIP metadata entry")?;
+        return Ok(Some(bytes));
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(flate2::write::GzEncoder::new(
+            Vec::new(),
+            flate2::Compression::default(),
+        ));
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    fn plain_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(Vec::new());
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap()
+    }
+
+    fn zip_bytes(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut cursor = std::io::Cursor::new(Vec::new());
+        {
+            let mut w = zip::ZipWriter::new(&mut cursor);
+            let opts: zip::write::FileOptions<'_, ()> = zip::write::FileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored);
+            for (name, data) in entries {
+                w.start_file(*name, opts).unwrap();
+                w.write_all(data).unwrap();
+            }
+            w.finish().unwrap();
+        }
+        cursor.into_inner()
+    }
+
+    fn is_chart(p: &Path) -> bool {
+        p.ends_with("Chart.yaml")
+    }
+
+    #[test]
+    fn positive_env_or_falls_back_on_blank_zero_nonnumeric() {
+        assert_eq!(positive_env_or("AK_TEST_UNSET_VAR_XYZ", 42), 42);
+    }
+
+    #[test]
+    fn tar_gz_normal_metadata_returns_bytes() {
+        let archive = tar_gz(&[("chart/Chart.yaml", b"name: nginx\nversion: 1.2.3")]);
+        let out = read_metadata_from_tar_gz_limited(
+            &archive[..],
+            is_chart,
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert_eq!(out.unwrap(), b"name: nginx\nversion: 1.2.3");
+    }
+
+    #[test]
+    fn tar_gz_absent_metadata_returns_none() {
+        let archive = tar_gz(&[("chart/values.yaml", b"key: val")]);
+        let out = read_metadata_from_tar_gz_limited(
+            &archive[..],
+            is_chart,
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn tar_gz_total_budget_breach_is_rejected() {
+        // A highly-compressible 1 MiB payload placed BEFORE the target entry,
+        // inflated past a tiny total budget → rejected mid-inflate even though
+        // the compressed fixture is tiny (the pre-target-inflation bomb shape).
+        let filler = vec![0u8; 1024 * 1024];
+        let archive = tar_gz(&[
+            ("chart/big.bin", &filler[..]),
+            ("chart/Chart.yaml", b"name: x\nversion: 1"),
+        ]);
+        let err =
+            read_metadata_from_tar_gz_limited(&archive[..], is_chart, 4096, 1000, 1024 * 1024);
+        assert!(err.is_err(), "pre-target inflation past budget must reject");
+    }
+
+    #[test]
+    fn tar_gz_entry_count_breach_is_rejected() {
+        let mut entries: Vec<(String, Vec<u8>)> = (0..50)
+            .map(|i| (format!("chart/f{}", i), vec![b'a']))
+            .collect();
+        entries.push(("chart/Chart.yaml".to_string(), b"name: x".to_vec()));
+        let refs: Vec<(&str, &[u8])> = entries
+            .iter()
+            .map(|(n, d)| (n.as_str(), d.as_slice()))
+            .collect();
+        let archive = tar_gz(&refs);
+        let err =
+            read_metadata_from_tar_gz_limited(&archive[..], is_chart, 1024 * 1024, 10, 1024 * 1024);
+        assert!(err.is_err(), "entry-count breach must reject");
+    }
+
+    #[test]
+    fn tar_gz_per_entry_breach_is_rejected() {
+        let archive = tar_gz(&[("chart/Chart.yaml", &vec![b'a'; 4096][..])]);
+        let err =
+            read_metadata_from_tar_gz_limited(&archive[..], is_chart, 1024 * 1024, 1000, 1024);
+        assert!(err.is_err(), "oversized metadata entry must reject");
+    }
+
+    #[test]
+    fn plain_tar_normal_and_missing() {
+        let archive = plain_tar(&[("metadata.config", b"x")]);
+        let out = read_metadata_from_tar_limited(
+            &archive[..],
+            |p| p == Path::new("metadata.config"),
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert_eq!(out.unwrap(), b"x");
+
+        let out2 = read_metadata_from_tar_limited(
+            &archive[..],
+            |p| p == Path::new("nope"),
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert!(out2.is_none());
+    }
+
+    #[test]
+    fn bz2_roundtrip_and_budget() {
+        let mut enc = bzip2::write::BzEncoder::new(Vec::new(), bzip2::Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut enc);
+            let data = b"name: x";
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder
+                .append_data(&mut header, "info/index.json", &data[..])
+                .unwrap();
+            builder.finish().unwrap();
+        }
+        let compressed = enc.finish().unwrap();
+        let out = read_metadata_from_tar_bz2_limited(
+            &compressed[..],
+            |p| p == Path::new("info/index.json"),
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert_eq!(out.unwrap(), b"name: x");
+    }
+
+    #[test]
+    fn zip_normal_absent_and_oversized() {
+        let archive = zip_bytes(&[("lib/foo.nuspec", b"<id>Foo</id>")]);
+        let cursor = std::io::Cursor::new(&archive);
+        let out =
+            read_metadata_from_zip_limited(cursor, |n| n.ends_with(".nuspec"), 1000, 1024 * 1024)
+                .unwrap();
+        assert_eq!(out.unwrap(), b"<id>Foo</id>");
+
+        // Absent.
+        let cursor2 = std::io::Cursor::new(&archive);
+        let out2 =
+            read_metadata_from_zip_limited(cursor2, |n| n.ends_with(".missing"), 1000, 1024 * 1024)
+                .unwrap();
+        assert!(out2.is_none());
+
+        // Oversized matched entry.
+        let big = zip_bytes(&[("a.nuspec", &vec![b'a'; 4096][..])]);
+        let cursor3 = std::io::Cursor::new(&big);
+        let err = read_metadata_from_zip_limited(cursor3, |n| n.ends_with(".nuspec"), 1000, 1024);
+        assert!(err.is_err(), "oversized zip entry must reject");
+    }
+
+    #[test]
+    fn zip_entry_count_breach_is_rejected() {
+        let entries: Vec<(String, Vec<u8>)> = (0..20)
+            .map(|i| (format!("f{}.txt", i), vec![b'a']))
+            .collect();
+        let refs: Vec<(&str, &[u8])> = entries
+            .iter()
+            .map(|(n, d)| (n.as_str(), d.as_slice()))
+            .collect();
+        let archive = zip_bytes(&refs);
+        let cursor = std::io::Cursor::new(&archive);
+        let err =
+            read_metadata_from_zip_limited(cursor, |n| n.ends_with(".nuspec"), 5, 1024 * 1024);
+        assert!(err.is_err(), "zip entry-count breach must reject");
+    }
+
+    #[test]
+    fn read_capped_rejects_oversized() {
+        assert!(read_capped(&b"abcdef"[..], 3, "x").is_err());
+        assert_eq!(read_capped(&b"ab"[..], 8, "x").unwrap(), b"ab");
+    }
+}

--- a/backend/src/util/bounded_archive.rs
+++ b/backend/src/util/bounded_archive.rs
@@ -246,10 +246,10 @@ pub fn read_metadata_from_tar_gz_limited<R: Read>(
     max_entries: u64,
     max_entry: u64,
 ) -> Result<Option<Vec<u8>>> {
-    let decoder = flate2::read::GzDecoder::new(reader);
-    read_tar_entries(
-        BudgetReader::new(decoder, max_total),
+    read_metadata_from_decoded_tar_limited(
+        flate2::read::GzDecoder::new(reader),
         matches,
+        max_total,
         max_entries,
         max_entry,
     )
@@ -278,13 +278,120 @@ pub fn read_metadata_from_tar_bz2_limited<R: Read>(
     max_entries: u64,
     max_entry: u64,
 ) -> Result<Option<Vec<u8>>> {
-    let decoder = bzip2::read::BzDecoder::new(reader);
+    read_metadata_from_decoded_tar_limited(
+        bzip2::read::BzDecoder::new(reader),
+        matches,
+        max_total,
+        max_entries,
+        max_entry,
+    )
+}
+
+/// Read the first matching metadata entry from an **xz**-compressed tar stream
+/// (debian `control.tar.xz`, incus `.tar.xz` images). xz of null/repeated bytes
+/// amplifies even harder than gzip, so the total-byte budget on the decoded
+/// stream is the primary defence.
+pub fn read_metadata_from_tar_xz<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_tar_xz_limited(
+        reader,
+        matches,
+        max_ingest_decompressed_bytes(),
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_tar_xz`].
+pub fn read_metadata_from_tar_xz_limited<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+    max_total: u64,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_decoded_tar_limited(
+        xz2::read::XzDecoder::new(reader),
+        matches,
+        max_total,
+        max_entries,
+        max_entry,
+    )
+}
+
+/// Read the first matching metadata entry from a **zstd**-compressed tar stream
+/// (debian `control.tar.zst`, incus `.tar.zst` images). Like xz, zstd bombs
+/// amplify hard, so the decoded-stream budget is the primary defence.
+pub fn read_metadata_from_tar_zst<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_tar_zst_limited(
+        reader,
+        matches,
+        max_ingest_decompressed_bytes(),
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_tar_zst`].
+pub fn read_metadata_from_tar_zst_limited<R: Read>(
+    reader: R,
+    matches: impl Fn(&Path) -> bool,
+    max_total: u64,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
+    let decoder = zstd::Decoder::new(reader)
+        .map_err(|e| AppError::Validation(format!("Invalid zstd stream: {}", e)))?;
+    read_metadata_from_decoded_tar_limited(decoder, matches, max_total, max_entries, max_entry)
+}
+
+/// Read the first matching metadata entry from an **already-decoded** tar stream
+/// where the caller chose the decompressor at runtime (e.g. incus dispatches on
+/// magic bytes, debian on the ar member extension, producing a `Box<dyn Read>`).
+/// Wraps the decoded stream in the shared total-byte budget and applies the
+/// entry-count + per-entry caps. This is the single seam through which every
+/// tar-family helper flows.
+pub fn read_metadata_from_decoded_tar<R: Read>(
+    decoded: R,
+    matches: impl Fn(&Path) -> bool,
+) -> Result<Option<Vec<u8>>> {
+    read_metadata_from_decoded_tar_limited(
+        decoded,
+        matches,
+        max_ingest_decompressed_bytes(),
+        MAX_INGEST_ARCHIVE_ENTRIES,
+        MAX_INGEST_METADATA_ENTRY_BYTES,
+    )
+}
+
+/// `_limited` seam for [`read_metadata_from_decoded_tar`]; the common core all
+/// tar-family variants delegate to.
+pub fn read_metadata_from_decoded_tar_limited<R: Read>(
+    decoded: R,
+    matches: impl Fn(&Path) -> bool,
+    max_total: u64,
+    max_entries: u64,
+    max_entry: u64,
+) -> Result<Option<Vec<u8>>> {
     read_tar_entries(
-        BudgetReader::new(decoder, max_total),
+        BudgetReader::new(decoded, max_total),
         matches,
         max_entries,
         max_entry,
     )
+}
+
+/// Decompress a standalone **gzip** stream (not a tar) to bytes, bounded by
+/// `max` so a gzip bomb aborts mid-inflate rather than buffering the whole
+/// inflated payload. Used for rubygems' `metadata.gz` inner blob. Returns `Err`
+/// when the decompressed size exceeds `max`.
+pub fn decompress_gz_capped<R: Read>(reader: R, max: u64, what: &str) -> Result<Vec<u8>> {
+    read_capped(flate2::read::GzDecoder::new(reader), max, what)
 }
 
 /// Read the first matching metadata entry from a *plain* (uncompressed) tar
@@ -313,12 +420,7 @@ pub fn read_metadata_from_tar_limited<R: Read>(
     max_entries: u64,
     max_entry: u64,
 ) -> Result<Option<Vec<u8>>> {
-    read_tar_entries(
-        BudgetReader::new(reader, max_total),
-        matches,
-        max_entries,
-        max_entry,
-    )
+    read_metadata_from_decoded_tar_limited(reader, matches, max_total, max_entries, max_entry)
 }
 
 /// Read the first matching metadata entry from a ZIP archive (`.nupkg`, `.whl`,
@@ -598,5 +700,105 @@ mod tests {
     fn read_capped_rejects_oversized() {
         assert!(read_capped(&b"abcdef"[..], 3, "x").is_err());
         assert_eq!(read_capped(&b"ab"[..], 8, "x").unwrap(), b"ab");
+    }
+
+    fn tar_xz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut builder = tar::Builder::new(xz2::write::XzEncoder::new(Vec::new(), 6));
+        for (name, data) in entries {
+            let mut header = tar::Header::new_gnu();
+            header.set_size(data.len() as u64);
+            header.set_mode(0o644);
+            header.set_cksum();
+            builder.append_data(&mut header, name, *data).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    fn tar_zst(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let raw = plain_tar(entries);
+        zstd::encode_all(std::io::Cursor::new(raw), 3).unwrap()
+    }
+
+    fn is_meta(p: &Path) -> bool {
+        p == Path::new("metadata.yaml")
+    }
+
+    #[test]
+    fn xz_normal_and_total_budget_breach() {
+        let archive = tar_xz(&[("metadata.yaml", b"name: img\nversion: 1")]);
+        let out = read_metadata_from_tar_xz_limited(
+            &archive[..],
+            is_meta,
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert_eq!(out.unwrap(), b"name: img\nversion: 1");
+
+        // 2 MiB of zeros before the target entry → past a tiny budget → reject.
+        let filler = vec![0u8; 2 * 1024 * 1024];
+        let bomb = tar_xz(&[("big.bin", &filler[..]), ("metadata.yaml", b"x")]);
+        assert!(bomb.len() < 64 * 1024, "xz of zeros compresses tiny");
+        let err = read_metadata_from_tar_xz_limited(&bomb[..], is_meta, 4096, 1000, 1024 * 1024);
+        assert!(
+            err.is_err(),
+            "xz pre-target inflation past budget must reject"
+        );
+    }
+
+    #[test]
+    fn zst_normal_and_total_budget_breach() {
+        let archive = tar_zst(&[("metadata.yaml", b"name: img\nversion: 2")]);
+        let out = read_metadata_from_tar_zst_limited(
+            &archive[..],
+            is_meta,
+            1024 * 1024,
+            1000,
+            1024 * 1024,
+        )
+        .unwrap();
+        assert_eq!(out.unwrap(), b"name: img\nversion: 2");
+
+        let filler = vec![0u8; 2 * 1024 * 1024];
+        let bomb = tar_zst(&[("big.bin", &filler[..]), ("metadata.yaml", b"x")]);
+        assert!(bomb.len() < 64 * 1024, "zstd of zeros compresses tiny");
+        let err = read_metadata_from_tar_zst_limited(&bomb[..], is_meta, 4096, 1000, 1024 * 1024);
+        assert!(
+            err.is_err(),
+            "zstd pre-target inflation past budget must reject"
+        );
+    }
+
+    #[test]
+    fn decompress_gz_capped_normal_and_bomb() {
+        // Normal small blob round-trips.
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(b"name: g\nversion: 1").unwrap();
+        let gz = enc.finish().unwrap();
+        assert_eq!(
+            decompress_gz_capped(&gz[..], 1024 * 1024, "x").unwrap(),
+            b"name: g\nversion: 1"
+        );
+
+        // A gzip bomb: tiny compressed, inflates past the cap → reject.
+        let mut enc2 = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::best());
+        enc2.write_all(&vec![0u8; 4 * 1024 * 1024]).unwrap();
+        let bomb = enc2.finish().unwrap();
+        assert!(bomb.len() < 64 * 1024, "gzip of zeros compresses tiny");
+        assert!(
+            decompress_gz_capped(&bomb[..], 1024, "x").is_err(),
+            "gzip bomb past cap must reject"
+        );
+    }
+
+    #[test]
+    fn decoded_tar_generic_matches_plain() {
+        // The generic decoded-tar seam over a plain (already-"decoded") stream.
+        let archive = plain_tar(&[("metadata.yaml", b"ok")]);
+        let out =
+            read_metadata_from_decoded_tar_limited(&archive[..], is_meta, 1024 * 1024, 1000, 1024)
+                .unwrap();
+        assert_eq!(out.unwrap(), b"ok");
     }
 }

--- a/backend/src/util/mod.rs
+++ b/backend/src/util/mod.rs
@@ -1,3 +1,4 @@
 //! Small, dependency-free utilities shared across the backend.
 
+pub mod bounded_archive;
 pub mod glob;


### PR DESCRIPTION
## Summary

Ingestion- and serve-time metadata extractors across ~9 package formats
decompressed uploaded/served archives to read a single small metadata file
(`Chart.yaml`, `.nuspec`, `pubspec.yaml`, `METADATA`, `.podspec.json`,
`metadata.config`, conda `index.json`, protobuf bundle entries) with **no cap on
total decompressed bytes, no entry-count cap, and no per-entry cap**. Those paths
run inside the request handler and never touched the scanner's bounded extractors
(`unpack_*_limited`, #2514) nor the Debian-index cap (#2482), so a crafted archive
could inflate unbounded during metadata parsing — a decompression-bomb /
unbounded-memory surface at upload and serve time.

This PR applies the existing bounded-decompression pattern uniformly by
consolidating it into one shared helper, `backend/src/util/bounded_archive.rs`,
and routing the previously-unbounded extractors through it. The helper mirrors the
already-correct `swift.rs::extract_manifest_from_zip` bounding (reference impl) and
reuses the `#2482` / `#2514` / conda `limited_decode_zstd` primitives.

### The shared caps (env-tunable, consistent with existing values)

- **Total decompressed-byte budget** on the decoded stream — default **128 MiB**
  (matches the Debian #2482 index cap), override `MAX_INGEST_DECOMPRESSED_BYTES`.
  This is the core mechanism: it defeats both the pre-target-inflation bomb (huge
  entries walked before the metadata file) and the entry-count bomb (the walk hits
  the byte budget and stops), and it aborts **mid-inflate** on the stream rather
  than buffering then checking length.
- **10 000 entry-count cap** (`MAX_INGEST_ARCHIVE_ENTRIES`, matches conda's
  `MAX_TAR_ENTRIES`) — defence-in-depth against inode/entry-count bombs.
- **8 MiB per-metadata-entry cap** (`MAX_INGEST_METADATA_ENTRY_BYTES`, ≥ helm's
  prior 4 MiB) — a metadata file larger than this is itself a bomb.

All caps sit far above real packages (metadata files are KB-scale), so legitimate
large charts/wheels/nupkgs/pods/gems still parse — a normal large package reads
only a few KB before the match and never approaches a cap.

### Sites bounded

P0 user-upload: `nuget.rs` (nuspec zip), `pub_registry.rs` (pubspec tar.gz),
`cocoapods.rs` (podspec tar.gz), `hex.rs` (metadata.config plain tar),
`formats/helm.rs` (Chart.yaml/values.yaml — added total + entry-count caps on top
of the existing per-entry cap), `conda.rs` (closed the v1 bz2 total-byte gap and
capped the v2 zip-entry reads).
P0/P1 serve: `pypi.rs` (wheel METADATA / sdist PKG-INFO), `protobuf.rs`
(`extract_files_from_bundle` — the worst in-memory site: reads every entry +
base64 — now total + entry-count + per-entry capped).
P1 (covered opportunistically via the shared helper): `swift.rs` (added an
entry-count cap on top of its existing byte cap), `rubygems.rs` upstream-spec
proxy fetch, `services/artifact_metadata.rs` npm/helm migration-worker readers.

Follow-ups (noted, out of scope): an optional process-wide
`MAX_CONCURRENT_INGEST_EXTRACTIONS` semaphore (the per-archive byte cap already
makes worst-case memory deterministic, so concurrency bounding is P2), and the
admin-only `test_format_handler` `formats/*.rs::parse_metadata` paths (not on the
live upload path).

No exploit payload or step-by-step reproduction is included. Closes #2556.


### Update — 3 additional production upload sites + xz/zstd module extension

Red-team completeness review found 3 more unbounded upload extractors reached
through `formats/*.rs` helpers (each a `read_to_string`/`read_to_end` reachable by
any authed writer), plus a module gap: incus/debian decode **xz and zstd**, which
the helper did not yet implement. Addressed on this branch:

- Extended `bounded_archive` with `read_metadata_from_tar_xz` / `_tar_zst`, a
  generic `read_metadata_from_decoded_tar` seam (for runtime codec dispatch), and
  `decompress_gz_capped` for standalone gzip blobs. xz/zstd of null/repeated bytes
  amplify harder than gzip, so the decoded-stream budget is the primary defence.
- `formats/incus.rs::extract_metadata_from_reader` (xz/zstd/gzip image
  `metadata.yaml`) — routed through the decoded-tar seam; a bomb now aborts
  mid-inflate (bounded, RSS flat) instead of ballooning. Best-effort metadata is
  preserved (upload still 202 when metadata is absent/unparseable).
- `formats/debian.rs::parse_control_tar` (gz/xz/bz2/zstd `control.tar`) — a bomb
  now returns 400 instead of after an unbounded `read_to_string`.
- `formats/rubygems.rs::extract_gemspec` (`.gem` `metadata.gz`) — the `.gem`
  upload path (distinct from the earlier `parse_upstream_specs` proxy-fetch
  hardening); a bomb now returns 400.

Verified on an isolated pool slot: ~KB-scale bombs inflating to 300 MiB for incus
(.tar.gz / .tar.xz / .tar.zst), .deb (control.tar.xz / .zst) and .gem are all
bounded with **RSS flat** (incus xz bomb peak 64.3 MiB, pre 63.5; gem/deb bombs
return 400 with RSS flat), while a normal incus image (202), .deb (201, control
parsed) and .gem (200, gemspec parsed) still succeed.


### Update 2 — composer upload (4th site) + upstream proxy-sync index decompression

Red-team's continued review found the last upload-reachable decompressor plus a
proxy-sync analogue. Both closed on this branch:

- **`formats/composer.rs::parse_composer_json`** (HIGH; composer upload
  `PUT/POST /composer/{repo}/api/packages`, `composer:write`) — the uploaded zip's
  `composer.json` was read with an unbounded `read_to_string`; a 600 KB deflate zip
  whose `composer.json` inflates to 600 MiB ballooned backend RSS +634 MiB before
  serde failed. Now routed through `read_metadata_from_zip`: bomb rejected 400,
  RSS flat.
- **`services/scheduler_service.rs`** upstream proxy-sync index decompression (LOW;
  attacker-controlled upstream mirror, egress) — RPM `primary.xml.gz` and Debian
  `Packages.gz` were decompressed with an unbounded `GzDecoder`/`read_to_string`.
  Consolidated into a `decompress_upstream_index_gz` helper bounded by the shared
  128 MiB total budget (the egress analogue of the rubygems `parse_upstream_specs`
  hardening; this also means RPM Phase-2's `primary.xml.gz` sync is bounded from
  the start). `bounded_archive` gained `budgeted_to(reader, budget)` for
  whole-stream decompression with an explicit budget.

Red-team confirmed composer is the last upload-reachable decompressor: the
remaining `formats/*.rs` decompressors (extract_package_json / extract_cargo_toml /
…) have no production caller (reachable only via maven XML or the admin-only
`test_format_handler`).

Verified on an isolated pool slot: composer 600 KB→600 MiB bomb → 400, RSS peak
41.8 MiB (pre 41.2) — flat; legit composer package → 201, parsed. Scheduler
upstream-index bounding is unit-verified (bomb → bounded/`Err`, legit index →
decompresses). All 16 prior sites still hold (1889 touched-module tests pass, no
regression).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

New tests: the `bounded_archive` module (total-budget, entry-count, per-entry, and
absent/normal cases for tar.gz / bz2 / plain-tar / zip variants), plus per-site
bomb+normal cases for nuget, helm (pre-target inflation + entry-count + normal),
conda v1 bz2, and protobuf bundle. Existing helm/nuget/conda/pypi/protobuf/pub/
cocoapods tests continue to pass.

Manual verification on an isolated instance: a decompression-bomb `.nupkg`
(9 MiB nuspec) and a bomb chart `.tgz` (200 MiB inflation before Chart.yaml) are
both rejected with a bounded 400 and flat backend memory (~42 MiB throughout),
while a normal chart and a normal `.nupkg` upload succeed and parse
name/version/description correctly.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
