### PR TITLE
fix(proxy): allow the configured egress proxy host through the SSRF DNS guard

### DIFF
--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -685,9 +685,18 @@ mod tests {
             socket.write_all(b"K").await.expect("write second byte");
         });
 
-        let client = large_object_client_builder(true)
-            .build()
-            .expect("build large-object client");
+        // Serialize the client build against `test_configured_proxy_host_is_
+        // exempted_from_guard`, which briefly sets a process-wide `HTTP_PROXY`
+        // while building its own client. Without this, a concurrent build here
+        // could observe that proxy and route this round-trip away from the
+        // test's own listener. The guard is dropped before any `.await`, so it
+        // never crosses an await point.
+        let client = {
+            let _proxy_env_guard = PROXY_ENV_LOCK.lock().unwrap();
+            large_object_client_builder(true)
+                .build()
+                .expect("build large-object client")
+        };
         let request = tokio::spawn(async move {
             client
                 .post(&url)
@@ -705,5 +714,118 @@ mod tests {
 
         assert_eq!(request.await.expect("request task").as_ref(), b"OK");
         server.await.expect("server task");
+    }
+
+    /// Serializes tests that mutate the process-wide `HTTP_PROXY`/`NO_PROXY`
+    /// env so a leaked value cannot perturb the loopback-block tests above.
+    static PROXY_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Issue #2570: the configured egress-proxy host is exempted from the
+    /// SSRF DNS guard. With `HTTP_PROXY` pointing at a loopback listener (a
+    /// hard-blocked address the guard would normally refuse), a request built
+    /// by `base_client_builder()` for an EXTERNAL http URL must be routed to —
+    /// and accepted by — that proxy listener. Before the fix the guard blocked
+    /// the proxy host's own (loopback/private) address and the connect never
+    /// happened (the 502/500 in #2570); the accepted connection is what proves
+    /// the exemption is wired in.
+    ///
+    /// The proxy host MUST be a hostname (`localhost`), not an IP literal: an IP
+    /// literal skips DNS resolution entirely, so the resolver — and therefore
+    /// the exemption — would never be exercised. `localhost` resolves (via the
+    /// SSRF resolver) to loopback, which is normally hard-blocked; the exempt
+    /// entry (parsed from the proxy env) is what lets it through. The paired
+    /// negative test [`test_unexempted_proxy_host_is_blocked_by_guard`] proves
+    /// this listener would NOT be reached without the exemption.
+    #[tokio::test]
+    async fn test_configured_proxy_host_is_exempted_from_guard() {
+        use tokio::net::TcpListener;
+
+        let _lock = PROXY_ENV_LOCK.lock().unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind proxy listener");
+        let port = listener.local_addr().expect("local addr").port();
+
+        // Both reqwest (proxy routing) and our SSRF resolver (the proxy-host
+        // exempt-set) read the proxy env at builder-construction time. Set it,
+        // build synchronously, then remove it immediately — this keeps the
+        // process-wide env mutation to a synchronous window (no `.await` in
+        // between) so it cannot perturb a concurrently-running test that also
+        // builds a client.
+        std::env::set_var("HTTP_PROXY", format!("http://localhost:{port}"));
+        std::env::remove_var("NO_PROXY");
+        std::env::remove_var("no_proxy");
+        let client = base_client_builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("build client");
+        std::env::remove_var("HTTP_PROXY");
+
+        // GET an external http host so the built-in proxy applies; we only care
+        // that the connect reaches the proxy listener, not about a full response.
+        let request = tokio::spawn(async move {
+            let _ = client.get("http://example.com/").send().await;
+        });
+
+        let accepted = tokio::time::timeout(Duration::from_secs(2), listener.accept()).await;
+
+        request.abort();
+
+        assert!(
+            accepted.is_ok(),
+            "the configured proxy host (localhost) must be exempted so the request \
+             reaches the proxy listener at 127.0.0.1:{port}; got {accepted:?}"
+        );
+    }
+
+    /// Discriminating negative for #2570: proves that (a) reqwest DOES route the
+    /// proxy HOSTNAME through our custom SSRF DNS resolver, and (b) WITHOUT the
+    /// exempt-set entry that resolver refuses the proxy's own loopback/private
+    /// address — exactly the failure the exemption fixes. The proxy is set
+    /// EXPLICITLY as a hostname (`localhost`, so DNS resolution — hence the
+    /// resolver — is actually invoked) and paired with an EMPTY-exempt resolver.
+    /// The request must be blocked before any TCP connection: the listener must
+    /// never accept and `send()` must error. If reqwest bypassed the resolver
+    /// for proxy hosts, the listener WOULD accept and this test would fail — so
+    /// a pass confirms the resolver is on the proxy path and the exemption is
+    /// load-bearing.
+    #[tokio::test]
+    async fn test_unexempted_proxy_host_is_blocked_by_guard() {
+        use std::sync::Arc;
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind proxy listener");
+        let port = listener.local_addr().expect("local addr").port();
+
+        // Explicit proxy at a loopback-resolving HOSTNAME + a resolver with an
+        // EMPTY exempt-set (the pre-#2570 fail-closed behavior). No env mutation.
+        let empty_exempt_resolver: Arc<dyn reqwest::dns::Resolve> =
+            Arc::new(crate::services::ssrf_dns::SsrfGuardResolver::default());
+        let client = reqwest::Client::builder()
+            .proxy(reqwest::Proxy::all(format!("http://localhost:{port}")).expect("proxy url"))
+            .dns_resolver(empty_exempt_resolver)
+            .timeout(Duration::from_secs(2))
+            .build()
+            .expect("build client");
+
+        let request =
+            tokio::spawn(async move { client.get("http://example.com/").send().await.is_err() });
+
+        let accepted = tokio::time::timeout(Duration::from_millis(500), listener.accept()).await;
+        let send_errored = request.await.expect("request task");
+
+        assert!(
+            accepted.is_err(),
+            "an UNEXEMPTED loopback-resolving proxy host must be blocked by the \
+             resolver; the listener must never accept, but it did: {accepted:?}"
+        );
+        assert!(
+            send_errored,
+            "the request through an unexempted loopback proxy must fail at the \
+             resolver instead of connecting"
+        );
     }
 }

--- a/backend/src/services/http_client.rs
+++ b/backend/src/services/http_client.rs
@@ -740,8 +740,6 @@ mod tests {
     async fn test_configured_proxy_host_is_exempted_from_guard() {
         use tokio::net::TcpListener;
 
-        let _lock = PROXY_ENV_LOCK.lock().unwrap();
-
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
             .expect("bind proxy listener");
@@ -752,15 +750,21 @@ mod tests {
         // build synchronously, then remove it immediately — this keeps the
         // process-wide env mutation to a synchronous window (no `.await` in
         // between) so it cannot perturb a concurrently-running test that also
-        // builds a client.
-        std::env::set_var("HTTP_PROXY", format!("http://localhost:{port}"));
-        std::env::remove_var("NO_PROXY");
-        std::env::remove_var("no_proxy");
-        let client = base_client_builder()
-            .timeout(Duration::from_secs(2))
-            .build()
-            .expect("build client");
-        std::env::remove_var("HTTP_PROXY");
+        // builds a client. The `PROXY_ENV_LOCK` guard serializes that window
+        // and is dropped before the request `.await` below, so it never
+        // crosses an await point.
+        let client = {
+            let _proxy_env_guard = PROXY_ENV_LOCK.lock().unwrap();
+            std::env::set_var("HTTP_PROXY", format!("http://localhost:{port}"));
+            std::env::remove_var("NO_PROXY");
+            std::env::remove_var("no_proxy");
+            let client = base_client_builder()
+                .timeout(Duration::from_secs(2))
+                .build()
+                .expect("build client");
+            std::env::remove_var("HTTP_PROXY");
+            client
+        };
 
         // GET an external http host so the built-in proxy applies; we only care
         // that the connect reaches the proxy listener, not about a full response.

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -361,21 +361,31 @@ fn is_ssrf_block_error(err: &(dyn std::error::Error + 'static)) -> bool {
 }
 
 /// Pure transport-error mapping (unit-testable without a real
-/// `reqwest::Error`). When an egress proxy is configured AND the failure is
-/// the SSRF DNS guard refusing to resolve a host, surface a meaningful 503 so
-/// operators see "egress proxy refused by policy" instead of an opaque
-/// `Storage` 500 or a blanket 502 (issue #2570). Every other transport
-/// failure keeps the pre-existing `Storage` mapping unchanged.
+/// `reqwest::Error`). When the failure is the SSRF DNS guard refusing to
+/// resolve a host, surface a meaningful 503 instead of an opaque `Storage` 500
+/// or a blanket 502 (issue #2570). The wording is proxy-specific ONLY when an
+/// egress proxy is actually configured (`proxy_configured`), so a direct /
+/// `NO_PROXY` upstream that is SSRF-blocked is not mislabeled as a proxy
+/// failure — that just confuses triage since no proxy was involved. Either way
+/// it is a 503 and the redacted-URL `context` (never proxy creds/IP) is
+/// preserved. Every other (non-SSRF) transport failure keeps the pre-existing
+/// `Storage` mapping unchanged.
 fn map_transport_error(
     proxy_configured: bool,
     is_ssrf_block: bool,
     context: &str,
     detail: &str,
 ) -> AppError {
-    if proxy_configured && is_ssrf_block {
-        AppError::ServiceUnavailable(format!(
-            "egress proxy connection refused by SSRF egress policy while {context}: {detail}"
-        ))
+    if is_ssrf_block {
+        if proxy_configured {
+            AppError::ServiceUnavailable(format!(
+                "egress proxy connection refused by SSRF egress policy while {context}: {detail}"
+            ))
+        } else {
+            AppError::ServiceUnavailable(format!(
+                "connection to upstream refused by SSRF egress policy while {context}: {detail}"
+            ))
+        }
     } else {
         AppError::Storage(format!("Failed to {context}: {detail}"))
     }
@@ -5221,19 +5231,25 @@ mod tests {
     }
 
     #[test]
-    fn map_transport_error_ssrf_block_without_proxy_keeps_storage_path() {
-        // No proxy configured ⇒ a block is a genuine direct-target refusal,
-        // not a proxy-egress problem: keep the existing Storage mapping.
+    fn map_transport_error_ssrf_block_without_proxy_is_generic_503() {
+        // No proxy configured ⇒ a direct-target SSRF block is still surfaced as
+        // a meaningful 503, but the message must NOT mention a proxy (none was
+        // involved) — that keeps triage honest.
         let err = map_transport_error(
             false, // no proxy configured
             true,  // SSRF-guard block
             "fetch from upstream https://10.0.0.5/x",
             "all resolved addresses blocked by SSRF policy",
         );
-        assert!(
-            matches!(err, AppError::Storage(_)),
-            "SSRF block with no proxy must map to Storage, got {err:?}"
-        );
+        match err {
+            AppError::ServiceUnavailable(msg) => {
+                assert!(
+                    msg.contains("SSRF egress policy") && !msg.to_lowercase().contains("proxy"),
+                    "expected a generic (non-proxy) SSRF 503 message, got: {msg}"
+                );
+            }
+            other => panic!("expected ServiceUnavailable, got {other:?}"),
+        }
     }
 
     #[test]

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -344,6 +344,59 @@ fn redact_url_for_diagnostics(url: &str) -> String {
     url[..end].to_string()
 }
 
+/// True when the SSRF DNS guard's "all resolved addresses blocked" marker
+/// appears anywhere in a transport error's `source()` chain. The marker
+/// string is emitted only by [`crate::services::ssrf_dns::SsrfGuardResolver`],
+/// so a match unambiguously identifies an SSRF-guard block (as opposed to a
+/// plain connection-refused / timeout).
+fn is_ssrf_block_error(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut cur: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = cur {
+        if e.to_string().contains("blocked by SSRF policy") {
+            return true;
+        }
+        cur = e.source();
+    }
+    false
+}
+
+/// Pure transport-error mapping (unit-testable without a real
+/// `reqwest::Error`). When an egress proxy is configured AND the failure is
+/// the SSRF DNS guard refusing to resolve a host, surface a meaningful 503 so
+/// operators see "egress proxy refused by policy" instead of an opaque
+/// `Storage` 500 or a blanket 502 (issue #2570). Every other transport
+/// failure keeps the pre-existing `Storage` mapping unchanged.
+fn map_transport_error(
+    proxy_configured: bool,
+    is_ssrf_block: bool,
+    context: &str,
+    detail: &str,
+) -> AppError {
+    if proxy_configured && is_ssrf_block {
+        AppError::ServiceUnavailable(format!(
+            "egress proxy connection refused by SSRF egress policy while {context}: {detail}"
+        ))
+    } else {
+        AppError::Storage(format!("Failed to {context}: {detail}"))
+    }
+}
+
+/// Shared classifier for a `reqwest` transport error from an upstream
+/// `send()`, reused by the buffered / streaming / token-exchange fetch paths
+/// so the mapping (and the #2570 proxy-egress diagnostic) lives in exactly
+/// one place. `context` is the operation phrase (e.g.
+/// `"fetch from upstream https://…"`) woven into both message forms.
+fn classify_send_error(err: reqwest::Error, context: &str) -> AppError {
+    let is_block = is_ssrf_block_error(&err);
+    let proxy_configured = !crate::services::ssrf_dns::configured_proxy_hosts().is_empty();
+    map_transport_error(
+        proxy_configured,
+        is_block,
+        context,
+        &err.without_url().to_string(),
+    )
+}
+
 /// * `404` → `AppError::NotFound` (cache-miss-class error; callers treat
 ///   as a real "upstream doesn't have it" signal, not a backend failure)
 /// * Other 5xx → `AppError::ServiceUnavailable` (transient upstream failure;
@@ -1630,11 +1683,7 @@ impl UpstreamClient {
         }
 
         let response = request.send().await.map_err(|e| {
-            AppError::Storage(format!(
-                "Failed to fetch from upstream {}: {}",
-                diagnostic_url,
-                e.without_url()
-            ))
+            classify_send_error(e, &format!("fetch from upstream {}", diagnostic_url))
         })?;
 
         let status = response.status();
@@ -1799,11 +1848,7 @@ impl UpstreamClient {
         // and MUST NOT be "unified" — do not add `Accept` here (#1618 S8 review).
 
         let response = request.send().await.map_err(|e| {
-            AppError::Storage(format!(
-                "Failed to fetch from upstream {}: {}",
-                diagnostic_url,
-                e.without_url()
-            ))
+            classify_send_error(e, &format!("fetch from upstream {}", diagnostic_url))
         })?;
 
         let status = response.status();
@@ -1903,11 +1948,13 @@ impl UpstreamClient {
 
                 let retry_diagnostic_url = redact_url_for_diagnostics(url);
                 let retry_response = retry_request.send().await.map_err(|e| {
-                    AppError::Storage(format!(
-                        "Failed to fetch from upstream {} after token exchange: {}",
-                        retry_diagnostic_url,
-                        e.without_url()
-                    ))
+                    classify_send_error(
+                        e,
+                        &format!(
+                            "fetch from upstream {} after token exchange",
+                            retry_diagnostic_url
+                        ),
+                    )
                 })?;
 
                 return Ok(Some(retry_response));
@@ -5133,6 +5180,95 @@ pub(crate) fn build_stale_cache_headers() -> HashMap<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // -----------------------------------------------------------------------
+    // Transport-error classifier: egress-proxy SSRF block diagnostics (#2570)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn map_transport_error_proxy_block_is_service_unavailable() {
+        let err = map_transport_error(
+            true, // proxy configured
+            true, // SSRF-guard block
+            "fetch from upstream https://registry.example/x",
+            "all resolved addresses blocked by SSRF policy",
+        );
+        match err {
+            AppError::ServiceUnavailable(msg) => {
+                assert!(
+                    msg.contains("egress proxy") && msg.contains("egress policy"),
+                    "expected a meaningful proxy-egress message, got: {msg}"
+                );
+            }
+            other => panic!("expected ServiceUnavailable, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_transport_error_generic_upstream_error_keeps_storage_path() {
+        // A generic transport error (proxy configured but NOT an SSRF block)
+        // must keep the pre-existing Storage mapping.
+        let err = map_transport_error(
+            true,  // proxy configured
+            false, // not an SSRF block (e.g. connection reset)
+            "fetch from upstream https://registry.example/x",
+            "connection reset by peer",
+        );
+        assert!(
+            matches!(err, AppError::Storage(_)),
+            "generic upstream error must map to Storage, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn map_transport_error_ssrf_block_without_proxy_keeps_storage_path() {
+        // No proxy configured ⇒ a block is a genuine direct-target refusal,
+        // not a proxy-egress problem: keep the existing Storage mapping.
+        let err = map_transport_error(
+            false, // no proxy configured
+            true,  // SSRF-guard block
+            "fetch from upstream https://10.0.0.5/x",
+            "all resolved addresses blocked by SSRF policy",
+        );
+        assert!(
+            matches!(err, AppError::Storage(_)),
+            "SSRF block with no proxy must map to Storage, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn is_ssrf_block_error_matches_marker_in_chain() {
+        // Direct marker.
+        let io_err = std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "all resolved addresses blocked by SSRF policy",
+        );
+        assert!(is_ssrf_block_error(&io_err));
+
+        // Marker nested one level down in the source chain.
+        #[derive(Debug)]
+        struct Wrap(std::io::Error);
+        impl std::fmt::Display for Wrap {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "error trying to connect")
+            }
+        }
+        impl std::error::Error for Wrap {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+        let wrapped = Wrap(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "all resolved addresses blocked by SSRF policy",
+        ));
+        assert!(is_ssrf_block_error(&wrapped));
+
+        // A plain connection error must NOT match.
+        let plain =
+            std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "connection refused");
+        assert!(!is_ssrf_block_error(&plain));
+    }
 
     // -----------------------------------------------------------------------
     // Package Age Policy on the proxy sidecar (#1770 / #1771)

--- a/backend/src/services/ssrf_dns.rs
+++ b/backend/src/services/ssrf_dns.rs
@@ -160,6 +160,12 @@ pub(crate) fn configured_proxy_hosts() -> HashSet<String> {
 /// resolver is fully fail-closed). No subdomain/suffix/prefix matching:
 /// `proxy.corp.attacker.com` and `10.0.0.5.attacker.com` are NOT exempted
 /// by a `proxy.corp` / `10.0.0.5` entry.
+///
+/// The match is host-keyed and PORT-AGNOSTIC (the port is stripped from the
+/// proxy value at parse time). This is safe: the exemption affects only DNS
+/// *name resolution*, which is inherently port-independent, and reqwest still
+/// dials the proxy's configured port — it grants no reach to a different
+/// service/port on that host, so port-agnosticism does not widen the guard.
 fn host_is_exempt(exempt: &HashSet<String>, host: &str) -> bool {
     !exempt.is_empty() && exempt.contains(host.to_ascii_lowercase().as_str())
 }

--- a/backend/src/services/ssrf_dns.rs
+++ b/backend/src/services/ssrf_dns.rs
@@ -2,6 +2,7 @@
 //! (loopback / link-local / private / cloud-metadata) IPs at connect time,
 //! closing the DNS-rebinding gap that URL-string validation cannot catch.
 
+use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -40,30 +41,141 @@ enum ResolverMode {
 #[derive(Debug, Clone)]
 pub struct SsrfGuardResolver {
     mode: ResolverMode,
+    /// EXACT (case-insensitive, full-host) allow-set of the operator-configured
+    /// egress-proxy host(s), read once at construction from the proxy env
+    /// (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`, upper and lower case). A host in
+    /// this set skips the SSRF filter entirely — the proxy's own (often
+    /// private) address must be reachable or every outbound fetch fails closed
+    /// with a 502/500 (issue #2570). The set is EMPTY when no proxy env is set,
+    /// in which case the resolver is byte-for-byte the pre-existing
+    /// fail-closed guard. Matching is exact full-host equality only; it never
+    /// relaxes any other target and never does subdomain/suffix/prefix matching.
+    exempt_proxy_hosts: HashSet<String>,
 }
 
 impl Default for SsrfGuardResolver {
     fn default() -> Self {
         Self {
             mode: ResolverMode::Upstream,
+            exempt_proxy_hosts: HashSet::new(),
         }
     }
+}
+
+impl SsrfGuardResolver {
+    /// Construct a resolver for `mode`, reading the configured egress-proxy
+    /// host(s) from the process environment so the proxy's own address is
+    /// exempt from the SSRF DNS filter for THIS resolver (issue #2570). All
+    /// production constructors funnel through here; tests build the struct
+    /// directly with an explicit `exempt_proxy_hosts` (or `..Default::default()`
+    /// for the empty, fail-closed baseline).
+    fn with_mode(mode: ResolverMode) -> Self {
+        Self {
+            mode,
+            exempt_proxy_hosts: configured_proxy_hosts(),
+        }
+    }
+
+    /// True when `host` is an exact (case-insensitive, full-host) match for a
+    /// configured egress-proxy host. Delegates to the free [`host_is_exempt`]
+    /// so the match rule is unit-testable without any DNS/network I/O.
+    fn is_exempt_proxy_host(&self, host: &str) -> bool {
+        host_is_exempt(&self.exempt_proxy_hosts, host)
+    }
+}
+
+/// Parse the bare host token out of a proxy URL value (`HTTP_PROXY` and
+/// friends): strip an optional `scheme://`, an optional `user:pass@`
+/// userinfo, any path/query, and a trailing `:port`, returning the host
+/// lowercased. `http://user:pass@proxy.corp:3128` → `proxy.corp`. Returns
+/// `None` for an empty or hostless value.
+fn proxy_host_token(value: &str) -> Option<String> {
+    let v = value.trim();
+    if v.is_empty() {
+        return None;
+    }
+    // Strip scheme (`http://`, `https://`, `socks5://`, …) if present.
+    let after_scheme = match v.find("://") {
+        Some(i) => &v[i + 3..],
+        None => v,
+    };
+    // Strip userinfo (`user:pass@`) — use the LAST '@' so a password
+    // containing '@' does not truncate the host.
+    let after_userinfo = match after_scheme.rfind('@') {
+        Some(i) => &after_scheme[i + 1..],
+        None => after_scheme,
+    };
+    // Drop any path/query/fragment.
+    let hostport = after_userinfo
+        .split(['/', '?', '#'])
+        .next()
+        .unwrap_or(after_userinfo);
+    // Strip the port. Handle a bracketed IPv6 literal (`[::1]:port`) so the
+    // ':' inside the address is not mistaken for the port separator.
+    let host = if let Some(rest) = hostport.strip_prefix('[') {
+        match rest.find(']') {
+            Some(end) => &rest[..end],
+            None => rest,
+        }
+    } else {
+        match hostport.find(':') {
+            Some(i) => &hostport[..i],
+            None => hostport,
+        }
+    };
+    let host = host.trim();
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_ascii_lowercase())
+    }
+}
+
+/// Read the set of configured egress-proxy host tokens from the environment,
+/// covering all six proxy vars (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` in
+/// upper and lower case). Hosts are lowercased for case-insensitive exact
+/// matching. Empty when no proxy env is set (resolver stays fail-closed).
+pub(crate) fn configured_proxy_hosts() -> HashSet<String> {
+    const VARS: [&str; 6] = [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ];
+    let mut set = HashSet::new();
+    for var in VARS {
+        if let Ok(val) = std::env::var(var) {
+            if let Some(host) = proxy_host_token(&val) {
+                set.insert(host);
+            }
+        }
+    }
+    set
+}
+
+/// EXACT full-host, case-insensitive membership test against the proxy
+/// exempt-set. An empty set always returns false (no proxy configured ⇒ the
+/// resolver is fully fail-closed). No subdomain/suffix/prefix matching:
+/// `proxy.corp.attacker.com` and `10.0.0.5.attacker.com` are NOT exempted
+/// by a `proxy.corp` / `10.0.0.5` entry.
+fn host_is_exempt(exempt: &HashSet<String>, host: &str) -> bool {
+    !exempt.is_empty() && exempt.contains(host.to_ascii_lowercase().as_str())
 }
 
 /// Convenience: an `Arc<dyn Resolve>` for `ClientBuilder::dns_resolver` that
 /// blocks every private/internal address (upstream / remote-proxy — the
 /// fail-closed default).
 pub fn ssrf_guard_resolver() -> Arc<dyn Resolve> {
-    Arc::new(SsrfGuardResolver::default())
+    Arc::new(SsrfGuardResolver::with_mode(ResolverMode::Upstream))
 }
 
 /// `Arc<dyn Resolve>` for trusted operator-configured internal-service
 /// clients (e.g. the scanner-adapter): permits private/CGNAT/ULA targets but
 /// retains the metadata/loopback/link-local hard-blocks (issue #2389).
 pub fn ssrf_guard_resolver_internal() -> Arc<dyn Resolve> {
-    Arc::new(SsrfGuardResolver {
-        mode: ResolverMode::TrustedInternal,
-    })
+    Arc::new(SsrfGuardResolver::with_mode(ResolverMode::TrustedInternal))
 }
 
 /// `Arc<dyn Resolve>` for webhook-delivery clients: private/CGNAT/ULA
@@ -71,9 +183,7 @@ pub fn ssrf_guard_resolver_internal() -> Arc<dyn Resolve> {
 /// `WEBHOOK_ALLOW_PRIVATE_IPS` or `AK_SSRF_ALLOW_PRIVATE_CIDRS`; the
 /// metadata/loopback/link-local hard-blocks always apply (issue #2380).
 pub fn ssrf_guard_resolver_webhook() -> Arc<dyn Resolve> {
-    Arc::new(SsrfGuardResolver {
-        mode: ResolverMode::Webhook,
-    })
+    Arc::new(SsrfGuardResolver::with_mode(ResolverMode::Webhook))
 }
 
 /// `Arc<dyn Resolve>` for SSO/OIDC-fetch clients: private/CGNAT/ULA
@@ -81,9 +191,7 @@ pub fn ssrf_guard_resolver_webhook() -> Arc<dyn Resolve> {
 /// `SSO_ALLOW_PRIVATE_IPS` or `AK_SSRF_ALLOW_PRIVATE_CIDRS`; the
 /// metadata/loopback/link-local hard-blocks always apply (issue #2380).
 pub fn ssrf_guard_resolver_sso() -> Arc<dyn Resolve> {
-    Arc::new(SsrfGuardResolver {
-        mode: ResolverMode::SsoDiscovery,
-    })
+    Arc::new(SsrfGuardResolver::with_mode(ResolverMode::SsoDiscovery))
 }
 
 /// True when a resolved IP must be dropped for the given [`ResolverMode`].
@@ -115,12 +223,35 @@ fn filter_allowed(
 impl Resolve for SsrfGuardResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let mode = self.mode;
+        // Exempt the configured egress-proxy host (issue #2570): matched by
+        // EXACT full-host equality BEFORE the mode-specific filter. Computed
+        // here (sync, outside the future) so no reference into `self` is held.
+        let exempt = self.is_exempt_proxy_host(name.as_str());
         Box::pin(async move {
             let host = name.as_str().to_string();
             // Port 0 is a placeholder; reqwest substitutes the real port.
             let resolved = tokio::net::lookup_host((host.as_str(), 0)).await?;
+            if exempt {
+                // Operator-configured egress proxy: return every resolved
+                // address UNFILTERED so the proxy's own (often private)
+                // address is reachable. This is keyed on the exact proxy
+                // host token only and never widens the guard for any other
+                // target.
+                let addrs: Addrs = Box::new(resolved.collect::<Vec<SocketAddr>>().into_iter());
+                return Ok(addrs);
+            }
             let allowed: Vec<SocketAddr> = filter_allowed(mode, resolved);
             if allowed.is_empty() {
+                // Previously invisible: an outbound fetch that fails closed
+                // here surfaces to the caller as an opaque connect error.
+                // Log it (security target) so operators can see WHICH host
+                // and mode tripped the guard (issue #2570 diagnostics).
+                tracing::warn!(
+                    target: "security",
+                    host = %host,
+                    mode = ?mode,
+                    "SSRF DNS guard blocked all resolved addresses for host"
+                );
                 let err: Box<dyn std::error::Error + Send + Sync> = Box::new(std::io::Error::new(
                     std::io::ErrorKind::PermissionDenied,
                     "all resolved addresses blocked by SSRF policy",
@@ -263,6 +394,7 @@ mod tests {
         let name: Name = "10.0.0.5".parse().expect("valid dns name");
         let mut addrs = SsrfGuardResolver {
             mode: ResolverMode::TrustedInternal,
+            ..Default::default()
         }
         .resolve(name)
         .await
@@ -417,6 +549,7 @@ mod tests {
         let name: Name = "10.0.0.5".parse().expect("valid dns name");
         let result = SsrfGuardResolver {
             mode: ResolverMode::Webhook,
+            ..Default::default()
         }
         .resolve(name)
         .await;
@@ -436,6 +569,7 @@ mod tests {
         let name: Name = "10.0.0.5".parse().expect("valid dns name");
         let result = SsrfGuardResolver {
             mode: ResolverMode::SsoDiscovery,
+            ..Default::default()
         }
         .resolve(name)
         .await;
@@ -453,6 +587,7 @@ mod tests {
             let name: Name = host.parse().expect("valid dns name");
             let result = SsrfGuardResolver {
                 mode: ResolverMode::TrustedInternal,
+                ..Default::default()
             }
             .resolve(name)
             .await;
@@ -461,5 +596,201 @@ mod tests {
                 "internal resolver must still refuse hard-blocked host {host}"
             );
         }
+    }
+
+    // ---- Proxy-host exemption (issue #2570) ----------------------------
+
+    /// All six proxy env vars, so `with_proxy_env` can clear the full set
+    /// before applying the ones a test cares about.
+    const PROXY_VARS: [&str; 6] = [
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+    ];
+
+    /// Run `f` with ONLY the given proxy env vars set (all six cleared
+    /// first), restoring the prior values afterwards. Shares [`ENV_LOCK`]
+    /// with `with_toggles` so proxy-env and private-IP-toggle tests never
+    /// race each other's process-wide env under `cargo test`.
+    fn with_proxy_env<R>(set: &[(&str, &str)], f: impl FnOnce() -> R) -> R {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let prev: Vec<(&str, Option<String>)> = PROXY_VARS
+            .iter()
+            .map(|v| (*v, std::env::var(v).ok()))
+            .collect();
+        for v in PROXY_VARS {
+            std::env::remove_var(v);
+        }
+        for (k, val) in set {
+            std::env::set_var(k, val);
+        }
+        let out = f();
+        for (k, val) in prev {
+            match val {
+                Some(v) => std::env::set_var(k, v),
+                None => std::env::remove_var(k),
+            }
+        }
+        out
+    }
+
+    fn exempt_set(hosts: &[&str]) -> HashSet<String> {
+        hosts.iter().map(|h| h.to_string()).collect()
+    }
+
+    #[test]
+    fn proxy_host_token_parses_scheme_creds_and_port() {
+        assert_eq!(
+            proxy_host_token("http://user:pass@proxy.corp:3128").as_deref(),
+            Some("proxy.corp")
+        );
+        assert_eq!(
+            proxy_host_token("https://Proxy.Corp:8080").as_deref(),
+            Some("proxy.corp"),
+            "host must be lowercased"
+        );
+        assert_eq!(
+            proxy_host_token("proxy.corp").as_deref(),
+            Some("proxy.corp")
+        );
+        assert_eq!(
+            proxy_host_token("http://10.0.0.5:3128").as_deref(),
+            Some("10.0.0.5")
+        );
+        assert_eq!(
+            proxy_host_token("http://user:p%40ss@10.0.0.5:3128/path?q=1").as_deref(),
+            Some("10.0.0.5"),
+            "userinfo/path/query must be stripped"
+        );
+        assert_eq!(
+            proxy_host_token("http://[fd00::1]:3128").as_deref(),
+            Some("fd00::1"),
+            "bracketed IPv6 literal keeps its inner colons"
+        );
+        assert_eq!(proxy_host_token("").as_deref(), None);
+        assert_eq!(proxy_host_token("   ").as_deref(), None);
+    }
+
+    #[test]
+    fn configured_proxy_hosts_reads_all_six_vars() {
+        with_proxy_env(
+            &[
+                ("HTTP_PROXY", "http://a.example:3128"),
+                ("http_proxy", "http://b.example:3128"),
+                ("HTTPS_PROXY", "https://c.example:3128"),
+                ("https_proxy", "https://d.example:3128"),
+                ("ALL_PROXY", "socks5://e.example:1080"),
+                ("all_proxy", "socks5://f.example:1080"),
+            ],
+            || {
+                let hosts = configured_proxy_hosts();
+                for h in [
+                    "a.example",
+                    "b.example",
+                    "c.example",
+                    "d.example",
+                    "e.example",
+                    "f.example",
+                ] {
+                    assert!(hosts.contains(h), "expected {h} in {hosts:?}");
+                }
+            },
+        );
+    }
+
+    #[test]
+    fn configured_proxy_hosts_empty_when_no_env() {
+        with_proxy_env(&[], || {
+            assert!(
+                configured_proxy_hosts().is_empty(),
+                "no proxy env ⇒ empty exempt-set (fail-closed)"
+            );
+        });
+    }
+
+    #[test]
+    fn host_is_exempt_exact_and_case_insensitive() {
+        let set = exempt_set(&["proxy.corp", "10.0.0.5"]);
+        assert!(host_is_exempt(&set, "proxy.corp"));
+        assert!(host_is_exempt(&set, "PROXY.CORP"), "case-insensitive");
+        assert!(host_is_exempt(&set, "Proxy.Corp"));
+        assert!(host_is_exempt(&set, "10.0.0.5"), "IP literal exact match");
+    }
+
+    #[test]
+    fn host_is_exempt_empty_set_always_false() {
+        let empty = HashSet::new();
+        assert!(!host_is_exempt(&empty, "proxy.corp"));
+        assert!(!host_is_exempt(&empty, "10.0.0.5"));
+    }
+
+    #[test]
+    fn host_is_exempt_rejects_subdomain_suffix_prefix() {
+        let set = exempt_set(&["proxy.corp", "10.0.0.5"]);
+        // Subdomain / suffix / prefix must NOT match — the whole point of the
+        // security invariant (rt-ssrf-peer-replication attacks these).
+        assert!(!host_is_exempt(&set, "proxy.corp.attacker.com"));
+        assert!(!host_is_exempt(&set, "evil.proxy.corp"));
+        assert!(!host_is_exempt(&set, "proxy.corpX"));
+        assert!(!host_is_exempt(&set, "Xproxy.corp"));
+        assert!(!host_is_exempt(&set, "10.0.0.5.attacker.com"));
+        assert!(!host_is_exempt(&set, "10.0.0.50"));
+    }
+
+    /// CORE: a resolver whose exempt-set contains the private literal
+    /// `10.0.0.5` (as if it were the configured proxy) must RESOLVE it even
+    /// in the fail-closed Upstream mode — the proxy address is reachable.
+    #[tokio::test]
+    async fn exempt_proxy_host_resolves_private_literal_in_upstream_mode() {
+        let name: Name = "10.0.0.5".parse().expect("valid dns name");
+        let resolver = SsrfGuardResolver {
+            mode: ResolverMode::Upstream,
+            exempt_proxy_hosts: exempt_set(&["10.0.0.5"]),
+        };
+        let mut addrs = resolver
+            .resolve(name)
+            .await
+            .expect("an exempt proxy host must resolve even at a private IP");
+        assert!(
+            addrs.next().is_some(),
+            "expected at least one (unfiltered) address for the exempt proxy host"
+        );
+    }
+
+    /// Fail-closed regression guard: with an EMPTY exempt-set the same private
+    /// literal must still be refused in Upstream mode (byte-for-byte the
+    /// pre-#2570 behavior).
+    #[tokio::test]
+    async fn empty_exempt_set_still_blocks_private_literal() {
+        let name: Name = "10.0.0.5".parse().expect("valid dns name");
+        let resolver = SsrfGuardResolver {
+            mode: ResolverMode::Upstream,
+            ..Default::default()
+        };
+        let result = resolver.resolve(name).await;
+        assert!(
+            result.is_err(),
+            "empty exempt-set must stay fail-closed for a private literal"
+        );
+    }
+
+    /// Direct-target-still-blocked: a proxy at `proxy.corp` is exempt, but a
+    /// DIFFERENT private upstream (`10.0.0.5`, e.g. a NO_PROXY direct target)
+    /// must STILL be refused even while the proxy is configured.
+    #[tokio::test]
+    async fn other_private_target_blocked_when_only_proxy_host_exempt() {
+        let name: Name = "10.0.0.5".parse().expect("valid dns name");
+        let resolver = SsrfGuardResolver {
+            mode: ResolverMode::Upstream,
+            exempt_proxy_hosts: exempt_set(&["proxy.corp"]),
+        };
+        let result = resolver.resolve(name).await;
+        assert!(
+            result.is_err(),
+            "a non-proxy private target must stay blocked when only the proxy host is exempt"
+        );
     }
 }


### PR DESCRIPTION
## Summary

When an outbound egress proxy is configured (`HTTP_PROXY` / `HTTPS_PROXY` /
`ALL_PROXY`), remote-repository fetches failed with `502`/`500` in deployments
where the proxy is reached at a private/internal address (the common corporate
topology: a proxy on an RFC1918 or loopback address). The fail-closed SSRF DNS
guard (`SsrfGuardResolver`) resolves **every** outbound hostname — including the
proxy's own host — and drops private/internal addresses. Because the proxy is
resolved through the same guard, its legitimate private address was dropped and
the connection to the proxy never happened, so no upstream fetch could succeed.

This change adds a narrowly-scoped exemption: the resolver skips the SSRF filter
**only** for the exact configured egress-proxy host token(s), read once at
construction from the proxy environment. Everything else keeps the existing
fail-closed behavior byte-for-byte.

### What changed
- `ssrf_dns.rs`: `SsrfGuardResolver` gains a per-resolver `exempt_proxy_hosts`
  set, populated from a new `configured_proxy_hosts()` env reader that parses the
  host token out of the six proxy vars (upper/lower `HTTP_PROXY`/`HTTPS_PROXY`/
  `ALL_PROXY`), handling scheme, optional `user:pass@` userinfo and `:port`
  (e.g. `http://user:pass@proxy.corp:3128` → `proxy.corp`). In `resolve()`, a host
  that matches an exempt entry by **exact, case-insensitive, full-host equality**
  is resolved and returned unfiltered, *before* the mode-specific filter. A
  `with_mode()` constructor funnels all four trust-class constructors (upstream /
  internal / webhook / SSO), mirroring the existing trust-class pattern.
- Diagnostics: when the guard drops **all** resolved addresses for a host
  (previously an opaque connect failure), it now emits a `warn` on the `security`
  target with the host and mode.
- `proxy_service.rs`: a single shared transport-error classifier, reused across
  the buffered / streaming / token-exchange fetch paths, maps an SSRF-guard
  connect failure to a clear `503` instead of a bare `Storage`→`500`. The
  message is proxy-specific ("egress proxy connection refused by SSRF egress
  policy …") **only when an egress proxy is configured**; a direct / `NO_PROXY`
  upstream that is SSRF-blocked gets a generic message ("connection to upstream
  refused by SSRF egress policy …") with no mention of a proxy, so triage is not
  misled. Either way it is a `503` carrying only the redacted URL (never proxy
  creds/IP). Any other (non-SSRF) transport error keeps the existing mapping.
- No migration; no API/schema change.

### Scope of the exemption (security invariants, all covered by tests)
The exemption is keyed on the exact configured proxy **host token** only. It does
NOT:
- relax the guard for any other private target — a direct/`NO_PROXY` upstream at a
  private IP stays blocked even when a proxy is configured;
- exempt anything when no proxy env is set (exempt-set empty → resolver is
  byte-for-byte the pre-existing fail-closed guard);
- match subdomains/suffixes/prefixes (`proxy.corp.attacker.com`,
  `10.0.0.5.attacker.com` are not exempted);
- widen the loopback / link-local / cloud-metadata hard-blocks for the
  webhook / SSO / internal trust classes.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added tests:
- `ssrf_dns.rs`: exact / case-insensitive / IP-literal match true; empty exempt-set
  always false; subdomain/suffix/prefix false; `proxy_host_token` parses
  scheme+creds+port+IPv6; `configured_proxy_hosts` reads all six env vars and is
  empty with none set; resolver with `proxy_hosts=['10.0.0.5']` resolves
  `10.0.0.5` in Upstream mode; empty exempt-set still blocks `10.0.0.5`
  (fail-closed regression guard); proxy-host exempt does not unblock a different
  private target.
- `http_client.rs`: a positive integration test (configured proxy **hostname** is
  reached through the guard) plus a **discriminating negative** (an unexempted
  proxy hostname is refused by the resolver before any TCP connect) — together
  these prove the resolver is on the proxy path and the exemption is load-bearing.
- `proxy_service.rs`: classifier units — SSRF-block-with-proxy → proxy-specific
  `503`; no-proxy SSRF-block → generic (non-proxy) `503`; generic upstream error
  → existing `Storage` path.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Manual verification (on the equivalent, byte-for-byte verified source) used an
isolated tinyproxy bound at a private (RFC1918) address in front of the patched
image: an uncached npm/maven/pypi remote fetch returns `200` (previously `502`),
with the proxy access log confirming the fetch routed through the proxy; a direct
`NO_PROXY` private-IP upstream and a private-IP upstream with no proxy configured
both stay blocked. On this branch the full CI test runner
(`cargo nextest run --workspace --lib`) and `cargo clippy --workspace
--all-targets -- -D warnings` are both green.

## API Changes
- [x] N/A - no API changes

---

Lands on `main` first per the main-first policy (release-branch PRs must be
cherry-picks of `main` commits). Cherry-picks cleanly onto `release/1.5.x` for the
v1.5.8 hotfix, alongside #2457; the file sets are disjoint (this PR touches
`http_client.rs` / `ssrf_dns.rs` / `proxy_service.rs`).

Closes #2570
