### PR TITLE
docs(sso): warn that map_groups_to_groups trusts the IdP group taxonomy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,3 +83,48 @@ lets an attacker forge tokens if it ever leaks, so treat it like a private key:
   `JWT_SECRET` invalidates all outstanding tokens, forcing re-authentication;
   schedule rotations during a low-traffic window and roll the new value out to
   every backend replica at once.
+
+### SSO group mapping trusts the IdP group taxonomy
+
+The optional `map_groups_to_groups` setting on an OIDC or SAML provider
+reflects the group names supplied by the identity provider into Artifact
+Keeper group memberships (groups are found-or-created **by name** on first
+sight). This is convenient for centralizing group management in the IdP, but
+it has a security implication operators must understand before enabling it:
+
+**When `map_groups_to_groups` is on, the IdP effectively controls membership
+of any local group whose name collides with an IdP-supplied group name.** If a
+privileged local group (for example one used to grant elevated repository
+permissions, or a group referenced elsewhere in your authorization policy)
+shares a name with a group the IdP can emit, then anyone the IdP places in
+that group is joined into the privileged local group on login. In other words,
+enabling this setting means you are **trusting the IdP's group taxonomy** — and
+anyone who can influence group assignment in the IdP — for the membership of
+those local groups.
+
+Note that a mapped group membership persists after login: reconciliation is
+scoped to the mapping source (e.g. it only prunes memberships tagged
+`external_source = 'saml'`), so a membership added because of a name collision
+is not automatically removed and must be cleaned up by an operator.
+
+This does **not** grant the `is_admin` flag — administrator status is conferred
+only through a provider's dedicated `admin_group` setting, not through general
+group mapping. The risk is scoped to whatever any collision-shadowed local
+group is authorized to do.
+
+**Recommended mitigations:**
+
+- **Review the IdP group taxonomy before enabling** `map_groups_to_groups`,
+  and confirm no IdP-emittable group name collides with a privileged or
+  policy-referenced local group.
+- **Name privileged local groups so they can't be shadowed** by an
+  IdP-supplied name — for example reserve an operator-only naming convention
+  (such as an `ak-` / `local-` prefix) for groups that carry elevated
+  permissions, and never use those names in the IdP.
+- **Namespace / prefix mapped groups** where your IdP or mapping supports it,
+  so IdP-sourced groups land in a distinct namespace and can never coincide
+  with a locally managed privileged group.
+- **Keep group-to-permission grants least-privilege**, so that even an
+  unexpected membership has limited blast radius.
+- Restrict who can create or assign groups in the IdP, since with this setting
+  enabled that control governs Artifact Keeper group membership too.

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -48,6 +48,14 @@ pub struct OidcConfigRow {
     /// When true, the OIDC `groups` claim values are reflected as
     /// Artifact Keeper group memberships (auto-creating groups on first
     /// sight). Otherwise legacy role mapping is used.
+    ///
+    /// SECURITY: groups are found-or-created by NAME, so enabling this
+    /// trusts the IdP's group taxonomy — an IdP-supplied group name that
+    /// collides with a privileged local group joins the user into that
+    /// local group. Ensure privileged local group names can't be shadowed
+    /// by IdP-emittable names (see SECURITY.md "SSO group mapping trusts
+    /// the IdP group taxonomy"). Does not grant `is_admin` (that is only
+    /// via `admin_group`).
     pub map_groups_to_groups: bool,
     /// Opt-in compatibility flag (migration 144): when true, ID tokens
     /// signed with RSA keys shorter than 2048 bits are accepted via a
@@ -117,6 +125,16 @@ pub struct SamlConfigRow {
     /// `external_source = 'saml'`, reconciled per login). Mirrors the OIDC
     /// flag from #1094; defaults to false so existing providers keep the
     /// admin-role-only group behavior (migration 157, #2333).
+    ///
+    /// SECURITY: groups are found-or-created by NAME, so enabling this
+    /// trusts the IdP's group taxonomy — a signed group claim whose name
+    /// collides with a privileged local group joins the user into that
+    /// local group, and (because prune is scoped to
+    /// `external_source = 'saml'`) that membership persists until an
+    /// operator removes it. Ensure privileged local group names can't be
+    /// shadowed by IdP-emittable names (see SECURITY.md "SSO group mapping
+    /// trusts the IdP group taxonomy"). Does not grant `is_admin` (that is
+    /// only via `admin_group`).
     pub map_groups_to_groups: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,


### PR DESCRIPTION
## Summary

Docs-only change for #2493 (from the #2448 SAML group-mapping red-team; verdict CLEAN / non-blocking LOW).

When `map_groups_to_groups` is enabled on an OIDC or SAML provider, IdP-supplied group names are reflected into Artifact Keeper group memberships **by name** (found-or-created). If an IdP-emittable group name collides with a privileged/policy-referenced **local** group, the IdP effectively controls membership of that local group. This adds the operator warning the issue asks for.

## Changes

- **SECURITY.md** — new "SSO group mapping trusts the IdP group taxonomy" subsection under *Security Best Practices for Operators*: explains the trust implication, notes that a collision-added membership persists (source-scoped prune), clarifies it does **not** confer `is_admin` (only via `admin_group`), and lists mitigations (review the IdP taxonomy before enabling; name privileged local groups so they can't be shadowed; namespace/prefix mapped groups; least-privilege group grants; restrict IdP group assignment).
- **backend/src/services/auth_config_service.rs** — shortened SECURITY warning added to the inline doc-comments of the OIDC (`OidcConfigRow`) and SAML (`SamlConfigRow`) `map_groups_to_groups` fields, cross-referencing the SECURITY.md section.

No dedicated SSO admin markdown guide exists in this repo; SECURITY.md's operator section is the discoverable home. Admin-UI help text lives in the separate web repo (not in this repo), so the in-repo shortened warning lives on the config field doc-comments.

Closes #2493