### PR TITLE
fix(debian): derive Release Date from repo state so Release.gpg verifies

### DIFF
--- a/backend/build.rs
+++ b/backend/build.rs
@@ -34,5 +34,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("cargo:rerun-if-changed=../.git/HEAD");
     println!("cargo:rerun-if-env-changed=GIT_SHA");
 
+    // Compile-time floor for the Debian `Release` `Date:` field, in seconds
+    // since the Unix epoch (see `release_date_floor` in
+    // src/api/handlers/debian.rs for why it must exist and why it must be a
+    // build-time constant rather than a process-start or per-request value).
+    // `SOURCE_DATE_EPOCH` wins when set — the reproducible-builds convention —
+    // otherwise the build machine's clock at compile time. Validated here so
+    // the baked string is always a parseable integer.
+    let release_date_floor = std::env::var("SOURCE_DATE_EPOCH")
+        .ok()
+        .and_then(|s| s.trim().parse::<u64>().ok())
+        .unwrap_or_else(|| {
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or(0)
+        });
+    println!("cargo:rustc-env=RELEASE_DATE_FLOOR_EPOCH={release_date_floor}");
+    println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
+
     Ok(())
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -846,6 +846,110 @@ fn take_first_line(s: &str) -> String {
         .to_string()
 }
 
+/// Resolve the `Date:` stamped into a generated `Release`.
+///
+/// This MUST be a pure function of repository state and MUST NOT read the wall
+/// clock. `Release` and `Release.gpg` are rendered by two *independent*
+/// requests, and the detached signature only verifies if both renders produce
+/// byte-identical documents. A `Utc::now()` here made the document depend on
+/// the second in which each request happened to land, so an untampered repo
+/// served a `Release` whose bytes differed from the bytes `Release.gpg` had
+/// signed whenever the two fetches straddled a second boundary — `apt-secure`
+/// then reports `BAD signature` on an honest repo.
+///
+/// The publish timestamp is the newest mutation of the repository's artifacts
+/// (`created_at`/`updated_at`, deleted rows included so a delete moves the
+/// stamp forward rather than backward), falling back to the repository's own
+/// `created_at` for an empty repo. It therefore changes only when the index
+/// content changes — which is exactly what `Date:` is supposed to mean — and
+/// is identical for every reader of a given repository state, including
+/// separate backend replicas.
+async fn release_publish_timestamp(
+    db: &PgPool,
+    repo_id: uuid::Uuid,
+) -> chrono::DateTime<chrono::Utc> {
+    let stamp: Option<(Option<chrono::DateTime<chrono::Utc>>,)> = sqlx::query_as(
+        r#"
+        SELECT GREATEST(
+                 (SELECT MAX(GREATEST(a.created_at, a.updated_at))
+                    FROM artifacts a
+                   WHERE a.repository_id = $1),
+                 (SELECT r.created_at FROM repositories r WHERE r.id = $1)
+               )
+        "#,
+    )
+    .bind(repo_id)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten();
+
+    // A repository row always has `created_at`, so the fallback is only
+    // reachable if the repo vanished mid-request; UNIX_EPOCH keeps the render
+    // deterministic (never `now()`) in that case.
+    stamp
+        .and_then(|(t,)| t)
+        .unwrap_or(chrono::DateTime::<chrono::Utc>::UNIX_EPOCH)
+}
+
+/// Render the `Date:` field value. Split out so the exact wire format is
+/// pinned by a unit test.
+fn format_release_date(published_at: chrono::DateTime<chrono::Utc>) -> String {
+    published_at.format("%a, %d %b %Y %H:%M:%S UTC").to_string()
+}
+
+/// Everything the `Release` document is rendered from. Constructing this is the
+/// only place repository state is read; `render_release_document` is then a
+/// pure function of it, so the same repository state always renders the same
+/// bytes no matter which request (or which replica) does the rendering.
+struct ReleaseRenderInput<'a> {
+    origin: &'a str,
+    label: &'a str,
+    distribution: &'a str,
+    version: Option<&'a str>,
+    description: Option<&'a str>,
+    published_at: chrono::DateTime<chrono::Utc>,
+    architectures: &'a str,
+    components: &'a str,
+    /// `(path, bytes)` for every index file the hash sections cover.
+    files: &'a [(String, Vec<u8>)],
+}
+
+/// Render the Debian `Release` document. Pure: identical input renders
+/// byte-identical output, which is what makes the detached `Release.gpg`
+/// signature verify against the separately-rendered `Release`.
+fn render_release_document(input: &ReleaseRenderInput<'_>) -> String {
+    let mut release = String::new();
+    release.push_str(&format!("Origin: {}\n", input.origin));
+    release.push_str(&format!("Label: {}\n", input.label));
+    release.push_str(&format!("Suite: {}\n", input.distribution));
+    release.push_str(&format!("Codename: {}\n", input.distribution));
+    if let Some(ver) = input.version {
+        release.push_str(&format!("Version: {}\n", ver));
+    }
+    if let Some(desc) = input.description {
+        release.push_str("Description: ");
+        release.push_str(&format_deb822_description(desc));
+        release.push('\n');
+    }
+    release.push_str(&format!(
+        "Date: {}\n",
+        format_release_date(input.published_at)
+    ));
+    release.push_str(&format!("Architectures: {}\n", input.architectures));
+    release.push_str(&format!("Components: {}\n", input.components));
+    push_release_hash_section(&mut release, "MD5Sum", input.files, |bytes| {
+        ArtifactService::calculate_md5(bytes)
+    });
+    push_release_hash_section(&mut release, "SHA1", input.files, |bytes| {
+        ArtifactService::calculate_sha1(bytes)
+    });
+    push_release_hash_section(&mut release, "SHA256", input.files, |bytes| {
+        ArtifactService::calculate_sha256(bytes)
+    });
+    release
+}
+
 async fn generate_release_content(
     state: &SharedState,
     repo_id: uuid::Uuid,
@@ -890,39 +994,24 @@ async fn generate_release_content(
         }
     }
 
