### PR TITLE
ci: announce backend releases to community Discord

### DIFF
--- a/.github/workflows/release-announce.yml
+++ b/.github/workflows/release-announce.yml
@@ -1,0 +1,69 @@
+# Curated release announcements → Discord #announcements
+#
+# Install: copy to .github/workflows/release-announce.yml in the artifact-keeper
+# (backend) repo. Create a webhook on the Discord #announcements channel
+# (Edit Channel → Integrations → Webhooks → New Webhook → Copy URL) and store it
+# as the repo secret DISCORD_RELEASE_WEBHOOK.
+#
+# Fires when a GitHub Release is published. Posts a clean embed with a human
+# title and a link to the full notes, instead of dumping raw release events.
+
+name: Announce release on Discord
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post release embed to Discord
+        env:
+          WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
+          TAG: ${{ github.event.release.tag_name }}
+          NAME: ${{ github.event.release.name }}
+          URL: ${{ github.event.release.html_url }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${WEBHOOK:-}" ]; then
+            echo "DISCORD_RELEASE_WEBHOOK not set; skipping."
+            exit 0
+          fi
+
+          TITLE="Artifact Keeper ${NAME:-$TAG} released"
+          if [ "${PRERELEASE}" = "true" ]; then
+            TITLE="Artifact Keeper ${NAME:-$TAG} (pre-release) is out"
+            COLOR=16763904   # amber
+          else
+            COLOR=4177711    # brand green (#3FB950)
+          fi
+
+          DESCRIPTION="A new ${PRERELEASE:+pre-}release is available. Read the full notes and upgrade instructions below.\n\n[Release notes and changelog](${URL})"
+
+          # Build payload with jq so release text is safely escaped.
+          PAYLOAD=$(jq -n \
+            --arg title "$TITLE" \
+            --arg desc "$DESCRIPTION" \
+            --arg url "$URL" \
+            --argjson color "$COLOR" \
+            '{
+              username: "Artifact Keeper",
+              embeds: [ {
+                title: $title,
+                description: $desc,
+                url: $url,
+                color: $color,
+                footer: { text: "artifactkeeper.com" }
+              } ]
+            }')
+
+          curl -sfSL -X POST -H "Content-Type: application/json" \
+            -d "$PAYLOAD" "$WEBHOOK"
+
+          echo "Announced ${TAG} to Discord."


### PR DESCRIPTION
## Summary
Adds `.github/workflows/release-announce.yml`, which posts published GitHub Releases of the backend to the community Discord `#announcements` channel as a curated embed (release title + link to the full notes), instead of a raw release event.

- Triggers on `release: published`.
- Reads the Discord webhook URL from the repo secret `DISCORD_RELEASE_WEBHOOK`; the job no-ops cleanly if the secret is unset (so forks and secret-less runs don't fail).
- Pre-releases post with a distinct label and amber color; stable releases use the brand green.
- Payload is built with `jq` so release names/notes are safely escaped.
- `permissions: contents: read` only.

Part of standing up the community Discord. Channels, roles, AutoMod, and the GitHub activity firehose are already in place; this adds curated release posts. Only the backend repo's releases go to `#announcements` (SDK/site releases are noise to end users).

Closes #2690

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes