### PR TITLE
fix(storage): fail loud on unrecognized STORAGE_BACKEND and Azure proxy gap

### DIFF
--- a/backend/src/config.rs
+++ b/backend/src/config.rs
@@ -151,7 +151,9 @@ pub struct Config {
     /// Deployment environment name (e.g. "development", "staging", "production")
     pub environment: String,
 
-    /// Storage backend: "filesystem" or "s3"
+    /// Storage backend: one of `filesystem`, `s3`, `gcs`, or `azure`.
+    /// Validated at startup by [`Config::validate_storage_backend`]; an
+    /// unrecognized value is rejected rather than silently defaulted.
     pub storage_backend: String,
 
     /// Filesystem storage path (when storage_backend = "filesystem")
@@ -1266,6 +1268,7 @@ impl Config {
         };
 
         config.validate_jwt_secret()?;
+        config.validate_storage_backend()?;
         config.validate_storage_paths()?;
 
         Ok(config)
@@ -1286,6 +1289,28 @@ impl Config {
                 "JWT_SECRET is unsuitable: {reason} \
                  Generate a secure random secret (e.g. `openssl rand -base64 48`)."
             )));
+        }
+        Ok(())
+    }
+
+    /// Validate that `STORAGE_BACKEND` names a recognized backend.
+    ///
+    /// An unrecognized value (a typo such as `gcs-prod`, or `s3 ` with a stray
+    /// trailing space) must never reach runtime. `main.rs` selects the primary
+    /// backend with a `match` whose catch-all arm silently falls back to the
+    /// filesystem backend, so a typo boots green while the deployment believes
+    /// it is running a cloud object store. Worse, [`backend_is_repo_isolated`]
+    /// keys the #2504 cross-tenant isolation guards off this exact string, so a
+    /// silent mismatch runs the wrong store with the wrong isolation semantics.
+    /// Reject the misconfiguration at startup instead. This is a
+    /// `from_env`-only check (like [`Config::validate_jwt_secret`]);
+    /// constructing `Config` directly skips it. Detection lives in the pure,
+    /// unit-testable [`storage_backend_error`] helper.
+    ///
+    /// [`backend_is_repo_isolated`]: crate::storage::backend_is_repo_isolated
+    fn validate_storage_backend(&self) -> Result<()> {
+        if let Some(message) = storage_backend_error(&self.storage_backend) {
+            return Err(AppError::Config(message));
         }
         Ok(())
     }
@@ -1416,6 +1441,38 @@ pub(crate) fn jwt_secret_warnings(secret: &str) -> Vec<JwtSecretWarning> {
 /// startup `from_env` check so callers get a single, ready-to-surface message.
 pub(crate) fn jwt_secret_strength_error(secret: &str) -> Option<&'static str> {
     jwt_secret_warnings(secret).first().map(|w| w.message())
+}
+
+/// Storage backends recognized by `STORAGE_BACKEND`.
+///
+/// `filesystem` gives each repository a physically isolated key space;
+/// `s3`, `gcs`, and `azure` are shared cloud object stores. These are exactly
+/// the values `main.rs` builds a primary backend for — any other value is an
+/// operator misconfiguration. Kept as a single source of truth so the validator
+/// and its error message never drift from the set of backends the binary can
+/// actually construct.
+pub(crate) const SUPPORTED_STORAGE_BACKENDS: [&str; 4] = ["filesystem", "s3", "gcs", "azure"];
+
+/// Pure validator for `STORAGE_BACKEND`. Returns `Some(message)` naming the
+/// offending value and listing [`SUPPORTED_STORAGE_BACKENDS`] when the value is
+/// not recognized, or `None` when it is one of the supported backends.
+///
+/// Used by the startup `from_env` check so an unrecognized value fails fast
+/// instead of silently falling back to the filesystem backend (see
+/// [`Config::validate_storage_backend`] for why that silent fallback is unsafe).
+pub(crate) fn storage_backend_error(storage_backend: &str) -> Option<String> {
+    if SUPPORTED_STORAGE_BACKENDS.contains(&storage_backend) {
+        return None;
+    }
+    Some(format!(
+        "STORAGE_BACKEND=`{storage_backend}` is not a recognized storage backend. \
+         Supported values are: {}. An unrecognized value silently falls back to the \
+         `filesystem` backend at startup, so the service would run the wrong store \
+         while looking healthy and the #2504 cross-tenant isolation guards \
+         (keyed off the backend name) would apply the wrong semantics; set \
+         STORAGE_BACKEND to one of the supported values.",
+        SUPPORTED_STORAGE_BACKENDS.join(", ")
+    ))
 }
 
 /// Pure filesystem-storage path gate. Returns `Some(message)` describing the
