### PR TITLE
fix(rpm): bound concurrent buffered proxy metadata + pin LARGE cap (#2665, #2664)

### DIFF
--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -25,7 +25,117 @@ pub use crate::services::proxy_service::{DEFAULT_METADATA_MAX_BYTES, LARGE_METAD
 use crate::storage::StorageLocation;
 use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+// ---------------------------------------------------------------------------
+// Global buffered-proxy-metadata byte budget (#2665)
+// ---------------------------------------------------------------------------
+
+/// Default ceiling on the TOTAL bytes the buffered proxy-metadata path may hold
+/// resident across ALL in-flight requests (#2665). 1 GiB — eight worst-case
+/// [`LARGE_METADATA_MAX_BYTES`] (128 MiB) buffers, or many more realistically
+/// sized ones — chosen so a legitimate concurrent `dnf` refresh does not block
+/// while a hostile fan-out cannot drive resident memory unbounded.
+pub const DEFAULT_PROXY_METADATA_BUDGET_BYTES: usize = 1024 * 1024 * 1024;
+
+/// Env override for [`DEFAULT_PROXY_METADATA_BUDGET_BYTES`]. A blank,
+/// non-numeric, or zero value falls back to the default.
+pub const PROXY_METADATA_BUDGET_BYTES_ENV: &str = "AK_PROXY_METADATA_BUDGET_BYTES";
+
+/// A process-wide byte budget bounding the TOTAL memory the *buffered*
+/// proxy-metadata path may hold resident at once, independent of request
+/// concurrency (#2665).
+///
+/// The buffered metadata fetch ([`proxy_fetch_capped`], used by the RPM repodata
+/// proxy) reads the whole upstream/cached document into a [`Bytes`] before
+/// responding. A per-request cap ([`LARGE_METADATA_MAX_BYTES`]) bounds ONE
+/// request, but nothing bounded the *sum* over concurrent requests: N anonymous,
+/// un-rate-limited requests each buffering up to the cap put ~N×cap resident (a
+/// realistic ~15 GiB from a cached ~30 MiB `filelists`). Cache hits made this
+/// worse — they return before the single-flight coordinator, so even cached
+/// responses each buffered independently.
+///
+/// This budget caps that sum: each buffered fetch reserves permits (one per
+/// byte, up to the cap) BEFORE it buffers and releases them once the buffered
+/// body has been handed to the response writer, so total concurrent buffering
+/// can never exceed `total_bytes`. Once the budget is exhausted, further
+/// requests await a reservation (bounded queueing) instead of admitting
+/// unbounded buffers. Mirrors the byte-bounded `scan_extraction_semaphore`
+/// pattern (`permits × per-item-cap` resident ceiling) already used by the
+/// scanner.
+pub struct ProxyMetadataBudget {
+    sem: Arc<Semaphore>,
+    total: usize,
+}
+
+impl ProxyMetadataBudget {
+    /// Build a budget of `total_bytes`, clamped to `[1, u32::MAX]` (and to
+    /// [`Semaphore::MAX_PERMITS`]). A single reservation is always `<=` the
+    /// per-request cap, far below `u32::MAX`, so it stays inside the acquirable
+    /// range.
+    pub fn new(total_bytes: usize) -> Self {
+        let ceiling = (u32::MAX as usize).min(Semaphore::MAX_PERMITS);
+        let total = total_bytes.clamp(1, ceiling);
+        Self {
+            sem: Arc::new(Semaphore::new(total)),
+            total,
+        }
+    }
+
+    /// Total budget in bytes.
+    pub fn total_bytes(&self) -> usize {
+        self.total
+    }
+
+    /// Currently unreserved bytes (observability / test helper).
+    pub fn available_bytes(&self) -> usize {
+        self.sem.available_permits()
+    }
+
+    fn permits_for(&self, bytes: usize) -> u32 {
+        // A single request can reserve at most the whole budget, so an oversized
+        // request degrades to "hold the whole budget" rather than deadlocking on
+        // a permit count the semaphore can never satisfy.
+        bytes.clamp(1, self.total) as u32
+    }
+
+    /// Reserve `bytes` of the budget, awaiting when it is exhausted. The
+    /// returned permit releases the reservation on drop — hold it for as long
+    /// as the buffered bytes are resident.
+    pub async fn reserve(&self, bytes: usize) -> OwnedSemaphorePermit {
+        // `acquire_many_owned` only errors when the semaphore is closed; this
+        // one lives for the process lifetime and is never closed.
+        Arc::clone(&self.sem)
+            .acquire_many_owned(self.permits_for(bytes))
+            .await
+            .expect("proxy metadata budget semaphore is never closed")
+    }
+
+    /// Non-blocking reservation: `None` when the budget cannot currently satisfy
+    /// `bytes`. Used to prove the bound rejects once exhausted.
+    pub fn try_reserve(&self, bytes: usize) -> Option<OwnedSemaphorePermit> {
+        Arc::clone(&self.sem)
+            .try_acquire_many_owned(self.permits_for(bytes))
+            .ok()
+    }
+}
+
+/// Process-wide buffered-proxy-metadata byte budget (#2665). Sized once from
+/// [`PROXY_METADATA_BUDGET_BYTES_ENV`] (default
+/// [`DEFAULT_PROXY_METADATA_BUDGET_BYTES`]); lives for the process lifetime.
+pub fn proxy_metadata_budget() -> &'static ProxyMetadataBudget {
+    static BUDGET: OnceLock<ProxyMetadataBudget> = OnceLock::new();
+    BUDGET.get_or_init(|| {
+        let total = std::env::var(PROXY_METADATA_BUDGET_BYTES_ENV)
+            .ok()
+            .and_then(|v| v.trim().parse::<usize>().ok())
+            .filter(|v| *v > 0)
+            .unwrap_or(DEFAULT_PROXY_METADATA_BUDGET_BYTES);
+        ProxyMetadataBudget::new(total)
+    })
+}
 
 // ---------------------------------------------------------------------------
 // Shared RepoInfo
@@ -4544,6 +4654,98 @@ pub(crate) fn build_remote_repo_with_format(
 mod tests {
     use super::*;
     use axum::http::StatusCode;
+
+    // ── Global buffered-metadata byte budget (#2665) ─────────────────
+    //
+    // Before this fix the buffered proxy-metadata path (RPM repodata) had a
+    // per-request cap but NO bound on total concurrent buffering: N requests
+    // each buffered up to the cap, so resident memory scaled with concurrency
+    // (~512× the cap in the issue). These pin the primitive that bounds the
+    // SUM, so total resident buffered bytes can never exceed the budget.
+
+    #[test]
+    fn proxy_metadata_budget_bounds_total_concurrent_reservation() {
+        // A budget of 3× the per-request cap admits exactly three cap-sized
+        // reservations, then REJECTS the fourth until one releases — this is
+        // the total-memory bound that was absent (unbounded per-request
+        // buffering) before #2665.
+        let cap = LARGE_METADATA_MAX_BYTES;
+        let budget = ProxyMetadataBudget::new(cap * 3);
+
+        let p1 = budget.try_reserve(cap).expect("1st reservation fits");
+        let p2 = budget.try_reserve(cap).expect("2nd reservation fits");
+        let _p3 = budget.try_reserve(cap).expect("3rd reservation fits");
+        assert_eq!(budget.available_bytes(), 0, "budget fully reserved");
+
+        // A fourth concurrent buffer would exceed the total budget: rejected.
+        assert!(
+            budget.try_reserve(cap).is_none(),
+            "budget must reject a reservation beyond the total budget"
+        );
+
+        // Releasing one reservation frees exactly its bytes for the next.
+        drop(p2);
+        assert_eq!(budget.available_bytes(), cap);
+        let _p4 = budget
+            .try_reserve(cap)
+            .expect("reservation fits again after a release");
+        drop((p1, _p3, _p4));
+        assert_eq!(budget.available_bytes(), cap * 3, "all bytes returned");
+    }
+
+    #[test]
+    fn proxy_metadata_budget_clamps_oversized_reservation_to_total() {
+        // A single request larger than the whole budget must not deadlock: it
+        // degrades to holding the entire budget, never requests an
+        // unsatisfiable permit count.
+        let budget = ProxyMetadataBudget::new(1024);
+        let p = budget.try_reserve(usize::MAX).expect("clamped to total");
+        assert_eq!(budget.available_bytes(), 0);
+        assert!(budget.try_reserve(1).is_none());
+        drop(p);
+        assert_eq!(budget.available_bytes(), 1024);
+    }
+
+    #[tokio::test]
+    async fn proxy_metadata_budget_queues_until_release() {
+        // The async reserve() path QUEUES when the budget is exhausted and
+        // unblocks on release — requests wait (bounded) rather than admitting
+        // unbounded concurrent buffers.
+        let budget = Arc::new(ProxyMetadataBudget::new(LARGE_METADATA_MAX_BYTES));
+        let held = budget.reserve(LARGE_METADATA_MAX_BYTES).await;
+        assert_eq!(budget.available_bytes(), 0);
+
+        let waiter_budget = Arc::clone(&budget);
+        let waiter =
+            tokio::spawn(async move { waiter_budget.reserve(LARGE_METADATA_MAX_BYTES).await });
+        // Let the waiter park on the exhausted budget.
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "a second full reservation must queue while the budget is exhausted"
+        );
+
+        drop(held);
+        let _got = waiter
+            .await
+            .expect("waiter joins once the budget is released");
+        assert_eq!(
+            budget.available_bytes(),
+            0,
+            "the released budget is handed straight to the queued waiter"
+        );
+    }
+
+    #[test]
+    fn proxy_metadata_budget_defaults_admit_a_full_metadata_buffer() {
+        // The process-wide budget must admit at least one full LARGE metadata
+        // buffer, so a legitimate lone request never blocks.
+        let budget = proxy_metadata_budget();
+        assert!(
+            budget.total_bytes() >= LARGE_METADATA_MAX_BYTES,
+            "shared budget must fit at least one full RPM metadata buffer"
+        );
+    }
 
     // ── Package Age Policy quarantine surfacing (#1770) ──────────────
 

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -116,6 +116,15 @@ fn reject_rpm_write_if_not_hosted(repo_type: &str) -> Result<(), Response> {
 /// repodata handlers always read from the local artifact table even
 /// when the repo was a proxy, so dnf saw an empty repository and
 /// silently did nothing.
+/// Buffered-metadata byte ceiling for the RPM repodata proxy.
+///
+/// RPM `primary`/`filelists` documents are legitimately large (an OL8
+/// `filelists` is tens of MiB), so #2623 raised this from the 8 MiB DEFAULT to
+/// the 128 MiB LARGE tier. It is the single source the handler reads, and a
+/// regression test (`rpm_proxy_metadata_cap_is_large_tier`, #2664) pins it to
+/// the LARGE value so a silent revert to DEFAULT is caught in CI.
+const RPM_PROXY_METADATA_MAX_BYTES: usize = proxy_helpers::LARGE_METADATA_MAX_BYTES;
+
 async fn try_proxy_repodata(
     state: &SharedState,
     repo: &RepoInfo,
@@ -130,25 +139,77 @@ async fn try_proxy_repodata(
         _ => return Ok(None),
     };
 
+    // #2665: reserve against the process-wide byte budget BEFORE buffering the
+    // upstream/cached document. Without this, N concurrent anonymous,
+    // un-rate-limited requests each buffered up to the per-request cap, so
+    // resident memory scaled with concurrency (~512× the cap in the issue) —
+    // and because a cache hit returns before the single-flight coordinator,
+    // even cached responses each re-buffered. The reservation is held for the
+    // buffered body's whole lifetime (it rides the response stream below) and
+    // released only after the bytes leave the server, so the SUM of concurrent
+    // buffering is capped regardless of request count.
+    let permit = proxy_helpers::proxy_metadata_budget()
+        .reserve(RPM_PROXY_METADATA_MAX_BYTES)
+        .await;
+
     let (content, upstream_ct) = proxy_helpers::proxy_fetch_capped(
         proxy,
         repo.id,
         &repo.key,
         upstream_url,
         upstream_path,
-        proxy_helpers::LARGE_METADATA_MAX_BYTES,
+        RPM_PROXY_METADATA_MAX_BYTES,
     )
     .await?;
 
     let content_type = upstream_ct.unwrap_or_else(|| default_content_type.to_string());
-    Ok(Some(
-        Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, content_type)
-            .header(CONTENT_LENGTH, content.len().to_string())
-            .body(Body::from(content))
-            .unwrap(),
-    ))
+    Ok(Some(buffered_metadata_response(
+        content,
+        content_type,
+        permit,
+    )))
+}
+
+/// Build the 200 response for a buffered proxy-metadata document, tying its
+/// [`ProxyMetadataBudget`] reservation to the response-body lifetime (#2665).
+///
+/// The `permit` rides the body stream (see [`metadata_body_stream`]) and is
+/// released only after the buffered chunk has been handed to the response
+/// writer, so the global byte budget accounts for the resident body until it
+/// leaves the server rather than releasing at handler return.
+fn buffered_metadata_response(
+    content: Bytes,
+    content_type: String,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) -> Response {
+    let content_length = content.len();
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(CONTENT_TYPE, content_type)
+        .header(CONTENT_LENGTH, content_length.to_string())
+        .body(Body::from_stream(metadata_body_stream(content, permit)))
+        .unwrap()
+}
+
+/// One-shot body stream over an already-buffered metadata document that also
+/// owns its budget reservation (#2665). The permit is carried in the stream
+/// state and dropped only after the buffered chunk has been yielded to the
+/// response writer, so the budget stays debited for the body's whole lifetime.
+fn metadata_body_stream(
+    content: Bytes,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) -> impl futures::Stream<Item = Result<Bytes, std::io::Error>> {
+    enum State {
+        Data(Bytes, tokio::sync::OwnedSemaphorePermit),
+        Done(tokio::sync::OwnedSemaphorePermit),
+    }
+    futures::stream::unfold(State::Data(content, permit), |state| async move {
+        match state {
+            State::Data(bytes, permit) => Some((Ok(bytes), State::Done(permit))),
+            // Permit dropped here, after the chunk reached the response writer.
+            State::Done(_permit) => None,
+        }
+    })
 }
 
 /// Build the HTTP 200 response for serving an RPM package body.
@@ -1305,6 +1366,60 @@ mod tests {
     use pgp::composed::{Deserializable, SignedPublicKey, StandaloneSignature};
 
     use crate::services::signing_service::{verify_detached, CreateKeyRequest};
+
+    // -----------------------------------------------------------------------
+    // RPM proxy metadata cap + memory bound (#2664 / #2665)
+    // -----------------------------------------------------------------------
+
+    /// #2664: pin the RPM repodata proxy buffered cap to the LARGE tier.
+    ///
+    /// #2623 raised it DEFAULT (8 MiB) → LARGE (128 MiB) because real
+    /// `filelists`/`primary` documents exceed 8 MiB and would otherwise 502.
+    /// If someone silently reverts the handler to the DEFAULT tier, this fails.
+    #[test]
+    fn rpm_proxy_metadata_cap_is_large_tier() {
+        assert_eq!(
+            RPM_PROXY_METADATA_MAX_BYTES,
+            proxy_helpers::LARGE_METADATA_MAX_BYTES,
+            "RPM proxy metadata cap must be the LARGE tier (#2623/#2664)"
+        );
+        assert!(
+            RPM_PROXY_METADATA_MAX_BYTES > proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            "RPM proxy metadata cap must exceed the DEFAULT tier"
+        );
+    }
+
+    /// #2665: the RPM repodata proxy response must keep its budget reservation
+    /// debited for the whole lifetime of the buffered body — releasing it only
+    /// once the response (and thus the body) is dropped. This is what makes the
+    /// total-memory bound hold under sustained concurrency: a request cannot
+    /// release its slice of the budget the instant it returns and let the next
+    /// request pile another buffer on top.
+    #[tokio::test]
+    async fn buffered_metadata_response_holds_budget_until_body_dropped() {
+        let budget = proxy_helpers::ProxyMetadataBudget::new(4096);
+        let permit = budget.reserve(1000).await;
+        assert_eq!(budget.available_bytes(), 3096, "reservation debited");
+
+        let resp = buffered_metadata_response(
+            Bytes::from_static(b"repodata-bytes"),
+            "application/gzip".to_string(),
+            permit,
+        );
+        // Still debited while the response (its body owns the permit) is alive.
+        assert_eq!(
+            budget.available_bytes(),
+            3096,
+            "budget stays debited while the response body is alive"
+        );
+
+        drop(resp);
+        assert_eq!(
+            budget.available_bytes(),
+            4096,
+            "budget is released once the response body is dropped"
+        );
+    }
 
     // -----------------------------------------------------------------------
     // Extracted pure functions (test-only)

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -1383,9 +1383,10 @@ mod tests {
             proxy_helpers::LARGE_METADATA_MAX_BYTES,
             "RPM proxy metadata cap must be the LARGE tier (#2623/#2664)"
         );
-        assert!(
-            RPM_PROXY_METADATA_MAX_BYTES > proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-            "RPM proxy metadata cap must exceed the DEFAULT tier"
+        assert_ne!(
+            RPM_PROXY_METADATA_MAX_BYTES,
+            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            "RPM proxy metadata cap must not be the DEFAULT tier"
         );
     }
 


### PR DESCRIPTION
## Summary
The RPM repodata proxy buffers the full upstream/cached metadata document into memory per request. There is a per-request size cap, but nothing bounded the **total** across concurrent requests: N anonymous, un-rate-limited requests each buffering up to the cap put ~N× the cap resident (a realistic ~15 GiB from a cached ~30 MiB OL8 `filelists`). Cache hits made it worse — a cache hit returns *before* the single-flight coordinator, so even cached responses each re-buffered independently.

This PR bounds total memory and pins the metadata cap:

- **#2665 — total concurrent buffering bound.** Adds a process-wide byte budget (`ProxyMetadataBudget`) that caps the **sum** of bytes the buffered proxy-metadata path may hold resident at once, independent of request concurrency. The RPM repodata proxy (`try_proxy_repodata`) reserves against it **before** buffering and holds the reservation for the buffered body's whole lifetime — the permit rides the response body stream and is released only after the bytes reach the response writer, so a request cannot release its slice the instant it returns and let the next request pile another buffer on top. When the budget is exhausted, further requests **queue** (bounded) instead of admitting unbounded buffers. Sized from `AK_PROXY_METADATA_BUDGET_BYTES` (default 1 GiB). Mirrors the existing byte-bounded `scan_extraction_semaphore` pattern.
- **#2664 — pin the LARGE tier.** #2623 raised the RPM proxy metadata cap DEFAULT (8 MiB) → LARGE (128 MiB). The handler now reads a single named constant `RPM_PROXY_METADATA_MAX_BYTES`, and an in-crate test pins it to the LARGE value so a silent revert to the 8 MiB DEFAULT (which would 502 large `filelists`/`primary` documents) is caught in CI.

Scope is limited to the RPM path. Legitimate RPM proxy pulls are unchanged (same cap, same content, same headers/Content-Length).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

In-crate `#[cfg(test)]` tests that run in CI:
- `proxy_metadata_budget_bounds_total_concurrent_reservation` / `_clamps_oversized_reservation_to_total` / `_queues_until_release` / `_defaults_admit_a_full_metadata_buffer` — the byte budget rejects/queues once the total is reached and releases exactly on drop. This bound did not exist before the fix (unbounded per-request buffering).
- `buffered_metadata_response_holds_budget_until_body_dropped` — the RPM response keeps its reservation debited for the buffered body's whole lifetime.
- `rpm_proxy_metadata_cap_is_large_tier` — pins the cap to LARGE; verified RED when flipped to DEFAULT (`left: 8388608, right: 134217728`).

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo test --lib`, `cargo fmt --check`, `cargo clippy --lib` all clean)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2665
Closes #2664