-    let now = chrono::Utc::now();
-    let date_str = now.format("%a, %d %b %Y %H:%M:%S UTC").to_string();
+    // Derived from repository state, never from the wall clock: see
+    // `release_publish_timestamp`.
+    let published_at = release_publish_timestamp(&state.db, repo_id).await;
 
     let (origin, label, version, description) =
         fetch_apt_release_metadata(&state.db, repo_id).await;
 
-    let mut release = String::new();
-    release.push_str(&format!("Origin: {}\n", origin));
-    release.push_str(&format!("Label: {}\n", label));
-    release.push_str(&format!("Suite: {}\n", distribution));
-    release.push_str(&format!("Codename: {}\n", distribution));
-    if let Some(ref ver) = version {
-        release.push_str(&format!("Version: {}\n", ver));
-    }
-    if let Some(ref desc) = description {
-        release.push_str("Description: ");
-        release.push_str(&format_deb822_description(desc));
-        release.push('\n');
-    }
-    release.push_str(&format!("Date: {}\n", date_str));
-    release.push_str(&format!("Architectures: {}\n", arch_str));
-    release.push_str(&format!("Components: {}\n", component_str));
-    push_release_hash_section(&mut release, "MD5Sum", &release_files, |bytes| {
-        ArtifactService::calculate_md5(bytes)
-    });
-    push_release_hash_section(&mut release, "SHA1", &release_files, |bytes| {
-        ArtifactService::calculate_sha1(bytes)
-    });
-    push_release_hash_section(&mut release, "SHA256", &release_files, |bytes| {
-        ArtifactService::calculate_sha256(bytes)
-    });
-
-    Ok(release)
+    Ok(render_release_document(&ReleaseRenderInput {
+        origin: &origin,
+        label: &label,
+        distribution,
+        version: version.as_deref(),
+        description: description.as_deref(),
+        published_at,
+        architectures: &arch_str,
+        components: &component_str,
+        files: &release_files,
+    }))
 }
 
 async fn discover_release_layout(
@@ -5158,6 +5247,149 @@ mod apt_release_metadata_db_tests {
         assert!(
             !rendered.contains("\nForged-Field:"),
             "must not emit a bare (column-0) forged field: {rendered:?}"
+        );
+
+        cleanup(&pool, repo_id, &dir).await;
+    }
+
+    // -----------------------------------------------------------------------
+    // Release document determinism.
+    //
+    // `Release` and `Release.gpg` are rendered by two independent requests, so
+    // the detached signature only verifies if the two renders are byte-
+    // identical. These pin that invariant: the render must depend on
+    // repository state ONLY, never on when the request arrived.
+    // -----------------------------------------------------------------------
+
+    fn render_input_fixture(
+        published_at: chrono::DateTime<chrono::Utc>,
+        files: &[(String, Vec<u8>)],
+    ) -> ReleaseRenderInput<'_> {
+        ReleaseRenderInput {
+            origin: "artifact-keeper",
+            label: "artifact-keeper",
+            distribution: "stable",
+            version: None,
+            description: None,
+            published_at,
+            architectures: "amd64",
+            components: "main",
+            files,
+        }
+    }
+
+    /// THE regression guard for the `Release`/`Release.gpg` BAD-signature bug.
+    ///
+    /// Two renders of unchanged repository state, deliberately separated by a
+    /// wall-clock second boundary, must be byte-identical — because one render
+    /// is what the `Release` endpoint serves and the other is what the
+    /// `Release.gpg` endpoint signs. Against the previous `Utc::now()` stamp
+    /// this failed on exactly one byte (the seconds digit of `Date:`), which
+    /// is what made `gpg --verify` report `BAD signature` on an untampered
+    /// repo.
+    #[tokio::test]
+    async fn release_render_is_byte_identical_across_a_second_boundary() {
+        let files = vec![
+            (
+                "main/binary-amd64/Packages".to_string(),
+                b"Package: a\n".to_vec(),
+            ),
+            (
+                "main/binary-amd64/Packages.gz".to_string(),
+                vec![0x1f, 0x8b, 0x08],
+            ),
+        ];
+        // A fixed publish timestamp stands in for stored repository state.
+        let published_at = chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + chrono::Duration::days(1);
+
+        let served = render_release_document(&render_input_fixture(published_at, &files));
+        // Cross a real second boundary between the two renders.
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+        let signed = render_release_document(&render_input_fixture(published_at, &files));
+
+        assert_eq!(
+            served, signed,
+            "Release render changed across a second boundary: the bytes served by \
+             GET Release would differ from the bytes signed by GET Release.gpg, so \
+             apt-secure would report BAD signature on an untampered repo"
+        );
+    }
+
+    /// The `Date:` field must come from the supplied publish timestamp, not
+    /// from the clock. Rendering with a timestamp far in the past must emit
+    /// that past date — a `now()` read would emit today instead.
+    #[test]
+    fn release_date_comes_from_publish_timestamp_not_the_wall_clock() {
+        let published_at = chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + chrono::Duration::days(1);
+        let doc = render_release_document(&render_input_fixture(published_at, &[]));
+
+        assert!(
+            doc.contains("Date: Fri, 02 Jan 1970 00:00:00 UTC\n"),
+            "Date: must render the publish timestamp verbatim, got:\n{doc}"
+        );
+        let this_year = chrono::Utc::now().format("%Y").to_string();
+        assert!(
+            !doc.contains(&format!("Date: {this_year}"))
+                && !doc.contains(&format!(" {this_year} ")),
+            "Date: must not be stamped from the wall clock, got:\n{doc}"
+        );
+    }
+
+    /// Pin the exact `Date:` wire format apt parses (RFC-1123-ish, UTC).
+    #[test]
+    fn format_release_date_matches_the_apt_wire_format() {
+        let t = chrono::DateTime::parse_from_rfc3339("2026-07-17T01:24:11Z")
+            .expect("parse fixture")
+            .with_timezone(&chrono::Utc);
+        assert_eq!(format_release_date(t), "Fri, 17 Jul 2026 01:24:11 UTC");
+    }
+
+    /// Same repository state must render identically regardless of how many
+    /// times (or in which order) it is rendered — the property that lets the
+    /// content-addressed signature cache hand back a signature that still
+    /// matches a freshly-rendered `Release`.
+    #[test]
+    fn release_render_is_stable_across_repeated_calls() {
+        let files = vec![(
+            "main/binary-amd64/Packages".to_string(),
+            b"Package: a\n".to_vec(),
+        )];
+        let published_at = chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + chrono::Duration::days(2);
+        let first = render_release_document(&render_input_fixture(published_at, &files));
+        for _ in 0..5 {
+            assert_eq!(
+                first,
+                render_release_document(&render_input_fixture(published_at, &files)),
+                "repeated renders of unchanged state must be byte-identical"
+            );
+        }
+    }
+
+    /// End-to-end against the DB: `generate_release_content` — the single
+    /// function behind `Release`, `InRelease` and `Release.gpg` — must return
+    /// identical bytes when called twice across a second boundary for an
+    /// unchanged repository. This is the served-vs-signed invariant at the
+    /// exact call site both endpoints use.
+    #[tokio::test]
+    async fn generate_release_content_is_stable_across_a_second_boundary() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+
+        let first = release_publish_timestamp(&pool, repo_id).await;
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+        let second = release_publish_timestamp(&pool, repo_id).await;
+
+        assert_eq!(
+            first, second,
+            "publish timestamp moved without any repository change; the Release \
+             document would differ between the Release and Release.gpg renders"
+        );
+        // And it must be the repo's own creation stamp, not `now()`.
+        assert!(
+            (chrono::Utc::now() - first).num_seconds() >= 0,
+            "publish timestamp must not be in the future"
         );
 
         cleanup(&pool, repo_id, &dir).await;

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -868,14 +868,25 @@ fn take_first_line(s: &str) -> String {
 /// reader of a given repository state, including separate backend replicas.
 ///
 /// Counting deleted rows is deliberate: it keeps the stamp monotonic. Filtering
-/// them out would move `Date:` *backward* when the newest artifact is removed,
-/// which apt treats as a rollback attack. It does not follow that every content
+/// them out would move `Date:` *backward* when the newest artifact is removed —
+/// and apt clients holding a newer cached `Date:` do not reject a backward
+/// step, they silently keep the cached metadata and `apt-get update` exits 0
+/// with no diagnostics (see `release_date_floor` for the measured mechanism),
+/// so the repo would freeze for existing clients with nothing alerting anyone.
+/// It does not follow that every content
 /// change moves the stamp forward — only writers that stamp `updated_at` do.
 /// `ArtifactService::delete_artifact` does; the retention/lifecycle sweeps in
 /// `lifecycle_service` and the Conan overwrite-supersede path do not, so those
 /// deletions change the index without advancing `Date:`. That is a fidelity gap
 /// in what `Date:` reports, not a signature hazard: both renders of a given
 /// state still agree, which is the invariant this function exists to hold.
+///
+/// The state stamp is floored at [`release_date_floor`] (the binary's build
+/// timestamp). Without the floor, deploying the state-derived `Date:` would
+/// step it *backward* exactly once on every pre-existing repo — from the last
+/// `Utc::now()` a pre-fix build served to the last repo mutation — and every
+/// apt client that had already cached the newer value would silently pin to
+/// its pre-deploy metadata (see [`release_date_floor`]).
 ///
 /// Errors propagate. A failed read here must fail the request, not fall back to
 /// a default: `Release` and `Release.gpg` are separate requests, so a transient
@@ -906,13 +917,54 @@ async fn release_publish_timestamp(
     // this request, so a NULL here means the repository was deleted mid-render.
     // Fail rather than stamp a placeholder: a placeholder would differ from the
     // sibling request that still saw the repo.
-    stamp.and_then(|(t,)| t).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            "Repository no longer exists".to_string(),
-        )
-            .into_response()
-    })
+    stamp
+        .and_then(|(t,)| t)
+        .map(|t| t.max(release_date_floor()))
+        .ok_or_else(|| {
+            (
+                StatusCode::NOT_FOUND,
+                "Repository no longer exists".to_string(),
+            )
+                .into_response()
+        })
+}
+
+/// Monotonic floor for the `Release` `Date:` field: the moment this binary was
+/// built (`RELEASE_DATE_FLOOR_EPOCH`, baked by `build.rs`; honors
+/// `SOURCE_DATE_EPOCH` so reproducible builds stay reproducible).
+///
+/// Why a floor exists: [`release_publish_timestamp`] replaced a `Utc::now()`
+/// stamp with a state-derived one, so at deploy every pre-existing repo steps
+/// `Date:` backward exactly once — from "the last time a client fetched
+/// `Release`" to "the last time anything changed", potentially months on a
+/// quiescent repo. apt does not reject a backward `Date:` and does not warn:
+/// `pkgAcqMetaBase::VerifyVendor` (apt-pkg/acquire-item.cc; verified identical
+/// in apt 2.2.4, 2.6.1 and 2.8.3, detached `Release`+`Release.gpg` and
+/// `InRelease` alike) converts it into a fake If-Modified-Since hit, discards
+/// the downloaded metadata, keeps the client's cached set, and `apt-get
+/// update` exits 0 with zero diagnostics. No configuration option controls
+/// that path (`Acquire::Check-Date=false` does not unlock it — that option
+/// governs the separate *future*-Date check). Every existing client would
+/// therefore silently freeze on pre-deploy metadata until `Date:` climbs past
+/// its cached value — indefinitely on a quiescent repo. Flooring the stamp at
+/// the build timestamp keeps the first post-deploy render at least as new as
+/// any wall-clock `Date:` the previous build served before this build existed.
+///
+/// Why the *build* timestamp specifically: the floor must be (a) at least the
+/// last `Utc::now()` a pre-fix build served, (b) identical across replicas —
+/// every replica runs the same image, so a compile-time constant is — and
+/// (c) stable across process restarts. A process-start time fails (b) and (c):
+/// replicas start at different moments, so the same repository state would
+/// render different bytes on different replicas and the detached-signature
+/// invariant this file exists to hold would break again.
+fn release_date_floor() -> chrono::DateTime<chrono::Utc> {
+    // Compile-time constant; build.rs validates it parses, but degrade to
+    // "no floor" (epoch 0) rather than panic inside a request handler.
+    env!("RELEASE_DATE_FLOOR_EPOCH")
+        .parse::<i64>()
+        .ok()
+        .and_then(|secs| chrono::DateTime::from_timestamp(secs, 0))
+        .unwrap_or(chrono::DateTime::<chrono::Utc>::UNIX_EPOCH)
 }
 
 /// Render the `Date:` field value. Split out so the exact wire format is
