### PR TITLE
fix(scanner-adapter): retry + mirror override for flaky trivy vuln-DB pull (#2167)

### DIFF
--- a/docker/Dockerfile.scanner-adapter
+++ b/docker/Dockerfile.scanner-adapter
@@ -67,6 +67,15 @@ RUN apk add --no-cache ca-certificates git rpm \
 COPY --from=trivy /usr/local/bin/trivy /usr/local/bin/trivy
 COPY --from=build /out/scanner-adapter /usr/local/bin/scanner-adapter
 
+# DB-download resilience (#2167): the trivy vuln-DB pull defaults to the
+# anonymous, rate-limited mirror.gcr.io/aquasecurity/trivy-db endpoint, which
+# made the release-gate scanner-efficacy check flaky. The adapter now retries
+# the download with exponential backoff (SCANNER_TRIVY_DB_UPDATE_RETRIES, default
+# 3). To eliminate the public mirror entirely, set SCANNER_TRIVY_DB_REPOSITORY
+# (chart / release-gate deploy) to an AK-controlled trivy-db mirror, e.g.
+# ghcr.io/artifact-keeper/trivy-db — trivy accepts a comma-separated fallback
+# list. No default repository is baked in here so the image works out of the box
+# against the public mirror; the mirror is an infra opt-in.
 ENV SCANNER_ADAPTER_ADDR=:8080 \
     SCANNER_TRIVY_PATH=/usr/local/bin/trivy \
     SCANNER_TRIVY_CACHE_DIR=/home/scanner/.cache/trivy

--- a/docker/scanner-adapter/config.go
+++ b/docker/scanner-adapter/config.go
@@ -23,6 +23,21 @@ type Config struct {
 	// SkipDBUpdate passes --skip-db-update so an air-gapped / pre-seeded cache
 	// is used verbatim instead of contacting the trivy DB registry.
 	SkipDBUpdate bool
+	// DBRepository overrides the OCI repository trivy pulls its vulnerability DB
+	// from (--db-repository). Empty means trivy's built-in default
+	// (mirror.gcr.io/aquasecurity/trivy-db), which is an anonymous, shared,
+	// rate-limited endpoint that made the release-gate scanner-efficacy check
+	// flaky (#2167). Point this at an AK-controlled mirror (e.g.
+	// ghcr.io/artifact-keeper/trivy-db) to avoid the public mirror entirely.
+	// trivy accepts a comma-separated fallback list.
+	DBRepository string
+	// DBUpdateRetries is how many EXTRA attempts DownloadDB makes after the first
+	// on a transient failure (rate-limit / network blip), with exponential
+	// backoff. 0 preserves the single-shot behaviour.
+	DBUpdateRetries int
+	// DBUpdateRetryDelay is the base backoff between DB-download attempts; the nth
+	// retry waits DBUpdateRetryDelay * 2^(n-1), capped by the download context.
+	DBUpdateRetryDelay time.Duration
 	// Severity is the trivy --severity filter (comma-separated UPPERCASE).
 	Severity string
 	// ScanTimeout bounds a single trivy image invocation.
@@ -54,8 +69,13 @@ func LoadConfig() *Config {
 		CacheDir:     getenv("SCANNER_TRIVY_CACHE_DIR", "/home/scanner/.cache/trivy"),
 		Insecure:     getenvBool("SCANNER_TRIVY_INSECURE", true),
 		SkipDBUpdate: getenvBool("SCANNER_TRIVY_SKIP_DB_UPDATE", false),
-		Severity:     getenv("SCANNER_TRIVY_SEVERITY", "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"),
-		ScanTimeout:  getenvDuration("SCANNER_TRIVY_TIMEOUT", 5*time.Minute),
+		DBRepository: getenv("SCANNER_TRIVY_DB_REPOSITORY", ""),
+		// Default to 3 extra attempts (2s, 4s, 8s backoff) so a transient
+		// public-mirror rate-limit no longer hard-fails the release-gate (#2167).
+		DBUpdateRetries:    getenvIntNonNeg("SCANNER_TRIVY_DB_UPDATE_RETRIES", 3),
+		DBUpdateRetryDelay: getenvDuration("SCANNER_TRIVY_DB_UPDATE_RETRY_DELAY", 2*time.Second),
+		Severity:           getenv("SCANNER_TRIVY_SEVERITY", "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"),
+		ScanTimeout:        getenvDuration("SCANNER_TRIVY_TIMEOUT", 5*time.Minute),
 		// Defaults mirror the backend's legacy CLI path: incus rootfs scans ran
 		// with --timeout 10m; the 64 GiB body cap matches the backend's
 		// MAX_INCUS_SCAN_EXTRACTED_BYTES default (the backend enforces its own
@@ -94,6 +114,20 @@ func getenvInt64(key string, def int64) int64 {
 	}
 	n, err := strconv.ParseInt(strings.TrimSpace(v), 10, 64)
 	if err != nil || n <= 0 {
+		return def
+	}
+	return n
+}
+
+// getenvIntNonNeg parses a non-negative int, allowing 0 (unlike getenvInt64,
+// which treats 0 as invalid). Used for retry counts where 0 = "no retries".
+func getenvIntNonNeg(key string, def int) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(v))
+	if err != nil || n < 0 {
 		return def
 	}
 	return n

--- a/docker/scanner-adapter/scan.go
+++ b/docker/scanner-adapter/scan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -71,6 +72,9 @@ func (s *Scanner) buildArgs(imageRef string) []string {
 	}
 	if s.cfg.SkipDBUpdate {
 		args = append(args, "--skip-db-update")
+	}
+	if s.cfg.DBRepository != "" {
+		args = append(args, "--db-repository", s.cfg.DBRepository)
 	}
 	args = append(args, imageRef)
 	return args
@@ -195,16 +199,62 @@ func dbPresent(cacheDir string) bool {
 // never advertises ready with no DB (which trivy treats as 0 vulnerabilities).
 func DBReady(cfg *Config) bool { return dbPresent(cfg.CacheDir) }
 
-// DownloadDB triggers a trivy DB download into cfg.CacheDir. It is run at
-// startup when DB updates are enabled so the DB is present before the adapter
-// marks itself ready (rather than lazily on the first scan, which would race the
-// readiness gate). Output is captured for the log; it never carries a token.
-func DownloadDB(ctx context.Context, cfg *Config) error {
-	cmd := exec.CommandContext(ctx, cfg.TrivyPath, "image", "--download-db-only", "--cache-dir", cfg.CacheDir)
+// downloadDBArgs builds the `trivy image --download-db-only` argument list,
+// honouring cfg.DBRepository (--db-repository) so the DB can be pulled from an
+// AK-controlled mirror instead of the shared public mirror.gcr.io endpoint.
+func downloadDBArgs(cfg *Config) []string {
+	args := []string{"image", "--download-db-only", "--cache-dir", cfg.CacheDir}
+	if cfg.DBRepository != "" {
+		args = append(args, "--db-repository", cfg.DBRepository)
+	}
+	return args
+}
+
+// downloadDBOnce runs a single `trivy --download-db-only`. Output is captured
+// for the log; it never carries a token (the DB pull is anonymous / host-scoped
+// away from the target-image credential).
+func downloadDBOnce(ctx context.Context, cfg *Config) error {
+	cmd := exec.CommandContext(ctx, cfg.TrivyPath, downloadDBArgs(cfg)...)
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("trivy --download-db-only failed: %v: %s", err, strings.TrimSpace(string(out)))
 	}
 	return nil
+}
+
+// DownloadDB triggers a trivy DB download into cfg.CacheDir. It is run at
+// startup when DB updates are enabled so the DB is present before the adapter
+// marks itself ready (rather than lazily on the first scan, which would race the
+// readiness gate).
+//
+// The default trivy DB mirror (mirror.gcr.io/aquasecurity/trivy-db) is an
+// anonymous, shared, rate-limited endpoint: a single-shot download made the
+// release-gate scanner-efficacy check flaky (#2167) — a transient
+// 429/UNAUTHORIZED left the adapter not-ready and hard-failed the release for
+// the wrong reason. DownloadDB therefore retries with exponential backoff
+// (cfg.DBUpdateRetries extra attempts, base cfg.DBUpdateRetryDelay), bounded by
+// ctx. For a durable fix, point cfg.DBRepository at an AK-controlled mirror.
+func DownloadDB(ctx context.Context, cfg *Config) error {
+	attempts := cfg.DBUpdateRetries + 1
+	if attempts < 1 {
+		attempts = 1
+	}
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			// Exponential backoff: base * 2^(i-1), interruptible by ctx.
+			delay := cfg.DBUpdateRetryDelay * time.Duration(1<<uint(i-1))
+			log.Printf("trivy DB download attempt %d/%d failed, retrying in %s: %v", i, attempts, delay, lastErr)
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("trivy DB download canceled after %d attempt(s): %w (last error: %v)", i, ctx.Err(), lastErr)
+			case <-time.After(delay):
+			}
+		}
+		if lastErr = downloadDBOnce(ctx, cfg); lastErr == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("trivy DB download failed after %d attempt(s): %w", attempts, lastErr)
 }
 
 // Scan runs trivy for the given request and returns the Harbor report. Any

