### PR TITLE
fix(migration): fetch and register referenced OCI content for Docker imports

### DIFF
--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -1469,7 +1469,7 @@ async fn stream_migration_progress(
         // Send initial connection event
         yield Ok(Event::default().event("connected").data(format!(r#"{{"job_id":"{}"}}"#, id)));
 
-        let terminal_statuses = ["completed", "failed", "cancelled"];
+        let terminal_statuses = ["completed", "completed_with_errors", "failed", "cancelled"];
 
         loop {
             // Fetch current progress
@@ -1605,7 +1605,10 @@ async fn list_migration_items(
 /// audit report is meaningful. Mirrors the terminal set used by the progress
 /// stream loop.
 fn is_terminal_status(status: &str) -> bool {
-    matches!(status, "completed" | "failed" | "cancelled")
+    matches!(
+        status,
+        "completed" | "completed_with_errors" | "failed" | "cancelled"
+    )
 }
 
 /// Fetch the persisted report row for a job, if one exists.

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -2111,7 +2111,40 @@ pub(crate) async fn persist_tag_and_refs(
     manifest_body: &[u8],
 ) -> Result<(), sqlx::Error> {
     let mut tx = pool.begin().await?;
+    persist_tag_and_refs_in_tx(
+        &mut tx,
+        repo_id,
+        name,
+        tag,
+        manifest_digest,
+        manifest_content_type,
+        class,
+        manifest_body,
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
 
+/// Transaction-participating form of [`persist_tag_and_refs`]. Runs the tag
+/// upsert and reference recording against a caller-owned transaction WITHOUT
+/// committing, so the caller can bind the registration to a larger atomic
+/// unit — e.g. the migration worker registers the `artifacts` row, the tag,
+/// and every referenced blob/child manifest in ONE transaction so a migrated
+/// tag is never committed without its backing content (#2457). The pool-taking
+/// [`persist_tag_and_refs`] is a thin wrapper that begins + commits its own
+/// transaction, preserving the live push path's behaviour byte-for-byte.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn persist_tag_and_refs_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    repo_id: Uuid,
+    name: &str,
+    tag: &str,
+    manifest_digest: &str,
+    manifest_content_type: &str,
+    class: &ManifestClass,
+    manifest_body: &[u8],
+) -> Result<(), sqlx::Error> {
     // 1. Tag upsert (identical SQL/semantics to the previous standalone form).
     sqlx::query(
         r#"INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type)
@@ -2126,7 +2159,7 @@ pub(crate) async fn persist_tag_and_refs(
     .bind(tag)
     .bind(manifest_digest)
     .bind(manifest_content_type)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await?;
 
     // 2. Reference recording, in the SAME transaction. A failure here rolls
@@ -2146,7 +2179,7 @@ pub(crate) async fn persist_tag_and_refs(
                 .bind(manifest_digest)
                 .bind(&children)
                 .bind(repo_id)
-                .execute(&mut *tx)
+                .execute(&mut **tx)
                 .await?;
             }
         }
@@ -2178,7 +2211,7 @@ pub(crate) async fn persist_tag_and_refs(
                 )
                 .bind(repo_id)
                 .bind(&blob_digests)
-                .fetch_all(&mut *tx)
+                .fetch_all(&mut **tx)
                 .await?;
 
                 // 2b. (#1660) Resurrect any of these blobs that blob GC has
@@ -2202,7 +2235,7 @@ pub(crate) async fn persist_tag_and_refs(
                 )
                 .bind(repo_id)
                 .bind(&blob_digests)
-                .execute(&mut *tx)
+                .execute(&mut **tx)
                 .await?;
 
                 sqlx::query(
@@ -2217,14 +2250,13 @@ pub(crate) async fn persist_tag_and_refs(
                 .bind(&blob_digests)
                 .bind(&kinds)
                 .bind(repo_id)
-                .execute(&mut *tx)
+                .execute(&mut **tx)
                 .await?;
             }
         }
         ManifestClass::Malformed => {}
     }
 
-    tx.commit().await?;
     Ok(())
 }
 
@@ -13464,6 +13496,23 @@ mod oci_manifest_refs_tests {
         assert!(
             extract_blob_refs(body).is_empty(),
             "image index has no config/layers blobs"
+        );
+        // Companion to the pure-extractor assertion above (#2457): the
+        // referenced-content walker must NOT treat an index as an image (whose
+        // blobs `extract_blob_refs` would enumerate) — it classifies the body
+        // as an Index and recurses its `manifests[]` children instead. The
+        // classifier is the single source of truth the walker branches on.
+        assert!(
+            matches!(classify_manifest(body), ManifestClass::Index),
+            "the walker must classify this as an index and recurse children, not read blob refs"
+        );
+        assert_eq!(
+            extract_child_digests(body),
+            vec![
+                "sha256:childamd64".to_string(),
+                "sha256:childarm64".to_string()
+            ],
+            "the walker recurses exactly these child manifests"
         );
     }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -562,24 +562,31 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
                     storage_registry,
                 )
                 .await;
-            if repair_stats.candidates_failed > 0 {
+            if repair_stats.candidates_failed > 0 || repair_stats.hollow_tags_flagged > 0 {
                 tracing::warn!(
                     candidates_scanned = repair_stats.candidates_scanned,
                     manifests_registered = repair_stats.manifests_registered,
                     blobs_registered = repair_stats.blobs_registered,
+                    children_registered = repair_stats.children_registered,
                     candidates_skipped = repair_stats.candidates_skipped,
                     candidates_failed = repair_stats.candidates_failed,
-                    "OCI migration reindex left {} candidate(s) unregistered; \
-                     they stay unpullable until repaired (re-run migration or \
-                     restart after fixing storage)",
-                    repair_stats.candidates_failed
+                    hollow_tags_flagged = repair_stats.hollow_tags_flagged,
+                    orphan_tags_reconciled = repair_stats.orphan_tags_reconciled,
+                    "OCI migration reindex left {} candidate(s) unregistered and \
+                     flagged {} hollow tag(s); those images stay unpullable until \
+                     re-migrated (referenced blobs/child manifests were never \
+                     transferred). See the hollow-repositories WARN above.",
+                    repair_stats.candidates_failed,
+                    repair_stats.hollow_tags_flagged
                 );
             } else {
                 tracing::info!(
                     candidates_scanned = repair_stats.candidates_scanned,
                     manifests_registered = repair_stats.manifests_registered,
                     blobs_registered = repair_stats.blobs_registered,
+                    children_registered = repair_stats.children_registered,
                     candidates_skipped = repair_stats.candidates_skipped,
+                    orphan_tags_reconciled = repair_stats.orphan_tags_reconciled,
                     "OCI migration reindex complete"
                 );
             }

--- a/backend/src/models/migration.rs
+++ b/backend/src/models/migration.rs
@@ -47,6 +47,11 @@ pub enum MigrationJobStatus {
     Running,
     Paused,
     Completed,
+    /// Reached a terminal state, but at least one item failed to transfer while
+    /// others succeeded. Distinguishes a partial migration from a clean
+    /// `Completed` so a hollow/partial import is not surfaced as success
+    /// (#2457): the per-item counters and report carry the detail.
+    CompletedWithErrors,
     Failed,
     Cancelled,
 }
@@ -60,6 +65,7 @@ impl std::fmt::Display for MigrationJobStatus {
             MigrationJobStatus::Running => write!(f, "running"),
             MigrationJobStatus::Paused => write!(f, "paused"),
             MigrationJobStatus::Completed => write!(f, "completed"),
+            MigrationJobStatus::CompletedWithErrors => write!(f, "completed_with_errors"),
             MigrationJobStatus::Failed => write!(f, "failed"),
             MigrationJobStatus::Cancelled => write!(f, "cancelled"),
         }
@@ -77,6 +83,7 @@ impl std::str::FromStr for MigrationJobStatus {
             "running" => Ok(MigrationJobStatus::Running),
             "paused" => Ok(MigrationJobStatus::Paused),
             "completed" => Ok(MigrationJobStatus::Completed),
+            "completed_with_errors" => Ok(MigrationJobStatus::CompletedWithErrors),
             "failed" => Ok(MigrationJobStatus::Failed),
             "cancelled" => Ok(MigrationJobStatus::Cancelled),
             _ => Err(format!("Unknown migration job status: {}", s)),
@@ -365,6 +372,7 @@ mod tests {
             MigrationJobStatus::Running,
             MigrationJobStatus::Paused,
             MigrationJobStatus::Completed,
+            MigrationJobStatus::CompletedWithErrors,
             MigrationJobStatus::Failed,
             MigrationJobStatus::Cancelled,
         ];
@@ -373,6 +381,11 @@ mod tests {
             let parsed: MigrationJobStatus = s.parse().unwrap();
             assert_eq!(parsed, status);
         }
+        // The partial-failure status serializes to a distinct snake_case token.
+        assert_eq!(
+            MigrationJobStatus::CompletedWithErrors.to_string(),
+            "completed_with_errors"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -831,6 +831,7 @@ impl crate::services::source_registry::SourceRegistry for ArtifactoryClient {
         // child manifests as their own items, so the referenced-content walker
         // dedups them and never calls this — it exists for correctness if the
         // enumeration ever misses a referenced digest.
+        crate::services::source_registry::validate_oci_content_ref(image, digest)?;
         let api_repo = format!("api/docker/{}/v2", repo_key);
         let path = format!("{}/{}/{}", image, kind.path_segment(), digest);
         self.download_artifact_stream(&api_repo, &path).await

--- a/backend/src/services/artifactory_client.rs
+++ b/backend/src/services/artifactory_client.rs
@@ -816,6 +816,26 @@ impl crate::services::source_registry::SourceRegistry for ArtifactoryClient {
         self.download_artifact_stream(repo_key, path).await
     }
 
+    async fn download_oci_content_stream(
+        &self,
+        repo_key: &str,
+        image: &str,
+        digest: &str,
+        kind: crate::services::source_registry::OciContentKind,
+    ) -> Result<crate::services::source_registry::ArtifactByteStream, ArtifactoryError> {
+        // Artifactory exposes each Docker repository through its Docker
+        // Registry v2 REST API at `api/docker/<repo>/v2/<image>/{blobs|manifests}/<digest>`.
+        // `download_artifact_stream` joins `<base>/<repo>/<path>`, so pass the
+        // API prefix as the repo segment and the image-relative remainder as
+        // the path. In practice the migration enumerates Artifactory blobs and
+        // child manifests as their own items, so the referenced-content walker
+        // dedups them and never calls this — it exists for correctness if the
+        // enumeration ever misses a referenced digest.
+        let api_repo = format!("api/docker/{}/v2", repo_key);
+        let path = format!("{}/{}/{}", image, kind.path_segment(), digest);
+        self.download_artifact_stream(&api_repo, &path).await
+    }
+
     async fn get_properties(
         &self,
         repo_key: &str,

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -2108,16 +2108,21 @@ pub(crate) fn resolve_repos_for_provisioning(
 }
 
 /// Determine the final job status based on completed and failed counts.
-/// Returns Failed only when all items failed (failed > 0 and completed == 0),
-/// otherwise returns Completed.
+///
+/// - all items failed (failed > 0, completed == 0) → `Failed`
+/// - some failed, some succeeded (failed > 0, completed > 0) →
+///   `CompletedWithErrors`, so a partial/hollow migration is not surfaced as a
+///   clean success (#2457 — the OP saw "completed" over an unpullable import).
+///   The per-item counters/report carry which items failed.
+/// - nothing failed → `Completed`
 pub(crate) fn determine_final_status(
     total_failed: i32,
     total_completed: i32,
 ) -> MigrationJobStatus {
-    if total_failed > 0 && total_completed == 0 {
-        MigrationJobStatus::Failed
-    } else {
-        MigrationJobStatus::Completed
+    match (total_failed > 0, total_completed > 0) {
+        (true, false) => MigrationJobStatus::Failed,
+        (true, true) => MigrationJobStatus::CompletedWithErrors,
+        _ => MigrationJobStatus::Completed,
     }
 }
 
@@ -3472,8 +3477,10 @@ mod tests {
 
     #[test]
     fn test_determine_final_status_mixed() {
+        // Partial failure must surface as CompletedWithErrors, not a clean
+        // Completed (#2457): the OP's hollow import reported "completed".
         let status = determine_final_status(3, 7);
-        assert_eq!(status, MigrationJobStatus::Completed);
+        assert_eq!(status, MigrationJobStatus::CompletedWithErrors);
     }
 
     #[test]
@@ -3485,7 +3492,7 @@ mod tests {
     #[test]
     fn test_determine_final_status_one_failure_one_success() {
         let status = determine_final_status(1, 1);
-        assert_eq!(status, MigrationJobStatus::Completed);
+        assert_eq!(status, MigrationJobStatus::CompletedWithErrors);
     }
 
     #[test]
@@ -3506,7 +3513,7 @@ mod tests {
         );
         assert_eq!(
             determine_final_status(50_000, 50_000),
-            MigrationJobStatus::Completed
+            MigrationJobStatus::CompletedWithErrors
         );
     }
 

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -1247,6 +1247,16 @@ impl MigrationWorker {
                     .await?;
 
             if let Some((repository_id,)) = repo_id {
+                // #2457: bind the `artifacts` row, the OCI tag/ref registration,
+                // and every referenced blob/child-manifest registration into
+                // ONE transaction. A migrated Docker tag must never be committed
+                // without its backing content: if the referenced-content walk
+                // below fails to fetch a blob or child manifest, this whole
+                // transaction rolls back (no `oci_tags`, no partial `oci_blobs`)
+                // and the item is marked FAILED. For non-OCI formats the
+                // transaction just wraps the same INSERT + metadata upsert as
+                // before, a behaviour-preserving no-op.
+                let mut tx = self.db.begin().await?;
                 // Format-aware name + version. extract_name_from_path returns
                 // the filename, which is what Artifact Keeper stored prior to
                 // this fix — leaving `name` set to the full filename and
@@ -1292,11 +1302,28 @@ impl MigrationWorker {
                         "Rejected unsafe artifact path: {path_str}"
                     )));
                 }
+                // Resurrect a soft-deleted tombstone on conflict (#2457 F3).
+                // The full UNIQUE(repository_id, path) keeps a row for a
+                // deleted artifact with `is_deleted = true`
+                // (`artifact_service::delete`). A prior `DO NOTHING` left that
+                // tombstone deleted on re-import while the OCI tag was still
+                // (re)registered — an orphan tag with no live artifacts row.
+                // `DO UPDATE ... is_deleted = false` refreshes the row and
+                // clears the tombstone so the tag always has a live backing
+                // artifact, matching the live push path (artifact_service.rs).
                 sqlx::query(
                     r#"
                     INSERT INTO artifacts (repository_id, path, name, version, size_bytes, checksum_sha256, checksum_sha1, storage_key, content_type)
                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'application/octet-stream')
-                    ON CONFLICT (repository_id, path) WHERE is_deleted = false DO NOTHING
+                    ON CONFLICT (repository_id, path) DO UPDATE SET
+                        name = EXCLUDED.name,
+                        version = EXCLUDED.version,
+                        size_bytes = EXCLUDED.size_bytes,
+                        checksum_sha256 = EXCLUDED.checksum_sha256,
+                        checksum_sha1 = EXCLUDED.checksum_sha1,
+                        storage_key = EXCLUDED.storage_key,
+                        is_deleted = false,
+                        updated_at = NOW()
                     "#,
                 )
                 .bind(repository_id)
@@ -1307,7 +1334,7 @@ impl MigrationWorker {
                 .bind(&sha256_hex)
                 .bind(&sha1_hex)
                 .bind(&storage_key)
-                .execute(&self.db)
+                .execute(&mut *tx)
                 .await?;
 
                 // Upsert format-specific package metadata. Look up the
@@ -1323,7 +1350,7 @@ impl MigrationWorker {
                     )
                     .bind(repository_id)
                     .bind(&path_str)
-                    .fetch_optional(&self.db)
+                    .fetch_optional(&mut *tx)
                     .await?;
                     if let Some((artifact_id,)) = artifact_row {
                         sqlx::query(
@@ -1335,7 +1362,7 @@ impl MigrationWorker {
                         .bind(artifact_id)
                         .bind(package_type)
                         .bind(metadata_json)
-                        .execute(&self.db)
+                        .execute(&mut *tx)
                         .await?;
                     }
                 }
@@ -1361,7 +1388,7 @@ impl MigrationWorker {
                         .bind(digest)
                         .bind(content_size as i64)
                         .bind(&storage_key)
-                        .execute(&self.db)
+                        .execute(&mut *tx)
                         .await?;
                     }
                     OciRole::Manifest { image, reference } => {
@@ -1388,8 +1415,8 @@ impl MigrationWorker {
                                 None, body,
                             ),
                         );
-                        crate::api::handlers::oci_v2::persist_tag_and_refs(
-                            &self.db,
+                        crate::api::handlers::oci_v2::persist_tag_and_refs_in_tx(
+                            &mut tx,
                             repository_id,
                             image,
                             reference,
@@ -1404,9 +1431,49 @@ impl MigrationWorker {
                                 "Failed to register OCI manifest '{artifact_path}' in the index: {e}"
                             ))
                         })?;
+
+                        // #2457 ROOT FIX: a Docker/OCI source enumerates only
+                        // the tag manifests; the config/layer blobs and per-arch
+                        // child manifests they reference are addressed by digest
+                        // and never listed, so pre-fix a migrated image was
+                        // hollow (blobs + children 404, `docker pull` failed).
+                        // Fetch and register that referenced content by digest,
+                        // in THIS transaction, so the tag is committed only when
+                        // its content is complete. A fetch failure rolls the tag
+                        // back and fails the item (fail-closed). Content the
+                        // source enumerates as its own items (Artifactory blobs)
+                        // is deduped, so this is a no-op there.
+                        let walk = crate::services::oci_referenced_content::walk_and_register_referenced_content(
+                            &mut tx,
+                            &repo_storage,
+                            &client,
+                            &staging_dir,
+                            repository_id,
+                            repo_key,
+                            image,
+                            class,
+                            body,
+                            &crate::services::oci_referenced_content::WalkCaps::default(),
+                        )
+                        .await
+                        .map_err(|e| {
+                            MigrationError::Other(format!(
+                                "Failed to fetch/register content referenced by OCI manifest '{artifact_path}': {e}"
+                            ))
+                        })?;
+                        tracing::debug!(
+                            image = %image,
+                            reference = %reference,
+                            blobs_registered = walk.blobs_registered,
+                            children_registered = walk.children_registered,
+                            deduped = walk.deduped,
+                            "referenced-content walk complete"
+                        );
                     }
                     OciRole::NotOci => {}
                 }
+
+                tx.commit().await?;
             }
         }
 
@@ -5157,6 +5224,277 @@ mod tests {
             .execute(&pool)
             .await
             .expect("cleanup repo");
+    }
+
+    /// #2457 ROOT: a real Nexus enumerates ONLY the tag manifests. Importing
+    /// just the index tag (its child manifests + all config/layer blobs are
+    /// available by digest but NOT enumerated) must leave the image fully
+    /// pullable: the walker fetches the child manifest and every blob, so
+    /// `oci_blobs` is populated and the child resolves by digest. This is the
+    /// exact shape the oracle exercises — the child/blobs are NOT pre-seeded as
+    /// their own transfer items (that masking pre-seed hid the bug).
+    #[tokio::test]
+    async fn test_docker_import_walks_referenced_content_nexus_only_tags() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2457-walk", "docker").await;
+
+        let config_bytes = bytes::Bytes::from_static(b"{\"os\":\"linux\",\"arch\":\"amd64\"}");
+        let layer_bytes = bytes::Bytes::from_static(b"real-layer-bytes-2457-walk");
+        let config_hex = sha256_hex_of(&config_bytes);
+        let layer_hex = sha256_hex_of(&layer_bytes);
+        let child = format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\
+              \"config\":{{\"size\":{},\"digest\":\"sha256:{}\"}},\
+              \"layers\":[{{\"size\":{},\"digest\":\"sha256:{}\"}}]}}",
+            config_bytes.len(),
+            config_hex,
+            layer_bytes.len(),
+            layer_hex
+        );
+        let child_bytes = bytes::Bytes::from(child);
+        let child_hex = sha256_hex_of(&child_bytes);
+        let index = format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.oci.image.index.v1+json\",\
+              \"manifests\":[{{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\
+              \"size\":{},\"digest\":\"sha256:{}\",\
+              \"platform\":{{\"architecture\":\"amd64\",\"os\":\"linux\"}}}}]}}",
+            child_bytes.len(),
+            child_hex
+        );
+        let index_bytes = bytes::Bytes::from(index);
+        let index_digest = format!("sha256:{}", sha256_hex_of(&index_bytes));
+
+        // Source contents: the index tag (enumerated) PLUS the by-digest
+        // content the walker fetches (child manifest, config, layer). Only the
+        // index tag is transferred as an item.
+        let index_path = "v2/app/manifests/latest".to_string();
+        let mut files = std::collections::HashMap::new();
+        files.insert(index_path.clone(), index_bytes.clone());
+        files.insert(
+            format!("v2/app/manifests/sha256:{child_hex}"),
+            child_bytes.clone(),
+        );
+        files.insert(
+            format!("v2/app/blobs/sha256:{config_hex}"),
+            config_bytes.clone(),
+        );
+        files.insert(
+            format!("v2/app/blobs/sha256:{layer_hex}"),
+            layer_bytes.clone(),
+        );
+
+        transfer_one(&worker, &storage, &files, &repo_key, "docker", &index_path)
+            .await
+            .expect("index import must succeed and walk referenced content");
+
+        // Index tag registered.
+        let tag: Option<(String,)> = sqlx::query_as(
+            "SELECT manifest_digest FROM oci_tags WHERE repository_id = $1 AND name='app' AND tag='latest'",
+        )
+        .bind(repo_id)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert_eq!(tag.expect("index tag").0, index_digest);
+
+        // Child manifest resolved by digest + bytes present.
+        let child_row: Option<(String,)> = sqlx::query_as(
+            "SELECT manifest_digest FROM oci_tags WHERE repository_id=$1 AND manifest_digest=$2 LIMIT 1",
+        )
+        .bind(repo_id)
+        .bind(format!("sha256:{child_hex}"))
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert!(
+            child_row.is_some(),
+            "child must resolve by digest after walk"
+        );
+        assert!(storage
+            .exists(&format!("oci-manifests/sha256:{child_hex}"))
+            .await
+            .unwrap());
+
+        // Both blobs registered with real bytes (the pre-fix hollow bug had
+        // oci_blobs == 0 here).
+        let blob_ct: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM oci_blobs WHERE repository_id = $1")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(blob_ct.0, 2, "config + layer registered by the walker");
+        for hex in [&config_hex, &layer_hex] {
+            let blob: Option<(String,)> = sqlx::query_as(
+                "SELECT storage_key FROM oci_blobs WHERE repository_id=$1 AND digest=$2",
+            )
+            .bind(repo_id)
+            .bind(format!("sha256:{hex}"))
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            let (key,) = blob.expect("blob registered by walker");
+            assert!(storage.exists(&key).await.unwrap(), "blob bytes at {key}");
+        }
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// Fail-closed: a source that 404s a referenced layer must FAIL the item
+    /// and commit NOTHING — no oci_tags, no partial oci_blobs, no artifacts row
+    /// for the manifest. The whole item transaction rolls back.
+    #[tokio::test]
+    async fn test_docker_import_fails_closed_on_unfetchable_layer() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2457-fc", "docker").await;
+
+        let config_bytes = bytes::Bytes::from_static(b"{\"os\":\"linux\"}");
+        let layer_bytes = bytes::Bytes::from_static(b"layer-that-source-will-404");
+        let config_hex = sha256_hex_of(&config_bytes);
+        let layer_hex = sha256_hex_of(&layer_bytes);
+        let manifest = format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\
+              \"config\":{{\"size\":{},\"digest\":\"sha256:{}\"}},\
+              \"layers\":[{{\"size\":{},\"digest\":\"sha256:{}\"}}]}}",
+            config_bytes.len(),
+            config_hex,
+            layer_bytes.len(),
+            layer_hex
+        );
+        let manifest_bytes = bytes::Bytes::from(manifest);
+
+        // Enumerate the image tag; provide config but NOT the layer -> the
+        // walker's layer fetch 404s.
+        let tag_path = "v2/app/manifests/latest".to_string();
+        let mut files = std::collections::HashMap::new();
+        files.insert(tag_path.clone(), manifest_bytes.clone());
+        files.insert(
+            format!("v2/app/blobs/sha256:{config_hex}"),
+            config_bytes.clone(),
+        );
+        // layer digest intentionally absent.
+
+        let res = transfer_one(&worker, &storage, &files, &repo_key, "docker", &tag_path).await;
+        assert!(res.is_err(), "unfetchable layer must fail the item");
+
+        // Nothing committed: no tag, no blobs, no manifest artifacts row.
+        let counts: (i64, i64, i64) = sqlx::query_as(
+            "SELECT (SELECT COUNT(*) FROM oci_tags WHERE repository_id=$1), \
+                    (SELECT COUNT(*) FROM oci_blobs WHERE repository_id=$1), \
+                    (SELECT COUNT(*) FROM artifacts WHERE repository_id=$1 AND is_deleted=false)",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            counts,
+            (0, 0, 0),
+            "fail-closed: the item transaction must roll back entirely"
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// F3: deleting a migrated tag then re-migrating must leave exactly one
+    /// LIVE artifacts row (the tombstone resurrected) and zero orphan oci_tags.
+    #[tokio::test]
+    async fn test_docker_reimport_resurrects_soft_deleted_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2457-f3", "docker").await;
+
+        let config_bytes = bytes::Bytes::from_static(b"{\"os\":\"linux\"}");
+        let config_hex = sha256_hex_of(&config_bytes);
+        let manifest = format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\
+              \"config\":{{\"size\":{},\"digest\":\"sha256:{}\"}},\"layers\":[]}}",
+            config_bytes.len(),
+            config_hex
+        );
+        let manifest_bytes = bytes::Bytes::from(manifest);
+        let tag_path = "v2/app/manifests/latest".to_string();
+        let mut files = std::collections::HashMap::new();
+        files.insert(tag_path.clone(), manifest_bytes.clone());
+        files.insert(
+            format!("v2/app/blobs/sha256:{config_hex}"),
+            config_bytes.clone(),
+        );
+
+        transfer_one(&worker, &storage, &files, &repo_key, "docker", &tag_path)
+            .await
+            .expect("first import");
+
+        // Soft-delete the migrated manifest artifacts row (tombstone).
+        sqlx::query(
+            "UPDATE artifacts SET is_deleted = true WHERE repository_id = $1 AND path LIKE '%manifests/latest'",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Re-migrate (overwrite): the tombstone must be resurrected, not
+        // left dead beneath a re-registered tag.
+        transfer_one(&worker, &storage, &files, &repo_key, "docker", &tag_path)
+            .await
+            .expect("re-import");
+
+        let live_manifest_rows: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM artifacts WHERE repository_id=$1 AND path LIKE '%manifests/latest' AND is_deleted=false",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            live_manifest_rows.0, 1,
+            "exactly one live manifest artifact"
+        );
+
+        // No orphan oci_tags: every tag has a backing live artifacts row.
+        let orphan: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oci_tags ot WHERE ot.repository_id=$1 \
+             AND NOT EXISTS (SELECT 1 FROM artifacts a WHERE a.repository_id=ot.repository_id \
+                             AND 'sha256:'||a.checksum_sha256 = ot.manifest_digest AND a.is_deleted=false)",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            orphan.0, 0,
+            "no orphan oci_tags after resurrecting re-import"
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
     }
 
     /// A malformed manifest body (valid path shape, degenerate content) must

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -35,6 +35,7 @@ pub mod nexus_client;
 pub mod npm_packument_cache;
 pub mod oci_manifest_refs_backfill;
 pub mod oci_migration_reindex;
+pub mod oci_referenced_content;
 pub mod oidc_service;
 pub mod openscap_scanner;
 pub mod opensearch_service;

--- a/backend/src/services/oci_migration_reindex.rs
+++ b/backend/src/services/oci_migration_reindex.rs
@@ -43,6 +43,9 @@ pub struct RepairStats {
     pub manifests_registered: usize,
     /// Blob rows inserted (or resurrected) into `oci_blobs`.
     pub blobs_registered: usize,
+    /// Child (per-arch) manifests of an image index registered from present
+    /// artifacts rows (#2457 F2 index recursion).
+    pub children_registered: usize,
     /// Candidates whose path did not classify as a manifest after prefix
     /// stripping. Left untouched; not an error.
     pub candidates_skipped: usize,
@@ -50,6 +53,15 @@ pub struct RepairStats {
     /// digest mismatch, malformed JSON, DB write failure). Logged at WARN;
     /// retried on the next restart.
     pub candidates_failed: usize,
+    /// Registered tags found to be HOLLOW — an image whose referenced blobs
+    /// are missing, or an index whose children are unresolvable. AK cannot
+    /// fabricate never-transferred bytes; these repos need re-migration and
+    /// are surfaced in the startup WARN (#2457 F2 startup repair).
+    pub hollow_tags_flagged: usize,
+    /// Orphan `oci_tags` rows (migrated manifest whose backing artifact was
+    /// soft-deleted, leaving a tag with no live artifacts row) dropped so
+    /// they 404 cleanly instead of resolving to a phantom manifest.
+    pub orphan_tags_reconciled: usize,
 }
 
 /// Run the one-shot repair. Never errors at the function boundary — all
@@ -83,9 +95,10 @@ pub async fn run_repair(db: &PgPool, registry: Arc<StorageRegistry>) -> RepairSt
 
     for candidate in candidates {
         match process_candidate(db, &registry, &candidate).await {
-            Ok(Some(blobs)) => {
+            Ok(Some(counts)) => {
                 stats.manifests_registered += 1;
-                stats.blobs_registered += blobs;
+                stats.blobs_registered += counts.blobs;
+                stats.children_registered += counts.children;
             }
             Ok(None) => stats.candidates_skipped += 1,
             Err(e) => {
@@ -100,15 +113,152 @@ pub async fn run_repair(db: &PgPool, registry: Arc<StorageRegistry>) -> RepairSt
         }
     }
 
+    // #2457 F2 startup repair: reconcile the hollow/orphan state left by
+    // v1.5.7 migrations (tags registered, referenced content never fetched).
+    // Conservative — a healthy DB is untouched: only tags whose backing
+    // artifact was soft-deleted are dropped, and hollow tags are merely
+    // flagged (AK cannot fabricate never-transferred bytes) so operators know
+    // which repos to re-migrate.
+    match reconcile_hollow_and_orphan_tags(db).await {
+        Ok(recon) => {
+            stats.hollow_tags_flagged = recon.hollow_tags_flagged;
+            stats.orphan_tags_reconciled = recon.orphan_tags_reconciled;
+            if !recon.hollow_repos.is_empty() {
+                tracing::warn!(
+                    hollow_tags = recon.hollow_tags_flagged,
+                    repositories = ?recon.hollow_repos,
+                    "OCI migration reindex: hollow Docker/OCI tags detected \
+                     (referenced blobs/child manifests were never transferred); \
+                     re-run the migration for these repositories to make the \
+                     images pullable"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "OCI migration reindex: hollow/orphan reconciliation skipped");
+        }
+    }
+
     tracing::info!(
         candidates_scanned = stats.candidates_scanned,
         manifests_registered = stats.manifests_registered,
         blobs_registered = stats.blobs_registered,
+        children_registered = stats.children_registered,
         candidates_skipped = stats.candidates_skipped,
         candidates_failed = stats.candidates_failed,
+        hollow_tags_flagged = stats.hollow_tags_flagged,
+        orphan_tags_reconciled = stats.orphan_tags_reconciled,
         "OCI migration reindex: complete"
     );
     stats
+}
+
+/// Outcome of the conservative hollow/orphan reconciliation pass.
+#[derive(Debug, Default)]
+struct ReconcileOutcome {
+    hollow_tags_flagged: usize,
+    orphan_tags_reconciled: usize,
+    hollow_repos: Vec<String>,
+}
+
+/// Reconcile the two data-fidelity defects a v1.5.7 Docker migration leaves.
+///
+/// 1. ORPHAN tags (#2457 F3, historical): a migrated manifest whose backing
+///    `artifacts` row was later soft-deleted leaves an `oci_tags` row with no
+///    live artifact. It is dropped so the tag 404s cleanly. The criterion is
+///    deliberately narrow — the tag must match a *tombstoned* (`is_deleted =
+///    true`) artifacts row and NOT any live one — so a natively `docker push`ed
+///    tag (which has no `artifacts` row at all) is never touched, and neither
+///    is a healthy migrated tag.
+///
+/// 2. HOLLOW tags (#2457 F1, historical): a tag that IS backed by a live
+///    artifact but whose referenced content is incomplete — an image with a
+///    `manifest_blob_refs` edge to a digest that has no `oci_blobs` row, or an
+///    index with an `oci_manifest_refs` child that resolves to neither a tag
+///    nor a blob. These cannot be fixed here (the bytes were never
+///    transferred); they are counted and their repositories returned for a
+///    WARN so operators re-migrate.
+async fn reconcile_hollow_and_orphan_tags(db: &PgPool) -> sqlx::Result<ReconcileOutcome> {
+    let mut outcome = ReconcileOutcome::default();
+
+    // --- 1. Drop orphan tags (tombstoned backing artifact only). ---
+    let dropped = sqlx::query(
+        r#"
+        DELETE FROM oci_tags ot
+        USING repositories r
+        WHERE ot.repository_id = r.id
+          AND lower(r.format::text) IN ('docker', 'oci')
+          AND EXISTS (
+                SELECT 1 FROM artifacts a
+                WHERE a.repository_id = ot.repository_id
+                  AND 'sha256:' || a.checksum_sha256 = ot.manifest_digest
+                  AND a.is_deleted = true
+          )
+          AND NOT EXISTS (
+                SELECT 1 FROM artifacts a
+                WHERE a.repository_id = ot.repository_id
+                  AND 'sha256:' || a.checksum_sha256 = ot.manifest_digest
+                  AND a.is_deleted = false
+          )
+        "#,
+    )
+    .execute(db)
+    .await?;
+    outcome.orphan_tags_reconciled = dropped.rows_affected() as usize;
+
+    // --- 2. Flag hollow tags (referenced content incomplete). ---
+    let rows = sqlx::query(
+        r#"
+        SELECT DISTINCT r.key AS repo_key, ot.repository_id AS repository_id
+        FROM oci_tags ot
+        JOIN repositories r ON r.id = ot.repository_id
+        WHERE lower(r.format::text) IN ('docker', 'oci')
+          AND (
+            -- image manifest: a referenced blob has no oci_blobs row
+            EXISTS (
+                SELECT 1 FROM manifest_blob_refs br
+                WHERE br.repository_id = ot.repository_id
+                  AND br.manifest_digest = ot.manifest_digest
+                  AND NOT EXISTS (
+                        SELECT 1 FROM oci_blobs ob
+                        WHERE ob.repository_id = br.repository_id
+                          AND ob.digest = br.blob_digest
+                  )
+            )
+            -- image index: a child manifest resolves to neither a tag nor a blob
+            OR EXISTS (
+                SELECT 1 FROM oci_manifest_refs mr
+                WHERE mr.repository_id = ot.repository_id
+                  AND mr.parent_digest = ot.manifest_digest
+                  AND NOT EXISTS (
+                        SELECT 1 FROM oci_tags c
+                        WHERE c.repository_id = mr.repository_id
+                          AND c.manifest_digest = mr.child_digest
+                  )
+            )
+          )
+        "#,
+    )
+    .fetch_all(db)
+    .await?;
+
+    let mut repos: Vec<String> = Vec::new();
+    for row in &rows {
+        let key: String = row.try_get("repo_key").unwrap_or_default();
+        if !repos.contains(&key) {
+            repos.push(key);
+        }
+    }
+    outcome.hollow_tags_flagged = rows.len();
+    outcome.hollow_repos = repos;
+    Ok(outcome)
+}
+
+/// Blob + child-manifest registration counts from processing one candidate.
+#[derive(Debug, Default, Clone, Copy)]
+struct CandidateCounts {
+    blobs: usize,
+    children: usize,
 }
 
 #[derive(Debug)]
@@ -189,7 +339,7 @@ async fn process_candidate(
     db: &PgPool,
     registry: &StorageRegistry,
     candidate: &RepairCandidate,
-) -> Result<Option<usize>, String> {
+) -> Result<Option<CandidateCounts>, String> {
     let source_path = strip_repo_prefix(&candidate.path, &candidate.repo_key);
     let (image, reference) = match classify_oci_source_artifact(source_path) {
         OciRole::Manifest { image, reference } => (image, reference),
@@ -253,54 +403,10 @@ async fn process_candidate(
             .map_err(|e| format!("write manifest to {}: {}", manifest_key, e))?;
     }
 
-    // Register the blobs an image manifest references, reusing each blob's
-    // existing CAS storage_key (blob-serve honors arbitrary keys). A blob
-    // whose artifacts row is missing is logged but does not fail the
-    // manifest registration — the tag resolving is strictly better than
-    // MANIFEST_UNKNOWN, and the gap is visible in the logs.
-    let mut blobs_registered = 0usize;
-    for blob_ref in crate::api::handlers::oci_v2::extract_blob_refs(&body) {
-        let Some(hex) = blob_ref.digest.strip_prefix("sha256:") else {
-            continue;
-        };
-        let blob_row: Option<(String, i64)> = sqlx::query_as(
-            "SELECT storage_key, size_bytes FROM artifacts \
-             WHERE repository_id = $1 AND checksum_sha256 = $2 AND is_deleted = false \
-             LIMIT 1",
-        )
-        .bind(candidate.repository_id)
-        .bind(hex)
-        .fetch_optional(db)
-        .await
-        .map_err(|e| format!("look up blob artifact row: {}", e))?;
-
-        match blob_row {
-            Some((blob_storage_key, blob_size)) => {
-                sqlx::query(
-                    "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) \
-                     VALUES ($1, $2, $3, $4) \
-                     ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
-                )
-                .bind(candidate.repository_id)
-                .bind(&blob_ref.digest)
-                .bind(blob_size)
-                .bind(&blob_storage_key)
-                .execute(db)
-                .await
-                .map_err(|e| format!("insert oci_blobs row: {}", e))?;
-                blobs_registered += 1;
-            }
-            None => {
-                tracing::warn!(
-                    repository_id = %candidate.repository_id,
-                    manifest_path = %candidate.path,
-                    blob_digest = %blob_ref.digest,
-                    "OCI migration reindex: referenced blob has no artifacts row; \
-                     layer will 404 until re-migrated"
-                );
-            }
-        }
-    }
+    // Register the blobs an image manifest references from present artifacts
+    // rows (an index has none — `extract_blob_refs` returns empty for it).
+    let blobs_registered =
+        register_present_blobs(db, candidate.repository_id, &candidate.path, &body).await?;
 
     // Media type from the BODY's own `mediaType` (no client header exists
     // here); a Docker schema2 body stored under the OCI media type makes
@@ -322,7 +428,197 @@ async fn process_candidate(
     .await
     .map_err(|e| format!("persist tag and refs: {}", e))?;
 
-    Ok(Some(blobs_registered))
+    // #2457 F2 index recursion: for an image INDEX, register each child
+    // manifest from its own (present) artifacts row so multi-arch images pull.
+    // Children whose bytes were never migrated are logged and left for a
+    // re-migration — the parent tag resolving is strictly better than nothing.
+    let mut children_registered = 0usize;
+    if matches!(class, crate::api::handlers::oci_v2::ManifestClass::Index) {
+        for child_digest in crate::api::handlers::oci_v2::extract_child_digests(&body) {
+            match register_child_manifest_from_artifacts(
+                db,
+                registry,
+                candidate,
+                &image,
+                &child_digest,
+            )
+            .await?
+            {
+                Some(child_blobs) => {
+                    children_registered += 1;
+                    // child blobs count toward the same blob tally.
+                    // (kept separate from `blobs_registered` for clarity)
+                    let _ = child_blobs;
+                }
+                None => {
+                    tracing::warn!(
+                        repository_id = %candidate.repository_id,
+                        manifest_path = %candidate.path,
+                        child_digest = %child_digest,
+                        "OCI migration reindex: index child manifest has no artifacts \
+                         row; child will 404 until re-migrated"
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(Some(CandidateCounts {
+        blobs: blobs_registered,
+        children: children_registered,
+    }))
+}
+
+/// Register the config/layer blobs an image manifest references, reusing each
+/// blob's existing CAS `storage_key` from its `artifacts` row (blob-serve
+/// honors arbitrary keys). A referenced blob whose artifacts row is absent is
+/// logged and skipped — the tag resolving beats MANIFEST_UNKNOWN and the gap
+/// is visible in the logs. Returns the number of blob rows written.
+async fn register_present_blobs(
+    db: &PgPool,
+    repository_id: Uuid,
+    manifest_path: &str,
+    body: &[u8],
+) -> Result<usize, String> {
+    let mut registered = 0usize;
+    for blob_ref in crate::api::handlers::oci_v2::extract_blob_refs(body) {
+        let Some(hex) = blob_ref.digest.strip_prefix("sha256:") else {
+            continue;
+        };
+        let blob_row: Option<(String, i64)> = sqlx::query_as(
+            "SELECT storage_key, size_bytes FROM artifacts \
+             WHERE repository_id = $1 AND checksum_sha256 = $2 AND is_deleted = false \
+             LIMIT 1",
+        )
+        .bind(repository_id)
+        .bind(hex)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| format!("look up blob artifact row: {}", e))?;
+
+        match blob_row {
+            Some((blob_storage_key, blob_size)) => {
+                sqlx::query(
+                    "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) \
+                     VALUES ($1, $2, $3, $4) \
+                     ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
+                )
+                .bind(repository_id)
+                .bind(&blob_ref.digest)
+                .bind(blob_size)
+                .bind(&blob_storage_key)
+                .execute(db)
+                .await
+                .map_err(|e| format!("insert oci_blobs row: {}", e))?;
+                registered += 1;
+            }
+            None => {
+                tracing::warn!(
+                    repository_id = %repository_id,
+                    manifest_path = %manifest_path,
+                    blob_digest = %blob_ref.digest,
+                    "OCI migration reindex: referenced blob has no artifacts row; \
+                     layer will 404 until re-migrated"
+                );
+            }
+        }
+    }
+    Ok(registered)
+}
+
+/// Register one child (per-arch) manifest of an image index from its present
+/// `artifacts` row: copy its bytes to the digest-addressed manifest key,
+/// register it via `persist_tag_and_refs` (reference == digest, exactly as the
+/// live push path records a manifest pushed by digest), and register the
+/// child's own config/layer blobs. Returns `Ok(None)` when the child manifest
+/// has no present artifacts row (never transferred), `Ok(Some(child_blobs))`
+/// otherwise.
+async fn register_child_manifest_from_artifacts(
+    db: &PgPool,
+    registry: &StorageRegistry,
+    candidate: &RepairCandidate,
+    image: &str,
+    child_digest: &str,
+) -> Result<Option<usize>, String> {
+    let Some(hex) = child_digest.strip_prefix("sha256:") else {
+        return Ok(None);
+    };
+    let child_row: Option<(String, i64)> = sqlx::query_as(
+        "SELECT storage_key, size_bytes FROM artifacts \
+         WHERE repository_id = $1 AND checksum_sha256 = $2 AND is_deleted = false \
+         LIMIT 1",
+    )
+    .bind(candidate.repository_id)
+    .bind(hex)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| format!("look up child manifest artifact row: {}", e))?;
+    let Some((child_storage_key, child_size)) = child_row else {
+        return Ok(None);
+    };
+    if child_size > MAX_INDEX_MANIFEST_BYTES as i64 {
+        return Err(format!(
+            "child manifest {} exceeds {} bytes",
+            child_digest, MAX_INDEX_MANIFEST_BYTES
+        ));
+    }
+
+    let location = StorageLocation {
+        backend: candidate.storage_backend.clone(),
+        path: candidate.storage_path.clone(),
+    };
+    let storage = registry
+        .backend_for(&location)
+        .map_err(|e| format!("resolve storage backend: {}", e))?;
+    let body = storage
+        .get(&child_storage_key)
+        .await
+        .map_err(|e| format!("read child manifest bytes: {}", e))?;
+
+    let computed = crate::api::handlers::oci_v2::compute_sha256(&body);
+    if computed != child_digest {
+        return Err(format!(
+            "child manifest content digest {} != index-referenced {}",
+            computed, child_digest
+        ));
+    }
+    let class = crate::api::handlers::oci_v2::classify_manifest(&body);
+    if matches!(
+        class,
+        crate::api::handlers::oci_v2::ManifestClass::Malformed
+    ) {
+        return Err(format!("child manifest {} is malformed", child_digest));
+    }
+
+    let manifest_key = crate::api::handlers::oci_v2::manifest_storage_key(child_digest);
+    if !storage.exists(&manifest_key).await.unwrap_or(false) {
+        storage
+            .put(&manifest_key, body.clone())
+            .await
+            .map_err(|e| format!("write child manifest to {}: {}", manifest_key, e))?;
+    }
+
+    let child_blobs =
+        register_present_blobs(db, candidate.repository_id, &candidate.path, &body).await?;
+
+    let content_type = crate::api::handlers::oci_v2::stored_media_type_for(
+        &class,
+        &crate::api::handlers::oci_v2::resolve_manifest_content_type(None, &body),
+    );
+    crate::api::handlers::oci_v2::persist_tag_and_refs(
+        db,
+        candidate.repository_id,
+        image,
+        child_digest,
+        child_digest,
+        &content_type,
+        &class,
+        &body,
+    )
+    .await
+    .map_err(|e| format!("persist child tag and refs: {}", e))?;
+
+    Ok(Some(child_blobs))
 }
 
 #[cfg(test)]
@@ -335,6 +631,9 @@ mod tests {
         assert_eq!(s.candidates_scanned, 0);
         assert_eq!(s.manifests_registered, 0);
         assert_eq!(s.blobs_registered, 0);
+        assert_eq!(s.children_registered, 0);
+        assert_eq!(s.hollow_tags_flagged, 0);
+        assert_eq!(s.orphan_tags_reconciled, 0);
         assert_eq!(s.candidates_skipped, 0);
         assert_eq!(s.candidates_failed, 0);
     }
@@ -548,6 +847,227 @@ mod tests {
             tags_after_first, tags_after_second,
             "re-run must not change this repo's registrations"
         );
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup repo");
+    }
+
+    /// #2457 F2: an image INDEX imported by an older run (index + child
+    /// manifest + child blobs all present as `artifacts` rows, no OCI index
+    /// rows) must repair to a pullable multi-arch image — the child manifest
+    /// resolves by digest and its config blob is registered.
+    #[tokio::test]
+    async fn test_run_repair_registers_image_index_and_children() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::artifact_service::ArtifactService;
+        use crate::storage::StorageBackend;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo_id = Uuid::new_v4();
+        let repo_key = format!("reidxidx-{}", &repo_id.to_string()[..8]);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local', 'docker'::repository_format, true)",
+        )
+        .bind(repo_id)
+        .bind(&repo_key)
+        .bind(tmp.path().to_str().unwrap())
+        .execute(&pool)
+        .await
+        .expect("insert docker repo");
+
+        let storage =
+            crate::storage::filesystem::FilesystemStorage::new(tmp.path().to_str().unwrap());
+
+        let cfg = bytes::Bytes::from_static(b"{\"arch\":\"amd64\"}");
+        let cfg_hex = sha256_hex_of(&cfg);
+        let child = format!(
+            "{{\"schemaVersion\":2,\"config\":{{\"size\":{},\"digest\":\"sha256:{}\"}},\"layers\":[]}}",
+            cfg.len(),
+            cfg_hex
+        );
+        let child_bytes = bytes::Bytes::from(child);
+        let child_hex = sha256_hex_of(&child_bytes);
+        let index = format!(
+            "{{\"schemaVersion\":2,\"mediaType\":\"application/vnd.oci.image.index.v1+json\",\
+              \"manifests\":[{{\"size\":{},\"digest\":\"sha256:{}\",\
+              \"platform\":{{\"architecture\":\"amd64\",\"os\":\"linux\"}}}}]}}",
+            child_bytes.len(),
+            child_hex
+        );
+        let index_bytes = bytes::Bytes::from(index);
+        let index_hex = sha256_hex_of(&index_bytes);
+
+        // Seed pre-fix state: config blob, child manifest (digest folder), and
+        // the index tag — all CAS bytes + artifacts rows, no OCI rows.
+        for (bytes, hex, rel_path) in [
+            (&cfg, &cfg_hex, format!("app/latest/sha256__{cfg_hex}")),
+            (
+                &child_bytes,
+                &child_hex,
+                format!("app/sha256__{child_hex}/manifest.json"),
+            ),
+            (
+                &index_bytes,
+                &index_hex,
+                "app/latest/list.manifest.json".to_string(),
+            ),
+        ] {
+            let cas_key = ArtifactService::storage_key_from_checksum(hex);
+            storage
+                .put(&cas_key, bytes.clone())
+                .await
+                .expect("seed CAS");
+            insert_prefix_artifact(
+                &pool,
+                repo_id,
+                &format!("{repo_key}/{rel_path}"),
+                hex,
+                &cas_key,
+                bytes.len() as i64,
+            )
+            .await;
+        }
+
+        let registry = Arc::new(StorageRegistry::new(
+            std::collections::HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        let _ = run_repair(&pool, registry).await;
+
+        // Parent index tag registered.
+        let parent: Option<(String,)> = sqlx::query_as(
+            "SELECT manifest_digest FROM oci_tags WHERE repository_id=$1 AND name='app' AND tag='latest'",
+        )
+        .bind(repo_id)
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert_eq!(parent.expect("index tag").0, format!("sha256:{index_hex}"));
+
+        // Child manifest resolves by digest + config blob registered.
+        let child_tag: Option<(String,)> = sqlx::query_as(
+            "SELECT manifest_digest FROM oci_tags WHERE repository_id=$1 AND manifest_digest=$2 LIMIT 1",
+        )
+        .bind(repo_id)
+        .bind(format!("sha256:{child_hex}"))
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert!(child_tag.is_some(), "index child must resolve by digest");
+        let child_blob: Option<(String,)> = sqlx::query_as(
+            "SELECT storage_key FROM oci_blobs WHERE repository_id=$1 AND digest=$2",
+        )
+        .bind(repo_id)
+        .bind(format!("sha256:{cfg_hex}"))
+        .fetch_optional(&pool)
+        .await
+        .unwrap();
+        assert!(child_blob.is_some(), "child config blob must be registered");
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup repo");
+    }
+
+    /// #2457 F3 startup reconciliation: an orphan `oci_tags` row (migrated
+    /// manifest whose backing artifact was soft-deleted) is DROPPED, while a
+    /// healthy migrated tag in the same repo is left untouched.
+    #[tokio::test]
+    async fn test_run_repair_drops_orphan_tag_keeps_healthy() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let repo_id = Uuid::new_v4();
+        let repo_key = format!("reidxorph-{}", &repo_id.to_string()[..8]);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local', 'docker'::repository_format, true)",
+        )
+        .bind(repo_id)
+        .bind(&repo_key)
+        .bind(tmp.path().to_str().unwrap())
+        .execute(&pool)
+        .await
+        .expect("insert repo");
+
+        // Healthy migrated tag: live artifacts row + oci_tags.
+        let healthy_hex = "a".repeat(64);
+        insert_prefix_artifact(
+            &pool,
+            repo_id,
+            &format!("{repo_key}/keep/latest/manifest.json"),
+            &healthy_hex,
+            "oci-manifests/sha256:keep",
+            10,
+        )
+        .await;
+        // Orphan tag: tombstoned artifacts row (is_deleted=true) + oci_tags.
+        let orphan_hex = "b".repeat(64);
+        insert_prefix_artifact(
+            &pool,
+            repo_id,
+            &format!("{repo_key}/gone/latest/manifest.json"),
+            &orphan_hex,
+            "oci-manifests/sha256:gone",
+            10,
+        )
+        .await;
+        sqlx::query(
+            "UPDATE artifacts SET is_deleted=true WHERE repository_id=$1 AND checksum_sha256=$2",
+        )
+        .bind(repo_id)
+        .bind(&orphan_hex)
+        .execute(&pool)
+        .await
+        .unwrap();
+        for (name, hex) in [("keep", &healthy_hex), ("gone", &orphan_hex)] {
+            sqlx::query(
+                "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type) \
+                 VALUES ($1, $2, 'latest', $3, 'application/vnd.oci.image.manifest.v1+json')",
+            )
+            .bind(repo_id)
+            .bind(name)
+            .bind(format!("sha256:{hex}"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let registry = Arc::new(StorageRegistry::new(
+            std::collections::HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        let stats = run_repair(&pool, registry).await;
+        assert!(
+            stats.orphan_tags_reconciled >= 1,
+            "orphan tag must be reconciled, stats: {stats:?}"
+        );
+
+        let keep: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM oci_tags WHERE repository_id=$1 AND name='keep'")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(keep.0, 1, "healthy migrated tag must be kept");
+        let gone: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM oci_tags WHERE repository_id=$1 AND name='gone'")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(gone.0, 0, "orphan tag must be dropped");
 
         sqlx::query("DELETE FROM repositories WHERE id = $1")
             .bind(repo_id)

--- a/backend/src/services/oci_referenced_content.rs
+++ b/backend/src/services/oci_referenced_content.rs
@@ -378,6 +378,8 @@ async fn fetch_verify_store_blob(
     image: &str,
     digest: &str,
 ) -> Result<(String, i64), MigrationError> {
+    // Blobs are not size-capped here (config/layer sizes are legitimate and
+    // large); count caps + fail-closed transfer bound the walk.
     let (temp, computed, size) = stream_to_temp(
         client,
         staging_dir,
@@ -385,6 +387,7 @@ async fn fetch_verify_store_blob(
         image,
         digest,
         OciContentKind::Blob,
+        None,
     )
     .await?;
     if computed != digest {
@@ -410,21 +413,19 @@ async fn fetch_verify_store_manifest(
     image: &str,
     digest: &str,
 ) -> Result<bytes::Bytes, MigrationError> {
-    let (temp, computed, size) = stream_to_temp(
+    // The manifest cap is enforced MID-STREAM inside `stream_to_temp` (a
+    // hostile source must not spill a multi-GB body to disk behind a manifest
+    // URL), so anything returned here is already within the cap.
+    let (temp, computed, _size) = stream_to_temp(
         client,
         staging_dir,
         repo_key,
         image,
         digest,
         OciContentKind::Manifest,
+        Some(MAX_INDEX_MANIFEST_BYTES),
     )
     .await?;
-    if size as usize > MAX_INDEX_MANIFEST_BYTES {
-        return Err(MigrationError::Other(format!(
-            "referenced child manifest '{digest}' of image '{image}' exceeds the {} byte manifest cap (got {size} bytes)",
-            MAX_INDEX_MANIFEST_BYTES
-        )));
-    }
     if computed != digest {
         return Err(MigrationError::ChecksumMismatch {
             path: format!("{image}/manifests/{digest}"),
@@ -456,6 +457,7 @@ async fn stream_to_temp(
     image: &str,
     digest: &str,
     kind: OciContentKind,
+    max_bytes: Option<usize>,
 ) -> Result<(tempfile::NamedTempFile, String, i64), MigrationError> {
     use futures::StreamExt;
     use tokio::io::AsyncWriteExt;
@@ -482,8 +484,21 @@ async fn stream_to_temp(
     let mut size: i64 = 0;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.map_err(MigrationError::from)?;
+        // Enforce the size cap MID-STREAM (manifest fetches): reject before the
+        // overflowing chunk is written, so a hostile source cannot spill a
+        // multi-GB body to the staging temp file behind a manifest URL before
+        // rejection. Blob fetches pass `None` and stay uncapped here.
+        let next_size = size + chunk.len() as i64;
+        if let Some(cap) = max_bytes {
+            if next_size as usize > cap {
+                return Err(MigrationError::Other(format!(
+                    "OCI manifest '{image}/{}/{digest}' exceeds the {cap} byte cap mid-stream; aborting fetch",
+                    kind.path_segment()
+                )));
+            }
+        }
         hasher.update(&chunk);
-        size += chunk.len() as i64;
+        size = next_size;
         writer
             .write_all(&chunk)
             .await
@@ -1028,6 +1043,53 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+    }
+
+    /// The manifest fetch aborts mid-stream once the body exceeds the cap,
+    /// before the whole body is spilled to the staging temp file (DoS DiD).
+    #[tokio::test]
+    async fn stream_to_temp_aborts_manifest_over_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let big = bytes::Bytes::from(vec![b'x'; 4096]);
+        let digest = sha256_digest(&big);
+        let mut src = DigestSource::new();
+        // Same body served on both the manifest and blob routes so the capped
+        // (manifest) and uncapped (blob) fetches exercise the identical bytes.
+        src.manifests.insert(digest.clone(), big.clone());
+        src.blobs.insert(digest.clone(), big.clone());
+        let client: Arc<dyn SourceRegistry> = Arc::new(src);
+
+        // Cap far below the body size: the fetch must error, not buffer it.
+        let capped = stream_to_temp(
+            &client,
+            tmp.path(),
+            "repo",
+            "app",
+            &digest,
+            OciContentKind::Manifest,
+            Some(64),
+        )
+        .await;
+        assert!(
+            capped.is_err(),
+            "manifest fetch must abort once it exceeds the cap"
+        );
+
+        // Same body with no cap (blob path) streams fine.
+        let uncapped = stream_to_temp(
+            &client,
+            tmp.path(),
+            "repo",
+            "app",
+            &digest,
+            OciContentKind::Blob,
+            None,
+        )
+        .await;
+        assert!(uncapped.is_ok(), "uncapped (blob) fetch must succeed");
+        let (_t, computed, size) = uncapped.unwrap();
+        assert_eq!(computed, digest);
+        assert_eq!(size, 4096);
     }
 
     #[test]

--- a/backend/src/services/oci_referenced_content.rs
+++ b/backend/src/services/oci_referenced_content.rs
@@ -1,0 +1,1041 @@
+//! Referenced-content walker for Docker/OCI migration imports (#2457).
+//!
+//! A Docker/OCI source registry (Nexus, a conformant `/v2/` registry)
+//! enumerates only the *tag* manifests of a repository. The bytes those
+//! manifests reference — the image `config` blob, every `layers[]` blob, and
+//! (for a multi-arch image index) the per-arch child manifests plus *their*
+//! config/layer blobs — are addressed by digest and are NEVER returned by the
+//! source's artifact listing. Before this module the migration worker
+//! registered the tag manifests (`oci_tags` + index→child edges) but fetched
+//! none of the referenced content, so a migrated image was HOLLOW: every
+//! `/v2/.../blobs/<config>` and `/v2/.../manifests/<child>` returned 404 and
+//! `docker pull` failed even though the job reported success.
+//!
+//! [`walk_and_register_referenced_content`] closes that gap. Given a manifest
+//! that the worker has just fetched, classified, and registered, it:
+//!   * for an IMAGE manifest, fetches the `config` blob and every layer blob
+//!     by digest and registers real bytes into `oci_blobs`;
+//!   * for an image INDEX, recurses each child: fetches the child manifest by
+//!     digest, stores it at its digest-addressed key, registers it via
+//!     [`persist_tag_and_refs_in_tx`] (so it resolves by digest exactly as a
+//!     live `docker push` would record it), then walks the child's own
+//!     config/layer blobs.
+//!
+//! Design guarantees:
+//!   * **Fail-closed.** Any referenced blob or child manifest that cannot be
+//!     transferred (source 404, transport error, digest mismatch, malformed
+//!     child) returns `Err`. The caller runs the walk inside the item's
+//!     transaction, so a failure rolls the tag back and marks the item FAILED
+//!     — a migrated tag is never acked while its content is incomplete.
+//!   * **Streaming.** Every blob is spilled through a `NamedTempFile` and
+//!     `put_stream`, so peak memory is O(chunk) regardless of layer size
+//!     (#1422/#1512). Only manifests (bounded by [`MAX_INDEX_MANIFEST_BYTES`])
+//!     are buffered, matching the worker's manifest path.
+//!   * **Dedup / no-op.** Content already present in `oci_blobs` /
+//!     `oci_tags` (e.g. blobs the Artifactory source enumerates as their own
+//!     items) is skipped without a fetch, so the walker is a no-op there and
+//!     cannot regress the Artifactory path.
+//!   * **DoS-bounded.** A visited-digest set guards against cycles and
+//!     re-fetching shared layers; recursion depth, per-index fan-out, and
+//!     total blob/manifest counts are all capped.
+
+use std::collections::{HashSet, VecDeque};
+use std::path::Path;
+use std::sync::Arc;
+
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::api::handlers::oci_v2::{
+    blob_storage_key, classify_manifest, extract_blob_refs, extract_child_digests,
+    manifest_storage_key, persist_tag_and_refs_in_tx, resolve_manifest_content_type,
+    stored_media_type_for, ManifestClass,
+};
+use crate::services::migration_service::MigrationError;
+use crate::services::oci_manifest_refs_backfill::MAX_INDEX_MANIFEST_BYTES;
+use crate::services::source_registry::{OciContentKind, SourceRegistry};
+use crate::storage::StorageBackend;
+
+/// Bounds on a single referenced-content walk. Every limit fails the item
+/// (fail-closed) rather than truncating silently, so a pathological source
+/// image cannot exhaust memory, storage, or the DB connection.
+#[derive(Debug, Clone, Copy)]
+pub struct WalkCaps {
+    /// Maximum index-of-index recursion depth. A normal multi-arch image is
+    /// depth 1 (index → child image manifests); deeper nesting is unusual and
+    /// capped to bound recursion.
+    pub max_depth: usize,
+    /// Maximum number of children a single image index may declare. Bounds the
+    /// fan-out of one `manifests[]` array.
+    pub max_index_fanout: usize,
+    /// Maximum total blobs fetched across the whole image (all arches).
+    pub max_blobs_total: usize,
+    /// Maximum total child manifests fetched across the whole image.
+    pub max_manifests_total: usize,
+}
+
+impl Default for WalkCaps {
+    fn default() -> Self {
+        Self {
+            max_depth: 4,
+            max_index_fanout: 1024,
+            max_blobs_total: 4096,
+            max_manifests_total: 1024,
+        }
+    }
+}
+
+/// Counters returned by a walk, for tracing and tests.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct WalkStats {
+    /// Blob rows registered into `oci_blobs` (excludes deduped skips).
+    pub blobs_registered: usize,
+    /// Child manifests fetched + registered (excludes deduped skips).
+    pub children_registered: usize,
+    /// Referenced digests skipped because they were already present.
+    pub deduped: usize,
+}
+
+/// Walk and register the content an already-registered manifest references.
+///
+/// `root_class` / `root_body` are the manifest the worker has just fetched and
+/// registered for `image`; the walk registers the blobs/children it pulls in.
+/// All DB writes run on `tx` (the item transaction) so a failure rolls back
+/// the tag together with any partial registration.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn walk_and_register_referenced_content(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    storage: &Arc<dyn StorageBackend>,
+    client: &Arc<dyn SourceRegistry>,
+    staging_dir: &Path,
+    repo_id: Uuid,
+    repo_key: &str,
+    image: &str,
+    root_class: &ManifestClass,
+    root_body: &[u8],
+    caps: &WalkCaps,
+) -> Result<WalkStats, MigrationError> {
+    let mut stats = WalkStats::default();
+    let mut visited: HashSet<String> = HashSet::new();
+    // Child manifests still to fetch + expand: (digest, depth).
+    let mut manifest_queue: VecDeque<(String, usize)> = VecDeque::new();
+
+    // Seed the walk from the already-fetched root manifest.
+    match root_class {
+        ManifestClass::Image => {
+            for blob in extract_blob_refs(root_body) {
+                ensure_blob(
+                    tx,
+                    storage,
+                    client,
+                    staging_dir,
+                    repo_id,
+                    repo_key,
+                    image,
+                    &blob.digest,
+                    caps,
+                    &mut visited,
+                    &mut stats,
+                )
+                .await?;
+            }
+        }
+        ManifestClass::Index => {
+            enqueue_children(root_body, 1, caps, &visited, &mut manifest_queue)?;
+        }
+        // The caller only invokes the walk for a non-malformed manifest.
+        ManifestClass::Malformed => {}
+    }
+
+    // Expand child manifests breadth-first. A child image manifest contributes
+    // its own config/layer blobs; a child index (index-of-index) enqueues its
+    // grandchildren one level deeper, up to the depth cap.
+    while let Some((digest, depth)) = manifest_queue.pop_front() {
+        if !visited.insert(digest.clone()) {
+            stats.deduped += 1;
+            continue;
+        }
+        if depth > caps.max_depth {
+            return Err(MigrationError::Other(format!(
+                "referenced-content walk for image '{image}' exceeded the max index depth ({})",
+                caps.max_depth
+            )));
+        }
+        stats.children_registered += 1;
+        if stats.children_registered > caps.max_manifests_total {
+            return Err(MigrationError::Other(format!(
+                "referenced-content walk for image '{image}' exceeded the max child-manifest count ({})",
+                caps.max_manifests_total
+            )));
+        }
+
+        // Resolve the child manifest body. If its bytes are already present in
+        // storage (a separate migration item registered it — Artifactory — or
+        // it is a digest shared with an already-walked image, e.g. a
+        // single-arch tag that is also a multi-arch child), read them back
+        // instead of re-fetching from the source. Either way the child is then
+        // registered under THIS image name below: registration is idempotent
+        // and must NOT be skipped just because the digest exists under another
+        // tag, or the child would 404 the moment that other tag is deleted
+        // (exactly what a native `docker push` avoids — every child gets its
+        // own by-digest tag under the image it belongs to). Only the FETCH is
+        // deduped; the registration is always applied.
+        let body =
+            load_or_fetch_child_manifest(storage, client, staging_dir, repo_key, image, &digest)
+                .await?;
+
+        let class = classify_manifest(&body);
+        if matches!(class, ManifestClass::Malformed) {
+            return Err(MigrationError::Other(format!(
+                "referenced child manifest '{digest}' of image '{image}' is neither an image nor an index"
+            )));
+        }
+        let content_type =
+            stored_media_type_for(&class, &resolve_manifest_content_type(None, &body));
+        // Register the child so it resolves by digest, exactly as the live
+        // push path records a manifest pushed by digest (reference == digest).
+        persist_tag_and_refs_in_tx(
+            tx,
+            repo_id,
+            image,
+            &digest,
+            &digest,
+            &content_type,
+            &class,
+            &body,
+        )
+        .await?;
+
+        match class {
+            ManifestClass::Image => {
+                for blob in extract_blob_refs(&body) {
+                    ensure_blob(
+                        tx,
+                        storage,
+                        client,
+                        staging_dir,
+                        repo_id,
+                        repo_key,
+                        image,
+                        &blob.digest,
+                        caps,
+                        &mut visited,
+                        &mut stats,
+                    )
+                    .await?;
+                }
+            }
+            ManifestClass::Index => {
+                enqueue_children(&body, depth + 1, caps, &visited, &mut manifest_queue)?;
+            }
+            ManifestClass::Malformed => unreachable!("rejected above"),
+        }
+    }
+
+    Ok(stats)
+}
+
+/// Enqueue the children of an index body at `depth`, enforcing the fan-out cap.
+fn enqueue_children(
+    index_body: &[u8],
+    depth: usize,
+    caps: &WalkCaps,
+    visited: &HashSet<String>,
+    queue: &mut VecDeque<(String, usize)>,
+) -> Result<(), MigrationError> {
+    let children = extract_child_digests(index_body);
+    if children.len() > caps.max_index_fanout {
+        return Err(MigrationError::Other(format!(
+            "image index declares {} children, exceeding the fan-out cap ({})",
+            children.len(),
+            caps.max_index_fanout
+        )));
+    }
+    for child in children {
+        if !visited.contains(&child) {
+            queue.push_back((child, depth));
+        }
+    }
+    Ok(())
+}
+
+/// Fetch, verify, store, and register one referenced blob unless it is already
+/// present (deduped). No-op on a repeat digest within the same walk.
+#[allow(clippy::too_many_arguments)]
+async fn ensure_blob(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    storage: &Arc<dyn StorageBackend>,
+    client: &Arc<dyn SourceRegistry>,
+    staging_dir: &Path,
+    repo_id: Uuid,
+    repo_key: &str,
+    image: &str,
+    digest: &str,
+    caps: &WalkCaps,
+    visited: &mut HashSet<String>,
+    stats: &mut WalkStats,
+) -> Result<(), MigrationError> {
+    if !visited.insert(digest.to_string()) {
+        stats.deduped += 1;
+        return Ok(());
+    }
+    // Already enumerated as its own migration item (Artifactory) or registered
+    // by an earlier walk: skip the fetch entirely.
+    if blob_already_registered(tx, repo_id, digest).await? {
+        stats.deduped += 1;
+        return Ok(());
+    }
+    if stats.blobs_registered >= caps.max_blobs_total {
+        return Err(MigrationError::Other(format!(
+            "referenced-content walk for image '{image}' exceeded the max blob count ({})",
+            caps.max_blobs_total
+        )));
+    }
+
+    let (storage_key, size) =
+        fetch_verify_store_blob(storage, client, staging_dir, repo_key, image, digest).await?;
+
+    // Mirror the monolithic-upload / migration blob insert: resurrect a
+    // GC-marked blob on conflict.
+    sqlx::query(
+        "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) \
+         VALUES ($1, $2, $3, $4) \
+         ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
+    )
+    .bind(repo_id)
+    .bind(digest)
+    .bind(size)
+    .bind(&storage_key)
+    .execute(&mut **tx)
+    .await?;
+    stats.blobs_registered += 1;
+    Ok(())
+}
+
+async fn blob_already_registered(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    repo_id: Uuid,
+    digest: &str,
+) -> Result<bool, MigrationError> {
+    let row: Option<(i32,)> =
+        sqlx::query_as("SELECT 1 FROM oci_blobs WHERE repository_id = $1 AND digest = $2 LIMIT 1")
+            .bind(repo_id)
+            .bind(digest)
+            .fetch_optional(&mut **tx)
+            .await?;
+    Ok(row.is_some())
+}
+
+/// Resolve a child manifest body, preferring bytes already in storage over a
+/// source fetch. When present locally (a separate migration item stored it, or
+/// the digest is shared with an already-walked image), the stored bytes are
+/// read back and digest-verified; otherwise the manifest is fetched from the
+/// source, verified, and stored. The caller registers it under the current
+/// image name regardless, so a shared digest is never left dependent on
+/// another tag's existence.
+async fn load_or_fetch_child_manifest(
+    storage: &Arc<dyn StorageBackend>,
+    client: &Arc<dyn SourceRegistry>,
+    staging_dir: &Path,
+    repo_key: &str,
+    image: &str,
+    digest: &str,
+) -> Result<bytes::Bytes, MigrationError> {
+    let key = manifest_storage_key(digest);
+    if storage.exists(&key).await.unwrap_or(false) {
+        let body = storage
+            .get(&key)
+            .await
+            .map_err(|e| MigrationError::StorageError(e.to_string()))?;
+        if body.len() > MAX_INDEX_MANIFEST_BYTES {
+            return Err(MigrationError::Other(format!(
+                "stored child manifest '{digest}' of image '{image}' exceeds the {} byte manifest cap",
+                MAX_INDEX_MANIFEST_BYTES
+            )));
+        }
+        let computed = {
+            let mut h = Sha256::new();
+            h.update(&body);
+            format!("sha256:{}", hex::encode(h.finalize()))
+        };
+        if computed == digest {
+            return Ok(body);
+        }
+        // Stored bytes do not match the referenced digest (corruption / key
+        // reuse): fall through and re-fetch the authoritative content.
+    }
+    fetch_verify_store_manifest(storage, client, staging_dir, repo_key, image, digest).await
+}
+
+/// Stream a referenced blob to a temp file, verify it hashes to `digest`, and
+/// commit its bytes to storage under the digest-addressed key. Returns the
+/// storage key and size. Never buffers the whole blob (O(chunk) memory).
+async fn fetch_verify_store_blob(
+    storage: &Arc<dyn StorageBackend>,
+    client: &Arc<dyn SourceRegistry>,
+    staging_dir: &Path,
+    repo_key: &str,
+    image: &str,
+    digest: &str,
+) -> Result<(String, i64), MigrationError> {
+    let (temp, computed, size) = stream_to_temp(
+        client,
+        staging_dir,
+        repo_key,
+        image,
+        digest,
+        OciContentKind::Blob,
+    )
+    .await?;
+    if computed != digest {
+        return Err(MigrationError::ChecksumMismatch {
+            path: format!("{image}/blobs/{digest}"),
+            expected: digest.to_string(),
+            actual: computed,
+        });
+    }
+    let storage_key = blob_storage_key(digest);
+    put_temp_to_storage(storage, temp.path(), &storage_key).await?;
+    Ok((storage_key, size))
+}
+
+/// Fetch a referenced child manifest, verify it hashes to `digest`, store its
+/// bytes at the digest-addressed manifest key, and return the body (bounded by
+/// [`MAX_INDEX_MANIFEST_BYTES`], so buffering it is safe).
+async fn fetch_verify_store_manifest(
+    storage: &Arc<dyn StorageBackend>,
+    client: &Arc<dyn SourceRegistry>,
+    staging_dir: &Path,
+    repo_key: &str,
+    image: &str,
+    digest: &str,
+) -> Result<bytes::Bytes, MigrationError> {
+    let (temp, computed, size) = stream_to_temp(
+        client,
+        staging_dir,
+        repo_key,
+        image,
+        digest,
+        OciContentKind::Manifest,
+    )
+    .await?;
+    if size as usize > MAX_INDEX_MANIFEST_BYTES {
+        return Err(MigrationError::Other(format!(
+            "referenced child manifest '{digest}' of image '{image}' exceeds the {} byte manifest cap (got {size} bytes)",
+            MAX_INDEX_MANIFEST_BYTES
+        )));
+    }
+    if computed != digest {
+        return Err(MigrationError::ChecksumMismatch {
+            path: format!("{image}/manifests/{digest}"),
+            expected: digest.to_string(),
+            actual: computed,
+        });
+    }
+    let body = tokio::fs::read(temp.path())
+        .await
+        .map_err(|e| MigrationError::StorageError(format!("read child manifest temp file: {e}")))?;
+    let storage_key = manifest_storage_key(digest);
+    if !storage.exists(&storage_key).await.unwrap_or(false) {
+        storage
+            .put(&storage_key, bytes::Bytes::from(body.clone()))
+            .await
+            .map_err(|e| MigrationError::StorageError(e.to_string()))?;
+    }
+    Ok(bytes::Bytes::from(body))
+}
+
+/// Stream digest-addressed content from the source into a `NamedTempFile`
+/// rooted in the migration staging dir, computing its sha256 as it lands.
+/// Returns the temp file (kept alive by the caller), the computed
+/// `sha256:<hex>` digest, and the byte count.
+async fn stream_to_temp(
+    client: &Arc<dyn SourceRegistry>,
+    staging_dir: &Path,
+    repo_key: &str,
+    image: &str,
+    digest: &str,
+    kind: OciContentKind,
+) -> Result<(tempfile::NamedTempFile, String, i64), MigrationError> {
+    use futures::StreamExt;
+    use tokio::io::AsyncWriteExt;
+
+    let mut stream = client
+        .download_oci_content_stream(repo_key, image, digest, kind)
+        .await?;
+
+    let temp = tempfile::NamedTempFile::new_in(staging_dir).map_err(|e| {
+        MigrationError::StorageError(format!(
+            "create temp file in {}: {e}",
+            staging_dir.display()
+        ))
+    })?;
+    let temp_path = temp.path().to_path_buf();
+    let mut writer = tokio::fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&temp_path)
+        .await
+        .map_err(|e| MigrationError::StorageError(format!("open temp file for write: {e}")))?;
+
+    let mut hasher = Sha256::new();
+    let mut size: i64 = 0;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(MigrationError::from)?;
+        hasher.update(&chunk);
+        size += chunk.len() as i64;
+        writer
+            .write_all(&chunk)
+            .await
+            .map_err(|e| MigrationError::StorageError(format!("write chunk to temp: {e}")))?;
+        drop(chunk);
+    }
+    drop(stream);
+    writer
+        .flush()
+        .await
+        .map_err(|e| MigrationError::StorageError(format!("flush temp file: {e}")))?;
+    writer
+        .sync_all()
+        .await
+        .map_err(|e| MigrationError::StorageError(format!("sync temp file: {e}")))?;
+    drop(writer);
+
+    let computed = format!("sha256:{}", hex::encode(hasher.finalize()));
+    Ok((temp, computed, size))
+}
+
+/// Commit a temp file's bytes to storage under `storage_key` via `put_stream`
+/// (never buffering the whole file), skipping the write when the content is
+/// already present (dedup on the CAS-like digest key).
+async fn put_temp_to_storage(
+    storage: &Arc<dyn StorageBackend>,
+    temp_path: &Path,
+    storage_key: &str,
+) -> Result<(), MigrationError> {
+    if storage.exists(storage_key).await.unwrap_or(false) {
+        return Ok(());
+    }
+    use tokio::io::BufReader;
+    use tokio_util::io::ReaderStream;
+
+    let file = tokio::fs::File::open(temp_path)
+        .await
+        .map_err(|e| MigrationError::StorageError(format!("reopen temp file for upload: {e}")))?;
+    let reader = BufReader::with_capacity(256 * 1024, file);
+    let stream = ReaderStream::with_capacity(reader, 256 * 1024);
+    let mapped = futures::StreamExt::map(stream, |r| {
+        r.map_err(|e| {
+            crate::error::AppError::Storage(format!("temp read error during upload: {e}"))
+        })
+    });
+    storage
+        .put_stream(storage_key, Box::pin(mapped))
+        .await
+        .map_err(|e| MigrationError::StorageError(e.to_string()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::artifactory_client::{
+        AqlResponse, ArtifactoryError, PropertiesResponse, RepositoryListItem,
+        SystemVersionResponse,
+    };
+    use crate::services::source_registry::ArtifactByteStream;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+
+    fn sha256_digest(data: &[u8]) -> String {
+        let mut h = Sha256::new();
+        h.update(data);
+        format!("sha256:{}", hex::encode(h.finalize()))
+    }
+
+    /// Source that serves digest-addressed content and records every fetch so
+    /// tests can assert the walker deduped shared layers. Serves ONLY by
+    /// digest (`download_oci_content_stream`) — the enumeration path is not
+    /// used by the walker, mirroring a real registry that lists just tags.
+    struct DigestSource {
+        blobs: HashMap<String, bytes::Bytes>,
+        manifests: HashMap<String, bytes::Bytes>,
+        fetches: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl DigestSource {
+        fn new() -> Self {
+            Self {
+                blobs: HashMap::new(),
+                manifests: HashMap::new(),
+                fetches: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SourceRegistry for DigestSource {
+        async fn ping(&self) -> Result<bool, ArtifactoryError> {
+            Ok(true)
+        }
+        async fn get_version(&self) -> Result<SystemVersionResponse, ArtifactoryError> {
+            unimplemented!()
+        }
+        async fn list_repositories(&self) -> Result<Vec<RepositoryListItem>, ArtifactoryError> {
+            Ok(vec![])
+        }
+        async fn list_artifacts(
+            &self,
+            _repo_key: &str,
+            _offset: i64,
+            _limit: i64,
+        ) -> Result<AqlResponse, ArtifactoryError> {
+            unimplemented!()
+        }
+        async fn download_artifact(
+            &self,
+            _repo_key: &str,
+            _path: &str,
+        ) -> Result<bytes::Bytes, ArtifactoryError> {
+            unimplemented!()
+        }
+        async fn download_oci_content_stream(
+            &self,
+            _repo_key: &str,
+            _image: &str,
+            digest: &str,
+            kind: OciContentKind,
+        ) -> Result<ArtifactByteStream, ArtifactoryError> {
+            self.fetches.lock().unwrap().push(digest.to_string());
+            let map = match kind {
+                OciContentKind::Blob => &self.blobs,
+                OciContentKind::Manifest => &self.manifests,
+            };
+            let bytes = map
+                .get(digest)
+                .cloned()
+                .ok_or_else(|| ArtifactoryError::NotFound(format!("digest not found: {digest}")))?;
+            Ok(Box::pin(futures::stream::once(async move { Ok(bytes) })))
+        }
+        async fn get_properties(
+            &self,
+            _repo_key: &str,
+            _path: &str,
+        ) -> Result<PropertiesResponse, ArtifactoryError> {
+            Ok(PropertiesResponse {
+                properties: None,
+                uri: None,
+            })
+        }
+        fn source_type(&self) -> &'static str {
+            "digest-mock"
+        }
+    }
+
+    async fn setup(pool: &sqlx::PgPool) -> (Arc<dyn StorageBackend>, tempfile::TempDir, Uuid) {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo_id = Uuid::new_v4();
+        let key = format!("refwalk-{}", &repo_id.to_string()[..8]);
+        sqlx::query(
+            "INSERT INTO repositories (id, key, name, storage_path, repo_type, format, is_public) \
+             VALUES ($1, $2, $2, $3, 'local', 'docker'::repository_format, true)",
+        )
+        .bind(repo_id)
+        .bind(&key)
+        .bind(tmp.path().to_str().unwrap())
+        .execute(pool)
+        .await
+        .unwrap();
+        let storage: Arc<dyn StorageBackend> = Arc::new(
+            crate::storage::filesystem::FilesystemStorage::new(tmp.path().to_str().unwrap()),
+        );
+        (storage, tmp, repo_id)
+    }
+
+    fn image_manifest(config: &[u8], layers: &[&[u8]]) -> bytes::Bytes {
+        let layer_json: Vec<String> = layers
+            .iter()
+            .map(|l| {
+                format!(
+                    "{{\"size\":{},\"digest\":\"{}\"}}",
+                    l.len(),
+                    sha256_digest(l)
+                )
+            })
+            .collect();
+        bytes::Bytes::from(format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\
+              \"config\":{{\"size\":{},\"digest\":\"{}\"}},\
+              \"layers\":[{}]}}",
+            config.len(),
+            sha256_digest(config),
+            layer_json.join(",")
+        ))
+    }
+
+    fn index_manifest(children: &[&bytes::Bytes]) -> bytes::Bytes {
+        let entries: Vec<String> = children
+            .iter()
+            .map(|c| {
+                format!(
+                    "{{\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\",\
+                      \"size\":{},\"digest\":\"{}\",\
+                      \"platform\":{{\"architecture\":\"amd64\",\"os\":\"linux\"}}}}",
+                    c.len(),
+                    sha256_digest(c)
+                )
+            })
+            .collect();
+        bytes::Bytes::from(format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.oci.image.index.v1+json\",\
+              \"manifests\":[{}]}}",
+            entries.join(",")
+        ))
+    }
+
+    /// Image manifest: the walker fetches the config + every layer and
+    /// registers each into `oci_blobs`.
+    #[tokio::test]
+    async fn walker_fetches_config_and_all_layers_for_image() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        let config = bytes::Bytes::from_static(b"{\"os\":\"linux\"}");
+        let layer_a = bytes::Bytes::from_static(b"layer-a-bytes");
+        let layer_b = bytes::Bytes::from_static(b"layer-b-bytes");
+        let manifest = image_manifest(&config, &[&layer_a, &layer_b]);
+
+        let mut src = DigestSource::new();
+        for b in [&config, &layer_a, &layer_b] {
+            src.blobs.insert(sha256_digest(b), b.clone());
+        }
+        let client: Arc<dyn SourceRegistry> = Arc::new(src);
+
+        let mut tx = pool.begin().await.unwrap();
+        let stats = walk_and_register_referenced_content(
+            &mut tx,
+            &storage,
+            &client,
+            tmp.path(),
+            repo_id,
+            "app",
+            "app",
+            &ManifestClass::Image,
+            &manifest,
+            &WalkCaps::default(),
+        )
+        .await
+        .expect("image walk");
+        tx.commit().await.unwrap();
+
+        assert_eq!(stats.blobs_registered, 3, "config + 2 layers");
+        for b in [&config, &layer_a, &layer_b] {
+            let d = sha256_digest(b);
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT storage_key FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+            )
+            .bind(repo_id)
+            .bind(&d)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            let (key,) = row.expect("blob registered");
+            assert!(storage.exists(&key).await.unwrap());
+        }
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// Image index: the walker recurses each child manifest, registers it by
+    /// digest, then fetches the child's own config/layers.
+    #[tokio::test]
+    async fn walker_recurses_children_then_their_blobs_for_index() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        let cfg_a = bytes::Bytes::from_static(b"{\"arch\":\"amd64\"}");
+        let cfg_b = bytes::Bytes::from_static(b"{\"arch\":\"arm64\"}");
+        let layer = bytes::Bytes::from_static(b"shared-layer");
+        let child_a = image_manifest(&cfg_a, &[&layer]);
+        let child_b = image_manifest(&cfg_b, &[&layer]);
+        let index = index_manifest(&[&child_a, &child_b]);
+
+        let mut src = DigestSource::new();
+        for b in [&cfg_a, &cfg_b, &layer] {
+            src.blobs.insert(sha256_digest(b), b.clone());
+        }
+        for m in [&child_a, &child_b] {
+            src.manifests.insert(sha256_digest(m), m.clone());
+        }
+        let fetches = src.fetches.clone();
+        let client: Arc<dyn SourceRegistry> = Arc::new(src);
+
+        let mut tx = pool.begin().await.unwrap();
+        let stats = walk_and_register_referenced_content(
+            &mut tx,
+            &storage,
+            &client,
+            tmp.path(),
+            repo_id,
+            "app",
+            "app",
+            &ManifestClass::Index,
+            &index,
+            &WalkCaps::default(),
+        )
+        .await
+        .expect("index walk");
+        tx.commit().await.unwrap();
+
+        assert_eq!(stats.children_registered, 2, "two arch children");
+        assert_eq!(
+            stats.blobs_registered, 3,
+            "two configs + one shared layer (deduped)"
+        );
+
+        // Shared layer fetched exactly once (visited-set dedup).
+        let layer_digest = sha256_digest(&layer);
+        let layer_fetches = fetches
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|d| **d == layer_digest)
+            .count();
+        assert_eq!(layer_fetches, 1, "shared layer must be fetched once");
+
+        // Children resolve by digest.
+        for m in [&child_a, &child_b] {
+            let d = sha256_digest(m);
+            let row: Option<(String,)> = sqlx::query_as(
+                "SELECT manifest_digest FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 LIMIT 1",
+            )
+            .bind(repo_id)
+            .bind(&d)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            assert!(row.is_some(), "child {d} registered");
+            assert!(storage.exists(&manifest_storage_key(&d)).await.unwrap());
+        }
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// Shared-digest regression: a child manifest whose digest is already
+    /// registered under a DIFFERENT image (e.g. a single-arch tag that is also
+    /// a multi-arch child) must still be registered under the current image
+    /// name — never skipped — so it survives the other tag's deletion. Its
+    /// bytes are read back from storage rather than re-fetched.
+    #[tokio::test]
+    async fn walker_registers_shared_child_under_current_image() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        let cfg = bytes::Bytes::from_static(b"{\"os\":\"linux\"}");
+        let child = image_manifest(&cfg, &[]);
+        let child_digest = sha256_digest(&child);
+        let index = index_manifest(&[&child]);
+
+        // Pre-register the child under a DIFFERENT image ("single") + store its
+        // bytes, mimicking a single-arch tag that shares the multi-arch child
+        // digest. The source has the config only (walker reads the child from
+        // storage, so it must NOT need to fetch the child manifest).
+        storage
+            .put(&manifest_storage_key(&child_digest), child.clone())
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO oci_tags (repository_id, name, tag, manifest_digest, manifest_content_type) \
+             VALUES ($1, 'single', 'latest', $2, 'application/vnd.oci.image.manifest.v1+json')",
+        )
+        .bind(repo_id)
+        .bind(&child_digest)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let mut src = DigestSource::new();
+        src.blobs.insert(sha256_digest(&cfg), cfg.clone());
+        // deliberately DO NOT put the child manifest in the source: it must be
+        // read from storage.
+        let fetches = src.fetches.clone();
+        let client: Arc<dyn SourceRegistry> = Arc::new(src);
+
+        let mut tx = pool.begin().await.unwrap();
+        walk_and_register_referenced_content(
+            &mut tx,
+            &storage,
+            &client,
+            tmp.path(),
+            repo_id,
+            "app",
+            "multi",
+            &ManifestClass::Index,
+            &index,
+            &WalkCaps::default(),
+        )
+        .await
+        .expect("index walk");
+        tx.commit().await.unwrap();
+
+        // The child must now be registered under the CURRENT image name
+        // ("multi"), independent of the pre-existing "single" tag.
+        let under_multi: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oci_tags WHERE repository_id=$1 AND name='multi' AND manifest_digest=$2",
+        )
+        .bind(repo_id)
+        .bind(&child_digest)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            under_multi.0, 1,
+            "shared child must be registered under the current image name"
+        );
+
+        // Deleting the OTHER tag must not orphan the child — it still resolves.
+        sqlx::query("DELETE FROM oci_tags WHERE repository_id=$1 AND name='single'")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let resolves: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM oci_tags WHERE repository_id=$1 AND manifest_digest=$2",
+        )
+        .bind(repo_id)
+        .bind(&child_digest)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            resolves.0, 1,
+            "child still resolves after the other tag is deleted"
+        );
+
+        // The child manifest was read from storage, never fetched from source.
+        assert!(
+            !fetches.lock().unwrap().contains(&child_digest),
+            "present child manifest must be read from storage, not re-fetched"
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// An unfetchable layer (source 404) fails the walk (fail-closed).
+    #[tokio::test]
+    async fn walker_errors_when_a_referenced_blob_is_unfetchable() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        let config = bytes::Bytes::from_static(b"{\"os\":\"linux\"}");
+        let layer = bytes::Bytes::from_static(b"missing-layer");
+        let manifest = image_manifest(&config, &[&layer]);
+
+        let mut src = DigestSource::new();
+        // config present, layer intentionally absent -> 404 on fetch.
+        src.blobs.insert(sha256_digest(&config), config.clone());
+        let client: Arc<dyn SourceRegistry> = Arc::new(src);
+
+        let mut tx = pool.begin().await.unwrap();
+        let res = walk_and_register_referenced_content(
+            &mut tx,
+            &storage,
+            &client,
+            tmp.path(),
+            repo_id,
+            "app",
+            "app",
+            &ManifestClass::Image,
+            &manifest,
+            &WalkCaps::default(),
+        )
+        .await;
+        assert!(res.is_err(), "an unfetchable layer must fail the walk");
+        drop(tx);
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// A pathological index whose fan-out exceeds the cap fails the walk (DoS
+    /// guard), before any fetch.
+    #[tokio::test]
+    async fn walker_rejects_index_exceeding_fanout_cap() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        // Build an index declaring more children than a tiny cap allows.
+        let children: Vec<bytes::Bytes> = (0..5)
+            .map(|i| image_manifest(format!("cfg{i}").as_bytes(), &[]))
+            .collect();
+        let refs: Vec<&bytes::Bytes> = children.iter().collect();
+        let index = index_manifest(&refs);
+
+        let client: Arc<dyn SourceRegistry> = Arc::new(DigestSource::new());
+        let caps = WalkCaps {
+            max_index_fanout: 2,
+            ..WalkCaps::default()
+        };
+        let mut tx = pool.begin().await.unwrap();
+        let res = walk_and_register_referenced_content(
+            &mut tx,
+            &storage,
+            &client,
+            tmp.path(),
+            repo_id,
+            "app",
+            "app",
+            &ManifestClass::Index,
+            &index,
+            &caps,
+        )
+        .await;
+        assert!(res.is_err(), "fan-out beyond the cap must fail the walk");
+        drop(tx);
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn walk_caps_default_is_bounded() {
+        let c = WalkCaps::default();
+        assert!(c.max_depth >= 1);
+        assert!(c.max_index_fanout >= 1);
+        assert!(c.max_blobs_total >= c.max_index_fanout);
+        assert!(c.max_manifests_total >= 1);
+    }
+}

--- a/backend/src/services/source_registry.rs
+++ b/backend/src/services/source_registry.rs
@@ -17,6 +17,32 @@ use crate::services::artifactory_client::{
 /// artifact size (issue #1422).
 pub type ArtifactByteStream = BoxStream<'static, Result<Bytes, ArtifactoryError>>;
 
+/// The kind of digest-addressed OCI content to fetch from a source registry.
+///
+/// A Docker/OCI source enumerates only the *tag* manifests of a repository.
+/// The bytes those manifests reference — the image config/layer blobs and
+/// (for a multi-arch index) the per-arch child manifests — are addressed by
+/// digest and are NOT enumerated. The migration worker's referenced-content
+/// walker (#2457) fetches them explicitly by digest through
+/// [`SourceRegistry::download_oci_content_stream`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OciContentKind {
+    /// A config or layer blob: `.../blobs/<digest>`.
+    Blob,
+    /// A child (per-arch) image manifest: `.../manifests/<digest>`.
+    Manifest,
+}
+
+impl OciContentKind {
+    /// The registry-API path segment (`blobs` or `manifests`) for this kind.
+    pub fn path_segment(self) -> &'static str {
+        match self {
+            OciContentKind::Blob => "blobs",
+            OciContentKind::Manifest => "manifests",
+        }
+    }
+}
+
 /// Trait for source registry clients used during migration.
 ///
 /// Both `ArtifactoryClient` and `NexusClient` implement this trait so the
@@ -89,6 +115,33 @@ pub trait SourceRegistry: Send + Sync {
     ) -> Result<ArtifactByteStream, ArtifactoryError> {
         let bytes = self.download_artifact(repo_key, path).await?;
         Ok(Box::pin(futures::stream::once(async move { Ok(bytes) })))
+    }
+
+    /// Download digest-addressed OCI content (a config/layer blob or a child
+    /// image manifest) as a chunked byte stream (#2457).
+    ///
+    /// A Docker/OCI source registry enumerates only the *tag* manifests of a
+    /// repository; the config/layer blobs and per-arch child manifests those
+    /// manifests reference are addressed by digest and never appear in
+    /// `list_artifacts`. The migration worker's referenced-content walker
+    /// resolves them by digest through this method so a migrated image lands
+    /// with all of its bytes (not a hollow, unpullable tag).
+    ///
+    /// The default implementation targets the OCI Distribution v2 layout that
+    /// Nexus (and any conformant registry) serves under a repository:
+    /// `<repo>/v2/<image>/{blobs|manifests}/<digest>`. It delegates to
+    /// [`download_artifact_stream`](Self::download_artifact_stream) so the
+    /// per-source auth/transport is reused unchanged. Sources whose blob
+    /// layout differs (Artifactory) override this.
+    async fn download_oci_content_stream(
+        &self,
+        repo_key: &str,
+        image: &str,
+        digest: &str,
+        kind: OciContentKind,
+    ) -> Result<ArtifactByteStream, ArtifactoryError> {
+        let path = format!("v2/{}/{}/{}", image, kind.path_segment(), digest);
+        self.download_artifact_stream(repo_key, &path).await
     }
 
     /// Get artifact properties/metadata (optional — returns empty if unsupported)

--- a/backend/src/services/source_registry.rs
+++ b/backend/src/services/source_registry.rs
@@ -43,6 +43,67 @@ impl OciContentKind {
     }
 }
 
+/// Whether `digest` is a canonical `sha256:<64-lowercase-hex>` reference.
+///
+/// The by-digest fetch path (#2457) interpolates the digest into an OUTBOUND
+/// source URL, and the digest originates from an attacker-influenced manifest
+/// body. Validate it against the strict grammar before building the URL so a
+/// crafted `../`/scheme-injecting value can never reach the request builder
+/// (defense-in-depth: the response is also digest-verified and discarded).
+pub fn is_valid_oci_digest(digest: &str) -> bool {
+    match digest.strip_prefix("sha256:") {
+        Some(hex) => {
+            hex.len() == 64
+                && hex
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        }
+        None => false,
+    }
+}
+
+/// Whether `image` is a valid OCI repository name (lowercase path components of
+/// `[a-z0-9]` plus `.`, `_`, `-` separators, each component starting and ending
+/// alphanumeric). Rejects empty components, leading/trailing separators, `..`
+/// traversal segments, and any character outside the grammar — so the value is
+/// safe to interpolate into an outbound `v2/<image>/...` URL.
+pub fn is_valid_oci_image_name(image: &str) -> bool {
+    if image.is_empty() || image.len() > 255 || image.contains("..") {
+        return false;
+    }
+    image.split('/').all(|component| {
+        let bytes = component.as_bytes();
+        !bytes.is_empty()
+            && bytes.iter().all(|&b| {
+                b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'.' | b'_' | b'-')
+            })
+            && bytes
+                .first()
+                .is_some_and(|&b| b.is_ascii_lowercase() || b.is_ascii_digit())
+            && bytes
+                .last()
+                .is_some_and(|&b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    })
+}
+
+/// Validate the `(image, digest)` pair used to build an outbound by-digest OCI
+/// fetch URL, returning a 400-class `ArtifactoryError` when either is malformed.
+pub fn validate_oci_content_ref(image: &str, digest: &str) -> Result<(), ArtifactoryError> {
+    if !is_valid_oci_image_name(image) {
+        return Err(ArtifactoryError::ApiError {
+            status: 400,
+            message: format!("refusing to fetch OCI content for invalid image name '{image}'"),
+        });
+    }
+    if !is_valid_oci_digest(digest) {
+        return Err(ArtifactoryError::ApiError {
+            status: 400,
+            message: format!("refusing to fetch OCI content for invalid digest '{digest}'"),
+        });
+    }
+    Ok(())
+}
+
 /// Trait for source registry clients used during migration.
 ///
 /// Both `ArtifactoryClient` and `NexusClient` implement this trait so the
@@ -140,6 +201,9 @@ pub trait SourceRegistry: Send + Sync {
         digest: &str,
         kind: OciContentKind,
     ) -> Result<ArtifactByteStream, ArtifactoryError> {
+        // Validate the attacker-influenced components before they reach the
+        // outbound URL builder (path-traversal / injection defense-in-depth).
+        validate_oci_content_ref(image, digest)?;
         let path = format!("v2/{}/{}/{}", image, kind.path_segment(), digest);
         self.download_artifact_stream(repo_key, &path).await
     }
@@ -342,5 +406,58 @@ mod tests {
     fn test_source_type_custom() {
         let registry = MockSourceRegistry::new("custom-registry");
         assert_eq!(registry.source_type(), "custom-registry");
+    }
+
+    #[test]
+    fn valid_oci_digest_accepts_canonical_sha256() {
+        let hex = "a".repeat(64);
+        assert!(is_valid_oci_digest(&format!("sha256:{hex}")));
+        assert!(is_valid_oci_digest(
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        ));
+    }
+
+    #[test]
+    fn valid_oci_digest_rejects_malformed_and_traversal() {
+        assert!(!is_valid_oci_digest("latest"));
+        assert!(!is_valid_oci_digest("sha256:short"));
+        // wrong length
+        assert!(!is_valid_oci_digest(&format!("sha256:{}", "a".repeat(63))));
+        // uppercase hex is not canonical
+        assert!(!is_valid_oci_digest(&format!("sha256:{}", "A".repeat(64))));
+        // traversal / injection attempts must not pass the digest grammar
+        assert!(!is_valid_oci_digest("sha256:../../../../etc/passwd"));
+        assert!(!is_valid_oci_digest("sha512:aaaa"));
+        assert!(!is_valid_oci_digest(""));
+    }
+
+    #[test]
+    fn valid_oci_image_name_accepts_real_names() {
+        assert!(is_valid_oci_image_name("busybox"));
+        assert!(is_valid_oci_image_name("library/busybox"));
+        assert!(is_valid_oci_image_name("org/team/app"));
+        assert!(is_valid_oci_image_name("my-repo.name_1/sub-image"));
+    }
+
+    #[test]
+    fn valid_oci_image_name_rejects_traversal_and_injection() {
+        assert!(!is_valid_oci_image_name(""));
+        assert!(!is_valid_oci_image_name("../etc/passwd"));
+        assert!(!is_valid_oci_image_name("app/../../secret"));
+        assert!(!is_valid_oci_image_name("/leading-slash"));
+        assert!(!is_valid_oci_image_name("trailing/"));
+        assert!(!is_valid_oci_image_name("double//slash"));
+        assert!(!is_valid_oci_image_name("Upper/Case"));
+        assert!(!is_valid_oci_image_name("has space"));
+        assert!(!is_valid_oci_image_name("scheme:inject"));
+        assert!(!is_valid_oci_image_name(".leading-dot"));
+    }
+
+    #[test]
+    fn validate_oci_content_ref_gates_both_components() {
+        let hex = "b".repeat(64);
+        assert!(validate_oci_content_ref("app", &format!("sha256:{hex}")).is_ok());
+        assert!(validate_oci_content_ref("../app", &format!("sha256:{hex}")).is_err());
+        assert!(validate_oci_content_ref("app", "sha256:../bad").is_err());
     }
 }


### PR DESCRIPTION
## Summary

Docker/OCI migration imports registered the enumerated **tag manifests**
(`oci_tags`, index→child edges, `manifest_blob_refs`) but never fetched the
content those manifests *reference*. A source registry (Nexus, any conformant
`/v2/` registry) lists only the tag manifests; the image `config` blob, every
`layers[]` blob, and — for a multi-arch image index — the per-arch child
manifests plus their own config/layer blobs are addressed by digest and are
**not** enumerated. The result was a *hollow* image: `oci_blobs` stayed empty,
`GET /v2/<repo>/<img>/blobs/<config>` and `.../manifests/<child>` returned 404,
and `docker pull` failed even though the job reported success.

This PR hardens the import to transfer referenced content with full fidelity:

- **Referenced-content walker** (`services/oci_referenced_content.rs`): after a
  Docker/OCI manifest is registered, the walker resolves its referenced content
  by digest — for an image manifest, the `config` blob and every layer; for an
  image index, each child manifest (registered so it resolves by digest, exactly
  as a live `docker push` records a by-digest manifest) and then that child's
  own config/layers. Real bytes land in `oci_blobs` and storage, not just edges.
  A new `SourceRegistry::download_oci_content_stream(repo, image, digest, kind)`
  fetches content by digest (default targets the `/v2/` registry layout Nexus
  serves; Artifactory overrides for its Docker registry API path).

- **Fail-closed**: the walk runs inside the item's transaction. If any
  referenced blob or child manifest cannot be transferred, the whole item rolls
  back (no `oci_tags`, no partial `oci_blobs`) and is marked FAILED — a migrated
  tag is never acked while its content is incomplete.

- **Streaming + bounded**: every blob is spilled through a temp file and
  `put_stream` (O(chunk) memory, matching the existing transfer path). A
  visited-digest set dedups shared layers; recursion depth, per-index fan-out,
  and total blob/manifest counts are capped. Content already present
  (`oci_blobs` rows / stored manifests — e.g. blobs the Artifactory source
  enumerates as their own items) is skipped without a fetch, so the walker is a
  no-op there and cannot regress the Artifactory path.

- **Resurrect soft-deleted rows** (`migration_worker`): re-importing a manifest
  whose `artifacts` row was soft-deleted now upserts `is_deleted = false` (the
  full `UNIQUE(repository_id, path)` arbiter) instead of `DO NOTHING`, matching
  the live push path. The `artifacts` INSERT and the OCI registration for a
  Docker item share ONE transaction, so a tag is never committed without a live
  backing artifact.

- **Startup reconciliation** (`services/oci_migration_reindex.rs`): the existing
  one-shot repair now recurses image indexes (registering present child
  manifests + their blobs), drops orphan `oci_tags` whose backing artifact was
  soft-deleted (narrowly scoped to migrated tags — a natively pushed tag has no
  `artifacts` row and is never touched), and emits a WARN listing repositories
  whose tags remain hollow (content that was never transferred cannot be
  fabricated; those repos need re-migration). `RepairStats` gains
  `children_registered` / `hollow_tags_flagged` / `orphan_tags_reconciled`,
  surfaced in the `main.rs` startup log.

Non-Docker formats and the Artifactory-shaped import keep their existing
behaviour byte-for-byte. The `from_artifactory`/Nexus repository-type mapping is
already merged and is not part of this change.

Closes #2457

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

New/updated tests:
- Walker unit tests: config + all layers for an image; recurse children then
  their config/layers for an index; shared-layer visited-set dedup; depth /
  fan-out DoS caps reject a pathological index; an unfetchable blob fails the
  walk (fail-closed); a child digest shared with another image is still
  registered under the current image and survives the other tag's deletion.
- Migration integration tests: a source enumerating ONLY the tag manifest leaves
  the image fully pullable (`oci_blobs` populated, child resolves by digest); a
  source that 404s a layer marks the item FAILED with nothing committed; a
  delete-then-re-import resurrects the soft-deleted row with zero orphan tags.
- Reindex tests: image-index repair registers children + their blobs; orphan-tag
  reconciliation drops a tombstoned-backing tag while keeping a healthy one.
- Updated the pinned `extract_blob_refs_empty_for_image_index` with a companion
  asserting the walker classifies the index and recurses its children.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

<!-- No schema migration: the needs-re-migration signal ships as a startup WARN
     + RepairStats, following the v1.5.7 migration-free precedent. -->
