### PR TITLE
feat(security): collapse not_applicable scan rows + document TRIVY_ADAPTER_URL (#2471)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -315,6 +315,16 @@ JWT_EXPIRATION_SECS=86400
 # SCAN_WORKSPACE_PATH=/scan-workspace
 # GITHUB_TOKEN=ghp_xxx
 
+# --- Trivy scanner-adapter (container-image scanning, optional) ---
+# Points the backend at the in-repo `docker/scanner-adapter` (Harbor Pluggable
+# Scanner API). Set this to register the dedicated Trivy *image* scanner
+# (`ImageScanner`); WITHOUT it, container images are still covered by grype
+# (registry mode) but no Trivy image report is produced. When set it also
+# drives filesystem/incus scans over HTTP (adapter >= 1.2.0), so no `trivy`
+# binary is needed in the backend image. Takes precedence over TRIVY_URL for
+# the fs/incus scanners. See docker/scanner-adapter/README.md.
+# TRIVY_ADAPTER_URL=http://scanner-adapter:8080
+
 # --- Incus/LXC image scan limits (optional) ---
 # Ceilings for the incus-image scanner's extraction-bomb guards, as plain byte
 # counts. Defaults (16 GiB compressed / 64 GiB extracted) admit a real

--- a/README.md
+++ b/README.md
@@ -206,6 +206,24 @@ flowchart LR
 - **Policies** - Configurable rules that block or quarantine artifacts
 - **Signing** - GPG/RSA signing for Debian, RPM, Alpine, and Conda packages
 
+> **Container-image scanning (`TRIVY_ADAPTER_URL`).** The base `docker-compose.yml`
+> wires `TRIVY_URL` for the legacy trivy *server* (filesystem / incus rootfs
+> scanning) only. To get first-class Trivy container-*image* reports, set
+> `TRIVY_ADAPTER_URL` (e.g. `http://scanner-adapter:8080`) so the backend
+> registers the dedicated `ImageScanner` against the in-repo
+> [`scanner-adapter`](docker/scanner-adapter/README.md) (Harbor Pluggable Scanner
+> API). Without it, images are still covered by grype (registry mode) but no
+> Trivy image report is produced. Uncomment the `TRIVY_ADAPTER_URL` line and the
+> `scanner-adapter` service in `docker-compose.yml` to enable it.
+>
+> **Not-applicable scanners.** A scanner that does not apply to an artifact's
+> format (e.g. the filesystem/incus/openscap scanners on a Docker image) records
+> a `not_applicable` result — a benign terminal state, distinct from `failed`.
+> The scan-list API folds multiple `not_applicable` results for the same
+> artifact into a single summary row (`collapsed_not_applicable_count` +
+> `collapsed_scan_types`) so they read as one muted "not applicable" indication
+> rather than N failures.
+
 ## Borg Replication
 
 Recursive peer-to-peer replication where every node is a full Artifact Keeper instance. No thin caches — each peer runs the same stack and can serve as an origin for other peers.

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -201,6 +201,21 @@ pub struct ScanResponse {
     /// satisfaction" in release-gate provenance checks. None for original
     /// (non-reused) scans.
     pub source_scan_id: Option<Uuid>,
+    /// #2471: number of `not_applicable` scanner rows folded into this row.
+    /// `Some(n)` marks a synthetic *summary* row that collapses `n` redundant
+    /// "this scanner does not apply" results (e.g. the image-family scanners
+    /// `filesystem`/`incus`/`openscap` all declining on a Docker image) into a
+    /// single muted "not applicable to this artifact" indication, so the UI
+    /// stops rendering N rows that read as N failures. `None` for every real
+    /// (non-collapsed) scan row. Omitted from the wire when `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collapsed_not_applicable_count: Option<i32>,
+    /// #2471: the individual `scan_type` values folded into a summary row,
+    /// sorted and de-duplicated (e.g. `["filesystem","incus","openscap"]`).
+    /// Present only on a synthetic summary row (alongside
+    /// `collapsed_not_applicable_count`); `None` / omitted otherwise.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub collapsed_scan_types: Option<Vec<String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -248,8 +263,84 @@ impl ScanResponse {
             created_at: s.created_at,
             is_reused: s.is_reused,
             source_scan_id: s.source_scan_id,
+            collapsed_not_applicable_count: None,
+            collapsed_scan_types: None,
         }
     }
