### PR TITLE
fix(helm): store and serve .prov provenance instead of discarding it

### DIFF
--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -38,6 +38,7 @@ use crate::api::SharedState;
 use crate::formats::helm::{generate_index_yaml, ChartYaml, HelmHandler, HelmIndex};
 use crate::models::repository::{RepositoryFormat, RepositoryType};
 use crate::services::proxy_service::ProxyService;
+use crate::services::quarantine_service;
 
 // ---------------------------------------------------------------------------
 // Router
@@ -639,6 +640,23 @@ async fn upload_chart(
         .await?;
     }
 
+    // A chart and its provenance are one publish, so they must land as one
+    // unit (#2635). Ordering below is load-bearing:
+    //
+    //   1. BOTH objects go to storage first. Object storage cannot join a DB
+    //      transaction, so every fallible storage write happens while the
+    //      repository still has no row pointing at this coordinate.
+    //   2. BOTH rows are inserted inside ONE transaction. A fault on the prov
+    //      row rolls the chart row back with it.
+    //
+    // The property that matters is that a failure is *retryable*: nothing
+    // commits a chart row until the prov is safely stored, so the publisher's
+    // retry cannot collide with a half-finished predecessor in
+    // `ensure_unique_artifact_path` and get a 409 it can never clear. An
+    // orphaned object left in storage by an interrupted upload is overwritten
+    // by that retry -- the storage key is fully determined by chart name and
+    // version.
+
     // Stream the staged archive into the repo's StorageBackend via `put_stream`,
     // which computes the SHA-256 incrementally as it copies (no re-hash pass).
     let storage_key = format!("helm/{}/{}/{}", chart_name, chart_version, filename);