@@ -3754,6 +3811,49 @@ mod tests {
         assert!(storage_path_error("s3", "artifact-keeper", "").is_none());
         assert!(storage_path_error("s3", "", "").is_none());
         assert!(storage_path_error("gcs", "some/prefix", "").is_none());
+    }
+
+    // -- storage_backend_error (#2669) ---------------------------------------
+
+    #[test]
+    fn storage_backend_error_accepts_every_supported_backend() {
+        // Each recognized backend must validate cleanly (no error).
+        for backend in SUPPORTED_STORAGE_BACKENDS {
+            assert!(
+                storage_backend_error(backend).is_none(),
+                "supported backend `{backend}` should validate"
+            );
+        }
+    }
+
+    #[test]
+    fn storage_backend_error_rejects_typo_and_names_value_and_supported_set() {
+        // Regression for #2669: an unrecognized value (here a typo) must be an
+        // error rather than silently defaulting to filesystem. Before the fix
+        // this string was accepted verbatim and main.rs's catch-all arm ran the
+        // filesystem backend under the wrong isolation semantics.
+        let message = storage_backend_error("gcs-prod").expect("a typo backend must be rejected");
+        assert!(
+            message.contains("gcs-prod"),
+            "message should name the offending value: {message}"
+        );
+        // The message must list the supported set so the operator can fix it.
+        for backend in SUPPORTED_STORAGE_BACKENDS {
+            assert!(
+                message.contains(backend),
+                "message should list supported backend `{backend}`: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn storage_backend_error_rejects_whitespace_padded_value() {
+        // `s3 ` (trailing space) is the classic env-var typo: it is NOT `s3`,
+        // so it must be rejected rather than silently falling back.
+        assert!(storage_backend_error("s3 ").is_some());
+        assert!(storage_backend_error(" s3").is_some());
+        assert!(storage_backend_error("S3").is_some());
+        assert!(storage_backend_error("").is_some());
     }
 
     /// Extract the text of a top-level `services.<name>` block (a 2-space

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -708,10 +708,53 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
             tracing::info!("Proxy service initialized for remote repositories");
         }
         Err(e) => {
-            tracing::warn!(
-                "Failed to initialize proxy service, remote repositories disabled: {}",
-                e
-            );
+            if artifact_keeper_backend::services::storage_service::backend_supports_proxy_cache(
+                &config.storage_backend,
+            ) {
+                // A backend that *can* back the proxy facade failed for a
+                // transient/optional reason (e.g. missing S3 credentials on a
+                // hosted-only deployment). Preserve the historical graceful
+                // degrade: remote repositories are simply disabled.
+                tracing::warn!(
+                    "Failed to initialize proxy service, remote repositories disabled: {}",
+                    e
+                );
+            } else {
+                // Structural gap (#2670/#1555): this backend has no proxy-cache
+                // StorageService arm (Azure). Booting green here silently
+                // black-holes every remote/proxy repository — the format
+                // handlers skip the upstream fetch when the proxy service is
+                // absent, so requests just fail to find packages with no error.
+                // Fail closed if any remote repository is already configured;
+                // otherwise log loudly so the gap is visible rather than silent.
+                let remote_repo_count: i64 = sqlx::query_scalar(
+                    "SELECT COUNT(*) FROM repositories \
+                     WHERE repo_type = 'remote'::repository_type",
+                )
+                .fetch_one(&db_pool)
+                .await?;
+
+                if remote_repo_count > 0 {
+                    return Err(artifact_keeper_backend::error::AppError::Config(format!(
+                        "STORAGE_BACKEND={} cannot serve remote/proxy repositories \
+                         (proxy StorageService unavailable: {}), but {} remote \
+                         repository(ies) are configured. Refusing to start rather than \
+                         boot healthy and silently black-hole their upstream traffic. \
+                         See #1555 for Azure proxy-cache support.",
+                        config.storage_backend, e, remote_repo_count
+                    )));
+                }
+
+                tracing::error!(
+                    backend = %config.storage_backend,
+                    error = %e,
+                    "Remote/proxy repositories are NOT supported on this storage \
+                     backend: the proxy StorageService has no arm for it (#1555). No \
+                     remote repositories are configured yet, so startup continues, \
+                     but any remote repository created later will silently fail to \
+                     proxy upstream content until #1555 is resolved."
+                );
+            }
         }
     }
 

--- a/backend/src/services/storage_service.rs
+++ b/backend/src/services/storage_service.rs
@@ -478,6 +478,21 @@ pub struct StorageService {
     backend: Arc<dyn StorageBackend>,
 }
 
