### PR TITLE
fix(rpm): sign repodata with real OpenPGP so dnf can verify it

### DIFF
--- a/.sqlx/query-4826fb4344ac9083cadfb880d9c6d89231479a93357b10eb64d98b76afc3bc98.json
+++ b/.sqlx/query-4826fb4344ac9083cadfb880d9c6d89231479a93357b10eb64d98b76afc3bc98.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO artifacts (\n                repository_id, path, name, version, size_bytes,\n                checksum_sha256, content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Bpchar",
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4826fb4344ac9083cadfb880d9c6d89231479a93357b10eb64d98b76afc3bc98"
+}

--- a/.sqlx/query-c8bf6d407a918f252604042bc99771308da0a1aabe2a377339c7996d931198f5.json
+++ b/.sqlx/query-c8bf6d407a918f252604042bc99771308da0a1aabe2a377339c7996d931198f5.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.updated_at, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n        ORDER BY a.name, a.version, a.path, a.id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c8bf6d407a918f252604042bc99771308da0a1aabe2a377339c7996d931198f5"
+}

--- a/.sqlx/query-ef0cd93097b53469f8e1f25e44a2735ba7b12b1c0a207b990349e9be6dd02382.json
+++ b/.sqlx/query-ef0cd93097b53469f8e1f25e44a2735ba7b12b1c0a207b990349e9be6dd02382.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE signing_keys SET key_type = 'gpg' WHERE repository_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ef0cd93097b53469f8e1f25e44a2735ba7b12b1c0a207b990349e9be6dd02382"
+}

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -37,6 +37,7 @@ use sqlx::PgPool;
 use tracing::info;
 use xz2::read::XzDecoder;
 
+use crate::api::handlers::error_helpers::require_signing_key;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::{SharedState, SIGNED_RELEASE_CACHE_MAX_ENTRIES};
@@ -1577,23 +1578,14 @@ async fn signed_release_cache_invalidate(state: &SharedState, repo_key: &str, di
 /// none is configured. We refuse to silently fall through to unsigned
 /// `InRelease` (#1236): clients trust the signature, so absence of a key
 /// is a configuration error the operator needs to see, not a soft fallback.
+///
+/// The 404-vs-500 decision itself lives in `error_helpers::require_signing_key`
+/// so RPM's repomd.xml.asc resolves its key identically (#2636).
 async fn require_active_signing_key(
     signing_svc: &SigningService,
     repo_id: uuid::Uuid,
 ) -> Result<SigningKey, Response> {
-    match signing_svc.get_active_key_for_repo(repo_id).await {
-        Ok(Some(k)) => Ok(k),
-        Ok(None) => Err((
-            StatusCode::NOT_FOUND,
-            "No signing key configured for this repository",
-        )
-            .into_response()),
-        Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to load signing key: {}", e),
-        )
-            .into_response()),
-    }
+    require_signing_key(signing_svc.get_active_key_for_repo(repo_id).await)
 }
 
 /// Iterate the virtual repo's Remote members for `upstream_path` and

--- a/backend/src/api/handlers/error_helpers.rs
+++ b/backend/src/api/handlers/error_helpers.rs
@@ -4,9 +4,11 @@
 //! `AppError` response, replacing the repetitive closure pattern that was
 //! copy-pasted across maven, npm, pypi, and cargo handlers.
 
+use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
 use crate::error::AppError;
+use crate::models::signing_key::SigningKey;
 
 /// Convert any `Display`-able error into a `Database` `AppError` response.
 ///
@@ -30,6 +32,43 @@ pub fn map_db_err(e: impl std::fmt::Display) -> Response {
 /// Usage: `.map_err(map_storage_err)?`
 pub fn map_storage_err(e: impl std::fmt::Display) -> Response {
     AppError::Storage(e.to_string()).into_response()
+}
+
+/// Resolve the outcome of an active-signing-key lookup for a repository
+/// metadata-signing endpoint (`InRelease`, `Release.gpg`, `repomd.xml.asc`, ...).
+///
+/// The two failure modes are deliberately kept distinct (#2636):
+///
+///   * `Ok(None)`  — the repository genuinely has no active signing key.
+///     That is a client-visible configuration state: **404**.
+///   * `Err(e)`    — the key exists but could not be loaded (decrypt failure,
+///     DB error, unparseable key material). That is a *server* failure and
+///     must stay loud: **500**, carrying the real error.
+///
+/// Collapsing the second case into the first is what let the RPM signing
+/// breakage hide: a repo that advertised a key it could not sign with reported
+/// "No signing key configured for this repository", so the real parse error
+/// was never seen. Taking the lookup `Result` by value keeps this decision a
+/// pure function, so the distinction is unit-testable without a database.
+// `Response` is the crate-wide handler error type; boxing it here would just
+// force every call site to unbox (see the same allow on the format handlers).
+#[allow(clippy::result_large_err)]
+pub fn require_signing_key(
+    lookup: crate::error::Result<Option<SigningKey>>,
+) -> Result<SigningKey, Response> {
+    match lookup {
+        Ok(Some(key)) => Ok(key),
+        Ok(None) => Err((
+            StatusCode::NOT_FOUND,
+            "No signing key configured for this repository",
+        )
+            .into_response()),
+        Err(e) => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to load signing key: {}", e),
+        )
+            .into_response()),
+    }
 }
 
 #[cfg(test)]

--- a/backend/src/api/handlers/error_helpers.rs
+++ b/backend/src/api/handlers/error_helpers.rs
@@ -71,6 +71,46 @@ pub fn require_signing_key(
     }
 }
 