@@ -647,9 +665,28 @@ async fn upload_chart(
 
     let size_bytes = put.bytes_written as i64;
 
-    // Insert artifact record
-    let artifact_id = proxy_helpers::insert_artifact(
-        &state.db,
+    // #2635: persist the provenance BEFORE the chart row is committed. Any
+    // failure here is propagated with `?` -- the handler must never fall
+    // through to a `{"saved":true}` reply while the prov is on the floor, and
+    // must never leave behind a chart that advertises provenance it cannot
+    // serve.
+    let prov_storage_key = format!("helm/{}/{}/{}", chart_name, chart_version, prov_filename);
+    let prov_put = match staged_prov {
+        Some(prov) => {
+            Some(proxy_helpers::put_artifact_stream(&state, &repo, &prov_storage_key, prov).await?)
+        }
+        None => None,
+    };
+
+    // Both objects are in storage. Commit both rows together or neither.
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(|e| proxy_helpers::internal_error("Database", e))?;
+
+    let artifact_id = proxy_helpers::insert_artifact_row(
+        &mut tx,
         proxy_helpers::NewArtifact {
             repository_id: repo.id,
             path: &artifact_path,
@@ -663,6 +700,37 @@ async fn upload_chart(
         },
     )
     .await?;
+
+    let prov_artifact_id = match prov_put.as_ref() {
+        Some(prov_put) => Some(
+            proxy_helpers::insert_artifact_row(
+                &mut tx,
+                proxy_helpers::NewArtifact {
+                    repository_id: repo.id,
+                    path: &prov_artifact_path,
+                    name: chart_name,
+                    version: chart_version,
+                    size_bytes: prov_put.bytes_written as i64,
+                    checksum_sha256: &prov_put.checksum_sha256,
+                    content_type: PROV_CONTENT_TYPE,
+                    storage_key: &prov_storage_key,
+                    uploaded_by: user_id,
+                },
+            )
+            .await?,
+        ),
+        None => None,
+    };
+
+    // Until this returns, a fault has left the repository exactly as it was.
+    tx.commit()
+        .await
+        .map_err(|e| proxy_helpers::internal_error("Database", e))?;
+
+    // Post-commit follow-ups. The quarantine hold reads the artifact row back
+    // through the pool, so it can only run once the rows are visible; metadata
+    // recording is best-effort by contract.
+    quarantine_service::apply_upload_hold_hosted(&state.db, repo.id, artifact_id).await;
 
     // Build metadata JSON including the full Chart.yaml data
     let helm_metadata = serde_json::json!({
@@ -680,30 +748,8 @@ async fn upload_chart(
     )
     .await;
 
-    // #2635: persist the provenance alongside its chart. Any failure here is
-    // propagated with `?` -- the handler must never fall through to a
-    // `{"saved":true}` reply while the prov is on the floor.
-    let mut prov_stored = false;
-    if let Some(prov) = staged_prov {
-        let prov_storage_key = format!("helm/{}/{}/{}", chart_name, chart_version, prov_filename);
-        let prov_put =
-            proxy_helpers::put_artifact_stream(&state, &repo, &prov_storage_key, prov).await?;
-
-        let prov_artifact_id = proxy_helpers::insert_artifact(
-            &state.db,
-            proxy_helpers::NewArtifact {
-                repository_id: repo.id,
-                path: &prov_artifact_path,
-                name: chart_name,
-                version: chart_version,
-                size_bytes: prov_put.bytes_written as i64,
-                checksum_sha256: &prov_put.checksum_sha256,
-                content_type: PROV_CONTENT_TYPE,
-                storage_key: &prov_storage_key,
-                uploaded_by: user_id,
-            },
-        )
-        .await?;
+    if let Some(prov_artifact_id) = prov_artifact_id {
+        quarantine_service::apply_upload_hold_hosted(&state.db, repo.id, prov_artifact_id).await;
 
         proxy_helpers::record_artifact_metadata(
             &state.db,
@@ -718,9 +764,9 @@ async fn upload_chart(
             }),
         )
         .await;
-
-        prov_stored = true;
     }
+
+    let prov_stored = prov_artifact_id.is_some();
 
     info!(
         "Helm upload: {} {} to repo {} (provenance: {})",
@@ -1476,6 +1522,148 @@ wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
         )
         .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+
+        f.teardown().await;
+    }
+
+    /// ATOMICITY (#2635), storage half: a fault while storing the provenance
+    /// must not leave a committed chart row behind.
+    ///
+    /// The chart used to be `put` **and its row committed** before the prov was
+    /// stored, so a storage fault on the prov returned 5xx over a repository
+    /// that now held a chart with no provenance -- and the publisher's retry hit
+    /// `ensure_unique_artifact_path` and got a permanent `409 Chart already
+    /// exists`. Unretryable, and the exact "signed chart that cannot be
+    /// verified" state this issue exists to eliminate.
+    #[tokio::test]
+    async fn test_helm_prov_storage_fault_leaves_no_chart_row_blocking_reupload() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let tgz = signed_chart_tgz();
+        let parts: &[(&str, &str, &[u8])] = &[
+            ("chart", "provchart-0.1.0.tgz", &tgz),
+            ("prov", "provchart-0.1.0.tgz.prov", REAL_PROV),
+        ];
+
+        // A real storage fault, scoped to the PROV object only: a directory
+        // squatting on the prov's destination makes the filesystem backend's
+        // final rename fail with EISDIR, while the chart's own put succeeds.
+        // This is the residual class the armor pre-validation cannot catch --
+        // the prov is perfectly well-formed, the storage write is what breaks.
+        let prov_object = f
+            .storage_dir
+            .join("helm/provchart/0.1.0/provchart-0.1.0.tgz.prov");
+        std::fs::create_dir_all(&prov_object).expect("inject prov storage fault");
+
+        let (status, _) = upload_parts(&f, parts).await;
+        assert!(
+            status.is_server_error(),
+            "a prov that cannot be stored must fail the upload, got {status}"
+        );
+
+        // THE POINT: nothing is committed. Not the chart, not the prov.
+        let rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1")
+                .bind(f.repo_id)
+                .fetch_one(&f.pool)
+                .await
+                .expect("count artifacts");
+        assert_eq!(
+            rows, 0,
+            "a failed publish must leave no artifact row -- a committed chart \
+             with no prov wedges the coordinate behind an unclearable 409"
+        );
+
+        // Clear the fault and retry exactly as the publisher would.
+        std::fs::remove_dir_all(&prov_object).expect("clear prov storage fault");
+        let (status, body) = upload_parts(&f, parts).await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "the retry after a transient storage fault must succeed, not 409"
+        );
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["prov"], serde_json::json!(true));
+
+        // And the retry really did publish a verifiable chart.
+        let app = f.router_anon(super::router());
+        let (status, got) = tdh::send(
+            app,
+            tdh::get(format!("/{}/charts/provchart-0.1.0.tgz.prov", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&got[..], REAL_PROV);
+
+        f.teardown().await;
+    }
+
+    /// ATOMICITY (#2635), database half: the chart row and its prov row are
+    /// inserted in ONE transaction, so a fault on the prov row takes the chart
+    /// row with it instead of stranding a chart nobody can re-upload.
+    ///
+    /// Object storage cannot join the transaction, but the rows can -- and that
+    /// alone is what turns an unretryable 409 into a retryable failure. The
+    /// fault injected here is a `UNIQUE(repository_id, path)` violation, the
+    /// shape a publisher racing between `ensure_unique_artifact_path` and the
+    /// insert produces.
+    #[tokio::test]
+    async fn test_helm_chart_and_prov_rows_roll_back_together() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let chart_path = "provchart/0.1.0/provchart-0.1.0.tgz";
+        let prov_path = "provchart/0.1.0/provchart-0.1.0.tgz.prov";
+
+        let checksum = "a".repeat(64);
+        let new_row = |path: &'static str, content_type: &'static str| proxy_helpers::NewArtifact {
+            repository_id: f.repo_id,
+            path,
+            name: "provchart",
+            version: "0.1.0",
+            size_bytes: 1,
+            checksum_sha256: &checksum,
+            content_type,
+            storage_key: path,
+            uploaded_by: f.user_id,
+        };
+
+        // Somebody already occupies the prov coordinate.
+        let mut conn = f.pool.acquire().await.expect("acquire");
+        proxy_helpers::insert_artifact_row(&mut conn, new_row(prov_path, PROV_CONTENT_TYPE))
+            .await
+            .expect("seed the conflicting prov row");
+        drop(conn);
+
+        // The publish transaction: chart row inserts, prov row collides.
+        let mut tx = f.pool.begin().await.expect("begin");
+        proxy_helpers::insert_artifact_row(&mut tx, new_row(chart_path, "application/gzip"))
+            .await
+            .expect("the chart row itself inserts fine");
+        let prov_result =
+            proxy_helpers::insert_artifact_row(&mut tx, new_row(prov_path, PROV_CONTENT_TYPE))
+                .await;
+        assert!(
+            prov_result.is_err(),
+            "the conflicting prov row must fail the insert"
+        );
+        // Exactly what the handler's `?` does: drop the transaction unfinished.
+        drop(tx);
+
+        // The chart row must have gone with it, leaving the coordinate free.
+        let chart_rows: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM artifacts WHERE repository_id = $1 AND path = $2",
+        )
+        .bind(f.repo_id)
+        .bind(chart_path)
+        .fetch_one(&f.pool)
+        .await
+        .expect("count chart rows");
+        assert_eq!(
+            chart_rows, 0,
+            "a rolled-back publish must not leave the chart row committed"
+        );
 
         f.teardown().await;
     }

--- a/backend/src/api/handlers/helm.rs
+++ b/backend/src/api/handlers/helm.rs
@@ -4,10 +4,22 @@
 //! and ChartMuseum-compatible upload/delete.
 //!
 //! Routes are mounted at `/helm/{repo_key}/...`:
-//!   GET    /helm/{repo_key}/index.yaml                    - Repository index
-//!   GET    /helm/{repo_key}/charts/{name}-{version}.tgz   - Download chart package
-//!   POST   /helm/{repo_key}/api/charts                    - Upload chart (multipart)
-//!   DELETE /helm/{repo_key}/api/charts/{name}/{version}    - Delete chart
+//!   GET    /helm/{repo_key}/index.yaml                        - Repository index
+//!   GET    /helm/{repo_key}/charts/{name}-{version}.tgz       - Download chart package
+//!   GET    /helm/{repo_key}/charts/{name}-{version}.tgz.prov  - Download chart provenance
+//!   POST   /helm/{repo_key}/api/charts                        - Upload chart (multipart)
+//!   DELETE /helm/{repo_key}/api/charts/{name}/{version}        - Delete chart
+//!
+//! ## Provenance (#2635)
+//!
+//! `helm package --sign` emits a clearsigned `<chart>.tgz.prov` next to the
+//! chart. The client does **not** discover it from `index.yaml` — the helm
+//! index schema has no provenance field. Instead `helm pull --verify` takes the
+//! chart URL it resolved from `index.yaml` and string-appends `.prov`
+//! (verified against helm 3.16.4). So provenance is served by the *existing*
+//! `charts/{filename}` route: the upload stores the prov under the chart's
+//! filename + `.prov`, and the download route resolves it by the same
+//! suffix lookup the chart itself uses.
 
 use axum::body::Body;
 use axum::extract::{Multipart, Path, State};
@@ -35,7 +47,7 @@ pub fn router() -> Router<SharedState> {
     Router::new()
         // Repository index
         .route("/:repo_key/index.yaml", get(index_yaml))
-        // Download chart package
+        // Download chart package (also serves `<chart>.tgz.prov` provenance)
         .route("/:repo_key/charts/:filename", get(download_chart))
         // ChartMuseum-compatible upload
         .route("/:repo_key/api/charts", post(upload_chart))
@@ -51,7 +63,78 @@ async fn resolve_helm_repo(db: &PgPool, repo_key: &str) -> Result<RepoInfo, Resp
     proxy_helpers::resolve_repo_by_key(db, repo_key, &["helm"], "a Helm").await
 }
 
+// ---------------------------------------------------------------------------
+// Provenance helpers (#2635)
+// ---------------------------------------------------------------------------
+
+/// Suffix helm appends to a chart URL to locate its provenance file.
+const PROV_SUFFIX: &str = ".prov";
+
+/// Armor header every `helm package --sign` provenance file starts with. The
+/// prov is a *clearsigned* PGP document (chart metadata + a `files:` digest
+/// block, then the signature).
+const PROV_ARMOR_HEADER: &str = "-----BEGIN PGP SIGNED MESSAGE-----";
+
+/// Content type used when serving a provenance file.
+const PROV_CONTENT_TYPE: &str = "application/pgp-signature";
+
+/// Bytes read from the head of a staged prov to check its armor header.
+const PROV_HEAD_PROBE_BYTES: usize = 128;
+
+/// Provenance filename for a chart package filename
+/// (`nginx-1.0.0.tgz` -> `nginx-1.0.0.tgz.prov`).
+fn prov_filename(chart_filename: &str) -> String {
+    format!("{}{}", chart_filename, PROV_SUFFIX)
+}
+
+/// Whether a requested `charts/{filename}` is a provenance file rather than a
+/// chart package.
+fn is_prov_filename(filename: &str) -> bool {
+    filename.ends_with(PROV_SUFFIX)
+}
+
+/// Validate that an uploaded `prov` part really is a clearsigned provenance
+/// document before it is stored.
+///
+/// Storing arbitrary bytes under `<chart>.tgz.prov` would just move the failure
+/// downstream: `helm pull --verify` would fetch them and die with an opaque
+/// error. Rejecting at the door keeps the upload response honest — the client
+/// learns immediately that its provenance was not accepted (#2635).
+fn validate_prov_bytes(head: &[u8]) -> Result<(), String> {
+    if head.is_empty() {
+        return Err("provenance file is empty".to_string());
+    }
+    let text = String::from_utf8_lossy(head);
+    if !text.trim_start().starts_with(PROV_ARMOR_HEADER) {
+        return Err(format!(
+            "provenance file must be a clearsigned PGP document starting with '{}'",
+            PROV_ARMOR_HEADER
+        ));
+    }
+    Ok(())
+}
+
+/// ChartMuseum-compatible upload response body.
+///
+/// `saved` reports the chart. `prov` is reported **only** when a provenance
+/// file was actually written to storage — never merely because a `prov` part
+/// was present in the request. Answering `{"saved":true}` for provenance that
+/// was discarded is the defect at the heart of #2635: it gives the publisher a
+/// false assurance that their chart is verifiable.
+fn upload_response_body(prov_stored: bool) -> serde_json::Value {
+    if prov_stored {
+        serde_json::json!({ "saved": true, "prov": true })
+    } else {
+        // Chart-only upload: byte-identical to the historical ChartMuseum reply.
+        serde_json::json!({ "saved": true })
+    }
+}
+
 /// Query Helm chart artifacts from a repository and append chart entries to `out`.
+///
+/// Provenance rows are excluded: a `.prov` is stored as its own artifact under
+/// the same `name`/`version` as its chart (#2635), so without the filter every
+/// signed chart would render a duplicate `index.yaml` entry.
 async fn query_charts_from_repo(
     db: &PgPool,
     repo_id: uuid::Uuid,
@@ -67,6 +150,7 @@ async fn query_charts_from_repo(
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
         WHERE a.repository_id = $1
           AND a.is_deleted = false
+          AND a.path NOT LIKE '%.prov'
         ORDER BY a.name ASC, a.created_at DESC
         "#,
     )
@@ -398,38 +482,56 @@ async fn download_chart(
 ) -> Result<Response, Response> {
     let repo = resolve_helm_repo(&state.db, &repo_key).await?;
 
+    // `<chart>.tgz.prov` is stored as an artifact under its own filename, so the
+    // same suffix lookup resolves both a chart and its provenance (#2635). Only
+    // the content type and the not-found wording differ.
+    let is_prov = is_prov_filename(&filename);
+
     // Find artifact by filename pattern; helper escapes wildcards in `filename`.
-    let artifact =
-        match proxy_helpers::find_local_by_filename_suffix(&state.db, repo.id, &filename).await? {
-            Some(a) => a,
-            None => {
-                // Parse name and version so we can look up the real download URL
-                // from the upstream's index.yaml instead of assuming
-                // {upstream_url}/charts/{name}-{version}.tgz.
-                let info = HelmHandler::parse_path(&filename).ok();
-                let name_version = info
-                    .as_ref()
-                    .and_then(|i| i.name.as_deref().zip(i.version.as_deref()))
-                    .map(|(n, v)| (n.to_string(), v.to_string()));
-
-                if let Some((name, version)) = name_version {
-                    if let Some(resp) =
-                        download_chart_via_index(&state, &repo, &name, &version, &filename).await?
-                    {
-                        return Ok(resp);
-                    }
-                }
-
-                return Err((StatusCode::NOT_FOUND, "Chart not found").into_response());
+    let artifact = match proxy_helpers::find_local_by_filename_suffix(&state.db, repo.id, &filename)
+        .await?
+    {
+        Some(a) => a,
+        None => {
+            if is_prov {
+                // Provenance is only ever served from local storage: helm
+                // derives this URL by appending `.prov` to the chart URL, so
+                // there is no upstream index entry to resolve it through.
+                return Err((StatusCode::NOT_FOUND, "Chart provenance not found").into_response());
             }
-        };
+            // Parse name and version so we can look up the real download URL
+            // from the upstream's index.yaml instead of assuming
+            // {upstream_url}/charts/{name}-{version}.tgz.
+            let info = HelmHandler::parse_path(&filename).ok();
+            let name_version = info
+                .as_ref()
+                .and_then(|i| i.name.as_deref().zip(i.version.as_deref()))
+                .map(|(n, v)| (n.to_string(), v.to_string()));
+
+            if let Some((name, version)) = name_version {
+                if let Some(resp) =
+                    download_chart_via_index(&state, &repo, &name, &version, &filename).await?
+                {
+                    return Ok(resp);
+                }
+            }
+
+            return Err((StatusCode::NOT_FOUND, "Chart not found").into_response());
+        }
+    };
+
+    let content_type = if is_prov {
+        PROV_CONTENT_TYPE
+    } else {
+        "application/gzip"
+    };
 
     proxy_helpers::serve_local_artifact(
         &state,
         &repo,
         artifact.id,
         &artifact.storage_key,
-        "application/gzip",
+        content_type,
         Some(&filename),
         &ctx,
     )
@@ -458,19 +560,40 @@ async fn upload_chart(
 
     // Spool the .tgz straight to a bounded scratch file instead of buffering
     // the whole archive in memory. See proxy_helpers::stage_upload_field.
+    //
+    // #2635: the `prov` part is staged too rather than being dropped on the
+    // floor. The loop no longer breaks on `chart` because ChartMuseum clients
+    // may send the parts in either order, and a part that is never read is a
+    // part that gets silently discarded.
     let mut staged: Option<proxy_helpers::StagedUpload> = None;
+    let mut staged_prov: Option<proxy_helpers::StagedUpload> = None;
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         (StatusCode::BAD_REQUEST, format!("Invalid multipart: {}", e)).into_response()
     })? {
         let name = field.name().unwrap_or("").to_string();
-        if name == "chart" {
-            staged = Some(proxy_helpers::stage_upload_field(&state, field).await?);
-            break;
+        match name.as_str() {
+            "chart" => staged = Some(proxy_helpers::stage_upload_field(&state, field).await?),
+            "prov" => staged_prov = Some(proxy_helpers::stage_upload_field(&state, field).await?),
+            _ => {}
         }
     }
 
     let staged =
         staged.ok_or_else(|| (StatusCode::BAD_REQUEST, "Missing 'chart' field").into_response())?;
+
+    // Validate the provenance before the chart is committed, so a bad prov
+    // fails the whole upload instead of leaving a chart that advertises
+    // provenance it cannot serve.
+    if let Some(prov) = staged_prov.as_ref() {
+        let head = read_prov_head(prov.path()).await?;
+        validate_prov_bytes(&head).map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("Invalid provenance file: {}", e),
+            )
+                .into_response()
+        })?;
+    }
 
     // Extract and validate Chart.yaml from the staged archive on disk, reading
     // only the Chart.yaml entry (bounded memory) rather than the whole package.
@@ -501,6 +624,20 @@ async fn upload_chart(
     );
     proxy_helpers::ensure_unique_artifact_path(&state.db, repo.id, &artifact_path, &conflict_msg)
         .await?;
+
+    // The prov is stored under the chart's filename + `.prov` -- the exact path
+    // helm derives from the index URL (#2635).
+    let prov_filename = prov_filename(&filename);
+    let prov_artifact_path = format!("{}/{}/{}", chart_name, chart_version, prov_filename);
+    if staged_prov.is_some() {
+        proxy_helpers::ensure_unique_artifact_path(
+            &state.db,
+            repo.id,
+            &prov_artifact_path,
+            &conflict_msg,
+        )
+        .await?;
+    }
 
     // Stream the staged archive into the repo's StorageBackend via `put_stream`,
     // which computes the SHA-256 incrementally as it copies (no re-hash pass).
@@ -543,9 +680,51 @@ async fn upload_chart(
     )
     .await;
 
+    // #2635: persist the provenance alongside its chart. Any failure here is
+    // propagated with `?` -- the handler must never fall through to a
+    // `{"saved":true}` reply while the prov is on the floor.
+    let mut prov_stored = false;
+    if let Some(prov) = staged_prov {
+        let prov_storage_key = format!("helm/{}/{}/{}", chart_name, chart_version, prov_filename);
+        let prov_put =
+            proxy_helpers::put_artifact_stream(&state, &repo, &prov_storage_key, prov).await?;
+
+        let prov_artifact_id = proxy_helpers::insert_artifact(
+            &state.db,
+            proxy_helpers::NewArtifact {
+                repository_id: repo.id,
+                path: &prov_artifact_path,
+                name: chart_name,
+                version: chart_version,
+                size_bytes: prov_put.bytes_written as i64,
+                checksum_sha256: &prov_put.checksum_sha256,
+                content_type: PROV_CONTENT_TYPE,
+                storage_key: &prov_storage_key,
+                uploaded_by: user_id,
+            },
+        )
+        .await?;
+
+        proxy_helpers::record_artifact_metadata(
+            &state.db,
+            prov_artifact_id,
+            repo.id,
+            "helm",
+            &serde_json::json!({
+                "name": chart_name,
+                "version": chart_version,
+                "provenance": true,
+                "chart_filename": filename,
+            }),
+        )
+        .await;
+
+        prov_stored = true;
+    }
+
     info!(
-        "Helm upload: {} {} to repo {}",
-        chart_name, chart_version, repo_key
+        "Helm upload: {} {} to repo {} (provenance: {})",
+        chart_name, chart_version, repo_key, prov_stored
     );
 
     // ChartMuseum-compatible response
@@ -553,12 +732,36 @@ async fn upload_chart(
         .status(StatusCode::CREATED)
         .header(CONTENT_TYPE, "application/json")
         .body(Body::from(
-            serde_json::to_string(&serde_json::json!({
-                "saved": true
-            }))
-            .unwrap(),
+            serde_json::to_string(&upload_response_body(prov_stored)).unwrap(),
         ))
         .unwrap())
+}
+
+/// Read the leading bytes of a staged provenance file for armor validation.
+///
+/// Bounded on purpose: only the armor header is needed, so the whole prov is
+/// never pulled into memory.
+#[allow(clippy::result_large_err)]
+async fn read_prov_head(path: &std::path::Path) -> Result<Vec<u8>, Response> {
+    use tokio::io::AsyncReadExt;
+
+    let mut file = tokio::fs::File::open(path).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to read staged provenance: {}", e),
+        )
+            .into_response()
+    })?;
+    let mut head = vec![0u8; PROV_HEAD_PROBE_BYTES];
+    let n = file.read(&mut head).await.map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to read staged provenance: {}", e),
+        )
+            .into_response()
+    })?;
+    head.truncate(n);
+    Ok(head)
 }
 
 /// Extract Chart.yaml from a staged .tgz archive on disk. The blocking