+}
+
+/// #2471: collapse redundant `not_applicable` scan rows into one summary row
+/// per artifact.
+///
+/// When an artifact is offered to several image-family scanners that decline to
+/// run (`filesystem`, `incus`, `openscap`, ... all returning the dedicated
+/// `not_applicable` status from #1470), the raw scan list carries one
+/// `not_applicable` row per scanner. Operators misread these as N separate
+/// failures. This folds every `not_applicable` row belonging to the same
+/// artifact into a single synthetic summary row that records how many scanners
+/// declined (`collapsed_not_applicable_count`) and which `scan_type`s they were
+/// (`collapsed_scan_types`), so the UI can render one muted "not applicable to
+/// this artifact" indication instead of N ❌-looking rows.
+///
+/// Only groups of **two or more** `not_applicable` rows are collapsed — a lone
+/// `not_applicable` row is not redundant and passes through untouched. Every
+/// non-`not_applicable` row (completed / running / failed / findings) passes
+/// through verbatim. Relative ordering is preserved: the summary row takes the
+/// position of the artifact's *first* (most-recent, since the query is
+/// `created_at DESC`) collapsed row, and inherits that row's `id` so the UI can
+/// still drill into a representative scanner result.
+fn collapse_not_applicable_rows(items: Vec<ScanResponse>) -> Vec<ScanResponse> {
+    const NOT_APPLICABLE: &str = "not_applicable";
+
+    // Count not_applicable rows per artifact so we know which groups qualify.
+    let mut na_per_artifact: std::collections::HashMap<Uuid, usize> =
+        std::collections::HashMap::new();
+    for item in &items {
+        if item.status == NOT_APPLICABLE {
+            *na_per_artifact.entry(item.artifact_id).or_insert(0) += 1;
+        }
+    }
+
+    let mut out: Vec<ScanResponse> = Vec::with_capacity(items.len());
+    // Track which artifacts have already had their summary row emitted.
+    let mut summarized: std::collections::HashSet<Uuid> = std::collections::HashSet::new();
+
+    for item in items {
+        let collapses = item.status == NOT_APPLICABLE
+            && na_per_artifact.get(&item.artifact_id).copied().unwrap_or(0) >= 2;
+
+        if !collapses {
+            out.push(item);
+            continue;
+        }
+
+        if summarized.contains(&item.artifact_id) {
+            // A later row of an already-summarized group: fold its scan_type in.
+            if let Some(summary) = out
+                .iter_mut()
+                .find(|r| r.artifact_id == item.artifact_id && r.collapsed_scan_types.is_some())
+            {
+                if let Some(types) = summary.collapsed_scan_types.as_mut() {
+                    types.push(item.scan_type.clone());
+                    types.sort();
+                    types.dedup();
+                    summary.collapsed_not_applicable_count = Some(types.len() as i32);
+                }
+            }
+            continue;
+        }
+
+        // First collapsed row for this artifact: turn it into the summary row.
+        summarized.insert(item.artifact_id);
+        let mut summary = item;
+        summary.collapsed_scan_types = Some(vec![summary.scan_type.clone()]);
+        summary.scan_type = NOT_APPLICABLE.to_string();
+        summary.collapsed_not_applicable_count = Some(1);
+        summary.error_message = Some("Not applicable to this artifact".to_string());
+        out.push(summary);
+    }
+
+    out
 }
 
 impl From<crate::models::security::ScanFinding> for FindingResponse {
@@ -788,7 +879,11 @@ async fn list_scans(
         )
         .await?;
 
-    let items = enrich_scans(&state.db, scans).await?;
+    // #2471: fold redundant per-artifact `not_applicable` rows into a single
+    // muted summary row before returning. `total` is left as the raw DB row
+    // count (it drives pagination); the collapse only shrinks the rows shown on
+    // this page, and the `total >= items.len()` invariant still holds.
+    let items = collapse_not_applicable_rows(enrich_scans(&state.db, scans).await?);
     Ok(Json(ScanListResponse { items, total }))
 }
 
@@ -1224,7 +1319,11 @@ async fn list_artifact_scans(
         )
         .await?;
 
-    let items = enrich_scans(&state.db, scans).await?;
+    // #2471: fold redundant per-artifact `not_applicable` rows into a single
+    // muted summary row before returning. `total` is left as the raw DB row
+    // count (it drives pagination); the collapse only shrinks the rows shown on
+    // this page, and the `total >= items.len()` invariant still holds.
+    let items = collapse_not_applicable_rows(enrich_scans(&state.db, scans).await?);
     Ok(Json(ScanListResponse { items, total }))
 }
 
