### PR TITLE
fix: add durable repository owner capability

### DIFF
--- a/backend/migrations/172_repository_owner_capability.sql
+++ b/backend/migrations/172_repository_owner_capability.sql
@@ -1,0 +1,68 @@
+-- Establish durable, action-aware repository ownership without switching
+-- existing installations to the new authorization model in one step.
+--
+-- The built-in roles were originally seeded with empty `permissions` arrays,
+-- so action-aware checks had to infer capabilities from role names. Populate
+-- the intended capabilities first; endpoint enforcement can then migrate to
+-- these values independently.
+UPDATE roles
+SET permissions = CASE name
+        WHEN 'admin' THEN ARRAY['read', 'write', 'delete', 'admin']::TEXT[]
+        WHEN 'developer' THEN ARRAY['read', 'write']::TEXT[]
+        WHEN 'reader' THEN ARRAY['read']::TEXT[]
+    END,
+    updated_at = NOW()
+WHERE name IN ('admin', 'developer', 'reader');
+
+-- Keep repository ownership distinct from the legacy developer role. The
+-- `admin` capability is durable: a fine-grained rule may narrow an ordinary
+-- role, but it must not silently strip the repository owner of control.
+INSERT INTO roles (name, description, permissions, is_system)
+VALUES (
+    'repository-owner',
+    'Full control of assigned repositories',
+    ARRAY['read', 'write', 'delete', 'admin']::TEXT[],
+    true
+)
+ON CONFLICT (name) DO UPDATE
+SET description = EXCLUDED.description,
+    permissions = EXCLUDED.permissions,
+    is_system = true,
+    updated_at = NOW();
+
+-- Repositories created after migration 128 have an authoritative creator.
+-- Add the owner role alongside the existing developer assignment so upgrades
+-- are additive and remain compatible with code that still reads legacy roles.
+INSERT INTO role_assignments (user_id, role_id, repository_id)
+SELECT repo.created_by, owner_role.id, repo.id
+FROM repositories repo
+CROSS JOIN roles owner_role
+WHERE owner_role.name = 'repository-owner'
+  AND repo.created_by IS NOT NULL
+ON CONFLICT (user_id, role_id, repository_id) DO NOTHING;
+
+-- Older repositories have no `created_by` value. On a rule-less repository,
+-- every repository-scoped developer currently receives the legacy mutation
+-- capability and may therefore be the historical owner. Preserve that
+-- effective access during the staged migration by promoting those principals
+-- to explicit owners. Repositories already governed by repository/project
+-- rules are deliberately left alone because their ACL is authoritative.
+INSERT INTO role_assignments (user_id, role_id, repository_id)
+SELECT legacy.user_id, owner_role.id, legacy.repository_id
+FROM role_assignments legacy
+JOIN roles legacy_role ON legacy_role.id = legacy.role_id
+JOIN repositories repo ON repo.id = legacy.repository_id
+CROSS JOIN roles owner_role
+WHERE legacy_role.name = 'developer'
+  AND owner_role.name = 'repository-owner'
+  AND repo.created_by IS NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM permissions permission
+      WHERE (permission.target_type = 'repository' AND permission.target_id = repo.id)
+         OR (
+             permission.target_type = 'project'
+             AND permission.target_id = repo.project_id
+         )
+  )
+ON CONFLICT (user_id, role_id, repository_id) DO NOTHING;

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -546,11 +546,9 @@ pub async fn send(app: Router, req: Request<Body>) -> (StatusCode, Bytes) {
     (status, body)
 }
 