--- a/docker/scanner-adapter/scan_fix_test.go
+++ b/docker/scanner-adapter/scan_fix_test.go
@@ -7,10 +7,92 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 )
+
+// writeFakeTrivy writes a shell "trivy" that increments a counter file on each
+// call and exits non-zero (simulating a rate-limited DB pull) until the
+// failUntil-th call, then exits 0. Returns the binary path and counter path.
+func writeFakeTrivy(t *testing.T, failUntil int) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	counter := filepath.Join(dir, "count")
+	bin := filepath.Join(dir, "trivy")
+	script := "#!/bin/sh\n" +
+		"c=$(cat " + counter + " 2>/dev/null || echo 0)\n" +
+		"c=$((c+1))\n" +
+		"echo $c > " + counter + "\n" +
+		"if [ \"$c\" -lt " + itoa(failUntil) + " ]; then\n" +
+		"  echo 'TOOMANYREQUESTS: too many requests to mirror.gcr.io' >&2\n" +
+		"  exit 1\n" +
+		"fi\n" +
+		"exit 0\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake trivy: %v", err)
+	}
+	return bin, counter
+}
+
+func itoa(n int) string {
+	return strconv.Itoa(n)
+}
+
+func readCount(t *testing.T, counter string) int {
+	t.Helper()
+	b, err := os.ReadFile(counter)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return n
+}
+
+// TestDownloadDBRetriesTransientFailure proves the #2167 resilience fix: a
+// transient DB-pull failure (rate-limit) is retried with backoff and eventually
+// succeeds, so the adapter becomes ready instead of hard-failing the gate.
+func TestDownloadDBRetriesTransientFailure(t *testing.T) {
+	bin, counter := writeFakeTrivy(t, 3) // fail on calls 1,2; succeed on 3
+	cfg := &Config{TrivyPath: bin, CacheDir: t.TempDir(), DBUpdateRetries: 3, DBUpdateRetryDelay: time.Millisecond}
+	if err := DownloadDB(context.Background(), cfg); err != nil {
+		t.Fatalf("DownloadDB should succeed after retries, got: %v", err)
+	}
+	if got := readCount(t, counter); got != 3 {
+		t.Errorf("expected 3 trivy invocations, got %d", got)
+	}
+}
+
+// TestDownloadDBExhaustsRetries proves DownloadDB gives up after the configured
+// attempts and surfaces a descriptive error (fail-closed at readiness).
+func TestDownloadDBExhaustsRetries(t *testing.T) {
+	bin, counter := writeFakeTrivy(t, 99) // always fails
+	cfg := &Config{TrivyPath: bin, CacheDir: t.TempDir(), DBUpdateRetries: 2, DBUpdateRetryDelay: time.Millisecond}
+	err := DownloadDB(context.Background(), cfg)
+	if err == nil {
+		t.Fatal("DownloadDB should fail when all attempts fail")
+	}
+	if !strings.Contains(err.Error(), "after 3 attempt(s)") {
+		t.Errorf("error should report attempt count; got: %v", err)
+	}
+	if got := readCount(t, counter); got != 3 { // 1 initial + 2 retries
+		t.Errorf("expected 3 trivy invocations, got %d", got)
+	}
+}
+
+// TestDownloadDBNoRetriesWhenDisabled proves DBUpdateRetries=0 keeps the
+// single-shot behaviour (one invocation, no retry loop).
+func TestDownloadDBNoRetriesWhenDisabled(t *testing.T) {
+	bin, counter := writeFakeTrivy(t, 99)
+	cfg := &Config{TrivyPath: bin, CacheDir: t.TempDir(), DBUpdateRetries: 0, DBUpdateRetryDelay: time.Millisecond}
+	if err := DownloadDB(context.Background(), cfg); err == nil {
+		t.Fatal("expected failure")
+	}
+	if got := readCount(t, counter); got != 1 {
+		t.Errorf("expected exactly 1 invocation with retries disabled, got %d", got)
+	}
+}
 
 // TestBuildCredentialHostScopedConfig proves the target-image bearer is written
 // to a host-scoped Docker config.json (keyed by trimRegistryHost(URL)) and

