### PR TITLE
fix(conda): resolve token-channel GET reads (repodata/download 401)

### DIFF
--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -783,53 +783,62 @@ pub fn router() -> Router<SharedState> {
 ///     - https://host/conda/t/<TOKEN>/my-channel
 pub fn token_router() -> Router<SharedState> {
     Router::new()
-        .route("/:token/:repo_key/channeldata.json", get(channeldata_json))
-        .route("/:token/:repo_key/notices.json", get(notices_json))
-        .route("/:token/:repo_key/keys/repo.pub", get(repo_public_key))
+        .route(
+            "/:token/:repo_key/channeldata.json",
+            get(channeldata_json_with_token),
+        )
+        .route(
+            "/:token/:repo_key/notices.json",
+            get(notices_json_with_token),
+        )
+        .route(
+            "/:token/:repo_key/keys/repo.pub",
+            get(repo_public_key_with_token),
+        )
         .route("/:token/:repo_key/upload", post(upload_post_with_token))
         .route(
             "/:token/:repo_key/:subdir/repodata.json",
-            get(repodata_json),
+            get(repodata_json_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/repodata.json.bz2",
-            get(repodata_json_bz2),
+            get(repodata_json_bz2_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/repodata.json.sig",
-            get(repodata_json_sig),
+            get(repodata_json_sig_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/repodata.json.zst",
-            get(repodata_json_zst),
+            get(repodata_json_zst_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/repodata.json.jlap",
-            get(repodata_json_jlap),
+            get(repodata_json_jlap_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/current_repodata.json",
-            get(current_repodata_json),
+            get(current_repodata_json_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/run_exports.json",
-            get(run_exports_json),
+            get(run_exports_json_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/patch_instructions.json",
-            get(patch_instructions_json),
+            get(patch_instructions_json_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/repodata_shards.msgpack.zst",
-            get(sharded_repodata_index),
+            get(sharded_repodata_index_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/shards/:shard_hash",
-            get(sharded_repodata_shard),
+            get(sharded_repodata_shard_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/:filename",
-            get(download_package).put(upload_package_put_with_token),
+            get(download_package_with_token).put(upload_package_put_with_token),
         )
         .route(
             "/:token/:repo_key/:subdir/:filename/attestation",
@@ -845,6 +854,136 @@ pub fn token_router() -> Router<SharedState> {
                 response
             },
         ))
+}
+
+// ---------------------------------------------------------------------------
+// Token-authenticated GET handlers (for /conda/t/<TOKEN>/ URL paths).
+//
+// The conda token router nests every read route under a leading `/:token`
+// segment. These handlers exist solely to bind that extra segment and delegate
+// to the shared non-token handler with a correctly-aligned `Path` tuple.
+//
+// Credential resolution for the URL token happens upstream in
+// `repo_visibility_middleware` (`extract_conda_url_token`), which validates the
+// token and injects the resulting `Option<AuthExtension>` before these handlers
+// run; the token segment itself is discarded here. Without these dedicated
+// handlers the non-token handlers bind `Path<(repo_key, subdir, ...)>`
+// positionally against the token-prefixed path, so every parameter shifts by
+// one (`repo_key` receives the token) and resolution never reaches a valid
+// channel -- a valid token-channel read then 401s.
+// ---------------------------------------------------------------------------
+
+async fn channeldata_json_with_token(
+    state: State<SharedState>,
+    auth: Extension<Option<AuthExtension>>,
+    headers: HeaderMap,
+    Path((_token, repo_key)): Path<(String, String)>,
+) -> Result<Response, Response> {
+    channeldata_json(state, auth, headers, Path(repo_key)).await
+}
+
+async fn notices_json_with_token(
+    state: State<SharedState>,
+    headers: HeaderMap,
+    Path((_token, repo_key)): Path<(String, String)>,
+) -> Result<Response, Response> {
+    notices_json(state, headers, Path(repo_key)).await
+}
+
+async fn repo_public_key_with_token(
+    state: State<SharedState>,
+    Path((_token, repo_key)): Path<(String, String)>,
+) -> Result<Response, Response> {
+    repo_public_key(state, Path(repo_key)).await
+}
+
+async fn repodata_json_with_token(
+    state: State<SharedState>,
+    auth: Extension<Option<AuthExtension>>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    repodata_json(state, auth, headers, Path((repo_key, subdir))).await
+}
+
+async fn repodata_json_bz2_with_token(
+    state: State<SharedState>,
+    auth: Extension<Option<AuthExtension>>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    repodata_json_bz2(state, auth, headers, Path((repo_key, subdir))).await
+}
+
+async fn repodata_json_sig_with_token(
+    state: State<SharedState>,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    repodata_json_sig(state, Path((repo_key, subdir))).await
+}
+
+async fn repodata_json_zst_with_token(
+    state: State<SharedState>,
+    auth: Extension<Option<AuthExtension>>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    repodata_json_zst(state, auth, headers, Path((repo_key, subdir))).await
+}
+
+async fn repodata_json_jlap_with_token(
+    state: State<SharedState>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    repodata_json_jlap(state, headers, Path((repo_key, subdir))).await
+}
+
+async fn current_repodata_json_with_token(
+    state: State<SharedState>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    current_repodata_json(state, headers, Path((repo_key, subdir))).await
+}
+
+async fn run_exports_json_with_token(
+    state: State<SharedState>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    run_exports_json(state, headers, Path((repo_key, subdir))).await
+}
+
+async fn patch_instructions_json_with_token(
+    state: State<SharedState>,
+    headers: HeaderMap,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    patch_instructions_json(state, headers, Path((repo_key, subdir))).await
+}
+
+async fn sharded_repodata_index_with_token(
+    state: State<SharedState>,
+    Path((_token, repo_key, subdir)): Path<(String, String, String)>,
+) -> Result<Response, Response> {
+    sharded_repodata_index(state, Path((repo_key, subdir))).await
+}
+
+async fn sharded_repodata_shard_with_token(
+    state: State<SharedState>,
+    Path((_token, repo_key, subdir, shard_hash)): Path<(String, String, String, String)>,
+) -> Result<Response, Response> {
+    sharded_repodata_shard(state, Path((repo_key, subdir, shard_hash))).await
+}
+
+async fn download_package_with_token(
+    state: State<SharedState>,
+    auth: Extension<Option<AuthExtension>>,
+    Path((_token, repo_key, subdir, filename)): Path<(String, String, String, String)>,
+    ctx: crate::api::middleware::download_telemetry::DownloadContext,
+) -> Result<Response, Response> {
+    download_package(state, auth, Path((repo_key, subdir, filename)), ctx).await
 }
 
 // ---------------------------------------------------------------------------
@@ -8552,5 +8691,141 @@ mod tests {
             verifying_key.verify(&json_bytes, &signature).is_ok(),
             "Signature should verify against the public key"
         );
+    }
+
+    // =======================================================================
+    // Token-channel GET routing (regression: token-router GET param shift)
+    // =======================================================================
+
+    /// The conda token router nests every read route under a leading
+    /// `/:token` segment. Before the fix, those routes pointed at the
+    /// non-token handlers whose `Path` extractors bound only
+    /// `(repo_key, subdir[, filename])`, so the leading token shifted every
+    /// parameter by one (`repo_key` received the token) and a valid
+    /// token-channel read 401/404'd because resolution ran against a bogus
+    /// repo key.
+    ///
+    /// This test mounts `token_router()` directly (credential injection is the
+    /// visibility middleware's job and is covered in `middleware::auth`
+    /// tests) and proves the token-aware handlers now bind the SECOND path
+    /// segment as the repo key: a valid key resolves (200) while a bogus key
+    /// 404s, and the package download binds the final segment as the
+    /// filename.
+    #[tokio::test]
+    async fn test_token_channel_get_routes_bind_repo_key_not_token() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(fx) = tdh::Fixture::setup("local", "conda").await else {
+            return;
+        };
+        let repo = fx.repo_info("local", None);
+        let filename = "pkg-1.0-0.tar.bz2";
+        let path = format!("noarch/{filename}");
+        let storage_key = format!("conda/{}/{}", fx.repo_id, path);
+        let content = Bytes::from_static(b"fake-conda-package-bytes");
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &storage_key,
+            &path,
+            "pkg",
+            "1.0",
+            "application/x-tar",
+            content.clone(),
+            fx.user_id,
+        )
+        .await;
+
+        // Any opaque string in the token slot; the handler discards it and the
+        // middleware (not mounted here) is what validates it.
+        let tok = "ak_url_token_placeholder";
+        let key = fx.repo_key.clone();
+
+        let assertions = async {
+            // repodata.json resolves the real repo key (segment 2) and lists
+            // the seeded package -> the token segment was correctly discarded.
+            let app = fx.router_with_auth(token_router());
+            let (status, body) =
+                tdh::send(app, tdh::get(format!("/{tok}/{key}/noarch/repodata.json"))).await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "token-channel repodata must resolve the real repo key"
+            );
+            let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert!(
+                json["packages"]
+                    .as_object()
+                    .is_some_and(|m| m.contains_key(filename)),
+                "repodata must list the seeded package, got: {json}"
+            );
+
+            // A bogus repo key in segment 2 must 404 -> confirms segment 2 (not
+            // segment 1, the token) is treated as the repo key.
+            let app = fx.router_with_auth(token_router());
+            let (status, _b) = tdh::send(
+                app,
+                tdh::get(format!("/{tok}/no-such-repo-xyz/noarch/repodata.json")),
+            )
+            .await;
+            assert_eq!(
+                status,
+                StatusCode::NOT_FOUND,
+                "an unknown repo key in the token URL must 404"
+            );
+
+            // Compressed + metadata read routes resolve the repo key too.
+            for suffix in [
+                "noarch/repodata.json.bz2",
+                "noarch/repodata.json.zst",
+                "noarch/current_repodata.json",
+                "noarch/run_exports.json",
+                "noarch/patch_instructions.json",
+                "noarch/repodata.json.jlap",
+                "channeldata.json",
+                "notices.json",
+            ] {
+                let app = fx.router_with_auth(token_router());
+                let (status, _b) = tdh::send(app, tdh::get(format!("/{tok}/{key}/{suffix}"))).await;
+                assert_eq!(
+                    status,
+                    StatusCode::OK,
+                    "token-channel read `{suffix}` must resolve the repo key"
+                );
+            }
+
+            // The package download binds the FINAL segment as the filename
+            // (4-tuple) and streams the stored bytes.
+            let app = fx.router_with_auth(token_router());
+            let (status, body) =
+                tdh::send(app, tdh::get(format!("/{tok}/{key}/noarch/{filename}"))).await;
+            assert_eq!(
+                status,
+                StatusCode::OK,
+                "token-channel package download must resolve the filename"
+            );
+            assert_eq!(
+                &body[..],
+                &content[..],
+                "download must stream the stored package bytes"
+            );
+
+            // Signing-key routes have no key configured for the fixture repo,
+            // so they 404 -- but the handler is reached (repo key bound),
+            // exercising the token-aware wrappers.
+            for suffix in ["keys/repo.pub", "noarch/repodata.json.sig"] {
+                let app = fx.router_with_auth(token_router());
+                let (status, _b) = tdh::send(app, tdh::get(format!("/{tok}/{key}/{suffix}"))).await;
+                assert_eq!(
+                    status,
+                    StatusCode::NOT_FOUND,
+                    "signing route `{suffix}` reaches the handler and 404s (no key)"
+                );
+            }
+        };
+
+        assertions.await;
+        fx.teardown().await;
     }
 }

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1253,8 +1253,58 @@ pub struct RepoVisibilityState {
 pub(crate) fn extract_repo_key(path: &str) -> &str {
     let trimmed = path.trim_start_matches('/');
     let mut segments = trimmed.split('/');
-    segments.next(); // skip format prefix (pypi, npm, maven, etc.)
+    // Format prefix (pypi, npm, maven, ...).
+    let format = segments.next().unwrap_or("");
+    // Conda token channels embed the credential in the URL path:
+    //   /conda/t/<TOKEN>/<repo_key>/<subdir>/...
+    // The generic "skip one prefix segment" rule would return "t" as the repo
+    // key (the conda token router is mounted at /conda/t), so the visibility
+    // middleware would resolve a nonexistent repo and 401 an otherwise valid
+    // token-channel read. Skip the `t/<TOKEN>` pair for conda token URLs so the
+    // actual repository key is returned.
+    if format == "conda" && segments.clone().next() == Some("t") {
+        segments.next(); // "t"
+        segments.next(); // "<TOKEN>"
+    }
     segments.next().unwrap_or("")
+}
+
+/// Extract the credential from a conda token-channel URL path.
+///
+/// Conda clients embed the token directly in the path as
+/// `/conda/t/<TOKEN>/<repo_key>/...` (configured in `.condarc`). This
+/// credential is invisible to [`extract_token`], which only inspects headers
+/// and cookies, so without this helper the visibility middleware treats an
+/// authenticated token-channel request as anonymous and rejects reads of
+/// private channels. Returns `None` for any non-conda-token path or an empty
+/// token segment.
+pub(crate) fn extract_conda_url_token(path: &str) -> Option<&str> {
+    let trimmed = path.trim_start_matches('/');
+    let mut segments = trimmed.split('/');
+    if segments.next()? != "conda" {
+        return None;
+    }
+    if segments.next()? != "t" {
+        return None;
+    }
+    match segments.next() {
+        Some(token) if !token.is_empty() => Some(token),
+        _ => None,
+    }
+}
+
+/// Resolve the request credential for the visibility middleware, falling back
+/// to the conda token-channel URL credential when no header/cookie credential
+/// is present. Header credentials always take precedence.
+fn extract_visibility_token(request: &Request) -> ExtractedToken<'_> {
+    let extracted = extract_token(request);
+    if !matches!(extracted, ExtractedToken::None) {
+        return extracted;
+    }
+    match extract_conda_url_token(request.uri().path()) {
+        Some(token) => ExtractedToken::ApiKey(token),
+        None => ExtractedToken::None,
+    }
 }
 
 /// Decide whether a request to a repository should be allowed.
@@ -1485,7 +1535,7 @@ pub async fn repo_visibility_middleware(
     // info-disclosure question (#-TBD); for now we mirror
     // `optional_auth_middleware` and prioritise honouring the deactivation.
     let Some(repo) = repo else {
-        let extracted = extract_token(&request);
+        let extracted = extract_visibility_token(&request);
         let outcome = try_resolve_auth_outcome(&vis_state.auth_service, extracted).await;
         // Transient bcrypt-capacity shed -> retryable 503 (see
         // `AuthOutcome::Overloaded`), never a 401.
@@ -1525,8 +1575,10 @@ pub async fn repo_visibility_middleware(
     let is_public = repo.is_public;
     let is_write = is_write_method(request.method());
 
-    // Perform optional auth (shared with optional_auth_middleware).
-    let extracted = extract_token(&request);
+    // Perform optional auth (shared with optional_auth_middleware). Conda
+    // token channels carry the credential in the URL path, so fall back to it
+    // when no header/cookie credential is present.
+    let extracted = extract_visibility_token(&request);
     let outcome = try_resolve_auth_outcome(&vis_state.auth_service, extracted).await;
     // Transient bcrypt-capacity shed -> retryable 503 (see
     // `AuthOutcome::Overloaded`), never a 401.
@@ -1775,6 +1827,40 @@ mod tests {
             .unwrap();
         let result = extract_token(&request);
         assert!(matches!(result, ExtractedToken::ApiKey("token-xyz")));
+    }
+
+    #[test]
+    fn test_extract_visibility_token_uses_conda_url_token() {
+        // No header credential: the conda token-channel URL supplies the token.
+        let request = Request::builder()
+            .uri("/conda/t/url-token-123/my-channel/noarch/repodata.json")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let result = extract_visibility_token(&request);
+        assert!(matches!(result, ExtractedToken::ApiKey("url-token-123")));
+    }
+
+    #[test]
+    fn test_extract_visibility_token_header_takes_priority() {
+        // A header credential always wins over the URL token.
+        let request = Request::builder()
+            .uri("/conda/t/url-token-123/my-channel/noarch/repodata.json")
+            .header(AUTHORIZATION, "Bearer header-jwt")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let result = extract_visibility_token(&request);
+        assert!(matches!(result, ExtractedToken::Bearer("header-jwt")));
+    }
+
+    #[test]
+    fn test_extract_visibility_token_none_for_plain_path() {
+        // A non-token path with no header credential yields no token.
+        let request = Request::builder()
+            .uri("/conda/my-channel/noarch/repodata.json")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let result = extract_visibility_token(&request);
+        assert!(matches!(result, ExtractedToken::None));
     }
 
     #[test]
@@ -2420,6 +2506,50 @@ mod tests {
     #[test]
     fn test_extract_repo_key_no_leading_slash() {
         assert_eq!(extract_repo_key("pypi/my-repo/simple"), "my-repo");
+    }
+
+    #[test]
+    fn test_extract_repo_key_conda_token_channel() {
+        // /conda/t/<TOKEN>/<repo_key>/... must resolve to the real repo key,
+        // not the literal "t" segment that the generic rule would return.
+        assert_eq!(
+            extract_repo_key("/conda/t/abc123token/my-channel/noarch/repodata.json"),
+            "my-channel"
+        );
+        assert_eq!(
+            extract_repo_key("/conda/t/abc123token/my-channel/channeldata.json"),
+            "my-channel"
+        );
+    }
+
+    #[test]
+    fn test_extract_repo_key_conda_non_token_unchanged() {
+        // A plain conda channel (no /t/ prefix) is unaffected.
+        assert_eq!(
+            extract_repo_key("/conda/my-channel/noarch/repodata.json"),
+            "my-channel"
+        );
+        // A conda channel that merely happens to be named "t" (no token
+        // segment shape) still resolves to that key when addressed plainly.
+        assert_eq!(extract_repo_key("/conda/t"), "");
+    }
+
+    #[test]
+    fn test_extract_conda_url_token() {
+        assert_eq!(
+            extract_conda_url_token("/conda/t/abc123token/my-channel/noarch/repodata.json"),
+            Some("abc123token")
+        );
+        // Non-conda paths carry no URL token.
+        assert_eq!(extract_conda_url_token("/pypi/t/abc/my-repo/simple"), None);
+        // Plain conda channel (no /t/) carries no URL token.
+        assert_eq!(
+            extract_conda_url_token("/conda/my-channel/noarch/repodata.json"),
+            None
+        );
+        // Empty token segment is not a credential.
+        assert_eq!(extract_conda_url_token("/conda/t//my-channel"), None);
+        assert_eq!(extract_conda_url_token("/conda/t"), None);
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Conda **token channels** (`/conda/t/<TOKEN>/<channel>`, the shape clients configure
in `.condarc`) returned **HTTP 401 on every read** -- repodata, channeldata, and
package download -- even with a freshly minted, valid personal access token, so a
`micromamba`/`conda` client pointed at a token channel could not read repodata.

Closes #2629.

There were two independent defects on the token-channel read path, both from the
leading `/t/<TOKEN>/` segment not being accounted for:

1. **Handler parameter shift** (`backend/src/api/handlers/conda.rs::token_router`).
   The token-scoped GET routes pointed at the **non-token** handlers, whose `axum`
   `Path` extractors bind only `(repo_key, subdir[, filename])`. Under the token
   router each route carries an extra leading `:token` segment, so positional
   binding shifted every parameter by one (`repo_key` received the token) and
   resolution ran against a bogus key. The token *upload* routes already had correct
   `*_with_token` handlers; the read routes did not. This PR adds dedicated
   `*_with_token` GET handlers that bind the leading token, discard it, and delegate
   to the shared non-token handler with a correctly aligned `Path` tuple.

2. **Visibility middleware mis-parse**
   (`backend/src/api/middleware/auth.rs::repo_visibility_middleware`). This
   middleware runs before the handler. `extract_repo_key` skips exactly one
   format-prefix segment, so for `/conda/t/<TOKEN>/<repo>/...` it returned the
   literal `"t"` as the repo key and never found the repository. It also resolved
   the caller's credential via `extract_token`, which only inspects
   Authorization/X-API-Key/Cookie headers and never sees the credential embedded in
   the URL path. The combined effect: an anonymous (header-less) token-channel
   request was treated as "no repo, no credential" and 401'd **before the handler
   ran** -- the actual 401 users saw. This PR teaches `extract_repo_key` to skip the
   `t/<TOKEN>` pair for conda token URLs, and adds a conda-scoped fallback that uses
   the URL-path token as the request credential when no header credential is present.

Both fixes are required: the handler fix alone still 401s at the middleware, and the
middleware fix alone still mis-binds parameters in the handler. The change is scoped
to conda token URLs (`/conda/t/...`) and does not alter behavior for any other
format or for plain conda channels.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added:
- `conda::tests::test_token_channel_get_routes_bind_repo_key_not_token` (DB-backed
  integration test): mounts `token_router()`, publishes a package, and proves a
  token-channel repodata read resolves the real repo key and lists the package
  (HTTP 200), a bogus repo key 404s (segment 2 is the repo key), the compressed and
  metadata read routes resolve, and the package download binds the final segment as
  the filename and streams the stored bytes.
- `middleware::auth::tests::test_extract_repo_key_conda_token_channel` /
  `_conda_non_token_unchanged`, `test_extract_conda_url_token`, and
  `test_extract_visibility_token_*`: unit tests pinning the repo-key extraction and
  URL-token credential fallback (and that header credentials still take precedence).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (existing token routes, no new endpoints or schema)
