### PR TITLE
fix: complete authorization hardening

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -465,9 +465,9 @@ fn oci_forbidden_scope(required: &str) -> Response {
 }
 
 /// Build a 403 Forbidden response when a caller is authenticated but lacks
-/// write/delete access to the target repository (private-repo members-only
-/// gate). Uses the OCI `DENIED` error code, the registry-standard code for an
-/// authorization failure on an authenticated request.
+/// write/delete access to the target repository. Uses the OCI `DENIED` error
+/// code, the registry-standard code for an authorization failure on an
+/// authenticated request.
 fn oci_denied_repo_access() -> Response {
     oci_error(
         StatusCode::FORBIDDEN,
@@ -522,46 +522,34 @@ fn enforce_token_repo_scope(
     }
 }
 
-/// OCI v2 write/delete authorization — parity with the REST artifact-write gate.
+/// OCI v2 write/delete authorization — parity with the REST artifact gates.
 ///
-/// The REST artifact path enforces a private-repository members-only gate
-/// (`require_repo_write_access` in `handlers/repositories.rs`, the #1764
-/// lineage): admins bypass, public repositories are writable by any
-/// authenticated caller, and every other caller must hold a role assignment
-/// scoped to the repository (direct or global) — exactly
-/// `RepositoryService::user_can_access_repo`. The /v2 write/delete handlers
-/// authenticate the caller and check the OCI token scope, but never consulted
-/// this per-repo membership gate, so a non-admin non-member could push to /
-/// delete from a PRIVATE repository that the REST path denies with 403. Apply
-/// the same decision here.
-///
-/// This is intentionally the per-repo membership check, NOT the fine-grained
-/// permission-rule check (`check_permission`/`has_any_rules_for_target`): the
-/// latter defaults to "no rules => allow", which would leave a freshly-created
-/// private repo with no rules wide open — the gap that the REST gate closes.
+/// Public visibility is read-only. Pushes and deletes require the requested
+/// repository action (or `admin`) once fine-grained rules exist, with legacy
+/// role assignments as the fallback for repositories without rules.
 ///
 /// Public-pull / anonymous-read paths never reach this helper (it is only
 /// invoked on write/delete handlers after authentication). Proxy/mirror flows
 /// are unaffected: remote/virtual repos reject pushes earlier, and replication
 /// identities hold a repo-scoped or global grant. Fails closed (503) if the
 /// membership lookup errors, mirroring the REST middleware.
-async fn require_oci_repo_write_access(
+async fn require_oci_repo_action_access(
     state: &SharedState,
     claims: &crate::services::auth_service::Claims,
     repo_id: Uuid,
-    repo_is_public: bool,
+    action: &str,
 ) -> Result<(), Response> {
     // An API-token-scoped bearer may only touch repositories in its declared
     // allow-list — a ceiling that applies even to admins (#2290). This mirrors
     // the REST #504 gate, which runs `can_access_repo` before the admin
     // fine-grained bypass. No-op for unscoped tokens / JWT-login sessions.
     enforce_token_repo_scope(claims, repo_id)?;
-    if claims.is_admin || repo_is_public {
+    if claims.is_admin {
         return Ok(());
     }
     match state
         .create_repository_service()
-        .user_can_access_repo(repo_id, claims.sub)
+        .user_can_perform_repo_action(repo_id, claims.sub, action)
         .await
     {
         Ok(true) => Ok(()),
@@ -574,61 +562,6 @@ async fn require_oci_repo_write_access(
                 "repository authorization temporarily unavailable",
             ))
         }
-    }
-}
-
-/// Fine-grained per-action OCI gate, applied AFTER `require_oci_repo_write_access`
-/// (the tenant-membership gate) on the destructive manifest-delete path.
-///
-/// `require_oci_repo_write_access` admits any member (incl. a read/write-only
-/// grantee) and any authed caller on a public repo, collapsing write/delete —
-/// the OCI half of #2321 (G2). When the repo has fine-grained permission rules,
-/// require the requested `action` (or `admin`, which implies all actions), the
-/// same `has_rules -> check_permission` block the REST path enforces. Admins
-/// bypass; a repo with no rules falls through unchanged. Fails closed (503) if
-/// the rule lookup errors, mirroring `require_oci_repo_write_access`.
-#[allow(clippy::result_large_err)] // Response-as-error is used throughout this module
-async fn require_oci_repo_fine_grained_action(
-    state: &SharedState,
-    claims: &crate::services::auth_service::Claims,
-    repo_id: Uuid,
-    action: &str,
-) -> Result<(), Response> {
-    if claims.is_admin {
-        return Ok(());
-    }
-    let has_rules = match state
-        .permission_service
-        .has_any_rules_for_target("repository", repo_id)
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::error!("OCI permission-rule lookup failed: {}", e);
-            return Err(oci_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "DENIED",
-                "repository authorization temporarily unavailable",
-            ));
-        }
-    };
-    if !has_rules {
-        return Ok(());
-    }
-    let has_action = state
-        .permission_service
-        .check_permission(claims.sub, "repository", repo_id, action, false)
-        .await
-        .unwrap_or(false);
-    let has_admin = state
-        .permission_service
-        .check_permission(claims.sub, "repository", repo_id, "admin", false)
-        .await
-        .unwrap_or(false);
-    if has_action || has_admin {
-        Ok(())
-    } else {
-        Err(oci_denied_repo_access())
     }
 }
 
@@ -4607,11 +4540,8 @@ async fn handle_start_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate, parity
-    // with the REST artifact-write path). Without this a non-admin non-member
-    // could open a blob upload against a PRIVATE repo it has no grant on.
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization, including rule-less public repositories.
+    if let Err(resp) = require_oci_repo_action_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     // #1776: only repositories that store their own manifests (Local/Staging)
@@ -4947,9 +4877,8 @@ async fn handle_patch_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_action_access(state, &claims, repo.id, "write").await {
         return resp;
     }
 
