### PR TITLE
fix(nuget): authenticate pushes presenting X-NuGet-ApiKey

### DIFF
--- a/backend/src/api/handlers/nuget.rs
+++ b/backend/src/api/handlers/nuget.rs
@@ -11,8 +11,6 @@
 //!   GET  /nuget/{repo_key}/v3/flatcontainer/{id}/{version}/{id}.{version}.nupkg — Download
 //!   PUT  /nuget/{repo_key}/api/v2/package                                     — Push package
 
-use std::sync::Arc;
-
 use axum::body::Body;
 use axum::extract::{Path, Query, State};
 use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
@@ -29,8 +27,6 @@ use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::models::repository::RepositoryType;
-use crate::models::user::User;
-use crate::services::auth_service::AuthService;
 use crate::services::curation_service::version_compare;
 
 // ---------------------------------------------------------------------------
@@ -846,43 +842,24 @@ async fn push_package(
     headers: HeaderMap,
     body: Body,
 ) -> Result<Response, Response> {
+    // `repo_visibility_middleware` resolves the caller for every format route
+    // — including the `X-NuGet-ApiKey` push credential (#2642) — and rejects an
+    // unauthenticated or invalid-credential write with 401 before this handler
+    // runs, so the auth extension is always present here.
+    //
+    // Require it rather than re-authenticating locally: a second credential
+    // path in the handler would be strictly weaker than the middleware's,
+    // because it can only reach `require_scope_response` with `None`, which is
+    // a no-op — silently skipping the GHSA-vvc3-h39c-mrq5 write-scope check.
+    let auth = auth.ok_or_else(|| {
+        Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .body(Body::from("Authentication required"))
+            .unwrap()
+    })?;
     // GHSA-vvc3-h39c-mrq5: enforce write scope before doing anything else.
-    crate::api::middleware::auth::require_scope_response(auth.as_ref(), "write")?;
-    let user_id = match auth {
-        Some(ext) => ext.user_id,
-        None => {
-            let api_key = headers
-                .get("X-NuGet-ApiKey")
-                .and_then(|v| v.to_str().ok())
-                .ok_or_else(|| {
-                    Response::builder()
-                        .status(StatusCode::UNAUTHORIZED)
-                        .body(Body::from("Authentication required"))
-                        .unwrap()
-                })?;
-            let (username, password) = if let Some((u, p)) = api_key.split_once(':') {
-                (u.to_string(), p.to_string())
-            } else {
-                ("apikey".to_string(), api_key.to_string())
-            };
-            let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
-            if let Ok((user, _)) = auth_service.authenticate(&username, &password).await {
-                user.id
-            } else if let Ok(validation) = auth_service.validate_api_token(&password).await {
-                validation.user.id
-            } else if let Ok(claims) = auth_service.validate_access_token_async(&password).await {
-                let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = $1")
-                    .bind(claims.sub)
-                    .fetch_optional(&state.db)
-                    .await
-                    .map_err(|_| (StatusCode::UNAUTHORIZED, "Invalid API key").into_response())?
-                    .ok_or_else(|| (StatusCode::UNAUTHORIZED, "Invalid API key").into_response())?;
-                user.id
-            } else {
-                return Err((StatusCode::UNAUTHORIZED, "Invalid API key").into_response());
-            }
-        }
-    };
+    crate::api::middleware::auth::require_scope_response(Some(&auth), "write")?;
+    let user_id = auth.user_id;
     let repo = resolve_nuget_repo(&state.db, &repo_key).await?;
     proxy_helpers::reject_write_if_not_hosted(&repo.repo_type)?;
     repo.reject_if_promotion_only(false)?;
@@ -1204,58 +1181,63 @@ mod tests {
     // Extracted pure functions (test-only)
     // -----------------------------------------------------------------------
 
+    /// The handler must never authenticate a push itself.
+    ///
+    /// `repo_visibility_middleware` is the single credential authority for
+    /// format routes: it resolves `X-NuGet-ApiKey` on the push route (#2642)
+    /// and 401s an unauthenticated or invalid-credential write before this
+    /// handler runs. The handler previously carried its own `X-NuGet-ApiKey`
+    /// fallback (`user:pass` -> `authenticate()`, or a raw JWT); those shapes
+    /// are unreachable now, and that path was strictly weaker — it could only
+    /// reach `require_scope_response` with `None`, which is a no-op that skips
+    /// the GHSA-vvc3-h39c-mrq5 write-scope check.
+    ///
+    /// Pin the deletion: a missing auth extension is 401 no matter what the
+    /// header carries, so the parallel auth path cannot be reintroduced by
+    /// accident.
     #[tokio::test]
-    async fn test_push_package_requires_nuget_api_key_when_unauthenticated() {
-        let state = test_state_with_secret("test-secret-at-least-32-bytes-long-for-testing");
-        let headers = HeaderMap::new();
-
-        let resp = push_package(
-            State(state),
-            Extension(None),
-            Path("nuget-test".to_string()),
-            headers,
-            Body::from("dummy"),
-        )
-        .await
-        .expect_err("missing api key should fail before repo resolution");
-
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-        let body = to_bytes(resp.into_body(), usize::MAX)
-            .await
-            .expect("read body");
-        assert_eq!(
-            std::str::from_utf8(&body).unwrap(),
-            "Authentication required"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_push_package_jwt_api_key_fallback_returns_invalid_key_on_db_error() {
+    async fn test_push_package_rejects_unauthenticated_push_whatever_the_api_key_header() {
         let secret = "test-secret-at-least-32-bytes-long-for-testing";
-        let state = test_state_with_secret(secret);
         let jwt = mint_access_jwt(secret, "ci-user");
 
-        let mut headers = HeaderMap::new();
-        headers.insert(
-            "X-NuGet-ApiKey",
-            HeaderValue::from_str(&format!("ci-user:{}", jwt)).expect("api key header"),
-        );
+        // No header, plus both credential shapes the removed fallback accepted.
+        let api_keys = [
+            None,
+            Some(format!("ci-user:{}", jwt)),
+            Some(jwt.clone()),
+            Some("apikey-value".to_string()),
+        ];
 
-        let resp = push_package(
-            State(state),
-            Extension(None),
-            Path("nuget-test".to_string()),
-            headers,
-            Body::from("dummy"),
-        )
-        .await
-        .expect_err("lazy pool should make JWT user lookup fail as invalid key");
+        for api_key in api_keys {
+            let state = test_state_with_secret(secret);
+            let mut headers = HeaderMap::new();
+            if let Some(key) = &api_key {
+                headers.insert(
+                    "X-NuGet-ApiKey",
+                    HeaderValue::from_str(key).expect("api key header"),
+                );
+            }
 
-        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
-        let body = to_bytes(resp.into_body(), usize::MAX)
+            let resp = push_package(
+                State(state),
+                Extension(None),
+                Path("nuget-test".to_string()),
+                headers,
+                Body::from("dummy"),
+            )
             .await
-            .expect("read body");
-        assert_eq!(std::str::from_utf8(&body).unwrap(), "Invalid API key");
+            .expect_err("no auth extension must fail before repo resolution");
+
+            assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+            let body = to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .expect("read body");
+            assert_eq!(
+                std::str::from_utf8(&body).unwrap(),
+                "Authentication required",
+                "X-NuGet-ApiKey {api_key:?} must not authenticate at the handler"
+            );
+        }
     }
 
     /// Build the base URL for NuGet service index resources.

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -1983,6 +1983,49 @@ mod tests {
     }
 
     #[test]
+    fn test_extract_visibility_token_malformed_auth_header_not_rescued_by_nuget_key() {
+        // Precedence must hold for a MALFORMED Authorization header, not just a
+        // valid one: a caller who presents a broken credential gets that
+        // credential's (failing) outcome, never a silent rescue by
+        // X-NuGet-ApiKey.
+        //
+        // This property currently rests on an implementation detail —
+        // `extract_token_from_auth_header` never returns `None`, so the early
+        // return in `extract_visibility_token` always fires and the worst case
+        // is `Invalid`, which `repo_visibility_middleware` maps to
+        // `InvalidCredential` -> 401. A refactor that made the parser return
+        // `None` for an unparseable header would silently open a real fallback
+        // (bogus Authorization + valid api key -> authenticated). Pin it here
+        // so that refactor fails loudly instead.
+        for (header_value, expected) in [
+            // Parsed as Basic, but the credentials are not valid base64 ->
+            // rejected downstream as InvalidCredential.
+            ("Basic !!!bad!!!", ExtractedToken::Basic("!!!bad!!!")),
+            // Unparseable: no known scheme, and multi-word so it cannot be
+            // taken for a scheme-less cargo token -> Invalid.
+            ("!!! bad !!!", ExtractedToken::Invalid),
+            ("Bogus scheme-with args", ExtractedToken::Invalid),
+        ] {
+            let mut request =
+                nuget_push_request("/nuget/my-feed/api/v2/package", Some("nuget-key-123"));
+            request.headers_mut().insert(
+                AUTHORIZATION,
+                axum::http::HeaderValue::from_str(header_value).unwrap(),
+            );
+            let resolved = extract_visibility_token(&request);
+            assert!(
+                !matches!(resolved, ExtractedToken::ApiKey("nuget-key-123")),
+                "malformed Authorization {header_value:?} must not fall back to X-NuGet-ApiKey"
+            );
+            match (&resolved, &expected) {
+                (ExtractedToken::Basic(got), ExtractedToken::Basic(want)) => assert_eq!(got, want),
+                (ExtractedToken::Invalid, ExtractedToken::Invalid) => {}
+                _ => panic!("Authorization {header_value:?} resolved to an unexpected credential"),
+            }
+        }
+    }
+
+    #[test]
     fn test_extract_visibility_token_empty_nuget_api_key_is_none() {
         // An empty header value is not a credential: fall through to anonymous
         // so the write gate fails closed with 401.
@@ -2031,19 +2074,29 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_visibility_token_nuget_api_key_ignored_on_read_methods() {
-        // Scoped to the PUT push. A GET carrying the header stays anonymous,
-        // so it can never unlock a private-repo read.
-        let request = Request::builder()
-            .method(Method::GET)
-            .uri("/nuget/my-feed/api/v2/package")
-            .header("x-nuget-apikey", "nuget-key-123")
-            .body(axum::body::Body::empty())
-            .unwrap();
-        assert!(matches!(
-            extract_visibility_token(&request),
-            ExtractedToken::None
-        ));
+    fn test_extract_visibility_token_nuget_api_key_ignored_on_other_methods() {
+        // Scoped to the PUT push and nothing else. A GET/HEAD carrying the
+        // header stays anonymous, so it can never unlock a private-repo read;
+        // POST/PATCH/DELETE on the push route are equally inert, so the header
+        // cannot become a credential for any other verb the router may grow.
+        for method in [
+            Method::GET,
+            Method::HEAD,
+            Method::POST,
+            Method::PATCH,
+            Method::DELETE,
+        ] {
+            let request = Request::builder()
+                .method(method.clone())
+                .uri("/nuget/my-feed/api/v2/package")
+                .header("x-nuget-apikey", "nuget-key-123")
+                .body(axum::body::Body::empty())
+                .unwrap();
+            assert!(
+                matches!(extract_visibility_token(&request), ExtractedToken::None),
+                "X-NuGet-ApiKey must be ignored on {method}"
+            );
+        }
     }
 
     #[test]

--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -7,6 +7,7 @@
 //! - `Authorization: Bearer <api_token>` - API tokens via Bearer scheme
 //! - `Authorization: ApiKey <api_token>` - API tokens via ApiKey scheme
 //! - `X-API-Key: <api_token>` - API tokens via custom header
+//! - `X-NuGet-ApiKey: <api_token>` - API tokens on the NuGet push route only
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -32,6 +33,13 @@ use crate::services::permission_service::PermissionService;
 
 /// Custom header name for API key
 static X_API_KEY: HeaderName = HeaderName::from_static("x-api-key");
+
+/// Header the NuGet client sends the push credential in.
+///
+/// `dotnet nuget push --api-key <key>` puts the credential here rather than in
+/// `Authorization` when the configured source carries no credentials. Only the
+/// NuGet push route honours it (see [`extract_nuget_push_api_key`]).
+static X_NUGET_API_KEY: HeaderName = HeaderName::from_static("x-nuget-apikey");
 
 /// Extension that holds authenticated user information
 ///
@@ -1293,18 +1301,81 @@ pub(crate) fn extract_conda_url_token(path: &str) -> Option<&str> {
     }
 }
 
+/// Is `path` the NuGet package-push route (`/nuget/<repo_key>/api/v2/package`)?
+///
+/// Matched exactly — with or without the trailing slash that `dotnet nuget
+/// push` appends to the `PackagePublish/2.0.0` URL it discovers from the v3
+/// service index (both spellings are registered in `nuget::router`). Every
+/// other NuGet route (service index, search, registration, flat container) and
+/// every other format returns `false`, which is what keeps the
+/// `X-NuGet-ApiKey` credential fallback from widening the accepted credential
+/// surface anywhere else.
+fn is_nuget_push_path(path: &str) -> bool {
+    let trimmed = path.trim_start_matches('/');
+    let mut segments = trimmed.split('/');
+    if segments.next() != Some("nuget") {
+        return false;
+    }
+    // Repository key.
+    match segments.next() {
+        Some(key) if !key.is_empty() => {}
+        _ => return false,
+    }
+    if segments.next() != Some("api") || segments.next() != Some("v2") {
+        return false;
+    }
+    if segments.next() != Some("package") {
+        return false;
+    }
+    // Nothing may follow except the optional trailing slash.
+    match segments.next() {
+        None => true,
+        Some("") => segments.next().is_none(),
+        Some(_) => false,
+    }
+}
+
+/// Extract the credential from the NuGet `X-NuGet-ApiKey` push header.
+///
+/// `dotnet nuget push --api-key <key>` against a source with no configured
+/// credentials sends the key in `X-NuGet-ApiKey` and nothing in
+/// `Authorization`. That header is invisible to [`extract_token`], so the
+/// visibility middleware treated such a push as anonymous and rejected it with
+/// 401 (writes always require auth) *before* `push_package` — which has its own
+/// `X-NuGet-ApiKey` fallback — could ever run.
+///
+/// Scoped to `PUT` on the push route alone: this header is a NuGet client
+/// convention, so it must not become a general-purpose credential channel on
+/// read routes or on other formats. Returns `None` for any other method, path,
+/// or an empty header value.
+fn extract_nuget_push_api_key(request: &Request) -> Option<&str> {
+    if request.method() != Method::PUT || !is_nuget_push_path(request.uri().path()) {
+        return None;
+    }
+    request
+        .headers()
+        .get(&X_NUGET_API_KEY)
+        .and_then(|v| v.to_str().ok())
+        .filter(|v| !v.is_empty())
+}
+
 /// Resolve the request credential for the visibility middleware, falling back
-/// to the conda token-channel URL credential when no header/cookie credential
-/// is present. Header credentials always take precedence.
+/// to format-specific credential channels when no header/cookie credential is
+/// present: the conda token-channel URL, and the NuGet push `X-NuGet-ApiKey`
+/// header. Header credentials always take precedence, and an unparseable or
+/// invalid fallback credential still fails closed downstream.
 fn extract_visibility_token(request: &Request) -> ExtractedToken<'_> {
     let extracted = extract_token(request);
     if !matches!(extracted, ExtractedToken::None) {
         return extracted;
     }
-    match extract_conda_url_token(request.uri().path()) {
-        Some(token) => ExtractedToken::ApiKey(token),
-        None => ExtractedToken::None,
+    if let Some(token) = extract_conda_url_token(request.uri().path()) {
+        return ExtractedToken::ApiKey(token);
     }
+    if let Some(token) = extract_nuget_push_api_key(request) {
+        return ExtractedToken::ApiKey(token);
+    }
+    ExtractedToken::None
 }
 
 /// Decide whether a request to a repository should be allowed.
@@ -1861,6 +1932,134 @@ mod tests {
             .unwrap();
         let result = extract_visibility_token(&request);
         assert!(matches!(result, ExtractedToken::None));
+    }
+
+    // -----------------------------------------------------------------------
+    // NuGet push X-NuGet-ApiKey fallback
+    // -----------------------------------------------------------------------
+
+    fn nuget_push_request(uri: &str, api_key: Option<&str>) -> Request {
+        let mut builder = Request::builder().method(Method::PUT).uri(uri);
+        if let Some(key) = api_key {
+            builder = builder.header("x-nuget-apikey", key);
+        }
+        builder.body(axum::body::Body::empty()).unwrap()
+    }
+
+    #[test]
+    fn test_extract_visibility_token_uses_nuget_push_api_key() {
+        // `dotnet nuget push --api-key <key>` against a credential-less source
+        // sends the key ONLY in X-NuGet-ApiKey. Without this fallback the
+        // visibility middleware saw an anonymous write and 401'd before the
+        // push handler (which has its own X-NuGet-ApiKey fallback) could run.
+        let request = nuget_push_request("/nuget/my-feed/api/v2/package", Some("nuget-key-123"));
+        assert!(matches!(
+            extract_visibility_token(&request),
+            ExtractedToken::ApiKey("nuget-key-123")
+        ));
+
+        // `dotnet nuget push` appends a trailing slash to the discovered
+        // PackagePublish URL; both spellings are registered routes.
+        let request = nuget_push_request("/nuget/my-feed/api/v2/package/", Some("nuget-key-123"));
+        assert!(matches!(
+            extract_visibility_token(&request),
+            ExtractedToken::ApiKey("nuget-key-123")
+        ));
+    }
+
+    #[test]
+    fn test_extract_visibility_token_nuget_header_credential_takes_priority() {
+        // An explicit Authorization credential always wins over X-NuGet-ApiKey.
+        let mut request =
+            nuget_push_request("/nuget/my-feed/api/v2/package", Some("nuget-key-123"));
+        request.headers_mut().insert(
+            AUTHORIZATION,
+            axum::http::HeaderValue::from_static("Bearer header-jwt"),
+        );
+        assert!(matches!(
+            extract_visibility_token(&request),
+            ExtractedToken::Bearer("header-jwt")
+        ));
+    }
+
+    #[test]
+    fn test_extract_visibility_token_empty_nuget_api_key_is_none() {
+        // An empty header value is not a credential: fall through to anonymous
+        // so the write gate fails closed with 401.
+        let request = nuget_push_request("/nuget/my-feed/api/v2/package", Some(""));
+        assert!(matches!(
+            extract_visibility_token(&request),
+            ExtractedToken::None
+        ));
+    }
+
+    #[test]
+    fn test_extract_visibility_token_nuget_api_key_ignored_off_push_path() {
+        // The fallback must not widen the credential surface beyond the push
+        // route: NuGet read routes ignore the header entirely.
+        for uri in [
+            "/nuget/my-feed/v3/index.json",
+            "/nuget/my-feed/v3/search",
+            "/nuget/my-feed/v3/flatcontainer/pkg/1.0.0/pkg.nupkg",
+            "/nuget/my-feed/api/v2/package/extra",
+            "/nuget/my-feed/api/v2/symbolpackage",
+            "/nuget/api/v2/package",
+        ] {
+            let request = nuget_push_request(uri, Some("nuget-key-123"));
+            assert!(
+                matches!(extract_visibility_token(&request), ExtractedToken::None),
+                "X-NuGet-ApiKey must be ignored on {uri}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_visibility_token_nuget_api_key_ignored_for_other_formats() {
+        // No cross-format blast radius: an identically-shaped path under any
+        // other format prefix never honours the header.
+        for uri in [
+            "/pypi/my-feed/api/v2/package",
+            "/npm/my-feed/api/v2/package",
+            "/conda/my-feed/api/v2/package",
+        ] {
+            let request = nuget_push_request(uri, Some("nuget-key-123"));
+            assert!(
+                matches!(extract_visibility_token(&request), ExtractedToken::None),
+                "X-NuGet-ApiKey must be ignored for {uri}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_extract_visibility_token_nuget_api_key_ignored_on_read_methods() {
+        // Scoped to the PUT push. A GET carrying the header stays anonymous,
+        // so it can never unlock a private-repo read.
+        let request = Request::builder()
+            .method(Method::GET)
+            .uri("/nuget/my-feed/api/v2/package")
+            .header("x-nuget-apikey", "nuget-key-123")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        assert!(matches!(
+            extract_visibility_token(&request),
+            ExtractedToken::None
+        ));
+    }
+
+    #[test]
+    fn test_is_nuget_push_path() {
+        assert!(is_nuget_push_path("/nuget/my-feed/api/v2/package"));
+        assert!(is_nuget_push_path("/nuget/my-feed/api/v2/package/"));
+        // Repo keys are single segments; nothing may follow `package`.
+        assert!(!is_nuget_push_path("/nuget/my-feed/api/v2/package//"));
+        assert!(!is_nuget_push_path("/nuget/my-feed/api/v2/package/x"));
+        assert!(!is_nuget_push_path("/nuget//api/v2/package"));
+        assert!(!is_nuget_push_path("/nuget/my-feed/api/v3/package"));
+        assert!(!is_nuget_push_path("/nuget/my-feed/api/v2"));
+        assert!(!is_nuget_push_path("/nuget"));
+        assert!(!is_nuget_push_path(""));
+        // Other formats never match, whatever the tail looks like.
+        assert!(!is_nuget_push_path("/pypi/my-feed/api/v2/package"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`dotnet nuget push --api-key <key>` against a source with no configured
credentials returned a hard **401**, even with a valid API token.

Closes #2642 — with one scope caveat, see [Scope](#scope--known-limitation).

`repo_visibility_middleware` resolves the caller via `extract_token`, which only
inspects `Authorization`, `X-API-Key`, and the session cookie. A `dotnet nuget
push --api-key` sends its credential *only* in the NuGet-specific
`X-NuGet-ApiKey` header, so the middleware classified the push as anonymous and
rejected it under the "writes always require authentication" gate (#508).

This is the same shape as the conda token-channel defect (#2629 / #2631) and is
fixed at the same seam: `extract_visibility_token` — the visibility
middleware's credential resolver — gains a NuGet fallback next to the existing
conda one.

The fallback is deliberately narrow. It applies only when **all** of these hold:

- no `Authorization` / `X-API-Key` / cookie credential is present
  (header credentials keep strict precedence, in both directions: a valid
  header credential wins over a bogus `X-NuGet-ApiKey`, and a *malformed* header
  credential still 401s rather than being silently rescued by the key);
- the method is `PUT`;
- the path is exactly `/nuget/<repo_key>/api/v2/package`, with or without the
  trailing slash `dotnet nuget push` appends to the `PackagePublish/2.0.0` URL
  it discovers from the v3 service index (both spellings are registered in
  `nuget::router`).

Anything else — NuGet read routes, other formats, non-PUT methods, an empty
header value, an invalid key — resolves to no credential or an invalid one and
still fails closed with 401. The header never becomes a general-purpose
credential channel, and it can never unlock a private-repo read.

### Removing the handler's parallel auth path

`push_package` had carried its own `X-NuGet-ApiKey` fallback (`user:pass` ->
`auth_service.authenticate()`, or a raw JWT) for this case. It never ran: the
middleware resolves the credential first, and now hard-401s exactly those shapes
as `InvalidCredential` before the handler is reached.

It is **removed rather than kept as a second line of defence**, because it was
not one. It could only be entered with `auth == None`, and it called
`require_scope_response(None, "write")` — which returns `Ok(())` on `None`,
silently skipping the GHSA-vvc3-h39c-mrq5 write-scope check. A credential path
weaker than the one in front of it is a liability, not depth: it survived only
because the middleware's write gate 401s `auth_ext == None` writes first.
The handler now requires the auth extension and passes it to the scope check, so
the write-scope check always runs.

### Scope / known limitation

**This fix is inert when `GUEST_ACCESS_ENABLED=false`.** `guest_access_guard` is
layered on the **root** router, i.e. outside `repo_visibility_middleware`, and
resolves credentials with `extract_token` — not the `extract_visibility_token`
extended here. `/nuget/...` is not allowlisted, so with guest access disabled a
`dotnet nuget push --api-key` resolves to `NoCredential` and 401s at the guard
before this code runs.

It fails closed and is not a regression (that call 401'd before this PR too),
and the default is `guest_access_enabled: true`, which is the posture the live
verification below exercises. But #2642 is **not** fully fixed for instances
with guest access disabled.

This is a class issue at that seam rather than something specific to NuGet: the
merged conda fix (#2631) has the identical latent gap. Both are tracked in
**#2655**, along with the argument that the fix belongs in `guest_access_guard`
itself — a global outer guard whose credential resolution deserves its own
review — rather than being smuggled in here.

### Blast radius

Both new helpers are private and single-caller, so the reachable surface is
fully enumerable (the `extract_repo_key` trace requested on #2631):

- `is_nuget_push_path` — one caller: `extract_nuget_push_api_key`.
- `extract_nuget_push_api_key` — one caller: `extract_visibility_token`.
- `extract_visibility_token` — two callers, both inside
  `repo_visibility_middleware` (the repo-miss and repo-hit branches).
- `repo_visibility_middleware` — applied at exactly one place
  (`routes.rs`, the `format_routes` nest).

On the repo-miss branch a valid `X-NuGet-ApiKey` now yields the handler's 404
for a nonexistent feed instead of 401 — which is precisely what the same
credential in an `Authorization` header already did, so the #1808
anonymous-repo-existence oracle is unaffected: a caller with no valid
credential still gets the identical 401 + challenge.

Two intentional non-behaviours, both pre-existing and shared with the conda
helpers, neither a privilege gain:

- A **non-UTF-8** `Authorization` header fails `.to_str()` and is treated as
  absent, so the NuGet key resolves. The caller authenticates as themselves with
  their own valid key; there is nothing to gain by garbling their own header.
- `trim_start_matches('/')` strips all leading slashes, so `//nuget/...`
  satisfies the predicate — and then 404s in the router.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added to `api::middleware::auth::tests` (all in `#[cfg(test)] mod tests`, none
`#[ignore]`d):

- `test_extract_visibility_token_uses_nuget_push_api_key` — the fix: the push
  header supplies the credential, with and without the trailing slash.
- `test_extract_visibility_token_nuget_header_credential_takes_priority` —
  a valid `Authorization` still wins when both are present.
- `test_extract_visibility_token_malformed_auth_header_not_rescued_by_nuget_key`
  — the precedence property that actually carries the risk: a **malformed**
  `Authorization` (`Basic !!!bad!!!`, and unparseable values) must resolve to
  that credential's failing outcome, never be silently rescued by a valid
  `X-NuGet-ApiKey`. This holds today only because
  `extract_token_from_auth_header` never returns `None` (worst case `Invalid`,
  which the middleware short-circuits to 401); a refactor that made it return
  `None` would open a real fallback, and this test is what fails when it does.
- `test_extract_visibility_token_empty_nuget_api_key_is_none` — empty value is
  not a credential.
- `test_extract_visibility_token_nuget_api_key_ignored_off_push_path` — inert on
  the service index, search, flat container, and near-miss push paths.
- `test_extract_visibility_token_nuget_api_key_ignored_for_other_formats` — no
  cross-format blast radius.
- `test_extract_visibility_token_nuget_api_key_ignored_on_other_methods` — the
  header is inert on GET/HEAD/POST/PATCH/DELETE, so it can never unlock a
  private-repo read or become a credential for another verb.
- `test_is_nuget_push_path` — exact route matching.

In `api::handlers::nuget::tests`,
`test_push_package_rejects_unauthenticated_push_whatever_the_api_key_header`
replaces the two tests that covered the removed fallback: it pins that a missing
auth extension is 401 regardless of what `X-NuGet-ApiKey` carries — including
the exact `user:jwt` and raw-JWT shapes the old path accepted — so the parallel
auth path cannot return by accident.

Verified with a **real `dotnet` 8 client** against an uncredentialed source, on
the DTF `format-conformance` topology:

| image | `dotnet nuget push --source ak --api-key $KEY` |
| --- | --- |
| pre-fix | `error: Response status code does not indicate success: 401 (Unauthorized).` |
| this PR | `Your package was pushed.` (`Created`, and the advertised flatcontainer index lists `1.0.0`) |

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`cargo nextest run --workspace --lib` → 13443/13443 passed. `cargo fmt --check`
and `cargo clippy --workspace --all-targets -- -D warnings` clean. DTF
`format-conformance` `FC_ONLY=nuget` 10/10 green on the patched image.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (existing push route; no new endpoints or schema)
