### PR TITLE
fix(ingestion): cap concurrent archive decompressions (global)

### DIFF
--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -284,19 +284,18 @@ async fn push_pod(
 
     // Try to extract podspec from the archive body.
     // The body should contain a tar.gz with a podspec.json inside.
-    let podspec = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); the permit is released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        extract_podspec_from_archive(&body).map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid pod archive: {}", e),
-            )
-                .into_response()
-        })?
-    };
+    // #2561: permit-scoped decode, fast-fail 503 on saturation.
+    let podspec = crate::util::bounded_archive::with_ingest_extraction(|| {
+        extract_podspec_from_archive(&body)
+    })
+    .map_err(|e| e.into_response())?
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid pod archive: {}", e),
+        )
+            .into_response()
+    })?;
 
     let pod_name = &podspec.name;
     let pod_version = &podspec.version;
@@ -970,6 +969,49 @@ mod tests {
 #[cfg(test)]
 mod db_cov_tests {
     use crate::api::handlers::test_db_helpers as tdh;
+
+    /// #2561: an authenticated pod push decodes the podspec through the
+    /// permit-scoped decode (uncontended) and stores the pod.
+    #[tokio::test]
+    async fn test_cocoapods_push_pod_succeeds_2561() {
+        let Some(fx) = tdh::Fixture::setup("local", "cocoapods").await else {
+            return;
+        };
+        let podspec_bytes = serde_json::to_vec(&serde_json::json!({
+            "name": "PushPod",
+            "version": "1.0.0",
+            "summary": "coverage pod",
+        }))
+        .unwrap();
+        let mut tar_data = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar_data);
+            let mut header = tar::Header::new_gnu();
+            header.set_path("PushPod.podspec.json").unwrap();
+            header.set_size(podspec_bytes.len() as u64);
+            header.set_cksum();
+            builder.append(&header, &podspec_bytes[..]).unwrap();
+            builder.finish().unwrap();
+        }
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut gz, &tar_data).unwrap();
+        let targz = gz.finish().unwrap();
+
+        let app = fx.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/{}/pods", fx.repo_key))
+            .body(axum::body::Body::from(targz))
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "pod push must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+        fx.teardown().await;
+    }
 
     // Exercises the DB-query happy paths so the sweep's db_err/db_status
     // call-site lines are covered by cargo llvm-cov --lib (#2083).

--- a/backend/src/api/handlers/cocoapods.rs
+++ b/backend/src/api/handlers/cocoapods.rs
@@ -284,13 +284,19 @@ async fn push_pod(
 
     // Try to extract podspec from the archive body.
     // The body should contain a tar.gz with a podspec.json inside.
-    let podspec = extract_podspec_from_archive(&body).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid pod archive: {}", e),
-        )
-            .into_response()
-    })?;
+    let podspec = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); the permit is released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        extract_podspec_from_archive(&body).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid pod archive: {}", e),
+            )
+                .into_response()
+        })?
+    };
 
     let pod_name = &podspec.name;
     let pod_version = &podspec.version;

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1348,19 +1348,18 @@ async fn upload(
     }
 
     // Parse composer.json from the archive to extract metadata
-    let composer_json = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); permit released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        ComposerHandler::parse_composer_json(&body).map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to parse composer.json from archive: {}", e),
-            )
-                .into_response()
-        })?
-    };
+    // #2561: permit-scoped decode, fast-fail 503 on saturation.
+    let composer_json = crate::util::bounded_archive::with_ingest_extraction(|| {
+        ComposerHandler::parse_composer_json(&body)
+    })
+    .map_err(|e| e.into_response())?
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Failed to parse composer.json from archive: {}", e),
+        )
+            .into_response()
+    })?;
 
     // Validate package name has vendor/package format
     let full_name = &composer_json.name;

--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -1348,13 +1348,19 @@ async fn upload(
     }
 
     // Parse composer.json from the archive to extract metadata
-    let composer_json = ComposerHandler::parse_composer_json(&body).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Failed to parse composer.json from archive: {}", e),
-        )
-            .into_response()
-    })?;
+    let composer_json = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); permit released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        ComposerHandler::parse_composer_json(&body).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Failed to parse composer.json from archive: {}", e),
+            )
+                .into_response()
+        })?
+    };
 
     // Validate package name has vendor/package format
     let full_name = &composer_json.name;

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -3059,15 +3059,13 @@ async fn store_conda_package(
         },
     )?;
 
-    // Validate package structure before storing
-    {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); permit released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
+    // Validate package structure before storing.
+    // #2561: permit-scoped decode, fast-fail 503 on saturation.
+    crate::util::bounded_archive::with_ingest_extraction(|| {
         validate_conda_package(&content, filename)
-            .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
-    }
+    })
+    .map_err(|e| e.into_response())?
+    .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
 
     // Compute SHA256 and MD5
     let mut sha256_hasher = Sha256::new();
@@ -3160,14 +3158,14 @@ async fn store_conda_package(
     crate::services::quarantine_service::apply_upload_hold_hosted(&state.db, repo.id, artifact_id)
         .await;
 
-    // Extract metadata from package contents. #2561: cap concurrent ingestion
-    // decompressions; the artifact row is already committed, so a saturated
-    // server skips (best-effort) metadata enrichment rather than failing the
-    // stored upload.
-    let extracted = match crate::util::bounded_archive::acquire_ingest_extraction() {
-        Ok(_ingest_permit) => extract_conda_metadata(&content, filename),
-        Err(_) => None,
-    };
+    // Extract metadata from package contents. #2561: permit-scoped decode; the
+    // artifact row is already committed, so a saturated server skips this
+    // best-effort enrichment rather than failing the stored upload.
+    let extracted = crate::util::bounded_archive::with_ingest_extraction(|| {
+        extract_conda_metadata(&content, filename)
+    })
+    .ok()
+    .flatten();
 
     let build_number = extracted
         .as_ref()

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -3060,8 +3060,14 @@ async fn store_conda_package(
     )?;
 
     // Validate package structure before storing
-    validate_conda_package(&content, filename)
-        .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
+    {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); permit released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        validate_conda_package(&content, filename)
+            .map_err(|e| (StatusCode::BAD_REQUEST, e).into_response())?;
+    }
 
     // Compute SHA256 and MD5
     let mut sha256_hasher = Sha256::new();
