### PR TITLE
feat(debian): dist/component/architecture filtering for APT remotes (passthrough-only)

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -40,7 +40,9 @@ use xz2::read::XzDecoder;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::{SharedState, SIGNED_RELEASE_CACHE_MAX_ENTRIES};
-use crate::formats::debian::{DebControl, DebianHandler};
+use crate::formats::debian::{
+    DebControl, DebianHandler, DebianRepositoryConfig, DEBIAN_CONFIG_KEY,
+};
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::models::signing_key::SigningKey;
 use crate::services::artifact_service::ArtifactService;
@@ -94,6 +96,89 @@ pub fn router() -> Router<SharedState> {
 
 async fn resolve_debian_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Response> {
     proxy_helpers::resolve_repo_by_key(db, repo_key, &["debian", "apt"], "a Debian").await
+}
+
+// ---------------------------------------------------------------------------
+// P2 (#2460) — pre-fetch distribution/component/architecture filter gate
+// ---------------------------------------------------------------------------
+
+/// Load the operator-configured Debian proxy filter (dist/component/arch
+/// allowlists) for a repository. An absent or unparseable config yields the
+/// default (empty) filter, which selects everything — i.e. the pre-#2460
+/// full-proxy behaviour is preserved for repositories with no filter set.
+async fn load_debian_filter(db: &PgPool, repo_id: uuid::Uuid) -> DebianRepositoryConfig {
+    let value: Option<String> = sqlx::query_scalar(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
+    )
+    .bind(repo_id)
+    .bind(DEBIAN_CONFIG_KEY)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten();
+    value
+        .as_deref()
+        .and_then(|v| serde_json::from_str::<DebianRepositoryConfig>(v).ok())
+        .unwrap_or_default()
+}
+
+/// Response returned when a request is refused by the P2 filter. A filtered-out
+/// path is answered with 404 (not 403) so the proxy does not advertise which
+/// distributions/components/architectures it actually mirrors.
+fn debian_filter_denied(dimension: &str, value: &str) -> Response {
+    tracing::debug!(
+        dimension = dimension,
+        value = value,
+        "debian proxy request denied by #2460 filter allowlist"
+    );
+    (StatusCode::NOT_FOUND, "Not found").into_response()
+}
+
+/// Pre-fetch allow/deny decision for a Debian proxy request. Each dimension is
+/// checked only when supplied (`Some`); an empty allowlist for a dimension
+/// permits everything. Returns a 404 [`Response`] as `Err` when any supplied
+/// dimension falls outside the configured allowlist. This runs BEFORE any
+/// upstream fetch, so an allowed request is left byte-identical through the P1
+/// integrity/passthrough path.
+#[allow(clippy::result_large_err)]
+fn debian_filter_decision(
+    filter: &DebianRepositoryConfig,
+    distribution: Option<&str>,
+    component: Option<&str>,
+    arch: Option<&str>,
+) -> Result<(), Response> {
+    if let Some(d) = distribution {
+        if !filter.distribution_selected(d) {
+            return Err(debian_filter_denied("distribution", d));
+        }
+    }
+    if let Some(c) = component {
+        if !filter.component_selected(c) {
+            return Err(debian_filter_denied("component", c));
+        }
+    }
+    if let Some(a) = arch {
+        if !filter.arch_selected(a) {
+            return Err(debian_filter_denied("architecture", a));
+        }
+    }
+    Ok(())
+}
+
+/// Return the component of a `dists/{dist}/*` sub-path when it is
+/// component-scoped (e.g. `main/i18n/Translation-en` -> `Some("main")`),
+/// or `None` for dist-level files that are not under a component
+/// (`Contents-amd64.gz`, `by-hash/...`, single-segment paths). Used to scope
+/// the catch-all metadata proxy to the component allowlist.
+fn catchall_component(dists_path: &str) -> Option<&str> {
+    let mut segments = dists_path.splitn(2, '/');
+    let first = segments.next()?;
+    // Not component-scoped: single-segment dist-level file, the by-hash tree,
+    // or dist-level Contents indices.
+    if segments.next().is_none() || first == "by-hash" || first.starts_with("Contents-") {
+        return None;
+    }
+    Some(first)
 }
 
 // ---------------------------------------------------------------------------
@@ -1429,6 +1514,11 @@ async fn release_file(
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    // #2460 P2: deny a distribution outside the operator allowlist before any
+    // upstream fetch. An allowed distribution passes through unchanged so the
+    // P1 signed-Release integrity path stays byte-identical.
+    let filter = load_debian_filter(&state.db, repo.id).await;
+    debian_filter_decision(&filter, Some(&distribution), None, None)?;
     proxy
         .dists_detecting_change("Release", "text/plain; charset=utf-8", &repo)
         .await?;
@@ -1451,6 +1541,9 @@ async fn in_release_file(
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch).
+    let filter = load_debian_filter(&state.db, repo.id).await;
+    debian_filter_decision(&filter, Some(&distribution), None, None)?;
     proxy
         .dists_detecting_change("InRelease", "text/plain; charset=utf-8", &repo)
         .await?;
@@ -1505,6 +1598,9 @@ async fn release_gpg(
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
+    // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch).
+    let filter = load_debian_filter(&state.db, repo.id).await;
+    debian_filter_decision(&filter, Some(&distribution), None, None)?;
     // Release.gpg is the detached signature of Release. We do not need
     // revalidation here because the matching Release fetch (called
     // by apt before Release.gpg) already drove epoch invalidation.
@@ -1754,6 +1850,18 @@ async fn dists_dispatch(
     Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
     if let Some(req) = parse_packages_request(&dists_path) {
+        // #2460 P2: pre-fetch dist/component/arch allowlist gate for Packages
+        // indices. An empty filter (default) permits everything.
+        let repo = resolve_debian_repo(&state.0.db, &repo_key).await?;
+        let filter = load_debian_filter(&state.0.db, repo.id).await;
+        let arch = strip_binary_arch_prefix(&req.binary_arch);
+        debian_filter_decision(
+            &filter,
+            Some(&distribution),
+            Some(&req.component),
+            Some(arch),
+        )?;
+
         let path = Path((repo_key, distribution, req.component, req.binary_arch));
         return match req.ext {
             PackagesExt::Plain => packages_index(state, path).await,
@@ -1777,6 +1885,18 @@ async fn dists_proxy_catchall(
     Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+
+    // #2460 P2: pre-fetch allowlist gate for catch-all dists metadata
+    // (i18n/Translation, Sources, dep11, Contents, ...). Always gate the
+    // distribution; additionally gate the component when the path is
+    // component-scoped. An empty filter permits everything.
+    let filter = load_debian_filter(&state.db, repo.id).await;
+    debian_filter_decision(
+        &filter,
+        Some(&distribution),
+        catchall_component(&dists_path),
+        None,
+    )?;
 
     let upstream_path = format!("dists/{}/{}", distribution, dists_path);
 
@@ -1890,6 +2010,14 @@ async fn pool_download(
     ctx: crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
+
+    // #2460 P2: pre-fetch allowlist gate for pool downloads. The pool path
+    // carries the component; the architecture is derived from the `.deb`
+    // filename when parseable. An empty filter permits everything.
+    let filter = load_debian_filter(&state.db, repo.id).await;
+    let pool_filename = path.rsplit('/').next().unwrap_or(&path);
+    let pool_arch = parse_deb_filename(pool_filename).map(|d| d.arch);
+    debian_filter_decision(&filter, None, Some(&component), pool_arch.as_deref())?;
 
     let artifact_path = format!("pool/{}/{}", component, path);
 
@@ -2409,6 +2537,72 @@ mod tests {
             sha1: None,
             md5: None,
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #2460 P2 — pre-fetch filter gate
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_catchall_component_scoping() {
+        // Component-scoped metadata paths return their component.
+        assert_eq!(catchall_component("main/i18n/Translation-en"), Some("main"));
+        assert_eq!(
+            catchall_component("contrib/dep11/Components-amd64.yml.gz"),
+            Some("contrib")
+        );
+        assert_eq!(catchall_component("main/Contents-amd64.gz"), Some("main"));
+        // Dist-level (non component-scoped) paths return None.
+        assert_eq!(catchall_component("Contents-amd64.gz"), None);
+        assert_eq!(catchall_component("Release"), None);
+        assert_eq!(catchall_component("by-hash/SHA256/abcdef"), None);
+    }
+
+    #[test]
+    fn test_filter_decision_empty_allows_everything() {
+        let filter = DebianRepositoryConfig::default();
+        assert!(
+            debian_filter_decision(&filter, Some("bookworm"), Some("contrib"), Some("arm64"))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_filter_decision_allows_in_allowlist() {
+        let filter = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        assert!(
+            debian_filter_decision(&filter, Some("bookworm"), Some("main"), Some("amd64")).is_ok()
+        );
+        // Arch-independent packages are always permitted.
+        assert!(
+            debian_filter_decision(&filter, Some("bookworm"), Some("main"), Some("all")).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_filter_decision_denies_out_of_allowlist_with_404() {
+        let filter = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        // Denied distribution.
+        let resp = debian_filter_decision(&filter, Some("trixie"), None, None).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Denied component.
+        let resp =
+            debian_filter_decision(&filter, Some("bookworm"), Some("contrib"), None).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Denied architecture.
+        let resp = debian_filter_decision(&filter, Some("bookworm"), Some("main"), Some("arm64"))
+            .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -250,35 +250,206 @@ fn decode_to_fixpoint(raw: &str) -> Option<String> {
     None
 }
 
-/// Reject a Debian proxy sub-path that, once the upstream URL parser
-/// percent-decodes and normalises it, would escape the gated
-/// distribution/component/architecture via path traversal. The pre-fetch
-/// allowlist gate reads the raw (axum-once-decoded) segments, but
-/// `build_upstream_url` -> `reqwest::Url::parse` decodes `%2e`/`%2E` and
-/// normalises `..`/`.` dot-segments AFTER the gate ran — so `main/%2e%2e/contrib`
-/// (or the double-encoded `main/%252e%252e/contrib`) is approved as `main` yet
-/// fetched as `contrib`. Decoding to a fixpoint and rejecting any residual
-/// dot-segment / backslash / NUL closes that gap. Legitimately percent-encoded
-/// filename bytes (e.g. an epoch colon `%3a`) decode to a non-separator and are
-/// preserved.
+/// The upstream base URL to gate against, or `None` for repositories the P2
+/// filter does not apply to (hosted/virtual, or a remote with no upstream).
+fn repo_remote_upstream(repo: &RepoInfo) -> Option<&str> {
+    if repo.repo_type == RepositoryType::Remote {
+        repo.upstream_url.as_deref()
+    } else {
+        None
+    }
+}
+
+/// Resolve the exact path reqwest will fetch for `relative`, returned relative
+/// to the upstream base. This is the structural defence against gate/fetch
+/// divergence: rather than hand-rolling normalisation, we build the URL the
+/// same way the proxy does and let the SAME WHATWG parser reqwest uses do the
+/// tab/LF/CR stripping and `.`/`..` dot-segment resolution, then gate on the
+/// result — so a request like `main/%2e%09%2e/contrib` (which axum decodes to a
+/// literal-tab segment that reqwest reforms into `..` -> contrib) is gated on
+/// the `contrib` it actually fetches.
+///
+/// A belt runs first: any C0 control byte (incl. tab/LF/CR) or space in the
+/// (already once-decoded) request path is refused outright rather than left to
+/// be silently stripped. Escapes above the base (scheme/host/port/prefix
+/// change) are refused too.
 #[allow(clippy::result_large_err)]
-fn reject_unsafe_debian_subpath(raw: &str) -> Result<(), Response> {
-    if raw.contains('\0') || raw.contains('\\') {
-        return Err(debian_filter_denied("path", raw));
+fn normalized_debian_relpath(base_url: &str, relative: &str) -> Result<String, Response> {
+    if relative.bytes().any(|b| b <= 0x20 || b == 0x7f) {
+        return Err(debian_filter_denied("path", relative));
     }
-    let decoded = match decode_to_fixpoint(raw) {
-        Some(d) => d,
-        None => return Err(debian_filter_denied("path", raw)),
-    };
-    if decoded.contains('\0') || decoded.contains('\\') {
-        return Err(debian_filter_denied("path", raw));
+    let base = reqwest::Url::parse(base_url).map_err(|_| debian_filter_denied("path", relative))?;
+    let full = format!(
+        "{}/{}",
+        base_url.trim_end_matches('/'),
+        relative.trim_start_matches('/')
+    );
+    let parsed = reqwest::Url::parse(&full).map_err(|_| debian_filter_denied("path", relative))?;
+    // The normalised URL must stay on the same origin as the base — a path that
+    // rewrites the host/scheme/port must never slip past the filter.
+    if parsed.scheme() != base.scheme()
+        || parsed.host_str() != base.host_str()
+        || parsed.port_or_known_default() != base.port_or_known_default()
+    {
+        return Err(debian_filter_denied("path", relative));
     }
-    for seg in decoded.split('/') {
-        if seg == ".." || seg == "." || seg.is_empty() {
-            return Err(debian_filter_denied("path", raw));
+    let base_prefix = base.path().trim_end_matches('/');
+    let rel = parsed
+        .path()
+        .strip_prefix(base_prefix)
+        .map(|r| r.trim_start_matches('/'))
+        .filter(|r| !r.is_empty())
+        .ok_or_else(|| debian_filter_denied("path", relative))?;
+    Ok(rel.to_string())
+}
+
+/// Normalise a `dists/{distribution}/{raw_suffix}` request to the path reqwest
+/// will fetch, returning `(distribution, suffix)` where `suffix` is everything
+/// after `dists/{distribution}/`. Errors (404) on a control byte, over-encoding,
+/// base escape, or a normalised path no longer rooted at `dists/`.
+#[allow(clippy::result_large_err)]
+fn normalized_dists_parts(
+    base_url: &str,
+    distribution: &str,
+    raw_suffix: &str,
+) -> Result<(String, String), Response> {
+    let relative = format!("dists/{}/{}", distribution, raw_suffix);
+    let norm = normalized_debian_relpath(base_url, &relative)?;
+    let mut it = norm.splitn(3, '/');
+    match it.next() {
+        Some("dists") => {}
+        _ => return Err(debian_filter_denied("path", &norm)),
+    }
+    let dist = it.next().unwrap_or("").to_string();
+    let suffix = it.next().unwrap_or("").to_string();
+    if dist.is_empty() {
+        return Err(debian_filter_denied("path", &norm));
+    }
+    Ok((dist, suffix))
+}
+
+/// Gate a `dists/...` proxy request on the reqwest-normalised path. Extracts the
+/// effective distribution/component/architecture from the path that will
+/// actually be fetched (not the raw axum segments), so encoded/tab/dot
+/// traversal cannot split the gate from the fetch. `raw_suffix` is the part
+/// after `dists/{distribution}/` (e.g. `Release`, `main/binary-amd64/Packages`).
+#[allow(clippy::result_large_err)]
+fn gate_debian_dists(
+    filter: &DebianRepositoryConfig,
+    base_url: &str,
+    distribution: &str,
+    raw_suffix: &str,
+) -> Result<(), Response> {
+    let (dist, suffix) = normalized_dists_parts(base_url, distribution, raw_suffix)?;
+    debian_filter_decision(
+        filter,
+        Some(&dist),
+        catchall_component(&suffix),
+        catchall_arch(&suffix).as_deref(),
+    )
+}
+
+/// Gate a `pool/{component}/{path}` proxy request on the reqwest-normalised
+/// path. Gates the component, then the architecture (fail CLOSED: when an arch
+/// allowlist is set but the `.deb` filename does not yield a parseable arch,
+/// deny rather than skip).
+#[allow(clippy::result_large_err)]
+fn gate_debian_pool(
+    filter: &DebianRepositoryConfig,
+    base_url: &str,
+    component: &str,
+    path: &str,
+) -> Result<(), Response> {
+    let relative = format!("pool/{}/{}", component, path);
+    let norm = normalized_debian_relpath(base_url, &relative)?;
+    let mut it = norm.splitn(3, '/');
+    match it.next() {
+        Some("pool") => {}
+        _ => return Err(debian_filter_denied("path", &norm)),
+    }
+    let comp = it.next().unwrap_or("");
+    let rest = it.next().unwrap_or("");
+    if comp.is_empty() || rest.is_empty() {
+        return Err(debian_filter_denied("path", &norm));
+    }
+    debian_filter_decision(filter, None, Some(comp), None)?;
+    if !filter.architectures.is_empty() {
+        let filename = rest.rsplit('/').next().unwrap_or(rest);
+        let decoded = decode_to_fixpoint(filename).unwrap_or_else(|| filename.to_string());
+        match parse_deb_filename(&decoded).map(|d| d.arch) {
+            Some(arch) => debian_filter_decision(filter, None, None, Some(&arch))?,
+            None => return Err(debian_filter_denied("architecture", filename)),
         }
     }
     Ok(())
+}
+
+/// Gate the architecture of a `by-hash` metadata request, where the arch is
+/// encoded in the content HASH rather than the path (so `catchall_arch` cannot
+/// see it). Cross-references the requested SHA-256 against the arch-scoped
+/// entries in the already-verified signed `Release`: the by-hash content is
+/// served only when its hash maps to an allowed-architecture index. Unknown
+/// hashes and non-SHA-256 by-hash trees fail CLOSED under an arch allowlist.
+/// A no-op when no arch allowlist is configured or the request is not by-hash.
+#[allow(clippy::result_large_err)]
+async fn enforce_by_hash_arch(
+    proxy: &ProxyService,
+    repo_id: uuid::Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    filter: &DebianRepositoryConfig,
+    distribution: &str,
+    raw_suffix: &str,
+) -> Result<(), Response> {
+    if filter.architectures.is_empty() {
+        return Ok(());
+    }
+    let (ndist, suffix) = normalized_dists_parts(upstream_url, distribution, raw_suffix)?;
+    if !suffix.contains("by-hash/") {
+        return Ok(());
+    }
+    // A by-hash tree under a non-SHA-256 algorithm cannot be arch-resolved from
+    // the SHA-256 Release table: refuse it under an arch filter.
+    let want_hash = match by_hash_sha256(&suffix) {
+        Some(h) => h,
+        None => return Err(debian_filter_denied("by-hash", &suffix)),
+    };
+    let table = match load_release_checksums(proxy, repo_id, repo_key, upstream_url, &ndist).await {
+        Some(t) => t,
+        None => return Err(debian_filter_denied("by-hash", want_hash)),
+    };
+    if by_hash_arch_allowed(&table, want_hash, filter) {
+        Ok(())
+    } else {
+        // Either the hash maps to a denied architecture, or the signed Release
+        // does not vouch for it at all — fail closed under an arch filter.
+        Err(debian_filter_denied("by-hash", want_hash))
+    }
+}
+
+/// Decide whether a by-hash request for `want_hash` is permitted under
+/// `filter`'s architecture allowlist, by cross-referencing the requested
+/// SHA-256 against the signed-Release checksum table (`path -> (hash, size)`).
+/// Returns `true` only when the hash is vouched for by the Release AND every
+/// index path it maps to is an allowed (or architecture-independent) arch;
+/// `false` for a denied arch or an unknown hash (fail closed).
+fn by_hash_arch_allowed(
+    table: &HashMap<String, (String, u64)>,
+    want_hash: &str,
+    filter: &DebianRepositoryConfig,
+) -> bool {
+    let mut matched = false;
+    for (path, (hash, _size)) in table {
+        if hash.eq_ignore_ascii_case(want_hash) {
+            matched = true;
+            if let Some(arch) = catchall_arch(path) {
+                if !filter.arch_selected(&arch) {
+                    return false;
+                }
+            }
+        }
+    }
+    matched
 }
 
 // ---------------------------------------------------------------------------
@@ -1615,11 +1786,13 @@ async fn release_file(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     // #2460 P2: deny a distribution outside the operator allowlist before any
-    // upstream fetch. An allowed distribution passes through unchanged so the
-    // P1 signed-Release integrity path stays byte-identical.
-    reject_unsafe_debian_subpath(&distribution)?;
-    let filter = load_debian_filter(&state.db, repo.id).await;
-    debian_filter_decision(&filter, Some(&distribution), None, None)?;
+    // upstream fetch, gating on the reqwest-normalised path. An allowed
+    // distribution passes through unchanged so the P1 signed-Release integrity
+    // path stays byte-identical.
+    if let Some(base) = repo_remote_upstream(&repo) {
+        let filter = load_debian_filter(&state.db, repo.id).await;
+        gate_debian_dists(&filter, base, &distribution, "Release")?;
+    }
     proxy
         .dists_detecting_change("Release", "text/plain; charset=utf-8", &repo)
         .await?;
@@ -1642,10 +1815,12 @@ async fn in_release_file(
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
-    // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch).
-    reject_unsafe_debian_subpath(&distribution)?;
-    let filter = load_debian_filter(&state.db, repo.id).await;
-    debian_filter_decision(&filter, Some(&distribution), None, None)?;
+    // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch),
+    // gating on the reqwest-normalised path.
+    if let Some(base) = repo_remote_upstream(&repo) {
+        let filter = load_debian_filter(&state.db, repo.id).await;
+        gate_debian_dists(&filter, base, &distribution, "InRelease")?;
+    }
     proxy
         .dists_detecting_change("InRelease", "text/plain; charset=utf-8", &repo)
         .await?;
@@ -1700,10 +1875,12 @@ async fn release_gpg(
     Path((repo_key, distribution)): Path<(String, String)>,
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
-    // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch).
-    reject_unsafe_debian_subpath(&distribution)?;
-    let filter = load_debian_filter(&state.db, repo.id).await;
-    debian_filter_decision(&filter, Some(&distribution), None, None)?;
+    // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch),
+    // gating on the reqwest-normalised path.
+    if let Some(base) = repo_remote_upstream(&repo) {
+        let filter = load_debian_filter(&state.db, repo.id).await;
+        gate_debian_dists(&filter, base, &distribution, "Release.gpg")?;
+    }
     // Release.gpg is the detached signature of Release. We do not need
     // revalidation here because the matching Release fetch (called
     // by apt before Release.gpg) already drove epoch invalidation.
@@ -1952,24 +2129,16 @@ async fn dists_dispatch(
     state: State<SharedState>,
     Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
-    // #2460 hardening: refuse encoded path-traversal BEFORE the allowlist gate,
-    // so the gate sees the same segments reqwest will resolve upstream (defeats
-    // `%2e%2e` / double-encoded `%252e%252e` component/dist/arch escapes).
-    reject_unsafe_debian_subpath(&distribution)?;
-    reject_unsafe_debian_subpath(&dists_path)?;
-
     if let Some(req) = parse_packages_request(&dists_path) {
-        // #2460 P2: pre-fetch dist/component/arch allowlist gate for Packages
-        // indices. An empty filter (default) permits everything.
+        // #2460 P2: gate the Packages index on the reqwest-normalised path so a
+        // dist/component/arch escape cannot split the gate from the fetch. An
+        // empty filter (default) permits everything. Non-Packages shapes fall
+        // through to the catch-all, which applies the same normalised gate.
         let repo = resolve_debian_repo(&state.0.db, &repo_key).await?;
-        let filter = load_debian_filter(&state.0.db, repo.id).await;
-        let arch = strip_binary_arch_prefix(&req.binary_arch);
-        debian_filter_decision(
-            &filter,
-            Some(&distribution),
-            Some(&req.component),
-            Some(arch),
-        )?;
+        if let Some(base) = repo_remote_upstream(&repo) {
+            let filter = load_debian_filter(&state.0.db, repo.id).await;
+            gate_debian_dists(&filter, base, &distribution, &dists_path)?;
+        }
 
         let path = Path((repo_key, distribution, req.component, req.binary_arch));
         return match req.ext {
@@ -1995,23 +2164,30 @@ async fn dists_proxy_catchall(
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
-    // #2460 hardening: refuse encoded path-traversal before gating.
-    reject_unsafe_debian_subpath(&distribution)?;
-    reject_unsafe_debian_subpath(&dists_path)?;
-
     // #2460 P2: pre-fetch allowlist gate for catch-all dists metadata
-    // (i18n/Translation, Sources, dep11, Contents, ...). Always gate the
-    // distribution; additionally gate the component when the path is
-    // component-scoped and the architecture when the metadata is arch-scoped
-    // (Contents-<arch>, dep11 Components-<arch>, binary-<arch>). An empty
-    // filter permits everything.
-    let filter = load_debian_filter(&state.db, repo.id).await;
-    debian_filter_decision(
-        &filter,
-        Some(&distribution),
-        catchall_component(&dists_path),
-        catchall_arch(&dists_path).as_deref(),
-    )?;
+    // (i18n/Translation, Sources, dep11, Contents, ...), gating on the exact
+    // reqwest-normalised path. Gates the distribution, the component when the
+    // path is component-scoped, and the architecture when the metadata is
+    // arch-scoped (Contents-<arch>, dep11 Components-<arch>, binary-<arch>).
+    // by-hash requests carry the arch in the content hash, not the path, so a
+    // second pass cross-references the requested SHA-256 against the signed
+    // Release. An empty filter permits everything.
+    if let Some(base) = repo_remote_upstream(&repo) {
+        let filter = load_debian_filter(&state.db, repo.id).await;
+        gate_debian_dists(&filter, base, &distribution, &dists_path)?;
+        if let Some(proxy) = state.proxy_service.as_deref() {
+            enforce_by_hash_arch(
+                proxy,
+                repo.id,
+                &repo_key,
+                base,
+                &filter,
+                &distribution,
+                &dists_path,
+            )
+            .await?;
+        }
+    }
 
     let upstream_path = format!("dists/{}/{}", distribution, dists_path);
 
@@ -2126,25 +2302,13 @@ async fn pool_download(
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
-    // #2460 hardening: refuse encoded path-traversal before gating.
-    reject_unsafe_debian_subpath(&component)?;
-    reject_unsafe_debian_subpath(&path)?;
-
-    // #2460 P2: pre-fetch allowlist gate for pool downloads. The pool path
-    // carries the component; the architecture is derived from the `.deb`
-    // filename. An empty filter permits everything.
-    let filter = load_debian_filter(&state.db, repo.id).await;
-    debian_filter_decision(&filter, None, Some(&component), None)?;
-    // Architecture gate: fail CLOSED when an arch allowlist is set but the
-    // architecture cannot be determined (e.g. a percent-encoded `.deb`
-    // extension that `parse_deb_filename` rejects) — never skip the check.
-    if !filter.architectures.is_empty() {
-        let decoded_path = decode_to_fixpoint(&path).unwrap_or_else(|| path.clone());
-        let pool_filename = decoded_path.rsplit('/').next().unwrap_or(&decoded_path);
-        match parse_deb_filename(pool_filename).map(|d| d.arch) {
-            Some(arch) => debian_filter_decision(&filter, None, None, Some(&arch))?,
-            None => return Err(debian_filter_denied("architecture", pool_filename)),
-        }
+    // #2460 P2: pre-fetch allowlist gate for pool downloads, gating on the
+    // reqwest-normalised path. Gates the component and the architecture (derived
+    // from the `.deb` filename, fail-closed when unparseable). An empty filter
+    // permits everything.
+    if let Some(base) = repo_remote_upstream(&repo) {
+        let filter = load_debian_filter(&state.db, repo.id).await;
+        gate_debian_pool(&filter, base, &component, &path)?;
     }
 
     let artifact_path = format!("pool/{}/{}", component, path);
@@ -2762,23 +2926,154 @@ mod tests {
         );
     }
 
+    const TEST_BASE: &str = "http://deb.debian.org/debian";
+
     #[test]
-    fn test_reject_unsafe_debian_subpath() {
-        // Clean paths pass, including a legit epoch-encoded filename.
-        assert!(reject_unsafe_debian_subpath("main/binary-amd64/Packages.gz").is_ok());
-        assert!(reject_unsafe_debian_subpath("g/gcc-defaults/gcc_4%3a10-1_amd64.deb").is_ok());
-        // Literal, single- and double-encoded traversal all rejected with 404.
-        for bad in [
-            "main/../contrib/binary-amd64/Packages.gz",
-            "main/%2e%2e/contrib/binary-amd64/Packages.gz",
-            "main/%252e%252e/contrib/binary-amd64/Packages.gz",
-            "main/%252e%252e/%252e%252e/trixie/main/binary-amd64/Packages.gz",
-            "main/./Packages",
-            "main\\..\\contrib",
+    fn test_normalized_relpath_matches_reqwest_fetch_path() {
+        // The gate input must equal the exact path reqwest fetches. For every
+        // tricky encoding, assert normalized_debian_relpath == the path reqwest
+        // (url crate) resolves for the same joined URL — no gate/fetch drift.
+        for raw in [
+            "dists/bookworm/main/binary-amd64/Packages.gz",
+            "dists/bookworm/main/%2e%2e/contrib/binary-amd64/Packages.gz",
+            // Literal-tab dot segment (what axum yields for %2e%09%2e).
+            "dists/bookworm/main/.\t./contrib/binary-amd64/Packages.gz",
         ] {
-            let resp = reject_unsafe_debian_subpath(bad).unwrap_err();
-            assert_eq!(resp.status(), StatusCode::NOT_FOUND, "should reject: {bad}");
+            let full = format!("{}/{}", TEST_BASE, raw);
+            let fetched = reqwest::Url::parse(&full).unwrap();
+            let base = reqwest::Url::parse(TEST_BASE).unwrap();
+            let expected = fetched
+                .path()
+                .strip_prefix(base.path().trim_end_matches('/'))
+                .unwrap()
+                .trim_start_matches('/')
+                .to_string();
+            // A control byte is refused up front (belt); otherwise parity holds.
+            if raw.bytes().any(|b| b <= 0x20 || b == 0x7f) {
+                assert!(normalized_debian_relpath(TEST_BASE, raw).is_err());
+            } else {
+                assert_eq!(
+                    normalized_debian_relpath(TEST_BASE, raw).unwrap(),
+                    expected,
+                    "gate input must equal reqwest fetch path for: {raw:?}"
+                );
+            }
         }
+    }
+
+    #[test]
+    fn test_gate_dists_blocks_tab_and_encoded_traversal() {
+        let filter = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        // Allowed request passes.
+        assert!(gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main/binary-amd64/Packages.gz"
+        )
+        .is_ok());
+        // Tab-formed dot-segment (axum-decoded %2e%09%2e) -> reforms to contrib.
+        let resp = gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main/.\t./contrib/binary-amd64/Packages.gz",
+        )
+        .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Distribution escape via tab dot-segments -> trixie.
+        let resp = gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main/.\t./.\t./trixie/main/binary-amd64/Packages.gz",
+        )
+        .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Single-encoded %2e%2e -> contrib.
+        let resp = gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main/%2e%2e/contrib/binary-amd64/Packages.gz",
+        )
+        .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_normalized_relpath_rejects_control_bytes_and_escape() {
+        // Raw control byte (tab/LF/CR/space) refused up front.
+        for bad in ["main/\t/Packages", "main/\n/Packages", "main/ /Packages"] {
+            assert!(
+                normalized_debian_relpath(TEST_BASE, bad).is_err(),
+                "should reject control/ws: {bad:?}"
+            );
+        }
+        // Escape above the base path is refused.
+        assert!(normalized_debian_relpath(TEST_BASE, "../../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_gate_pool_fail_closed_on_unparseable_arch() {
+        let filter = DebianRepositoryConfig {
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        // Allowed amd64 .deb passes.
+        assert!(
+            gate_debian_pool(&filter, TEST_BASE, "main", "0/0ad/0ad_0.0.26-3_amd64.deb").is_ok()
+        );
+        // arm64 denied.
+        let resp = gate_debian_pool(&filter, TEST_BASE, "main", "0/0ad/0ad_0.0.26-3_arm64.deb")
+            .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Denied component.
+        let resp =
+            gate_debian_pool(&filter, TEST_BASE, "contrib", "1/1oom/1oom_1_amd64.deb").unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Unparseable arch (encoded extension) -> fail closed.
+        let resp = gate_debian_pool(
+            &filter,
+            TEST_BASE,
+            "main",
+            "0/0ad/0ad_0.0.26-3_arm64%252edeb",
+        )
+        .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_by_hash_arch_allowed_cross_reference() {
+        use std::collections::HashMap;
+        let filter = DebianRepositoryConfig {
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        let mut table: HashMap<String, (String, u64)> = HashMap::new();
+        table.insert("main/Contents-amd64.gz".into(), ("aaa".into(), 1));
+        table.insert("main/Contents-arm64.gz".into(), ("bbb".into(), 2));
+        table.insert(
+            "main/dep11/Components-arm64.yml.gz".into(),
+            ("ccc".into(), 3),
+        );
+        table.insert("main/i18n/Translation-en".into(), ("ddd".into(), 4));
+        // amd64 index hash -> allowed.
+        assert!(by_hash_arch_allowed(&table, "aaa", &filter));
+        // arm64 Contents hash -> denied.
+        assert!(!by_hash_arch_allowed(&table, "bbb", &filter));
+        // arm64 dep11 hash -> denied.
+        assert!(!by_hash_arch_allowed(&table, "ccc", &filter));
+        // arch-independent i18n hash -> allowed.
+        assert!(by_hash_arch_allowed(&table, "ddd", &filter));
+        // Unknown hash -> fail closed.
+        assert!(!by_hash_arch_allowed(&table, "zzz", &filter));
     }
 
     #[test]

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -181,6 +181,106 @@ fn catchall_component(dists_path: &str) -> Option<&str> {
     Some(first)
 }
 
+/// Strip a trailing index-compression suffix (`.gz`/`.xz`/`.bz2`/`.zst`/
+/// `.zstd`/`.lz4`) from a metadata leaf name, so an embedded architecture can
+/// be recovered from e.g. `Contents-arm64.gz`.
+fn strip_index_compression_suffix(name: &str) -> &str {
+    for suffix in [".gz", ".xz", ".bz2", ".zst", ".zstd", ".lz4"] {
+        if let Some(base) = name.strip_suffix(suffix) {
+            return base;
+        }
+    }
+    name
+}
+
+/// Extract the architecture a catch-all `dists/{dist}/*` metadata path is
+/// scoped to, if any, so the allowlist can gate it. Recognises
+/// `.../binary-<arch>/...` (Packages-family), `.../Contents-[udeb-]<arch>[.comp]`
+/// (Contents index), and `.../Components-<arch>.yml[.comp]` (dep11 metadata).
+///
+/// Architecture-independent metadata (`all`/`source`, i18n/Translation,
+/// Sources, Release, by-hash, and so on) returns `None` and is never
+/// arch-gated.
+fn catchall_arch(dists_path: &str) -> Option<String> {
+    for seg in dists_path.split('/') {
+        let candidate = if let Some(rest) = seg.strip_prefix("binary-") {
+            Some(rest.to_string())
+        } else if let Some(rest) = seg.strip_prefix("Contents-") {
+            // `Contents-amd64.gz` and `Contents-udeb-amd64.gz`: the arch is the
+            // last `-`-separated token of the compression-stripped base.
+            strip_index_compression_suffix(rest)
+                .rsplit('-')
+                .next()
+                .map(|s| s.to_string())
+        } else if let Some(rest) = seg.strip_prefix("Components-") {
+            // dep11 `Components-<arch>.yml[.comp]`.
+            rest.split('.').next().map(|s| s.to_string())
+        } else {
+            None
+        };
+        if let Some(arch) = candidate {
+            if arch.is_empty() || arch == "all" || arch == "source" {
+                // Architecture-independent — not gated.
+                return None;
+            }
+            return Some(arch);
+        }
+    }
+    None
+}
+
+/// Percent-decode `raw` repeatedly until it stops changing (a fixpoint), so a
+/// single- OR multiply-encoded sequence collapses to the exact form reqwest's
+/// WHATWG URL parser will resolve when it builds the upstream request. Returns
+/// `None` on invalid UTF-8 or if more than a small number of decode layers are
+/// required (a pathological over-encoding, refused out of caution).
+fn decode_to_fixpoint(raw: &str) -> Option<String> {
+    let mut cur = raw.to_string();
+    for _ in 0..8 {
+        if !cur.contains('%') {
+            return Some(cur);
+        }
+        let decoded = urlencoding::decode(&cur).ok()?.into_owned();
+        if decoded == cur {
+            // A `%` that is not part of a valid escape — treat as a literal.
+            return Some(cur);
+        }
+        cur = decoded;
+    }
+    None
+}
+
+/// Reject a Debian proxy sub-path that, once the upstream URL parser
+/// percent-decodes and normalises it, would escape the gated
+/// distribution/component/architecture via path traversal. The pre-fetch
+/// allowlist gate reads the raw (axum-once-decoded) segments, but
+/// `build_upstream_url` -> `reqwest::Url::parse` decodes `%2e`/`%2E` and
+/// normalises `..`/`.` dot-segments AFTER the gate ran — so `main/%2e%2e/contrib`
+/// (or the double-encoded `main/%252e%252e/contrib`) is approved as `main` yet
+/// fetched as `contrib`. Decoding to a fixpoint and rejecting any residual
+/// dot-segment / backslash / NUL closes that gap. Legitimately percent-encoded
+/// filename bytes (e.g. an epoch colon `%3a`) decode to a non-separator and are
+/// preserved.
+#[allow(clippy::result_large_err)]
+fn reject_unsafe_debian_subpath(raw: &str) -> Result<(), Response> {
+    if raw.contains('\0') || raw.contains('\\') {
+        return Err(debian_filter_denied("path", raw));
+    }
+    let decoded = match decode_to_fixpoint(raw) {
+        Some(d) => d,
+        None => return Err(debian_filter_denied("path", raw)),
+    };
+    if decoded.contains('\0') || decoded.contains('\\') {
+        return Err(debian_filter_denied("path", raw));
+    }
+    for seg in decoded.split('/') {
+        if seg == ".." || seg == "." || seg.is_empty() {
+            return Err(debian_filter_denied("path", raw));
+        }
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Debian metadata from filename
 // ---------------------------------------------------------------------------
@@ -1517,6 +1617,7 @@ async fn release_file(
     // #2460 P2: deny a distribution outside the operator allowlist before any
     // upstream fetch. An allowed distribution passes through unchanged so the
     // P1 signed-Release integrity path stays byte-identical.
+    reject_unsafe_debian_subpath(&distribution)?;
     let filter = load_debian_filter(&state.db, repo.id).await;
     debian_filter_decision(&filter, Some(&distribution), None, None)?;
     proxy
@@ -1542,6 +1643,7 @@ async fn in_release_file(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch).
+    reject_unsafe_debian_subpath(&distribution)?;
     let filter = load_debian_filter(&state.db, repo.id).await;
     debian_filter_decision(&filter, Some(&distribution), None, None)?;
     proxy
@@ -1599,6 +1701,7 @@ async fn release_gpg(
 ) -> Result<Response, Response> {
     let (proxy, repo) = DebianProxy::resolve(&state, &repo_key, &distribution).await?;
     // #2460 P2: deny a distribution outside the operator allowlist (pre-fetch).
+    reject_unsafe_debian_subpath(&distribution)?;
     let filter = load_debian_filter(&state.db, repo.id).await;
     debian_filter_decision(&filter, Some(&distribution), None, None)?;
     // Release.gpg is the detached signature of Release. We do not need
@@ -1849,6 +1952,12 @@ async fn dists_dispatch(
     state: State<SharedState>,
     Path((repo_key, distribution, dists_path)): Path<(String, String, String)>,
 ) -> Result<Response, Response> {
+    // #2460 hardening: refuse encoded path-traversal BEFORE the allowlist gate,
+    // so the gate sees the same segments reqwest will resolve upstream (defeats
+    // `%2e%2e` / double-encoded `%252e%252e` component/dist/arch escapes).
+    reject_unsafe_debian_subpath(&distribution)?;
+    reject_unsafe_debian_subpath(&dists_path)?;
+
     if let Some(req) = parse_packages_request(&dists_path) {
         // #2460 P2: pre-fetch dist/component/arch allowlist gate for Packages
         // indices. An empty filter (default) permits everything.
@@ -1886,16 +1995,22 @@ async fn dists_proxy_catchall(
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
+    // #2460 hardening: refuse encoded path-traversal before gating.
+    reject_unsafe_debian_subpath(&distribution)?;
+    reject_unsafe_debian_subpath(&dists_path)?;
+
     // #2460 P2: pre-fetch allowlist gate for catch-all dists metadata
     // (i18n/Translation, Sources, dep11, Contents, ...). Always gate the
     // distribution; additionally gate the component when the path is
-    // component-scoped. An empty filter permits everything.
+    // component-scoped and the architecture when the metadata is arch-scoped
+    // (Contents-<arch>, dep11 Components-<arch>, binary-<arch>). An empty
+    // filter permits everything.
     let filter = load_debian_filter(&state.db, repo.id).await;
     debian_filter_decision(
         &filter,
         Some(&distribution),
         catchall_component(&dists_path),
-        None,
+        catchall_arch(&dists_path).as_deref(),
     )?;
 
     let upstream_path = format!("dists/{}/{}", distribution, dists_path);
@@ -2011,13 +2126,26 @@ async fn pool_download(
 ) -> Result<Response, Response> {
     let repo = resolve_debian_repo(&state.db, &repo_key).await?;
 
+    // #2460 hardening: refuse encoded path-traversal before gating.
+    reject_unsafe_debian_subpath(&component)?;
+    reject_unsafe_debian_subpath(&path)?;
+
     // #2460 P2: pre-fetch allowlist gate for pool downloads. The pool path
     // carries the component; the architecture is derived from the `.deb`
-    // filename when parseable. An empty filter permits everything.
+    // filename. An empty filter permits everything.
     let filter = load_debian_filter(&state.db, repo.id).await;
-    let pool_filename = path.rsplit('/').next().unwrap_or(&path);
-    let pool_arch = parse_deb_filename(pool_filename).map(|d| d.arch);
-    debian_filter_decision(&filter, None, Some(&component), pool_arch.as_deref())?;
+    debian_filter_decision(&filter, None, Some(&component), None)?;
+    // Architecture gate: fail CLOSED when an arch allowlist is set but the
+    // architecture cannot be determined (e.g. a percent-encoded `.deb`
+    // extension that `parse_deb_filename` rejects) — never skip the check.
+    if !filter.architectures.is_empty() {
+        let decoded_path = decode_to_fixpoint(&path).unwrap_or_else(|| path.clone());
+        let pool_filename = decoded_path.rsplit('/').next().unwrap_or(&decoded_path);
+        match parse_deb_filename(pool_filename).map(|d| d.arch) {
+            Some(arch) => debian_filter_decision(&filter, None, None, Some(&arch))?,
+            None => return Err(debian_filter_denied("architecture", pool_filename)),
+        }
+    }
 
     let artifact_path = format!("pool/{}/{}", component, path);
 
@@ -2603,6 +2731,109 @@ mod tests {
         let resp = debian_filter_decision(&filter, Some("bookworm"), Some("main"), Some("arm64"))
             .unwrap_err();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    // -----------------------------------------------------------------------
+    // #2460 hardening — encoded traversal, catch-all arch, pool fail-closed
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_decode_to_fixpoint_collapses_multi_encoding() {
+        assert_eq!(decode_to_fixpoint("main").as_deref(), Some("main"));
+        // Single-encoded dot-dot.
+        assert_eq!(
+            decode_to_fixpoint("main/%2e%2e/contrib").as_deref(),
+            Some("main/../contrib")
+        );
+        // Double-encoded dot-dot.
+        assert_eq!(
+            decode_to_fixpoint("main/%252e%252e/contrib").as_deref(),
+            Some("main/../contrib")
+        );
+        // Legit epoch colon survives (not a separator).
+        assert_eq!(
+            decode_to_fixpoint("gcc_4%3a10.2.1-1_amd64.deb").as_deref(),
+            Some("gcc_4:10.2.1-1_amd64.deb")
+        );
+        // Encoded `.deb` extension.
+        assert_eq!(
+            decode_to_fixpoint("0ad_1_arm64%252edeb").as_deref(),
+            Some("0ad_1_arm64.deb")
+        );
+    }
+
+    #[test]
+    fn test_reject_unsafe_debian_subpath() {
+        // Clean paths pass, including a legit epoch-encoded filename.
+        assert!(reject_unsafe_debian_subpath("main/binary-amd64/Packages.gz").is_ok());
+        assert!(reject_unsafe_debian_subpath("g/gcc-defaults/gcc_4%3a10-1_amd64.deb").is_ok());
+        // Literal, single- and double-encoded traversal all rejected with 404.
+        for bad in [
+            "main/../contrib/binary-amd64/Packages.gz",
+            "main/%2e%2e/contrib/binary-amd64/Packages.gz",
+            "main/%252e%252e/contrib/binary-amd64/Packages.gz",
+            "main/%252e%252e/%252e%252e/trixie/main/binary-amd64/Packages.gz",
+            "main/./Packages",
+            "main\\..\\contrib",
+        ] {
+            let resp = reject_unsafe_debian_subpath(bad).unwrap_err();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND, "should reject: {bad}");
+        }
+    }
+
+    #[test]
+    fn test_catchall_arch_gates_arch_scoped_metadata() {
+        // Contents / dep11 expose the architecture in the leaf name.
+        assert_eq!(
+            catchall_arch("main/Contents-arm64.gz").as_deref(),
+            Some("arm64")
+        );
+        assert_eq!(catchall_arch("Contents-amd64.gz").as_deref(), Some("amd64"));
+        assert_eq!(
+            catchall_arch("main/dep11/Components-arm64.yml.gz").as_deref(),
+            Some("arm64")
+        );
+        assert_eq!(
+            catchall_arch("main/Contents-udeb-arm64.gz").as_deref(),
+            Some("arm64")
+        );
+        // Architecture-independent / non-arch metadata is not gated.
+        assert_eq!(catchall_arch("main/Contents-all.gz"), None);
+        assert_eq!(catchall_arch("main/Contents-source.gz"), None);
+        assert_eq!(catchall_arch("main/i18n/Translation-en.gz"), None);
+        assert_eq!(catchall_arch("main/source/Sources.gz"), None);
+        assert_eq!(catchall_arch("main/binary-all/Packages.gz"), None);
+    }
+
+    #[test]
+    fn test_catchall_arch_denies_out_of_allowlist() {
+        let filter = DebianRepositoryConfig {
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        // Contents-arm64 (F3a) must be denied.
+        let arch = catchall_arch("main/Contents-arm64.gz");
+        let resp = debian_filter_decision(&filter, None, None, arch.as_deref()).unwrap_err();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // Contents-amd64 stays allowed.
+        let arch = catchall_arch("main/Contents-amd64.gz");
+        assert!(debian_filter_decision(&filter, None, None, arch.as_deref()).is_ok());
+    }
+
+    #[test]
+    fn test_pool_arch_parse_fail_closed_semantics() {
+        // The pool handler denies when an arch allowlist is set but the arch
+        // cannot be parsed. Model that decision here: a percent-encoded `.deb`
+        // extension collapses to a parseable filename via decode_to_fixpoint,
+        // and a genuinely unparseable name yields None (handler -> 404).
+        let decoded = decode_to_fixpoint("0ad_0.0.26-3_arm64%252edeb").unwrap();
+        let fname = decoded.rsplit('/').next().unwrap();
+        assert_eq!(
+            parse_deb_filename(fname).map(|d| d.arch).as_deref(),
+            Some("arm64")
+        );
+        // Unparseable -> None (fail-closed at the call site).
+        assert!(parse_deb_filename("not-a-package").is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -27,6 +27,7 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
+use crate::formats::debian::{DebianConfigPatch, DebianRepositoryConfig, DEBIAN_CONFIG_KEY};
 use crate::formats::maven::MavenHandler;
 use crate::models::access_scope::AccessScope;
 use crate::models::repository::{RepositoryFormat, RepositoryType};
@@ -584,6 +585,12 @@ pub struct CreateRepositoryRequest {
     /// `npm_allowed_name_patterns`. A name is allowed if its scope is allowed
     /// OR any glob matches (e.g. `@acme/*`, `internal-*`).
     pub npm_allowed_name_patterns: Option<Vec<String>>,
+    /// Debian remote (proxy) distribution/component/architecture filter
+    /// (#2460, epic #2458). Only valid for Debian *Remote* repositories.
+    /// Passthrough-only: allowed paths are proxied byte-for-byte; denied
+    /// paths are refused. Stored as JSON under `debian_config`. Omit or set
+    /// empty allowlists to proxy the whole upstream (default behaviour).
+    pub debian: Option<DebianRepositoryConfig>,
 }
 
 impl CreateRepositoryRequest {
@@ -682,6 +689,28 @@ pub struct UpdateRepositoryRequest {
     /// repository (#2424). When provided, replaces the stored
     /// `npm_allowed_name_patterns` list.
     pub npm_allowed_name_patterns: Option<Vec<String>>,
+    /// Update the Debian remote proxy filter (#2460). Three-way semantics:
+    /// omit the field to leave the stored config unchanged; send `null` to
+    /// clear it (revert to full-proxy); send an object to merge a partial
+    /// update onto the stored config. Only valid for Debian Remote repos.
+    #[serde(default, deserialize_with = "deserialize_double_option")]
+    #[schema(value_type = Option<DebianConfigPatch>)]
+    pub debian: Option<Option<DebianConfigPatch>>,
+}
+
+/// Deserialize a nullable optional field into `Option<Option<T>>` so a handler
+/// can distinguish three states: the key absent (`None`), the key present and
+/// `null` (`Some(None)`), and the key present with a value (`Some(Some(v))`).
+/// Serde maps a bare `Option<T>` null to `None`, collapsing the first two —
+/// this preserves the distinction needed for partial-update-vs-clear.
+fn deserialize_double_option<'de, D, T>(
+    deserializer: D,
+) -> std::result::Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Ok(Some(Option::<T>::deserialize(deserializer)?))
 }
 
 impl UpdateRepositoryRequest {
@@ -756,6 +785,10 @@ pub struct RepositoryResponse {
     /// `repository_config`. Omitted for non-npm repositories or when unset.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub npm_allowed_name_patterns: Option<Vec<String>>,
+    /// Debian remote proxy filter (#2460), read back from `repository_config`.
+    /// Omitted for non-Debian-remote repositories or when no filter is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub debian: Option<DebianRepositoryConfig>,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
@@ -801,6 +834,7 @@ fn repo_to_response(
         npm_allowed_scopes: None,
         npm_allow_unscoped: None,
         npm_allowed_name_patterns: None,
+        debian: None,
         created_at: repo.created_at,
         updated_at: repo.updated_at,
     }
@@ -895,6 +929,63 @@ async fn with_apt_settings(
                 _ => {}
             }
         }
+    }
+    response
+}
+
+// ---------------------------------------------------------------------------
+// #2460 P2 — Debian remote proxy filter config persistence / read-back
+// ---------------------------------------------------------------------------
+
+/// True when a repository is a Debian *Remote* (proxy) repo — the only kind for
+/// which the P2 dist/component/arch filter is meaningful.
+fn is_debian_remote(repo_type: &RepositoryType, format: &RepositoryFormat) -> bool {
+    *repo_type == RepositoryType::Remote && matches!(format, RepositoryFormat::Debian)
+}
+
+/// Validate a `DebianRepositoryConfig` for the 1.6.0 passthrough-only feature
+/// set, mapping the reason string to a 422 [`AppError::UnprocessableEntity`].
+fn validate_debian_config(cfg: &DebianRepositoryConfig) -> Result<()> {
+    cfg.validate_passthrough_only()
+        .map_err(AppError::UnprocessableEntity)
+}
+
+/// Persist a resolved Debian filter config as JSON under `debian_config`.
+async fn upsert_debian_config(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    cfg: &DebianRepositoryConfig,
+) -> Result<()> {
+    let json = serde_json::to_string(cfg).map_err(|e| AppError::Internal(e.to_string()))?;
+    upsert_repo_config(db, repo_id, DEBIAN_CONFIG_KEY, &json).await
+}
+
+/// Read back the stored Debian filter config (if any) for a repository.
+async fn load_debian_config(db: &sqlx::PgPool, repo_id: Uuid) -> Option<DebianRepositoryConfig> {
+    let value: Option<String> = sqlx::query_scalar(
+        "SELECT value FROM repository_config WHERE repository_id = $1 AND key = $2",
+    )
+    .bind(repo_id)
+    .bind(DEBIAN_CONFIG_KEY)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten();
+    value
+        .as_deref()
+        .and_then(|v| serde_json::from_str::<DebianRepositoryConfig>(v).ok())
+}
+
+/// Populate `RepositoryResponse.debian` from `repository_config` for Debian
+/// remote repositories.
+async fn with_debian_config(
+    db: &sqlx::PgPool,
+    repo_id: Uuid,
+    is_debian_remote: bool,
+    mut response: RepositoryResponse,
+) -> RepositoryResponse {
+    if is_debian_remote {
+        response.debian = load_debian_config(db, repo_id).await;
     }
     response
 }
@@ -2144,6 +2235,21 @@ pub async fn create_repository(
         payload.npm_allowed_name_patterns.as_deref(),
     )?;
 
+    // Debian remote proxy filter (#2460): validate up-front — before the
+    // repository row is created — so a rejected config (wrong repo type or an
+    // unsupported strategy/inconsistent filter) cannot leave an orphaned
+    // repository behind, mirroring the apt_* and npm guards above. Persistence
+    // happens after `service.create(...)`, once `repo.id` exists.
+    if let Some(ref cfg) = payload.debian {
+        if !is_debian_remote(&repo_type, &format) {
+            return Err(AppError::Validation(
+                "debian filter config is only valid for Debian remote (proxy) repositories"
+                    .to_string(),
+            ));
+        }
+        validate_debian_config(cfg)?;
+    }
+
     // Resolve storage backend: use the requested one or fall back to the default.
     let storage_backend = match &payload.storage_backend {
         None => state.config.storage_backend.clone(),
@@ -2292,6 +2398,12 @@ pub async fn create_repository(
         }
     }
 
+    // Persist the Debian remote proxy filter (#2460). Validation already ran
+    // up-front (before create), so here we only serialize + store it.
+    if let Some(ref cfg) = payload.debian {
+        upsert_debian_config(&state.db, repo.id, cfg).await?;
+    }
+
     // Add virtual repository members. Post-#1444, the validator accepts
     // `member_repos == None` (deferred-population pattern: caller will
     // POST /members later) and only rejects `Some(empty_vec)`. Treat the
@@ -2385,6 +2497,15 @@ pub async fn create_repository(
     response.apt_label = trimmed_nonempty(payload.apt_label);
     response.apt_release_version = trimmed_nonempty(payload.apt_release_version);
     response.apt_description = trimmed_nonempty(payload.apt_description);
+    // Echo the Debian remote proxy filter that was persisted (#2460) so the
+    // create response round-trips with a subsequent GET.
+    let response = with_debian_config(
+        &state.db,
+        repo_id,
+        is_debian_remote(&repo_type_out, &repo_format_out),
+        response,
+    )
+    .await;
     // Echo the npm scope policy that was persisted (#2424) so the create
     // response round-trips with a subsequent GET.
     let response = with_npm_scope_policy(
@@ -2439,6 +2560,13 @@ pub async fn get_repository(
     } else {
         response
     };
+    let response = with_debian_config(
+        &state.db,
+        repo_id,
+        is_debian_remote(&repo_type, &repo_format),
+        response,
+    )
+    .await;
     let response =
         with_npm_scope_policy(&state.db, repo_id, &repo_type, &repo_format, response).await;
     Ok(Json(response))
@@ -2722,6 +2850,39 @@ pub async fn update_repository(
         }
     }
 
+    // Debian remote proxy filter (#2460). Three-way semantics:
+    //   * field omitted (`None`)      -> leave the stored config unchanged
+    //   * field `null` (`Some(None)`) -> clear it (revert to full-proxy)
+    //   * field object                -> merge the partial update onto the
+    //                                    stored config, validate, persist.
+    // The gate reads the config live on every request, so no cache
+    // invalidation is required for a change to take effect.
+    match payload.debian {
+        None => {}
+        Some(None) => {
+            sqlx::query("DELETE FROM repository_config WHERE repository_id = $1 AND key = $2")
+                .bind(repo.id)
+                .bind(DEBIAN_CONFIG_KEY)
+                .execute(&state.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+        Some(Some(ref patch)) => {
+            if !is_debian_remote(&existing.repo_type, &existing.format) {
+                return Err(AppError::Validation(
+                    "debian filter config is only valid for Debian remote (proxy) repositories"
+                        .to_string(),
+                ));
+            }
+            let base = load_debian_config(&state.db, repo.id)
+                .await
+                .unwrap_or_default();
+            let merged = patch.clone().apply_to(base);
+            validate_debian_config(&merged)?;
+            upsert_debian_config(&state.db, repo.id, &merged).await?;
+        }
+    }
+
     // Invalidate the in-memory repo cache so that visibility changes take
     // effect immediately instead of waiting for the TTL to expire. Remove
     // both the old key and the new key (in case the key was renamed). This
@@ -2782,6 +2943,13 @@ pub async fn update_repository(
     } else {
         response
     };
+    let response = with_debian_config(
+        &state.db,
+        repo_id,
+        is_debian_remote(&repo_type, &repo_format),
+        response,
+    )
+    .await;
     let response =
         with_npm_scope_policy(&state.db, repo_id, &repo_type, &repo_format, response).await;
     Ok(Json(response))
@@ -7026,6 +7194,10 @@ async fn load_routing_rules(db: &sqlx::PgPool, repo_id: Uuid) -> Vec<RoutingRule
         SetRoutingRulesRequest,
         RoutingRulesResponse,
         RoutingRule,
+        DebianRepositoryConfig,
+        DebianConfigPatch,
+        crate::formats::debian::DebianMetadataStrategy,
+        crate::formats::debian::DebianPackageFetchStrategy,
     ))
 )]
 pub struct RepositoriesApiDoc;
@@ -8591,6 +8763,7 @@ mod tests {
             npm_allowed_scopes: None,
             npm_allow_unscoped: None,
             npm_allowed_name_patterns: None,
+            debian: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -9926,6 +10099,7 @@ mod tests {
             npm_allowed_scopes: None,
             npm_allow_unscoped: None,
             npm_allowed_name_patterns: None,
+            debian: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };
@@ -15994,6 +16168,7 @@ mod tests {
             npm_allowed_scopes: None,
             npm_allow_unscoped: None,
             npm_allowed_name_patterns: None,
+            debian: None,
             created_at: chrono::Utc::now(),
             updated_at: chrono::Utc::now(),
         };

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -81,6 +81,15 @@ pub enum AppError {
     #[error("Validation error: {0}")]
     Validation(String),
 
+    /// The request was well-formed and syntactically valid but asks for a
+    /// configuration that is semantically unsupported in this release (e.g. a
+    /// Debian proxy filter that requests metadata regeneration/re-signing, or
+    /// an internally inconsistent filter). Mapped to 422 so clients can tell
+    /// "the server understood but won't do this yet" apart from a plain 400
+    /// schema/validation error.
+    #[error("Unprocessable entity: {0}")]
+    UnprocessableEntity(String),
+
     #[error("Quota exceeded: {0}")]
     QuotaExceeded(String),
 
@@ -172,6 +181,9 @@ impl AppError {
             Self::NotFound(_) => (StatusCode::NOT_FOUND, "NOT_FOUND"),
             Self::Conflict(_) => (StatusCode::CONFLICT, "CONFLICT"),
             Self::Validation(_) => (StatusCode::BAD_REQUEST, "VALIDATION_ERROR"),
+            Self::UnprocessableEntity(_) => {
+                (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE_ENTITY")
+            }
             Self::QuotaExceeded(_) => (StatusCode::INSUFFICIENT_STORAGE, "QUOTA_EXCEEDED"),
             // ENAMETOOLONG is a client-supplied path that exceeds the
             // underlying filesystem's name limit (255 bytes on ext4/xfs).
@@ -272,6 +284,7 @@ impl AppError {
             | Self::NotFound(msg)
             | Self::Conflict(msg)
             | Self::Validation(msg)
+            | Self::UnprocessableEntity(msg)
             | Self::QuotaExceeded(msg)
             | Self::BadGateway(msg)
             | Self::ServiceUnavailable(msg)

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -18,6 +18,253 @@ use crate::error::{AppError, Result};
 use crate::formats::FormatHandler;
 use crate::models::repository::RepositoryFormat;
 
+// ---------------------------------------------------------------------------
+// P2 (#2460) — Debian remote/mirror proxy filter configuration
+// ---------------------------------------------------------------------------
+//
+// Operator-scoped distribution/component/architecture allowlists for Debian
+// *Remote* (proxy) repositories. This is a PRE-FETCH allow/deny gate only:
+// allowed paths pass through the existing (P1-hardened) proxy path
+// byte-for-byte; denied paths are refused before any upstream fetch. There is
+// NO metadata regeneration (P3) and NO local re-signing (P4) in this release —
+// those strategies are accepted on the enum but rejected with 422 by
+// [`DebianRepositoryConfig::validate_passthrough_only`].
+//
+// Stored as a JSON string under the [`DEBIAN_CONFIG_KEY`] key in the existing
+// generic `repository_config` KV table (no schema migration), the same pattern
+// used by `apt_origin` / `index_upstream_url`.
+
+/// `repository_config` key under which the Debian proxy filter config JSON is
+/// stored for a remote repository.
+pub const DEBIAN_CONFIG_KEY: &str = "debian_config";
+
+/// How metadata (`Packages`/`Release`) is produced for a Debian remote.
+///
+/// Only [`DebianMetadataStrategy::UpstreamPassthrough`] is implemented in
+/// 1.6.0; the other variants are reserved for P3 (filtered generation) / P4
+/// (local re-signing) and are rejected with 422 until then. The enum lands now
+/// so those phases can flip it on without a schema/config-shape change.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DebianMetadataStrategy {
+    /// Serve upstream `Release`/`InRelease`/`Release.gpg`/`Packages`
+    /// byte-for-byte (clients keep trusting the distro key). Default.
+    #[default]
+    UpstreamPassthrough,
+    /// P3 (1.7.0): regenerate a filtered, AK-authored (unsigned) index.
+    FilterAndGenerate,
+    /// P4 (1.7.0): regenerate a filtered index and re-sign it with a local key.
+    FilterGenerateAndSign,
+    /// Hosted-repo style generation (AK is the origin). Reserved.
+    HostedGenerate,
+}
+
+/// How package bodies are fetched for a Debian remote.
+///
+/// Only [`DebianPackageFetchStrategy::UpstreamPassthrough`] is implemented in
+/// 1.6.0.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DebianPackageFetchStrategy {
+    /// Fetch `.deb` bodies lazily from upstream on demand (pull-through). Default.
+    #[default]
+    UpstreamPassthrough,
+    /// P3 (1.7.0): eagerly mirror the selected subset ahead of requests.
+    Eager,
+}
+
+/// Deserialize a `Vec<String>` where `null` (or an absent field paired with
+/// `#[serde(default)]`) yields an empty vector. Empty and `["*"]` both mean
+/// "select all" for the filter predicates.
+fn deserialize_vec_string_or_null<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let opt = Option::<Vec<String>>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_default())
+}
+
+/// P2 Debian remote proxy filter config (dist/component/arch allowlists).
+///
+/// Semantics for each allowlist: an empty list OR a list containing `"*"`
+/// selects everything (today's full-proxy behaviour); otherwise only exact
+/// matches are selected. Architecture-independent (`all`) packages are always
+/// permitted regardless of the `architectures` allowlist.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct DebianRepositoryConfig {
+    /// Distributions (a.k.a. suites/codenames, e.g. `bookworm`) to proxy.
+    /// Empty or `["*"]` = all.
+    #[serde(
+        default,
+        alias = "distributions",
+        deserialize_with = "deserialize_vec_string_or_null"
+    )]
+    pub distribution_paths: Vec<String>,
+    /// Components (e.g. `main`, `contrib`, `non-free`) to proxy. Empty/`["*"]` = all.
+    #[serde(default, deserialize_with = "deserialize_vec_string_or_null")]
+    pub components: Vec<String>,
+    /// Architectures (e.g. `amd64`, `arm64`) to proxy. Empty/`["*"]` = all.
+    /// `all` (arch-independent) is always permitted.
+    #[serde(default, deserialize_with = "deserialize_vec_string_or_null")]
+    pub architectures: Vec<String>,
+    /// Whether source packages (`Sources`, `.dsc`) are included. Advisory in
+    /// passthrough (upstream metadata is unchanged); honored under P3.
+    #[serde(default)]
+    pub include_source_packages: bool,
+    /// Flat (non-`dists/`) repository layout flag. Accepted but does NOT weaken
+    /// P1's flat/redirect abuse posture in passthrough.
+    #[serde(default)]
+    pub flat_repository: bool,
+    /// Whether to verify the upstream signed `Release` before serving. In P2 the
+    /// P1 integrity gate already enforces index/Release consistency; this flag
+    /// is reserved for P4 trust-anchor verification.
+    #[serde(default)]
+    pub verify_upstream_metadata: bool,
+    /// Upstream GPG key id used to verify upstream metadata (reserved for P4).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_gpg_key_id: Option<String>,
+    /// Metadata production strategy. Only `upstream_passthrough` in 1.6.0.
+    #[serde(default)]
+    pub metadata_strategy: DebianMetadataStrategy,
+    /// Package-body fetch strategy. Only `upstream_passthrough` in 1.6.0.
+    #[serde(default)]
+    pub package_fetch_strategy: DebianPackageFetchStrategy,
+    /// Package-name-level queries. NOT honored in passthrough (that needs P3);
+    /// a non-empty value here with `upstream_passthrough` is rejected with 422
+    /// rather than silently advertising content the proxy would then block.
+    #[serde(default, deserialize_with = "deserialize_vec_string_or_null")]
+    pub package_queries: Vec<String>,
+}
+
+/// Partial-update patch for [`DebianRepositoryConfig`]. Fields left absent are
+/// preserved; provided fields (including an explicit empty list) replace the
+/// stored value. Applied on top of the currently stored config, or on top of
+/// the default when none exists yet.
+#[derive(Clone, Debug, Default, Deserialize, utoipa::ToSchema)]
+pub struct DebianConfigPatch {
+    #[serde(default, alias = "distributions")]
+    pub distribution_paths: Option<Vec<String>>,
+    #[serde(default)]
+    pub components: Option<Vec<String>>,
+    #[serde(default)]
+    pub architectures: Option<Vec<String>>,
+    #[serde(default)]
+    pub include_source_packages: Option<bool>,
+    #[serde(default)]
+    pub flat_repository: Option<bool>,
+    #[serde(default)]
+    pub verify_upstream_metadata: Option<bool>,
+    #[serde(default)]
+    pub upstream_gpg_key_id: Option<String>,
+    #[serde(default)]
+    pub metadata_strategy: Option<DebianMetadataStrategy>,
+    #[serde(default)]
+    pub package_fetch_strategy: Option<DebianPackageFetchStrategy>,
+    #[serde(default)]
+    pub package_queries: Option<Vec<String>>,
+}
+
+impl DebianConfigPatch {
+    /// Merge this patch onto `base`, returning the updated config.
+    pub fn apply_to(self, mut base: DebianRepositoryConfig) -> DebianRepositoryConfig {
+        if let Some(v) = self.distribution_paths {
+            base.distribution_paths = v;
+        }
+        if let Some(v) = self.components {
+            base.components = v;
+        }
+        if let Some(v) = self.architectures {
+            base.architectures = v;
+        }
+        if let Some(v) = self.include_source_packages {
+            base.include_source_packages = v;
+        }
+        if let Some(v) = self.flat_repository {
+            base.flat_repository = v;
+        }
+        if let Some(v) = self.verify_upstream_metadata {
+            base.verify_upstream_metadata = v;
+        }
+        if let Some(v) = self.upstream_gpg_key_id {
+            base.upstream_gpg_key_id = Some(v);
+        }
+        if let Some(v) = self.metadata_strategy {
+            base.metadata_strategy = v;
+        }
+        if let Some(v) = self.package_fetch_strategy {
+            base.package_fetch_strategy = v;
+        }
+        if let Some(v) = self.package_queries {
+            base.package_queries = v;
+        }
+        base
+    }
+}
+
+impl DebianRepositoryConfig {
+    /// True when no dimension is filtered (all allowlists empty) — behaves
+    /// exactly like the pre-#2460 full-proxy repository.
+    pub fn is_passthrough_all(&self) -> bool {
+        self.distribution_paths.is_empty()
+            && self.components.is_empty()
+            && self.architectures.is_empty()
+    }
+
+    /// Shared allowlist test: empty list or a `"*"` wildcard selects everything;
+    /// otherwise an exact match is required.
+    fn list_selects(list: &[String], value: &str) -> bool {
+        list.is_empty() || list.iter().any(|v| v == "*" || v == value)
+    }
+
+    /// Whether `distribution` is within the configured allowlist.
+    pub fn distribution_selected(&self, distribution: &str) -> bool {
+        Self::list_selects(&self.distribution_paths, distribution)
+    }
+
+    /// Whether `component` is within the configured allowlist.
+    pub fn component_selected(&self, component: &str) -> bool {
+        Self::list_selects(&self.components, component)
+    }
+
+    /// Whether `arch` is within the configured allowlist. Architecture-
+    /// independent (`all`) packages are always permitted because a
+    /// single-arch client still needs them.
+    pub fn arch_selected(&self, arch: &str) -> bool {
+        arch == "all" || Self::list_selects(&self.architectures, arch)
+    }
+
+    /// Validate that this config only asks for functionality implemented in the
+    /// 1.6.0 passthrough-only release. Returns an error message suitable for a
+    /// 422 response when it asks for metadata regeneration / re-signing, a
+    /// non-passthrough fetch strategy, or an internally inconsistent filter.
+    pub fn validate_passthrough_only(&self) -> std::result::Result<(), String> {
+        if self.metadata_strategy != DebianMetadataStrategy::UpstreamPassthrough {
+            return Err(
+                "metadata_strategy other than 'upstream_passthrough' is not yet supported in this release"
+                    .to_string(),
+            );
+        }
+        if self.package_fetch_strategy != DebianPackageFetchStrategy::UpstreamPassthrough {
+            return Err(
+                "package_fetch_strategy other than 'upstream_passthrough' is not yet supported in this release"
+                    .to_string(),
+            );
+        }
+        // Consistency reject: passthrough serves upstream metadata unchanged, so
+        // it cannot honor package-name-level filtering. Advertising blocked
+        // content would be a correctness footgun — reject rather than lie.
+        if !self.package_queries.is_empty() {
+            return Err(
+                "package_queries requires filtered metadata generation, which is not supported with upstream_passthrough"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+}
+
 /// Debian format handler
 pub struct DebianHandler;
 
@@ -1454,5 +1701,180 @@ Size: 100
     #[test]
     fn test_parse_packages_index_empty() {
         assert!(parse_packages_index("").is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // P2 (#2460) filter config predicates + (de)serialization
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_distribution_selected_empty_selects_all() {
+        let cfg = DebianRepositoryConfig::default();
+        assert!(cfg.is_passthrough_all());
+        assert!(cfg.distribution_selected("bookworm"));
+        assert!(cfg.distribution_selected("anything"));
+    }
+
+    #[test]
+    fn test_distribution_selected_wildcard_selects_all() {
+        let cfg = DebianRepositoryConfig {
+            distribution_paths: vec!["*".to_string()],
+            ..Default::default()
+        };
+        assert!(cfg.distribution_selected("bookworm"));
+        assert!(cfg.distribution_selected("trixie"));
+    }
+
+    #[test]
+    fn test_distribution_selected_exact_and_case_sensitive() {
+        let cfg = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm".to_string()],
+            ..Default::default()
+        };
+        assert!(cfg.distribution_selected("bookworm"));
+        assert!(!cfg.distribution_selected("trixie"));
+        // Debian codenames are lowercase; matching is exact (case-sensitive).
+        assert!(!cfg.distribution_selected("Bookworm"));
+        assert!(!cfg.is_passthrough_all());
+    }
+
+    #[test]
+    fn test_component_selected_matrix() {
+        let cfg = DebianRepositoryConfig {
+            components: vec!["main".to_string()],
+            ..Default::default()
+        };
+        assert!(cfg.component_selected("main"));
+        assert!(!cfg.component_selected("contrib"));
+        assert!(!cfg.component_selected("non-free"));
+    }
+
+    #[test]
+    fn test_arch_selected_matrix_and_all_always_allowed() {
+        let cfg = DebianRepositoryConfig {
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        assert!(cfg.arch_selected("amd64"));
+        assert!(!cfg.arch_selected("arm64"));
+        // Architecture-independent packages are always permitted.
+        assert!(cfg.arch_selected("all"));
+        // Empty allowlist selects everything.
+        let empty = DebianRepositoryConfig::default();
+        assert!(empty.arch_selected("arm64"));
+        assert!(empty.arch_selected("amd64"));
+    }
+
+    #[test]
+    fn test_config_roundtrip_serde() {
+        let cfg = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm".to_string()],
+            components: vec!["main".to_string(), "contrib".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: DebianRepositoryConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(cfg, back);
+    }
+
+    #[test]
+    fn test_config_deserialize_null_lists_and_distributions_alias() {
+        // `distributions` is an accepted alias for `distribution_paths`, and a
+        // null list deserializes to an empty (select-all) vector.
+        let json = r#"{"distributions":["trixie"],"components":null}"#;
+        let cfg: DebianRepositoryConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.distribution_paths, vec!["trixie".to_string()]);
+        assert!(cfg.components.is_empty());
+    }
+
+    #[test]
+    fn test_config_default_strategies_are_passthrough() {
+        let cfg = DebianRepositoryConfig::default();
+        assert_eq!(
+            cfg.metadata_strategy,
+            DebianMetadataStrategy::UpstreamPassthrough
+        );
+        assert_eq!(
+            cfg.package_fetch_strategy,
+            DebianPackageFetchStrategy::UpstreamPassthrough
+        );
+        assert!(cfg.validate_passthrough_only().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_generation_strategy() {
+        let cfg = DebianRepositoryConfig {
+            metadata_strategy: DebianMetadataStrategy::FilterAndGenerate,
+            ..Default::default()
+        };
+        let err = cfg.validate_passthrough_only().unwrap_err();
+        assert!(err.contains("not yet supported"));
+    }
+
+    #[test]
+    fn test_validate_rejects_signing_strategy() {
+        let cfg = DebianRepositoryConfig {
+            metadata_strategy: DebianMetadataStrategy::FilterGenerateAndSign,
+            ..Default::default()
+        };
+        assert!(cfg.validate_passthrough_only().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_non_passthrough_fetch_strategy() {
+        let cfg = DebianRepositoryConfig {
+            package_fetch_strategy: DebianPackageFetchStrategy::Eager,
+            ..Default::default()
+        };
+        assert!(cfg.validate_passthrough_only().is_err());
+    }
+
+    #[test]
+    fn test_validate_rejects_package_queries_in_passthrough() {
+        let cfg = DebianRepositoryConfig {
+            package_queries: vec!["nginx".to_string()],
+            ..Default::default()
+        };
+        let err = cfg.validate_passthrough_only().unwrap_err();
+        assert!(err.contains("package_queries"));
+    }
+
+    #[test]
+    fn test_config_patch_merges_only_provided_fields() {
+        let base = DebianRepositoryConfig {
+            distribution_paths: vec!["bookworm".to_string()],
+            components: vec!["main".to_string()],
+            architectures: vec!["amd64".to_string()],
+            ..Default::default()
+        };
+        // Patch only components; the rest is preserved.
+        let patch = DebianConfigPatch {
+            components: Some(vec!["main".to_string(), "contrib".to_string()]),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(base);
+        assert_eq!(merged.distribution_paths, vec!["bookworm".to_string()]);
+        assert_eq!(
+            merged.components,
+            vec!["main".to_string(), "contrib".to_string()]
+        );
+        assert_eq!(merged.architectures, vec!["amd64".to_string()]);
+    }
+
+    #[test]
+    fn test_config_patch_explicit_empty_list_clears_dimension() {
+        let base = DebianRepositoryConfig {
+            components: vec!["main".to_string()],
+            ..Default::default()
+        };
+        let patch = DebianConfigPatch {
+            components: Some(vec![]),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(base);
+        // Now select-all again for components.
+        assert!(merged.components.is_empty());
+        assert!(merged.component_selected("contrib"));
     }
 }


### PR DESCRIPTION
## Summary

Adds operator-configurable **distribution / component / architecture filtering**
for Debian (APT) **remote (proxy)** repositories — the P2 increment of the
Debian advanced repo-support epic (#2458). Closes #2460.

An operator can now scope which suites/components/architectures a Debian remote
proxies, instead of proxying the entire upstream catalog. The filter is a
**pre-fetch allow/deny gate** on the Debian proxy paths:

- Release / InRelease / Release.gpg (distribution gate)
- `dists/{dist}/{component}/binary-{arch}/Packages{,.gz,.xz}` (dist + component + arch)
- `dists/{dist}/*` catch-all metadata — i18n / Translation / Sources / dep11 / Contents
  (distribution gate + component gate when the path is component-scoped)
- `pool/{component}/*` downloads (component gate + architecture derived from the
  `.deb` filename)

Behaviour:

- **Passthrough-only.** Allowed requests flow through the existing P1-hardened
  proxy path unchanged; upstream `Release`/`InRelease`/`Release.gpg` are served
  **byte-for-byte** with the upstream signature intact. Clients still trust the
  distro key — **no new trust surface, no metadata regeneration, no re-signing.**
- **Empty/absent config = today's full-proxy behaviour** (existing Debian remotes
  are unaffected).
- Denied paths return **404** (indistinguishable from a genuinely absent path — the
  proxy does not advertise which dists/components/arches it mirrors).
- Architecture-independent (`all`) packages are always permitted regardless of the
  arch allowlist.

Config is stored as a JSON string under the `debian_config` key in the existing
generic `repository_config` KV table (same pattern as `apt_origin` /
`index_upstream_url`) — **no schema migration**. Create takes a full `debian`
object; update supports **partial merge**, and `debian: null` clears the filter
(reverts to full-proxy).

The `DebianMetadataStrategy` / `DebianPackageFetchStrategy` enums land now so the
deferred P3 (filtered metadata generation) and P4 (local re-signing + trust
anchors) phases can flip them on without a config-shape change, but in this
release **only `upstream_passthrough` is accepted** — any other strategy returns
**422 "not yet supported"**. A consistency guard also **422**-rejects
`upstream_passthrough` + non-empty `package_queries` (passthrough serves upstream
metadata unchanged and cannot honor package-name filtering, so advertising blocked
content would be a footgun — reject rather than lie).

Part of epic **#2458**. P3 (#2461) and P4 (#2462) remain deferred and paired
(unsigned generated metadata without re-signing is a `[trusted=yes]` footgun).

## Regression test (required for `fix/*` PRs)
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
  - `formats::debian`: dist/component/arch selection predicates (empty = all,
    `["*"]` = all, exact, case-sensitivity, `all` always allowed); config
    (de)serialize round-trip + `distributions` alias + null lists; default
    strategies; 422 validation for generation/signing/eager strategies and for
    `package_queries` under passthrough; partial-update merge + explicit-empty
    clear.
  - `api::handlers::debian`: catch-all component scoping; the pre-fetch decision
    allows in-allowlist, denies out-of-allowlist with 404, and permits everything
    on an empty filter.
- [x] Integration tests added/updated (if applicable) — covered by existing
  Debian proxy integration tests (unchanged, still green: allowed paths remain
  byte-identical through the P1 integrity gate).
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — isolated pool stack against `deb.debian.org`:
  - in-allowlist `bookworm`/`main`/`amd64` Packages + a real pool `.deb` → **200**
    (served through the proxy);
  - out-of-allowlist dist / component / arch / catch-all / pool → **404**;
  - `dists/bookworm/Release` + `InRelease` proxied **byte-identical** to upstream
    (P1 signature preserved);
  - empty-config repo proxies contrib / arm64 / trixie unrestricted;
  - `metadata_strategy=filter_and_generate` and `package_fetch_strategy=eager` → **422**;
  - `upstream_passthrough` + `package_queries=[nginx]` → **422**;
  - `debian: null` clears the filter and reverts to full proxy;
  - partial update merges components while preserving distribution/architecture.
- [x] No regressions in existing tests

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations — N/A (no new endpoints;
  extends existing repository create/detail/update request+response bodies).
- [x] Request/response types have `#[derive(ToSchema)]` — `DebianRepositoryConfig`,
  `DebianConfigPatch`, `DebianMetadataStrategy`, `DebianPackageFetchStrategy`
  registered in `RepositoriesApiDoc`.
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no migration (JSON key in the
  existing `repository_config` KV table).
- [ ] N/A - no API changes

Closes #2460
