### PR TITLE
fix(promotion): guard cross-repo write in promotion and approval copy paths

### DIFF
--- a/backend/src/api/handlers/approval.rs
+++ b/backend/src/api/handlers/approval.rs
@@ -827,6 +827,22 @@ pub async fn approve_promotion(
         }
     }
 
+    // Cross-repository write guard (#2511): the approval-execute copy re-uses the
+    // SOURCE artifact's flat storage key when writing into the TARGET repo. On a
+    // shared-namespace cloud backend that key may already be owned by a third
+    // repository, so an approval-grant holder could overwrite/collide another
+    // repo's object. This is the same guard the per-format upload handlers apply;
+    // it is skipped for repo-isolated (filesystem) backends. The tenant-access
+    // gate above governs who may execute the approval — this closes the residual
+    // write attribution hole.
+    crate::services::artifact_service::guard_foreign_storage_key_for_backend(
+        &state.db,
+        target_repo.id,
+        &target_repo.storage_backend,
+        &artifact.storage_key,
+    )
+    .await?;
+
     // Copy storage content
     let source_storage = state.storage_for_repo(&source_repo.storage_location())?;
     let target_storage = state.storage_for_repo(&target_repo.storage_location())?;

--- a/backend/src/api/handlers/promotion.rs
+++ b/backend/src/api/handlers/promotion.rs
@@ -751,6 +751,23 @@ pub async fn promote_artifact(
     }
 
     let new_artifact_id = Uuid::new_v4();
+
+    // Cross-repository write guard (#2511): the promotion copy re-uses the
+    // SOURCE artifact's flat storage key when writing into the TARGET repo. On a
+    // shared-namespace cloud backend that key may already be owned by a third
+    // repository, so a grant-holding promoter could overwrite/collide another
+    // repo's object. This is the same guard the per-format upload handlers apply;
+    // it is skipped for repo-isolated (filesystem) backends where each repo has
+    // its own directory tree. `require_promotion_tenant_access` above already
+    // gates who may promote — this closes the residual write attribution hole.
+    crate::services::artifact_service::guard_foreign_storage_key_for_backend(
+        &state.db,
+        target_repo.id,
+        &target_repo.storage_backend,
+        &artifact.storage_key,
+    )
+    .await?;
+
     let source_storage = state.storage_for_repo(&source_repo.storage_location())?;
     let target_storage = state.storage_for_repo(&target_repo.storage_location())?;
 
@@ -1000,6 +1017,28 @@ pub async fn promote_artifacts_bulk(
                 ));
                 continue;
             }