@@ -3154,8 +3160,14 @@ async fn store_conda_package(
     crate::services::quarantine_service::apply_upload_hold_hosted(&state.db, repo.id, artifact_id)
         .await;
 
-    // Extract metadata from package contents
-    let extracted = extract_conda_metadata(&content, filename);
+    // Extract metadata from package contents. #2561: cap concurrent ingestion
+    // decompressions; the artifact row is already committed, so a saturated
+    // server skips (best-effort) metadata enrichment rather than failing the
+    // stored upload.
+    let extracted = match crate::util::bounded_archive::acquire_ingest_extraction() {
+        Ok(_ingest_permit) => extract_conda_metadata(&content, filename),
+        Err(_) => None,
+    };
 
     let build_number = extracted
         .as_ref()

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1426,16 +1426,23 @@ fn read_index_capped<R: Read>(reader: R) -> Option<String> {
 
 /// Tier B resolver: find the SHA-256 the cached Packages index records for a
 /// pool artifact, so the streamed `.deb` download can gate its cache commit on
-/// it. Best-effort: `None` when no cached Packages index covers the file
+/// it. Best-effort: `Ok(None)` when no cached Packages index covers the file
 /// (which leaves the download's cache behaviour unchanged from before #2459).
+/// `Err` only when the server is saturated with concurrent ingestion decodes
+/// (#2561), which sheds the request with a retryable 503 before any upstream
+/// fetch or cache write — the resolve fails cleanly, no partial state.
 async fn resolve_pool_expected_checksum(
     proxy: &ProxyService,
     repo_key: &str,
     component: &str,
     artifact_path: &str,
-) -> Option<String> {
-    let filename = artifact_path.rsplit('/').next()?;
-    let (_, _, arch) = DebianHandler::parse_deb_filename(filename).ok()?;
+) -> crate::error::Result<Option<String>> {
+    let Some(filename) = artifact_path.rsplit('/').next() else {
+        return Ok(None);
+    };
+    let Ok((_, _, arch)) = DebianHandler::parse_deb_filename(filename) else {
+        return Ok(None);
+    };
     for cache_path in proxy.list_cached_paths(repo_key).await {
         if !is_matching_packages_index(&cache_path, component, &arch) {
             continue;
@@ -1446,15 +1453,23 @@ async fn resolve_pool_expected_checksum(
         else {
             continue;
         };
-        let Some(text) = decompress_packages_index(&cache_path, &bytes) else {
-            continue;
+        // #2561: cap concurrent ingestion decompressions on this serve path
+        // (each cached index inflates up to the 128 MiB budget). Fast-fail 503
+        // on saturation; the permit is scoped to the decode only, so it is
+        // released before the next cache read.
+        let text = {
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()?;
+            match decompress_packages_index(&cache_path, &bytes) {
+                Some(text) => text,
+                None => continue,
+            }
         };
         let map = crate::formats::debian::parse_packages_index(&text);
         if let Some(sha) = resolve_pool_deb_checksum(&map, artifact_path) {
-            return Some(sha);
+            return Ok(Some(sha));
         }
     }
-    None
+    Ok(None)
 }
 
 // ---------------------------------------------------------------------------
@@ -2358,7 +2373,8 @@ async fn pool_download(
                         &component,
                         &artifact_path,
                     )
-                    .await;
+                    .await
+                    .map_err(|e| e.into_response())?;
                     let result = proxy_helpers::proxy_fetch_streaming_with_cache_key_verified(
                         proxy,
                         repo.id,

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1453,16 +1453,14 @@ async fn resolve_pool_expected_checksum(
         else {
             continue;
         };
-        // #2561: cap concurrent ingestion decompressions on this serve path
-        // (each cached index inflates up to the 128 MiB budget). Fast-fail 503
-        // on saturation; the permit is scoped to the decode only, so it is
-        // released before the next cache read.
-        let text = {
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()?;
-            match decompress_packages_index(&cache_path, &bytes) {
-                Some(text) => text,
-                None => continue,
-            }
+        // #2561: permit-scoped decode on this serve path (each cached index
+        // inflates up to the 128 MiB budget), fast-fail 503 on saturation; the
+        // permit is released before the next cache read.
+        let Some(text) = crate::util::bounded_archive::with_ingest_extraction(|| {
+            decompress_packages_index(&cache_path, &bytes)
+        })?
+        else {
+            continue;
         };
         let map = crate::formats::debian::parse_packages_index(&text);
         if let Some(sha) = resolve_pool_deb_checksum(&map, artifact_path) {

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -474,15 +474,22 @@ async fn upload_chart(
 
     // Extract and validate Chart.yaml from the staged archive on disk, reading
     // only the Chart.yaml entry (bounded memory) rather than the whole package.
-    let chart_yaml = extract_chart_yaml_from_staged(staged.path())
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid chart package: {}", e),
-            )
-                .into_response()
-        })?;
+    let chart_yaml = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); the permit is held across the blocking decode and
+        // released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        extract_chart_yaml_from_staged(staged.path())
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid chart package: {}", e),
+                )
+                    .into_response()
+            })?
+    };
 
     let chart_name = &chart_yaml.name;
     let chart_version = &chart_yaml.version;

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -474,22 +474,19 @@ async fn upload_chart(
 
     // Extract and validate Chart.yaml from the staged archive on disk, reading
     // only the Chart.yaml entry (bounded memory) rather than the whole package.
-    let chart_yaml = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); the permit is held across the blocking decode and
-        // released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
+    // #2561: permit held across the blocking decode, fast-fail 503 on saturation.
+    let chart_yaml = crate::util::bounded_archive::with_ingest_extraction_async(|| {
         extract_chart_yaml_from_staged(staged.path())
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid chart package: {}", e),
-                )
-                    .into_response()
-            })?
-    };
+    })
+    .await
+    .map_err(|e| e.into_response())?
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid chart package: {}", e),
+        )
+            .into_response()
+    })?;
 
     let chart_name = &chart_yaml.name;
     let chart_version = &chart_yaml.version;

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -379,13 +379,19 @@ async fn publish_package(
     //   - metadata.config (Erlang term format)
     //   - contents.tar.gz (the actual package files)
     //   - CHECKSUM (SHA-256 of the above)
-    let (pkg_name, pkg_version) = extract_name_version_from_tarball(&body).map_err(|e| {
-        (
-            StatusCode::BAD_REQUEST,
-            format!("Invalid hex tarball: {}", e),
-        )
-            .into_response()
-    })?;
+    let (pkg_name, pkg_version) = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); permit released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        extract_name_version_from_tarball(&body).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid hex tarball: {}", e),
+            )
+                .into_response()
+        })?
+    };
 
     if pkg_name.is_empty() || pkg_version.is_empty() {
         return Err((

--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -379,19 +379,18 @@ async fn publish_package(
     //   - metadata.config (Erlang term format)
     //   - contents.tar.gz (the actual package files)
     //   - CHECKSUM (SHA-256 of the above)
-    let (pkg_name, pkg_version) = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); permit released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        extract_name_version_from_tarball(&body).map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid hex tarball: {}", e),
-            )
-                .into_response()
-        })?
-    };
+    // #2561: permit-scoped decode, fast-fail 503 on saturation.
+    let (pkg_name, pkg_version) = crate::util::bounded_archive::with_ingest_extraction(|| {
+        extract_name_version_from_tarball(&body)
+    })
+    .map_err(|e| e.into_response())?
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid hex tarball: {}", e),
+        )
+            .into_response()
+    })?;
 
     if pkg_name.is_empty() || pkg_version.is_empty() {
         return Err((
@@ -1934,6 +1933,41 @@ mod tests {
     // -----------------------------------------------------------------------
 
     use crate::api::handlers::test_db_helpers as tdh;
+
+    /// #2561: an authenticated hex publish decodes the outer tarball through
+    /// the permit-scoped decode (uncontended) and stores the package.
+    #[tokio::test]
+    async fn test_hex_publish_succeeds_2561() {
+        let Some(f) = tdh::Fixture::setup("local", "hex").await else {
+            return;
+        };
+        let metadata = r#"{<<"name">>, <<"pushpkg">>}.
+{<<"version">>, <<"1.2.3">>}.
+"#;
+        let data = metadata.as_bytes();
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_path("metadata.config").unwrap();
+        header.set_size(data.len() as u64);
+        header.set_cksum();
+        builder.append(&header, data).unwrap();
+        let tar_data = builder.into_inner().unwrap();
+
+        let app = f.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/{}/publish", f.repo_key))
+            .body(axum::body::Body::from(tar_data))
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "hex publish must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
+        f.teardown().await;
+    }
 
     #[tokio::test]
     async fn test_hex_tarball_download_404_when_missing() {

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -878,14 +878,15 @@ async fn upload_image(
     let mut staged = StagedTempFile::new(temp_path.clone());
     let (size_bytes, checksum) = stream_body_to_file(body, &temp_path).await?;
 
-    // Extract metadata from the file on disk. #2561: cap concurrent ingestion
-    // decompressions; the artifact is already staged, so a saturated server
-    // skips best-effort metadata extraction rather than shedding the upload.
-    let metadata = match crate::util::bounded_archive::acquire_ingest_extraction() {
-        Ok(_ingest_permit) => IncusHandler::parse_metadata_from_file(&artifact_path, &temp_path)
-            .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"})),
-        Err(_) => serde_json::json!({"file_type": "unknown"}),
-    };
+    // Extract metadata from the file on disk. #2561: permit-scoped decode; the
+    // artifact is already staged, so a saturated server skips this best-effort
+    // extraction rather than shedding the upload.
+    let metadata = crate::util::bounded_archive::with_ingest_extraction(|| {
+        IncusHandler::parse_metadata_from_file(&artifact_path, &temp_path).ok()
+    })
+    .ok()
+    .flatten()
+    .unwrap_or_else(|| serde_json::json!({"file_type": "unknown"}));
 
     // Record an upload session in `finalizing` state, then push to the
     // StorageBackend on a background task and return 202. Doing the
@@ -1241,16 +1242,15 @@ async fn complete_chunked_upload(
         }
     }
 
-    // Extract metadata from the file on disk. #2561: cap concurrent ingestion
-    // decompressions; the artifact is already staged, so a saturated server
-    // skips best-effort metadata extraction rather than shedding the upload.
-    let metadata = match crate::util::bounded_archive::acquire_ingest_extraction() {
-        Ok(_ingest_permit) => {
-            IncusHandler::parse_metadata_from_file(&session.artifact_path, &temp_path)
-                .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"}))
-        }
-        Err(_) => serde_json::json!({"file_type": "unknown"}),
-    };
+    // Extract metadata from the file on disk. #2561: permit-scoped decode; the
+    // artifact is already staged, so a saturated server skips this best-effort
+    // extraction rather than shedding the upload.
+    let metadata = crate::util::bounded_archive::with_ingest_extraction(|| {
+        IncusHandler::parse_metadata_from_file(&session.artifact_path, &temp_path).ok()
+    })
+    .ok()
+    .flatten()
+    .unwrap_or_else(|| serde_json::json!({"file_type": "unknown"}));
 
     // Finalize asynchronously: mark the session `finalizing`, push to the
     // StorageBackend on a background task, and return 202. The assembled

--- a/backend/src/api/handlers/incus.rs
+++ b/backend/src/api/handlers/incus.rs
@@ -878,9 +878,14 @@ async fn upload_image(
     let mut staged = StagedTempFile::new(temp_path.clone());
     let (size_bytes, checksum) = stream_body_to_file(body, &temp_path).await?;
 
-    // Extract metadata from the file on disk
-    let metadata = IncusHandler::parse_metadata_from_file(&artifact_path, &temp_path)
-        .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"}));
+    // Extract metadata from the file on disk. #2561: cap concurrent ingestion
+    // decompressions; the artifact is already staged, so a saturated server
+    // skips best-effort metadata extraction rather than shedding the upload.
+    let metadata = match crate::util::bounded_archive::acquire_ingest_extraction() {
+        Ok(_ingest_permit) => IncusHandler::parse_metadata_from_file(&artifact_path, &temp_path)
+            .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"})),
+        Err(_) => serde_json::json!({"file_type": "unknown"}),
+    };
 
     // Record an upload session in `finalizing` state, then push to the
     // StorageBackend on a background task and return 202. Doing the
@@ -1236,9 +1241,16 @@ async fn complete_chunked_upload(
         }
     }
 
-    // Extract metadata from the file on disk
-    let metadata = IncusHandler::parse_metadata_from_file(&session.artifact_path, &temp_path)
-        .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"}));
+    // Extract metadata from the file on disk. #2561: cap concurrent ingestion
+    // decompressions; the artifact is already staged, so a saturated server
+    // skips best-effort metadata extraction rather than shedding the upload.
+    let metadata = match crate::util::bounded_archive::acquire_ingest_extraction() {
+        Ok(_ingest_permit) => {
+            IncusHandler::parse_metadata_from_file(&session.artifact_path, &temp_path)
+                .unwrap_or_else(|_| serde_json::json!({"file_type": "unknown"}))
+        }
+        Err(_) => serde_json::json!({"file_type": "unknown"}),
+    };
 
     // Finalize asynchronously: mark the session `finalizing`, push to the
     // StorageBackend on a background task, and return 202. The assembled

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -925,6 +925,11 @@ async fn push_package(
     // Parse .nuspec from the SEEKABLE staged file (the ZIP reader needs
     // Read + Seek); run the blocking archive read off the async runtime.
     let nuspec = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); the permit is held across the blocking decode and
+        // released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
         let staged_path = staged.path().to_path_buf();
         tokio::task::spawn_blocking(move || {
             let file = std::fs::File::open(&staged_path)

--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -924,34 +924,31 @@ async fn push_package(
 
     // Parse .nuspec from the SEEKABLE staged file (the ZIP reader needs
     // Read + Seek); run the blocking archive read off the async runtime.
-    let nuspec = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); the permit is held across the blocking decode and
-        // released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        let staged_path = staged.path().to_path_buf();
+    // #2561: permit held across the blocking decode, fast-fail 503 on saturation.
+    let staged_path = staged.path().to_path_buf();
+    let nuspec = crate::util::bounded_archive::with_ingest_extraction_async(|| {
         tokio::task::spawn_blocking(move || {
             let file = std::fs::File::open(&staged_path)
                 .map_err(|e| format!("Cannot open staged package: {e}"))?;
             parse_nuspec_from_reader(file)
         })
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("nuspec parse task failed: {e}"),
-            )
-                .into_response()
-        })?
-        .map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Failed to read .nuspec from package: {e}"),
-            )
-                .into_response()
-        })?
-    };
+    })
+    .await
+    .map_err(|e| e.into_response())?
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("nuspec parse task failed: {e}"),
+        )
+            .into_response()
+    })?
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Failed to read .nuspec from package: {e}"),
+        )
+            .into_response()
+    })?;
 
     let package_id = nuspec.id.to_lowercase();
     let version = nuspec.version.clone();

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1358,14 +1358,13 @@ async fn download(
                         )
                         .await?;
 