-/// Grant `user_id` the `developer` role scoped to `repo_id`, mirroring the
-/// owner auto-grant that `RepositoryService::create` performs for real
-/// callers. Handler smoke tests authenticate as the fixture user, so without
-/// this grant the per-repo authorization check in `require_visible` /
-/// `require_repo_write_access` would reject them on private repositories.
+/// Grant `user_id` the `developer` role scoped to `repo_id`. Handler smoke
+/// tests use this for an ordinary read/write repository member; owner-specific
+/// tests should grant the `repository-owner` role explicitly.
 pub async fn grant_repo_access(pool: &PgPool, repo_id: Uuid, user_id: Uuid) {
     sqlx::query(
         "INSERT INTO role_assignments (user_id, role_id, repository_id) \
@@ -1018,10 +1016,9 @@ impl Fixture {
         let pool = try_pool().await?;
         let (user_id, username) = create_user(&pool).await;
         let (repo_id, repo_key, storage_dir) = create_repo(&pool, repo_type, format).await;
-        // Owner auto-grant: the fixture user is the de-facto owner of the
-        // fixture repo, so grant them per-repo access. This keeps the
+        // Make the fixture user an ordinary repository member. This keeps the
         // authenticated-router smoke tests valid under per-repo authorization
-        // (private repos now require a role assignment, not just a token).
+        // without silently giving every fixture durable owner capability.
         grant_repo_access(&pool, repo_id, user_id).await;
         let state = build_state(pool.clone(), storage_dir.to_str().unwrap());
         Some(Self {

--- a/backend/src/services/permission_service.rs
+++ b/backend/src/services/permission_service.rs
@@ -150,6 +150,92 @@ impl PermissionService {
         Ok(actions.iter().any(|a| a == action))
     }
 
+    /// Check an action against repository ownership, fine-grained rules, and
+    /// legacy role assignments in one decision.
+    ///
+    /// A role carrying `admin` is a durable owner capability and always wins.
+    /// For every other principal, an applicable direct/group repository rule
+    /// (or inherited project rule) is authoritative for that principal only.
+    /// Users without an applicable rule retain their role-based capabilities.
+    /// This principal-scoped transition prevents the first rule on a target
+    /// from dropping every unrelated legacy principal to no access.
+    pub async fn check_repository_action(
+        &self,
+        user_id: Uuid,
+        repository_id: Uuid,
+        action: &str,
+        is_admin: bool,
+    ) -> Result<bool> {
+        if is_admin {
+            return Ok(true);
+        }
+
+        let allowed: bool = sqlx::query_scalar(
+            r#"
+            WITH applicable_rules AS (
+                SELECT p.actions
+                FROM permissions p
+                WHERE (
+                    (p.principal_type IN ('user', 'service_account') AND p.principal_id = $1)
+                    OR (
+                        p.principal_type = 'group'
+                        AND p.principal_id IN (
+                            SELECT group_id
+                            FROM user_group_members
+                            WHERE user_id = $1
+                        )
+                    )
+                )
+                AND (
+                    (p.target_type = 'repository' AND p.target_id = $2)
+                    OR (
+                        p.target_type = 'project'
+                        AND p.target_id = (
+                            SELECT project_id
+                            FROM repositories
+                            WHERE id = $2
+                        )
+                    )
+                )
+            ),
+            assigned_roles AS (
+                SELECT r.permissions
+                FROM role_assignments ra
+                JOIN roles r ON r.id = ra.role_id
+                WHERE ra.user_id = $1
+                  AND (ra.repository_id = $2 OR ra.repository_id IS NULL)
+            )
+            SELECT
+                EXISTS (
+                    SELECT 1
+                    FROM assigned_roles
+                    WHERE 'admin' = ANY(permissions)
+                )
+                OR CASE
+                    WHEN EXISTS (SELECT 1 FROM applicable_rules)
+                    THEN EXISTS (
+                        SELECT 1
+                        FROM applicable_rules
+                        WHERE $3 = ANY(actions) OR 'admin' = ANY(actions)
+                    )
+                    ELSE EXISTS (
+                        SELECT 1
+                        FROM assigned_roles
+                        WHERE $3 = ANY(permissions) OR 'admin' = ANY(permissions)
+                    )
+                END
+            "#,
+        )
+        .bind(user_id)
+        .bind(repository_id)
+        .bind(action)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(allowed)
+    }
+
     /// Return true when at least one permission rule exists for the given
     /// target, regardless of principal. This is used by middleware to decide
     /// whether fine-grained rules should be enforced at all (targets without
@@ -1561,5 +1647,369 @@ mod tests {
             .await
             .unwrap();
         assert!(!art_read);
+    }
+
+    // -----------------------------------------------------------------------
+    // Repository action model -- DB-backed lib tests run in Tier 1 CI
+    // -----------------------------------------------------------------------
+
+    mod repository_actions_db {
+        use super::*;
+        use crate::api::handlers::test_db_helpers as tdh;
+        use sqlx::PgPool;
+
+        async fn assign_repo_role(pool: &PgPool, user_id: Uuid, repo_id: Uuid, role: &str) {
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+                 SELECT $1, id, $2 FROM roles WHERE name = $3 \
+                 ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
+            )
+            .bind(user_id)
+            .bind(repo_id)
+            .bind(role)
+            .execute(pool)
+            .await
+            .expect("assign repository role");
+        }
+
+        async fn cleanup_action_fixture(
+            pool: &PgPool,
+            repo_id: Uuid,
+            user_ids: &[Uuid],
+            storage_dir: &std::path::Path,
+        ) {
+            let _ = sqlx::query(
+                "DELETE FROM permissions \
+                 WHERE target_type = 'repository' AND target_id = $1",
+            )
+            .bind(repo_id)
+            .execute(pool)
+            .await;
+            let _ = sqlx::query("DELETE FROM role_assignments WHERE repository_id = $1")
+                .bind(repo_id)
+                .execute(pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+                .bind(repo_id)
+                .execute(pool)
+                .await;
+            let _ = sqlx::query("DELETE FROM users WHERE id = ANY($1)")
+                .bind(user_ids)
+                .execute(pool)
+                .await;
+            let _ = std::fs::remove_dir_all(storage_dir);
+        }
+
+        #[tokio::test]
+        async fn test_repository_action_uses_owner_roles_and_principal_scoped_rules() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = PermissionService::new(pool.clone());
+            let (repo_id, _, storage_dir) = tdh::create_repo(&pool, "local", "generic").await;
+            let (owner_id, _) = tdh::create_user(&pool).await;
+            let (developer_id, _) = tdh::create_user(&pool).await;
+            let (reader_id, _) = tdh::create_user(&pool).await;
+            let (other_id, _) = tdh::create_user(&pool).await;
+            let user_ids = [owner_id, developer_id, reader_id, other_id];
+
+            let project_id: Uuid =
+                sqlx::query_scalar("INSERT INTO projects (key, name) VALUES ($1, $2) RETURNING id")
+                    .bind(format!("owner-model-{}", Uuid::new_v4()))
+                    .bind("Repository owner model test")
+                    .fetch_one(&pool)
+                    .await
+                    .expect("create project");
+            sqlx::query("UPDATE repositories SET project_id = $1 WHERE id = $2")
+                .bind(project_id)
+                .bind(repo_id)
+                .execute(&pool)
+                .await
+                .expect("assign repository project");
+
+            let group_id: Uuid =
+                sqlx::query_scalar("INSERT INTO groups (name) VALUES ($1) RETURNING id")
+                    .bind(format!("owner-model-{}", Uuid::new_v4()))
+                    .fetch_one(&pool)
+                    .await
+                    .expect("create permission group");
+            sqlx::query("INSERT INTO user_group_members (user_id, group_id) VALUES ($1, $2)")
+                .bind(reader_id)
+                .bind(group_id)
+                .execute(&pool)
+                .await
+                .expect("assign permission group");
+
+            assign_repo_role(&pool, owner_id, repo_id, "repository-owner").await;
+            assign_repo_role(&pool, developer_id, repo_id, "developer").await;
+            assign_repo_role(&pool, reader_id, repo_id, "reader").await;
+
+            assert!(service
+                .check_repository_action(other_id, repo_id, "admin", true)
+                .await
+                .expect("global admin short-circuit"));
+            assert!(!service
+                .check_repository_action(other_id, repo_id, "read", false)
+                .await
+                .expect("unassigned user decision"));
+            assert!(service
+                .check_repository_action(owner_id, repo_id, "admin", false)
+                .await
+                .expect("owner admin decision"));
+            assert!(service
+                .check_repository_action(owner_id, repo_id, "delete", false)
+                .await
+                .expect("owner delete decision"));
+            assert!(service
+                .check_repository_action(developer_id, repo_id, "write", false)
+                .await
+                .expect("developer write decision"));
+            assert!(!service
+                .check_repository_action(developer_id, repo_id, "delete", false)
+                .await
+                .expect("developer delete decision"));
+            assert!(service
+                .check_repository_action(reader_id, repo_id, "read", false)
+                .await
+                .expect("reader read decision"));
+            assert!(!service
+                .check_repository_action(reader_id, repo_id, "write", false)
+                .await
+                .expect("reader write decision"));
+
+            // Project rules and group membership participate in the same
+            // principal-scoped decision. Once applicable, the rule replaces
+            // this reader's legacy role fallback.
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('group', $1, 'project', $2, ARRAY['write'])",
+            )
+            .bind(group_id)
+            .bind(project_id)
+            .execute(&pool)
+            .await
+            .expect("insert inherited group rule");
+            assert!(service
+                .check_repository_action(reader_id, repo_id, "write", false)
+                .await
+                .expect("inherited group write decision"));
+            assert!(!service
+                .check_repository_action(reader_id, repo_id, "read", false)
+                .await
+                .expect("inherited group rule replaces role fallback"));
+
+            // A rule for somebody else must not disable the developer's role
+            // fallback. This is the first-rule-falls-closed regression.
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
+            )
+            .bind(other_id)
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("insert unrelated fine-grained rule");
+            assert!(service
+                .check_repository_action(developer_id, repo_id, "write", false)
+                .await
+                .expect("developer fallback with unrelated rule"));
+
+            // A rule that does apply to the developer is authoritative for
+            // that principal and may narrow the legacy role to read-only.
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
+            )
+            .bind(developer_id)
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("insert developer override");
+            assert!(!service
+                .check_repository_action(developer_id, repo_id, "write", false)
+                .await
+                .expect("developer principal override"));
+
+            // Owner/admin is durable and cannot be accidentally stripped by
+            // an ordinary fine-grained rule on the same principal.
+            sqlx::query(
+                "INSERT INTO permissions \
+                   (principal_type, principal_id, target_type, target_id, actions) \
+                 VALUES ('user', $1, 'repository', $2, ARRAY['read'])",
+            )
+            .bind(owner_id)
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("insert owner rule");
+            assert!(service
+                .check_repository_action(owner_id, repo_id, "delete", false)
+                .await
+                .expect("durable owner decision"));
+
+            sqlx::query("DELETE FROM permissions WHERE target_type = 'project' AND target_id = $1")
+                .bind(project_id)
+                .execute(&pool)
+                .await
+                .expect("delete project permissions");
+            cleanup_action_fixture(&pool, repo_id, &user_ids, &storage_dir).await;
+            sqlx::query("DELETE FROM groups WHERE id = $1")
+                .bind(group_id)
+                .execute(&pool)
+                .await
+                .expect("delete permission group");
+            sqlx::query("DELETE FROM projects WHERE id = $1")
+                .bind(project_id)
+                .execute(&pool)
+                .await
+                .expect("delete project");
+        }
+
+        #[tokio::test]
+        async fn test_repository_owner_migration_backfills_without_flag_day() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let mut tx = pool.begin().await.expect("begin migration fixture");
+
+            // Shadow only the tables touched by migration 172. Executing the
+            // exact migration file against temporary tables tests upgrade
+            // behavior without mutating the shared CI database.
+            sqlx::raw_sql(
+                r#"
+                CREATE TEMP TABLE roles (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    name TEXT UNIQUE NOT NULL,
+                    description TEXT,
+                    permissions TEXT[] NOT NULL DEFAULT '{}',
+                    is_system BOOLEAN NOT NULL DEFAULT false,
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+                ) ON COMMIT DROP;
+                CREATE TEMP TABLE repositories (
+                    id UUID PRIMARY KEY,
+                    created_by UUID,
+                    project_id UUID
+                ) ON COMMIT DROP;
+                CREATE TEMP TABLE role_assignments (
+                    user_id UUID NOT NULL,
+                    role_id UUID NOT NULL,
+                    repository_id UUID,
+                    UNIQUE (user_id, role_id, repository_id)
+                ) ON COMMIT DROP;
+                CREATE TEMP TABLE permissions (
+                    target_type TEXT NOT NULL,
+                    target_id UUID NOT NULL
+                ) ON COMMIT DROP;
+                "#,
+            )
+            .execute(&mut *tx)
+            .await
+            .expect("create isolated migration tables");
+
+            sqlx::query(
+                "INSERT INTO roles (name, description) VALUES \
+                 ('admin', 'admin'), ('developer', 'developer'), ('reader', 'reader')",
+            )
+            .execute(&mut *tx)
+            .await
+            .expect("seed legacy roles");
+
+            let known_repo = Uuid::new_v4();
+            let known_owner = Uuid::new_v4();
+            let legacy_repo = Uuid::new_v4();
+            let legacy_developer = Uuid::new_v4();
+            let ruled_repo = Uuid::new_v4();
+            let ruled_developer = Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO repositories (id, created_by) VALUES \
+                 ($1, $2), ($3, NULL), ($4, NULL)",
+            )
+            .bind(known_repo)
+            .bind(known_owner)
+            .bind(legacy_repo)
+            .bind(ruled_repo)
+            .execute(&mut *tx)
+            .await
+            .expect("seed legacy repositories");
+            sqlx::query(
+                "INSERT INTO role_assignments (user_id, role_id, repository_id) \
+                 SELECT $1, id, $2 FROM roles WHERE name = 'developer' \
+                 UNION ALL \
+                 SELECT $3, id, $4 FROM roles WHERE name = 'developer'",
+            )
+            .bind(legacy_developer)
+            .bind(legacy_repo)
+            .bind(ruled_developer)
+            .bind(ruled_repo)
+            .execute(&mut *tx)
+            .await
+            .expect("seed legacy developer assignments");
+            sqlx::query(
+                "INSERT INTO permissions (target_type, target_id) \
+                 VALUES ('repository', $1)",
+            )
+            .bind(ruled_repo)
+            .execute(&mut *tx)
+            .await
+            .expect("seed authoritative rule");
+
+            sqlx::raw_sql(include_str!(
+                "../../migrations/172_repository_owner_capability.sql"
+            ))
+            .execute(&mut *tx)
+            .await
+            .expect("run repository owner migration");
+
+            // The SQL is intentionally safe to replay while an operator
+            // repairs or validates a staged upgrade.
+            sqlx::raw_sql(include_str!(
+                "../../migrations/172_repository_owner_capability.sql"
+            ))
+            .execute(&mut *tx)
+            .await
+            .expect("re-run repository owner migration");
+
+            let developer_actions: Vec<String> =
+                sqlx::query_scalar("SELECT permissions FROM roles WHERE name = 'developer'")
+                    .fetch_one(&mut *tx)
+                    .await
+                    .expect("read developer actions");
+            let reader_actions: Vec<String> =
+                sqlx::query_scalar("SELECT permissions FROM roles WHERE name = 'reader'")
+                    .fetch_one(&mut *tx)
+                    .await
+                    .expect("read reader actions");
+            assert_eq!(developer_actions, vec!["read", "write"]);
+            assert_eq!(reader_actions, vec!["read"]);
+
+            for (user_id, repo_id, expected) in [
+                (known_owner, known_repo, true),
+                (legacy_developer, legacy_repo, true),
+                (ruled_developer, ruled_repo, false),
+            ] {
+                let has_owner: bool = sqlx::query_scalar(
+                    "SELECT EXISTS ( \
+                         SELECT 1 FROM role_assignments ra \
+                         JOIN roles r ON r.id = ra.role_id \
+                         WHERE ra.user_id = $1 AND ra.repository_id = $2 \
+                           AND r.name = 'repository-owner' \
+                     )",
+                )
+                .bind(user_id)
+                .bind(repo_id)
+                .fetch_one(&mut *tx)
+                .await
+                .expect("read owner backfill");
+                assert_eq!(
+                    has_owner, expected,
+                    "unexpected owner backfill for {repo_id}"
+                );
+            }
+
+            tx.rollback().await.expect("rollback migration fixture");
+        }
     }
 }

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -73,9 +73,9 @@ pub struct CreateRepositoryRequest {
     /// legacy unverified-ingest behavior. Persisted in the create tx.
     pub curation_allow_unverified: Option<bool>,
     /// User who is creating this repository. When set, the repository records
-    /// this user as `created_by` and the creator is auto-granted the
-    /// `developer` role scoped to the new repository (owner auto-grant), so the
-    /// creator retains access under per-repo authorization.
+    /// this user as `created_by` and the creator is auto-granted the durable
+    /// `repository-owner` role scoped to the new repository. The legacy
+    /// `developer` grant is retained during the staged authorization rollout.
     pub created_by: Option<Uuid>,
 }
 