--- a/docker/scanner-adapter/scan_test.go
+++ b/docker/scanner-adapter/scan_test.go
@@ -102,6 +102,32 @@ func TestBuildArgsOmitsOptionalFlags(t *testing.T) {
 	if strings.Contains(args, "--skip-db-update") {
 		t.Error("--skip-db-update should be absent when SkipDBUpdate=false")
 	}
+	if strings.Contains(args, "--db-repository") {
+		t.Error("--db-repository should be absent when DBRepository is empty")
+	}
+}
+
+func TestBuildArgsIncludesDBRepository(t *testing.T) {
+	cfg := &Config{Severity: "LOW", ScanTimeout: time.Minute, CacheDir: "/c",
+		DBRepository: "ghcr.io/artifact-keeper/trivy-db"}
+	args := strings.Join(NewScanner(cfg).buildArgs("ref"), " ")
+	if !strings.Contains(args, "--db-repository ghcr.io/artifact-keeper/trivy-db") {
+		t.Errorf("expected --db-repository in args; got: %s", args)
+	}
+}
+
+func TestDownloadDBArgs(t *testing.T) {
+	// Default: no --db-repository.
+	got := strings.Join(downloadDBArgs(&Config{CacheDir: "/c"}), " ")
+	want := "image --download-db-only --cache-dir /c"
+	if got != want {
+		t.Errorf("downloadDBArgs = %q, want %q", got, want)
+	}
+	// With a mirror configured.
+	got = strings.Join(downloadDBArgs(&Config{CacheDir: "/c", DBRepository: "ghcr.io/ak/trivy-db"}), " ")
+	if !strings.Contains(got, "--db-repository ghcr.io/ak/trivy-db") {
+		t.Errorf("downloadDBArgs missing --db-repository; got %q", got)
+	}
 }
 
 func TestLoadConfigDefaults(t *testing.T) {
@@ -119,6 +145,30 @@ func TestLoadConfigDefaults(t *testing.T) {
 	}
 	if cfg.ScanTimeout != 5*time.Minute || cfg.JobTTL != 30*time.Minute {
 		t.Errorf("unexpected duration defaults: %+v", cfg)
+	}
+	// #2167 DB-download resilience defaults.
+	if cfg.DBRepository != "" {
+		t.Errorf("DBRepository should default to empty; got %q", cfg.DBRepository)
+	}
+	if cfg.DBUpdateRetries != 3 || cfg.DBUpdateRetryDelay != 2*time.Second {
+		t.Errorf("unexpected DB retry defaults: retries=%d delay=%s", cfg.DBUpdateRetries, cfg.DBUpdateRetryDelay)
+	}
+}
+
+func TestLoadConfigDBRepositoryAndRetryOverrides(t *testing.T) {
+	t.Setenv("SCANNER_TRIVY_DB_REPOSITORY", "ghcr.io/artifact-keeper/trivy-db")
+	t.Setenv("SCANNER_TRIVY_DB_UPDATE_RETRIES", "0")
+	t.Setenv("SCANNER_TRIVY_DB_UPDATE_RETRY_DELAY", "500ms")
+	cfg := LoadConfig()
+	if cfg.DBRepository != "ghcr.io/artifact-keeper/trivy-db" {
+		t.Errorf("DBRepository override not applied: %q", cfg.DBRepository)
+	}
+	// 0 is a valid "no retries" value and must NOT fall back to the default 3.
+	if cfg.DBUpdateRetries != 0 {
+		t.Errorf("DBUpdateRetries=0 override not applied; got %d", cfg.DBUpdateRetries)
+	}
+	if cfg.DBUpdateRetryDelay != 500*time.Millisecond {
+		t.Errorf("DBUpdateRetryDelay override not applied; got %s", cfg.DBUpdateRetryDelay)
 	}
 }
 