-                        let files = {
-                            // #2561: cap concurrent ingestion decompressions
-                            // (fast-fail 503 on saturation).
-                            let _ingest_permit =
-                                crate::util::bounded_archive::acquire_ingest_extraction()
-                                    .map_err(|e| e.into_response())?;
-                            extract_files_from_bundle(&bundle_data)?
-                        };
+                        // #2561: permit-scoped decode, fast-fail 503 on saturation.
+                        #[allow(clippy::result_large_err)]
+                        // Response-as-error matches this module's handler convention.
+                        let files = crate::util::bounded_archive::with_ingest_extraction(|| {
+                            extract_files_from_bundle(&bundle_data)
+                        })
+                        .map_err(|e| e.into_response())??;
                         let commit = CommitInfo {
                             id: digest.to_string(),
                             create_time: chrono::Utc::now().to_rfc3339(),
@@ -1409,14 +1408,13 @@ async fn download(
 
                     let bundle_data = result.collect().await.map_err(|e| e.into_response())?;
 
-                    let files = {
-                        // #2561: cap concurrent ingestion decompressions
-                        // (fast-fail 503 on saturation).
-                        let _ingest_permit =
-                            crate::util::bounded_archive::acquire_ingest_extraction()
-                                .map_err(|e| e.into_response())?;
-                        extract_files_from_bundle(&bundle_data)?
-                    };
+                    // #2561: permit-scoped decode, fast-fail 503 on saturation.
+                    #[allow(clippy::result_large_err)]
+                    // Response-as-error matches this module's handler convention.
+                    let files = crate::util::bounded_archive::with_ingest_extraction(|| {
+                        extract_files_from_bundle(&bundle_data)
+                    })
+                    .map_err(|e| e.into_response())??;
                     let commit = CommitInfo {
                         id: digest.clone(),
                         create_time: chrono::Utc::now().to_rfc3339(),
@@ -1461,12 +1459,13 @@ async fn download(
             )
         })?;
 
-        let files = {
-            // #2561: cap concurrent ingestion decompressions (fast-fail 503).
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-                .map_err(|e| e.into_response())?;
-            extract_files_from_bundle(&bundle_data)?
-        };
+        // #2561: permit-scoped decode, fast-fail 503 on saturation.
+        #[allow(clippy::result_large_err)]
+        // Response-as-error matches this module's handler convention.
+        let files = crate::util::bounded_archive::with_ingest_extraction(|| {
+            extract_files_from_bundle(&bundle_data)
+        })
+        .map_err(|e| e.into_response())??;
         let commit = build_commit_info_from_row(&artifact_row);
 
         // Record download

--- a/backend/src/api/handlers/protobuf.rs
+++ b/backend/src/api/handlers/protobuf.rs
@@ -1358,7 +1358,14 @@ async fn download(
                         )
                         .await?;
 
-                        let files = extract_files_from_bundle(&bundle_data)?;
+                        let files = {
+                            // #2561: cap concurrent ingestion decompressions
+                            // (fast-fail 503 on saturation).
+                            let _ingest_permit =
+                                crate::util::bounded_archive::acquire_ingest_extraction()
+                                    .map_err(|e| e.into_response())?;
+                            extract_files_from_bundle(&bundle_data)?
+                        };
                         let commit = CommitInfo {
                             id: digest.to_string(),
                             create_time: chrono::Utc::now().to_rfc3339(),
@@ -1402,7 +1409,14 @@ async fn download(
 
                     let bundle_data = result.collect().await.map_err(|e| e.into_response())?;
 
-                    let files = extract_files_from_bundle(&bundle_data)?;
+                    let files = {
+                        // #2561: cap concurrent ingestion decompressions
+                        // (fast-fail 503 on saturation).
+                        let _ingest_permit =
+                            crate::util::bounded_archive::acquire_ingest_extraction()
+                                .map_err(|e| e.into_response())?;
+                        extract_files_from_bundle(&bundle_data)?
+                    };
                     let commit = CommitInfo {
                         id: digest.clone(),
                         create_time: chrono::Utc::now().to_rfc3339(),
@@ -1447,7 +1461,12 @@ async fn download(
             )
         })?;
 
-        let files = extract_files_from_bundle(&bundle_data)?;
+        let files = {
+            // #2561: cap concurrent ingestion decompressions (fast-fail 503).
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+                .map_err(|e| e.into_response())?;
+            extract_files_from_bundle(&bundle_data)?
+        };
         let commit = build_commit_info_from_row(&artifact_row);
 
         // Record download

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -647,22 +647,19 @@ async fn upload_package(
 
     // Extract pubspec.yaml from the staged archive on disk, decoding the gzip
     // stream incrementally so we never hold the whole archive in memory.
-    let pubspec = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); the permit is held across the blocking decode and
-        // released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
+    // #2561: permit held across the blocking decode, fast-fail 503 on saturation.
+    let pubspec = crate::util::bounded_archive::with_ingest_extraction_async(|| {
         extract_pubspec_from_staged(staged.path())
-            .await
-            .map_err(|e| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    format!("Invalid Pub package: {}", e),
-                )
-                    .into_response()
-            })?
-    };
+    })
+    .await
+    .map_err(|e| e.into_response())?
+    .map_err(|e| {
+        (
+            StatusCode::BAD_REQUEST,
+            format!("Invalid Pub package: {}", e),
+        )
+            .into_response()
+    })?;
 
     let pkg_name = &pubspec.name;
     let pkg_version = &pubspec.version;