+        }
+
+        // Cross-repository write guard (#2511): fail just this item (not the
+        // batch) if the source's flat storage key is already owned by another
+        // repository on a shared-namespace cloud backend. Same guard the
+        // per-format upload handlers apply; skipped for repo-isolated
+        // (filesystem) backends. See the single-promote path for the rationale.
+        if let Err(e) = crate::services::artifact_service::guard_foreign_storage_key_for_backend(
+            &state.db,
+            target_repo.id,
+            &target_repo.storage_backend,
+            &artifact.storage_key,
+        )
+        .await
+        {
+            failed += 1;
+            results.push(failed_response(
+                source_display,
+                target_display,
+                e.to_string(),
+            ));
+            continue;
         }
 
         let source_storage = state.storage_for_repo(&source_repo.storage_location())?;

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -3992,12 +3992,10 @@ pub async fn guard_cross_repo_write(
     storage_backend: &str,
     storage_key: &str,
 ) -> Result<(), Response> {
-    if crate::storage::backend_is_repo_isolated(storage_backend) {
-        return Ok(());
-    }
-    crate::services::artifact_service::guard_foreign_storage_key(
+    crate::services::artifact_service::guard_foreign_storage_key_for_backend(
         &state.db,
         repository_id,
+        storage_backend,
         storage_key,
     )
     .await

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -1994,6 +1994,33 @@ pub async fn guard_foreign_storage_key(
     Ok(())
 }
 
+/// Isolation-aware cross-repository write guard (service layer, `AppError`).
+///
+/// Same guard the per-format upload handlers apply through
+/// [`crate::api::handlers::proxy_helpers::guard_cross_repo_write`], but returning
+/// the service-layer [`AppError`] so `Result<_, AppError>` callers (promotion /
+/// approval copy paths) can invoke it with `?`. This is the single source of
+/// truth for the "skip repo-isolated backends, then check for a foreign owner"
+/// sequence — `guard_cross_repo_write` delegates here.
+///
+/// The foreign-owner check applies **only to shared-namespace (cloud) backends**.
+/// On a repo-isolated backend (`filesystem`) each repository has its own physically
+/// separate directory tree, so two repositories legitimately hold the same
+/// coordinate key without colliding; running the check there would wrongly reject
+/// the second repository's write. `storage_backend` is therefore checked first and
+/// the guard is skipped for filesystem.
+pub async fn guard_foreign_storage_key_for_backend(
+    db: &PgPool,
+    repository_id: Uuid,
+    storage_backend: &str,
+    storage_key: &str,
+) -> Result<()> {
+    if crate::storage::backend_is_repo_isolated(storage_backend) {
+        return Ok(());
+    }
+    guard_foreign_storage_key(db, repository_id, storage_key).await
+}
+
 /// Best-effort recorder for a completed local-artifact download (#2365).
 ///
 /// Writes real attribution (validated client IP or NULL, authenticated user
@@ -2234,6 +2261,68 @@ mod tests {
         guard_foreign_storage_key(&pool, repo_a, &key)
             .await
             .expect("same-repo soft-deleted reclaim must be allowed");
+    }
+
+    // -- #2511 cross-repo write guard on the promotion/approval copy paths -----
+    // These exercise `guard_foreign_storage_key_for_backend` — the isolation-aware
+    // guard the promotion (`promote_artifact` / `promote_artifacts_bulk`) and
+    // approval-execute copy sites now call before writing the SOURCE artifact's
+    // flat key into the TARGET repo.
+
+    #[tokio::test]
+    async fn test_promotion_guard_blocks_cross_repo_key_on_cloud_backend() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (target_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let (foreign_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        // A third repository already owns the flat coordinate the promotion copy
+        // would re-use in `target_repo`.
+        let key = format!("maven/com/acme/lib/1.0/lib-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, foreign_repo, "com/acme/lib/1.0/lib-1.0.jar", &key).await;
+
+        // On a shared-namespace cloud backend the promotion/approval copy MUST be
+        // refused (409 Conflict) — this is the cross-tenant write hole (#2511).
+        let err = guard_foreign_storage_key_for_backend(&pool, target_repo, "s3", &key)
+            .await
+            .expect_err("cross-repo-attributed key must be blocked on cloud");
+        assert!(matches!(err, AppError::Conflict(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_promotion_guard_allows_cross_repo_key_on_filesystem_backend() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (target_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let (foreign_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let key = format!("maven/com/acme/lib/1.0/lib-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, foreign_repo, "com/acme/lib/1.0/lib-1.0.jar", &key).await;
+
+        // On a repo-isolated (filesystem) backend each repo has its own directory
+        // tree, so the same coordinate legitimately coexists — a legit
+        // cross-repo filesystem promotion must NOT be blocked.
+        guard_foreign_storage_key_for_backend(&pool, target_repo, "filesystem", &key)
+            .await
+            .expect("filesystem promotion must be allowed");
+    }
+
+    #[tokio::test]
+    async fn test_promotion_guard_allows_same_repo_key_on_cloud_backend() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (target_repo, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        // A legitimate same-tenant re-promotion of a key this repo already owns.
+        let key = format!("maven/com/acme/lib/1.0/lib-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, target_repo, "com/acme/lib/1.0/lib-1.0.jar", &key).await;
+
+        guard_foreign_storage_key_for_backend(&pool, target_repo, "s3", &key)
+            .await
+            .expect("same-repo promotion must be allowed on cloud");
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The promotion and approval-execute copy paths re-use the **source** artifact's flat storage key when writing into the **target** repository, but — unlike the ~13 per-format upload handlers — they never call the cross-repository write guard. On a shared-namespace (cloud) backend, that flat key may already be owned by a third repository, so a promotion/approval-grant holder can overwrite or collide another repository's object at that key. The existing tenant-access gate (`require_promotion_tenant_access`) governs *who* may promote/approve; this closes the residual *write attribution* hole.

The guard is added at all three copy sites:
- `promote_artifact` (single) — propagates `409 Conflict`
- `promote_artifacts_bulk` — fails the individual item (not the whole batch)
- `execute_approval` copy — propagates `409 Conflict`

It reuses the same enforcement the format handlers already apply and is **skipped for repo-isolated (`filesystem`) backends**, where each repository has its own directory tree and the same coordinate legitimately coexists — so legitimate same-tenant and cross-repo filesystem promotions are unaffected. The "skip isolated backend, then check for a foreign owner" sequence is extracted into one service-layer helper (`guard_foreign_storage_key_for_backend`) that both the handler wrapper (`guard_cross_repo_write`) and these copy paths share, keeping a single source of truth.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Three DB-backed tests in `services::artifact_service::tests`: the cross-repo cloud write is blocked (`409 Conflict`), while a cross-repo filesystem write and a same-repo cloud write are allowed. Verified the block test **fails without the guard** and **passes with it**; the two allow-tests pass in both states.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

Closes #2511