@@ -1268,7 +1367,11 @@ async fn list_repo_scans(
         .list_scans(Some(repo), None, query.status.as_deref(), offset, per_page)
         .await?;
 
-    let items = enrich_scans(&state.db, scans).await?;
+    // #2471: fold redundant per-artifact `not_applicable` rows into a single
+    // muted summary row before returning. `total` is left as the raw DB row
+    // count (it drives pagination); the collapse only shrinks the rows shown on
+    // this page, and the `total >= items.len()` invariant still holds.
+    let items = collapse_not_applicable_rows(enrich_scans(&state.db, scans).await?);
     Ok(Json(ScanListResponse { items, total }))
 }
 
@@ -1792,6 +1895,150 @@ mod tests {
         assert_eq!(resp.created_at, created);
         assert_eq!(resp.started_at, started);
         assert_eq!(resp.completed_at, completed);
+    }
+
+    // -----------------------------------------------------------------------
+    // collapse_not_applicable_rows (#2471)
+    // -----------------------------------------------------------------------
+
+    /// Build a `ScanResponse` for a given artifact/scan_type/status. Keeps the
+    /// collapse tests terse and independent of a DB.
+    fn make_scan_response(artifact_id: Uuid, scan_type: &str, status: &str) -> ScanResponse {
+        let mut resp = scan_result_to_response(make_scan_result(), None, None);
+        resp.artifact_id = artifact_id;
+        resp.scan_type = scan_type.to_string();
+        resp.status = status.to_string();
+        resp
+    }
+
+    /// N `not_applicable` rows for one artifact collapse into a single summary
+    /// row that records the count and the sorted, de-duplicated scan_types,
+    /// while a genuine finding row for the same artifact passes through.
+    #[test]
+    fn test_collapse_folds_multiple_not_applicable_into_one_summary() {
+        let art = Uuid::new_v4();
+        let items = vec![
+            make_scan_response(art, "image", "completed"),
+            make_scan_response(art, "openscap", "not_applicable"),
+            make_scan_response(art, "incus", "not_applicable"),
+            make_scan_response(art, "filesystem", "not_applicable"),
+        ];
+
+        let out = collapse_not_applicable_rows(items);
+
+        // 1 real finding row + 1 summary row.
+        assert_eq!(out.len(), 2);
+        let real = out
+            .iter()
+            .find(|r| r.status == "completed")
+            .expect("finding row survives");
+        assert_eq!(real.scan_type, "image");
+        assert!(real.collapsed_not_applicable_count.is_none());
+
+        let summary = out
+            .iter()
+            .find(|r| r.collapsed_not_applicable_count.is_some())
+            .expect("summary row emitted");
+        assert_eq!(summary.status, "not_applicable");
+        assert_eq!(summary.scan_type, "not_applicable");
+        assert_eq!(summary.collapsed_not_applicable_count, Some(3));
+        assert_eq!(
+            summary.collapsed_scan_types.as_deref(),
+            Some(
+                [
+                    "filesystem".to_string(),
+                    "incus".to_string(),
+                    "openscap".to_string()
+                ]
+                .as_slice()
+            )
+        );
+    }
+
+    /// A lone `not_applicable` row is not redundant and must pass through
+    /// unchanged (no synthetic summary, no annotation).
+    #[test]
+    fn test_collapse_leaves_single_not_applicable_untouched() {
+        let art = Uuid::new_v4();
+        let items = vec![
+            make_scan_response(art, "image", "completed"),
+            make_scan_response(art, "filesystem", "not_applicable"),
+        ];
+
+        let out = collapse_not_applicable_rows(items);
+
+        assert_eq!(out.len(), 2);
+        let na = out
+            .iter()
+            .find(|r| r.status == "not_applicable")
+            .expect("na row survives");
+        assert_eq!(na.scan_type, "filesystem");
+        assert!(na.collapsed_not_applicable_count.is_none());
+        assert!(na.collapsed_scan_types.is_none());
+    }
+
+    /// Collapse is scoped per-artifact: two artifacts each with their own
+    /// group of `not_applicable` rows collapse independently.
+    #[test]
+    fn test_collapse_groups_per_artifact() {
+        let a1 = Uuid::new_v4();
+        let a2 = Uuid::new_v4();
+        let items = vec![
+            make_scan_response(a1, "incus", "not_applicable"),
+            make_scan_response(a1, "openscap", "not_applicable"),
+            make_scan_response(a2, "filesystem", "not_applicable"),
+            make_scan_response(a2, "openscap", "not_applicable"),
+        ];
+
+        let out = collapse_not_applicable_rows(items);
+
+        assert_eq!(out.len(), 2);
+        for summary in &out {
+            assert_eq!(summary.collapsed_not_applicable_count, Some(2));
+        }
+        assert_ne!(out[0].artifact_id, out[1].artifact_id);
+    }
+
+    /// Rows with no `not_applicable` status are returned verbatim, in order.
+    #[test]
+    fn test_collapse_noop_without_not_applicable() {
+        let art = Uuid::new_v4();
+        let items = vec![
+            make_scan_response(art, "image", "completed"),
+            make_scan_response(art, "dependency", "failed"),
+        ];
+
+        let out = collapse_not_applicable_rows(items);
+
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[0].scan_type, "image");
+        assert_eq!(out[1].scan_type, "dependency");
+        assert!(out
+            .iter()
+            .all(|r| r.collapsed_not_applicable_count.is_none()));
+    }
+
+    /// The summary row keeps the position and `id` of the artifact's first
+    /// (most-recent) collapsed row so the UI can still drill into a
+    /// representative result and ordering is stable.
+    #[test]
+    fn test_collapse_summary_inherits_first_row_id_and_position() {
+        let art = Uuid::new_v4();
+        let first_na = make_scan_response(art, "incus", "not_applicable");
+        let first_id = first_na.id;
+        let items = vec![
+            first_na,
+            make_scan_response(art, "openscap", "not_applicable"),
+            make_scan_response(art, "image", "completed"),
+        ];
+
+        let out = collapse_not_applicable_rows(items);
+
+        assert_eq!(out.len(), 2);
+        // Summary takes the first slot (where the first not_applicable row was).
+        assert_eq!(out[0].id, first_id);
+        assert_eq!(out[0].collapsed_not_applicable_count, Some(2));
+        assert_eq!(out[1].status, "completed");
     }
 
     // -----------------------------------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -239,6 +239,17 @@ services:
       # subnets; keep it in sync with the actual proxy network.
       RATE_LIMIT_TRUSTED_PROXY_CIDRS: ${RATE_LIMIT_TRUSTED_PROXY_CIDRS:-172.30.0.0/24}
       TRIVY_URL: http://trivy:8090