--- a/backend/src/api/handlers/pub_registry.rs
+++ b/backend/src/api/handlers/pub_registry.rs
@@ -647,15 +647,22 @@ async fn upload_package(
 
     // Extract pubspec.yaml from the staged archive on disk, decoding the gzip
     // stream incrementally so we never hold the whole archive in memory.
-    let pubspec = extract_pubspec_from_staged(staged.path())
-        .await
-        .map_err(|e| {
-            (
-                StatusCode::BAD_REQUEST,
-                format!("Invalid Pub package: {}", e),
-            )
-                .into_response()
-        })?;
+    let pubspec = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); the permit is held across the blocking decode and
+        // released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        extract_pubspec_from_staged(staged.path())
+            .await
+            .map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("Invalid Pub package: {}", e),
+                )
+                    .into_response()
+            })?
+    };
 
     let pkg_name = &pubspec.name;
     let pkg_version = &pubspec.version;

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2297,17 +2297,18 @@ async fn serve_metadata(
         .await
         .map_err(map_storage_err)?;
 
-    // #2561: cap concurrent ingestion decompressions on the serve path
-    // (fast-fail 503 on saturation); the permit is released before the response
-    // is built. Only taken for the branches that actually decode an archive.
+    // #2561: permit-scoped decode on the serve path, fast-fail 503 on
+    // saturation. Only taken for the branches that actually decode an archive.
     let metadata_text = if filename.ends_with(".whl") {
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        extract_metadata_from_wheel(&content)
+        crate::util::bounded_archive::with_ingest_extraction(|| {
+            extract_metadata_from_wheel(&content)
+        })
+        .map_err(|e| e.into_response())?
     } else if filename.ends_with(".tar.gz") {
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        extract_metadata_from_sdist(&content)
+        crate::util::bounded_archive::with_ingest_extraction(|| {
+            extract_metadata_from_sdist(&content)
+        })
+        .map_err(|e| e.into_response())?
     } else {
         None
     };

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -2297,9 +2297,16 @@ async fn serve_metadata(
         .await
         .map_err(map_storage_err)?;
 
+    // #2561: cap concurrent ingestion decompressions on the serve path
+    // (fast-fail 503 on saturation); the permit is released before the response
+    // is built. Only taken for the branches that actually decode an archive.
     let metadata_text = if filename.ends_with(".whl") {
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
         extract_metadata_from_wheel(&content)
     } else if filename.ends_with(".tar.gz") {
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
         extract_metadata_from_sdist(&content)
     } else {
         None

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -291,9 +291,15 @@ async fn push_gem(
     }
 
     // Extract gemspec from the .gem file
-    let gemspec = RubygemsHandler::extract_gemspec(&body).map_err(|e| {
-        (StatusCode::BAD_REQUEST, format!("Invalid gem file: {}", e)).into_response()
-    })?;
+    let gemspec = {
+        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+        // saturation); permit released as this block ends, before storage.
+        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+            .map_err(|e| e.into_response())?;
+        RubygemsHandler::extract_gemspec(&body).map_err(|e| {
+            (StatusCode::BAD_REQUEST, format!("Invalid gem file: {}", e)).into_response()
+        })?
+    };
 
     let gem_name = &gemspec.name;
     let gem_version = &gemspec.version;
@@ -458,7 +464,12 @@ async fn collect_remote_specs(
         state.proxy_service.as_deref(),
         virtual_repo_id,
         upstream_path,
-        |bytes, _member_key| async move { parse_upstream_specs(&bytes) },
+        |bytes, _member_key| async move {
+            // #2561: cap concurrent proxy-index decompressions (fast-fail 503).
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+                .map_err(|e| e.into_response())?;
+            parse_upstream_specs(&bytes)
+        },
     )
     .await?;
 

--- a/backend/src/api/handlers/rubygems.rs
+++ b/backend/src/api/handlers/rubygems.rs
@@ -291,15 +291,12 @@ async fn push_gem(
     }
 
     // Extract gemspec from the .gem file
-    let gemspec = {
-        // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-        // saturation); permit released as this block ends, before storage.
-        let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-            .map_err(|e| e.into_response())?;
-        RubygemsHandler::extract_gemspec(&body).map_err(|e| {
-            (StatusCode::BAD_REQUEST, format!("Invalid gem file: {}", e)).into_response()
-        })?
-    };
+    // #2561: permit-scoped decode, fast-fail 503 on saturation.
+    let gemspec = crate::util::bounded_archive::with_ingest_extraction(|| {
+        RubygemsHandler::extract_gemspec(&body)
+    })
+    .map_err(|e| e.into_response())?
+    .map_err(|e| (StatusCode::BAD_REQUEST, format!("Invalid gem file: {}", e)).into_response())?;
 
     let gem_name = &gemspec.name;
     let gem_version = &gemspec.version;
@@ -465,10 +462,13 @@ async fn collect_remote_specs(
         virtual_repo_id,
         upstream_path,
         |bytes, _member_key| async move {
-            // #2561: cap concurrent proxy-index decompressions (fast-fail 503).
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-                .map_err(|e| e.into_response())?;
-            parse_upstream_specs(&bytes)
+            // #2561: permit-scoped decode, fast-fail 503 on saturation.
+            #[allow(clippy::result_large_err)]
+            // Response-as-error matches this module's handler convention.
+            let specs = crate::util::bounded_archive::with_ingest_extraction(|| {
+                parse_upstream_specs(&bytes)
+            });
+            specs.map_err(|e| e.into_response())?
         },
     )
     .await?;
@@ -1004,6 +1004,42 @@ mod tests {
             .unwrap();
         let (status, _) = tdh::send(app, req).await;
         assert_eq!(status, StatusCode::UNAUTHORIZED);
+        f.teardown().await;
+    }
+
+    /// #2561: an authenticated gem push decodes the gemspec through the
+    /// permit-scoped decode (uncontended) and stores the gem.
+    #[tokio::test]
+    async fn test_rubygems_push_gem_succeeds_2561() {
+        let Some(f) = tdh::Fixture::setup("local", "rubygems").await else {
+            return;
+        };
+        // A .gem is a plain tar carrying a gzip'd gemspec-YAML `metadata.gz`.
+        let yaml = b"--- !ruby/object:Gem::Specification\nname: pushgem\nversion: 1.0.0\n";
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        std::io::Write::write_all(&mut gz, yaml).unwrap();
+        let metadata_gz = gz.finish().unwrap();
+        let mut builder = tar::Builder::new(Vec::new());
+        let mut header = tar::Header::new_gnu();
+        header.set_path("metadata.gz").unwrap();
+        header.set_size(metadata_gz.len() as u64);
+        header.set_cksum();
+        builder.append(&header, &metadata_gz[..]).unwrap();
+        let gem = builder.into_inner().unwrap();
+
+        let app = f.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/{}/api/v1/gems", f.repo_key))
+            .body(axum::body::Body::from(gem))
+            .unwrap();
+        let (status, body) = tdh::send(app, req).await;
+        assert!(
+            status.is_success(),
+            "gem push must succeed: {} {:?}",
+            status,
+            String::from_utf8_lossy(&body[..])
+        );
         f.teardown().await;
     }
 }

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -752,6 +752,10 @@ async fn fetch_manifest(
                     &format!("Storage error: {}", e),
                 )
             })?;
+            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+            // saturation); permit released as this block ends.
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+                .map_err(|e| e.into_response())?;
             extract_manifest_from_zip(&zip_bytes).ok_or_else(|| {
                 swift_error_response(StatusCode::NOT_FOUND, "Manifest not found for this release")
             })?