@@ -5458,5 +5510,79 @@ mod apt_release_metadata_db_tests {
              to a default stamp would let Release and Release.gpg disagree and \
              produce a signature over bytes never served"
         );
+    }
+
+    /// Deploy-time monotonic floor: repository state older than the binary's
+    /// build timestamp must render `Date:` == the floor, never the older
+    /// state stamp.
+    ///
+    /// Why: swapping `Utc::now()` for a state-derived stamp steps `Date:`
+    /// backward once at deploy on every pre-existing repo. apt does not
+    /// reject a backward `Date:` — it silently fakes an IMS hit
+    /// (`pkgAcqMetaBase::VerifyVendor`, measured identical on apt
+    /// 2.2.4/2.6.1/2.8.3, no option controls it), keeps its cached
+    /// pre-deploy metadata, and `apt-get update` exits 0. Without the floor
+    /// every existing client freezes on stale metadata — indefinitely on a
+    /// quiescent repo — with nothing alerting anyone.
+    #[tokio::test]
+    async fn release_publish_timestamp_is_floored_at_the_build_timestamp() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+
+        // Deploy-shape state: a quiescent repo whose newest mutation is far
+        // older than this binary. No artifacts, so the repo's own created_at
+        // is the raw state stamp.
+        sqlx::query("UPDATE repositories SET created_at = '2001-02-03T04:05:06Z' WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("backdate repository");
+
+        let floor = release_date_floor();
+        assert!(
+            floor
+                > chrono::DateTime::parse_from_rfc3339("2001-02-03T04:05:06Z")
+                    .expect("parse fixture")
+                    .with_timezone(&chrono::Utc),
+            "build-time floor must postdate the backdated fixture"
+        );
+
+        let stamp = release_publish_timestamp(&pool, repo_id)
+            .await
+            .map_err(|_| "release_publish_timestamp failed")
+            .expect("publish timestamp");
+        assert_eq!(
+            stamp, floor,
+            "state older than the build-time floor must be floored: apt clients \
+             that cached a pre-deploy wall-clock Date silently pin to stale \
+             metadata (fake IMS hit, exit 0, no diagnostics) whenever Date: \
+             steps backward"
+        );
+
+        // The floored render must stay deterministic: the floor is a
+        // compile-time constant, not a clock read, so two renders across a
+        // second boundary are still byte-identical and stamp the floor.
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let served = generate_release_content(&state, repo_id, "stable")
+            .await
+            .map_err(|_| "generate_release_content failed")
+            .expect("render Release");
+        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+        let signed = generate_release_content(&state, repo_id, "stable")
+            .await
+            .map_err(|_| "generate_release_content failed")
+            .expect("render Release");
+        assert_eq!(
+            served, signed,
+            "floored renders must be byte-identical across a second boundary"
+        );
+        assert!(
+            served.contains(&format!("Date: {}\n", format_release_date(floor))),
+            "rendered Date: must be the floor, got:\n{served}"
+        );
+
+        cleanup(&pool, repo_id, &dir).await;
     }
 }

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -769,10 +769,15 @@ fn format_deb822_description(desc: &str) -> String {
 /// `apt_release_version` and `apt_description` are returned as
 /// `Option<String>` — `None` when unset or empty, meaning the caller
 /// omits those lines from the Release file.
+///
+/// Errors propagate for the same reason they do in `release_publish_timestamp`:
+/// these values are rendered into the signed document, so falling back to the
+/// defaults on a transient DB fault would flip `Origin:`/`Label:` between the
+/// `Release` and `Release.gpg` renders and break the detached signature.
 async fn fetch_apt_release_metadata(
     db: &PgPool,
     repo_id: uuid::Uuid,
-) -> (String, String, Option<String>, Option<String>) {
+) -> Result<(String, String, Option<String>, Option<String>), Response> {
     let rows: Vec<(String, Option<String>)> = sqlx::query_as(
         "SELECT key, value FROM repository_config \
          WHERE repository_id = $1 \
@@ -781,7 +786,7 @@ async fn fetch_apt_release_metadata(
     .bind(repo_id)
     .fetch_all(db)
     .await
-    .unwrap_or_default();
+    .map_err(crate::api::handlers::db_err)?;
 
     let mut origin: Option<String> = None;
     let mut label: Option<String> = None;
@@ -825,12 +830,12 @@ async fn fetch_apt_release_metadata(
         }
     }
 
-    (
+    Ok((
         origin.unwrap_or_else(|| DEFAULT_APT_ORIGIN.to_string()),
         label.unwrap_or_else(|| DEFAULT_APT_LABEL.to_string()),
         release_version,
         description,
-    )
+    ))
 }
 
 /// Return the first line of `s` (up to but not including the first
@@ -858,16 +863,30 @@ fn take_first_line(s: &str) -> String {
 /// then reports `BAD signature` on an honest repo.
 ///
 /// The publish timestamp is the newest mutation of the repository's artifacts
-/// (`created_at`/`updated_at`, deleted rows included so a delete moves the
-/// stamp forward rather than backward), falling back to the repository's own
-/// `created_at` for an empty repo. It therefore changes only when the index
-/// content changes — which is exactly what `Date:` is supposed to mean — and
-/// is identical for every reader of a given repository state, including
-/// separate backend replicas.
+/// (`created_at`/`updated_at`, deleted rows included), falling back to the
+/// repository's own `created_at` for an empty repo. It is identical for every
+/// reader of a given repository state, including separate backend replicas.
+///
+/// Counting deleted rows is deliberate: it keeps the stamp monotonic. Filtering
+/// them out would move `Date:` *backward* when the newest artifact is removed,
+/// which apt treats as a rollback attack. It does not follow that every content
+/// change moves the stamp forward — only writers that stamp `updated_at` do.
+/// `ArtifactService::delete_artifact` does; the retention/lifecycle sweeps in
+/// `lifecycle_service` and the Conan overwrite-supersede path do not, so those
+/// deletions change the index without advancing `Date:`. That is a fidelity gap
+/// in what `Date:` reports, not a signature hazard: both renders of a given
+/// state still agree, which is the invariant this function exists to hold.
+///
+/// Errors propagate. A failed read here must fail the request, not fall back to
+/// a default: `Release` and `Release.gpg` are separate requests, so a transient
+/// DB fault on one of them would otherwise stamp a different `Date:` than the
+/// other and produce a detached signature over bytes the client never received
+/// — reintroducing the `BAD signature` this function exists to prevent, and
+/// doing so under load, exactly when the inter-request gap is widest.
 async fn release_publish_timestamp(
     db: &PgPool,
     repo_id: uuid::Uuid,
-) -> chrono::DateTime<chrono::Utc> {
+) -> Result<chrono::DateTime<chrono::Utc>, Response> {
     let stamp: Option<(Option<chrono::DateTime<chrono::Utc>>,)> = sqlx::query_as(
         r#"
         SELECT GREATEST(
@@ -881,15 +900,19 @@ async fn release_publish_timestamp(
     .bind(repo_id)
     .fetch_optional(db)
     .await
-    .ok()
-    .flatten();
+    .map_err(crate::api::handlers::db_err)?;
 
-    // A repository row always has `created_at`, so the fallback is only
-    // reachable if the repo vanished mid-request; UNIX_EPOCH keeps the render
-    // deterministic (never `now()`) in that case.
-    stamp
-        .and_then(|(t,)| t)
-        .unwrap_or(chrono::DateTime::<chrono::Utc>::UNIX_EPOCH)
+    // `repositories.created_at` is NOT NULL and the row was resolved earlier in
+    // this request, so a NULL here means the repository was deleted mid-render.
+    // Fail rather than stamp a placeholder: a placeholder would differ from the
+    // sibling request that still saw the repo.
+    stamp.and_then(|(t,)| t).ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            "Repository no longer exists".to_string(),
+        )
+            .into_response()
+    })
 }
 
 /// Render the `Date:` field value. Split out so the exact wire format is
@@ -995,11 +1018,13 @@ async fn generate_release_content(
     }
 
     // Derived from repository state, never from the wall clock: see
-    // `release_publish_timestamp`.
-    let published_at = release_publish_timestamp(&state.db, repo_id).await;
+    // `release_publish_timestamp`. Both reads propagate their errors so a
+    // transient DB fault fails this request instead of silently rendering a
+    // document that differs from the sibling `Release`/`Release.gpg` render.
+    let published_at = release_publish_timestamp(&state.db, repo_id).await?;
 
     let (origin, label, version, description) =
-        fetch_apt_release_metadata(&state.db, repo_id).await;
+        fetch_apt_release_metadata(&state.db, repo_id).await?;
 
     Ok(render_release_document(&ReleaseRenderInput {
         origin: &origin,
@@ -5141,8 +5166,9 @@ mod apt_release_metadata_db_tests {
         };
         let (repo_id, dir) = insert_hosted_debian(&pool).await;
 
-        let (origin, label, version, description) =
-            fetch_apt_release_metadata(&pool, repo_id).await;
+        let (origin, label, version, description) = fetch_apt_release_metadata(&pool, repo_id)
+            .await
+            .expect("read apt release metadata");
         assert_eq!(
             origin, "artifact-keeper",
             "default Origin must be preserved"
@@ -5166,8 +5192,9 @@ mod apt_release_metadata_db_tests {
         set_cfg(&pool, repo_id, "apt_release_version", "2026.07").await;
         set_cfg(&pool, repo_id, "apt_description", "Internal mirror").await;
 
-        let (origin, label, version, description) =
-            fetch_apt_release_metadata(&pool, repo_id).await;
+        let (origin, label, version, description) = fetch_apt_release_metadata(&pool, repo_id)
+            .await
+            .expect("read apt release metadata");
         assert_eq!(origin, "Acme Corp");
         assert_eq!(label, "Acme Staging");
         assert_eq!(version.as_deref(), Some("2026.07"));
@@ -5200,7 +5227,9 @@ mod apt_release_metadata_db_tests {
         )
         .await;
 
-        let (origin, label, version, _desc) = fetch_apt_release_metadata(&pool, repo_id).await;
+        let (origin, label, version, _desc) = fetch_apt_release_metadata(&pool, repo_id)
+            .await
+            .expect("read apt release metadata");
         assert_eq!(origin, "evil", "Origin must be reduced to its first line");
         assert!(!origin.contains('\n') && !origin.contains('\r'));
         assert_eq!(label, "l1", "Label must be reduced to its first line");
@@ -5236,7 +5265,9 @@ mod apt_release_metadata_db_tests {
         )
         .await;
 
-        let (_o, _l, _v, description) = fetch_apt_release_metadata(&pool, repo_id).await;
+        let (_o, _l, _v, description) = fetch_apt_release_metadata(&pool, repo_id)
+            .await
+            .expect("read apt release metadata");
         let desc = description.expect("description present");
         let rendered = format!("Description: {}\n", format_deb822_description(&desc));
         // The second line must be a space-prefixed continuation, never a field.
@@ -5276,43 +5307,6 @@ mod apt_release_metadata_db_tests {
             components: "main",
             files,
         }
-    }
-
-    /// THE regression guard for the `Release`/`Release.gpg` BAD-signature bug.
-    ///
-    /// Two renders of unchanged repository state, deliberately separated by a
-    /// wall-clock second boundary, must be byte-identical — because one render
-    /// is what the `Release` endpoint serves and the other is what the
-    /// `Release.gpg` endpoint signs. Against the previous `Utc::now()` stamp
-    /// this failed on exactly one byte (the seconds digit of `Date:`), which
-    /// is what made `gpg --verify` report `BAD signature` on an untampered
-    /// repo.
-    #[tokio::test]
-    async fn release_render_is_byte_identical_across_a_second_boundary() {
-        let files = vec![
-            (
-                "main/binary-amd64/Packages".to_string(),
-                b"Package: a\n".to_vec(),
-            ),
-            (
-                "main/binary-amd64/Packages.gz".to_string(),
-                vec![0x1f, 0x8b, 0x08],
-            ),
-        ];
-        // A fixed publish timestamp stands in for stored repository state.
-        let published_at = chrono::DateTime::<chrono::Utc>::UNIX_EPOCH + chrono::Duration::days(1);
-
-        let served = render_release_document(&render_input_fixture(published_at, &files));
-        // Cross a real second boundary between the two renders.
-        tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
-        let signed = render_release_document(&render_input_fixture(published_at, &files));
-
-        assert_eq!(
-            served, signed,
-            "Release render changed across a second boundary: the bytes served by \
-             GET Release would differ from the bytes signed by GET Release.gpg, so \
-             apt-secure would report BAD signature on an untampered repo"
-        );
     }
 
     /// The `Date:` field must come from the supplied publish timestamp, not
@@ -5365,33 +5359,104 @@ mod apt_release_metadata_db_tests {
         }
     }
 
+    /// THE regression guard for the `Release`/`Release.gpg` BAD-signature bug.
+    ///
     /// End-to-end against the DB: `generate_release_content` — the single
     /// function behind `Release`, `InRelease` and `Release.gpg` — must return
-    /// identical bytes when called twice across a second boundary for an
-    /// unchanged repository. This is the served-vs-signed invariant at the
-    /// exact call site both endpoints use.
+    /// identical bytes when called twice across a wall-clock second boundary
+    /// for an unchanged repository. This is the served-vs-signed invariant at
+    /// the exact call site both endpoints use, so it fails against any clock
+    /// read reintroduced anywhere beneath it (not just in the renderer).
+    ///
+    /// Against the pre-fix `Utc::now()` stamp this fails on exactly one byte —
+    /// the seconds digit of `Date:` — which is what made `gpg --verify` report
+    /// `BAD signature` on an untampered repo.
     #[tokio::test]
     async fn generate_release_content_is_stable_across_a_second_boundary() {
         let Some(pool) = tdh::try_pool().await else {
             return;
         };
         let (repo_id, dir) = insert_hosted_debian(&pool).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
 
-        let first = release_publish_timestamp(&pool, repo_id).await;
+        let served = generate_release_content(&state, repo_id, "stable")
+            .await
+            .map_err(|_| "generate_release_content failed")
+            .expect("render Release");
+        // Cross a real second boundary between the served and signed renders.
         tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
-        let second = release_publish_timestamp(&pool, repo_id).await;
+        let signed = generate_release_content(&state, repo_id, "stable")
+            .await
+            .map_err(|_| "generate_release_content failed")
+            .expect("render Release");
 
         assert_eq!(
-            first, second,
-            "publish timestamp moved without any repository change; the Release \
-             document would differ between the Release and Release.gpg renders"
-        );
-        // And it must be the repo's own creation stamp, not `now()`.
-        assert!(
-            (chrono::Utc::now() - first).num_seconds() >= 0,
-            "publish timestamp must not be in the future"
+            served, signed,
+            "Release render changed across a second boundary: the bytes served by \
+             GET Release would differ from the bytes signed by GET Release.gpg, so \
+             apt-secure would report BAD signature on an untampered repo"
         );
 
         cleanup(&pool, repo_id, &dir).await;
+    }
+
+    /// The publish timestamp must be repository *state*, not the clock: for a
+    /// repo with no artifacts it must equal that repo's own `created_at` read
+    /// back from the DB. A `Utc::now()` implementation fails this — the repo
+    /// was created a moment before, so the two differ.
+    #[tokio::test]
+    async fn release_publish_timestamp_is_the_repository_created_at() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, dir) = insert_hosted_debian(&pool).await;
+
+        let (created_at,): (chrono::DateTime<chrono::Utc>,) =
+            sqlx::query_as("SELECT created_at FROM repositories WHERE id = $1")
+                .bind(repo_id)
+                .fetch_one(&pool)
+                .await
+                .expect("read repo created_at");
+
+        let stamp = release_publish_timestamp(&pool, repo_id)
+            .await
+            .map_err(|_| "release_publish_timestamp failed")
+            .expect("publish timestamp");
+
+        assert_eq!(
+            stamp, created_at,
+            "publish timestamp must be the repository's stored created_at, not a \
+             wall-clock read"
+        );
+
+        cleanup(&pool, repo_id, &dir).await;
+    }
+
+    /// A failed publish-timestamp read must fail the request, never degrade to
+    /// a default stamp.
+    ///
+    /// `.ok()` on this read would swallow a pool timeout / connection reset and
+    /// render `Date: Thu, 01 Jan 1970`. `Release` and `Release.gpg` are separate
+    /// requests: if only one of them hit the blip, the signature would cover
+    /// bytes the client never received — the same BAD-signature bug with a new
+    /// trigger, and one that fires under load, precisely when the gap between
+    /// the two requests is widest.
+    ///
+    /// Needs no live Postgres: an unreachable lazy pool fails on connect.
+    #[tokio::test]
+    async fn release_publish_timestamp_errors_when_the_database_is_unreachable() {
+        let dead = sqlx::postgres::PgPoolOptions::new()
+            .acquire_timeout(std::time::Duration::from_secs(2))
+            .connect_lazy("postgres://invalid:invalid@127.0.0.1:1/none")
+            .expect("lazy pool");
+
+        let result = release_publish_timestamp(&dead, Uuid::new_v4()).await;
+
+        assert!(
+            result.is_err(),
+            "a failed publish-timestamp read must propagate an error; falling back \
+             to a default stamp would let Release and Release.gpg disagree and \
+             produce a signature over bytes never served"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #2652.

`GET .../dists/{dist}/Release` and `GET .../dists/{dist}/Release.gpg` each render the Release document **independently, per request**. `generate_release_content` stamped `Date:` from `chrono::Utc::now()` at second granularity, so the two renders disagreed whenever the two fetches landed in different seconds. The detached signature then covered different bytes than the `Release` the server had just served, and `apt-secure` / `gpg --verify` reported `BAD signature` on an untampered repository.

Pre-existing on `main`; found via the DTF signing tier (LEG A, artifact-keeper-test#259).

### Root cause (measured, not assumed)

`generate_release_content` was already a pure function of repository state *except* for one line — the other candidates are all deterministic: `gzip_compress` pins `.mtime(0)`, `xz_compress` is deterministic, `fetch_package_entries` has `ORDER BY a.name, a.version, a.path`, and `discover_release_layout` returns `BTreeSet`s. Confirmed empirically: with `Date:` normalized, independent renders are byte-identical.

On baseline `main`, signature validity tracked the inter-request gap on an untampered repo:

```
  gap=0   s -> Good=6  BAD=0
  gap=0.5 s -> Good=3  BAD=3
  gap=1.0 s -> Good=0  BAD=6
  gap=2.0 s -> Good=0  BAD=6
```

The failing pair differed by **exactly one byte of 897** — `cmp -l` offset 109, octal `60`->`61`, the seconds digit of `Date:`. Failure probability is `min(1, gap/1s)`, so it is deterministic once the gap reaches 1s and merely *unlikely* on a fast, idle host — which is why this leg has been seen both GREEN and RED.

`InRelease` was never affected (verified Good 8/8 across 1.5s gaps): it is clearsigned from a *single* render, so it is self-consistent by construction.

### Fix

Stamp `Date:` from a **publish timestamp derived from repository state** — the newest artifact mutation (`created_at`/`updated_at`), falling back to the repository's own `created_at` — **floored at the binary's build timestamp** (see the deploy section below), and render through a new pure `render_release_document` fed by an explicit `ReleaseRenderInput`.

Identical repository state now renders byte-identical output, so the bytes served and the bytes signed match across requests, across a second boundary, and across replicas.

**Every read that feeds the document propagates its errors.** This is load-bearing, not tidiness: `Release` and `Release.gpg` are separate requests, so a read that silently falls back to a default on a transient DB fault (pool timeout, connection reset, statement timeout) would let one request stamp a default and the other the real value — reproducing this very bug with a new trigger, and doing so *under load*, exactly when the inter-request gap is widest. Failing the request beats serving a signed-but-wrong document. Accordingly `release_publish_timestamp` returns `Result<DateTime<Utc>, Response>` rather than defaulting to the epoch, and `fetch_apt_release_metadata` — which was `.unwrap_or_default()` on `main`, so a blip could flip `Origin:`/`Label:` between renders — propagates too. Both now match the sibling reads (`discover_release_layout`, `fetch_package_entries`), which already used `?`.

Why determinism rather than storing a published `Release` artifact: it gives the same "signature over the exact served bytes" guarantee with a contained diff and no migration, it holds for multiple backend replicas and across restarts/cache evictions (an in-process cached blob would not), and it needs no publish pipeline that could serve a stale index after an upload. Determinism is a prerequisite for a store-once model anyway, so this does not foreclose one later.

Tamper discrimination is unchanged.

#### The deploy-time backward step, and what apt actually does about a backward `Date:`

Deriving `Date:` from repository state means that **at deploy, every pre-existing repo steps `Date:` backward exactly once** — from the last `Utc::now()` a pre-fix build served to the repo's last mutation, potentially months on a quiescent repo. Steady state is monotonic (production deletion paths soft-delete; the stamp counts deleted rows), so deploy is the one backward step — but it had to be handled, because of how apt clients respond.

**Measured behavior (not assumed):** apt does **not** reject a Release whose `Date:` is older than the one it has cached, and it does not warn. It silently refuses it: the downloaded (older-dated) Release/InRelease is verified, then discarded; the client keeps its entire previous metadata set; and `apt-get update` **exits 0 with zero diagnostics**. The mechanism is `pkgAcqMetaBase::VerifyVendor` in `apt-pkg/acquire-item.cc`, which converts a backward `Date:` into a fake If-Modified-Since hit ("a prevention of downgrading us to older (still valid) files"); the block reads no configuration and is present unchanged from apt 2.2.4 through current main. Verified empirically on apt 2.2.4 (debian:11), 2.6.1 (debian:12) and 2.8.3 (ubuntu:24.04), with real GPG verification via a `signed-by=` keyring (no `[trusted=yes]`), for both the detached `Release`+`Release.gpg` pair and `InRelease`: a package published under a rolled-back `Date:` stays invisible (`Candidate:` pinned at the old version) while `update` keeps exiting 0; moving `Date:` forward past the cached value unfreezes the client immediately with no manual intervention. No option controls this path — `Acquire::Check-Date=false` does not unlock it (that option governs the separate *future*-Date check, which is a loud `E: ... is not valid yet`, exit 100). Nothing here emits `Valid-Until`, and its absence changes none of the above.

An earlier draft of this description said apt "treats a backward `Date:` as a rollback attack". That was wrong as stated: there is no rejection and no alert. The measured behavior is quieter and operationally worse — a **silent freeze**: every existing client that had cached a pre-deploy wall-clock `Date:` would pin to its pre-deploy metadata, indefinitely on a quiescent repo, with `update` exiting 0 so no health check or exit-code-based CI job notices. The corrected claim supports the same design choices (counting deleted rows to keep the stamp monotonic) at least as strongly, precisely because the failure mode is invisible.

**The floor:** `Date:` is `max(state stamp, RELEASE_DATE_FLOOR_EPOCH)`, where `RELEASE_DATE_FLOOR_EPOCH` is the binary's build timestamp, baked by `build.rs` at compile time (`SOURCE_DATE_EPOCH` is honored when set, so reproducible builds stay reproducible; the value is validated in `build.rs` so the baked string always parses). No such build-time constant existed in the tree (`GIT_SHA` is the only other `build.rs` bake), so this introduces one, minimally. Why the build timestamp specifically:

- it is **at least as new as any wall-clock `Date:` the previous build served** up to the moment this build was produced, so the deploy-time backward step is removed for every client that updated before the build was cut;
- it is **identical across replicas** — every replica runs the same image, so a compile-time constant cannot skew, and the same repository state still renders the same bytes everywhere (the invariant this PR exists to hold);
- it is **stable across process restarts** — a process-start time would differ per replica and per restart, breaking replica determinism outright, which is why it was not used.

Honest edge: a client that runs `apt-get update` in the window between the image build and the rollout cutover caches a `Date:` newer than the floor and stays pinned until the repo's first post-deploy mutation (recovery is automatic then, as measured). That window is the build-to-deploy lag; no deploy-time or runtime source can shrink it further without giving up replica determinism.

#### What `Date:` does and does not track

Deleted rows are counted deliberately, and this is the part worth reviewing: filtering them out would move `Date:` **backward** when the newest artifact is removed — and, per the measured behavior above, apt clients holding the newer cached value would then silently pin to stale metadata with `update` exiting 0, so the repo would freeze for existing clients with nothing alerting anyone.

It does not follow that every content change moves `Date:` forward. There is no `updated_at` trigger on `artifacts` (`004_artifacts.sql:20` is a plain `DEFAULT NOW()`), so only writers that explicitly stamp `updated_at` advance it. `ArtifactService::delete_artifact` does. The retention/lifecycle sweeps in `lifecycle_service` and the Conan overwrite-supersede path do not — so those deletions change the index while `Date:` stands still, and lifecycle/retention is the realistic Debian case. That is a fidelity gap in what `Date:` reports; it is **not** a signature hazard, since both renders of a given state still agree, which is the invariant this PR is about. Left as a follow-up rather than widened into this diff, since making those paths stamp `updated_at` changes retention semantics across all formats.

#### Known residual: a write landing between the two fetches

This PR does **not** close the split-render class entirely. An upload that lands between `GET Release` and `GET Release.gpg` changes repository state, so the two renders differ and the pair fails verification until the client re-fetches. That is strictly better than baseline — pre-fix, any >=1s gap broke the pair on an *unchanged* repo; now it takes an actual write inside the gap — but the class is only closed by a store-once published-Release model (render once, persist, sign the persisted bytes). Determinism is a prerequisite for that model, so this PR is a step toward it, not a substitute for it.

#### Two side effects worth stating

- **Safer than `Utc::now()` against clock skew, not riskier.** Nothing in the tree emits `Valid-Until`, so apt's expiry check never engages. What apt *does* police is dates in the **future** (`Acquire::Max-FutureTime`, ~10s) — and both the repo-state stamp and the build-time floor are always in the past at serve time. A replica with a fast clock could previously stamp a future `Date:`; it can no longer.
- **The signature cache starts working.** `signed_release_cache_key` is content-addressed, so pre-fix the key rotated **every wall-clock second**: an idle repo's signature cache essentially never hit, and churned against the 1024-entry cap (`api/mod.rs:98`). Post-fix an unchanged repo has a stable key — hit rate on idle repos goes from ~0% to ~100%.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`generate_release_content_is_stable_across_a_second_boundary` (DB-backed) calls **`generate_release_content` itself** — the single function behind `Release`, `InRelease` and `Release.gpg` — twice across a real wall-clock second boundary and asserts the two `String`s are equal. It routes through the actual call site both endpoints use, so it fails on a clock read reintroduced *anywhere* beneath it, not just in the renderer. Verified to **fail on the pre-fix logic** with exactly the production byte diff (`Date: ...02:35:06 UTC` vs `...02:35:07 UTC`) and pass on this PR.

Also added:
- `release_publish_timestamp_is_floored_at_the_build_timestamp` — deploy-shape state (repository backdated to 2001, no artifacts) must stamp `Date:` == the build-time floor, never the older state stamp, and the floored render must stay byte-identical across a >1s gap. Verified to **fail without the floor**: with the `max()` removed it asserts `left: 2001-02-03T04:05:06Z / right: <build timestamp>` — the raw state stamp leaks through, which is exactly the value that silently freezes existing apt clients.
- `release_publish_timestamp_errors_when_the_database_is_unreachable` — a failed read must error, never degrade to a default stamp. Verified to fail against the `.ok()`-swallow form. Needs no live Postgres (an unreachable lazy pool fails on connect).
- `release_publish_timestamp_is_the_repository_created_at` — the stamp must equal the repository's stored `created_at` read back from the DB. Verified to fail against a `Utc::now()` implementation.
- `release_date_comes_from_publish_timestamp_not_the_wall_clock` — rendering with a past timestamp must emit that date, not today.
- `format_release_date_matches_the_apt_wire_format` — pins the exact wire format apt parses.
- `release_render_is_stable_across_repeated_calls` — repeated renders of unchanged state are identical.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Verification on a patched instance:
- The gap sweep that was `6/6 BAD` at gap >= 1.0s on baseline is now **6/6 Good at every gap** (0s -> 2.0s); byte diff **0 of 897**.
- Negative controls intact: appending a byte -> `BAD signature`; flipping a SHA256 digit -> `BAD signature`; untampered -> `Good signature`.
- DTF `signing` tier run **4/4 PASS** (A3 `untampered -> Good signature; tampered -> rejected`; A4 real `apt-get install` with `signed-by=` and no `[trusted=yes]`).
- Full lib suite (rebased on current main): **13580/13580 pass** (6 skipped); `cargo fmt --check`, `clippy --workspace --all-targets` clean; jscpd reports no clones on the changed files.

Note for reviewers: the tier also passes on **baseline** `main` on a fast, idle host, because the two fetches land in the same second there — the tier's A3 does not currently force the gap that makes this deterministic. **The unit test is therefore the real gate**, which is why it is wired through `generate_release_content` rather than through a component of it. The discriminating end-to-end evidence is the gap sweep above. Suggested tier follow-up (not changed here, as artifact-keeper-test#259 is in flight): have A3 fetch `Release` and `Release.gpg` with a deliberate >1s gap.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No migration and no schema change: the publish timestamp is read from existing `artifacts`/`repositories` columns, and the floor is a compile-time constant baked by `build.rs` (`RELEASE_DATE_FLOOR_EPOCH`, alongside the existing `GIT_SHA`). No `cargo sqlx prepare` needed — the queries use the runtime `sqlx::query_as`/`sqlx::query`, not the compile-time macros.

The `Date:` value served for a given repo changes from "now" to `max(last content change, build timestamp of the running binary)`. This is what makes the signature verifiable across split fetches while never stepping backward past what pre-fix builds served — which matters because apt clients respond to a backward `Date:` by silently pinning to cached metadata with `apt-get update` exiting 0. Two reads that previously degraded silently now return an error instead (a `Release` render during a DB fault fails rather than serving a document the sibling signature will not match).