@@ -821,10 +821,9 @@ impl RepositoryService {
                     .await
                     .map_err(|e| AppError::Database(e.to_string()))?;
                 }
-                // Owner auto-grant: record the creator and grant them the
-                // `developer` role scoped to this repository, so the creator
-                // retains access under per-repo authorization. Runs inside the
-                // same tx as the INSERT so creator-grant is atomic with create.
+                // Owner auto-grant: dual-write the durable repository-owner
+                // and legacy developer roles during the staged rollout. Both
+                // grants land in the same transaction as the repository.
                 if let Some(creator_id) = req.created_by {
                     sqlx::query("UPDATE repositories SET created_by = $1 WHERE id = $2")
                         .bind(creator_id)
@@ -834,7 +833,8 @@ impl RepositoryService {
                         .map_err(|e| AppError::Database(e.to_string()))?;
                     sqlx::query(
                         "INSERT INTO role_assignments (user_id, role_id, repository_id) \
-                         SELECT $1, r.id, $2 FROM roles r WHERE r.name = 'developer' \
+                         SELECT $1, r.id, $2 FROM roles r \
+                         WHERE r.name IN ('repository-owner', 'developer') \
                          ON CONFLICT (user_id, role_id, repository_id) DO NOTHING",
                     )
                     .bind(creator_id)
@@ -3646,7 +3646,25 @@ mod tests {
             req.created_by = Some(owner_id);
             let repo = service.create(req).await.expect("create private repo");
 
-            // Owner (auto-granted developer role scoped to the repo) -> allowed.
+            let creator_roles: Vec<String> = sqlx::query_scalar(
+                "SELECT r.name::text FROM role_assignments ra \
+                 JOIN roles r ON r.id = ra.role_id \
+                 WHERE ra.user_id = $1 AND ra.repository_id = $2 \
+                   AND r.name IN ('developer', 'repository-owner') \
+                 ORDER BY r.name",
+            )
+            .bind(owner_id)
+            .bind(repo.id)
+            .fetch_all(&pool)
+            .await
+            .expect("creator role lookup");
+            assert_eq!(
+                creator_roles,
+                vec!["developer", "repository-owner"],
+                "creator must receive owner and retain developer during staged rollout"
+            );
+
+            // Owner (auto-granted repository-owner role) -> allowed.
             assert!(
                 service
                     .user_can_access_repo(repo.id, owner_id)


### PR DESCRIPTION
## Summary

This PR proposes the staged ownership foundation requested in #2666. If
accepted and merged, it resolves #2666 and provides the prerequisite needed to
revisit the authorization work originally proposed in #2610.

The change makes repository ownership durable, gives the seeded roles explicit
capabilities, preserves legacy access during upgrade, and adds one
principal-scoped repository action decision that later authorization hardening
can adopt consistently.

### Chosen design

This PR combines the first two options from #2666:

1. Add a real repository-scoped `repository-owner` role with
   `read`, `write`, `delete`, and `admin` capabilities.
2. Backfill `roles.permissions` for the seeded roles:
   - `admin`: `read`, `write`, `delete`, `admin`
   - `developer`: `read`, `write`
   - `reader`: `read`

It then adds the staged compatibility needed to make that combination safe:

- New repository creators receive both `repository-owner` and the existing
  `developer` assignment in the same transaction as repository creation.
- Repositories with an authoritative `created_by` value backfill that creator
  as owner.
- Older repositories without `created_by` promote their repository-scoped
  developers only when neither the repository nor its project has a
  fine-grained rule. This preserves their previous effective control without
  guessing through an ACL that is already authoritative.
- Legacy repositories governed by repository or project rules are deliberately
  left unchanged.

This PR does not relax the global-admin gate on permission-rule management.
That policy can be considered separately after endpoints have a durable
repository-admin capability to check; it is not required to establish owner
identity or complete this migration.

### Staged upgrade path

The rollout is additive rather than a flag day:

1. Migration `172_repository_owner_capability.sql` establishes truthful role
   capabilities and backfills ownership without removing existing assignments.
2. Repository creation dual-writes owner and developer grants, so old and new
   authorization code can coexist during the transition.
3. Existing handlers keep their current behavior in this PR. The new
   `check_repository_action` decision is available for later endpoint-by-endpoint
   adoption.
4. An application rollback remains compatible with the migrated database:
   existing columns and developer assignments are retained, and older code can
   ignore the additional owner role.

The migration uses conflict-safe inserts, and its regression test executes the
exact migration twice to verify replay safety.

### Repository action semantics

`PermissionService::check_repository_action` defines the transition target for
future handler hardening:

- Global administrators retain the existing bypass.
- A role carrying `admin` is a durable owner capability and cannot be
  accidentally narrowed by an ordinary fine-grained rule.
- An applicable direct, service-account, or group rule on the repository or
  inherited project is authoritative for that principal only.
- A rule for another principal does not disable an unrelated user's role
  fallback. This avoids the first-rule-falls-closed failure described in #2666.
- Without an applicable rule, the decision reads the assigned role's explicit
  capabilities rather than inferring actions from the role name.
- `admin` implies the narrower repository actions.

### Explicit non-goals and follow-up

- This prerequisite does not rewire repository mutation handlers or change
  their externally visible authorization behavior.
- It does not include the endpoint-level hardening from #2610.
- It does not change the permission-management API or add HTTP endpoints.

After this prerequisite merges, the endpoint hardening originally proposed in
#2610 can be adapted to the durable owner/action model in a fresh, focused
follow-up from the then-current `upstream/main`. Keeping those handler changes
separate lets this PR settle the ownership and migration model first.

### CI placement and regression coverage

The regression tests live in the library target rather than `backend/tests/*`:

- `test_repository_action_uses_owner_roles_and_principal_scoped_rules` covers
  owner durability, developer/reader capabilities, group and project
  inheritance, principal-scoped overrides, the global-admin bypass, and the
  first-rule-falls-closed regression.
- `test_repository_owner_migration_backfills_without_flag_day` executes the
  exact migration against isolated temporary tables, checks creator and legacy
  backfill behavior, verifies ruled repositories are not promoted, and reruns
  the migration to check idempotency.
- The existing repository-create regression now asserts that a creator receives
  exactly `developer` plus `repository-owner` during the staged rollout.
- Shared handler fixtures continue to grant ordinary `developer` membership;
  they no longer describe every test principal as an owner.

Both the Backend Unit Tests and Code Coverage jobs provision PostgreSQL, apply
migrations, set `DATABASE_URL`, and run `cargo nextest run --workspace --lib`.
These tests therefore execute in PR CI instead of landing in an integration or
E2E target that the workflow does not run.

### CI notes and test changes

No existing test was disabled, weakened, or rewritten to make this change pass.
The only changes to existing test code add the repository-create dual-write
assertion and keep shared handler fixtures as ordinary `developer` members.
The repository-action and migration/backfill checks are new DB-backed library
regressions.

Local Docker verification passed formatting, full workspace Clippy, a fresh
database migration through the complete branch migration set rebased onto
current `upstream/main`, and the three focused DB-backed owner/action,
migration/backfill, and repository-create regressions. The new DB-backed
regressions execute in the library target, so the same tests are included in PR
CI.

### Manual E2E verification

Before the latest upstream rebase, I deployed an earlier revision of this
feature patch as a `linux/amd64` image to a non-production Kubernetes
environment backed by an existing PostgreSQL database at migration `162`.

The feature migration was numbered `167` in that image and was later
renumbered to `172` to avoid conflicts with current `main`. Its SQL is
unchanged, and the current migration file is exercised directly by the
DB-backed library regression. The observations below retain the number used by
the deployed image.

Before rollout, I inserted controlled upgrade fixtures for:

- a repository with an authoritative creator;
- a rule-less legacy repository with a scoped developer;
- legacy developers governed by repository and project rules;
- a rule-less legacy repository with only a reader assignment.

Observed after rollout:

- migrations `163` through `167` completed successfully;
- all `41/41` repositories with `created_by` received a matching owner grant;
- the rule-less legacy developer was promoted;
- repository-rule, project-rule, and reader-only fixtures were not promoted;
- duplicate role-assignment groups remained at zero;
- a repository created through the authenticated REST endpoint received exactly
  one `developer` and one `repository-owner` grant for its creator;
- after replacing the backend pod, migration `167` remained recorded once,
  role and assignment counts were unchanged, and readiness returned HTTP 200;
- primary and replica agreed on the migrated state.

All disposable repositories, permission rows, project, and user records were
removed after verification. The environment retained only the intended role
capabilities and owner grants for its existing repositories.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A - this is not a bug fix

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (migration 172 is additive and forward-only;
      application rollback compatibility is retained through dual-write)
- [x] N/A - no HTTP API changes