@@ -871,11 +875,22 @@ async fn publish_release(
     // `PUT ... application/zip` uploads fail SwiftPM dependency resolution
     // because the manifest endpoint returns 404 even though the archive is
     // perfectly valid (issue #1100).
-    let manifest = headers
+    let manifest = match headers
         .get("X-Swift-Package-Manifest")
         .and_then(|v| v.to_str().ok())
         .map(|s| s.to_string())
-        .or_else(|| extract_manifest_from_zip(&body));
+    {
+        Some(m) => Some(m),
+        None => {
+            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+            // saturation); the permit is released as this arm ends, before the
+            // artifact INSERT. Only taken when the header fallback actually
+            // needs to decode the uploaded zip.
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
+                .map_err(|e| e.into_response())?;
+            extract_manifest_from_zip(&body)
+        }
+    };
 
     let swift_metadata = serde_json::json!({
         "scope": scope,

--- a/backend/src/api/handlers/swift.rs
+++ b/backend/src/api/handlers/swift.rs
@@ -752,11 +752,12 @@ async fn fetch_manifest(
                     &format!("Storage error: {}", e),
                 )
             })?;
-            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-            // saturation); permit released as this block ends.
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-                .map_err(|e| e.into_response())?;
-            extract_manifest_from_zip(&zip_bytes).ok_or_else(|| {
+            // #2561: permit-scoped decode, fast-fail 503 on saturation.
+            crate::util::bounded_archive::with_ingest_extraction(|| {
+                extract_manifest_from_zip(&zip_bytes)
+            })
+            .map_err(|e| e.into_response())?
+            .ok_or_else(|| {
                 swift_error_response(StatusCode::NOT_FOUND, "Manifest not found for this release")
             })?
         }
@@ -881,15 +882,12 @@ async fn publish_release(
         .map(|s| s.to_string())
     {
         Some(m) => Some(m),
-        None => {
-            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-            // saturation); the permit is released as this arm ends, before the
-            // artifact INSERT. Only taken when the header fallback actually
-            // needs to decode the uploaded zip.
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()
-                .map_err(|e| e.into_response())?;
+        // #2561: permit-scoped decode, fast-fail 503 on saturation. Only taken
+        // when the header fallback actually needs to decode the uploaded zip.
+        None => crate::util::bounded_archive::with_ingest_extraction(|| {
             extract_manifest_from_zip(&body)
-        }
+        })
+        .map_err(|e| e.into_response())?,
     };
 
     let swift_metadata = serde_json::json!({

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -156,12 +156,14 @@ impl FormatHandler for ComposerHandler {
 
         // Extract composer.json from archive packages
         if matches!(info.kind, ComposerPathKind::Archive) && !content.is_empty() {
-            // #2561: cap concurrent ingestion decompressions; on saturation skip
-            // this best-effort metadata enrichment rather than blocking/queueing.
-            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
-                if let Ok(composer_json) = Self::parse_composer_json(content) {
-                    metadata["composer"] = serde_json::to_value(&composer_json)?;
-                }
+            // #2561: permit-scoped decode; on saturation skip this best-effort
+            // metadata enrichment rather than blocking/queueing.
+            if let Ok(Ok(composer_json)) =
+                crate::util::bounded_archive::with_ingest_extraction(|| {
+                    Self::parse_composer_json(content)
+                })
+            {
+                metadata["composer"] = serde_json::to_value(&composer_json)?;
             }
         }
 
@@ -415,6 +417,19 @@ mod tests {
 
     /// #2556: a `composer.json` entry that inflates past the 8 MiB per-metadata
     /// cap is rejected (bounded memory), while the compressed zip stays tiny.
+    /// #2561: the archive branch of `parse_metadata` still enriches the
+    /// metadata through the permit-scoped decode (uncontended path).
+    #[tokio::test]
+    async fn test_parse_metadata_archive_enriches_composer_2561() {
+        let handler = ComposerHandler::new();
+        let zip = composer_zip(br#"{"name":"vendor/pkg","version":"1.2.3"}"#);
+        let meta = handler
+            .parse_metadata("dist/vendor/pkg/1.2.3/abc123.zip", &Bytes::from(zip))
+            .await
+            .expect("archive parse_metadata succeeds");
+        assert_eq!(meta["composer"]["name"], "vendor/pkg");
+    }
+
     #[test]
     fn test_parse_composer_json_bomb_rejected_2556() {
         let mut body = br#"{"name":"vendor/bomb","description":""#.to_vec();

--- a/backend/src/formats/composer.rs
+++ b/backend/src/formats/composer.rs
@@ -156,8 +156,12 @@ impl FormatHandler for ComposerHandler {
 
         // Extract composer.json from archive packages
         if matches!(info.kind, ComposerPathKind::Archive) && !content.is_empty() {
-            if let Ok(composer_json) = Self::parse_composer_json(content) {
-                metadata["composer"] = serde_json::to_value(&composer_json)?;
+            // #2561: cap concurrent ingestion decompressions; on saturation skip
+            // this best-effort metadata enrichment rather than blocking/queueing.
+            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
+                if let Ok(composer_json) = Self::parse_composer_json(content) {
+                    metadata["composer"] = serde_json::to_value(&composer_json)?;
+                }
             }
         }
 

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -617,12 +617,12 @@ impl FormatHandler for DebianHandler {
 
         // Extract control if this is a package
         if !content.is_empty() && matches!(info.operation, DebianOperation::Package) {
-            // #2561: cap concurrent ingestion decompressions; on saturation skip
-            // this best-effort metadata enrichment rather than blocking/queueing.
-            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
-                if let Ok(control) = Self::extract_control(content) {
-                    metadata["control"] = serde_json::to_value(&control)?;
-                }
+            // #2561: permit-scoped decode; on saturation skip this best-effort
+            // metadata enrichment rather than blocking/queueing.
+            if let Ok(Ok(control)) = crate::util::bounded_archive::with_ingest_extraction(|| {
+                Self::extract_control(content)
+            }) {
+                metadata["control"] = serde_json::to_value(&control)?;
             }
         }
 
@@ -634,10 +634,10 @@ impl FormatHandler for DebianHandler {
 
         // Validate .deb packages
         if !content.is_empty() && matches!(info.operation, DebianOperation::Package) {
-            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-            // saturation); permit released at the end of this validation scope.
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()?;
-            let control = Self::extract_control(content)?;
+            // #2561: permit-scoped decode, fast-fail 503 on saturation.
+            let control = crate::util::bounded_archive::with_ingest_extraction(|| {
+                Self::extract_control(content)
+            })??;
 
             // Verify package name matches
             if let Some(path_package) = &info.package {
@@ -1438,6 +1438,31 @@ Source: full-pkg-src
         assert_eq!(control.package, "xz-pkg");
         assert_eq!(control.version, "1.0-1");
         assert_eq!(control.architecture, "amd64");
+    }
+
+    /// #2561: `validate` and `parse_metadata` on a package path still decode
+    /// the control tar through the permit-scoped decode (uncontended path).
+    #[tokio::test]
+    async fn test_validate_and_parse_metadata_deb_2561() {
+        use std::io::Write;
+
+        let control = "Package: xzpkg\nVersion: 1.0-1\nArchitecture: amd64\n";
+        let tar_bytes = control_tar(control);
+        let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 6);
+        encoder.write_all(&tar_bytes).expect("write xz");
+        let deb = deb_with_control_member("control.tar.xz", &encoder.finish().expect("finish xz"));
+
+        let handler = DebianHandler::new();
+        let path = "pool/main/x/xzpkg/xzpkg_1.0-1_amd64.deb";
+        handler
+            .validate(path, &Bytes::from(deb.clone()))
+            .await
+            .expect("matching .deb validates");
+        let meta = handler
+            .parse_metadata(path, &Bytes::from(deb))
+            .await
+            .expect("parse_metadata succeeds");
+        assert_eq!(meta["control"]["package"], "xzpkg");
     }
 
     /// Build a `control.tar` whose `control` entry itself inflates past the

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -617,8 +617,12 @@ impl FormatHandler for DebianHandler {
 
         // Extract control if this is a package
         if !content.is_empty() && matches!(info.operation, DebianOperation::Package) {
-            if let Ok(control) = Self::extract_control(content) {
-                metadata["control"] = serde_json::to_value(&control)?;
+            // #2561: cap concurrent ingestion decompressions; on saturation skip
+            // this best-effort metadata enrichment rather than blocking/queueing.
+            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
+                if let Ok(control) = Self::extract_control(content) {
+                    metadata["control"] = serde_json::to_value(&control)?;
+                }
             }
         }
 
@@ -630,6 +634,9 @@ impl FormatHandler for DebianHandler {
 
         // Validate .deb packages
         if !content.is_empty() && matches!(info.operation, DebianOperation::Package) {
+            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+            // saturation); permit released at the end of this validation scope.
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()?;
             let control = Self::extract_control(content)?;
 
             // Verify package name matches

--- a/backend/src/formats/incus.rs
+++ b/backend/src/formats/incus.rs
@@ -247,9 +247,13 @@ impl FormatHandler for IncusHandler {
 
         // Try extracting metadata.yaml from tarballs
         if !content.is_empty() && info.file_type.is_tarball() {
-            if let Some(image_meta) = Self::extract_metadata(content) {
-                metadata["image_metadata"] =
-                    serde_json::to_value(&image_meta).unwrap_or(serde_json::Value::Null);
+            // #2561: cap concurrent ingestion decompressions; on saturation skip
+            // this best-effort metadata enrichment rather than blocking/queueing.
+            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
+                if let Some(image_meta) = Self::extract_metadata(content) {
+                    metadata["image_metadata"] =
+                        serde_json::to_value(&image_meta).unwrap_or(serde_json::Value::Null);
+                }
             }
         }
 

--- a/backend/src/formats/incus.rs
+++ b/backend/src/formats/incus.rs
@@ -247,13 +247,15 @@ impl FormatHandler for IncusHandler {
 
         // Try extracting metadata.yaml from tarballs
         if !content.is_empty() && info.file_type.is_tarball() {
-            // #2561: cap concurrent ingestion decompressions; on saturation skip
-            // this best-effort metadata enrichment rather than blocking/queueing.
-            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
-                if let Some(image_meta) = Self::extract_metadata(content) {
-                    metadata["image_metadata"] =
-                        serde_json::to_value(&image_meta).unwrap_or(serde_json::Value::Null);
-                }
+            // #2561: permit-scoped decode; on saturation skip this best-effort
+            // metadata enrichment rather than blocking/queueing.
+            if let Ok(Some(image_meta)) =
+                crate::util::bounded_archive::with_ingest_extraction(|| {
+                    Self::extract_metadata(content)
+                })
+            {
+                metadata["image_metadata"] =
+                    serde_json::to_value(&image_meta).unwrap_or(serde_json::Value::Null);
             }
         }
 
@@ -615,6 +617,26 @@ properties:
             IncusHandler::extract_metadata(&zst).unwrap().os,
             Some("Ubuntu".to_string())
         );
+    }
+
+    /// #2561: the tarball branch of `parse_metadata` still enriches the
+    /// metadata through the permit-scoped decode (uncontended path).
+    #[tokio::test]
+    async fn test_parse_metadata_tarball_enriches_2561() {
+        use std::io::Write;
+
+        let yaml = b"architecture: x86_64\nproperties:\n  os: Ubuntu\n  release: noble\n";
+        let raw = image_tar(yaml, 0);
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        gz.write_all(&raw).unwrap();
+        let gz = gz.finish().unwrap();
+
+        let handler = IncusHandler::new();
+        let meta = handler
+            .parse_metadata("ubuntu-noble/20240215/incus.tar.gz", &Bytes::from(gz))
+            .await
+            .expect("tarball parse_metadata succeeds");
+        assert_eq!(meta["image_metadata"]["os"], "Ubuntu");
     }
 
     #[tokio::test]

--- a/backend/src/formats/rubygems.rs
+++ b/backend/src/formats/rubygems.rs
@@ -403,12 +403,12 @@ impl FormatHandler for RubygemsHandler {
 
         // Extract gemspec if this is a gem file
         if !content.is_empty() && matches!(info.operation, RubygemsOperation::Gem) {
-            // #2561: cap concurrent ingestion decompressions; on saturation skip
-            // this best-effort metadata enrichment rather than blocking/queueing.
-            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
-                if let Ok(gemspec) = Self::extract_gemspec(content) {
-                    metadata["gemspec"] = serde_json::to_value(&gemspec)?;
-                }
+            // #2561: permit-scoped decode; on saturation skip this best-effort
+            // metadata enrichment rather than blocking/queueing.
+            if let Ok(Ok(gemspec)) = crate::util::bounded_archive::with_ingest_extraction(|| {
+                Self::extract_gemspec(content)
+            }) {
+                metadata["gemspec"] = serde_json::to_value(&gemspec)?;
             }
         }
 
@@ -420,10 +420,10 @@ impl FormatHandler for RubygemsHandler {
 
         // Validate gem packages
         if !content.is_empty() && matches!(info.operation, RubygemsOperation::Gem) {
-            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
-            // saturation); permit released at the end of this validation scope.
-            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()?;
-            let gemspec = Self::extract_gemspec(content)?;
+            // #2561: permit-scoped decode, fast-fail 503 on saturation.
+            let gemspec = crate::util::bounded_archive::with_ingest_extraction(|| {
+                Self::extract_gemspec(content)
+            })??;
 
             // Verify name matches
             if let Some(path_name) = &info.name {
@@ -1150,6 +1150,25 @@ summary: A summary
         );
         let spec = RubygemsHandler::extract_gemspec(&gem).expect("normal gem parses");
         assert_eq!(spec.name, "rails");
+    }
+
+    /// #2561: `validate` and `parse_metadata` on a gem path still decode the
+    /// gemspec through the permit-scoped decode (uncontended path).
+    #[tokio::test]
+    async fn test_validate_and_parse_metadata_gem_2561() {
+        let gem = gem_with_metadata(
+            b"--- !ruby/object:Gem::Specification\nname: rails\nversion: 7.0.8\n",
+        );
+        let handler = RubygemsHandler::new();
+        handler
+            .validate("gems/rails-7.0.8.gem", &Bytes::from(gem.clone()))
+            .await
+            .expect("matching gem validates");
+        let meta = handler
+            .parse_metadata("gems/rails-7.0.8.gem", &Bytes::from(gem))
+            .await
+            .expect("parse_metadata succeeds");
+        assert_eq!(meta["gemspec"]["name"], "rails");
     }
 
     /// #2556: a `.gem` whose `metadata.gz` inflates past the per-metadata cap is

--- a/backend/src/formats/rubygems.rs
+++ b/backend/src/formats/rubygems.rs
@@ -403,8 +403,12 @@ impl FormatHandler for RubygemsHandler {
 
         // Extract gemspec if this is a gem file
         if !content.is_empty() && matches!(info.operation, RubygemsOperation::Gem) {
-            if let Ok(gemspec) = Self::extract_gemspec(content) {
-                metadata["gemspec"] = serde_json::to_value(&gemspec)?;
+            // #2561: cap concurrent ingestion decompressions; on saturation skip
+            // this best-effort metadata enrichment rather than blocking/queueing.
+            if let Ok(_ingest_permit) = crate::util::bounded_archive::acquire_ingest_extraction() {
+                if let Ok(gemspec) = Self::extract_gemspec(content) {
+                    metadata["gemspec"] = serde_json::to_value(&gemspec)?;
+                }
             }
         }
 
@@ -416,6 +420,9 @@ impl FormatHandler for RubygemsHandler {
 
         // Validate gem packages
         if !content.is_empty() && matches!(info.operation, RubygemsOperation::Gem) {
+            // #2561: cap concurrent ingestion decompressions (fast-fail 503 on
+            // saturation); permit released at the end of this validation scope.
+            let _ingest_permit = crate::util::bounded_archive::acquire_ingest_extraction()?;
             let gemspec = Self::extract_gemspec(content)?;
 
             // Verify name matches

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -1174,19 +1174,16 @@ impl MigrationWorker {
         // and is bounded for npm/helm because those tarballs are small.
         // Returns None for unknown formats; the artifact INSERT proceeds
         // either way and only the metadata row is skipped.
-        // #2561: cap concurrent ingestion decompressions on the migration
-        // reprocessing path; on saturation skip best-effort metadata extraction
-        // (the artifact INSERT proceeds either way — only the metadata row is
-        // skipped, same as for unknown formats).
-        let extracted_metadata = match crate::util::bounded_archive::acquire_ingest_extraction() {
-            Ok(_ingest_permit) => {
-                crate::services::artifact_metadata::extract_artifact_metadata_from_path(
-                    package_type,
-                    &temp_path,
-                )
-            }
-            Err(_) => None,
-        };
+        // #2561: permit-scoped decode; on saturation skip the best-effort
+        // extraction (only the metadata row is skipped).
+        let extracted_metadata = crate::util::bounded_archive::with_ingest_extraction(|| {
+            crate::services::artifact_metadata::extract_artifact_metadata_from_path(
+                package_type,
+                &temp_path,
+            )
+        })
+        .ok()
+        .flatten();
 
         // Get metadata if requested
         let metadata = if include_metadata {

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -1174,11 +1174,19 @@ impl MigrationWorker {
         // and is bounded for npm/helm because those tarballs are small.
         // Returns None for unknown formats; the artifact INSERT proceeds
         // either way and only the metadata row is skipped.
-        let extracted_metadata =
-            crate::services::artifact_metadata::extract_artifact_metadata_from_path(
-                package_type,
-                &temp_path,
-            );
+        // #2561: cap concurrent ingestion decompressions on the migration
+        // reprocessing path; on saturation skip best-effort metadata extraction
+        // (the artifact INSERT proceeds either way — only the metadata row is
+        // skipped, same as for unknown formats).
+        let extracted_metadata = match crate::util::bounded_archive::acquire_ingest_extraction() {
+            Ok(_ingest_permit) => {
+                crate::services::artifact_metadata::extract_artifact_metadata_from_path(
+                    package_type,
+                    &temp_path,
+                )
+            }
+            Err(_) => None,
+        };
 
         // Get metadata if requested
         let metadata = if include_metadata {

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -1025,6 +1025,9 @@ async fn run_curation_sync_cycle(
                             // Bound the upstream-index decompression (#2556): a
                             // malicious/compromised upstream mirror cannot inflate
                             // primary.xml.gz unbounded during sync.
+                            // #2561: also cap CONCURRENT index decompressions.
+                            let _ingest_permit =
+                                crate::util::bounded_archive::acquire_ingest_extraction()?;
                             decompress_upstream_index_gz(&bytes)?
                         } else {
                             String::from_utf8_lossy(&bytes).to_string()
@@ -1056,6 +1059,9 @@ async fn run_curation_sync_cycle(
                         // Bound the upstream-index decompression (#2556): a
                         // malicious/compromised upstream mirror cannot inflate
                         // Packages.gz unbounded during sync.
+                        // #2561: also cap CONCURRENT index decompressions.
+                        let _ingest_permit =
+                            crate::util::bounded_archive::acquire_ingest_extraction()?;
                         let content = decompress_upstream_index_gz(&bytes)?;
                         curation_sync::parse_deb_packages_index(&content, "main")
                     }

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -1024,11 +1024,11 @@ async fn run_curation_sync_cycle(
                         let xml = if primary_path.ends_with(".gz") {
                             // Bound the upstream-index decompression (#2556): a
                             // malicious/compromised upstream mirror cannot inflate
-                            // primary.xml.gz unbounded during sync.
-                            // #2561: also cap CONCURRENT index decompressions.
-                            let _ingest_permit =
-                                crate::util::bounded_archive::acquire_ingest_extraction()?;
-                            decompress_upstream_index_gz(&bytes)?
+                            // primary.xml.gz unbounded during sync. #2561: the
+                            // permit-scoped decode also caps CONCURRENT decodes.
+                            crate::util::bounded_archive::with_ingest_extraction(|| {
+                                decompress_upstream_index_gz(&bytes)
+                            })??
                         } else {
                             String::from_utf8_lossy(&bytes).to_string()
                         };
@@ -1058,11 +1058,12 @@ async fn run_curation_sync_cycle(
                         let bytes = resp.bytes().await?;
                         // Bound the upstream-index decompression (#2556): a
                         // malicious/compromised upstream mirror cannot inflate
-                        // Packages.gz unbounded during sync.
-                        // #2561: also cap CONCURRENT index decompressions.
-                        let _ingest_permit =
-                            crate::util::bounded_archive::acquire_ingest_extraction()?;
-                        let content = decompress_upstream_index_gz(&bytes)?;
+                        // Packages.gz unbounded during sync. #2561: the
+                        // permit-scoped decode also caps CONCURRENT decodes.
+                        let content =
+                            crate::util::bounded_archive::with_ingest_extraction(|| {
+                                decompress_upstream_index_gz(&bytes)
+                            })??;
                         curation_sync::parse_deb_packages_index(&content, "main")
                     }
                     _ => {

--- a/backend/src/util/bounded_archive.rs
+++ b/backend/src/util/bounded_archive.rs
@@ -180,15 +180,47 @@ fn acquire_ingest_extraction_from(sem: &Arc<Semaphore>) -> Result<IngestExtracti
 
 /// Reserve one process-wide ingestion-decompression slot, FAST-FAIL to a 503 on
 /// saturation. Call this in the async handler immediately before invoking the
-/// (synchronous) archive extractor and hold the returned guard across that call:
-///
-/// ```ignore
-/// let _ingest = acquire_ingest_extraction()?; // 503 if the server is saturated
-/// let meta = read_metadata_from_tar_gz(reader, matches)?; // bounded decode
-/// // `_ingest` drops here, releasing the slot before any DB/storage work
-/// ```
+/// (synchronous) archive extractor and hold the returned guard across that call.
+/// Most call sites should prefer [`with_ingest_extraction`] /
+/// [`with_ingest_extraction_async`], which scope the permit for you.
 pub fn acquire_ingest_extraction() -> Result<IngestExtractionGuard> {
     acquire_ingest_extraction_from(ingest_extraction_semaphore())
+}
+
+/// Run `decode` (a synchronous archive decompression) while holding one
+/// process-wide ingestion-decompression slot. FAST-FAILS with the 503
+/// [`AppError::ServiceUnavailable`] on saturation *without* invoking `decode`;
+/// otherwise the permit is held exactly for the duration of `decode` and
+/// released as it returns (before any DB/storage work in the caller). `decode`'s
+/// own return value — `Result`, `Option`, plain value — passes through inside
+/// the `Ok`, so callers layer their existing error mapping on top:
+///
+/// ```ignore
+/// let spec = with_ingest_extraction(|| extract_gemspec(&body))
+///     .map_err(|e| e.into_response())?   // 503 shed
+///     .map_err(|e| bad_request(e))?;     // decode's own error
+/// ```
+pub fn with_ingest_extraction<T>(decode: impl FnOnce() -> T) -> Result<T> {
+    with_ingest_extraction_from(ingest_extraction_semaphore(), decode)
+}
+
+/// `_from` seam for [`with_ingest_extraction`] — lets unit tests drive a local
+/// cap without touching the process singleton.
+fn with_ingest_extraction_from<T>(sem: &Arc<Semaphore>, decode: impl FnOnce() -> T) -> Result<T> {
+    let _permit = acquire_ingest_extraction_from(sem)?;
+    Ok(decode())
+}
+
+/// Like [`with_ingest_extraction`] but holds the slot across an `.await` — for
+/// decodes that hop to a blocking thread (`spawn_blocking`) so the permit must
+/// span the join. Same fast-fail-503 semantics; the future is never constructed
+/// when the server is saturated.
+pub async fn with_ingest_extraction_async<T, F>(decode: impl FnOnce() -> F) -> Result<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    let _permit = acquire_ingest_extraction_from(ingest_extraction_semaphore())?;
+    Ok(decode().await)
 }
 
 /// A `Read` wrapper enforcing a hard cumulative-byte budget on a *decoded*
@@ -1020,6 +1052,53 @@ mod tests {
         drop(first);
         let _third = acquire_ingest_extraction_from(&sem)
             .expect("slot must be reusable after the guard drops");
+    }
+
+    #[test]
+    fn global_wrappers_uncontended_happy_path() {
+        // The process-wide entry points (which the handlers call) work
+        // uncontended: acquire + release, then a scoped decode passes through.
+        let guard = acquire_ingest_extraction().expect("global acquire uncontended");
+        drop(guard);
+        let out = with_ingest_extraction(|| 5).expect("global scoped decode uncontended");
+        assert_eq!(out, 5);
+    }
+
+    #[test]
+    fn with_ingest_extraction_runs_decode_and_releases() {
+        let sem = Arc::new(Semaphore::new(1));
+
+        // Under cap: the decode runs and its value passes through.
+        let out = with_ingest_extraction_from(&sem, || 41 + 1).expect("under-cap decode runs");
+        assert_eq!(out, 42);
+
+        // The permit was released when the closure returned: the slot is free
+        // again immediately (no leak), so a second scoped decode also runs.
+        let out2 = with_ingest_extraction_from(&sem, || "ok").expect("slot released after decode");
+        assert_eq!(out2, "ok");
+
+        // Saturated: the decode is NEVER invoked and the caller gets the 503.
+        let held = acquire_ingest_extraction_from(&sem).expect("hold the only slot");
+        let mut ran = false;
+        let err = with_ingest_extraction_from(&sem, || ran = true)
+            .expect_err("saturated helper must shed");
+        assert!(
+            matches!(err, AppError::ServiceUnavailable(_)),
+            "saturation must map to a 503 ServiceUnavailable, got {:?}",
+            err
+        );
+        assert!(!ran, "decode must not run when the acquire sheds");
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn with_ingest_extraction_async_holds_across_await() {
+        // Happy path on the process-wide semaphore (uncontended in tests):
+        // the future runs to completion and its value passes through.
+        let out = with_ingest_extraction_async(|| async { 7 * 6 })
+            .await
+            .expect("uncontended async decode runs");
+        assert_eq!(out, 42);
     }
 
     #[test]

--- a/backend/src/util/bounded_archive.rs
+++ b/backend/src/util/bounded_archive.rs
@@ -123,13 +123,26 @@ pub const DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS: usize = 8;
 /// every upload, so it is treated as "unset").
 pub const MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV: &str = "MAX_CONCURRENT_INGEST_EXTRACTIONS";
 
+/// Clamp a parsed permit count into the range tokio's `Semaphore` accepts.
+/// `Semaphore::new` panics above [`Semaphore::MAX_PERMITS`] (2^61 - 1), and a
+/// panic inside the `OnceLock` initializer would re-panic on EVERY subsequent
+/// decode (the init is retried), wedging all ingestion — so an absurd override
+/// is clamped rather than trusted. The floor of 1 keeps the semaphore usable
+/// even if a caller ever bypasses `positive_env_or`'s zero filter.
+fn clamp_ingest_permits(v: u64) -> usize {
+    usize::try_from(v)
+        .unwrap_or(usize::MAX)
+        .clamp(1, Semaphore::MAX_PERMITS)
+}
+
 /// Effective concurrent-ingest-extraction cap, honouring
-/// [`MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV`] over the default.
+/// [`MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV`] over the default, clamped to what
+/// `Semaphore::new` accepts (see [`clamp_ingest_permits`]).
 fn max_concurrent_ingest_extractions() -> usize {
-    positive_env_or(
+    clamp_ingest_permits(positive_env_or(
         MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV,
         DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS as u64,
-    ) as usize
+    ))
 }
 
 /// Process-wide semaphore bounding concurrent ingestion decompressions. Seeded
@@ -933,10 +946,54 @@ mod tests {
             );
         }
 
+        // A parseable-but-absurd value above tokio's `Semaphore::MAX_PERMITS`
+        // (2^61 - 1) must be CLAMPED, not passed through: `Semaphore::new`
+        // panics above that bound, and a panicking `OnceLock` initializer
+        // re-panics on every subsequent decode, wedging all ingestion. Kept in
+        // this test fn (not a sibling) so no two tests race on the env var.
+        std::env::set_var(key, "9999999999999999999");
+        assert_eq!(
+            max_concurrent_ingest_extractions(),
+            Semaphore::MAX_PERMITS,
+            "huge override must clamp to Semaphore::MAX_PERMITS, not panic"
+        );
+
         match saved {
             Some(v) => std::env::set_var(key, v),
             None => std::env::remove_var(key),
         }
+    }
+
+    #[test]
+    fn clamp_ingest_permits_bounds_and_floor() {
+        // In-range values pass through untouched.
+        assert_eq!(clamp_ingest_permits(1), 1);
+        assert_eq!(
+            clamp_ingest_permits(DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS as u64),
+            DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS
+        );
+
+        // The exact bound is accepted; anything above clamps to it.
+        assert_eq!(
+            clamp_ingest_permits(Semaphore::MAX_PERMITS as u64),
+            Semaphore::MAX_PERMITS
+        );
+        assert_eq!(
+            clamp_ingest_permits(Semaphore::MAX_PERMITS as u64 + 1),
+            Semaphore::MAX_PERMITS
+        );
+        assert_eq!(
+            clamp_ingest_permits(9_999_999_999_999_999_999),
+            Semaphore::MAX_PERMITS
+        );
+        assert_eq!(clamp_ingest_permits(u64::MAX), Semaphore::MAX_PERMITS);
+
+        // Floor: a zero (only reachable if positive_env_or's filter is ever
+        // bypassed) still yields a usable semaphore.
+        assert_eq!(clamp_ingest_permits(0), 1);
+
+        // The clamped ceiling actually constructs without panicking.
+        let _sem = Semaphore::new(clamp_ingest_permits(u64::MAX));
     }
 
     #[test]

--- a/backend/src/util/bounded_archive.rs
+++ b/backend/src/util/bounded_archive.rs
@@ -42,6 +42,9 @@
 
 use std::io::{self, Read, Seek};
 use std::path::Path;
+use std::sync::{Arc, OnceLock};
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 use crate::error::{AppError, Result};
 
@@ -86,6 +89,93 @@ pub fn max_ingest_decompressed_bytes() -> u64 {
         MAX_INGEST_DECOMPRESSED_BYTES_ENV,
         DEFAULT_MAX_INGEST_DECOMPRESSED_BYTES,
     )
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency cap (#2561)
+// ---------------------------------------------------------------------------
+//
+// The three per-archive caps above bound a *single* extraction's memory/CPU,
+// but place no bound on the NUMBER of extractions running at once. Every
+// ingestion/serve metadata extractor decodes on the request path, so N parallel
+// uploads decode N archives concurrently — N × up-to-`max_ingest_decompressed_bytes()`
+// decode buffers plus N × decompressor CPU at the same time. This mirrors the
+// scanner's own concurrent-extraction gap (`scanner_service.rs` #2540), which
+// caps in-flight scan-workspace extractions with a process-wide semaphore.
+//
+// This module adds the ingestion analogue: a process-wide semaphore whose
+// permits bound the number of concurrent ingestion decodes. Unlike the
+// scanner's FIFO *blocking* acquire (detached background scans have no client
+// latency SLA and must complete), ingestion decode happens on the request path,
+// so the guard is acquired FAST-FAIL: on saturation it sheds the request with a
+// 503 ([`AppError::ServiceUnavailable`]) instead of queueing more decode work.
+// It is a *separate* semaphore from the scanner's, so ingestion and scan
+// extractions do not double-count against one shared budget.
+
+/// Default cap on how many ingestion/serve archive decompressions may run at
+/// once, across ALL format extractors. Bounds worst-case concurrent decode
+/// memory/CPU to roughly `cap × per-archive-cap`. A small default keeps the
+/// out-of-the-box worst case modest while still allowing parallel uploads.
+pub const DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS: usize = 8;
+
+/// Env var overriding [`DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS`]. A blank,
+/// non-numeric, or zero value falls back to the default (a zero cap would wedge
+/// every upload, so it is treated as "unset").
+pub const MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV: &str = "MAX_CONCURRENT_INGEST_EXTRACTIONS";
+
+/// Effective concurrent-ingest-extraction cap, honouring
+/// [`MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV`] over the default.
+fn max_concurrent_ingest_extractions() -> usize {
+    positive_env_or(
+        MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV,
+        DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS as u64,
+    ) as usize
+}
+
+/// Process-wide semaphore bounding concurrent ingestion decompressions. Seeded
+/// once from [`max_concurrent_ingest_extractions`]; each in-flight extraction
+/// holds one permit (via [`IngestExtractionGuard`]) only for the duration of the
+/// decode. Never `close()`d — it lives for the process lifetime.
+fn ingest_extraction_semaphore() -> &'static Arc<Semaphore> {
+    static SEM: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    SEM.get_or_init(|| Arc::new(Semaphore::new(max_concurrent_ingest_extractions())))
+}
+
+/// RAII guard representing one in-flight ingestion decompression. Hold it across
+/// the (synchronous) decode call and drop it promptly afterwards — dropping it
+/// releases the permit so a slow downstream (DB/storage) never keeps a decode
+/// slot occupied. Acquire it with [`acquire_ingest_extraction`].
+#[must_use = "hold the guard across the decode; dropping it immediately releases the permit"]
+#[derive(Debug)]
+pub struct IngestExtractionGuard {
+    _permit: OwnedSemaphorePermit,
+}
+
+/// Try to reserve one ingestion-decompression slot on `sem`, FAST-FAIL: on
+/// saturation return an [`AppError::ServiceUnavailable`] (HTTP 503) rather than
+/// blocking, so an overloaded server sheds excess decode work instead of piling
+/// up memory/CPU. The `_from` seam takes the semaphore explicitly so tests can
+/// drive a local cap without touching the process singleton.
+fn acquire_ingest_extraction_from(sem: &Arc<Semaphore>) -> Result<IngestExtractionGuard> {
+    match sem.clone().try_acquire_owned() {
+        Ok(permit) => Ok(IngestExtractionGuard { _permit: permit }),
+        Err(_) => Err(AppError::ServiceUnavailable(
+            "Server is busy decompressing other uploads; please retry shortly".to_string(),
+        )),
+    }
+}
+
+/// Reserve one process-wide ingestion-decompression slot, FAST-FAIL to a 503 on
+/// saturation. Call this in the async handler immediately before invoking the
+/// (synchronous) archive extractor and hold the returned guard across that call:
+///
+/// ```ignore
+/// let _ingest = acquire_ingest_extraction()?; // 503 if the server is saturated
+/// let meta = read_metadata_from_tar_gz(reader, matches)?; // bounded decode
+/// // `_ingest` drops here, releasing the slot before any DB/storage work
+/// ```
+pub fn acquire_ingest_extraction() -> Result<IngestExtractionGuard> {
+    acquire_ingest_extraction_from(ingest_extraction_semaphore())
 }
 
 /// A `Read` wrapper enforcing a hard cumulative-byte budget on a *decoded*
@@ -808,5 +898,86 @@ mod tests {
             read_metadata_from_decoded_tar_limited(&archive[..], is_meta, 1024 * 1024, 1000, 1024)
                 .unwrap();
         assert_eq!(out.unwrap(), b"ok");
+    }
+
+    // -----------------------------------------------------------------------
+    // #2561 — concurrent-ingest-extraction cap
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn max_concurrent_ingest_extractions_env_override() {
+        // Default when unset; a valid override wins; blank / non-numeric / zero
+        // fall back to the default (a zero cap would wedge every upload).
+        let key = MAX_CONCURRENT_INGEST_EXTRACTIONS_ENV;
+        let saved = std::env::var(key).ok();
+
+        std::env::remove_var(key);
+        assert_eq!(
+            max_concurrent_ingest_extractions(),
+            DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS
+        );
+
+        std::env::set_var(key, "3");
+        assert_eq!(max_concurrent_ingest_extractions(), 3);
+
+        std::env::set_var(key, "64");
+        assert_eq!(max_concurrent_ingest_extractions(), 64);
+
+        for bad in ["0", "", "   ", "abc", "-1"] {
+            std::env::set_var(key, bad);
+            assert_eq!(
+                max_concurrent_ingest_extractions(),
+                DEFAULT_MAX_CONCURRENT_INGEST_EXTRACTIONS,
+                "value {:?} should fall back to default",
+                bad
+            );
+        }
+
+        match saved {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    #[test]
+    fn acquire_ingest_extraction_fast_fails_when_saturated() {
+        // A *local* cap-1 semaphore (not the process singleton) so this test is
+        // deterministic regardless of test-thread count.
+        let sem = Arc::new(Semaphore::new(1));
+
+        // Under cap: the first acquire succeeds.
+        let first = acquire_ingest_extraction_from(&sem).expect("first acquire is under cap");
+
+        // Saturated: the next acquire FAST-FAILS to a 503 (ServiceUnavailable),
+        // it does NOT block.
+        let err = acquire_ingest_extraction_from(&sem)
+            .expect_err("acquire past the cap must fail fast, not block");
+        assert!(
+            matches!(err, AppError::ServiceUnavailable(_)),
+            "saturation must map to a 503 ServiceUnavailable, got {:?}",
+            err
+        );
+
+        // Releasing the guard frees the slot promptly (no permit leak): a
+        // subsequent acquire succeeds again.
+        drop(first);
+        let _third = acquire_ingest_extraction_from(&sem)
+            .expect("slot must be reusable after the guard drops");
+    }
+
+    #[test]
+    fn under_cap_ingest_extractions_all_proceed() {
+        // With headroom every concurrent extraction proceeds unchanged.
+        let sem = Arc::new(Semaphore::new(4));
+        let g1 = acquire_ingest_extraction_from(&sem).expect("1/4");
+        let g2 = acquire_ingest_extraction_from(&sem).expect("2/4");
+        let g3 = acquire_ingest_extraction_from(&sem).expect("3/4");
+        // Fourth still fits; fifth would shed.
+        let g4 = acquire_ingest_extraction_from(&sem).expect("4/4");
+        assert!(
+            acquire_ingest_extraction_from(&sem).is_err(),
+            "the 5th concurrent extraction past a cap of 4 must shed"
+        );
+        drop((g1, g2, g3, g4));
     }
 }


### PR DESCRIPTION
## Summary

Ingestion/serve metadata extraction decompresses uploaded (and proxied/served)
archives *inside the request path* to read a small coordinate file
(`Chart.yaml`, `.nuspec`, `pubspec.yaml`, `METADATA`, `.podspec.json`, control
tar, …). `util/bounded_archive` (#2557) caps a **single** extraction (128 MiB
total / 10k entries / 8 MiB per entry), but nothing bounds the **number** of
extractions running at once. ~20 extractor call sites each decode with no shared
concurrency guard, so N parallel uploads decode N archives concurrently —
`N × up-to-128 MiB` decode buffers plus N decompressors' CPU at the same time —
a resource-exhaustion surface under many concurrent uploads.

The scanner already solved the analogous gap for scan-workspace extraction with
a process-wide semaphore (`scanner_service.rs` #2540). This PR adds the
**ingestion-side** analogue: a **global** concurrency cap.

What changed:
- `util/bounded_archive`: a process-wide `Semaphore` sized by
  `MAX_CONCURRENT_INGEST_EXTRACTIONS` (default **8**, parsed with the existing
  `positive_env_or` idiom — blank/zero/non-numeric falls back to the default so a
  misconfig never wedges ingestion), plus an RAII `IngestExtractionGuard` and a
  single `acquire_ingest_extraction()` helper.
- The guard is acquired **fast-fail** (`try_acquire`) in the async handler
  immediately before the synchronous extractor and held only across that call.
  On saturation it returns `AppError::ServiceUnavailable` → **HTTP 503** (with the
  existing `Retry-After`), so an overloaded server **sheds** excess decode work
  instead of queueing/OOMing. The permit is released promptly (before DB/storage
  I/O) so a slow downstream never occupies a decode slot.
- Wired into every extractor entrypoint across conda, pypi, cocoapods,
  rubygems, protobuf, pub, nuget, hex, helm, composer, **swift**, debian
  (upload + **proxy pool-download index decode**), incus, the npm/helm
  migration-reprocessing path, and the upstream-index proxy-sync path.
  Post-commit / best-effort enrichment paths (e.g. conda post-insert metadata,
  format-handler `parse_metadata`, migration/incus metadata) **skip** the decode
  on saturation rather than failing an already-accepted upload; primary
  validation/serve paths shed with 503. The debian pool-resolve helper returns
  `Result<Option<String>>` and sheds a clean retryable 503 before any upstream
  fetch or cache write, so a saturated resolve fails cleanly with no partial
  state.
- This is a **separate** semaphore from the scanner's, so ingestion and scan
  extractions do not double-count against one shared budget.
- The parsed `MAX_CONCURRENT_INGEST_EXTRACTIONS` is **clamped** to
  `Semaphore::MAX_PERMITS` (2^61 - 1) with a floor of 1, so an absurd but
  parseable override (e.g. `9999999999999999999`) falls back sanely instead of
  panicking `Semaphore::new` on first decode (a panic in the `OnceLock`
  initializer would re-panic on every subsequent decode and wedge ingestion).

Per-tenant fairness (so one noisy tenant cannot monopolise the global permits)
is a deliberate follow-up, tracked separately in #2598 (1.7.0) — this PR ships
the global cap only.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Unit tests in `util::bounded_archive::tests` (mirroring the scanner's #2540
tests):
- `acquire_ingest_extraction_fast_fails_when_saturated` — a saturated semaphore
  makes the next acquire **fast-fail** to a 503 (`ServiceUnavailable`), never
  block; dropping the guard frees the slot promptly (no permit leak).
- `max_concurrent_ingest_extractions_env_override` — default when unset, a valid
  override wins, and blank/zero/non-numeric fall back to the default.
- `under_cap_ingest_extractions_all_proceed` — under-cap extractions proceed
  unchanged; the first over-cap one sheds.
- `clamp_ingest_permits_bounds_and_floor` + a huge-value case in the env-override
  test — a parseable value above `Semaphore::MAX_PERMITS` clamps to that bound
  (constructs without panicking) instead of wedging ingestion.
- `with_ingest_extraction_runs_decode_and_releases` /
  `with_ingest_extraction_async_holds_across_await` /
  `global_wrappers_uncontended_happy_path` — the scoped helpers (which every call
  site uses) run the decode under cap, never invoke it when shedding, and release
  the permit promptly.

Plus end-to-end tests through the permit-scoped decode paths: formats
`parse_metadata`/`validate` fixtures (composer zip, `.deb` control tar, gem
gemspec, incus image tarball) and DB-backed authenticated pushes (rubygems gem,
hex tarball, cocoapods pod) via the `test_db_helpers` router harness.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Full backend lib suite: **13347 passed, 0 failed, 6 skipped** (throwaway
Postgres). `cargo fmt --check` clean; `cargo clippy --workspace --all-targets -- -D
warnings` clean (exit 0); jscpd on the gate's measured changed-file set **2.0%**
(< 3%); new-code coverage (CI-gate replica against a local `cargo llvm-cov`
lcov) **75%** (>= 70%).

Isolated-instance proof (bluefix pool slot, `MAX_CONCURRENT_INGEST_EXTRACTIONS`
lowered to make saturation crisp):
- **helm** upload burst (cap 2): 24 concurrent → 2×201, 22×503 with `Retry-After: 1`,
  503s fast (~20 ms) vs 201s holding the decode (~55 ms); post-burst singles all 201.
- **swift** upload burst (cap 1): 20 concurrent → 4×201, 16×503 fast; post-burst single 201 (no leak).
- **debian proxy pool-download** (cap 1): 30 concurrent distinct `.deb` GETs, each
  driving a ~43 MiB cached-`Packages` index decode → 1×200 (resolve+decode+fetch),
  29×503 whose body is the ingest-guard shed message (not the proxy's), and a single
  GET still resolves to 200 — the saturated resolve fails cleanly with no partial state.

Peak concurrent decodes stay bounded to the cap; excess sheds 503 fast (previously
unbounded); permits release promptly with no leak.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2561