+/// Require that a repository's active signing key can produce an OpenPGP
+/// chain, for the endpoints that can only serve OpenPGP (`repomd.xml.asc`,
+/// `repomd.xml.key`, `Release.gpg`, ...).
+///
+/// An `rsa` key (the *default* `key_type`) holds X.509 material and can never
+/// satisfy these endpoints, so this is **409 Conflict**, not 500: the request
+/// is fine and the server is healthy — the repository's signing *configuration*
+/// conflicts with what the endpoint must produce, and only an operator can
+/// resolve it. Nothing will change until they do (#2651 proposes rejecting the
+/// combination at config time, upstream of here).
+///
+/// The status matters operationally, because these endpoints are anonymous:
+/// every `dnf` poll of a misconfigured repo hits this path. Returning 500 +
+/// `ERROR!` would let any unauthenticated client drive unbounded error logs and
+/// 500-rate alerts — paging an on-call engineer for someone else's config
+/// mistake. A 500 must keep meaning "this server is broken"; callers log this
+/// at `WARN` instead.
+///
+/// A key that *claims* `key_type=gpg` but whose material will not parse is a
+/// different animal — that is a genuine server-side fault and stays a loud 500
+/// at the point of signing.
+///
+/// Pure, like `require_signing_key`, so the mapping is unit-testable.
+#[allow(clippy::result_large_err)]
+pub fn require_openpgp_capable_key(key: SigningKey) -> Result<SigningKey, Response> {
+    if key.supports_openpgp() {
+        return Ok(key);
+    }
+    Err((
+        StatusCode::CONFLICT,
+        format!(
+            "This repository's active signing key '{}' has key_type='{}', which cannot \
+             produce an OpenPGP signature. Metadata signing requires a key with \
+             key_type='gpg'.",
+            key.name, key.key_type
+        ),
+    )
+        .into_response())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backend/src/api/handlers/metadata_epoch.rs
+++ b/backend/src/api/handlers/metadata_epoch.rs
@@ -1,0 +1,104 @@
+//! Repository-state metadata epoch for reproducible repository metadata.
+//!
+//! Signed repository metadata must be a **pure function of repository state**.
+//! The bytes a client verifies and the bytes the server signs are produced by
+//! two *independent* renders, in two *separate* requests:
+//!
+//! | format | served document        | detached signature over it |
+//! |--------|------------------------|----------------------------|
+//! | RPM    | `repodata/repomd.xml`  | `repodata/repomd.xml.asc`  |
+//! | Debian | `dists/{d}/Release`    | `dists/{d}/Release.gpg`    |
+//!
+//! If any part of a render reads a wall clock, the two renders disagree
+//! whenever the two requests land in different seconds — and the client
+//! reports a **BAD signature on a repository nobody tampered with**. The
+//! failure probability is `min(1, gap / 1s)` where `gap` is the time between
+//! the two renders, so it grows with repo size, host load, and client latency
+//! rather than with anything the operator can see or control. Caching the
+//! render does not fix it either: a `repomd.xml` held in a client's metadata
+//! cache from an earlier run can never match a freshly stamped signature.
+//!
+//! Deriving the metadata timestamp from repository *state* instead of `now()`
+//! removes the clock from the render entirely: unchanged state renders
+//! byte-identical bytes, forever, on every replica. That is also closer to
+//! what `createrepo`/`apt-ftparchive` produce, and it makes the metadata
+//! cacheable and reproducible.
+//!
+//! See #2636 (RPM `repomd.xml.asc`) and #2652 (Debian `Release.gpg`) — one
+//! root cause, two formats.
+
+use chrono::{DateTime, Utc};
+
+/// The metadata epoch for a rendered document: the most recent `updated_at`
+/// among the artifacts that document describes.
+///
+/// This is the timestamp to stamp into `<revision>`/`<timestamp>` (RPM) or
+/// `Date:` (Debian) instead of `now()`. It is derived from exactly the rows
+/// being rendered, so it changes if and only if the rendered content can
+/// change, and two renders of unchanged state agree by construction — no
+/// second query, and no coordination between the two handlers.
+///
+/// An empty repository has no state to derive from and yields the Unix epoch:
+/// a repository with no packages has no meaningful metadata age, and a fixed
+/// value keeps the render deterministic (`unwrap_or(now())` would reintroduce
+/// exactly the bug this exists to prevent).
+pub fn metadata_epoch<I>(updated_ats: I) -> DateTime<Utc>
+where
+    I: IntoIterator<Item = DateTime<Utc>>,
+{
+    updated_ats
+        .into_iter()
+        .max()
+        .unwrap_or(DateTime::<Utc>::UNIX_EPOCH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn at(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).unwrap()
+    }
+
+    #[test]
+    fn test_metadata_epoch_is_the_most_recent_update() {
+        assert_eq!(
+            metadata_epoch(vec![at(100), at(300), at(200)]),
+            at(300),
+            "the epoch must track the most recently updated artifact",
+        );
+    }
+
+    #[test]
+    fn test_metadata_epoch_is_order_independent() {
+        // The epoch must not depend on the order rows come back in, so a
+        // query-plan change cannot move it.
+        assert_eq!(
+            metadata_epoch(vec![at(300), at(100), at(200)]),
+            metadata_epoch(vec![at(100), at(200), at(300)]),
+        );
+    }
+
+    #[test]
+    fn test_metadata_epoch_of_empty_repo_is_the_unix_epoch() {
+        // Deterministic, and — decisively — not `now()`.
+        assert_eq!(metadata_epoch(vec![]), DateTime::<Utc>::UNIX_EPOCH);
+        assert_eq!(metadata_epoch(vec![]).timestamp(), 0);
+    }
+
+    /// The property the signature chain depends on: the same state always
+    /// yields the same epoch, no matter how much wall-clock time passes
+    /// between the two renders.
+    #[test]
+    fn test_metadata_epoch_is_stable_across_calls() {
+        let state = vec![at(1_700_000_000), at(1_600_000_000)];
+        let first = metadata_epoch(state.clone());
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let second = metadata_epoch(state);
+        assert_eq!(
+            first, second,
+            "unchanged state must yield the same epoch across a second boundary",
+        );
+    }
+}

--- a/backend/src/api/handlers/mod.rs
+++ b/backend/src/api/handlers/mod.rs
@@ -202,6 +202,7 @@ pub fn escape_path_prefix(components: &[&str]) -> String {
 }
 
 pub mod error_helpers;
+pub mod metadata_epoch;
 
 #[cfg(test)]
 pub(crate) mod test_db_helpers;

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -8,8 +8,8 @@
 //!   GET  /rpm/{repo_key}/repodata/filelists.xml.gz  - File lists (stub)
 //!   GET  /rpm/{repo_key}/repodata/other.xml.gz      - Other metadata (stub)
 //!   GET  /rpm/{repo_key}/repodata/updateinfo.xml.gz - Update advisories (stub)
-//!   GET  /rpm/{repo_key}/repodata/repomd.xml.asc    - Detached GPG signature
-//!   GET  /rpm/{repo_key}/repodata/repomd.xml.key    - Public key (PEM)
+//!   GET  /rpm/{repo_key}/repodata/repomd.xml.asc    - Detached OpenPGP signature
+//!   GET  /rpm/{repo_key}/repodata/repomd.xml.key    - OpenPGP public key
 //!   GET  /rpm/{repo_key}/packages/*path              - Download RPM package
 //!   PUT  /rpm/{repo_key}/packages/*path              - Upload RPM package
 //!   POST /rpm/{repo_key}/upload                      - Upload RPM (alternative)
@@ -22,14 +22,14 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post, put};
 use axum::Extension;
 use axum::Router;
-use base64::Engine;
 use bytes::Bytes;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use sha2::{Digest, Sha256};
 use std::io::Write;
-use tracing::info;
+use tracing::{error, info};
 
+use crate::api::handlers::error_helpers::require_signing_key;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
@@ -438,37 +438,43 @@ async fn repomd_xml_asc(
     let repomd_content = generate_repomd_xml_content(&artifacts);
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
-    let signature = signing_svc
-        .sign_data(repo.id, repomd_content.as_bytes())
+    // #2636: this endpoint must emit a real detached OpenPGP signature — the
+    // same thing Debian's Release.gpg serves — because that is the only form
+    // `dnf` (repo_gpgcheck=1) and `rpm --import` can verify. It previously
+    // signed via `SigningService::sign_data()`, which returns raw PKCS#1 v1.5
+    // bytes, and hand-wrapped them in "BEGIN PGP SIGNATURE" markers: no packet
+    // framing and no CRC24 armor checksum, so every real client rejected it.
+    let key = require_signing_key(signing_svc.get_active_key_for_repo(repo.id).await)?;
+    let armored = signing_svc
+        .sign_openpgp_detached_with_key(&key, repomd_content.as_bytes())
         .await
-        .unwrap_or(None);
-
-    match signature {
-        Some(sig_bytes) => {
-            let b64 = base64::engine::general_purpose::STANDARD.encode(&sig_bytes);
-            // Wrap base64 at 76 characters per line (PGP armor convention)
-            let wrapped: Vec<&str> = b64
-                .as_bytes()
-                .chunks(76)
-                .map(|c| std::str::from_utf8(c).unwrap_or(""))
-                .collect();
-            let armored = format!(
-                "-----BEGIN PGP SIGNATURE-----\n\n{}\n-----END PGP SIGNATURE-----\n",
-                wrapped.join("\n"),
+        .map_err(|e| {
+            // A key that cannot sign is a server-side failure, not a missing
+            // configuration. Log it and return it: the previous
+            // `.unwrap_or(None)` collapsed this into a 404 "No signing key
+            // configured" while repomd.xml.key was serving that very key.
+            error!(
+                repo_id = %repo.id,
+                key_id = %key.id,
+                error = %e,
+                "failed to sign repomd.xml with the repository's active signing key",
             );
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to sign repomd.xml: {}", e),
+            )
+                .into_response()
+        })?;
+    // Best-effort `last_used_at` stamp; the signature already succeeded, so an
+    // audit-update error must not fail the request.
+    let _ = signing_svc.mark_key_used(key.id).await;
 
-            Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(CONTENT_TYPE, "application/pgp-signature")
-                .body(Body::from(armored))
-                .unwrap())
-        }
-        None => Err((
-            StatusCode::NOT_FOUND,
-            "No signing key configured for this repository",
-        )
-            .into_response()),
-    }
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/pgp-signature")
+        .header(CONTENT_LENGTH, armored.len().to_string())
+        .body(Body::from(armored))
+        .unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -482,23 +488,19 @@ async fn repomd_xml_key(
     let repo = resolve_rpm_repo(&state.db, &repo_key).await?;
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
-    let public_key = signing_svc
-        .get_repo_public_key(repo.id)
-        .await
-        .unwrap_or(None);
+    // #2636: `dnf`'s `gpgkey=` and `rpm --import` both require an OpenPGP
+    // public key. The active key's stored `public_key_pem` is that armored
+    // OpenPGP block for `key_type=gpg` keys — the same material Debian's
+    // gpg-key.asc serves. A lookup error is surfaced rather than swallowed, so
+    // "cannot load the key" is never reported as "no key configured".
+    let key = require_signing_key(signing_svc.get_active_key_for_repo(repo.id).await)?;
 
-    match public_key {
-        Some(pem) => Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "application/x-pem-file")
-            .body(Body::from(pem))
-            .unwrap()),
-        None => Err((
-            StatusCode::NOT_FOUND,
-            "No signing key configured for this repository",
-        )
-            .into_response()),
-    }
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, "application/pgp-keys")
+        .header(CONTENT_LENGTH, key.public_key_pem.len().to_string())
+        .body(Body::from(key.public_key_pem))
+        .unwrap())
 }
 
 // ---------------------------------------------------------------------------