### PR DESCRIPTION
## Problem

The release-gate `pinned-cve-image-gate` (the #237/#238 scanner-efficacy check) intermittently fails-closed on every recent release cut (v1.5.4–v1.5.7) because the scanner-adapter's trivy cannot download its vulnerability DB:

```
Scanner adapter returned 500: trivy scan failed
  * GET https://mirror.gcr.io/v2/aquasec/trivy-db/manifests/2: UNAUTHORIZED
```

trivy's default DB mirror (`mirror.gcr.io/aquasecurity/trivy-db`) is an **anonymous, shared, rate-limited** endpoint. A transient 429/UNAUTHORIZED leaves the adapter not-ready and hard-fails the release for the *wrong reason* (DB unavailability, not a broken scanner) — which risks a security-critical gate being routinely bypassed.

The deeper token-poisoning root cause (the per-scan registry bearer bleeding into the anonymous DB pull) was already fixed via host-scoped `DOCKER_CONFIG`. This PR adds the remaining durable resilience the **adapter can self-serve**.

## Change

- **Retry with backoff** — `DownloadDB` now retries on transient failure instead of a single shot, riding out public-mirror rate-limits.
  - `SCANNER_TRIVY_DB_UPDATE_RETRIES` (default `3`; `0` = single-shot)
  - `SCANNER_TRIVY_DB_UPDATE_RETRY_DELAY` (base backoff, default `2s`; exponential `2s/4s/8s`, bounded by the download context)
- **Mirror override** — `SCANNER_TRIVY_DB_REPOSITORY` plumbs trivy's `--db-repository` through both the image scan and the DB download, so the chart / release-gate deploy can point the adapter at an **AK-controlled trivy-db mirror** (e.g. `ghcr.io/artifact-keeper/trivy-db`, comma-separated fallback list) and avoid the public mirror entirely.
  - No default mirror is baked in — the image still works out of the box against the public mirror; the AK mirror is an infra opt-in.
- Dockerfile documents the new knobs.

## Tests

New unit tests cover: `--db-repository` flag threading (scan + download args), retry-until-success (fails twice, succeeds on 3rd), retry-exhaustion error (reports attempt count), and retries-disabled single-shot. `go vet`, `gofmt -l`, `go build`, and the full adapter suite pass.

## Scope / follow-up

This is the full **repo-self-serviceable** fix: retry (works immediately, zero infra) + `TRIVY_DB_REPOSITORY` plumbing. It substantially de-flakes the gate on its own via retry.

Remaining **infra opt-in** (cannot be done from this repo): provision an AK-controlled `trivy-db` mirror (mirror `ghcr.io/aquasecurity/trivy-db:2` into `ghcr.io/artifact-keeper/trivy-db` on a schedule) and set `SCANNER_TRIVY_DB_REPOSITORY` in the scanner-adapter deployment (iac chart values / release-gate). That eliminates the shared public-mirror dependency entirely.

Closes #2167