### PR TITLE
fix(rpm): align primary.xml package location with the hosted packages route for generically-uploaded RPMs

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -2637,20 +2637,10 @@ pub async fn local_fetch_by_path_suffix(
     location: &StorageLocation,
     path_suffix: &str,
 ) -> Result<StreamingFetchResult, Response> {
-    let reversed_pattern = reverse_suffix_for_like(path_suffix);
-    let path: String = sqlx::query_scalar(
-        "SELECT path FROM artifacts \
-         WHERE repository_id = $1 \
-           AND reverse(path) LIKE $2 || '%' ESCAPE '\\' \
-           AND is_deleted = false \
-         LIMIT 1",
-    )
-    .bind(repo_id)
-    .bind(&reversed_pattern)
-    .fetch_optional(db)
-    .await
-    .map_err(|e| internal_error("Database", e))?
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
+    let path = resolve_local_artifact_by_suffix(db, repo_id, path_suffix)
+        .await?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?
+        .path;
 
     local_fetch_by_path(db, state, repo_id, location, &path).await
 }
@@ -2672,20 +2662,10 @@ pub async fn local_fetch_or_redirect_by_suffix(
     path_suffix: &str,
     ctx: &crate::api::middleware::download_telemetry::DownloadContext,
 ) -> Result<Response, Response> {
-    let reversed_pattern = reverse_suffix_for_like(path_suffix);
-    let path: String = sqlx::query_scalar(
-        "SELECT path FROM artifacts \
-         WHERE repository_id = $1 \
-           AND reverse(path) LIKE $2 || '%' ESCAPE '\\' \
-           AND is_deleted = false \
-         LIMIT 1",
-    )
-    .bind(repo_id)
-    .bind(&reversed_pattern)
-    .fetch_optional(db)
-    .await
-    .map_err(|e| internal_error("Database", e))?
-    .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?;
+    let path = resolve_local_artifact_by_suffix(db, repo_id, path_suffix)
+        .await?
+        .ok_or_else(|| (StatusCode::NOT_FOUND, "Artifact not found").into_response())?
+        .path;
 
     local_fetch_or_redirect(db, state, repo_id, location, &path, ctx).await
 }
@@ -2710,6 +2690,70 @@ fn reverse_suffix_for_like(path_suffix: &str) -> String {
     with_slash.push_str(path_suffix);
     let reversed: String = with_slash.chars().rev().collect();
     super::escape_like_literal(&reversed)
+}
+
+/// Row resolved by [`resolve_local_artifact_by_suffix`].
+struct ResolvedLocalArtifact {
+    id: Uuid,
+    path: String,
+    storage_key: String,
+}
+
+/// Resolve a single local artifact by trailing path-suffix, with an
+/// exact-path fallback for artifacts stored at their bare (root) path.
+///
+/// The primary lookup is the indexed reverse-suffix LIKE, which matches
+/// `path` values ending in `/<suffix>` — i.e. every artifact stored under a
+/// directory. Artifacts uploaded through the generic flow are stored at their
+/// bare filename (no leading directory), so the `'/'`-anchored suffix pattern
+/// never matches them. On a suffix MISS we retry with an exact `path = $suffix`
+/// match to resolve those root-stored artifacts.
+///
+/// The fallback fires ONLY on a suffix miss, so any lookup that already
+/// succeeded returns the identical row and every currently-passing caller is
+/// unaffected. The exact match also can't produce a substring false positive
+/// (a request for `b.rpm` will not resolve a root-stored `ab.rpm`).
+async fn resolve_local_artifact_by_suffix(
+    db: &PgPool,
+    repository_id: Uuid,
+    path_suffix: &str,
+) -> Result<Option<ResolvedLocalArtifact>, Response> {
+    use sqlx::Row;
+    let reversed_pattern = reverse_suffix_for_like(path_suffix);
+    let row = sqlx::query(
+        "SELECT id, path, storage_key FROM artifacts \
+         WHERE repository_id = $1 \
+           AND is_deleted = false \
+           AND reverse(path) LIKE $2 || '%' ESCAPE '\\' \
+         LIMIT 1",
+    )
+    .bind(repository_id)
+    .bind(&reversed_pattern)
+    .fetch_optional(db)
+    .await
+    .map_err(|e| internal_error("Database", e))?;
+
+    let row = match row {
+        Some(r) => Some(r),
+        None => sqlx::query(
+            "SELECT id, path, storage_key FROM artifacts \
+             WHERE repository_id = $1 \
+               AND is_deleted = false \
+               AND path = $2 \
+             LIMIT 1",
+        )
+        .bind(repository_id)
+        .bind(path_suffix)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| internal_error("Database", e))?,
+    };
+
+    Ok(row.map(|r| ResolvedLocalArtifact {
+        id: r.try_get("id").unwrap_or_default(),
+        path: r.try_get("path").unwrap_or_default(),
+        storage_key: r.try_get("storage_key").unwrap_or_default(),
+    }))
 }
 
 /// Look up a local artifact by path and return a presigned redirect if the