+      # Trivy scanner-adapter URL (container-image scanning, #2471 / #2305).
+      # TRIVY_URL above only wires the legacy trivy *server* used for
+      # filesystem / incus (rootfs) scanning. To get first-class Trivy
+      # container-*image* reports, point the backend at the in-repo
+      # scanner-adapter (Harbor Pluggable Scanner API); this registers the
+      # dedicated `ImageScanner`. WITHOUT it, images are still covered by grype
+      # (registry mode), but no Trivy image report is produced and operators
+      # cannot tell why. When set it also drives fs/incus scans over HTTP
+      # (adapter >= 1.2.0), taking precedence over TRIVY_URL there. Uncomment
+      # this line and the `scanner-adapter` service block below to enable it.
+      # TRIVY_ADAPTER_URL: http://scanner-adapter:8080
       OPENSCAP_URL: http://openscap:8091
       SCAN_WORKSPACE_PATH: /scan-workspace
       OPENSEARCH_URL: http://opensearch:9200
@@ -335,6 +346,29 @@ services:
       - trivy_cache:/root/.cache/trivy
       - scan_workspace:/scan-workspace:ro
     restart: unless-stopped
+
+  # ---------------------------------------------------------------------------
+  # Trivy scanner-adapter (container-image scanning) — optional
+  # ---------------------------------------------------------------------------
+  # Fronts trivy with the Harbor Pluggable Scanner API so the backend can run
+  # first-class container-*image* scans (the `ImageScanner`) and, from adapter
+  # 1.2.0, filesystem/incus scans over HTTP with no trivy binary in the backend
+  # image. Uncomment this service AND set `TRIVY_ADAPTER_URL` on the backend
+  # (see the commented line in the backend `environment:` above) to enable it.
+  # Without it, container images are still scanned by grype (registry mode) but
+  # no Trivy image report is produced. See docker/scanner-adapter/README.md.
+  # scanner-adapter:
+  #   image: ghcr.io/artifact-keeper/artifact-keeper-scanner-adapter:1  # or artifactkeeper/scanner-adapter:1
+  #   container_name: artifact-keeper-scanner-adapter
+  #   environment:
+  #     SCANNER_ADAPTER_ADDR: ":8080"
+  #     # Pull image manifests/blobs from the AK registry over the compose
+  #     # network's plain HTTP. Leave true on the internal network.
+  #     SCANNER_TRIVY_INSECURE: "true"
+  #   volumes:
+  #     - trivy_cache:/home/scanner/.cache/trivy
+  #     - scan_workspace:/scan-workspace:ro
+  #   restart: unless-stopped
 
   # ---------------------------------------------------------------------------
   # OpenSCAP (compliance scanner)