@@ -1242,19 +1244,9 @@ fn xml_escape(s: &str) -> String {
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+    use pgp::composed::{Deserializable, SignedPublicKey, StandaloneSignature};
 
-    /// Wrap a base64-encoded signature in PGP armor format.
-    fn pgp_armor_signature(b64: &str) -> String {
-        let wrapped: Vec<&str> = b64
-            .as_bytes()
-            .chunks(76)
-            .map(|c| std::str::from_utf8(c).unwrap_or(""))
-            .collect();
-        format!(
-            "-----BEGIN PGP SIGNATURE-----\n\n{}\n-----END PGP SIGNATURE-----\n",
-            wrapped.join("\n"),
-        )
-    }
+    use crate::services::signing_service::{verify_detached, CreateKeyRequest};
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (test-only)
@@ -1699,47 +1691,6 @@ mod tests {
             extract_rpm_filename(&headers, "hash1234567890123456"),
             "quoted.rpm"
         );
-    }
-
-    // -----------------------------------------------------------------------
-    // pgp_armor_signature
-    // -----------------------------------------------------------------------
-
-    #[test]
-    fn test_pgp_armor_signature_basic() {
-        let armored = pgp_armor_signature("dGVzdA==");
-        assert!(armored.starts_with("-----BEGIN PGP SIGNATURE-----"));
-        assert!(armored.ends_with("-----END PGP SIGNATURE-----\n"));
-        assert!(armored.contains("dGVzdA=="));
-    }
-
-    #[test]
-    fn test_pgp_armor_signature_wrapping() {
-        // Create a long base64 string that exceeds 76 chars
-        let long_b64 = "A".repeat(200);
-        let armored = pgp_armor_signature(&long_b64);
-        // Each line in the body should be at most 76 characters
-        let body = armored
-            .strip_prefix("-----BEGIN PGP SIGNATURE-----\n\n")
-            .unwrap()
-            .strip_suffix("\n-----END PGP SIGNATURE-----\n")
-            .unwrap();
-        for line in body.lines() {
-            assert!(line.len() <= 76, "Line exceeds 76 chars: {}", line);
-        }
-    }
-
-    #[test]
-    fn test_pgp_armor_signature_empty() {
-        let armored = pgp_armor_signature("");
-        assert!(armored.contains("-----BEGIN PGP SIGNATURE-----"));
-        assert!(armored.contains("-----END PGP SIGNATURE-----"));
-    }
-
-    #[test]
-    fn test_pgp_armor_signature_short() {
-        let armored = pgp_armor_signature("YQ==");
-        assert!(armored.contains("YQ=="));
     }
 
     // -----------------------------------------------------------------------
@@ -2767,5 +2718,225 @@ mod tests {
             .await
             .ok();
         f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // repomd.xml.asc / repomd.xml.key — the OpenPGP contract (#2636)
+    //
+    // These replace the former `pgp_armor_signature` tests, which asserted the
+    // shape of hand-rolled "BEGIN PGP SIGNATURE" markers wrapped around raw
+    // base64 PKCS#1 bytes. Those tests passed against output no OpenPGP client
+    // could parse: they pinned the bug. What matters is not that the markers
+    // are present, but that the bytes between them are a real OpenPGP
+    // signature packet that verifies against the key the repo advertises.
+    // -----------------------------------------------------------------------
+
+    /// Mint a signing key of `key_type` and attach it to the fixture repo for
+    /// metadata signing. Returns the armored public key the repo will serve.
+    async fn attach_signing_key(f: &tdh::Fixture, key_type: &str) -> String {
+        let svc = SigningService::new(f.pool.clone(), &f.state.config.jwt_secret);
+        let key = svc
+            .create_key(CreateKeyRequest {
+                repository_id: Some(f.repo_id),
+                name: format!("rpm-sign-{}", f.repo_key),
+                key_type: key_type.to_string(),
+                algorithm: "rsa2048".to_string(),
+                uid_name: Some("AK RPM".to_string()),
+                uid_email: Some("rpm@example.com".to_string()),
+                created_by: None,
+            })
+            .await
+            .expect("create signing key");
+        svc.update_signing_config(f.repo_id, Some(key.id), true, false, false)
+            .await
+            .expect("attach signing key");
+        key.public_key_pem
+    }
+
+    async fn get_repodata(f: &tdh::Fixture, file: &str) -> (StatusCode, Bytes) {
+        tdh::send(
+            f.router_anon(super::router()),
+            tdh::get(format!("/{}/repodata/{}", f.repo_key, file)),
+        )
+        .await
+    }
+
+    /// The end-to-end contract `dnf repo_gpgcheck=1` enforces: the signature
+    /// served at repodata/repomd.xml.asc must be real, CRC24-armored OpenPGP
+    /// that verifies over the exact repomd.xml bytes under the key served at
+    /// repodata/repomd.xml.key.
+    ///
+    /// Before #2636 this endpoint returned raw PKCS#1 RSA bytes base64'd
+    /// inside hand-rolled "BEGIN PGP SIGNATURE" markers — no packet framing,
+    /// no CRC24 — and the key endpoint served an X.509 SPKI PEM.
+    #[tokio::test]
+    async fn test_repomd_asc_is_verifiable_openpgp_against_advertised_key() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        attach_signing_key(&f, "gpg").await;
+
+        let (xml_status, repomd) = get_repodata(&f, "repomd.xml").await;
+        let (asc_status, asc) = get_repodata(&f, "repomd.xml.asc").await;
+        let (key_status, pubkey) = get_repodata(&f, "repomd.xml.key").await;
+        assert_eq!(xml_status, StatusCode::OK);
+        assert_eq!(
+            asc_status,
+            StatusCode::OK,
+            "asc: {}",
+            String::from_utf8_lossy(&asc)
+        );
+        assert_eq!(key_status, StatusCode::OK);
+
+        let asc = String::from_utf8(asc.to_vec()).expect("asc must be ASCII armor");
+        let pubkey = String::from_utf8(pubkey.to_vec()).expect("key must be ASCII armor");
+
+        assert!(asc.starts_with("-----BEGIN PGP SIGNATURE-----"));
+        assert!(asc.trim_end().ends_with("-----END PGP SIGNATURE-----"));
+        // Real armor carries a CRC24 checksum line ("=XXXX") before END; its
+        // absence is what made gpg report "invalid packet (ctb=37)".
+        assert!(
+            asc.lines().any(|l| l.len() == 5 && l.starts_with('=')),
+            "armor must carry a CRC24 checksum line; got:\n{}",
+            asc
+        );
+        // Decisive: a parseable signature packet that verifies over the served
+        // metadata under the advertised key — exactly what dnf and gpg do.
+        StandaloneSignature::from_string(&asc)
+            .expect("armor must parse as an OpenPGP signature packet");
+        verify_detached(&pubkey, &repomd, &asc)
+            .expect("the served signature must verify against the advertised key");
+
+        f.teardown().await;
+    }
+
+    /// The served signature must not verify over metadata it did not sign.
+    #[tokio::test]
+    async fn test_repomd_asc_rejects_tampered_metadata() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        attach_signing_key(&f, "gpg").await;
+
+        let (_, repomd) = get_repodata(&f, "repomd.xml").await;
+        let (_, asc) = get_repodata(&f, "repomd.xml.asc").await;
+        let (_, pubkey) = get_repodata(&f, "repomd.xml.key").await;
+        let asc = String::from_utf8(asc.to_vec()).unwrap();
+        let pubkey = String::from_utf8(pubkey.to_vec()).unwrap();
+
+        let tampered = String::from_utf8(repomd.to_vec())
+            .unwrap()
+            .replace("</repomd>", "<data type=\"evil\"></data></repomd>");
+        assert!(
+            verify_detached(&pubkey, tampered.as_bytes(), &asc).is_err(),
+            "a tampered repomd.xml must fail signature verification"
+        );
+
+        f.teardown().await;
+    }
+
+    /// repodata/repomd.xml.key must serve an importable OpenPGP public key.
+    /// `dnf`'s `gpgkey=` and `rpm --import` reject an X.509 SPKI PEM
+    /// ("no valid OpenPGP data found").
+    #[tokio::test]
+    async fn test_repomd_key_serves_importable_openpgp_key() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        attach_signing_key(&f, "gpg").await;
+
+        let (status, body) = get_repodata(&f, "repomd.xml.key").await;
+        assert_eq!(status, StatusCode::OK);
+        let pubkey = String::from_utf8(body.to_vec()).unwrap();
+
+        assert!(
+            pubkey.starts_with("-----BEGIN PGP PUBLIC KEY BLOCK-----"),
+            "must be an OpenPGP key block, got: {}",
+            pubkey.lines().next().unwrap_or("")
+        );
+        assert!(
+            !pubkey.contains("BEGIN PUBLIC KEY"),
+            "must not be an X.509 SubjectPublicKeyInfo PEM"
+        );
+        let (parsed, _) = SignedPublicKey::from_string(&pubkey).expect("key must parse as OpenPGP");
+        parsed.verify().expect("advertised key must self-verify");
+
+        f.teardown().await;
+    }
+
+    /// **The regression guard that matters (#2636).**
+    ///
+    /// A key that cannot produce an OpenPGP signature must surface a real,
+    /// logged 500 — never a 404 "No signing key configured for this
+    /// repository" while repomd.xml.key serves that very key.
+    ///
+    /// The old path was `sign_data(..).await.unwrap_or(None)`: the `Err`
+    /// collapsed into `None`, and the resulting misleading 404 is why this
+    /// stayed invisible. An X.509 (`key_type=rsa`) key reproduces that load
+    /// failure, since OpenPGP signing requires `key_type=gpg`.
+    #[tokio::test]
+    async fn test_unusable_signing_key_is_a_loud_500_not_a_misleading_404() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        attach_signing_key(&f, "rsa").await;
+
+        let (key_status, _) = get_repodata(&f, "repomd.xml.key").await;
+        let (asc_status, body) = get_repodata(&f, "repomd.xml.asc").await;
+
+        assert_eq!(
+            key_status,
+            StatusCode::OK,
+            "the repo advertises a key, so the signing failure below must not be reported as 'not configured'",
+        );
+        assert_eq!(
+            asc_status,
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a signing failure must not be swallowed into 404 'No signing key configured'",
+        );
+        let body = String::from_utf8_lossy(&body);
+        assert!(
+            body.contains("Failed to sign repomd.xml"),
+            "the response must carry the real cause, got: {}",
+            body
+        );
+
+        f.teardown().await;
+    }
+
+    /// A repo with genuinely no signing key still 404s: the 500 above is a
+    /// signing *failure*, not a missing configuration. Keeps the two distinct.
+    #[tokio::test]
+    async fn test_repo_without_signing_key_still_404s() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+
+        let (asc_status, _) = get_repodata(&f, "repomd.xml.asc").await;
+        let (key_status, _) = get_repodata(&f, "repomd.xml.key").await;
+        assert_eq!(asc_status, StatusCode::NOT_FOUND);
+        assert_eq!(key_status, StatusCode::NOT_FOUND);
+
+        f.teardown().await;
+    }
+
+    /// The 404-vs-500 decision itself, as a pure mapping (#2636). A *missing*
+    /// key is a client-visible 404; a key that fails to load is a loud 500
+    /// carrying the real error. Collapsing the second into the first is the
+    /// bug class this guards.
+    #[test]
+    fn test_require_signing_key_separates_missing_from_broken() {
+        let missing = require_signing_key(Ok(None)).expect_err("None must be an error response");
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+
+        let broken = require_signing_key(Err(crate::error::AppError::Internal(
+            "Failed to parse OpenPGP private key".to_string(),
+        )))
+        .expect_err("Err must be an error response");
+        assert_eq!(
+            broken.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "a key-load failure must be a loud 500, never a 404 'not configured'"
+        );
     }
 }

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -27,9 +27,10 @@ use flate2::write::GzEncoder;
 use flate2::Compression;
 use sha2::{Digest, Sha256};
 use std::io::Write;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use crate::api::handlers::error_helpers::require_signing_key;