+/// Whether the given `STORAGE_BACKEND` value can back the proxy-cache
+/// [`StorageService`] facade used for remote/proxy repositories.
+///
+/// `filesystem`, `s3`, and `gcs` each have an arm in
+/// [`StorageService::from_config`]. Azure deliberately does not (#1555):
+/// `main.rs` builds an Azure *primary* backend for hosted repositories, but the
+/// proxy facade has no `AzureBackendWrapper`, so remote/proxy repositories
+/// cannot be served on Azure. Callers use this to make the gap loud at startup
+/// (fail closed / log at error level) instead of booting green and silently
+/// black-holing every proxy request (handlers skip the upstream fetch when the
+/// proxy service is absent). Kept in lockstep with the arms in `from_config`.
+pub fn backend_supports_proxy_cache(storage_backend: &str) -> bool {
+    matches!(storage_backend, "filesystem" | "s3" | "gcs")
+}
+
 impl StorageService {
     /// Create storage service from config
     pub async fn from_config(config: &Config) -> Result<Self> {
@@ -1042,6 +1057,36 @@ mod tests {
             err_msg.contains("bogus"),
             "Error should mention the unknown backend name, got: {}",
             err_msg
+        );
+    }
+
+    // -- Azure proxy-cache gap (#2670) ---------------------------------------
+
+    #[test]
+    fn backend_supports_proxy_cache_matches_from_config_arms() {
+        // The backends that have an arm in from_config can back the proxy facade.
+        assert!(backend_supports_proxy_cache("filesystem"));
+        assert!(backend_supports_proxy_cache("s3"));
+        assert!(backend_supports_proxy_cache("gcs"));
+        // Azure has no arm (#1555): remote/proxy repositories cannot be served,
+        // so this must report false. Booting with azure + proxy repos must be
+        // made loud/fatal by the caller rather than silently disabled.
+        assert!(!backend_supports_proxy_cache("azure"));
+    }
+
+    #[tokio::test]
+    async fn test_storage_service_from_config_azure_is_unsupported() {
+        // Regression for #2670: with STORAGE_BACKEND=azure the proxy StorageService
+        // cannot be built (no azure arm, #1555), so from_config returns Err. The
+        // boot path must treat this as an explicit, loud failure rather than a
+        // silent warn-and-continue that black-holes proxy traffic — and
+        // backend_supports_proxy_cache is the decision function it keys off.
+        assert!(!backend_supports_proxy_cache("azure"));
+        let config = minimal_config("azure");
+        let result = StorageService::from_config(&config).await;
+        assert!(
+            result.is_err(),
+            "from_config must fail for azure until #1555 wires an Azure proxy arm"
         );
     }
 


### PR DESCRIPTION
## Summary
Two storage-config-honesty bugs let the backend boot green while silently running a different storage backend than the operator intended.

**#2669 — silent filesystem fallback (fiction-green trap).** `STORAGE_BACKEND` was a plain `String` with no validation, so an unrecognized/typo value (e.g. `gcs-prod`, or `s3 ` with a trailing space) fell through `main.rs`'s catch-all `match` arm to the filesystem backend. Because `backend_is_repo_isolated()` keys the #2504 cross-tenant isolation guards off the backend name, a silent mismatch runs the wrong store with the wrong isolation semantics while looking healthy. The value is now validated at config load via a pure, unit-testable `storage_backend_error()` helper: an unrecognized value fails fast, naming the offending value and listing the supported set (`filesystem`, `s3`, `gcs`, `azure`). Valid backends behave exactly as before.

**#2670 — Azure silently disables all remote/proxy repos.** The proxy-cache `StorageService` has no Azure arm (tracked by #1555), so with `STORAGE_BACKEND=azure` the proxy service failed to initialize and `main.rs` swallowed it as a single `warn!` — booting green while every remote/proxy repository silently black-holed (the format handlers skip the upstream fetch when the proxy service is absent, returning no error). The boot path now keys off a `backend_supports_proxy_cache()` decision function:
- a backend that genuinely supports proxy caching keeps the historical graceful degrade (transient/optional failures just disable remote repos);
- an unsupported backend (Azure) **fails closed** at boot when any remote repository is already configured, and otherwise logs at **error** level naming #1555.

I chose a **boot-time** fix over a request-time 501 because the request-time path is spread across ~40 format handlers (each silently `continue`s on a missing proxy service) — changing all of them is neither minimal nor low-risk, whereas the boot path is a single honest decision point. Full Azure `StorageService` support remains out of scope (#1555).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Both regressions were verified fail-before / pass-after:
- `config::tests::storage_backend_error_rejects_typo_and_names_value_and_supported_set`, `storage_backend_error_rejects_whitespace_padded_value`, `storage_backend_error_accepts_every_supported_backend`
- `services::storage_service::tests::backend_supports_proxy_cache_matches_from_config_arms`, `test_storage_service_from_config_azure_is_unsupported`

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo test`/`cargo build`; fail-before/pass-after captured)
- [x] No regressions in existing tests (full `config::tests` 125 pass, `storage_service::tests` 52 pass)

## API Changes
- [x] N/A - no API changes

Closes #2669
Closes #2670