### PR DESCRIPTION
## Summary

Closes #2471.

Two small scanner UX/docs papercuts flagged in discussion #2305 (a user misread a
filesystem-scanner `not_applicable` row on a Docker image as a real failure). No
gate/status bug — this is UX + docs only.

**1. Collapse redundant `not_applicable` rows (backend serialization).**
When an artifact is offered to several image-family scanners that decline to run
(`filesystem`, `incus`, `openscap`, ... all returning the dedicated
`not_applicable` status from #1470), the scan list carries one `not_applicable`
row per scanner. Operators misread these N rows as N failures. The scan-list
endpoints now fold every `not_applicable` result for the same artifact into a
single muted summary row that records how many scanners declined
(`collapsed_not_applicable_count`) and which `scan_type`s they were
(`collapsed_scan_types`), so the UI can render one "not applicable to this
artifact" indication instead of N ❌-looking rows.

- Only groups of **two or more** `not_applicable` rows collapse; a lone
  `not_applicable` row is not redundant and passes through untouched.
- Every non-`not_applicable` row (completed / running / failed / findings) passes
  through verbatim, in original order. A real finding still shows.
- The summary row inherits the artifact's first (most-recent) collapsed row's
  `id`, so the UI can still drill into a representative result.
- `total` stays the raw DB row count (it drives pagination); collapse only
  shrinks the rows shown on a page, and `total >= items.len()` still holds.
- Applied to all three scan-list handlers: `list_scans`, `list_artifact_scans`,
  `list_repo_scans`.

Before/after (a Docker image with 3 image-family `not_applicable` rows + 1 real
`image` finding), `GET /api/v1/security/scans?artifact_id=…`:

- Before: `items` = 4 rows (3 separate `not_applicable` + 1 `completed`).
- After: `items` = 2 rows — the `completed` finding unchanged, plus one summary
  row `{ "status":"not_applicable", "scan_type":"not_applicable",
  "collapsed_not_applicable_count":3, "collapsed_scan_types":
  ["filesystem","incus","openscap"] }`. `total` = 4.

**2. Document `TRIVY_ADAPTER_URL` in base compose + docs.**
The base `docker-compose.yml` wires `TRIVY_URL` (legacy trivy *server*, used for
filesystem/incus scanning) but not `TRIVY_ADAPTER_URL`, so the dedicated
container-*image* scanner (`ImageScanner`) is never registered. Images are still
covered by grype (registry mode), but operators expecting a Trivy image report
get none and cannot tell why. Added:

- a commented `TRIVY_ADAPTER_URL: http://scanner-adapter:8080` line in the backend
  `environment:` block, next to `TRIVY_URL`, with an explanatory comment;
- a commented `scanner-adapter` service block (image, addr, cache/workspace
  volumes) so the whole thing is copy-paste enableable;
- an `.env.example` entry;
- a README "Security Scanning Pipeline" note covering both the adapter URL and the
  `not_applicable` collapse.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix (enhancement: UX/docs, no status/gate bug)

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Five unit tests for `collapse_not_applicable_rows` cover: N→1 summary with sorted
de-duplicated scan_types while a finding passes through; single `not_applicable`
untouched; per-artifact grouping; no-op without `not_applicable`; summary inherits
the first row's id and position. Verified live on an isolated stack (built image,
seeded, inserted 3 `not_applicable` + 1 finding, confirmed the collapsed API
response and that the real finding still shows).

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations (N/A — no new endpoints)
- [x] Request/response types have `#[derive(ToSchema)]` (`ScanResponse` keeps its
  `ToSchema` derive; two new optional fields are `skip_serializing_if =
  "Option::is_none"` so existing consumers see no wire change)
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no breaking API changes