+use crate::api::handlers::error_helpers::{require_openpgp_capable_key, require_signing_key};
+use crate::api::handlers::metadata_epoch::metadata_epoch;
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
@@ -228,8 +229,22 @@ struct RpmArtifact {
     checksum_sha256: String,
     storage_key: String,
     metadata: Option<serde_json::Value>,
+    /// Drives the repodata metadata epoch (`<revision>`/`<timestamp>`) so the
+    /// render stays a pure function of repository state (#2636).
+    updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// List a repository's RPM artifacts in a **deterministic total order**.
+///
+/// The order is part of the repodata contract, not a display choice: it fixes
+/// the package order in `primary.xml`/`filelists.xml`, hence their checksums,
+/// hence the `repomd.xml` bytes that `repomd.xml.asc` signs. The previous
+/// `ORDER BY a.created_at DESC` was not a *total* order — artifacts sharing a
+/// `created_at` (a bulk upload commits many rows with the same `NOW()`) could
+/// come back in either order, so two renders of unchanged state could differ
+/// and the detached signature would not match the served document (#2636).
+/// `(name, version, path)` is the order Debian's package index already uses;
+/// `id` is unique, so appending it makes the order total.
 async fn list_rpm_artifacts(
     db: &sqlx::PgPool,
     repo_id: uuid::Uuid,
@@ -237,11 +252,11 @@ async fn list_rpm_artifacts(
     let rows = sqlx::query!(
         r#"
         SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,
-               a.storage_key, am.metadata as "metadata?"
+               a.storage_key, a.updated_at, am.metadata as "metadata?"
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
         WHERE a.repository_id = $1 AND a.is_deleted = false
-        ORDER BY a.created_at DESC
+        ORDER BY a.name, a.version, a.path, a.id
         "#,
         repo_id
     )
@@ -260,6 +275,7 @@ async fn list_rpm_artifacts(
             checksum_sha256: r.checksum_sha256,
             storage_key: r.storage_key,
             metadata: r.metadata,
+            updated_at: r.updated_at,
         })
         .collect())
 }