@@ -590,37 +793,46 @@ async fn delete_chart(
     let _user_id = require_auth_basic_scope(auth, "helm", "delete")?.user_id;
     let repo = resolve_helm_repo(&state.db, &repo_key).await?;
 
-    // Find the artifact (using non-macro query)
-    let row = sqlx::query(
+    // Find the chart's artifacts. #2635: a signed chart owns TWO rows -- the
+    // .tgz and its .tgz.prov -- under the same name/version. Select them all:
+    // the previous `LIMIT 1` had no ORDER BY, so once provenance exists it could
+    // just as easily have matched the .prov and left the chart behind.
+    let rows = sqlx::query(
         r#"
-        SELECT id, storage_key
+        SELECT id, path
         FROM artifacts
         WHERE repository_id = $1
           AND name = $2
           AND version = $3
           AND is_deleted = false
-        LIMIT 1
         "#,
     )
     .bind(repo.id)
     .bind(&name)
     .bind(&version)
-    .fetch_optional(&state.db)
+    .fetch_all(&state.db)
     .await
-    .map_err(super::db_err)?
-    .ok_or_else(|| {
-        (
+    .map_err(super::db_err)?;
+
+    if rows.is_empty() {
+        return Err((
             StatusCode::NOT_FOUND,
             format!("Chart {} version {} not found", name, version),
         )
-            .into_response()
-    })?;
+            .into_response());
+    }
 
-    let artifact_id: uuid::Uuid = row.get("id");
+    let artifact_ids: Vec<uuid::Uuid> = rows.iter().map(|r| r.get("id")).collect();
+    let prov_count = rows
+        .iter()
+        .filter(|r| is_prov_filename(&r.get::<String, _>("path")))
+        .count();
 
-    // Soft-delete the artifact
-    sqlx::query("UPDATE artifacts SET is_deleted = true, updated_at = NOW() WHERE id = $1")
-        .bind(artifact_id)
+    // Soft-delete the chart together with its provenance: leaving an orphaned
+    // .prov behind would let a later re-upload serve provenance for a chart it
+    // does not describe.
+    sqlx::query("UPDATE artifacts SET is_deleted = true, updated_at = NOW() WHERE id = ANY($1)")
+        .bind(&artifact_ids)
         .execute(&state.db)
         .await
         .map_err(crate::api::handlers::db_err)?;
@@ -633,7 +845,14 @@ async fn delete_chart(
     .execute(&state.db)
     .await;
 
-    info!("Helm delete: {} {} from repo {}", name, version, repo_key);
+    info!(
+        "Helm delete: {} {} from repo {} ({} artifact(s), {} provenance)",
+        name,
+        version,
+        repo_key,
+        artifact_ids.len(),
+        prov_count
+    );
 
     // ChartMuseum-compatible response
     Ok(Response::builder()
@@ -774,8 +993,127 @@ mod tests {
     }
 
     // -----------------------------------------------------------------------
+    // Provenance (#2635)
+    //
+    // Ground truth for these tests came from real helm 3.16.4 (arm64), not from
+    // a spec: `helm pull --verify` resolves the chart URL from `index.yaml` and
+    // string-appends `.prov`, requesting
+    //   GET /helm/<repo>/charts/<chart>-<version>.tgz.prov
+    // With that file absent it dies with
+    //   Error: failed to fetch provenance ".../<chart>-<version>.tgz.prov"
+    // and with it present at exactly that path (index.yaml unchanged) it prints
+    // "Chart Hash Verified: sha256:...". The helm index schema has no
+    // provenance field, so serving that path IS the advertised layout.
+    // -----------------------------------------------------------------------
+
+    /// A real `helm package --sign` provenance file (helm 3.16.4), truncated in
+    /// the signature body. The backend never checks the signature -- that is
+    /// helm's job -- but the clearsigned armor is what it gates on.
+    const REAL_PROV: &[u8] = b"-----BEGIN PGP SIGNED MESSAGE-----\n\
+Hash: SHA512\n\
+\n\
+apiVersion: v2\n\
+appVersion: 1.0.0\n\
+description: probe\n\
+name: provchart\n\
+type: application\n\
+version: 0.1.0\n\
+\n\
+...\n\
+files:\n\
+  provchart-0.1.0.tgz: sha256:20a0fa5a75b0929b97fc5b23e01333d2e1683a93cdbb2441baceb586c040c50e\n\
+-----BEGIN PGP SIGNATURE-----\n\
+\n\
+wsDcBAEBCgAQBQJqWW7VCRA8wAoTVPCkgwAAVAoMACmQbvnhlkWncOkVJXfissGD\n\
+-----END PGP SIGNATURE-----\n";
+
+    #[test]
+    fn test_prov_filename_appends_to_chart_filename() {
+        // helm derives the provenance URL by appending `.prov` to the chart
+        // URL -- the stored filename must match byte for byte.
+        assert_eq!(prov_filename("nginx-1.24.0.tgz"), "nginx-1.24.0.tgz.prov");
+        assert_eq!(
+            prov_filename("my-chart-2.0.0-rc.1.tgz"),
+            "my-chart-2.0.0-rc.1.tgz.prov"
+        );
+    }
+
+    #[test]
+    fn test_is_prov_filename_discriminates_chart_from_provenance() {
+        assert!(is_prov_filename("nginx-1.24.0.tgz.prov"));
+        assert!(!is_prov_filename("nginx-1.24.0.tgz"));
+        // A chart whose name merely contains "prov" is not provenance.
+        assert!(!is_prov_filename("provchart-0.1.0.tgz"));
+    }
+
+    #[test]
+    fn test_validate_prov_bytes_accepts_real_helm_provenance() {
+        assert!(validate_prov_bytes(REAL_PROV).is_ok());
+        // Only the head is ever read, so validation must work on a probe-sized
+        // prefix too.
+        assert!(validate_prov_bytes(&REAL_PROV[..PROV_HEAD_PROBE_BYTES]).is_ok());
+    }
+
+    #[test]
+    fn test_validate_prov_bytes_rejects_empty_and_non_pgp() {
+        assert!(validate_prov_bytes(b"").is_err());
+        assert!(validate_prov_bytes(b"not a signature").is_err());
+        // gzip magic: a .tgz mistakenly sent as the prov part.
+        assert!(validate_prov_bytes(&[0x1f, 0x8b, 0x08, 0x00]).is_err());
+    }
+
+    #[test]
+    fn test_upload_response_body_chart_only_stays_chartmuseum_compatible() {
+        // No prov uploaded -> byte-identical to the historical reply.
+        assert_eq!(
+            upload_response_body(false),
+            serde_json::json!({"saved": true})
+        );
+    }
+
+    #[test]
+    fn test_upload_response_body_reports_stored_provenance() {
+        assert_eq!(
+            upload_response_body(true),
+            serde_json::json!({"saved": true, "prov": true})
+        );
+    }
+
+    /// REGRESSION GUARD (#2635): the response may never advertise provenance
+    /// that was not written to storage. The original bug was not the missing
+    /// feature alone -- it was answering `{"saved":true}` for a `prov` part that
+    /// had been dropped, which left publishers believing their charts were
+    /// verifiable. `upload_response_body` takes the *storage outcome*, never the
+    /// mere presence of the part, so a dropped prov cannot be reported as saved.
+    #[test]
+    fn test_dropped_prov_can_never_report_saved_prov() {
+        let dropped = upload_response_body(false);
+        assert_ne!(dropped.get("prov"), Some(&serde_json::Value::Bool(true)));
+        assert!(
+            dropped.get("prov").is_none(),
+            "a discarded prov must not appear in the upload response at all"
+        );
+    }
+
+    // -----------------------------------------------------------------------
     // Format-specific logic: filename, artifact_path, storage_key
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_helm_prov_artifact_path_and_storage_key() {
+        let name = "provchart";
+        let version = "0.1.0";
+        let filename = format!("{}-{}.tgz", name, version);
+        let prov = prov_filename(&filename);
+        assert_eq!(
+            format!("{}/{}/{}", name, version, prov),
+            "provchart/0.1.0/provchart-0.1.0.tgz.prov"
+        );
+        assert_eq!(
+            format!("helm/{}/{}/{}", name, version, prov),
+            "helm/provchart/0.1.0/provchart-0.1.0.tgz.prov"
+        );
+    }
 
     #[test]
     fn test_helm_chart_filename() {
@@ -944,6 +1282,264 @@ mod tests {
         );
         let (status, _) = tdh::send(app, req).await;
         assert_eq!(status, StatusCode::METHOD_NOT_ALLOWED);
+        f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Provenance round-trip through the real router (#2635)
+    // -----------------------------------------------------------------------
+
+    /// Build a multipart body of `(field_name, filename, bytes)` parts.
+    fn multipart_body(boundary: &str, parts: &[(&str, &str, &[u8])]) -> bytes::Bytes {
+        let mut body: Vec<u8> = Vec::new();
+        for (field, filename, content) in parts {
+            body.extend_from_slice(format!("--{}\r\n", boundary).as_bytes());
+            body.extend_from_slice(
+                format!(
+                    "Content-Disposition: form-data; name=\"{}\"; filename=\"{}\"\r\n",
+                    field, filename
+                )
+                .as_bytes(),
+            );
+            body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+            body.extend_from_slice(content);
+            body.extend_from_slice(b"\r\n");
+        }
+        body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+        bytes::Bytes::from(body)
+    }
+
+    fn signed_chart_tgz() -> Vec<u8> {
+        build_tgz(
+            "provchart/Chart.yaml",
+            b"apiVersion: v2\nname: provchart\nversion: 0.1.0\n",
+        )
+    }
+
+    /// POST a ChartMuseum multipart upload; returns (status, body).
+    async fn upload_parts(
+        f: &tdh::Fixture,
+        parts: &[(&str, &str, &[u8])],
+    ) -> (StatusCode, bytes::Bytes) {
+        let app = f.router_with_auth(super::router());
+        let req = tdh::post(
+            format!("/{}/api/charts", f.repo_key),
+            "multipart/form-data; boundary=BOUNDARY",
+            multipart_body("BOUNDARY", parts),
+        );
+        tdh::send(app, req).await
+    }
+
+    /// The core of #2635: a `.prov` uploaded next to its chart must be
+    /// PERSISTED and served back byte-for-byte at the URL helm derives.
+    #[tokio::test]
+    async fn test_helm_upload_persists_prov_and_serves_exact_bytes() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let tgz = signed_chart_tgz();
+
+        let (status, body) = upload_parts(
+            &f,
+            &[
+                ("chart", "provchart-0.1.0.tgz", &tgz),
+                ("prov", "provchart-0.1.0.tgz.prov", REAL_PROV),
+            ],
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+
+        // The response reports provenance only because it was really stored.
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json["saved"], serde_json::json!(true));
+        assert_eq!(json["prov"], serde_json::json!(true));
+
+        // The chart still downloads.
+        let app = f.router_anon(super::router());
+        let (status, got) = tdh::send(
+            app,
+            tdh::get(format!("/{}/charts/provchart-0.1.0.tgz", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&got[..], &tgz[..]);
+
+        // And the provenance is served at <chart>.tgz.prov -- EXACT bytes, or
+        // helm's signature check would fail on a single changed byte.
+        let app = f.router_anon(super::router());
+        let (status, got) = tdh::send(
+            app,
+            tdh::get(format!("/{}/charts/provchart-0.1.0.tgz.prov", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "the .prov must not 404 (#2635)");
+        assert_eq!(&got[..], REAL_PROV);
+
+        f.teardown().await;
+    }
+
+    /// The advertised layout must resolve: take the URL out of `index.yaml`,
+    /// append `.prov` exactly as helm does, and fetch it. Also guards against
+    /// the prov artifact leaking into the index as a duplicate chart entry.
+    #[tokio::test]
+    async fn test_helm_index_yaml_advertised_url_resolves_prov() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let tgz = signed_chart_tgz();
+        let (status, _) = upload_parts(
+            &f,
+            &[
+                ("chart", "provchart-0.1.0.tgz", &tgz),
+                ("prov", "provchart-0.1.0.tgz.prov", REAL_PROV),
+            ],
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let app = f.router_anon(super::router());
+        let (status, body) = tdh::send(app, tdh::get(format!("/{}/index.yaml", f.repo_key))).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let index: HelmIndex =
+            serde_yaml::from_str(std::str::from_utf8(&body).expect("utf8 index")).expect("index");
+        let entries = index.entries.get("provchart").expect("chart in index");
+        // The .prov shares the chart's name/version: it must NOT render its own
+        // index entry.
+        assert_eq!(
+            entries.len(),
+            1,
+            "provenance must not appear as a second chart entry in index.yaml"
+        );
+
+        // This is precisely what helm does: chart URL + ".prov".
+        let chart_url = entries[0].urls.first().expect("chart url");
+        assert_eq!(
+            chart_url,
+            &format!("/helm/{}/charts/provchart-0.1.0.tgz", f.repo_key)
+        );
+        let prov_url = format!("{}.prov", chart_url);
+        // The router under test is mounted without the `/helm` nest prefix.
+        let prov_path = prov_url.strip_prefix("/helm").expect("nest prefix");
+
+        let app = f.router_anon(super::router());
+        let (status, got) = tdh::send(app, tdh::get(prov_path.to_string())).await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "the URL helm derives from index.yaml must serve the prov"
+        );
+        assert_eq!(&got[..], REAL_PROV);
+
+        f.teardown().await;
+    }
+
+    /// REGRESSION GUARD (#2635): an upload whose provenance is not stored must
+    /// not answer `{"saved":true}`. A prov the backend refuses is rejected
+    /// outright rather than dropped behind a success reply.
+    #[tokio::test]
+    async fn test_helm_upload_rejects_invalid_prov_instead_of_dropping_it() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let tgz = signed_chart_tgz();
+
+        let (status, body) = upload_parts(
+            &f,
+            &[
+                ("chart", "provchart-0.1.0.tgz", &tgz),
+                (
+                    "prov",
+                    "provchart-0.1.0.tgz.prov",
+                    b"totally-not-a-signature",
+                ),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "an unstorable prov must fail the upload, not vanish"
+        );
+        assert!(
+            !String::from_utf8_lossy(&body).contains("\"saved\":true"),
+            "a dropped prov must never be reported as saved (#2635)"
+        );
+
+        // The chart must not have been committed either -- a chart that
+        // advertises provenance it cannot serve is the original bug.
+        let app = f.router_anon(super::router());
+        let (status, _) = tdh::send(
+            app,
+            tdh::get(format!("/{}/charts/provchart-0.1.0.tgz", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        f.teardown().await;
+    }
+
+    /// A chart-only upload stays exactly ChartMuseum-compatible and honestly
+    /// reports no provenance.
+    #[tokio::test]
+    async fn test_helm_upload_without_prov_is_unchanged_and_prov_404s() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let tgz = signed_chart_tgz();
+        let (status, body) = upload_parts(&f, &[("chart", "provchart-0.1.0.tgz", &tgz)]).await;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let json: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert_eq!(json, serde_json::json!({"saved": true}));
+
+        let app = f.router_anon(super::router());
+        let (status, _) = tdh::send(
+            app,
+            tdh::get(format!("/{}/charts/provchart-0.1.0.tgz.prov", f.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        f.teardown().await;
+    }
+
+    /// Deleting a chart must take its provenance with it: an orphaned .prov
+    /// would otherwise be served for a chart it no longer describes.
+    #[tokio::test]
+    async fn test_helm_delete_chart_also_removes_prov() {
+        let Some(f) = tdh::Fixture::setup("local", "helm").await else {
+            return;
+        };
+        let tgz = signed_chart_tgz();
+        let (status, _) = upload_parts(
+            &f,
+            &[
+                ("chart", "provchart-0.1.0.tgz", &tgz),
+                ("prov", "provchart-0.1.0.tgz.prov", REAL_PROV),
+            ],
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let app = f.router_with_auth(super::router());
+        let req = axum::http::Request::builder()
+            .method("DELETE")
+            .uri(format!("/{}/api/charts/provchart/0.1.0", f.repo_key))
+            .body(Body::empty())
+            .unwrap();
+        let (status, _) = tdh::send(app, req).await;
+        assert_eq!(status, StatusCode::OK);
+
+        // Both the chart AND its provenance are gone.
+        for path in ["provchart-0.1.0.tgz", "provchart-0.1.0.tgz.prov"] {
+            let app = f.router_anon(super::router());
+            let (status, _) =
+                tdh::send(app, tdh::get(format!("/{}/charts/{}", f.repo_key, path))).await;
+            assert_eq!(status, StatusCode::NOT_FOUND, "{} must be deleted", path);
+        }
+
         f.teardown().await;
     }
 

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -4227,7 +4227,47 @@ pub struct NewArtifact<'a> {
 /// "Database error" response.
 #[allow(clippy::result_large_err)]
 pub async fn insert_artifact(db: &PgPool, art: NewArtifact<'_>) -> Result<Uuid, Response> {
-    let id: Uuid = sqlx::query_scalar(
+    let repository_id = art.repository_id;
+
+    let mut conn = db
+        .acquire()
+        .await
+        .map_err(|e| internal_error("Database", e))?;
+    let id = insert_artifact_row(&mut conn, art).await?;
+    drop(conn);
+
+    // Apply the upload-time quarantine hold at the shared chokepoint used by the
+    // helper-based format handlers (helm, hex, cran, ansible, puppet, rubygems,
+    // rpm, huggingface). Scoped to hosted repositories so proxy/remote cache
+    // inserts — which carry their own sidecar quarantine state — are not
+    // double-held. Best-effort: never fails the insert.
+    crate::services::quarantine_service::apply_upload_hold_hosted(db, repository_id, id).await;
+
+    Ok(id)
+}
+
+/// Insert a row into `artifacts` on a caller-supplied connection or
+/// transaction, returning the new id.
+///
+/// This is the body of [`insert_artifact`] without the quarantine hold. Use it
+/// when several artifact rows must commit **together** — pass `&mut *tx` from a
+/// `db.begin()` transaction so a failure on a later row rolls the earlier ones
+/// back. Object storage cannot join the transaction, but the rows can, which is
+/// what keeps a half-written upload retryable instead of wedging the coordinate
+/// behind a 409 (#2635).
+///
+/// The caller owns two follow-ups that deliberately do **not** belong inside the
+/// transaction:
+///   * `quarantine_service::apply_upload_hold_hosted` — it reads the artifact
+///     row through the pool, so it must run *after* the commit makes the row
+///     visible.
+///   * `record_artifact_metadata` — already best-effort/post-commit by contract.
+#[allow(clippy::result_large_err)]
+pub async fn insert_artifact_row(
+    conn: &mut sqlx::PgConnection,
+    art: NewArtifact<'_>,
+) -> Result<Uuid, Response> {
+    sqlx::query_scalar(
         "INSERT INTO artifacts ( \
              repository_id, path, name, version, size_bytes, \
              checksum_sha256, content_type, storage_key, uploaded_by \
@@ -4243,18 +4283,9 @@ pub async fn insert_artifact(db: &PgPool, art: NewArtifact<'_>) -> Result<Uuid, 
     .bind(art.content_type)
     .bind(art.storage_key)
     .bind(art.uploaded_by)
-    .fetch_one(db)
+    .fetch_one(conn)
     .await
-    .map_err(|e| internal_error("Database", e))?;
-
-    // Apply the upload-time quarantine hold at the shared chokepoint used by the
-    // helper-based format handlers (helm, hex, cran, ansible, puppet, rubygems,
-    // rpm, huggingface). Scoped to hosted repositories so proxy/remote cache
-    // inserts — which carry their own sidecar quarantine state — are not
-    // double-held. Best-effort: never fails the insert.
-    crate::services::quarantine_service::apply_upload_hold_hosted(db, art.repository_id, id).await;
-
-    Ok(id)
+    .map_err(|e| internal_error("Database", e))
 }
 
 /// Reject if `(repository_id, path)` already exists, otherwise sweep any


### PR DESCRIPTION
## Summary

Helm provenance was accepted and silently thrown away. `handlers/helm.rs` declared four routes and the string `prov` appeared **nowhere** in the file: the ChartMuseum multipart upload took a `prov` part, answered `201 {"saved":true}`, and dropped it — and no route served `<chart>-<version>.tgz.prov` back. So `helm pull --verify` / `helm verify` could **never** succeed against a hosted AK helm repo: a correctly signed chart round-tripped through AK and came out unverifiable, while the API reported success.

The misleading `{"saved":true}` is why this was believed to work, and why the corpus missed it — `tests/formats/test-helm-conformance.sh:362-392` asserts only that the POST returns 2xx, which it did.

This PR stores the prov alongside its chart and serves it at the URL the client actually derives.

### The path was verified against the real client, not the spec

Against real helm **3.16.4** (`alpine/helm:3.16`, arm64), `helm pull --verify` takes the chart URL it resolved from `index.yaml` and **string-appends `.prov`**:

```
GET /helm/<repo>/index.yaml                          200
GET /helm/<repo>/charts/<chart>-<ver>.tgz            200
GET /helm/<repo>/charts/<chart>-<ver>.tgz.prov       404   <- the bug
Error: failed to fetch provenance ".../<chart>-<ver>.tgz.prov"
```

Dropping the `.prov` at exactly that path — with `index.yaml` **unchanged** — flips it to `Chart Hash Verified`. Two consequences worth flagging for review:

- The **existing** `charts/{filename}` route is the right place to serve it; no new route is needed once the upload stores the prov under that filename.
- The helm index schema has **no** provenance field, so there is nothing to "advertise" in `index.yaml` (the finding listed this as an optional extra). The real requirement is that *the advertised chart URL + `.prov` resolves*, which is what the tests assert.

## Changes

- `upload_chart` stages the `prov` part and persists it as an artifact at `<chart>-<version>.tgz.prov`. The multipart loop no longer `break`s on `chart`, so part order does not matter — a part that is never read is a part that gets silently discarded.
- **The response no longer lies.** A prov that cannot be stored fails the upload (`400`) instead of vanishing behind a success reply. `prov` is reported only when provenance was actually written; a chart-only upload still returns exactly `{"saved":true}` (ChartMuseum-compatible).
- `query_charts_from_repo` excludes prov rows — the prov shares its chart's `name`/`version`, so without the filter every signed chart would render a **duplicate** `index.yaml` entry.
- **A chart and its provenance commit atomically.** Both objects are written to storage *before* either artifact row is inserted, and both rows are inserted inside **one transaction**. Ordering here is load-bearing — see below.
- `delete_chart` removes the chart together with its provenance. Its previous unordered `LIMIT 1` could just as easily have matched the prov row and left the chart behind once provenance exists, so this was load-bearing rather than cosmetic.

### Why the chart and the prov commit together

Storing the prov after committing the chart's artifact row is not safe, even though the prov is validated first.

The armor validation deliberately runs **before** the chart commits, which catches the overwhelmingly likely failure (a malformed prov) — but it cannot catch a *storage or database* fault on the prov. If one happened, the chart row was already committed: the response was an honest 5xx, but the repository now held a chart with **no provenance**, and the publisher's retry hit `ensure_unique_artifact_path` and got a permanent `409 Chart already exists`. Unretryable — and precisely the "signed chart that cannot be verified" state this issue exists to eliminate, just with an honest error code instead of a lying one.

So:

1. **Both objects go to storage first.** Object storage cannot join a DB transaction, so every fallible storage write now happens while the repository still has no row pointing at the coordinate.
2. **Both rows insert in one transaction.** A fault on the prov row rolls the chart row back with it.

Any fault therefore leaves the coordinate exactly as it was, and the retry succeeds. An object orphaned in storage by an interrupted upload is overwritten by that retry — the storage key is fully determined by chart name and version.

`proxy_helpers::insert_artifact_row` is the body of `insert_artifact` **without** the quarantine hold (which reads the row back through the pool and so must run post-commit). `insert_artifact`'s signature is unchanged and now delegates to it, so the other 44 call sites are untouched — the full `--lib` suite (13451 tests) passes.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

13 tests added in the crate's `#[cfg(test)] mod tests` (`--lib`, none `#[ignore]`). The core ones were **confirmed to fail against the unfixed behavior** and pass with the fix:

| test | on unfixed code |
|---|---|
| `test_helm_upload_persists_prov_and_serves_exact_bytes` | **FAIL** |
| `test_helm_index_yaml_advertised_url_resolves_prov` | **FAIL** |
| `test_helm_upload_rejects_invalid_prov_instead_of_dropping_it` | **FAIL** |
| `test_helm_prov_storage_fault_leaves_no_chart_row_blocking_reupload` | **FAIL** (chart row committed; retry → 409) |

- `..._persists_prov_and_serves_exact_bytes` — real multipart upload; the `.prov` comes back byte-for-byte (a single changed byte breaks helm's signature check).
- `..._index_yaml_advertised_url_resolves_prov` — takes the URL **out of** `index.yaml`, appends `.prov` exactly as helm does, fetches it; also asserts the prov does not leak in as a second chart entry.
- `..._rejects_invalid_prov_instead_of_dropping_it` — regression guard: an unstorable prov must not report `saved:true`.
- `test_dropped_prov_can_never_report_saved_prov` — regression guard on the response builder, which takes the *storage outcome* rather than the presence of the part.
- `..._prov_storage_fault_leaves_no_chart_row_blocking_reupload` — **atomicity, storage half.** Injects a real, prov-scoped storage fault (a directory squatting on the prov's destination makes the filesystem backend's final rename fail with `EISDIR`, while the chart's own put succeeds — the residual class the armor pre-validation cannot catch). Asserts the upload fails, **no** artifact row is committed, and the retry after clearing the fault returns `201`, not `409`. Against the pre-atomicity code this test reproduces the defect exactly: `artifact rows committed after prov fault = 1`, and the retry returns **`409`** where `201` is required.
- `..._chart_and_prov_rows_roll_back_together` — **atomicity, DB half.** A `UNIQUE(repository_id, path)` violation on the prov row (the shape a publisher racing between the pre-flight uniqueness check and the insert produces) must take the chart row with it, exercising the same drop-rollback the handler's `?` performs.
- `..._delete_chart_also_removes_prov`, `..._upload_without_prov_is_unchanged_and_prov_404s`, plus pure unit tests for the filename/armor helpers (fixture is a real `helm package --sign` prov).

### Two things reviewers should know

- **`prov: true` means "stored", not "verified".** AK does not validate the signature and should not — verification is helm's job, with the user's keyring. The upload validates only that the part is PGP-armored provenance, so a malformed prov is rejected at the door instead of being stored as garbage that helm will later refuse. Release notes should not imply AK verifies chart signatures.
- **5 of the 13 tests are DB-backed and no-op without `DATABASE_URL`** (`Fixture::setup` returns `None` → early return). That is this crate's existing house idiom rather than something this PR introduces, but it is the same shape as the silently-skipping-coverage problem, so it is worth naming: the results below were produced **with** a live `DATABASE_URL`, and the core tests were independently confirmed to fail on the unfixed code — they are not passing vacuously.

## End-to-end proof: DTF signing tier LEG D

LEG D of the `signing` tier (artifact-keeper-test#259) is the helm provenance leg, pinned as **2 KNOWN-REDs**. Against `ak-backend:fix-helm-prov`, both pins tripped their designed tripwire:

```
FAIL: KNOWN-RED leg now PASSES — the backend bug looks FIXED. Remove the pin ... (D2)
FAIL: KNOWN-RED leg now PASSES — the backend bug looks FIXED. Remove the pin ... (D3)
```

Un-pinning D2/D3 to plain assertions makes the tier **genuinely green** (`TIER signing: PASS (exit 0)`, 0 FAILs), with the assertions un-softened:

```
D1: POST /api/charts (chart + prov) -> 201  {"prov":true,"saved":true}
D2: GET charts/dtf-provchart-0.1.0.tgz.prov -> HTTP 200  -----BEGIN PGP SIGNED MESSAGE-----
D3: REAL `helm pull --verify` ->  Signed by: dtf-helm-prov <dtf@example.com>
                                  Chart Hash Verified: sha256:42b37ef1c253e5f9...
D4: discrimination — same chart also pulls without --verify
```

Re-run against the atomicity change (same un-pin, `artifact-keeper-backend:fix-helm-prov`) — the real client flow is unaffected by the reordering + transaction:

```
D1: POST /api/charts (chart + prov) -> 201  {"prov":true,"saved":true}
D2: GET charts/dtf-provchart-0.1.0.tgz.prov -> HTTP 200  -----BEGIN PGP SIGNED MESSAGE-----
D3: REAL `helm pull --verify` ->  Signed by: dtf-helm-prov <dtf@example.com>
                                  Using Key With Fingerprint: 7EF60D643F29A39CABE268A212BA41048F10D764
                                  Chart Hash Verified: sha256:f33ae766cd7b2e6eb933b5e76c348f0a7f24edaa9ca1ea8a6835cd06546e78ef
D4: discrimination — same chart also pulls without --verify

Results: 24 passed, 0 failed, 0 skipped (24 total, 41s)
=== TIER signing: PASS (exit 0) ===
```

The matching tier un-pin needs to land alongside this PR, otherwise the tripwire fires on merge (which is the design working as intended).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable) — DTF `signing` tier LEG D un-pinned
- [x] Manually tested locally
- [x] No regressions in existing tests — `cargo nextest run --workspace --lib`: **13451 passed, 0 failed** (the `insert_artifact` delegation touches 44 other call sites; the full suite is the blast-radius gate)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No new routes, no schema change, no migration: provenance is served by the existing `charts/{filename}` route. The upload response gains an additive `prov` field on chart+prov uploads only; the chart-only reply is unchanged.

Closes #2635