@@ -3740,25 +3784,14 @@ pub async fn find_local_by_filename_suffix(
     repository_id: Uuid,
     path_suffix: &str,
 ) -> Result<Option<LocalArtifactHit>, Response> {
-    use sqlx::Row;
-    let reversed_pattern = reverse_suffix_for_like(path_suffix);
-    let row = sqlx::query(
-        "SELECT id, storage_key FROM artifacts \
-         WHERE repository_id = $1 \
-           AND is_deleted = false \
-           AND reverse(path) LIKE $2 || '%' ESCAPE '\\' \
-         LIMIT 1",
+    Ok(
+        resolve_local_artifact_by_suffix(db, repository_id, path_suffix)
+            .await?
+            .map(|r| LocalArtifactHit {
+                id: r.id,
+                storage_key: r.storage_key,
+            }),
     )
-    .bind(repository_id)
-    .bind(&reversed_pattern)
-    .fetch_optional(db)
-    .await
-    .map_err(|e| internal_error("Database", e))?;
-
-    Ok(row.map(|r| LocalArtifactHit {
-        id: r.try_get("id").unwrap_or_default(),
-        storage_key: r.try_get("storage_key").unwrap_or_default(),
-    }))
 }
 
 /// Parse a two-field multipart upload (`file` + a named JSON metadata field).
@@ -7584,6 +7617,121 @@ mod tests {
         db_helpers::cleanup(&pool, repo_id, user_id).await;
     }
 
+    #[tokio::test]
+    async fn test_find_local_by_filename_suffix_root_stored_exact_fallback() {
+        // #2580: an artifact stored at its bare (root) path — as produced by the
+        // generic upload flow — is not matched by the '/'-anchored suffix LIKE.
+        // The exact-path fallback resolves it by filename.
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _, _) = db_helpers::create_repo(&pool, "local", "rpm").await;
+
+        let id = insert_artifact(
+            &pool,
+            NewArtifact {
+                repository_id: repo_id,
+                path: "hello-1.0-1.x86_64.rpm",
+                name: "hello",
+                version: "1.0-1",
+                size_bytes: 5,
+                checksum_sha256: "x",
+                content_type: "application/x-rpm",
+                storage_key: "rpm/hello/hello-1.0-1.x86_64.rpm",
+                uploaded_by: user_id,
+            },
+        )
+        .await
+        .expect("insert");
+
+        let hit = find_local_by_filename_suffix(&pool, repo_id, "hello-1.0-1.x86_64.rpm")
+            .await
+            .expect("find")
+            .expect("root-stored artifact must resolve via exact fallback");
+        assert_eq!(hit.id, id);
+        assert_eq!(hit.storage_key, "rpm/hello/hello-1.0-1.x86_64.rpm");
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_find_local_by_filename_suffix_hit_wins_over_fallback() {
+        // When the suffix LIKE hits, the exact-path fallback must NOT fire: the
+        // directory-stored row is returned, identical to pre-fix behaviour.
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _, _) = db_helpers::create_repo(&pool, "local", "rpm").await;
+
+        let dir_id = insert_artifact(
+            &pool,
+            NewArtifact {
+                repository_id: repo_id,
+                path: "packages/hello-1.0-1.x86_64.rpm",
+                name: "hello",
+                version: "1.0-1",
+                size_bytes: 5,
+                checksum_sha256: "x",
+                content_type: "application/x-rpm",
+                storage_key: "rpm/hello/packages.rpm",
+                uploaded_by: user_id,
+            },
+        )
+        .await
+        .expect("insert dir");
+
+        let hit = find_local_by_filename_suffix(&pool, repo_id, "hello-1.0-1.x86_64.rpm")
+            .await
+            .expect("find")
+            .expect("some");
+        assert_eq!(
+            hit.id, dir_id,
+            "suffix hit must return the directory-stored row, not fire the fallback"
+        );
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_find_local_by_filename_suffix_no_substring_false_positive() {
+        // The exact fallback must not substring-match: a request for `b.rpm`
+        // must NOT resolve a root-stored `ab.rpm`.
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _, _) = db_helpers::create_repo(&pool, "local", "rpm").await;
+
+        let _ = insert_artifact(
+            &pool,
+            NewArtifact {
+                repository_id: repo_id,
+                path: "ab.rpm",
+                name: "ab",
+                version: "1",
+                size_bytes: 1,
+                checksum_sha256: "x",
+                content_type: "application/x-rpm",
+                storage_key: "rpm/ab/ab.rpm",
+                uploaded_by: user_id,
+            },
+        )
+        .await
+        .expect("insert");
+
+        let miss = find_local_by_filename_suffix(&pool, repo_id, "b.rpm")
+            .await
+            .expect("ok");
+        assert!(
+            miss.is_none(),
+            "`b.rpm` must not substring-match root-stored `ab.rpm`"
+        );
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
     // ── ensure_unique_artifact_path ──────────────────────────────────────
 
     #[tokio::test]
@@ -8131,6 +8279,126 @@ mod tests {
             .expect("fetch suffix");
         let content2 = result2.collect().await.unwrap();
         assert_eq!(&content2[..], b"abc123");
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_local_fetch_by_path_suffix_root_stored_and_false_positive() {
+        // #2580: a root-stored artifact (generic upload) resolves by filename
+        // through the exact-path fallback; a substring must NOT false-positive.
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _, storage_dir) = db_helpers::create_repo(&pool, "local", "rpm").await;
+        let state = db_helpers::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let repo = RepoInfo {
+            id: repo_id,
+            key: "irrelevant".to_string(),
+            storage_path: storage_dir.to_string_lossy().into_owned(),
+            storage_backend: "filesystem".to_string(),
+            repo_type: "local".to_string(),
+            upstream_url: None,
+            format: "rpm".to_string(),
+            promotion_only: false,
+            age_gate_enabled: false,
+            age_gate_min_age_days: 7,
+        };
+        let bytes = Bytes::from_static(b"rpmbytes");
+        put_artifact_bytes(&state, &repo, "rpm/ab.rpm", bytes.clone())
+            .await
+            .expect("put");
+
+        // Root-stored bare path (no leading directory).
+        let _ = insert_artifact(
+            &pool,
+            NewArtifact {
+                repository_id: repo_id,
+                path: "ab.rpm",
+                name: "ab",
+                version: "1",
+                size_bytes: bytes.len() as i64,
+                checksum_sha256: "x",
+                content_type: "application/x-rpm",
+                storage_key: "rpm/ab.rpm",
+                uploaded_by: user_id,
+            },
+        )
+        .await
+        .expect("insert");
+
+        let location = repo.storage_location();
+
+        // Exact fallback resolves the root-stored artifact by its full filename.
+        let ok = local_fetch_by_path_suffix(&pool, &state, repo_id, &location, "ab.rpm")
+            .await
+            .expect("root-stored artifact must resolve");
+        let content = ok.collect().await.unwrap();
+        assert_eq!(&content[..], b"rpmbytes");
+
+        // Substring must NOT match: `b.rpm` != root-stored `ab.rpm`.
+        let miss = local_fetch_by_path_suffix(&pool, &state, repo_id, &location, "b.rpm").await;
+        assert!(
+            miss.is_err(),
+            "`b.rpm` must not substring-match root-stored `ab.rpm`"
+        );
+
+        db_helpers::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    #[tokio::test]
+    async fn test_local_fetch_by_path_suffix_hit_wins_over_fallback() {
+        // A directory-stored artifact still resolves via the suffix LIKE; the
+        // exact-path fallback does not shadow it.
+        let Some(pool) = db_helpers::try_pool().await else {
+            return;
+        };
+        let user_id = db_helpers::create_user(&pool).await;
+        let (repo_id, _, storage_dir) = db_helpers::create_repo(&pool, "local", "rpm").await;
+        let state = db_helpers::build_state(pool.clone(), storage_dir.to_str().unwrap());
+
+        let repo = RepoInfo {
+            id: repo_id,
+            key: "irrelevant".to_string(),
+            storage_path: storage_dir.to_string_lossy().into_owned(),
+            storage_backend: "filesystem".to_string(),
+            repo_type: "local".to_string(),
+            upstream_url: None,
+            format: "rpm".to_string(),
+            promotion_only: false,
+            age_gate_enabled: false,
+            age_gate_min_age_days: 7,
+        };
+        let bytes = Bytes::from_static(b"dirbytes");
+        put_artifact_bytes(&state, &repo, "rpm/packages/hello.rpm", bytes.clone())
+            .await
+            .expect("put");
+
+        let _ = insert_artifact(
+            &pool,
+            NewArtifact {
+                repository_id: repo_id,
+                path: "packages/hello.rpm",
+                name: "hello",
+                version: "1",
+                size_bytes: bytes.len() as i64,
+                checksum_sha256: "x",
+                content_type: "application/x-rpm",
+                storage_key: "rpm/packages/hello.rpm",
+                uploaded_by: user_id,
+            },
+        )
+        .await
+        .expect("insert");
+
+        let location = repo.storage_location();
+        let ok = local_fetch_by_path_suffix(&pool, &state, repo_id, &location, "hello.rpm")
+            .await
+            .expect("directory-stored artifact must resolve via suffix");
+        let content = ok.collect().await.unwrap();
+        assert_eq!(&content[..], b"dirbytes");
 
         db_helpers::cleanup(&pool, repo_id, user_id).await;
     }

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1033,6 +1033,17 @@ fn generate_primary_xml(artifacts: &[RpmArtifact]) -> String {
             )
         };
 
+        // The hosted RPM route serves packages under `packages/<file>` (see the
+        // `/rpm/{repo}/{path}` handler). Artifacts uploaded through the native
+        // RPM PUT already carry a `packages/`-prefixed path, but ones pushed via
+        // the generic upload flow are stored at their bare path. Emit a location
+        // that always matches the download route so both upload paths resolve.
+        let location = if artifact.path.starts_with("packages/") {
+            artifact.path.clone()
+        } else {
+            format!("packages/{filename}")
+        };
+
         xml.push_str(&format!(
             r#"  <package type="rpm">
     <name>{name}</name>
@@ -1051,7 +1062,7 @@ fn generate_primary_xml(artifacts: &[RpmArtifact]) -> String {
             checksum = artifact.checksum_sha256,
             summary = xml_escape(&summary),
             size = artifact.size_bytes,
-            location = xml_escape(&artifact.path),
+            location = xml_escape(&location),
         ));
     }
 
@@ -1787,6 +1798,91 @@ mod tests {
         }];
         let xml = generate_primary_xml(&artifacts);
         assert!(xml.contains("test&lt;pkg&gt;"));