@@ -5193,9 +5122,8 @@ async fn handle_cancel_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_action_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     let storage = match state.storage_for_repo(&repo.location) {
@@ -5435,9 +5363,8 @@ async fn handle_complete_upload(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_action_access(state, &claims, repo.id, "write").await {
         return resp;
     }
 
@@ -6985,9 +6912,8 @@ async fn handle_put_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
+    // Repository write authorization.
+    if let Err(resp) = require_oci_repo_action_access(state, &claims, repo.id, "write").await {
         return resp;
     }
     // #1776: only repositories that store their own manifests (Local/Staging)
@@ -8031,17 +7957,8 @@ async fn handle_delete_manifest(
         Ok(r) => r,
         Err(e) => return e,
     };
-    // Repository write/delete authorization (private-repo members-only gate).
-    if let Err(resp) = require_oci_repo_write_access(state, &claims, repo.id, repo.is_public).await
-    {
-        return resp;
-    }
-    // Fine-grained delete gate (#2321 G2): the tenant gate above admits any
-    // member regardless of action, collapsing read/write/delete. Require the
-    // `delete` action when the repo has permission rules, matching the REST
-    // `delete_artifact` path.
-    if let Err(resp) = require_oci_repo_fine_grained_action(state, &claims, repo.id, "delete").await
-    {
+    // Repository delete authorization.
+    if let Err(resp) = require_oci_repo_action_access(state, &claims, repo.id, "delete").await {
         return resp;
     }
 
@@ -14196,6 +14113,9 @@ mod manifest_digest_db_tests {
         assert_eq!(st, StatusCode::NOT_FOUND, "absent digest still 404s");
 
         // 5. DELETE by digest removes the object; the digest then 404s.
+        // This fixture's legacy developer role grants write, not delete. Give
+        // the actor the explicit actions needed by the remainder of the test.
+        tdh::grant_repo_actions(&fx.pool, fx.repo_id, fx.user_id, &["read", "delete"]).await;
         let (st, _, _) = send(
             router().with_state(fx.state.clone()),
             req(
@@ -14442,6 +14362,7 @@ mod manifest_digest_db_tests {
         .await
         .expect("create failure trigger");
 
+        tdh::grant_repo_actions(&fx.pool, fx.repo_id, fx.user_id, &["delete"]).await;
         let (status, _, _) = send(
             router().with_state(fx.state.clone()),
             req(
@@ -14809,6 +14730,10 @@ mod oci_blob_upload_streaming_tests {
             }
         };
 
+        // Keep this test focused on the promotion-only gate: the actor is
+        // otherwise authorized to delete from the repository.
+        tdh::grant_repo_actions(&f.inner.pool, f.inner.repo_id, f.inner.user_id, &["delete"]).await;
+
         // (a) promotion_only=true, non-admin (default fixture token, is_admin=false):
         //     DELETE must be rejected 403 DENIED and leave the tag intact.
         f.inner.set_promotion_only(true).await;
@@ -15058,6 +14983,7 @@ mod oci_blob_upload_streaming_tests {
         .await
         .expect("seed refs");
 
+        tdh::grant_repo_actions(&f.inner.pool, f.inner.repo_id, f.inner.user_id, &["delete"]).await;
         let (status, _h, _b) = send(
             f.app(),
             request(
@@ -15106,6 +15032,7 @@ mod oci_blob_upload_streaming_tests {
         .await
         .expect("seed child refs");
 
+        tdh::grant_repo_actions(&f.inner.pool, f.inner.repo_id, f.inner.user_id, &["delete"]).await;
         let (status, _h, _b) = send(
             f.app(),
             request(
@@ -22240,11 +22167,9 @@ mod cross_repo_session_regression_tests {
 // ===========================================================================
 // OCI v2 write authorization + body-size cap.
 //
-// Authorization: the /v2 blob-upload and manifest write/delete paths must
-// enforce the SAME private-repo members-only gate the REST artifact path
-// enforces (`require_repo_write_access` -> `user_can_access_repo`, the #1764
-// lineage). A non-admin non-member is denied on a PRIVATE repo; admins and
-// granted members are allowed; public repos and anonymous reads are unaffected.
+// Authorization: the /v2 blob-upload and manifest write/delete paths enforce
+// the same action-aware repository gate as REST. Public visibility is read-only;
+// mutations require the matching repository action or global admin.
 //
 // Size cap: an over-limit body must yield 413 Payload Too Large (declared
 // Content-Length / Content-Range rejection, or the streaming cumulative cap),
@@ -22408,6 +22333,32 @@ mod oci_write_authz_and_size_tests {
             .execute(&pool)
             .await;
         tdh::cleanup(&pool, repo_id, member).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    #[tokio::test]
+    async fn start_upload_denied_for_ungranted_user_on_public_repo() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, storage_dir) = create_private_docker_repo(&pool).await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("make OCI repository public");
+        let state = tdh::build_state(pool.clone(), storage_dir.to_str().unwrap());
+        let outsider = create_oci_user(&pool, false).await;
+        let bearer = bearer_for(&state, outsider).await;
+
+        let status = start_upload_status(&state, &repo_key, &bearer).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "public pull visibility must not authorize an OCI push"
+        );
+
+        tdh::cleanup(&pool, repo_id, outsider).await;
         let _ = std::fs::remove_dir_all(&storage_dir);
     }
 

--- a/backend/src/api/handlers/peers.rs
+++ b/backend/src/api/handlers/peers.rs
@@ -236,14 +236,18 @@ fn parse_status(s: &str) -> Option<InstanceStatus> {
     params(ListPeersQuery),
     responses(
         (status = 200, description = "List of peer instances", body = PeerInstanceListResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 500, description = "Internal server error")
     ),
     security(("bearer_auth" = []))
 )]
 pub async fn list_peers(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListPeersQuery>,
 ) -> Result<Json<PeerInstanceListResponse>> {
+    auth.require_admin()?;
+
     let page = query.page.unwrap_or(1).max(1);
     let per_page = query.per_page.unwrap_or(20).min(100);
     let offset = ((page - 1) * per_page) as i64;
@@ -367,6 +371,7 @@ pub async fn register_peer(
     ),
     responses(
         (status = 200, description = "Peer instance details", body = PeerInstanceResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Peer instance not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -374,8 +379,11 @@ pub async fn register_peer(
 )]
 pub async fn get_peer(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<PeerInstanceResponse>> {
+    auth.require_admin()?;
+
     let service = PeerInstanceService::new(state.db.clone());
     let instance = service.get_by_id(id).await?;
 
@@ -501,6 +509,7 @@ pub async fn trigger_sync(
     ),
     responses(
         (status = 200, description = "List of pending sync tasks", body = Vec<SyncTaskResponse>),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Peer instance not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -508,9 +517,12 @@ pub async fn trigger_sync(
 )]
 pub async fn get_sync_tasks(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
     Query(query): Query<ListPeersQuery>,
 ) -> Result<Json<Vec<SyncTaskResponse>>> {
+    auth.require_admin()?;
+
     let limit = query.per_page.unwrap_or(50) as i64;
     let service = PeerInstanceService::new(state.db.clone());
     let tasks = service.get_pending_sync_tasks(id, limit).await?;
@@ -544,6 +556,7 @@ pub async fn get_sync_tasks(
     ),
     responses(
         (status = 200, description = "List of assigned repository IDs", body = Vec<Uuid>),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Peer instance not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -551,8 +564,11 @@ pub async fn get_sync_tasks(
 )]
 pub async fn get_assigned_repos(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path(id): Path<Uuid>,
 ) -> Result<Json<Vec<Uuid>>> {
+    auth.require_admin()?;
+
     let service = PeerInstanceService::new(state.db.clone());
     let repos = service.get_assigned_repositories(id).await?;
     Ok(Json(repos))
@@ -628,6 +644,7 @@ pub async fn assign_repo(
     ),
     responses(
         (status = 200, description = "Subscription details", body = SubscriptionResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Subscription not found"),
         (status = 500, description = "Internal server error")
     ),
@@ -635,8 +652,11 @@ pub async fn assign_repo(
 )]
 pub async fn get_subscription(
     State(state): State<SharedState>,
+    Extension(auth): Extension<AuthExtension>,
     Path((id, repo_id)): Path<(Uuid, Uuid)>,
 ) -> Result<Json<SubscriptionResponse>> {
+    auth.require_admin()?;
+
     let service = PeerInstanceService::new(state.db.clone());
     let sub = service.get_subscription(id, repo_id).await?;
     Ok(Json(SubscriptionResponse {
@@ -1627,10 +1647,8 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // Admin gate: the mutating peer handlers (register / unregister /
-    // trigger_sync / assign / unassign / run-now) now call
-    // auth.require_admin()? before touching the service, matching the
-    // in-file pattern already used by heartbeat / announce / identity.
+    // Admin gate: peer management mutations and sensitive inventory reads call
+    // auth.require_admin()? before touching the service.
     // -----------------------------------------------------------------------
 
     /// Build an [`AuthExtension`] for a non-admin caller.
@@ -1672,5 +1690,28 @@ mod tests {
     #[test]
     fn test_peer_write_guard_allows_admin() {
         assert!(admin_auth().require_admin().is_ok());
+    }
+
+    #[test]
+    fn test_peer_inventory_handlers_require_admin() {
+        let source = include_str!("peers.rs");
+        for handler in [
+            "list_peers",
+            "get_peer",
+            "get_sync_tasks",
+            "get_assigned_repos",
+            "get_subscription",
+        ] {
+            let marker = format!("pub async fn {handler}(");
+            let start = source
+                .find(&marker)
+                .unwrap_or_else(|| panic!("handler {handler} not found"));
+            let rest = &source[start + marker.len()..];
+            let end = rest.find("\npub async fn ").unwrap_or(rest.len());
+            assert!(
+                rest[..end].contains("auth.require_admin()?"),
+                "peer inventory handler {handler} must require global admin"
+            );
+        }
     }
 }

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -9313,7 +9313,7 @@ mod tests {
             &proxy,
             &state,
             Uuid::nil(),
-            "npm-proxy",
+            "npm-proxy-held-entry-2075",
             "https://upstream.example.test",
             "lodash",
         )
@@ -9348,7 +9348,7 @@ mod tests {
             &proxy,
             &state,
             Uuid::nil(),
-            "npm-proxy",
+            "npm-proxy-unheld-entry-2075",
             "https://upstream.example.test",
             "lodash",
         )

--- a/backend/src/api/handlers/repo_tokens.rs
+++ b/backend/src/api/handlers/repo_tokens.rs
@@ -1,7 +1,7 @@
 //! Repository-scoped access token management.
 //!
-//! Allows repository administrators (users with write scope or global admins)
-//! to create, list, and revoke API tokens scoped to a specific repository.
+//! Allows repository administrators to create, list, and revoke API tokens
+//! scoped to a specific repository.
 //! Tokens created through these endpoints are automatically restricted to the
 //! repository they were created on via the `api_token_repositories` join table.
 
@@ -12,6 +12,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::{OpenApi, ToSchema};
@@ -116,7 +117,8 @@ fn caller_owns_token(auth: &AuthExtension, created_by_user_id: Option<Uuid>) -> 
 }
 
 /// Require that the caller is authenticated and has write scope on repos
-/// (or is a global admin).
+/// (or is a global admin). Repository-admin authorization is checked after the
+/// target repository is resolved.
 fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
     let auth =
         auth.ok_or_else(|| AppError::Authentication("Authentication required".to_string()))?;
@@ -130,11 +132,10 @@ fn require_repo_write(auth: Option<AuthExtension>) -> Result<AuthExtension> {
 /// Authorize the caller for a repo-tokens endpoint and resolve the target
 /// repository. Returns the validated `(auth, repo)` pair on success.
 ///
-/// This collapses the three-step pre-amble shared by every handler in this
-/// module: `require_repo_write`, `RepositoryService::get_by_key`, and the
-/// per-caller `can_access_repo` visibility check. The `NotFound` (rather
-/// than `Forbidden`) response on visibility failure is intentional: it
-/// prevents an unauthorized caller from probing repository existence.
+/// Repository-scoped tokens delegate repository access, so every operation on
+/// them requires repository `admin` (or global admin). This helper centralizes
+/// authentication, token repository scope, and repository-admin authorization
+/// before token lookup and request parsing.
 async fn authorize_repo_for_tokens(
     state: &SharedState,
     auth: Option<AuthExtension>,
@@ -152,23 +153,18 @@ async fn authorize_repo_for_tokens(
         )));
     }
 
-    // Per-repo authorization (mirrors `require_visible` in the repositories
-    // handler). The `can_access_repo` check above only enforces the *token's*
-    // repo scope — a broad `write:repositories` token (`allowed_repo_ids =
-    // None`) passes it for ANY repo. Without this DB-level check, any
-    // authenticated user with the write scope could mint repo-scoped tokens on
-    // a PRIVATE repository they cannot see (#1783). A private repo is visible
-    // only to an admin or a user with a role assignment scoped to it.
-    if !repo.is_public
-        && !auth.is_admin
-        && !repo_service
-            .user_can_access_repo(repo.id, auth.user_id)
-            .await?
-    {
-        return Err(AppError::NotFound(format!(
-            "Repository '{}' not found",
-            key
-        )));
+    // Repository-scoped tokens are delegation credentials. Visibility or write
+    // access is not enough: public repositories must not let every authenticated
+    // principal mint a token, and writers must not escalate into token issuance.
+    if !auth.is_admin {
+        let allowed = repo_service
+            .user_can_perform_repo_action(repo.id, auth.user_id, "admin")
+            .await?;
+        if !allowed {
+            return Err(AppError::Authorization(
+                "Insufficient permissions to manage repository tokens".to_string(),
+            ));
+        }
     }
 
     Ok((auth, repo))
@@ -298,9 +294,11 @@ pub async fn create_repo_token(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
-    Json(payload): Json<CreateRepoTokenRequest>,
+    body: Bytes,
 ) -> Result<Json<CreateRepoTokenResponse>> {
     let (auth, repo) = authorize_repo_for_tokens(&state, auth, &key).await?;
+    let payload: CreateRepoTokenRequest = serde_json::from_slice(&body)
+        .map_err(|e| AppError::Validation(format!("Invalid JSON: {}", e)))?;
 
     // Validate inputs
     validate_scopes_pure(&payload.scopes).map_err(AppError::Validation)?;
@@ -914,16 +912,16 @@ mod admin_scope_policy_tests {
     async fn setup() -> Option<(sqlx::PgPool, SharedState, Uuid, String, String)> {
         let pool = tdh::try_pool().await?;
         let (user_id, username) = tdh::create_user(&pool).await;
-        let (_repo_id, repo_key, _storage_dir) = tdh::create_repo(&pool, "local", "maven").await;
-        // These tests assert the admin-scope 403 gate, not repo visibility. The
-        // #1783 private-repo check returns 404 before that gate for a private,
-        // rule-less repo, so make the setup repo public to reach the scope gate.
-        // The dedicated private-repo test flips this back to private itself.
+        let (repo_id, repo_key, _storage_dir) = tdh::create_repo(&pool, "local", "maven").await;
+        // These tests target delegated-scope policy after repository
+        // authorization, so grant repository admin to the fixture caller. The
+        // dedicated no-role test removes this grant before issuing its request.
         sqlx::query("UPDATE repositories SET is_public = true WHERE key = $1")
             .bind(&repo_key)
             .execute(&pool)
             .await
             .expect("make setup repo public");
+        tdh::grant_repo_admin(&pool, repo_id, user_id).await;
         let state = tdh::build_state(pool.clone(), "/tmp");
         Some((pool, state, user_id, username, repo_key))
     }
@@ -998,11 +996,60 @@ mod admin_scope_policy_tests {
         cleanup(&pool, user_id, &repo_key).await;
     }
 
+    #[tokio::test]
+    async fn non_admin_without_repo_admin_cannot_mint_token_on_public_repo() {
+        let Some((pool, state, user_id, username, repo_key)) = setup().await else {
+            return;
+        };
+        sqlx::query(
+            "DELETE FROM permissions WHERE target_type = 'repository' \
+             AND target_id = (SELECT id FROM repositories WHERE key = $1)",
+        )
+        .bind(&repo_key)
+        .execute(&pool)
+        .await
+        .expect("remove repository-admin grant");
+
+        let mut auth = tdh::make_auth(user_id, &username);
+        auth.is_api_token = true;
+        auth.scopes = Some(vec!["write:repositories".to_string()]);
+
+        let req = post_repo_token_request(&repo_key, "public-probe", &["read:artifacts"]);
+        let (status, _) = tdh::send(build_app(state.clone(), auth.clone()), req).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "public visibility must not authorize repository token delegation"
+        );
+
+        let malformed = Request::builder()
+            .method(Method::POST)
+            .uri(format!("/{}/tokens", repo_key))
+            .header("content-type", "application/json")
+            .body(Body::from("{"))
+            .unwrap();
+        let (status, _) = tdh::send(build_app(state, auth), malformed).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "repository-admin authorization must precede token body parsing"
+        );
+
+        let created: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM api_tokens WHERE user_id = $1")
+            .bind(user_id)
+            .fetch_one(&pool)
+            .await
+            .expect("count denied token creations");
+        assert_eq!(created, 0, "denied requests must not create API tokens");
+
+        cleanup(&pool, user_id, &repo_key).await;
+    }
+
     /// #1783: a non-admin holding only the broad `write:repositories` scope
     /// (token `allowed_repo_ids = None`, so `can_access_repo` passes for ANY
     /// repo) must NOT be able to mint a repo token on a PRIVATE repository it
-    /// has no role on. Before the fix the endpoint returned 200/created; it
-    /// must now 404 (existence-hiding), exactly like `require_visible`.
+    /// has no repository-admin grant. Before the fix the endpoint returned
+    /// 200/created; delegated token issuance must now return 403.
     #[tokio::test]
     async fn non_admin_without_role_cannot_mint_token_on_private_repo() {
         let Some((pool, state, user_id, username, repo_key)) = setup().await else {
@@ -1014,6 +1061,14 @@ mod admin_scope_policy_tests {
             .execute(&pool)
             .await
             .expect("set repo private");
+        sqlx::query(
+            "DELETE FROM permissions WHERE target_type = 'repository' \
+             AND target_id = (SELECT id FROM repositories WHERE key = $1)",
+        )
+        .bind(&repo_key)
+        .execute(&pool)
+        .await
+        .expect("remove repository-admin grant");
 
         // Non-admin API token with the delegatable write scope but no repo
         // restriction, requesting a SAFE (non-admin) scope so it clears the
@@ -1028,8 +1083,8 @@ mod admin_scope_policy_tests {
 
         assert_eq!(
             status,
-            StatusCode::NOT_FOUND,
-            "non-admin without a role must not mint tokens on a private repo (existence-hiding); got {} body: {}",
+            StatusCode::FORBIDDEN,
+            "non-admin without repository-admin must not mint tokens; got {} body: {}",
             status,
             String::from_utf8_lossy(&body_bytes),
         );
@@ -1095,11 +1150,10 @@ mod admin_scope_policy_tests {
 // ---------------------------------------------------------------------------
 // Per-token ownership gate tests (CWE-639 / BOLA)
 //
-// Repository-scoped token GET/DELETE and list-detail were authorized only via
-// `authorize_repo_for_tokens` (repo-level access), which every same-tenant
-// member with `write:repositories` passes. These tests prove the per-token
-// ownership gate: a peer cannot read, enumerate, or revoke another member's
-// repo token; the creator and global admins still can.
+// Repository-scoped token GET/DELETE and list-detail first require repository
+// admin. These tests prove the additional per-token ownership gate: one
+// repository admin cannot read, enumerate, or revoke another repository
+// admin's token; the creator and global admins still can.
 // ---------------------------------------------------------------------------
 
 #[cfg(test)]
@@ -1179,10 +1233,8 @@ mod ownership_gate_tests {
         row.0
     }
 
-    /// Full public-repo setup with two members (victor=creator, sam=peer) and a
-    /// token seeded on the repo by victor. The repo is public so the #1783
-    /// private-repo gate is satisfied and the gate under test is purely
-    /// per-token, not visibility.
+    /// Full public-repo setup with two users (victor=repository admin/creator,
+    /// sam=peer) and a token seeded on the repo by victor.
     struct Fixture {
         pool: sqlx::PgPool,
         state: SharedState,
@@ -1203,6 +1255,7 @@ mod ownership_gate_tests {
             .expect("make repo public");
         let (victor, victor_name) = tdh::create_user(&pool).await;
         let (sam, _sam_name) = tdh::create_user(&pool).await;
+        tdh::grant_repo_admin(&pool, repo_id, victor).await;
         let state = tdh::build_state(pool.clone(), "/tmp");
         let token_id = create_token_as(&state, member_auth(victor, &victor_name), &repo_key).await;
         Some(Fixture {
@@ -1237,23 +1290,23 @@ mod ownership_gate_tests {
         }
     }
 
-    /// (1) A peer GET of another member's token returns 404 (was 200).
+    /// (1) A peer without repository admin is rejected before token lookup.
     #[tokio::test]
-    async fn peer_get_token_is_404() {
+    async fn peer_get_token_is_403() {
         let Some(f) = fixture().await else { return };
         let app = app_as(f.state.clone(), member_auth(f.sam, "sam"));
         let (status, _) = tdh::send(app, get_token_req(&f.repo_key, f.token_id)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND, "peer GET must 404");
+        assert_eq!(status, StatusCode::FORBIDDEN, "peer GET must 403");
         teardown(&f).await;
     }
 
-    /// (2) A peer DELETE returns 404 and the token is NOT revoked.
+    /// (2) A peer DELETE returns 403 and the token is not revoked.
     #[tokio::test]
-    async fn peer_delete_token_is_404_and_not_revoked() {
+    async fn peer_delete_token_is_403_and_not_revoked() {
         let Some(f) = fixture().await else { return };
         let app = app_as(f.state.clone(), member_auth(f.sam, "sam"));
         let (status, _) = tdh::send(app, delete_token_req(&f.repo_key, f.token_id)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND, "peer DELETE must 404");
+        assert_eq!(status, StatusCode::FORBIDDEN, "peer DELETE must 403");
         assert!(
             revoked_at(&f.pool, f.token_id).await.is_none(),
             "peer DELETE must NOT revoke the token"
@@ -1316,25 +1369,20 @@ mod ownership_gate_tests {
         teardown(&f).await;
     }
 
-    /// (6) The list omits a peer's token for a non-admin, but an admin sees all.
+    /// (6) Repository admins see their tokens; peers cannot list the repository
+    /// token inventory; global admins see all.
     #[tokio::test]
     async fn list_scopes_to_owner_for_non_admin_and_all_for_admin() {
         let Some(f) = fixture().await else { return };
 
-        // Peer sees no items (victor's token is filtered out).
+        // Peer cannot list repository-scoped tokens without repository admin.
         let app = app_as(f.state.clone(), member_auth(f.sam, "sam"));
         let (status, bytes) = tdh::send(app, list_tokens_req(&f.repo_key)).await;
-        assert_eq!(status, StatusCode::OK);
-        let v: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        let peer_ids: Vec<&str> = v["items"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|i| i["id"].as_str().unwrap())
-            .collect();
         assert!(
-            !peer_ids.contains(&f.token_id.to_string().as_str()),
-            "peer list must not contain victor's token"
+            status == StatusCode::FORBIDDEN,
+            "peer list must 403, got {} body: {}",
+            status,
+            String::from_utf8_lossy(&bytes)
         );
 
         // Creator sees their own token.

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -93,12 +93,11 @@ fn require_repo_access(auth: &AuthExtension, repo_id: Uuid) -> Result<()> {
     }
 }
 
-/// Authorize a write/delete operation against a repository.
+/// Authorize a mutating or administrative operation against a repository.
 ///
-/// Enforces both the token-scope check (`require_repo_access`) and, for private
-/// repositories, per-repo authorization: admins bypass; every other caller must
-/// hold a role assignment scoped to the repo (direct or global). Public repos
-/// keep their existing behavior (token-scope only).
+/// Enforces both token scope and action-specific repository authorization.
+/// Public visibility is deliberately read-only and never grants write, delete,
+/// or repository-admin access by itself.
 ///
 /// Exposed as `pub(crate)` so the repository sub-resource handlers that live in
 /// sibling modules (labels, security, email subscriptions) and the chunked
@@ -106,99 +105,50 @@ fn require_repo_access(auth: &AuthExtension, repo_id: Uuid) -> Result<()> {
 /// rather than re-deriving (or forgetting) it. The `/api/v1/repositories` nest
 /// runs under `optional_auth_middleware` only, NOT `repo_visibility_middleware`,
 /// so each sub-handler must enforce this itself.
-pub(crate) async fn require_repo_write_access(
+async fn require_repo_action_access(
     auth: &AuthExtension,
     repo: &crate::models::repository::Repository,
     repo_service: &RepositoryService,
+    action: &str,
 ) -> Result<()> {
     require_repo_access(auth, repo.id)?;
-    if repo.is_public || auth.is_admin {
-        return Ok(());
-    }
-    if repo_service
-        .user_can_access_repo(repo.id, auth.user_id)
-        .await?
-    {
-        Ok(())
-    } else {
-        Err(AppError::Authorization(
-            "You do not have access to this repository".to_string(),
-        ))
-    }
-}
-
-/// Pure fine-grained per-action decision, mirroring `upload_write_decision`
-/// (#817) in the chunked-upload path. Admins always pass; a repository with no
-/// permission rules falls through to the default access model; otherwise the
-/// caller must hold the requested action or `admin` (which implies all actions).
-///
-/// Factored out so both branches are unit-testable without a database.
-fn repo_fine_grained_action_allowed(
-    is_admin: bool,
-    has_rules: bool,
-    has_action: bool,
-    has_admin: bool,
-) -> bool {
-    if is_admin {
-        return true;
-    }
-    if !has_rules {
-        return true;
-    }
-    has_action || has_admin
-}
-
-/// Fine-grained per-action authorization, applied AFTER `require_repo_write_access`
-/// (the outer tenant gate) on the generic REST artifact write/delete handlers.
-///
-/// `require_repo_write_access` is only a tenant-membership gate: it treats a
-/// public repository or ANY role-assignment grantee (including a read-only one)
-/// as authorized, collapsing read/write/delete into a single "has access"
-/// predicate. That is the gap #2321 (G2) reports: on a rules-bearing repo a
-/// read-only grantee could still PUT/DELETE, and on a public repo any authed
-/// caller could write. This adds the SAME `has_rules -> check_permission(action)`
-/// block the chunked upload-session path (`upload.rs::create_session`, #817)
-/// already enforces, so the action actually maps to the granted permission.
-///
-/// `action` is `"write"` for uploads and `"delete"` for deletes. Admins bypass;
-/// a repository with no permission rules falls through unchanged (the rules-less
-/// public-repo case is a separate global default-access decision, out of scope
-/// here). A permission-rule lookup error fails closed (503), mirroring
-/// `repo_visibility_middleware` and `create_session`.
-async fn require_repo_fine_grained_action(
-    auth: &AuthExtension,
-    repo_id: Uuid,
-    action: &str,
-    permission_service: &crate::services::permission_service::PermissionService,
-) -> Result<()> {
     if auth.is_admin {
         return Ok(());
     }
-    let has_rules = permission_service
-        .has_any_rules_for_target("repository", repo_id)
-        .await
-        .map_err(|_| {
-            tracing::error!("permission check failed: database unreachable");
-            AppError::ServiceUnavailable("permission service temporarily unavailable".to_string())
-        })?;
-    if !has_rules {
-        return Ok(());
-    }
-    let has_action = permission_service
-        .check_permission(auth.user_id, "repository", repo_id, action, false)
-        .await
-        .unwrap_or(false);
-    let has_admin = permission_service
-        .check_permission(auth.user_id, "repository", repo_id, "admin", false)
-        .await
-        .unwrap_or(false);
-    if repo_fine_grained_action_allowed(auth.is_admin, has_rules, has_action, has_admin) {
+    if repo_service
+        .user_can_perform_repo_action(repo.id, auth.user_id, action)
+        .await?
+    {
         Ok(())
     } else {
         Err(AppError::Authorization(
             "You do not have permission to perform this action on this repository".to_string(),
         ))
     }
+}
+
+pub(crate) async fn require_repo_write_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_action_access(auth, repo, repo_service, "write").await
+}
+
+pub(crate) async fn require_repo_delete_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_action_access(auth, repo, repo_service, "delete").await
+}
+
+pub(crate) async fn require_repo_admin_access(
+    auth: &AuthExtension,
+    repo: &crate::models::repository::Repository,
+    repo_service: &RepositoryService,
+) -> Result<()> {
+    require_repo_action_access(auth, repo, repo_service, "admin").await
 }
 
 /// Ensure a repository is visible to the current user.
@@ -1935,15 +1885,17 @@ pub async fn put_pypi_track(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, project)): Path<(String, String)>,
-    Json(payload): Json<PypiTrackRequest>,
+    body: Bytes,
 ) -> Result<Json<PypiTrackResponse>> {
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
     require_pypi_tracks_repo(&repo)?;
 
+    let payload: PypiTrackRequest = serde_json::from_slice(&body)
+        .map_err(|e| AppError::Validation(format!("Invalid JSON: {}", e)))?;
     let tracks_url = payload.tracks_url.trim().to_string();
     if !(tracks_url.starts_with("http://") || tracks_url.starts_with("https://")) {
         return Err(AppError::Validation(
@@ -2003,7 +1955,7 @@ pub async fn delete_pypi_track(
     auth.require_scope("write")?;
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
 
     let normalized = crate::api::handlers::pypi::normalize_pep503(&project);
     sqlx::query(
@@ -5536,23 +5488,17 @@ pub async fn upload_artifact(
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
 
-    // Validate the composed artifact path against traversal, null bytes,
-    // backslashes, percent-encoded traversal, absolute paths, etc. This
-    // protects all upload entry points (URL-path variant, multipart with
-    // path in URL, and multipart with `path` form field added in #1237).
-    // Filesystem storage's `key_to_path` would strip `..` segments, but S3
-    // and other object backends would happily accept `../etc/passwd`.
-    upload_service::validate_artifact_path(&path)
-        .map_err(|e| AppError::Validation(e.to_string()))?;
-
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
-    // Fine-grained write gate (#2321 G2): the tenant gate above admits any
-    // grantee (incl. a read-only one) and any authed caller on a public repo,
-    // collapsing read/write. Require the `write` action when rules exist, the
-    // same block `upload.rs::create_session` applies to the chunked path.
-    require_repo_fine_grained_action(&auth, repo.id, "write", &state.permission_service).await?;
+
+    // Validate only after repository authorization so an ungranted caller
+    // cannot use path-validation responses as an oracle. Filesystem storage's
+    // `key_to_path` would strip `..` segments, while object backends would
+    // accept them, so every authorized upload still passes this gate before
+    // any storage operation.
+    upload_service::validate_artifact_path(&path)
+        .map_err(|e| AppError::Validation(e.to_string()))?;
 
     // Reject direct uploads to promotion-only repositories. Such repos accept
     // artifacts only via the promotion path (staging -> promotion -> approval);
@@ -6613,12 +6559,7 @@ pub async fn delete_artifact(
     auth.require_scope("delete")?;
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &repo_service).await?;
-    // Fine-grained delete gate (#2321 G2): the tenant gate above admits any
-    // grantee (incl. a write-only or read-only one), collapsing write/delete.
-    // Require the `delete` action when rules exist so a write-scoped grantee
-    // cannot destroy artifacts. Mirrors the upload path's `write` gate.
-    require_repo_fine_grained_action(&auth, repo.id, "delete", &state.permission_service).await?;
+    require_repo_delete_access(&auth, &repo, &repo_service).await?;
 
     // Resolve the npm canonical `/-/` URL shape the Web UI emits to the
     // version-segmented path the tarball is actually stored under (#2269),
@@ -7191,13 +7132,20 @@ pub async fn set_upstream_auth(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
-    Json(payload): Json<UpstreamAuthRequest>,
+    body: Bytes,
 ) -> Result<Json<serde_json::Value>> {
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
-    let repo = load_remote_repo(&state, &auth, &key).await?;
     let repo_service = RepositoryService::new(state.db.clone());
-    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    let repo = repo_service.get_by_key(&key).await?;
+    require_repo_admin_access(&auth, &repo, &repo_service).await?;
+    if repo.repo_type != RepositoryType::Remote {
+        return Err(AppError::Validation(
+            "This operation is only valid for remote repositories".to_string(),
+        ));
+    }
+    let payload: UpstreamAuthRequest = serde_json::from_slice(&body)
+        .map_err(|e| AppError::Validation(format!("Invalid JSON: {}", e)))?;
 
     if payload.auth_type == "none" {
         crate::services::upstream_auth::remove_upstream_auth(&state.db, repo.id).await?;
@@ -7378,10 +7326,17 @@ pub async fn set_routing_rules(
     State(state): State<SharedState>,
     Extension(auth): Extension<Option<AuthExtension>>,
     Path(key): Path<String>,
-    Json(payload): Json<SetRoutingRulesRequest>,
+    body: Bytes,
 ) -> Result<Json<RoutingRulesResponse>> {
     let auth = require_auth(auth)?;
     auth.require_scope("write")?;
+
+    let service = RepositoryService::new(state.db.clone());
+    let repo = service.get_by_key(&key).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
+
+    let payload: SetRoutingRulesRequest = serde_json::from_slice(&body)
+        .map_err(|e| AppError::Validation(format!("Invalid JSON: {}", e)))?;
 
     // Validate every rule before persisting
     for (i, rule) in payload.rules.iter().enumerate() {
@@ -7392,10 +7347,6 @@ pub async fn set_routing_rules(
             )));
         }
     }
-
-    let service = RepositoryService::new(state.db.clone());
-    let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
 
     let value = serde_json::to_string(&payload.rules)
         .map_err(|e| AppError::Internal(format!("Failed to serialize routing rules: {}", e)))?;
@@ -7446,7 +7397,7 @@ pub async fn delete_routing_rules(
 
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &service).await?;
+    require_repo_admin_access(&auth, &repo, &service).await?;
 
     sqlx::query(
         r#"
@@ -11045,44 +10996,6 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
-    // #2321 G2: pure fine-grained per-action decision (write/delete) applied
-    // after the tenant gate on the generic REST + OCI artifact paths. Mirrors
-    // `upload.rs::upload_write_decision`.
-    // -----------------------------------------------------------------------
-    #[test]
-    fn test_repo_fine_grained_action_admin_always_allowed() {
-        // Admins bypass regardless of rules/actions state.
-        assert!(repo_fine_grained_action_allowed(true, false, false, false));
-        assert!(repo_fine_grained_action_allowed(true, true, false, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_no_rules_falls_through() {
-        // A repo with no permission rules keeps the default access model.
-        assert!(repo_fine_grained_action_allowed(false, false, false, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_rules_require_matching_action() {
-        // Rules exist but the caller holds neither the action nor admin -> deny.
-        // This is the read-only-grantee-cannot-write / write-only-cannot-delete
-        // collapse that #2321 G2 closes.
-        assert!(!repo_fine_grained_action_allowed(false, true, false, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_rules_with_action_allowed() {
-        // Holding the requested action (write or delete) passes.
-        assert!(repo_fine_grained_action_allowed(false, true, true, false));
-    }
-
-    #[test]
-    fn test_repo_fine_grained_action_rules_with_admin_action_allowed() {
-        // `admin` implies all actions, so it passes any per-action gate.
-        assert!(repo_fine_grained_action_allowed(false, true, false, true));
-    }
-
-    // -----------------------------------------------------------------------
     // xtenant-write-authz-systemic: behavioral coverage for the two shared
     // tenant gates (`require_repo_write_access` / `require_visible`) that every
     // repository sub-resource handler now routes through. The no-DB
@@ -11106,14 +11019,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_require_repo_write_access_public_allowed_no_db() {
-        let repo = make_repo(true); // is_public = true
-        let res =
-            require_repo_write_access(&make_auth_ext(None), &repo, &no_db_repo_service()).await;
+    async fn test_require_repo_write_access_public_requires_grant_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, _dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        let mut repo = make_repo_with_id(repo_id, &key);
+        repo.is_public = true;
+        let ext = tdh::make_auth(user_id, &username);
+        let svc = RepositoryService::new(pool.clone());
+
+        let denied = require_repo_write_access(&ext, &repo, &svc).await;
         assert!(
-            res.is_ok(),
-            "a public repo is writable past the gate, no DB: {res:?}"
+            matches!(denied, Err(AppError::Authorization(_))),
+            "public visibility must not grant write without an explicit repository grant: {denied:?}"
         );
+
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let allowed = require_repo_write_access(&ext, &repo, &svc).await;
+        assert!(
+            allowed.is_ok(),
+            "legacy repository membership remains a write grant when no fine-grained rules exist: {allowed:?}"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
     }
 
     #[tokio::test]
@@ -11239,6 +11170,11 @@ mod tests {
         .await;
         assert!(up.is_ok(), "initial publish must succeed: {up:?}");
 
+        // The legacy developer role grants writes but no destructive action.
+        // Explicitly authorize both operations exercised below so the test
+        // reaches the release-immutability backstop.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["write", "delete"]).await;
+
         // 2) DELETE (soft-delete -> tombstone). Generic classifies mutable, so
         // the delete guard permits this even for a non-admin.
         let del = delete_artifact(
@@ -11330,6 +11266,10 @@ mod tests {
         )
         .await
         .expect("initial publish must succeed");
+
+        // From this point the actor must be able to reach both the promotion
+        // guard and the normal-repository delete path under test.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["write", "delete"]).await;
 
         // (1) promotion_only=true, non-admin -> 403 FORBIDDEN, artifact intact.
         set_promotion_only(true).await;
@@ -12102,6 +12042,39 @@ mod tests {
             .execute(&pool)
             .await
             .expect("make repo public");
+
+        let no_rules_public = upload_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                pub_dir.to_string_lossy().as_ref(),
+            )),
+            Extension(Some(tdh::make_auth(user_id, &username))),
+            Path((pub_key.clone(), "pub/no-rules.bin".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await;
+        assert!(
+            matches!(no_rules_public, Err(AppError::Authorization(_))),
+            "public visibility must not grant write when no permission rules exist: {no_rules_public:?}"
+        );
+
+        let invalid_path_denied = upload_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                pub_dir.to_string_lossy().as_ref(),
+            )),
+            Extension(Some(tdh::make_auth(user_id, &username))),
+            Path((pub_key.clone(), "../invalid.bin".to_string())),
+            HeaderMap::new(),
+            Bytes::from_static(b"BYTES"),
+        )
+        .await;
+        assert!(
+            matches!(invalid_path_denied, Err(AppError::Authorization(_))),
+            "repository authorization must precede artifact-path validation: {invalid_path_denied:?}"
+        );
+
         let (other_id, _other_name) = tdh::create_user(&pool).await;
         tdh::grant_repo_actions(&pool, pub_repo_id, other_id, &["read", "write"]).await;
         let nonmember_pub = upload_artifact(
@@ -12198,21 +12171,141 @@ mod tests {
             "delete grant must delete, got: {allowed:?}"
         );
 
+        // Public visibility with no rules must not grant delete, even when the
+        // target artifact exists. Seed it as an admin, then attempt deletion as
+        // an unrelated authenticated user.
+        let (public_id, public_key, public_dir) = tdh::create_repo(&pool, "local", "generic").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(public_id)
+            .execute(&pool)
+            .await
+            .expect("make delete probe repository public");
+        let public_path = "public/existing-delete-probe.bin".to_string();
+        let admin = AuthExtension {
+            is_admin: true,
+            ..tdh::make_auth(user_id, &username)
+        };
+        upload_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                public_dir.to_string_lossy().as_ref(),
+            )),
+            Extension(Some(admin)),
+            Path((public_key.clone(), public_path.clone())),
+            HeaderMap::new(),
+            Bytes::from_static(b"PUBLIC"),
+        )
+        .await
+        .expect("admin must seed public delete probe");
+        let (outsider_id, outsider_name) = tdh::create_user(&pool).await;
+        let public_denied = delete_artifact(
+            State(tdh::build_state(
+                pool.clone(),
+                public_dir.to_string_lossy().as_ref(),
+            )),
+            Extension(Some(tdh::make_auth(outsider_id, &outsider_name))),
+            Path((public_key, public_path)),
+            HeaderMap::new(),
+        )
+        .await;
+        assert!(
+            matches!(public_denied, Err(AppError::Authorization(_))),
+            "public visibility must not grant delete without a repository grant: {public_denied:?}"
+        );
+
+        tdh::cleanup(&pool, public_id, outsider_id).await;
+        let _ = std::fs::remove_dir_all(&public_dir);
+
         tdh::cleanup(&pool, repo_id, user_id).await;
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// #2321 G2 binding test: the generic artifact write/delete handlers must
-    /// keep routing through `require_repo_fine_grained_action` after the tenant
-    /// gate. A handler that dropped the call would silently re-collapse
-    /// read/write/delete, so pin it structurally (the DB tests above cannot run
-    /// without a Postgres).
+    #[tokio::test]
+    async fn repo_admin_subresources_deny_public_non_admin_before_parsing_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (remote_id, remote_key, remote_dir) =
+            tdh::create_repo(&pool, "remote", "generic").await;
+        let (pypi_id, pypi_key, pypi_dir) = tdh::create_repo(&pool, "local", "pypi").await;
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = ANY($1)")
+            .bind(vec![remote_id, pypi_id])
+            .execute(&pool)
+            .await
+            .expect("make admin probe repositories public");
+
+        let state = tdh::build_state(pool.clone(), remote_dir.to_string_lossy().as_ref());
+        let auth = Some(tdh::make_auth(user_id, &username));
+
+        let upstream_denied = set_upstream_auth(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path(remote_key.clone()),
+            Bytes::from_static(br#"{"auth_type":"none"}"#),
+        )
+        .await;
+        assert!(
+            matches!(upstream_denied, Err(AppError::Authorization(_))),
+            "public visibility must not authorize upstream credentials: {upstream_denied:?}"
+        );
+
+        let routing_denied = set_routing_rules(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path(remote_key),
+            Bytes::from_static(br#"{"rules":[]}"#),
+        )
+        .await;
+        assert!(
+            matches!(routing_denied, Err(AppError::Authorization(_))),
+            "public visibility must not authorize routing rules: {routing_denied:?}"
+        );
+
+        let pypi_denied = put_pypi_track(
+            State(state),
+            Extension(auth),
+            Path((pypi_key, "ak-security-probe".to_string())),
+            Bytes::from_static(br#"{"tracks":["ak-security-probe"]}"#),
+        )
+        .await;
+        assert!(
+            matches!(pypi_denied, Err(AppError::Authorization(_))),
+            "repository-admin authorization must precede PyPI body validation: {pypi_denied:?}"
+        );
+
+        let config_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM repository_config WHERE repository_id = $1 \
+             AND key IN ('upstream_auth_type', 'upstream_auth_credentials', 'routing_rules')",
+        )
+        .bind(remote_id)
+        .fetch_one(&pool)
+        .await
+        .expect("count denied repository configuration writes");
+        assert_eq!(config_rows, 0, "denied requests must not mutate config");
+        let track_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM pypi_project_tracks WHERE repository_id = $1")
+                .bind(pypi_id)
+                .fetch_one(&pool)
+                .await
+                .expect("count denied PyPI track writes");
+        assert_eq!(track_rows, 0, "denied request must not create a track");
+
+        tdh::cleanup(&pool, pypi_id, user_id).await;
+        tdh::cleanup(&pool, remote_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&pypi_dir);
+        let _ = std::fs::remove_dir_all(&remote_dir);
+    }
+
+    /// Binding test: generic artifact mutations must use the helper matching
+    /// their action so write and delete cannot collapse into one broad gate.
     #[test]
-    fn test_generic_artifact_handlers_call_fine_grained_gate() {
+    fn test_generic_artifact_handlers_call_action_gate() {
         let source = include_str!("repositories.rs");
-        for (handler, action) in [
-            ("upload_artifact", "\"write\""),
-            ("delete_artifact", "\"delete\""),
+        for (handler, helper) in [
+            ("upload_artifact", "require_repo_write_access("),
+            ("delete_artifact", "require_repo_delete_access("),
         ] {
             let marker = format!("pub async fn {}(", handler);
             let start = source
@@ -12222,10 +12315,10 @@ mod tests {
             let end = rest.find("\npub async fn ").unwrap_or(rest.len());
             let body = &rest[..end];
             assert!(
-                body.contains("require_repo_fine_grained_action(") && body.contains(action),
-                "handler `{}` must call require_repo_fine_grained_action with {} (#2321 G2)",
+                body.contains(helper),
+                "handler `{}` must call `{}`",
                 handler,
-                action
+                helper
             );
         }
     }
@@ -12348,29 +12441,25 @@ mod tests {
         );
     }
 
-    /// Cross-tenant write authz (xtenant-write-authz-systemic):
+    /// Cross-tenant mutation authz (xtenant-write-authz-systemic):
     ///
     /// The `/api/v1/repositories` REST nest runs under `optional_auth_middleware`
     /// only, NOT `repo_visibility_middleware`, so each sub-resource mutation
-    /// handler must enforce the tenant write gate itself. Assert every such
-    /// handler references `require_repo_write_access` (the canonical
-    /// `is_public + role_assignments` gate) so a future handler cannot silently
-    /// fall open to a non-member, non-admin caller on a private repo. String-grep
-    /// because the handlers need a full `SharedState` to run.
+    /// handler must enforce the action-specific repository gate itself.
     #[test]
-    fn test_repo_mutation_handlers_call_write_gate() {
+    fn test_repo_mutation_handlers_call_action_gate() {
         let source = include_str!("repositories.rs");
 
-        for handler in [
-            "set_cache_ttl",
-            "invalidate_cache",
-            "put_pypi_track",
-            "delete_pypi_track",
-            "set_routing_rules",
-            "delete_routing_rules",
-            "set_upstream_auth",
-            "upload_artifact",
-            "delete_artifact",
+        for (handler, helper) in [
+            ("set_cache_ttl", "require_repo_write_access("),
+            ("invalidate_cache", "require_repo_write_access("),
+            ("put_pypi_track", "require_repo_admin_access("),
+            ("delete_pypi_track", "require_repo_admin_access("),
+            ("set_routing_rules", "require_repo_admin_access("),
+            ("delete_routing_rules", "require_repo_admin_access("),
+            ("set_upstream_auth", "require_repo_admin_access("),
+            ("upload_artifact", "require_repo_write_access("),
+            ("delete_artifact", "require_repo_delete_access("),
         ] {
             let marker = format!("pub async fn {}(", handler);
             let start = source
@@ -12384,14 +12473,31 @@ mod tests {
             let body = &rest[..end];
 
             assert!(
-                body.contains("require_repo_write_access("),
-                "handler `{}` does not call `require_repo_write_access` \
-                 (xtenant-write-authz-systemic). The /repositories nest is not \
-                 covered by repo_visibility_middleware, so each mutation handler \
-                 must enforce the tenant write gate itself. If you intentionally \
-                 restructured the authz model, update this test to match.",
-                handler
+                body.contains(helper),
+                "handler `{}` does not call `{}` (xtenant-write-authz-systemic)",
+                handler,
+                helper
             );
+
+            if matches!(
+                handler,
+                "put_pypi_track" | "set_routing_rules" | "set_upstream_auth"
+            ) {
+                let gate_pos = body
+                    .find("require_repo_admin_access(")
+                    .unwrap_or_else(|| panic!("{handler} must authorize repository admin"));
+                let parse_pos = body
+                    .find("serde_json::from_slice")
+                    .unwrap_or_else(|| panic!("{handler} must parse JSON explicitly"));
+                assert!(
+                    body.contains("body: Bytes"),
+                    "{handler} must accept raw bytes so authz precedes schema validation"
+                );
+                assert!(
+                    gate_pos < parse_pos,
+                    "{handler} must authorize before parsing the request body"
+                );
+            }
         }
     }
 
@@ -12507,22 +12613,10 @@ mod tests {
     // -----------------------------------------------------------------------
     // require_repo_write_access (authz-private-repo-membership)
     //
-    // Write/delete authorization on a repository. The public-repo and admin
-    // arms short-circuit before the grant lookup, so they are DB-free. The
-    // private + non-admin grant lookup is covered by
-    // `repository_service::tests::test_user_can_access_repo_private_grant_enforced`.
+    // Action-specific authorization on a repository. Only admins and
+    // out-of-token-scope denials short-circuit before the database lookup.
+    // Public visibility deliberately does not short-circuit mutation authz.
     // -----------------------------------------------------------------------
-
-    #[tokio::test]
-    async fn test_require_repo_write_access_public_ok() {
-        let repo = make_repo(true);
-        let auth = make_auth_ext(None);
-        let svc = RepositoryService::new(crate::api::handlers::test_db_helpers::lazy_pool());
-        assert!(
-            require_repo_write_access(&auth, &repo, &svc).await.is_ok(),
-            "any authenticated caller may write to a public repo"
-        );
-    }
 
     #[tokio::test]
     async fn test_require_repo_write_access_admin_ok() {
@@ -17564,6 +17658,11 @@ mod tests {
             matches!(dl_bogus, Err(AppError::NotFound(_))),
             "an unknown npm tarball must still 404 (resolver leaves a miss path unchanged)"
         );
+
+        // The fixture's developer role is intentionally write-only. Grant the
+        // destructive action so the remaining assertions exercise npm path
+        // canonicalization rather than repository authorization.
+        tdh::grant_repo_actions(&pool, repo_id, user_id, &["delete"]).await;
 
         // (4) Scoped delete via the canonical `/-/` URL shape -> Ok (was 404),
         // and the row is soft-deleted. npm tarballs classify Mutable (no `/-/`

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -661,13 +661,16 @@ async fn get_all_scores(
     tag = "security",
     responses(
         (status = 200, description = "List of scan configurations", body = Vec<ScanConfigResponse>),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
 )]
 async fn list_scan_configs(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
 ) -> Result<Json<Vec<ScanConfigResponse>>> {
+    auth.require_admin()?;
+
     let svc = ScanConfigService::new(state.db.clone());
     let configs = svc.list_configs().await?;
     let response: Vec<ScanConfigResponse> =
@@ -1475,6 +1478,10 @@ mod tests {
                 writer
             );
         }
+        assert!(
+            body_of("list_scan_configs").contains("require_admin("),
+            "global scan configuration inventory must require admin"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/api/handlers/signing.rs
+++ b/backend/src/api/handlers/signing.rs
@@ -96,14 +96,17 @@ pub struct SigningConfigResponse {
     responses(
         (status = 200, description = "List of signing keys", body = KeyListResponse),
         (status = 401, description = "Unauthorized", body = crate::api::openapi::ErrorResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
 )]
 async fn list_keys(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Query(query): Query<ListKeysQuery>,
 ) -> Result<Json<KeyListResponse>> {
+    require_signing_admin(&auth)?;
+
     let svc = signing_service(&state);
     let keys = svc.list_keys(query.repository_id).await?;
     let total = keys.len();
@@ -204,15 +207,18 @@ fn resolve_key_type_and_algorithm(
     responses(
         (status = 200, description = "Signing key details", body = SigningKeyPublic),
         (status = 401, description = "Unauthorized", body = crate::api::openapi::ErrorResponse),
+        (status = 403, description = "Admin privileges required", body = crate::api::openapi::ErrorResponse),
         (status = 404, description = "Key not found", body = crate::api::openapi::ErrorResponse),
     ),
     security(("bearer_auth" = []))
 )]
 async fn get_key(
     State(state): State<SharedState>,
-    Extension(_auth): Extension<AuthExtension>,
+    Extension(auth): Extension<AuthExtension>,
     Path(key_id): Path<Uuid>,
 ) -> Result<Json<SigningKeyPublic>> {
+    require_signing_admin(&auth)?;
+
     let svc = signing_service(&state);
     let key = svc.get_key(key_id).await?;
     Ok(Json(key))
@@ -772,6 +778,16 @@ mod tests {
             signing_handler_body("sign_artifact").contains("require_signing_admin"),
             "sign_artifact MUST call require_signing_admin (admin gate) — #2535 bypass guard"
         );
+    }
+
+    #[test]
+    fn test_global_signing_key_inventory_requires_admin() {
+        for name in ["list_keys", "get_key"] {
+            assert!(
+                signing_handler_body(name).contains("require_signing_admin"),
+                "{name} must require global admin before returning key metadata"
+            );
+        }
     }
 
     #[test]

--- a/backend/src/api/handlers/upload.rs
+++ b/backend/src/api/handlers/upload.rs
@@ -24,6 +24,7 @@ use crate::api::handlers::proxy_helpers;
 use crate::api::handlers::repositories::require_repo_write_access;
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
+use crate::error::AppError;
 use crate::services::package_service::PackageService;
 use crate::services::repository_service::RepositoryService;
 use crate::services::upload_service::{self, UploadError, UploadService};
@@ -128,46 +129,6 @@ pub struct CompleteResponse {
 // POST / -- Create upload session
 // ---------------------------------------------------------------------------
 
-/// Pure write-authorization decision for creating a chunked-upload session.
-///
-/// Mirrors the semantics `repo_visibility_middleware` enforces on every other
-/// repository write path, so the body-addressed `/uploads` flow is gated the
-/// same way the URL-addressed legacy artifact PUT is:
-///
-/// * **Token repo-scope (#504):** an API token restricted to a set of repos
-///   (`auth.can_access_repo`) may only target a repo in that set.
-/// * **Admin bypass:** admins skip the fine-grained checks entirely.
-/// * **No-rules fall-through:** a repo with no fine-grained permission rules
-///   keeps working under the default access model (`has_rules == false`).
-/// * **Fine-grained write (#817):** when rules exist, the caller must hold the
-///   `write` (or `admin`) action on the repo.
-///
-/// The permission-service lookups that produce `has_rules`/`has_write`/
-/// `has_admin` are done by the caller; keeping the decision pure makes it
-/// unit-testable without a database.
-fn session_write_authorized(
-    auth: &AuthExtension,
-    repo_id: Uuid,
-    has_rules: bool,
-    has_write: bool,
-    has_admin: bool,
-) -> bool {
-    // #504: token repository scope.
-    if !auth.can_access_repo(repo_id) {
-        return false;
-    }
-    // Admins bypass fine-grained permission checks.
-    if auth.is_admin {
-        return true;
-    }
-    // No fine-grained rules: fall through to the default access model.
-    if !has_rules {
-        return true;
-    }
-    // Rules exist: the caller must hold write (or admin) on this repo.
-    has_write || has_admin
-}
-
 #[utoipa::path(
     post,
     path = "/api/v1/uploads",
@@ -190,47 +151,23 @@ async fn create_session(
 ) -> Result<Response, Response> {
     let user_id = auth.user_id;
 
-    // Validate artifact path before doing anything else
-    upload_service::validate_artifact_path(&req.artifact_path).map_err(map_upload_err)?;
-
-    // Resolve repository. The `repositories` table has no `is_deleted` column
-    // (the soft-delete pattern lives on `artifacts`); the previous
-    // `AND is_deleted = false` predicate was a copy-paste from artifact
-    // queries that crashed every session create (issue #1168).
-    let repo = sqlx::query_as::<_, (Uuid, bool)>(
-        "SELECT id, promotion_only FROM repositories WHERE key = $1",
-    )
-    .bind(&req.repository_key)
-    .fetch_optional(&state.db)
-    .await
-    .map_err(|e| map_err(StatusCode::INTERNAL_SERVER_ERROR, e))?
-    .ok_or_else(|| {
-        map_err(
-            StatusCode::NOT_FOUND,
-            format!("Repository '{}' not found", req.repository_key),
-        )
-    })?;
-    let repo_id = repo.0;
-    let repo_promotion_only = repo.1;
-
-    // Tenant write gate (xtenant-write-authz-systemic).
-    //
-    // The /uploads router runs under auth_middleware only (no
-    // repo_visibility_middleware), and the target repo is named in the JSON body,
-    // so the tenant-membership gate that protects the URL-addressed artifact PUT
-    // never sees this request. The fine-grained RBAC checks below fall OPEN when
-    // a repo has no permission rules (`has_rules == false`), so derive the tenant
-    // boundary from `is_public` + role_assignments membership
-    // (`require_repo_write_access`): a non-member, non-admin can never open a
-    // session against another tenant's private repo regardless of whether any
-    // permission rule exists. Admins, public-repo writers, same-org members and
-    // write/admin-holding peer-replication identities all pass unchanged. Mirrors
-    // `repositories::upload_artifact`.
+    // Resolve the repository and apply the same action-aware write gate as the
+    // URL-addressed artifact API. The target repository lives in the JSON body,
+    // so repo_visibility_middleware cannot enforce it for this route.
     let repo_service = RepositoryService::new(state.db.clone());
-    let repo_record = repo_service
-        .get_by_key(&req.repository_key)
-        .await
-        .map_err(IntoResponse::into_response)?;
+    let repo_record =
+        repo_service
+            .get_by_key(&req.repository_key)
+            .await
+            .map_err(|err| match err {
+                AppError::NotFound(_) => map_err(
+                    StatusCode::NOT_FOUND,
+                    format!("Repository '{}' not found", req.repository_key),
+                ),
+                other => other.into_response(),
+            })?;
+    let repo_id = repo_record.id;
+    let repo_promotion_only = repo_record.promotion_only;
     require_repo_write_access(&auth, &repo_record, &repo_service)
         .await
         .map_err(IntoResponse::into_response)?;
@@ -254,119 +191,13 @@ async fn create_session(
         return Err(rejection);
     }
 
-    // Repository write authorization (#817 parity).
-    //
-    // The chunked upload-session create path must enforce the same
-    // fine-grained RBAC write gate that `repo_visibility_middleware` applies to
-    // the rest of the artifact-write surface (see middleware/auth.rs): the
-    // /api/v1/uploads router is layered only with `auth_middleware`
-    // (authentication), so without this check any authenticated user could open
-    // a session against a release/promotion-only repository.
-    //
-    // Admins bypass the check. For a non-admin, if any permission rule exists
-    // for this repository the caller must hold the `write` action (or `admin`,
-    // which implies all actions); a repository with no rules falls through
-    // unchanged. A DB error on the rule lookup fails closed (503), mirroring the
-    // middleware. Authorized peer-replication identities hold write/admin on the
-    // target and continue to pass.
-    let has_rules = if auth.is_admin {
-        false
-    } else {
-        match state
-            .permission_service
-            .has_any_rules_for_target("repository", repo_id)
-            .await
-        {
-            Ok(v) => v,
-            Err(_) => {
-                tracing::error!("permission check failed: database unreachable");
-                return Err(map_err(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "permission service temporarily unavailable",
-                ));
-            }
-        }
-    };
-    let (has_write, has_admin) = if !auth.is_admin && has_rules {
-        (
-            state
-                .permission_service
-                .check_permission(user_id, "repository", repo_id, "write", false)
-                .await
-                .unwrap_or(false),
-            state
-                .permission_service
-                .check_permission(user_id, "repository", repo_id, "admin", false)
-                .await
-                .unwrap_or(false),
-        )
-    } else {
-        (false, false)
-    };
-    if !upload_write_decision(auth.is_admin, has_rules, has_write, has_admin) {
-        return Err(map_err(
-            StatusCode::FORBIDDEN,
-            "You do not have permission to perform this action on this repository",
-        ));
-    }
-
-    // Repository write authorization.
-    //
-    // The `/uploads` routes are nested under `auth_middleware` only, not
-    // `repo_visibility_middleware`, and the target repo is named in the JSON
-    // body rather than the URL path -- so the repo-scope (#504) and
-    // fine-grained permission (#817) gates that protect every other write
-    // path never see this request. Apply the same decision here, at the single
-    // point where the cross-tenant write would originate, right after the repo
-    // is resolved (the 404-for-unknown-repo behaviour above is unchanged).
-    //
-    // Only consult the permission service for a non-admin caller that is in
-    // token scope for the repo; admins bypass and out-of-scope tokens are
-    // denied without a DB round-trip. Fail closed (503) on a permission lookup
-    // error, matching `repo_visibility_middleware`.
-    let (has_rules, has_write, has_admin) = if auth.is_admin || !auth.can_access_repo(repo.0) {
-        (false, false, false)
-    } else {
-        let has_rules = state
-            .permission_service
-            .has_any_rules_for_target("repository", repo.0)
-            .await
-            .map_err(|_| {
-                tracing::error!("permission check failed: database unreachable");
-                map_err(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "permission service temporarily unavailable",
-                )
-            })?;
-        if has_rules {
-            let has_write = state
-                .permission_service
-                .check_permission(auth.user_id, "repository", repo.0, "write", false)
-                .await
-                .unwrap_or(false);
-            let has_admin = state
-                .permission_service
-                .check_permission(auth.user_id, "repository", repo.0, "admin", false)
-                .await
-                .unwrap_or(false);
-            (true, has_write, has_admin)
-        } else {
-            (false, false, false)
-        }
-    };
-
-    if !session_write_authorized(&auth, repo.0, has_rules, has_write, has_admin) {
-        return Err(map_err(
-            StatusCode::FORBIDDEN,
-            "You do not have permission to perform this action on this repository",
-        ));
-    }
+    upload_service::validate_artifact_path(&req.artifact_path).map_err(map_upload_err)?;
 
     let is_replication = super::is_replication_request(&headers);
     let replication_metadata = replication_session_metadata_from_request(&headers, &req);
 
     if is_replication {
-        cleanup_stale_replication_upload_sessions(&state.db, repo.0, &req.artifact_path).await;
+        cleanup_stale_replication_upload_sessions(&state.db, repo_id, &req.artifact_path).await;
     }
 
     // Repository storage-quota gate (parity with the direct artifact-write
@@ -453,6 +284,11 @@ async fn upload_chunk(
 ) -> Result<Response, Response> {
     let user_id = auth.user_id;
 
+    // Re-authorize every mutating session request. A session may outlive the
+    // role or permission that allowed its creation, and revoked access must
+    // take effect before request validation or any chunk state/file mutation.
+    let session = require_upload_session_write_access(&state, &auth, session_id).await?;
+
     // Parse Content-Range header
     let range_header = headers
         .get("content-range")
@@ -465,11 +301,6 @@ async fn upload_chunk(
             format!("Invalid Content-Range: {}", e),
         )
     })?;
-
-    // C3: get_session now verifies user ownership
-    let session = UploadService::get_session(&state.db, session_id, Some(user_id))
-        .await
-        .map_err(map_upload_err)?;
 
     let chunk_index = (start / session.chunk_size as i64) as i32;
 
@@ -552,12 +383,7 @@ async fn get_session_status(
     Extension(auth): Extension<AuthExtension>,
     Path(session_id): Path<Uuid>,
 ) -> Result<Response, Response> {
-    let user_id = auth.user_id;
-
-    // C3: Verify user owns this session
-    let session = UploadService::get_session(&state.db, session_id, Some(user_id))
-        .await
-        .map_err(map_upload_err)?;
+    let session = require_upload_session_write_access(&state, &auth, session_id).await?;
 
     Ok(Json(SessionStatusResponse {
         session_id: session.id,
@@ -603,7 +429,10 @@ async fn complete(
     let user_id = auth.user_id;
     let is_replication_request = super::is_replication_request(&headers);
 
-    // C3: Verify user owns this session
+    // Authorization must precede checksum/chunk validation and the transition
+    // to `completed`; grants can be revoked while a session is in progress.
+    require_upload_session_write_access(&state, &auth, session_id).await?;
+
     let session = UploadService::complete_session(&state.db, session_id, user_id)
         .await
         .map_err(map_upload_err)?;
@@ -756,7 +585,9 @@ async fn cancel(
 ) -> Result<Response, Response> {
     let user_id = auth.user_id;
 
-    // C3: Verify user owns this session
+    // Cancellation only removes caller-owned staged bytes; keeping it
+    // available after a grant is revoked lets the owner release temporary
+    // storage without permitting a repository mutation.
     UploadService::cancel_session(&state.db, session_id, user_id)
         .await
         .map_err(map_upload_err)?;
@@ -794,6 +625,25 @@ pub struct UploadApiDoc;
 // Helpers
 // ---------------------------------------------------------------------------
 
+async fn require_upload_session_write_access(
+    state: &SharedState,
+    auth: &AuthExtension,
+    session_id: Uuid,
+) -> Result<upload_service::UploadSession, Response> {
+    let session = UploadService::get_session(&state.db, session_id, Some(auth.user_id))
+        .await
+        .map_err(map_upload_err)?;
+    let repo_service = RepositoryService::new(state.db.clone());
+    let repo = repo_service
+        .get_by_id(session.repository_id)
+        .await
+        .map_err(IntoResponse::into_response)?;
+    require_repo_write_access(auth, &repo, &repo_service)
+        .await
+        .map_err(IntoResponse::into_response)?;
+    Ok(session)
+}
+
 /// Map an UploadError to an HTTP response.
 fn map_upload_err(e: UploadError) -> Response {
     let (status, msg) = match &e {
@@ -830,28 +680,6 @@ fn map_err(status: StatusCode, e: impl std::fmt::Display) -> Response {
         axum::Json(serde_json::json!({"error": e.to_string()})),
     )
         .into_response()
-}
-
-/// Pure authorization decision for chunked upload-session creation, mirroring
-/// the non-admin RBAC write gate enforced by `repo_visibility_middleware`.
-///
-/// - Admins always pass (any rules state).
-/// - Non-admins on a repository with no permission rules fall through (allowed).
-/// - Non-admins on a rules-bearing repository must hold the `write` action or
-///   the `admin` action (which implies all actions).
-fn upload_write_decision(
-    is_admin: bool,
-    has_rules: bool,
-    has_write: bool,
-    has_admin: bool,
-) -> bool {
-    if is_admin {
-        return true;
-    }
-    if !has_rules {
-        return true;
-    }
-    has_write || has_admin
 }
 
 /// Build the rejection for a direct upload-session create against a
@@ -1144,12 +972,9 @@ fn replication_session_metadata_from_request<'a>(
 mod tests {
     use super::*;
 
-    /// Cross-tenant authz guard (xtenant-write-authz-systemic). `session_write_authorized`
-    /// (and `upload_write_decision`) fall OPEN when the target repo has no
-    /// fine-grained permission rules (`!has_rules`), so `create_session` must
-    /// ALSO enforce the rule-independent tenant gate `require_repo_write_access`
-    /// (is_public + role_assignments membership). String-grep because the handler
-    /// needs a real DB to run.
+    /// Cross-tenant authz guard. Chunked uploads name the repository in the
+    /// body, so the handler must call the same canonical action-aware write gate
+    /// used by URL-addressed artifact uploads.
     #[test]
     fn test_create_session_enforces_tenant_gate() {
         let source = include_str!("upload.rs");
@@ -1160,120 +985,13 @@ mod tests {
         let end = rest.find("\nasync fn ").unwrap_or(rest.len());
         assert!(
             rest[..end].contains("require_repo_write_access("),
-            "create_session must call require_repo_write_access independent of \
-             fine-grained rule existence (xtenant)"
+            "create_session must call the canonical repository write gate"
         );
-    }
-
-    // -----------------------------------------------------------------------
-    // session_write_authorized (pure write-authorization decision)
-    // -----------------------------------------------------------------------
-
-    /// Build an `AuthExtension` for the pure-helper tests. `allowed` is the
-    /// token repo-scope (`None` = unrestricted, matching a JWT login).
-    fn auth_for(is_admin: bool, allowed: Option<Vec<Uuid>>) -> AuthExtension {
-        AuthExtension {
-            user_id: Uuid::new_v4(),
-            username: "tester".to_string(),
-            email: "tester@example.test".to_string(),
-            is_admin,
-            is_api_token: allowed.is_some(),
-            is_service_account: false,
-            scopes: None,
-            allowed_repo_ids: crate::models::access_scope::AccessScope::from(allowed),
-            iat_ms: None,
-        }
-    }
-
-    #[test]
-    fn session_write_authorized_denies_token_scoped_out() {
-        let repo = Uuid::new_v4();
-        let other = Uuid::new_v4();
-        // Token restricted to a different repo: denied before any rule check.
-        let auth = auth_for(false, Some(vec![other]));
-        assert!(!session_write_authorized(&auth, repo, false, false, false));
-        // Even an admin token is bound by its repo scope.
-        let admin = auth_for(true, Some(vec![other]));
-        assert!(!session_write_authorized(&admin, repo, false, false, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_admin() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(true, None);
-        // Admin bypasses fine-grained rules even when the user holds nothing.
-        assert!(session_write_authorized(&auth, repo, true, false, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_when_no_rules() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        // No fine-grained rules -> default access model (fall-through).
-        assert!(session_write_authorized(&auth, repo, false, false, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_with_write_grant() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        assert!(session_write_authorized(&auth, repo, true, true, false));
-    }
-
-    #[test]
-    fn session_write_authorized_allows_with_admin_action() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        assert!(session_write_authorized(&auth, repo, true, false, true));
-    }
-
-    #[test]
-    fn session_write_authorized_denies_rules_without_grant() {
-        let repo = Uuid::new_v4();
-        let auth = auth_for(false, None);
-        // Rules exist but the user holds neither write nor admin: denied.
-        assert!(!session_write_authorized(&auth, repo, true, false, false));
     }
 
     // -----------------------------------------------------------------------
     // artifact_name_from_path
     // -----------------------------------------------------------------------
-
-    // -----------------------------------------------------------------------
-    // upload_write_decision (#817 parity with repo_visibility_middleware)
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_upload_write_decision_admin_always_allowed() {
-        // Admins bypass the check regardless of rules/actions.
-        assert!(upload_write_decision(true, false, false, false));
-        assert!(upload_write_decision(true, true, false, false));
-        assert!(upload_write_decision(true, true, true, true));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_no_rules_allowed() {
-        // A repository with no permission rules falls through unchanged.
-        assert!(upload_write_decision(false, false, false, false));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_rules_with_write_allowed() {
-        assert!(upload_write_decision(false, true, true, false));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_rules_with_admin_action_allowed() {
-        // The `admin` action implies all actions (including write).
-        assert!(upload_write_decision(false, true, false, true));
-    }
-
-    #[test]
-    fn test_upload_write_decision_non_admin_rules_neither_denied() {
-        // Release/promotion-only repo: rules exist but caller holds neither
-        // write nor admin -> denied.
-        assert!(!upload_write_decision(false, true, false, false));
-    }
 
     // -----------------------------------------------------------------------
     // reject_session_if_promotion_only (#817 parity with direct upload path)
@@ -2908,6 +2626,131 @@ mod tests {
         assert_eq!(count, 0, "denied request must not create a session");
 
         delete_repo_permissions(&f.pool, f.repo_id).await;
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn create_session_denies_public_repo_write_without_grant() {
+        let Some(f) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        sqlx::query("UPDATE repositories SET is_public = true WHERE id = $1")
+            .bind(f.repo_id)
+            .execute(&f.pool)
+            .await
+            .expect("make repository public");
+        let (outsider_id, outsider_name) = tdh::create_user(&f.pool).await;
+        let app =
+            upload_router_with_auth(f.state.clone(), tdh::make_auth(outsider_id, &outsider_name));
+
+        let req = create_session_req(&serde_json::json!({
+            "repository_key": f.repo_key,
+            "artifact_path": "public/no-grant.bin",
+            "total_size": 16_i64,
+            "checksum_sha256": "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+        }));
+        let (status, _body) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "public visibility must not authorize upload-session creation"
+        );
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM upload_sessions WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .unwrap_or(0);
+        assert_eq!(count, 0, "denied request must not create a session");
+
+        tdh::cleanup_user(&f.pool, outsider_id).await;
+        f.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn active_session_rechecks_write_access_before_use() {
+        let Some(f) = tdh::Fixture::setup("local", "generic").await else {
+            return;
+        };
+        let auth = tdh::make_auth(f.user_id, &f.username);
+        let app = upload_router_with_auth(f.state.clone(), auth);
+        let req = create_session_req(&serde_json::json!({
+            "repository_key": f.repo_key,
+            "artifact_path": "revoked/session.bin",
+            "total_size": 16_i64,
+            "checksum_sha256": "deadbeef0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+        }));
+        let (status, create_body) = tdh::send(app, req).await;
+        assert_eq!(status, StatusCode::CREATED);
+        let create_response: serde_json::Value =
+            serde_json::from_slice(&create_body).expect("create response JSON");
+        let session_id: Uuid =
+            serde_json::from_value(create_response["session_id"].clone()).expect("session_id");
+
+        sqlx::query("DELETE FROM role_assignments WHERE user_id = $1 AND repository_id = $2")
+            .bind(f.user_id)
+            .bind(f.repo_id)
+            .execute(&f.pool)
+            .await
+            .expect("revoke repository role");
+
+        let app = upload_router_with_auth(f.state.clone(), tdh::make_auth(f.user_id, &f.username));
+        let req = axum::http::Request::builder()
+            .method("PATCH")
+            .uri(format!("/{}", session_id))
+            .body(axum::body::Body::from(vec![0_u8; 16]))
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "authorization must run before Content-Range validation"
+        );
+
+        let app = upload_router_with_auth(f.state.clone(), tdh::make_auth(f.user_id, &f.username));
+        let req = axum::http::Request::builder()
+            .method("GET")
+            .uri(format!("/{}", session_id))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        let app = upload_router_with_auth(f.state.clone(), tdh::make_auth(f.user_id, &f.username));
+        let req = axum::http::Request::builder()
+            .method("PUT")
+            .uri(format!("/{}/complete", session_id))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::FORBIDDEN,
+            "authorization must run before completion validation"
+        );
+
+        let persisted: (String, i32) =
+            sqlx::query_as("SELECT status, completed_chunks FROM upload_sessions WHERE id = $1")
+                .bind(session_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("query denied session");
+        assert_eq!(persisted, ("pending".to_string(), 0));
+
+        let app = upload_router_with_auth(f.state.clone(), tdh::make_auth(f.user_id, &f.username));
+        let req = axum::http::Request::builder()
+            .method("DELETE")
+            .uri(format!("/{}", session_id))
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(
+            status,
+            StatusCode::NO_CONTENT,
+            "the owner may still cancel staged data after access is revoked"
+        );
+
+        cleanup_created_session(&f.pool, &create_body).await;
         f.teardown().await;
     }
 

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -29,6 +29,7 @@ use crate::models::access_scope::AccessScope;
 use crate::models::user::User;
 use crate::services::auth_service::{AuthService, Claims};
 use crate::services::permission_service::PermissionService;
+use crate::services::repository_service::RepositoryService;
 
 /// Custom header name for API key
 static X_API_KEY: HeaderName = HeaderName::from_static("x-api-key");
@@ -1248,12 +1249,32 @@ pub struct RepoVisibilityState {
 
 /// Extract the repository key from a format handler request path.
 ///
-/// Format routes are nested as `/{format}/{repo_key}/...`, so the repo key
-/// is the second path segment (e.g. `/pypi/my-repo/simple/` -> `"my-repo"`).
+/// Format routes are nested as `/{format}/{repo_key}/...`, but middleware can
+/// observe either the nest-stripped form or the full `/api/v1/...` URI. In both
+/// cases the repo key is the segment immediately after the format prefix.
 pub(crate) fn extract_repo_key(path: &str) -> &str {
-    let trimmed = path.trim_start_matches('/');
-    let mut segments = trimmed.split('/');
-    segments.next(); // skip format prefix (pypi, npm, maven, etc.)
+    let mut segments = path.split('/').filter(|segment| !segment.is_empty());
+    let first = match segments.next() {
+        Some(segment) => segment,
+        None => return "",
+    };
+
+    let format = if first == "api" {
+        let Some(version) = segments.next() else {
+            return "";
+        };
+        if !version.starts_with('v') {
+            return "";
+        }
+        segments.next()
+    } else {
+        Some(first)
+    };
+
+    if format.is_none() {
+        return "";
+    }
+
     segments.next().unwrap_or("")
 }
 
@@ -1655,36 +1676,24 @@ pub async fn repo_visibility_middleware(
                         return forbidden_permission_response();
                     }
                 }
-            } else if !is_public {
-                // A private repo with NO fine-grained permission rules must
-                // still not be readable by every authenticated user. Mirror
-                // the REST `require_visible` model: a non-admin needs a role
-                // assignment scoped to this repo (or a global assignment).
+            } else if is_write || !is_public {
+                // Repositories with no fine-grained rules fall back to legacy
+                // role assignments. Private repositories require that grant
+                // for reads and writes; public repositories require it for
+                // writes because public visibility is read-only.
                 //
-                // Without this branch the native-protocol path default-ALLOWED
-                // rule-less private repos to any authenticated principal, while
-                // the REST download path denied the same caller (404) — a
-                // cross-tenant private-artifact leak (red-team round 2).
-                //
-                // Uses sqlx::query_scalar (not the macro) so no new entry in
-                // the sqlx offline-query cache is required, matching the rest
-                // of this middleware. Same predicate as
-                // RepositoryService::user_can_access_repo.
-                let granted = sqlx::query_scalar::<_, bool>(
-                    "SELECT EXISTS ( \
-                         SELECT 1 FROM role_assignments ra \
-                         WHERE ra.user_id = $1 \
-                           AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
-                     )",
-                )
-                .bind(ext.user_id)
-                .bind(repo.id)
-                .fetch_one(&vis_state.db)
-                .await;
+                // This mirrors RepositoryService::user_can_perform_repo_action
+                // and keeps the legacy SQL in one service implementation.
+                let action = action_for_method(request.method());
+                let granted = RepositoryService::new(vis_state.db.clone())
+                    .user_can_perform_legacy_repo_action(repo.id, ext.user_id, action)
+                    .await;
 
                 match granted {
                     Ok(true) => {}
-                    // Existence-hiding 404, matching REST `require_visible`.
+                    Ok(false) if is_write => return forbidden_permission_response(),
+                    // Existence-hiding 404 for unauthorized private reads,
+                    // matching the REST `require_visible` behavior.
                     Ok(false) => return not_found_response(),
                     Err(_) => {
                         // DB error on access check: fail closed.
@@ -2420,6 +2429,20 @@ mod tests {
     #[test]
     fn test_extract_repo_key_no_leading_slash() {
         assert_eq!(extract_repo_key("pypi/my-repo/simple"), "my-repo");
+    }
+
+    #[test]
+    fn test_extract_repo_key_full_api_path() {
+        assert_eq!(extract_repo_key("/api/v1/pypi/my-repo/simple/"), "my-repo");
+        assert_eq!(
+            extract_repo_key("/api/v1/maven/my-repo/com/example/artifact"),
+            "my-repo"
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_key_full_api_path_without_repo() {
+        assert_eq!(extract_repo_key("/api/v1/pypi"), "");
     }
 
     // -----------------------------------------------------------------------
@@ -4624,6 +4647,7 @@ mod tests {
             repo_key: &str,
             repo_id: Uuid,
             storage_path: String,
+            is_public: bool,
         ) -> RepoVisibilityState {
             let cache: RepoCache =
                 Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
@@ -4634,7 +4658,7 @@ mod tests {
                 upstream_url: None,
                 storage_path,
                 storage_backend: "filesystem".to_string(),
-                is_public: false,
+                is_public,
                 index_upstream_url: None,
             };
             cache
@@ -4657,6 +4681,14 @@ mod tests {
                 .body(axum::body::Body::empty())
                 .unwrap()
         };
+        let write_req = || {
+            axum::http::Request::builder()
+                .method(Method::PUT)
+                .uri(format!("/api/v1/pypi/{}/", repo_key))
+                .header("Authorization", &bearer)
+                .body(axum::body::Body::empty())
+                .unwrap()
+        };
         let storage = storage_dir.to_string_lossy().into_owned();
 
         // 1) No role assignment -> existence-hiding 404 (the fix). Without the
@@ -4667,6 +4699,7 @@ mod tests {
             &repo_key,
             repo_id,
             storage.clone(),
+            false,
         )
         .await;
         let resp = run_through_visibility(state, req()).await;
@@ -4674,17 +4707,51 @@ mod tests {
             resp.status(),
             StatusCode::NOT_FOUND,
             "authenticated non-admin without a role assignment must NOT read a \
-             rule-less private repo via the native path"
+            rule-less private repo via the native path"
         );
 
-        // 2) Grant a role assignment -> access restored (parity with REST).
+        // 2) Public visibility remains read-only. A full /api/v1 native-format
+        //    path must resolve the real repo key and deny an ungranted write.
+        let state = mk_state(
+            &pool,
+            auth_service.clone(),
+            &repo_key,
+            repo_id,
+            storage.clone(),
+            true,
+        )
+        .await;
+        let resp = run_through_visibility(state, write_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::FORBIDDEN,
+            "public visibility must not authorize native-format writes"
+        );
+
+        // 3) Grant a role assignment -> private read access restored (parity
+        //    with REST), and the legacy developer role remains a write grant.
         tdh::grant_repo_access(&pool, repo_id, user_id).await;
-        let state = mk_state(&pool, auth_service, &repo_key, repo_id, storage).await;
+        let state = mk_state(
+            &pool,
+            auth_service.clone(),
+            &repo_key,
+            repo_id,
+            storage.clone(),
+            false,
+        )
+        .await;
         let resp = run_through_visibility(state, req()).await;
         assert_eq!(
             resp.status(),
             StatusCode::OK,
             "a role assignment must restore native-path access to the private repo"
+        );
+        let state = mk_state(&pool, auth_service, &repo_key, repo_id, storage, true).await;
+        let resp = run_through_visibility(state, write_req()).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "legacy developer membership must retain native-format write access"
         );
 
         tdh::cleanup(&pool, repo_id, user_id).await;

--- a/backend/src/api/routes.rs
+++ b/backend/src/api/routes.rs
@@ -894,6 +894,8 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
             )),
         )
         // Remote instance management & proxy routes with auth middleware.
+        // Instances are user-owned integration records; handlers scope every
+        // operation to the authenticated user's id.
         // The global body limit is disabled above, so apply a route-scoped
         // request-body limit here (default 32 MiB, env-tunable via
         // REMOTE_PROXY_BODY_LIMIT_BYTES) to bound the proxy request path. The
@@ -918,12 +920,13 @@ fn api_v1_routes(state: SharedState) -> Router<SharedState> {
                 auth_middleware,
             )),
         )
-        // Migration routes with auth middleware
+        // Migration connections and jobs are system-wide administrative state.
+        // Gate the whole nest so authz runs before UUID lookup or JSON parsing.
         .nest(
             "/migrations",
             handlers::migration::router().layer(middleware::from_fn_with_state(
                 auth_service.clone(),
-                auth_middleware,
+                admin_middleware,
             )),
         )
         // Chunked/resumable upload routes with auth middleware
@@ -1059,6 +1062,22 @@ mod tests {
         assert!(
             ROUTES_RS_SRC.contains("\"/dependency-track\","),
             "/dependency-track nest registration missing"
+        );
+    }
+
+    #[test]
+    fn migrations_nest_requires_admin() {
+        let nest = ROUTES_RS_SRC
+            .split("handlers::migration::router()")
+            .nth(1)
+            .expect("migration::router() must be nested under /migrations");
+        let next_middleware = nest
+            .split("from_fn_with_state")
+            .nth(1)
+            .expect("/migrations nest must attach middleware");
+        assert!(
+            next_middleware.contains("admin_middleware"),
+            "/migrations must reject non-admins before validation or lookup"
         );
     }
 }

--- a/backend/src/services/proxy_service.rs
+++ b/backend/src/services/proxy_service.rs
@@ -7245,7 +7245,7 @@ mod tests {
         let service = build_proxy_service_with_storage(mock.clone());
 
         let err = service
-            .cache_quarantine_gate("npm-proxy", "lodash")
+            .cache_quarantine_gate("npm-proxy-quarantine-active", "lodash")
             .await
             .expect_err("an active hold must block the redirect fast path");
         match err {
@@ -7265,7 +7265,7 @@ mod tests {
 
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate("npm-proxy-quarantine-elapsed", "lodash")
                 .await
                 .is_ok(),
             "an elapsed hold must not block the redirect"
@@ -7282,7 +7282,7 @@ mod tests {
 
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate("npm-proxy-quarantine-none", "lodash")
                 .await
                 .is_ok(),
             "a sidecar with no hold must not block the redirect"
@@ -7296,7 +7296,7 @@ mod tests {
 
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate("npm-proxy-quarantine-missing", "lodash")
                 .await
                 .is_ok(),
             "a missing sidecar means no hold known -> allow"
@@ -7316,7 +7316,7 @@ mod tests {
 
         assert!(
             service
-                .cache_quarantine_gate("npm-proxy", "lodash")
+                .cache_quarantine_gate("npm-proxy-quarantine-read-error", "lodash")
                 .await
                 .is_ok(),
             "a sidecar read/parse error must be treated as no hold known"

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -874,6 +874,103 @@ impl RepositoryService {
         Ok(granted)
     }
 
+    /// Check whether a user may perform a specific action on a repository.
+    ///
+    /// Fine-grained repository or inherited project permissions are
+    /// authoritative once any applicable rules exist: callers need the
+    /// requested action or `admin`. Repositories without rules fall back to
+    /// legacy role assignments so existing installations retain their
+    /// configured read/write behavior.
+    pub async fn user_can_perform_repo_action(
+        &self,
+        repo_id: Uuid,
+        user_id: Uuid,
+        action: &str,
+    ) -> Result<bool> {
+        let has_rules: bool = sqlx::query_scalar(
+            "SELECT EXISTS( \
+                 SELECT 1 FROM permissions \
+                 WHERE (target_type = 'repository' AND target_id = $1) \
+                    OR (target_type = 'project' AND target_id = ( \
+                        SELECT project_id FROM repositories WHERE id = $1 \
+                    )) \
+             )",
+        )
+        .bind(repo_id)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        if !has_rules {
+            return self
+                .user_can_perform_legacy_repo_action(repo_id, user_id, action)
+                .await;
+        }
+
+        let allowed: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM permissions p \
+                 WHERE ( \
+                       (p.target_type = 'repository' AND p.target_id = $2) \
+                       OR (p.target_type = 'project' AND p.target_id = ( \
+                           SELECT project_id FROM repositories WHERE id = $2 \
+                       )) \
+                   ) \
+                   AND ($3 = ANY(p.actions) OR 'admin' = ANY(p.actions)) \
+                   AND ( \
+                       (p.principal_type IN ('user', 'service_account') \
+                           AND p.principal_id = $1) \
+                       OR (p.principal_type = 'group' AND p.principal_id IN ( \
+                           SELECT group_id FROM user_group_members WHERE user_id = $1 \
+                       )) \
+                   ) \
+             )",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .bind(action)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(allowed)
+    }
+
+    /// Evaluate the legacy role-assignment model for a repository action.
+    ///
+    /// Callers must first establish that no applicable fine-grained repository
+    /// or project rules exist; those rules are authoritative when present.
+    pub(crate) async fn user_can_perform_legacy_repo_action(
+        &self,
+        repo_id: Uuid,
+        user_id: Uuid,
+        action: &str,
+    ) -> Result<bool> {
+        let allowed: bool = sqlx::query_scalar(
+            "SELECT EXISTS ( \
+                 SELECT 1 FROM role_assignments ra \
+                 INNER JOIN roles r ON r.id = ra.role_id \
+                 WHERE ra.user_id = $1 \
+                   AND (ra.repository_id = $2 OR ra.repository_id IS NULL) \
+                   AND ( \
+                       r.name = 'admin' \
+                       OR $3 = ANY(r.permissions) \
+                       OR 'admin' = ANY(r.permissions) \
+                       OR ($3 = 'read') \
+                       OR ($3 = 'write' AND r.name = 'developer') \
+                   ) \
+             )",
+        )
+        .bind(user_id)
+        .bind(repo_id)
+        .bind(action)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(allowed)
+    }
+
     /// Get a repository by ID
     pub async fn get_by_id(&self, id: Uuid) -> Result<Repository> {
         let repo = sqlx::query_as!(
@@ -3286,6 +3383,199 @@ mod tests {
 
             cleanup_repo(&pool, repo.id).await;
             for uid in [owner_id, other_id] {
+                let _ = sqlx::query("DELETE FROM users WHERE id = $1")
+                    .bind(uid)
+                    .execute(&pool)
+                    .await;
+            }
+        }
+
+        /// Action-specific RBAC must not turn visibility/read grants into
+        /// write or delete, while repository `admin` implies every action.
+        #[tokio::test]
+        async fn test_user_can_perform_repo_action_honors_specific_actions() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+
+            let (owner_id, _) = tdh::create_user(&pool).await;
+            let (grantee_id, _) = tdh::create_user(&pool).await;
+
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let mut req = make_create_req(&suffix, RepositoryFormat::Generic);
+            req.created_by = Some(owner_id);
+            let repo = service.create(req).await.expect("create private repo");
+
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
+            )
+            .bind(grantee_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("insert read permission");
+
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "write")
+                    .await
+                    .expect("write check"),
+                "read permission must not grant write"
+            );
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("delete check"),
+                "read permission must not grant delete"
+            );
+
+            sqlx::query(
+                "UPDATE permissions SET actions = ARRAY['write'] \
+                 WHERE principal_type = 'user' AND principal_id = $1 \
+                   AND target_type = 'repository' AND target_id = $2",
+            )
+            .bind(grantee_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("update to write permission");
+
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "write")
+                    .await
+                    .expect("write check"),
+                "write permission must grant write"
+            );
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("delete check"),
+                "write permission must not grant delete"
+            );
+
+            sqlx::query(
+                "UPDATE permissions SET actions = ARRAY['admin'] \
+                 WHERE principal_type = 'user' AND principal_id = $1 \
+                   AND target_type = 'repository' AND target_id = $2",
+            )
+            .bind(grantee_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("update to admin permission");
+
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("delete check"),
+                "admin permission must grant delete"
+            );
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "admin")
+                    .await
+                    .expect("admin check"),
+                "admin permission must grant admin"
+            );
+
+            let (service_account_id, _) = tdh::create_user(&pool).await;
+            sqlx::query("UPDATE users SET is_service_account = true WHERE id = $1")
+                .bind(service_account_id)
+                .execute(&pool)
+                .await
+                .expect("mark service-account principal");
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('service_account', $1, 'repository', $2, ARRAY['write'])",
+            )
+            .bind(service_account_id)
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("insert service-account write permission");
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, service_account_id, "write")
+                    .await
+                    .expect("service-account write check"),
+                "service-account repository grants must be honored"
+            );
+
+            // Project grants are inherited by their repositories and become
+            // authoritative just like direct repository rules. In particular,
+            // the owner's legacy developer assignment must not bypass a
+            // project rule granted to somebody else.
+            sqlx::query(
+                "DELETE FROM permissions WHERE target_type = 'repository' AND target_id = $1",
+            )
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("remove direct repository rules");
+            let project_id: Uuid =
+                sqlx::query_scalar("INSERT INTO projects (key, name) VALUES ($1, $1) RETURNING id")
+                    .bind(format!("action-test-{}", Uuid::new_v4()))
+                    .fetch_one(&pool)
+                    .await
+                    .expect("create action-test project");
+            sqlx::query("UPDATE repositories SET project_id = $2 WHERE id = $1")
+                .bind(repo.id)
+                .bind(project_id)
+                .execute(&pool)
+                .await
+                .expect("assign repository to project");
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('user', $1, 'project', $2, ARRAY['write'])",
+            )
+            .bind(grantee_id)
+            .bind(project_id)
+            .execute(&pool)
+            .await
+            .expect("insert inherited project write permission");
+            assert!(
+                service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "write")
+                    .await
+                    .expect("inherited project write check"),
+                "project write permission must apply to an assigned repository"
+            );
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, grantee_id, "delete")
+                    .await
+                    .expect("inherited project delete check"),
+                "project write permission must not grant repository delete"
+            );
+            assert!(
+                !service
+                    .user_can_perform_repo_action(repo.id, owner_id, "write")
+                    .await
+                    .expect("legacy fallback check with project rules"),
+                "applicable project rules must prevent legacy-role fallback"
+            );
+
+            let _ = sqlx::query(
+                "DELETE FROM permissions WHERE target_type = 'project' AND target_id = $1",
+            )
+            .bind(project_id)
+            .execute(&pool)
+            .await;
+            cleanup_repo(&pool, repo.id).await;
+            let _ = sqlx::query("DELETE FROM projects WHERE id = $1")
+                .bind(project_id)
+                .execute(&pool)
+                .await;
+            for uid in [owner_id, grantee_id, service_account_id] {
                 let _ = sqlx::query("DELETE FROM users WHERE id = $1")
                     .bind(uid)
                     .execute(&pool)


### PR DESCRIPTION
## Summary

Closes #2603 

This follow-up completes the authorization hardening that remained after the
earlier work was split into upstream changes. It keeps public repository
visibility read-only, centralizes action-aware repository authorization, and
applies the same decision consistently to generic, resumable, native, and OCI
mutation paths.

It also requires repository administration for delegated repository tokens and
repository configuration subresources, and applies early global-admin guards to
system-wide peer, signing-key, security-configuration, and migration routes.
Protected routes now stop unauthorized callers before request validation or
resource lookup.

The detailed reproduction matrix is intentionally not included in this public
PR. A sanitized endpoint/status report is available privately to maintainers.

### Authorization model

- Public visibility permits reads; it does not imply `write` or `delete`.
- Repository actions are evaluated as `read`, `write`, `delete`, or `admin`.
- Applicable direct, group, service-account, and inherited project rules are
  authoritative; repository `admin` implies the narrower actions.
- Repositories without applicable fine-grained rules retain legacy role
  compatibility for read/write, but `developer` no longer implies delete.
- Upload sessions recheck repository write access on chunk, status, and complete
  operations; their owner can still cancel staged data after access is revoked.
- Global administrators retain the existing bypass.

### Explicit non-goals

- Remote instances remain authenticated user-owned self-service records; their
  service scopes operations by the caller's user id.
- SBOM generation retains the current upstream artifact-visibility policy,
  including generation for artifacts visible in public repositories.

### CI notes and existing test updates

Several existing positive-path tests used a legacy developer fixture while
expecting a destructive operation to reach an immutability, promotion, OCI
cleanup, or npm-path assertion. Those fixtures now explicitly grant `delete`
(and `write` where a later republish is part of the case). Their original
business assertions are unchanged; an ungranted developer remains denied.

The in-process full suite also exposed seven proxy quarantine tests that shared
one process-wide metadata-LRU key across different mock storage instances. Their
test repository keys are now unique. Production cache behavior and the expected
hold/no-hold results are unchanged.

No schema migration or new endpoint is introduced.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local checks:

```text
cargo fmt --all --check
cargo clippy --workspace --all-targets -- -D warnings
DB-backed authorization and handler regression tests
workspace library test suite after refreshing from upstream/main:
13,374 passed, 0 failed, 6 ignored, 0 filtered
```

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes