### PR TITLE
fix: use LARGE_METADATA_MAX_BYTES for RPM metadata proxy (Fixes #2622)

### DIFF
--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -135,7 +135,7 @@ async fn try_proxy_repodata(
         &repo.key,
         upstream_url,
         upstream_path,
-        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+        proxy_helpers::LARGE_METADATA_MAX_BYTES,
     )
     .await?;
 


### PR DESCRIPTION
## Summary  
Fixes #2622  
  
RPM proxy repositories return 502 Bad Gateway when fetching metadata files (primary.xml.gz, filelists.xml.gz) that exceed 8 MB. This changes the limit from DEFAULT_METADATA_MAX_BYTES (8 MB) to LARGE_METADATA_MAX_BYTES (128 MB), aligning with how PyPI and Debian metadata are handled.  
  
## Test Checklist  
- [x] Manual testing with Oracle Linux 8 baseos repository  
- [x] Large metadata files (>8 MB) now proxy successfully  
  
## API Changes  
None - this only changes the metadata size limit for RPM proxy repositories.