@@ -272,6 +288,13 @@ async fn list_rpm_artifacts(
 /// `packages="0"` and `dnf` treats the aggregate repo as empty even though
 /// the members hold packages (#1780). We resolve the member repo IDs via
 /// `fetch_virtual_members` and concatenate each member's artifact list.
+///
+/// The result is sorted into the same deterministic total order
+/// `list_rpm_artifacts` returns. Concatenating per-member lists inherits
+/// `fetch_virtual_members`' `ORDER BY vrm.priority`, which is not a total
+/// order — members sharing a priority can be visited in either order — so the
+/// merged list needed its own ordering for the render (and therefore the
+/// detached signature) to be reproducible (#2636).
 async fn collect_repodata_artifacts(
     db: &sqlx::PgPool,
     repo: &RepoInfo,
@@ -285,6 +308,9 @@ async fn collect_repodata_artifacts(
     for member in &members {
         artifacts.extend(list_rpm_artifacts(db, member.id).await?);
     }
+    artifacts.sort_by(|a, b| {
+        (&a.name, &a.version, &a.path, &a.id).cmp(&(&b.name, &b.version, &b.path, &b.id))
+    });
     Ok(artifacts)
 }
 
@@ -321,10 +347,15 @@ fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
     let updateinfo_gz = gzip_bytes(updateinfo_xml.as_bytes());
     let updateinfo_sha256 = sha256_hex(&updateinfo_gz);
 
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    // #2636: the metadata epoch is derived from repository *state*, never from
+    // the clock. `repomd.xml` and `repomd.xml.asc` render this document
+    // independently, one request apart, and the client verifies the signature
+    // from the second render against the bytes of the first. A `now()` here
+    // makes those two renders disagree whenever the requests straddle a second
+    // boundary — a BAD signature on a repo nobody touched. See the
+    // `metadata_epoch` module docs; Debian's `Release`/`Release.gpg` pair has
+    // the same defect (#2652).
+    let timestamp = metadata_epoch(artifacts.iter().map(|a| a.updated_at)).timestamp();
 
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -445,6 +476,19 @@ async fn repomd_xml_asc(
     // bytes, and hand-wrapped them in "BEGIN PGP SIGNATURE" markers: no packet
     // framing and no CRC24 armor checksum, so every real client rejected it.
     let key = require_signing_key(signing_svc.get_active_key_for_repo(repo.id).await)?;
+    // An X.509 (`key_type=rsa`) key can never sign OpenPGP, so refuse before
+    // attempting it: 409 + WARN, not 500 + ERROR. This route is anonymous, so
+    // every `dnf` poll of a misconfigured repo lands here; a 500 would let an
+    // unauthenticated client drive unbounded ERROR logs and 500-rate alerts for
+    // what is an operator config mistake, not a server fault.
+    let key = require_openpgp_capable_key(key).map_err(|resp| {
+        warn!(
+            repo_id = %repo.id,
+            "repomd.xml.asc requested but the repository's active signing key cannot \
+             produce an OpenPGP signature (requires key_type='gpg')",
+        );
+        resp
+    })?;
     let armored = signing_svc
         .sign_openpgp_detached_with_key(&key, repomd_content.as_bytes())
         .await
@@ -494,6 +538,20 @@ async fn repomd_xml_key(
     // gpg-key.asc serves. A lookup error is surfaced rather than swallowed, so
     // "cannot load the key" is never reported as "no key configured".
     let key = require_signing_key(signing_svc.get_active_key_for_repo(repo.id).await)?;
+    // For any other key type `public_key_pem` is an X.509 SPKI PEM: not
+    // importable by `rpm --import`, and useless to `dnf gpgkey=` even if it
+    // were served honestly as `application/x-pem-file`, because the matching
+    // `.asc` can never exist. Refusing here keeps the repo from advertising a
+    // key it cannot sign with, and means the `application/pgp-keys` below is
+    // always the truth rather than a claim about the bytes.
+    let key = require_openpgp_capable_key(key).map_err(|resp| {
+        warn!(
+            repo_id = %repo.id,
+            "repomd.xml.key requested but the repository's active signing key is not an \
+             OpenPGP key (requires key_type='gpg')",
+        );
+        resp
+    })?;
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -1697,6 +1755,14 @@ mod tests {
     // XML generation helpers
     // -----------------------------------------------------------------------
 
+    /// A fixed `updated_at` for artifact fixtures. Deliberately a constant and
+    /// never `Utc::now()`: the repodata render must be a pure function of
+    /// repository state, so a fixture that carried a clock reading would let
+    /// the very bug these tests pin (#2636) slip back in unnoticed.
+    fn test_updated_at() -> chrono::DateTime<chrono::Utc> {
+        chrono::TimeZone::timestamp_opt(&chrono::Utc, 1_700_000_000, 0).unwrap()
+    }
+
     #[test]
     fn test_generate_primary_xml_empty() {
         let xml = generate_primary_xml(&[]);
@@ -1715,6 +1781,7 @@ mod tests {
             size_bytes: 1024,
             checksum_sha256: "abc123".to_string(),
             storage_key: "rpm/1/test-1.0-1.x86_64.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: Some(serde_json::json!({
                 "name": "test",
                 "version": "1.0",
@@ -1740,6 +1807,7 @@ mod tests {
             size_bytes: 512,
             checksum_sha256: "def456".to_string(),
             storage_key: "rpm/1/test.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: Some(serde_json::json!({
                 "name": "test<pkg>",
                 "version": "1.0",
@@ -1763,6 +1831,7 @@ mod tests {
             size_bytes: 1024,
             checksum_sha256: "abc123".to_string(),
             storage_key: "rpm/1/hello.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: None,
         }];
         let xml = generate_primary_xml(&artifacts);
@@ -1782,6 +1851,7 @@ mod tests {
             size_bytes: 1024,
             checksum_sha256: "abc123".to_string(),
             storage_key: "rpm/1/hello.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: None,
         }];
         let xml = generate_primary_xml(&artifacts);
@@ -1803,6 +1873,7 @@ mod tests {
             size_bytes: 1024,
             checksum_sha256: "abc123".to_string(),
             storage_key: "rpm/1/hello.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: None,
         }];
         let xml = generate_primary_xml(&artifacts);
@@ -1827,6 +1898,7 @@ mod tests {
             size_bytes: 1024,
             checksum_sha256: "abc123".to_string(),
             storage_key: "rpm/1/weird.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: None,
         }];
         let xml = generate_primary_xml(&artifacts);
@@ -1853,6 +1925,7 @@ mod tests {
             size_bytes: 256,
             checksum_sha256: "sha256hash".to_string(),
             storage_key: "rpm/1/hello.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: Some(serde_json::json!({
                 "name": "hello",
                 "version": "1.0",
@@ -1883,6 +1956,7 @@ mod tests {
             size_bytes: 4096,
             checksum_sha256: "otherhash".to_string(),
             storage_key: "rpm/1/util.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: Some(serde_json::json!({
                 "name": "util",
                 "version": "2.0",
@@ -1934,6 +2008,7 @@ mod tests {
             size_bytes: 2048,
             checksum_sha256: "fallbackhash".to_string(),
             storage_key: "rpm/1/curl.rpm".to_string(),
+            updated_at: test_updated_at(),
             metadata: None,
         }];
         let xml = generate_primary_xml(&artifacts);
@@ -2581,6 +2656,78 @@ mod tests {
         );
     }
 
+    /// **The determinism gate (#2636).**
+    ///
+    /// `repomd.xml` and `repomd.xml.asc` render this document independently,
+    /// one request apart, and the client verifies the second render's
+    /// signature against the first render's bytes. So the render must depend
+    /// on repository state and nothing else — above all, not on the clock.
+    ///
+    /// The `sleep` is the whole point: this stamped `SystemTime::now()` into
+    /// `<revision>` and every `<data><timestamp>`, so back-to-back renders
+    /// agreed ~99.9% of the time and *looked* fine. Crossing a second boundary
+    /// is what exposes it — and is exactly what a real `dnf` run does between
+    /// fetching the two URLs.
+    #[test]
+    fn test_repomd_render_is_byte_identical_over_unchanged_state() {
+        let artifacts = vec![RpmArtifact {
+            id: uuid::Uuid::new_v4(),
+            path: "packages/det-1.0-1.x86_64.rpm".to_string(),
+            name: "det".to_string(),
+            version: Some("1.0-1".to_string()),
+            size_bytes: 4096,
+            checksum_sha256: "feed".to_string(),
+            storage_key: "rpm/det.rpm".to_string(),
+            metadata: None,
+            updated_at: test_updated_at(),
+        }];
+
+        let first = generate_repomd_xml_content(&artifacts);
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        let second = generate_repomd_xml_content(&artifacts);
+
+        assert_eq!(
+            first, second,
+            "unchanged repository state must render byte-identical repomd.xml across a \
+             second boundary; a wall-clock read in the render makes repomd.xml.asc sign \
+             different bytes than repomd.xml serves",
+        );
+    }
+
+    /// The epoch must come from repository state, not the clock: it equals the
+    /// newest artifact's `updated_at`, and an empty repo pins to 0.
+    #[test]
+    fn test_repomd_revision_is_the_repo_state_epoch() {
+        let mk = |secs: i64| RpmArtifact {
+            id: uuid::Uuid::new_v4(),
+            path: format!("packages/p-{secs}.rpm"),
+            name: format!("p{secs}"),
+            version: Some("1.0-1".to_string()),
+            size_bytes: 1,
+            checksum_sha256: "aa".to_string(),
+            storage_key: format!("rpm/p-{secs}.rpm"),
+            metadata: None,
+            updated_at: chrono::TimeZone::timestamp_opt(&chrono::Utc, secs, 0).unwrap(),
+        };
+
+        let xml = generate_repomd_xml_content(&[mk(1_600_000_000), mk(1_700_000_000)]);
+        assert!(
+            xml.contains("<revision>1700000000</revision>"),
+            "<revision> must be the most recent artifact updated_at: {xml}"
+        );
+        assert_eq!(
+            xml.matches("<timestamp>1700000000</timestamp>").count(),
+            4,
+            "every <data><timestamp> must carry the repo-state epoch: {xml}"
+        );
+
+        let empty = generate_repomd_xml_content(&[]);
+        assert!(
+            empty.contains("<revision>0</revision>"),
+            "an empty repo has no state to date, and must not fall back to now(): {empty}"
+        );
+    }
+
     #[test]
     fn test_generate_repomd_open_checksum_matches_uncompressed_primary() {
         // The primary <open-checksum> must equal sha256 of the *uncompressed*
@@ -2761,6 +2908,32 @@ mod tests {
         .await
     }
 
+    /// Give the repo a package, so the metadata epoch is derived from real
+    /// repository state rather than the empty-repo fallback.
+    async fn insert_rpm_artifact(f: &tdh::Fixture, name: &str) {
+        sqlx::query!(
+            r#"
+            INSERT INTO artifacts (
+                repository_id, path, name, version, size_bytes,
+                checksum_sha256, content_type, storage_key, uploaded_by
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+            "#,
+            f.repo_id,
+            format!("packages/{}-1.0-1.x86_64.rpm", name),
+            name,
+            "1.0-1",
+            1024i64,
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            "application/x-rpm",
+            format!("rpm/{}/{}-1.0-1.x86_64.rpm", f.repo_key, name),
+            f.user_id,
+        )
+        .execute(&f.pool)
+        .await
+        .expect("insert rpm artifact");
+    }
+
     /// The end-to-end contract `dnf repo_gpgcheck=1` enforces: the signature
     /// served at repodata/repomd.xml.asc must be real, CRC24-armored OpenPGP
     /// that verifies over the exact repomd.xml bytes under the key served at
@@ -2806,6 +2979,77 @@ mod tests {
             .expect("armor must parse as an OpenPGP signature packet");
         verify_detached(&pubkey, &repomd, &asc)
             .expect("the served signature must verify against the advertised key");
+
+        f.teardown().await;
+    }
+
+    /// **The cross-request determinism gate (#2636).**
+    ///
+    /// A real `dnf` run fetches `repomd.xml` and `repomd.xml.asc` as two
+    /// separate requests, and verifies the signature from the second against
+    /// the bytes of the first. The two handlers render the document
+    /// independently, so anything clock-derived in the render makes them
+    /// disagree whenever the fetches straddle a second boundary — `BAD
+    /// signature` on a repo nobody touched, at roughly `gap / 1s` probability.
+    /// dnf's metadata cache makes it worse: a `repomd.xml` retained from an
+    /// earlier run can never match a freshly stamped signature.
+    ///
+    /// `test_repomd_asc_is_verifiable_openpgp_against_advertised_key` models
+    /// the same contract but fetches back-to-back in well under a millisecond,
+    /// so it passed ~99.9% of the time even while this was broken — a latent
+    /// flake, not a gate. The sleep is what turns it into one.
+    #[tokio::test]
+    async fn test_repomd_asc_verifies_against_a_repomd_fetched_a_second_earlier() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        attach_signing_key(&f, "gpg").await;
+        insert_rpm_artifact(&f, "delayed").await;
+
+        let (xml_status, repomd) = get_repodata(&f, "repomd.xml").await;
+        assert_eq!(xml_status, StatusCode::OK);
+
+        // Straddle a second boundary, as any real client trivially does.
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+        let (asc_status, asc) = get_repodata(&f, "repomd.xml.asc").await;
+        let (key_status, pubkey) = get_repodata(&f, "repomd.xml.key").await;
+        assert_eq!(asc_status, StatusCode::OK);
+        assert_eq!(key_status, StatusCode::OK);
+
+        let asc = String::from_utf8(asc.to_vec()).expect("asc must be ASCII armor");
+        let pubkey = String::from_utf8(pubkey.to_vec()).expect("key must be ASCII armor");
+
+        verify_detached(&pubkey, &repomd, &asc).expect(
+            "repomd.xml.asc must verify over the repomd.xml served a second earlier: the \
+             signature must cover repository state, not the time the request arrived",
+        );
+
+        f.teardown().await;
+    }
+
+    /// The same repository state must serve byte-identical `repomd.xml` no
+    /// matter when it is asked for — through the real route, over a second
+    /// boundary. This is what makes the metadata cacheable and reproducible,
+    /// and what lets a cached `repomd.xml` still match a later signature.
+    #[tokio::test]
+    async fn test_repomd_xml_route_is_byte_stable_over_time() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        insert_rpm_artifact(&f, "stable").await;
+
+        let (_, first) = get_repodata(&f, "repomd.xml").await;
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        let (_, second) = get_repodata(&f, "repomd.xml").await;
+
+        assert_eq!(
+            first,
+            second,
+            "unchanged repo state must serve identical repomd.xml bytes; got:\n{}\n---\n{}",
+            String::from_utf8_lossy(&first),
+            String::from_utf8_lossy(&second),
+        );
 
         f.teardown().await;
     }
@@ -2866,39 +3110,85 @@ mod tests {
 
     /// **The regression guard that matters (#2636).**
     ///
-    /// A key that cannot produce an OpenPGP signature must surface a real,
-    /// logged 500 — never a 404 "No signing key configured for this
-    /// repository" while repomd.xml.key serves that very key.
+    /// A key that claims `key_type=gpg` but whose stored material will not
+    /// parse as an OpenPGP secret key (a legacy PEM key predating OpenPGP
+    /// support) is a genuine server-side fault: it must surface a real, logged
+    /// 500 carrying the cause — never a 404 "No signing key configured for
+    /// this repository" while `repomd.xml.key` serves that very key.
     ///
     /// The old path was `sign_data(..).await.unwrap_or(None)`: the `Err`
     /// collapsed into `None`, and the resulting misleading 404 is why this
-    /// stayed invisible. An X.509 (`key_type=rsa`) key reproduces that load
-    /// failure, since OpenPGP signing requires `key_type=gpg`.
+    /// stayed invisible. Storing X.509 material under `key_type=gpg`
+    /// reproduces that load failure past the key-type gate.
     #[tokio::test]
-    async fn test_unusable_signing_key_is_a_loud_500_not_a_misleading_404() {
+    async fn test_unloadable_signing_key_is_a_loud_500_not_a_misleading_404() {
         let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
             return;
         };
         attach_signing_key(&f, "rsa").await;
+        // Present X.509 material as an OpenPGP key: the key type now claims it
+        // can sign, so the failure happens where the material is parsed.
+        sqlx::query!(
+            "UPDATE signing_keys SET key_type = 'gpg' WHERE repository_id = $1",
+            f.repo_id
+        )
+        .execute(&f.pool)
+        .await
+        .expect("force key_type=gpg");
 
-        let (key_status, _) = get_repodata(&f, "repomd.xml.key").await;
         let (asc_status, body) = get_repodata(&f, "repomd.xml.asc").await;
 
         assert_eq!(
-            key_status,
-            StatusCode::OK,
-            "the repo advertises a key, so the signing failure below must not be reported as 'not configured'",
-        );
-        assert_eq!(
             asc_status,
             StatusCode::INTERNAL_SERVER_ERROR,
-            "a signing failure must not be swallowed into 404 'No signing key configured'",
+            "a key that cannot be loaded is a server fault, and must not be swallowed \
+             into 404 'No signing key configured'",
         );
         let body = String::from_utf8_lossy(&body);
         assert!(
             body.contains("Failed to sign repomd.xml"),
             "the response must carry the real cause, got: {}",
             body
+        );
+
+        f.teardown().await;
+    }
+
+    /// An `rsa` key — the *default* `key_type` — cannot produce an OpenPGP
+    /// chain, so both signing endpoints refuse with **409 Conflict**: the
+    /// repository's signing config conflicts with what these endpoints must
+    /// serve. Distinctly not 404 (the repo *does* advertise a key) and
+    /// distinctly not 500 (nothing is broken server-side).
+    ///
+    /// The status is load-bearing: these routes are anonymous, so every `dnf`
+    /// poll of a misconfigured repo lands here. A 500 would let an
+    /// unauthenticated client drive unbounded ERROR logs and 500-rate alerts —
+    /// paging an on-call engineer for an operator config mistake.
+    #[tokio::test]
+    async fn test_rsa_key_is_a_409_conflict_on_both_signing_endpoints() {
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        attach_signing_key(&f, "rsa").await;
+
+        let (asc_status, asc_body) = get_repodata(&f, "repomd.xml.asc").await;
+        let (key_status, _) = get_repodata(&f, "repomd.xml.key").await;
+
+        assert_eq!(
+            asc_status,
+            StatusCode::CONFLICT,
+            "an unsignable key type is a config conflict, not a server error",
+        );
+        assert_eq!(
+            key_status,
+            StatusCode::CONFLICT,
+            "the repo must not advertise a key it can never sign with",
+        );
+        let asc_body = String::from_utf8_lossy(&asc_body);
+        assert!(
+            asc_body.contains("key_type='gpg'"),
+            "the response must name the fix, got: {}",
+            asc_body
         );
 
         f.teardown().await;
@@ -2937,6 +3227,47 @@ mod tests {
             broken.status(),
             StatusCode::INTERNAL_SERVER_ERROR,
             "a key-load failure must be a loud 500, never a 404 'not configured'"
+        );
+    }
+
+    fn key_of_type(key_type: &str) -> crate::models::signing_key::SigningKey {
+        crate::models::signing_key::SigningKey {
+            id: uuid::Uuid::new_v4(),
+            repository_id: None,
+            name: "k".to_string(),
+            key_type: key_type.to_string(),
+            fingerprint: None,
+            key_id: None,
+            public_key_pem: String::new(),
+            private_key_enc: Vec::new(),
+            algorithm: "rsa2048".to_string(),
+            uid_name: None,
+            uid_email: None,
+            expires_at: None,
+            is_active: true,
+            created_at: test_updated_at(),
+            created_by: None,
+            rotated_from: None,
+            last_used_at: None,
+        }
+    }
+
+    /// The 409-vs-500 decision as a pure mapping (#2636): a key type that can
+    /// never sign OpenPGP is an operator config conflict, not a server fault.
+    #[test]
+    fn test_require_openpgp_capable_key_separates_conflict_from_capable() {
+        assert!(
+            require_openpgp_capable_key(key_of_type("gpg")).is_ok(),
+            "a gpg key must be accepted"
+        );
+
+        let conflict = require_openpgp_capable_key(key_of_type("rsa"))
+            .expect_err("an rsa key cannot produce an OpenPGP chain");
+        assert_eq!(
+            conflict.status(),
+            StatusCode::CONFLICT,
+            "an unsignable key type must be a 409 an anonymous client cannot turn into \
+             an ERROR-log/500-alert amplifier",
         );
     }
 }

--- a/backend/src/models/signing_key.rs
+++ b/backend/src/models/signing_key.rs
@@ -29,6 +29,22 @@ pub struct SigningKey {
     pub last_used_at: Option<DateTime<Utc>>,
 }
 
+impl SigningKey {
+    /// Whether this key can produce an OpenPGP chain — a detached signature
+    /// (`repomd.xml.asc`, `Release.gpg`) plus an importable public key that
+    /// `dnf`/`apt` will accept.
+    ///
+    /// Only `key_type = "gpg"` stores OpenPGP material. An `rsa` key — the
+    /// *default* type — stores an X.509 keypair, which cannot produce an
+    /// OpenPGP signature at all; `SigningService::load_openpgp_secret_key`
+    /// rejects it. Callers use this to refuse the operation up front, rather
+    /// than advertising a key the repository can never sign with (#2636,
+    /// #2651).
+    pub fn supports_openpgp(&self) -> bool {
+        self.key_type == "gpg"
+    }
+}
+
 /// Public view of a signing key (no private material).
 #[derive(Debug, Serialize, ToSchema)]
 pub struct SigningKeyPublic {


### PR DESCRIPTION
## Summary

RPM repodata signing produced output that no real client could verify. `dnf` with
`repo_gpgcheck=1` — the shipped, documented RPM trust path — refused **every** hosted
AK RPM repo, in every key configuration, so the RPM signing feature was non-functional
end to end. Both endpoints returned HTTP 200 with PGP-*looking* content, so the surface
appeared healthy.

This **fails closed** (`dnf` refuses rather than accepting a bad signature), so it is a
broken feature rather than a forgery vulnerability — but anyone relying on signed RPM
repositories had no working path.

**Root cause: `rpm.rs` called the wrong function.** `repomd_xml_asc()` signed via
`SigningService::sign_data()`, which returns raw PKCS#1 v1.5 signature bytes; the
handler base64'd those and hand-wrapped them in `-----BEGIN PGP SIGNATURE-----`
markers. That is not OpenPGP armor: no signature-packet framing, no CRC24 checksum
line. `repomd_xml_key()` served the stored `public_key_pem`, an X.509
SubjectPublicKeyInfo PEM for `key_type=rsa`. Debian already does this correctly via
`sign_openpgp_detached_with_key` in the **same** `SigningService`, using the `pgp`
crate that is already a dependency.

The `gpg` 404 was a **swallowed error**: `sign_data(..).await.unwrap_or(None)` collapsed
the OpenPGP-key parse failure into `None`, which the handler reported as "no signing key
configured" — while `repomd.xml.key` served that very key. That masking is why this
stayed invisible.

### Second defect, found in review: `.asc` signed a different document than `repomd.xml` served

Making the signature verifiable exposed a **pre-existing** defect that was previously
unobservable. `generate_repomd_xml_content` stamped `SystemTime::now()` into
`<revision>` and all four `<data><timestamp>` elements, and the two handlers each render
the document **independently, per request**:

* `repomd_xml()` renders at **T1** and serves those bytes
* `repomd_xml_asc()` renders its **own** copy at **T2** and signs *that*

The client verifies the T2 signature against the T1 body, so any pair of requests that
straddles a second boundary yields **BAD signature on an untampered, static repo**.
This PR is simply the first commit where the timestamp is a *functional* defect: before
it, the signature was unverifiable 100% of the time, so the mismatch could not be seen.

The fix derives the metadata epoch from **repository state** — `max(artifacts.updated_at)`
over exactly the rows being rendered — instead of the clock. Unchanged state now renders
byte-identical bytes, on every replica, forever. This is closer to what `createrepo`
emits, and it makes the metadata cacheable and reproducible. An empty repo pins to the
Unix epoch rather than falling back to `now()`.

Two further sources of per-render variance are closed, so the render is a pure function
of repository state rather than of the query plan:

* `ORDER BY a.created_at DESC` was **not a total order** — a bulk upload commits many
  rows with the same `NOW()`, and tied rows may come back in either order.
  Now `ORDER BY a.name, a.version, a.path, a.id` (the order Debian's index already uses;
  `id` is unique, making it total).
* The virtual-repo merge concatenated per-member lists in `fetch_virtual_members`'
  `ORDER BY vrm.priority`, which also ties. The merged list is now sorted explicitly.

`metadata_epoch` is deliberately a **shared** helper rather than RPM-local: Debian's
`Release`/`Release.gpg` pair has the identical defect (**#2652**) — one root cause, two
formats. Debian's fix can consume it unchanged (it needs the same epoch, formatted as
`Date:` instead of `<revision>`). Debian is **not** touched here; that is #2652's change.

## Changes

- `repomd.xml.asc` routes through `sign_openpgp_detached_with_key` — the same path
  Debian's `Release.gpg` uses — producing a real detached OpenPGP signature with proper
  packet framing and CRC24 armor.
- `repomd.xml.key` serves the active key's armored OpenPGP public key
  (`application/pgp-keys`), which is what `dnf`'s `gpgkey=` and `rpm --import` require.
- **`<revision>`/`<timestamp>` derive from repository state**, not `SystemTime::now()`,
  via the new shared `handlers::metadata_epoch` helper.
- **Repodata ordering is a deterministic total order**, so the render cannot vary with
  the query plan or with virtual-member priority ties.
- Signing failures surface: a key that claims `key_type=gpg` but whose material cannot
  be loaded is a logged `ERROR` plus a 500 carrying the real cause, never a misleading
  404. A genuinely absent key stays a 404.
- **An `rsa` key is refused with 409 Conflict + `WARN`** at both `repomd.xml.asc` and
  `repomd.xml.key`, via the shared `error_helpers::require_openpgp_capable_key`.
  `rsa` is the *default* `key_type` and holds X.509 material, so it can never produce an
  OpenPGP chain — that is an operator **config conflict**, not a server fault. The status
  is load-bearing because both routes are **anonymous**: a 500 let any unauthenticated
  client poll a misconfigured repo into unbounded `ERROR` logs and 500-rate alerts,
  paging an on-call engineer for a config mistake. Refusing at `.key` also stops the repo
  advertising a key it cannot sign with, and keeps the `application/pgp-keys`
  content-type honest rather than a claim about X.509 bytes (the old
  `application/x-pem-file` was honest but the key was still useless, since a matching
  `.asc` can never exist).

Deliberately **not** in scope: rejecting `key_type=rsa` for metadata signing at *config*
time is **#2651** (it touches the signing-config route shared with Debian).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

**The determinism gates (new).** Both use a real `sleep > 1s`, and **both fail on the
previous head of this branch**:

- `test_repomd_asc_verifies_against_a_repomd_fetched_a_second_earlier` — fetches
  `repomd.xml` through the real route, sleeps 1.1s, fetches `.asc` and `.key`, and
  verifies. This is what `dnf repo_gpgcheck=1` does.
- `test_repomd_render_is_byte_identical_over_unchanged_state` — two renders of unchanged
  state across a second boundary must be byte-identical.
- `test_repomd_xml_route_is_byte_stable_over_time` — the same, through the route.
- `test_repomd_revision_is_the_repo_state_epoch` — `<revision>` is the newest
  `updated_at`; an empty repo pins to `0`, never `now()`.
- `metadata_epoch` unit tests, including `test_metadata_epoch_is_stable_across_calls`.

The sleep is the entire point. The pre-existing
`test_repomd_asc_is_verifiable_openpgp_against_advertised_key` models the same contract
but fetches back-to-back in well under a millisecond, so it **passed 3/3 against the
broken code** — a latent flake, not a gate.

Other tests in `rpm.rs`, five DB-backed against the real routes:

- `test_repomd_asc_is_verifiable_openpgp_against_advertised_key` — the served `.asc`
  parses as an OpenPGP signature packet, carries a CRC24 line, and verifies over the
  exact served `repomd.xml` under the key served at `repomd.xml.key`.
- `test_repomd_asc_rejects_tampered_metadata` — guards against vacuous verification.
- `test_repomd_key_serves_importable_openpgp_key` — OpenPGP key block, self-verifies,
  and is not an X.509 SPKI PEM.
- `test_unloadable_signing_key_is_a_loud_500_not_a_misleading_404` — the swallow guard:
  a key claiming `gpg` whose material will not parse (the legacy-PEM case) yields 500
  with the real cause. Fails on `main`, where this path returns 404.
- `test_rsa_key_is_a_409_conflict_on_both_signing_endpoints` — the default key type is a
  config conflict on both endpoints; distinctly not 404, distinctly not 500.
- `test_repo_without_signing_key_still_404s` — keeps "missing" distinct from "broken".
- `test_require_signing_key_separates_missing_from_broken` and
  `test_require_openpgp_capable_key_separates_conflict_from_capable` — the pure mappings.

This also removes four tests (`test_pgp_armor_signature_*`) that asserted the *shape* of
the hand-rolled markers. They passed against output no OpenPGP client could parse: they
pinned the bug.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [x] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No migration: `artifacts.updated_at` already exists (migration 004). `.sqlx` is
regenerated (`cargo sqlx prepare --workspace -- --all-targets`) because the repodata
query changed; `SQLX_OFFLINE=true` builds clean.

The response *shape* of two existing endpoints changes (that is the fix): `.asc` now
returns OpenPGP instead of unverifiable bytes, and `.key` returns `application/pgp-keys`
instead of `application/x-pem-file`. Neither is in the OpenAPI spec (both are
format-native routes). `.asc`/`.key` with an `rsa` key now return 409 rather than
200-with-unusable-bytes.

## Verification

### The determinism defect, and its fix, against a real client

Same script, same host, two images built from this branch — **before** the determinism
fix (previous head `62c41eb`) and **after** (`6d9a038`). Hosted RPM repo, one package,
`key_type=gpg`, real `gpg` verifying the served pair:

| check (repo untouched between fetches) | head `62c41eb` | this PR `6d9a038` |
|---|---|---|
| fetch `repomd.xml`, **sleep 1.2s**, fetch `.asc`, `gpg --verify` (×6) | **Good=0 BAD=6** | **Good=6 BAD=0** |
| `repomd.xml` byte-identity over a 2s gap | **DIFFER** | **IDENTICAL** (1743 bytes) |
| real `dnf install`, `repo_gpgcheck=1`, cache cleared (×6) | installed 6/6 | installed 6/6 |

The byte diff on the unpatched head is exactly the defect:

```
3c3
<   <revision>1784255005</revision>
---
>   <revision>1784255007</revision>
8c8
<     <timestamp>1784255005</timestamp>
```

With the fix, `<revision>` is the repo-state epoch (`1784254930` = the package's
`updated_at`) and does not move.

### Why the `dnf` leg alone could never have caught this

Note the last row: **real `dnf` installs 6/6 on the broken build.** That is not a
contradiction — it is the finding. Measured against the unpatched head on this host:

```
measured gap between the two fetches (loopback, 1-package repo):  ~0.015s

signature failure rate vs gap, UNPATCHED head (30 trials per gap):
  gap=0s    -> Good=30 BAD=0    (0%)
  gap=0.3s  -> Good=20 BAD=10   (33%)
  gap=0.5s  -> Good=15 BAD=15   (50%)
  gap=1.0s  -> Good=0  BAD=30   (100%)
```

The failure probability is `min(1, gap / 1s)` — the same model #2652 measured for
Debian. On an idle host with a one-package repo the two fetches land ~15ms apart, so
each `dnf` run has only a ~1.5% chance of failing, and repeating it 5–6 times is
overwhelmingly likely to pass. The window widens with repo size, host load, client
latency, and replica skew, and dnf's metadata cache makes it worse still: a `repomd.xml`
retained from an earlier run can *never* match a freshly stamped `.asc`.

So the repeated `dnf` runs above are a **regression check, not the discriminator**. The
discriminating evidence is the explicit `>1s` gap — 0/6 vs 6/6 — which is why the new
lib tests sleep rather than fetching back-to-back.

### Gates

`cargo fmt --check` pass. `cargo clippy --workspace --all-targets -- -D warnings` pass.
`cargo nextest run --workspace --lib` — **13447 passed, 6 skipped, 1 failed**: the single
failure is `repositories::tests::npm_scope_policy_put_get_round_trip_db`, which is
**pre-existing and unrelated** — it fails identically on this branch's previous head with
my changes stashed. It asserts settings rows in a fixed order from a query with no
`ORDER BY`, so it depends on physical row order and is environment-dependent (amusingly,
the same bug class this PR fixes, in a different file). jscpd: 0 clones.

## Note on the missing gate

The `signing` tier's LEG B does **not exist in either checkout** — it lives on the
unmerged `feat/dtf-signing-legs` branch (artifact-keeper-test#259). The real-client
evidence above is therefore a PR transcript, not a re-runnable gate, **which is exactly
the hole this defect slipped through**. That tier's merge is being sequenced separately;
this PR depends on it for standing coverage.

Two things worth flagging to whoever lands that tier:

1. **LEG B's premise needs updating.** `B0` attaches an **`rsa`** key and `B1`–`B3` then
   assert an importable OpenPGP key, a `gpg`-verifiable `.asc`, and a successful
   `dnf repo_gpgcheck=1` install. Those cannot pass for *any* correct backend: X.509 RSA
   material cannot produce an OpenPGP chain. With this PR they fail as **409** (an honest
   refusal) instead of 200-with-fake-armor. B1–B3 should attach `key_type=gpg` (as `B5`
   already does), and the `rsa` case should assert the 409 refusal.
2. **The tier cannot detect the determinism defect as written**, for the reason measured
   above: its `dnf` leg fetches back-to-back on a fast local network. A `>1s` gap between
   the `repomd.xml` and `.asc` fetches (or a `gpg --verify` of a deliberately delayed
   pair) would make it a real gate for both RPM and Debian.

Filed while here, not fixed here:

- **#2660** — `alpine.rs` swallows APKINDEX signing failures via
  `sign_data(...).await.unwrap_or(None)` and serves an **unsigned** index with a 200.
  Same swallow class, but fail-**open**, so it is worse than the RPM 404 fixed here.
  Alpine's use of `sign_data` is legitimate (apk verifies raw RSA against an X.509 key),
  so the fix there is surfacing the error, **not** switching to OpenPGP.

Closes #2636
