### PR TITLE
test(streaming): reconcile streaming_invariant allowlist with current npm/pypi/remote_instances source

### DIFF
--- a/backend/tests/streaming_invariant.rs
+++ b/backend/tests/streaming_invariant.rs
@@ -48,14 +48,26 @@ use std::path::{Path, PathBuf};
 /// `response.bytes_stream()` under a running byte ceiling instead of calling
 /// `response.bytes()`. With no gated call left, the proxy_service.rs row is
 /// removed: 32 -> 31.
+///
+/// Reconciliation (#2491): three post-Phase-4b merges drifted the source from
+/// this allowlist. Reconciled to match the current, correct source:
+///   * npm.rs 5 -> 6: the packument stale-while-revalidate cache (#2166) added a
+///     bounded `axum::body::to_bytes` read of a computed packument JSON, capped
+///     at `NPM_PACKUMENT_BUFFER_CAP`. A legitimate new metadata buffer site.
+///   * pypi.rs 1 -> removed: the shared content-addressed upload primitive
+///     (#2199) streamed the pypi upload to storage, deleting the last `.bytes()`
+///     multipart-field read. Phase progress — the row is gone.
+///   * remote_instances.rs 1 -> removed: the remote-instance proxy (#2532) now
+///     forwards `resp.bytes_stream()` instead of buffering `.bytes()`. Phase
+///     progress — the row is gone.
+///
+/// Net: 31 -> 30 (+1 npm, -1 pypi, -1 remote_instances).
 const ALLOWLIST: &[(&str, usize)] = &[
     ("src/api/handlers/goproxy.rs", 1),
-    ("src/api/handlers/npm.rs", 5),
+    ("src/api/handlers/npm.rs", 6),
     ("src/api/handlers/oci_v2.rs", 1),
     ("src/api/handlers/plugins.rs", 2),
     ("src/api/handlers/proxy_helpers.rs", 2),
-    ("src/api/handlers/pypi.rs", 1),
-    ("src/api/handlers/remote_instances.rs", 1),
     ("src/api/handlers/repositories.rs", 2),
     ("src/api/middleware/rate_limit.rs", 1),
     ("src/main.rs", 1),
@@ -415,8 +427,9 @@ fn streaming_invariant_exempt_sites_match_allowlist() {
 
     let total: usize = actual_marks.values().sum();
     assert_eq!(
-        total, 31,
-        "expected 31 exempt sites after #1608 Phase 4b (proxy_service buffered \
-         metadata read capped via running-bounded bytes_stream); got {total}"
+        total, 30,
+        "expected 30 exempt sites after #1608 Phase 4b + #2491 reconciliation \
+         (npm packument cache +1; pypi and remote_instances streamed to storage, \
+         -1 each); got {total}"
     );
 }


### PR DESCRIPTION
## Summary

Reconciles the `streaming_invariant` source-scan allowlist (`backend/tests/streaming_invariant.rs`) with the current backend source. The scan asserts that every full-body-buffering call on an artifact/proxy path is a known, annotated `STREAMING-EXEMPT` site, and fails if a new un-annotated `.bytes()` / `to_bytes(...)` read appears. Three post-Phase-4b merges moved the source without updating the allowlist, so the guard failed on a clean `main` checkout and no longer matched reality.

Reconciled the per-file counts to the current, correct source (no production code changed):

- `npm.rs` **5 → 6**: the packument stale-while-revalidate cache (#2166) added a bounded `axum::body::to_bytes` read of a computed packument JSON, capped at `NPM_PACKUMENT_BUFFER_CAP`. This is a legitimate, annotated metadata buffer site — the allowlist entry grows to match.
- `pypi.rs` **1 → removed**: the shared content-addressed upload primitive (#2199) streamed the pypi upload to storage and deleted the last `.bytes()` multipart-field read. Phase progress — the row is gone.
- `remote_instances.rs` **1 → removed**: the remote-instance proxy (#2532) now forwards `resp.bytes_stream()` instead of buffering `.bytes()`. Phase progress — the row is gone.

Net exempt-site total: **31 → 30** (+1 npm, −1 pypi, −1 remote_instances). The `assert_eq!` total and the doc comment are updated accordingly. This is a corrective reconciliation, not a suppression — the guard still fails on any new un-annotated full-body read.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

The changed file *is* the guard. Verified both directions:
- On clean `main`, `cargo test --test streaming_invariant` now **passes** (previously failed with `npm.rs allowlist=5 actual=6`, `pypi.rs allowlist=1 actual=0`, `remote_instances.rs allowlist=1 actual=0`).
- Injecting a deliberate un-annotated `resp.bytes().await` into a handler still makes the scan **fail** (`2 disallowed-call candidate(s) but only 1 STREAMING-EXEMPT annotation(s)`), confirming the guard still catches a genuine future streaming regression.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2491