+    }
+
+    // The <location href> must match the hosted download route (`packages/<file>`)
+    // regardless of how the artifact was stored (native PUT vs. generic upload).
+    #[test]
+    fn test_generate_primary_xml_bare_path_location_prefixed() {
+        let artifacts = vec![RpmArtifact {
+            id: uuid::Uuid::new_v4(),
+            path: "hello-1.0-1.x86_64.rpm".to_string(),
+            name: "hello".to_string(),
+            version: Some("1.0-1".to_string()),
+            size_bytes: 1024,
+            checksum_sha256: "abc123".to_string(),
+            storage_key: "rpm/1/hello.rpm".to_string(),
+            metadata: None,
+        }];
+        let xml = generate_primary_xml(&artifacts);
+        assert!(
+            xml.contains(r#"<location href="packages/hello-1.0-1.x86_64.rpm"/>"#),
+            "bare-path RPM must emit a packages/-prefixed href: {xml}"
+        );
+    }
+
+    #[test]
+    fn test_generate_primary_xml_nested_non_packages_path_uses_basename() {
+        let artifacts = vec![RpmArtifact {
+            id: uuid::Uuid::new_v4(),
+            path: "some/nested/dir/hello-1.0-1.x86_64.rpm".to_string(),
+            name: "hello".to_string(),
+            version: Some("1.0-1".to_string()),
+            size_bytes: 1024,
+            checksum_sha256: "abc123".to_string(),
+            storage_key: "rpm/1/hello.rpm".to_string(),
+            metadata: None,
+        }];
+        let xml = generate_primary_xml(&artifacts);
+        assert!(
+            xml.contains(r#"<location href="packages/hello-1.0-1.x86_64.rpm"/>"#),
+            "nested non-packages path must map to packages/<basename>: {xml}"
+        );
+    }
+
+    // Regression pin: a native `packages/`-prefixed path must be emitted
+    // byte-for-byte identically (no double-prefixing, no rewrite).
+    #[test]
+    fn test_generate_primary_xml_native_packages_path_location_identical() {
+        let artifacts = vec![RpmArtifact {
+            id: uuid::Uuid::new_v4(),
+            path: "packages/hello-1.0-1.x86_64.rpm".to_string(),
+            name: "hello".to_string(),
+            version: Some("1.0-1".to_string()),
+            size_bytes: 1024,
+            checksum_sha256: "abc123".to_string(),
+            storage_key: "rpm/1/hello.rpm".to_string(),
+            metadata: None,
+        }];
+        let xml = generate_primary_xml(&artifacts);
+        assert!(
+            xml.contains(r#"<location href="packages/hello-1.0-1.x86_64.rpm"/>"#),
+            "native packages/ path must be emitted verbatim: {xml}"
+        );
+        assert!(
+            !xml.contains("packages/packages/"),
+            "native packages/ path must not be double-prefixed: {xml}"
+        );
+    }
+
+    // xml_escape must still apply to the computed location.
+    #[test]
+    fn test_generate_primary_xml_location_is_xml_escaped() {
+        let artifacts = vec![RpmArtifact {
+            id: uuid::Uuid::new_v4(),
+            path: "weird&name-1.0-1.x86_64.rpm".to_string(),
+            name: "weird".to_string(),
+            version: Some("1.0-1".to_string()),
+            size_bytes: 1024,
+            checksum_sha256: "abc123".to_string(),
+            storage_key: "rpm/1/weird.rpm".to_string(),
+            metadata: None,
+        }];
+        let xml = generate_primary_xml(&artifacts);
+        assert!(
+            xml.contains(r#"<location href="packages/weird&amp;name-1.0-1.x86_64.rpm"/>"#),
+            "location must be xml-escaped: {xml}"
+        );
     }
 
     #[test]

--- a/scripts/e2e-syspkg/test-rpm.sh
+++ b/scripts/e2e-syspkg/test-rpm.sh
@@ -120,4 +120,107 @@ echo "$INSTALLED_CONTENT" | grep -q "$TEST_VERSION" || fail "Version mismatch in
 log "Installed file content verified"
 
 echo ""
-echo "=== RPM/YUM E2E test PASSED ==="
+echo "=== RPM/YUM native-PUT E2E leg PASSED ==="
+
+# ============================================================================
+# Generic-push leg (#2580)
+# ----------------------------------------------------------------------------
+# CI previously only exercised the native RPM PUT (which stores the artifact
+# under `packages/<file>`). An RPM pushed through the GENERIC chunked upload
+# flow — exactly what `ak artifact push` does — is stored at its bare path, and
+# the on-demand primary.xml emitted a bare `<location href>` that did not match
+# the hosted `/rpm/{repo}/packages/<file>` download route, so `dnf install`
+# 404'd. This leg reproduces that path end-to-end and is the regression guard.
+# ============================================================================
+GEN_REPO="${REPO_KEY}-generic"
+RPM_BASENAME="$(basename "$RPM_FILE")"
+RPM_SIZE=$(stat -c%s "$RPM_FILE")
+RPM_SHA=$(sha256sum "$RPM_FILE" | awk '{print $1}')
+
+log "[generic] Setting up hosted rpm repo $GEN_REPO..."
+# TOKEN is already exported from the native leg's api_login.
+api_create_repo "$GEN_REPO" "rpm"
+api_create_signing_key
+api_configure_signing
+
+log "[generic] Creating upload session for $RPM_BASENAME (size=$RPM_SIZE)..."
+SESSION_JSON=$(curl -sf -X POST "$BACKEND_URL/api/v1/uploads" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'Content-Type: application/json' \
+    -d "{\"repository_key\":\"$GEN_REPO\",\"artifact_path\":\"$RPM_BASENAME\",\"total_size\":$RPM_SIZE,\"checksum_sha256\":\"$RPM_SHA\",\"content_type\":\"application/x-rpm\"}")
+SESSION_ID=$(echo "$SESSION_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['session_id'])" 2>/dev/null) \
+    || SESSION_ID=$(echo "$SESSION_JSON" | sed -n 's/.*"session_id":"\([^"]*\)".*/\1/p')
+[ -n "$SESSION_ID" ] || fail "[generic] no session id: $SESSION_JSON"
+log "[generic] Session: $SESSION_ID"
+
+log "[generic] Uploading chunk 0 (Content-Range bytes 0-$((RPM_SIZE-1))/$RPM_SIZE)..."
+CHUNK_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PATCH \
+    "$BACKEND_URL/api/v1/uploads/$SESSION_ID" \
+    -H "Authorization: Bearer $TOKEN" \
+    -H "Content-Range: bytes 0-$((RPM_SIZE-1))/$RPM_SIZE" \
+    -H "Content-Type: application/octet-stream" \
+    --data-binary "@$RPM_FILE")
+[ "$CHUNK_CODE" = "200" ] || [ "$CHUNK_CODE" = "201" ] || fail "[generic] chunk upload HTTP $CHUNK_CODE"
+
+log "[generic] Completing upload..."
+COMPLETE_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+    "$BACKEND_URL/api/v1/uploads/$SESSION_ID/complete" \
+    -H "Authorization: Bearer $TOKEN")
+[ "$COMPLETE_CODE" = "200" ] || [ "$COMPLETE_CODE" = "201" ] || fail "[generic] complete HTTP $COMPLETE_CODE"
+log "[generic] Upload complete"
+
+sleep 1
+
+log "[generic] Fetching + parsing primary.xml..."
+curl -sf "$BACKEND_URL/rpm/$GEN_REPO/repodata/primary.xml.gz" -o /tmp/generic-primary.xml.gz \
+    || fail "[generic] primary.xml.gz fetch failed"
+gunzip -f /tmp/generic-primary.xml.gz
+HREF=$(python3 -c "
+import re
+xml = open('/tmp/generic-primary.xml').read()
+m = re.search(r'<location href=\"([^\"]+)\"', xml)
+print(m.group(1) if m else '')
+")
+[ -n "$HREF" ] || fail "[generic] no <location href> in primary.xml"
+log "[generic] location href = $HREF"
+case "$HREF" in
+    packages/*) log "[generic] href correctly prefixed with packages/ (fix #2580)";;
+    *) fail "[generic] href not packages/-prefixed: '$HREF' (bug #2580)";;
+esac
+
+log "[generic] Downloading $HREF from the hosted route..."
+curl -sf "$BACKEND_URL/rpm/$GEN_REPO/$HREF" -o /tmp/generic-download.rpm \
+    || fail "[generic] GET $HREF failed — hosted route did not serve the generic RPM (bug #2580)"
+DL_SHA=$(sha256sum /tmp/generic-download.rpm | awk '{print $1}')
+[ "$DL_SHA" = "$RPM_SHA" ] || fail "[generic] downloaded sha256 mismatch ($DL_SHA != $RPM_SHA)"
+log "[generic] Downloaded bytes match the local RPM"
+
+XML_SHA=$(python3 -c "
+import re
+xml = open('/tmp/generic-primary.xml').read()
+m = re.search(r'<checksum type=\"sha256\"[^>]*>([0-9a-fA-F]+)</checksum>', xml)
+print(m.group(1) if m else '')
+")
+[ "$XML_SHA" = "$RPM_SHA" ] || fail "[generic] primary.xml checksum mismatch ($XML_SHA != $RPM_SHA)"
+log "[generic] primary.xml <checksum> matches the local RPM"
+
+log "[generic] Installing $PKG_NAME end-to-end from the generic repo..."
+# Remove the native-leg install and repo so the package can only come from the
+# generically-pushed copy.
+dnf remove -y "$PKG_NAME" > /dev/null 2>&1 || true
+rm -f /etc/yum.repos.d/e2e-registry.repo
+cat > /etc/yum.repos.d/e2e-generic.repo << EOF
+[e2e-generic]
+name=E2E Generic Push Registry
+baseurl=$BACKEND_URL/rpm/$GEN_REPO
+enabled=1
+gpgcheck=0
+EOF
+dnf clean all > /dev/null 2>&1
+dnf install -y "$PKG_NAME" 2>&1 | tail -8 || fail "[generic] dnf install of generically-pushed RPM failed"
+INSTALLED_CONTENT=$(cat "/opt/$PKG_NAME/test-file.txt" 2>/dev/null) || fail "[generic] installed file not found"
+echo "$INSTALLED_CONTENT" | grep -q "$TEST_VERSION" || fail "[generic] version mismatch in installed file"
+log "[generic] dnf install of the generically-pushed RPM succeeded"
+
+echo ""
+echo "=== RPM/YUM E2E test PASSED (native-PUT + generic-push) ==="


### PR DESCRIPTION
## Summary

Closes #2580.

An RPM pushed to a **hosted** RPM repository through the **generic chunked upload
flow** (`ak artifact push` → `POST /api/v1/uploads` → `PATCH .../{id}` →
`PUT .../{id}/complete`) is stored at its **bare artifact path** (e.g.
`hello-1.0-1.x86_64.rpm`), whereas the native RPM `PUT /rpm/{repo}/packages/{file}`
route stores it under `packages/{file}`.

Two independent effects of that bare path made a generically-pushed RPM
undownloadable, so `dnf install` 404'd:

1. **`primary.xml` advertised the wrong location.** `generate_primary_xml`
   emitted `<location href>` = the raw stored `path`, so clients were told to
   fetch the package at its bare path — a URL the hosted download route
   (`GET /rpm/{repo}/packages/*path`) does not serve.
2. **The hosted download route could not resolve the bare-path row.** The
   `/packages/{file}` handler resolves by filename via
   `find_local_by_filename_suffix`, whose indexed reverse-suffix `LIKE` is
   anchored on a leading `/` (`path ends with '/<file>'`). A root-stored
   artifact has no leading directory, so it never matched.

### Fix (serve-time, no migration — retroactive for all historical bare-path RPMs)

- **`rpm.rs::generate_primary_xml`** now computes the `<location href>` to match
  the hosted route: it keeps a `packages/`-prefixed stored path verbatim, and
  otherwise emits `packages/<filename>`. `xml_escape` is still applied.
- **`proxy_helpers.rs`**: the three suffix-resolvers
  (`find_local_by_filename_suffix`, `local_fetch_by_path_suffix`,
  `local_fetch_or_redirect_by_suffix`) now share one small private helper,
  `resolve_local_artifact_by_suffix`, that runs the existing indexed
  reverse-suffix `LIKE` and, **only on a miss**, falls back to an exact
  `path = $suffix` match. Every lookup that already succeeded returns the
  identical row; the exact fallback also cannot substring-match
  (`b.rpm` will not resolve a root-stored `ab.rpm`). Both queries use runtime
  `sqlx::query` (no `sqlx::query!` macros, so the offline `Check Rust` gate is
  unaffected). Sharing the helper keeps the change under the duplication gate.

No schema change: the fix is entirely at serve time, so it also repairs
previously-uploaded bare-path RPMs.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Regression coverage that fails on `main` and passes here:
- **Unit (`rpm.rs`)** — bare path → `href="packages/<file>"`; nested
  non-`packages/` path → `packages/<basename>`; native `packages/<file>` path
  emitted **byte-identical**; `xml_escape` still applied to the location.
- **Unit (`proxy_helpers.rs`, sqlx-backed)** — a root-stored artifact now
  resolves by filename; a suffix **hit** still returns the same directory-stored
  row (fallback does not fire on a hit); no substring false positive; the same
  trio for `local_fetch_by_path_suffix`.
- **E2E (`scripts/e2e-syspkg/test-rpm.sh`)** — a new generic-push section (the
  case CI missed) uploads the built RPM through the generic chunked flow,
  asserts the `primary.xml` `<location href>` is `packages/`-prefixed, downloads
  it from the hosted route (HTTP 200 + sha256 matches both the local RPM and the
  `<checksum>` in `primary.xml`), and `dnf install`s it end-to-end. The existing
  native-PUT section is retained as the regression leg.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verified on an isolated pool worker (patched image on :8102, unpatched base on
:8101; red target untouched):

```
PRE-FIX  (unpatched)  generic href = <bare>.rpm            GET packages/<file> = 404   <-- bug
POST-FIX (patched)    generic href = packages/<bare>.rpm   GET packages/<file> = 200   sha MATCH
regression (patched)  native  href = packages/<file>       GET packages/<file> = 200
native-only primary.xml byte-identical pre/post (same artifact): IDENTICAL
full test-rpm.sh against patched slot: native-PUT leg PASS + generic-push leg PASS (dnf install OK)
full test-rpm.sh against unpatched slot: native leg PASS, generic leg FAILS at the href assertion (exit 1)
```

Gates: `cargo fmt --check` pass · `cargo clippy --workspace --all-targets -D warnings`
exit 0 · `cargo nextest --workspace --lib` 335 passed / 0 failed (9 new) ·
`jscpd --min-lines 10 --threshold 3` under threshold.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Deliberate follow-ups (out of scope here)
- Generically-pushed packages carry **blank format metadata** (`Source:` etc.):
  `generate_primary_xml` falls back to filename parsing because the generic
  upload path stores no RPM header metadata. This is a separate
  "format-metadata-on-generic-push" concern, not a download bug — tracked in #2588.
- The exact-path fallback also fixes the **metadata half for other
  suffix-resolved formats** (npm/helm/pypi/etc. served from a bare path), but
  each format's own on-demand index/metadata generation should be audited the
  same way `primary.xml` was — tracked in #2589.
- `list_rpm_artifacts` returns **every** artifact in the repo regardless of
  extension; non-`.rpm` objects should be filtered for repodata hygiene —
  tracked in #2590.