### PR TITLE
fix(curation): default RPM keyless sync to fail-closed (#2569)

### DIFF
--- a/backend/migrations/169_curation_allow_unverified.sql
+++ b/backend/migrations/169_curation_allow_unverified.sql
@@ -1,0 +1,17 @@
+-- #2569 (RPM curation fail-closed default): explicit opt-in to ingest
+-- UNVERIFIED upstream metadata when no trusted_gpg_key is configured.
+--
+-- With #2568 landed (create/update API for `trusted_gpg_key`), the safe default
+-- flips fail-closed: a curation sync whose staging repo has NO trusted GPG key
+-- available now REFUSES to ingest unverified upstream metadata rather than
+-- silently trusting an unauthenticated upstream (the pre-#2569 behavior). A
+-- repository may opt back into the legacy "unverified upstream" behavior by
+-- setting this flag true — the deliberate, auditable escape hatch for existing
+-- keyless RPM curation repos.
+--
+-- Defaults false (fail-closed). Read on the keyless RPM curation-sync path
+-- (`run_curation_sync_cycle`); NULL/absent is impossible (NOT NULL DEFAULT).
+--
+-- Reversible: DROP COLUMN restores the pre-#2569 shape.
+ALTER TABLE repositories
+    ADD COLUMN IF NOT EXISTS curation_allow_unverified BOOLEAN NOT NULL DEFAULT false;

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -571,6 +571,12 @@ pub struct CreateRepositoryRequest {
     /// the response exposes only the boolean `has_trusted_gpg_key`, never the
     /// key material.
     pub trusted_gpg_key: Option<String>,
+    /// Opt into ingesting UNVERIFIED upstream metadata on the keyless RPM
+    /// curation-sync path (#2569). Omit or `false` to keep the fail-closed
+    /// default (a keyless curation sync refuses to ingest unverified upstream
+    /// packages); `true` reverts to the legacy unverified-ingest behavior. Only
+    /// meaningful for RPM curation staging repositories.
+    pub curation_allow_unverified: Option<bool>,
     /// Custom Origin field for Debian/APT Release files.
     /// Stored in `repository_config` under `apt_origin`.
     pub apt_origin: Option<String>,
@@ -683,6 +689,11 @@ pub struct UpdateRepositoryRequest {
     #[serde(default, deserialize_with = "deserialize_double_option")]
     #[schema(value_type = Option<String>)]
     pub trusted_gpg_key: Option<Option<String>>,
+    /// Update the keyless-sync unverified-ingest opt-in (#2569). When provided,
+    /// sets `curation_allow_unverified` (`false` restores the fail-closed
+    /// default; `true` opts into legacy unverified ingest). Omit to leave it
+    /// unchanged.
+    pub curation_allow_unverified: Option<bool>,
     /// Custom Origin field for Debian/APT Release files. Pass an empty string
     /// to reset to the default ("artifact-keeper").
     /// Stored in `repository_config` under `apt_origin`.
@@ -2466,6 +2477,9 @@ pub async fn create_repository(
             // Trusted upstream GPG key for RPM curation (#2568). Already
             // validated up-front; the service persists it in the create tx.
             trusted_gpg_key: payload.trusted_gpg_key,
+            // Keyless-sync unverified-ingest opt-in (#2569). Fail-closed by
+            // default; only an explicit `true` opts into unverified ingest.
+            curation_allow_unverified: payload.curation_allow_unverified,
             // Owner auto-grant: record the creator and grant them per-repo
             // access so they retain access under per-repo authorization.
             created_by: Some(auth.user_id),
@@ -3053,6 +3067,9 @@ pub async fn update_repository(
                 // Trusted upstream GPG key (#2568). Three-way: omit = unchanged,
                 // Some(None) = clear, Some(Some(key)) = set (already validated).
                 trusted_gpg_key: payload.trusted_gpg_key,
+                // Keyless-sync unverified-ingest opt-in (#2569): omit = unchanged,
+                // Some(false) = fail-closed default, Some(true) = unverified.
+                curation_allow_unverified: payload.curation_allow_unverified,
             },
         )
         .await?;

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -43,6 +43,11 @@ pub struct CreateRepositoryRequest {
     /// verification (#2568). `None` leaves the column NULL ("unverified
     /// upstream"). Validated by the handler before it reaches the service.
     pub trusted_gpg_key: Option<String>,
+    /// Opt into ingesting UNVERIFIED upstream metadata on the keyless RPM
+    /// curation-sync path (#2569). `None`/`Some(false)` keep the fail-closed
+    /// default (a keyless sync refuses to ingest); `Some(true)` reverts to the
+    /// legacy unverified-ingest behavior. Persisted in the create tx.
+    pub curation_allow_unverified: Option<bool>,
     /// User who is creating this repository. When set, the repository records
     /// this user as `created_by` and the creator is auto-granted the
     /// `developer` role scoped to the new repository (owner auto-grant), so the
@@ -75,6 +80,10 @@ pub struct UpdateRepositoryRequest {
     /// leaves the stored key unchanged. Validated by the handler before it
     /// reaches the service.
     pub trusted_gpg_key: Option<Option<String>>,
+    /// When `Some`, sets the keyless-sync unverified-ingest opt-in (#2569);
+    /// `None` leaves it unchanged. `Some(false)` restores the fail-closed
+    /// default; `Some(true)` opts into legacy unverified ingest.
+    pub curation_allow_unverified: Option<bool>,
 }
 
 /// Controls which repositories a caller can see in listing results.
@@ -773,6 +782,21 @@ impl RepositoryService {
                         .await
                         .map_err(|e| AppError::Database(e.to_string()))?;
                 }
+                // Keyless-sync unverified-ingest opt-in (#2569). Persisted in the
+                // same tx as the INSERT. Off the `Repository` model (the sync
+                // reads it via its own targeted query, like `trusted_gpg_key`);
+                // the column defaults false (fail-closed) so only an explicit
+                // value needs a write.
+                if let Some(allow_unverified) = req.curation_allow_unverified {
+                    sqlx::query(
+                        "UPDATE repositories SET curation_allow_unverified = $1 WHERE id = $2",
+                    )
+                    .bind(allow_unverified)
+                    .bind(repo.id)
+                    .execute(&mut *tx)
+                    .await
+                    .map_err(|e| AppError::Database(e.to_string()))?;
+                }
                 // Owner auto-grant: record the creator and grant them the
                 // `developer` role scoped to this repository, so the creator
                 // retains access under per-repo authorization. Runs inside the
@@ -1110,6 +1134,20 @@ impl RepositoryService {
                 "UPDATE repositories SET trusted_gpg_key = $1, updated_at = NOW() WHERE id = $2",
             )
             .bind(gpg_key.as_deref())
+            .bind(id)
+            .execute(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        }
+
+        // Keyless-sync unverified-ingest opt-in (#2569). `None` leaves it
+        // unchanged; `Some(v)` sets it (false restores the fail-closed default,
+        // true opts into legacy unverified ingest).
+        if let Some(allow_unverified) = req.curation_allow_unverified {
+            sqlx::query(
+                "UPDATE repositories SET curation_allow_unverified = $1, updated_at = NOW() WHERE id = $2",
+            )
+            .bind(allow_unverified)
             .bind(id)
             .execute(&self.db)
             .await
@@ -1785,6 +1823,7 @@ mod tests {
             format_key: None,
             project_id: None,
             trusted_gpg_key: None,
+            curation_allow_unverified: None,
             created_by: None,
         };
         assert_eq!(req.key, "my-repo");
@@ -1812,6 +1851,7 @@ mod tests {
             format_key: None,
             project_id: None,
             trusted_gpg_key: None,
+            curation_allow_unverified: None,
             created_by: None,
         };
         assert_eq!(
@@ -1838,6 +1878,7 @@ mod tests {
             promotion_only: None,
             project_id: None,
             trusted_gpg_key: None,
+            curation_allow_unverified: None,
         };
         assert!(req.key.is_none());
         assert!(req.name.is_none());
@@ -1860,6 +1901,7 @@ mod tests {
             promotion_only: None,
             project_id: None,
             trusted_gpg_key: None,
+            curation_allow_unverified: None,
         };
         assert_eq!(req.name, Some("Updated Name".to_string()));
         assert_eq!(req.is_public, Some(false));
@@ -1880,6 +1922,7 @@ mod tests {
             promotion_only: None,
             project_id: None,
             trusted_gpg_key: None,
+            curation_allow_unverified: None,
         };
         assert_eq!(req.quota_bytes, Some(None));
     }
@@ -3039,6 +3082,7 @@ mod tests {
                 format_key: None,
                 project_id: None,
                 trusted_gpg_key: None,
+                curation_allow_unverified: None,
                 created_by: None,
             }
         }
@@ -3148,6 +3192,7 @@ mod tests {
                 versioning_enabled: None,
                 project_id: None,
                 trusted_gpg_key: Some(None),
+                curation_allow_unverified: None,
             };
             service.update(repo.id, clear_req).await.expect("clear gpg");
             assert!(
@@ -3167,6 +3212,7 @@ mod tests {
                 versioning_enabled: None,
                 project_id: None,
                 trusted_gpg_key: Some(Some(TEST_TRUSTED_PUB_KEY.to_string())),
+                curation_allow_unverified: None,
             };
             service.update(repo.id, set_req).await.expect("set gpg");
             assert_eq!(
@@ -3187,6 +3233,7 @@ mod tests {
                 versioning_enabled: None,
                 project_id: None,
                 trusted_gpg_key: None,
+                curation_allow_unverified: None,
             };
             service.update(repo.id, noop_req).await.expect("noop gpg");
             assert_eq!(
@@ -3196,6 +3243,107 @@ mod tests {
             );
 
             cleanup_repo(&pool, repo.id).await;
+        }
+
+        /// #2569: the `curation_allow_unverified` opt-in round-trips through
+        /// create and update, and the column defaults false (fail-closed) when
+        /// the field is omitted. The column is read directly (it is off the
+        /// `Repository` model, like `trusted_gpg_key`) — the keyless sync path
+        /// consults it to decide whether to refuse or ingest unverified upstream.
+        #[tokio::test]
+        async fn test_curation_allow_unverified_create_update_roundtrip() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let service = RepositoryService::new(pool.clone());
+
+            let read_flag = |pool: PgPool, id: Uuid| async move {
+                sqlx::query_scalar::<_, bool>(
+                    "SELECT curation_allow_unverified FROM repositories WHERE id = $1",
+                )
+                .bind(id)
+                .fetch_one(&pool)
+                .await
+                .expect("read curation_allow_unverified")
+            };
+
+            // Create with the field omitted -> column defaults false (fail-closed).
+            let repo = service
+                .create(make_create_req(&suffix, RepositoryFormat::Rpm))
+                .await
+                .expect("create rpm curation repo");
+            assert!(
+                !read_flag(pool.clone(), repo.id).await,
+                "default must be fail-closed (curation_allow_unverified = false)"
+            );
+
+            // A builder for an all-omitted update carrying only the opt-in flag,
+            // so each call gets its own owned request (update takes ownership).
+            let allow_update = |flag: Option<bool>| UpdateRepositoryRequest {
+                key: None,
+                name: None,
+                description: None,
+                is_public: None,
+                quota_bytes: None,
+                upstream_url: None,
+                promotion_only: None,
+                versioning_enabled: None,
+                project_id: None,
+                trusted_gpg_key: None,
+                curation_allow_unverified: flag,
+            };
+
+            // Update -> Some(true) opts into unverified ingest.
+            service
+                .update(repo.id, allow_update(Some(true)))
+                .await
+                .expect("set allow_unverified");
+            assert!(
+                read_flag(pool.clone(), repo.id).await,
+                "Some(true) update must set the opt-in"
+            );
+
+            // Update -> Some(false) restores the fail-closed default.
+            service
+                .update(repo.id, allow_update(Some(false)))
+                .await
+                .expect("clear allow_unverified");
+            assert!(
+                !read_flag(pool.clone(), repo.id).await,
+                "Some(false) update must restore fail-closed default"
+            );
+
+            // Update with the field omitted (None) -> unchanged. First set it
+            // true, then a no-op update (opt-in omitted), and assert it stays true.
+            service
+                .update(repo.id, allow_update(Some(true)))
+                .await
+                .expect("re-set allow_unverified");
+            service
+                .update(repo.id, allow_update(None))
+                .await
+                .expect("noop update");
+            assert!(
+                read_flag(pool.clone(), repo.id).await,
+                "omitted field must leave the opt-in unchanged"
+            );
+
+            // Create with Some(true) -> persisted in the create tx.
+            let suffix2 = format!("{}", uuid::Uuid::new_v4().simple());
+            let mut create_true = make_create_req(&suffix2, RepositoryFormat::Rpm);
+            create_true.curation_allow_unverified = Some(true);
+            let repo2 = service
+                .create(create_true)
+                .await
+                .expect("create with opt-in");
+            assert!(
+                read_flag(pool.clone(), repo2.id).await,
+                "create with Some(true) must persist the opt-in"
+            );
+
+            cleanup_repo(&pool, repo.id).await;
+            cleanup_repo(&pool, repo2.id).await;
         }
 
         /// Regression (#1783 HIGH): a duplicate key on create must roll back the

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -981,8 +981,9 @@ async fn update_gauge_metrics(db: &PgPool) -> crate::error::Result<()> {
 
 /// One row of the curation-sync work query: `(staging_id, format,
 /// remote_id, upstream_url, default_action, sync_interval_secs,
-/// trusted_gpg_key)`. Named to keep the `query_as` type off clippy's
-/// `type_complexity` radar (#2357 added the trusted-key column).
+/// trusted_gpg_key, allow_unverified)`. Named to keep the `query_as` type off
+/// clippy's `type_complexity` radar (#2357 added the trusted-key column; #2569
+/// added the fail-closed opt-out flag).
 type CurationSyncRow = (
     uuid::Uuid,
     String,
@@ -991,7 +992,37 @@ type CurationSyncRow = (
     String,
     i32,
     Option<String>,
+    bool,
 );
+
+/// Outcome of the keyless RPM curation-sync gate (#2569). When no trusted GPG
+/// key is configured, the sync no longer defaults open: it is fail-closed and
+/// ingests nothing unless the repo has explicitly opted into unverified
+/// upstream ingest.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeylessSync {
+    /// The repo opted into unverified upstream (`curation_allow_unverified =
+    /// true`): proceed, but treat the batch as UNVERIFIED (no checksum-chain
+    /// enforcement — the legacy pre-#2357 behavior, preserved for existing
+    /// keyless repos that opt in).
+    ProceedUnverified,
+    /// No trusted key and no opt-in: refuse (fail-closed default). Skip this
+    /// repo — zero packages ingested — rather than trusting unauthenticated
+    /// upstream metadata.
+    Refuse,
+}
+
+/// Decide the keyless-upstream outcome (#2569). Pure so the fail-closed default
+/// is unit-testable without any DB or network I/O: `false` (no opt-in) must be
+/// `Refuse`; only an explicit `curation_allow_unverified = true` opts back into
+/// the legacy unverified-ingest behavior.
+fn keyless_sync_decision(allow_unverified: bool) -> KeylessSync {
+    if allow_unverified {
+        KeylessSync::ProceedUnverified
+    } else {
+        KeylessSync::Refuse
+    }
+}
 
 /// Find all staging repos with curation enabled, fetch upstream metadata, and evaluate new packages.
 ///
@@ -1013,7 +1044,7 @@ pub(crate) async fn run_curation_sync_cycle(
     let repos: Vec<CurationSyncRow> = sqlx::query_as(
         r#"SELECT r.id, r.format::text, r.curation_source_repo_id, remote.upstream_url,
                       r.curation_default_action, r.curation_sync_interval_secs,
-                      remote.trusted_gpg_key
+                      remote.trusted_gpg_key, r.curation_allow_unverified
                FROM repositories r
                JOIN repositories remote ON remote.id = r.curation_source_repo_id
                WHERE r.curation_enabled = true
@@ -1035,8 +1066,16 @@ pub(crate) async fn run_curation_sync_cycle(
         .timeout(std::time::Duration::from_secs(60))
         .build()?;
 
-    for (staging_id, format, remote_id, upstream_url, default_action, _interval, trusted_gpg_key) in
-        &repos
+    for (
+        staging_id,
+        format,
+        remote_id,
+        upstream_url,
+        default_action,
+        _interval,
+        trusted_gpg_key,
+        allow_unverified,
+    ) in &repos
     {
         let upstream_auth = crate::services::upstream_auth::load_upstream_auth(db, *remote_id)
             .await
@@ -1080,7 +1119,11 @@ pub(crate) async fn run_curation_sync_cycle(
                 // detached signature over repomd.xml. Fail-closed — any fetch,
                 // parse, or verification failure skips this repo (zero packages
                 // ingested) rather than trusting unauthenticated metadata. With
-                // no trusted key the batch proceeds as "unverified upstream".
+                // no trusted key the sync is now ALSO fail-closed by default
+                // (#2569): it refuses to ingest unverified upstream metadata
+                // unless the repo has explicitly opted in via
+                // `curation_allow_unverified`, in which case the batch proceeds
+                // as "unverified upstream" (the legacy behavior).
                 // `verified` gates the primary.xml checksum-chain enforcement
                 // below: a signature over repomd alone does NOT authenticate a
                 // tampered primary — repomd's <checksum> must pin it.
@@ -1126,13 +1169,26 @@ pub(crate) async fn run_curation_sync_cycle(
                             }
                         }
                     }
-                    None => {
-                        tracing::warn!(
-                            "RPM curation sync: no trusted GPG key configured for staging repo {}; ingesting UNVERIFIED upstream metadata (set trusted_gpg_key to enforce upstream signatures)",
-                            staging_id
-                        );
-                        false
-                    }
+                    None => match keyless_sync_decision(*allow_unverified) {
+                        // Fail-closed default (#2569): no trusted key and no
+                        // explicit opt-in — refuse the upstream, ingest nothing.
+                        KeylessSync::Refuse => {
+                            tracing::warn!(
+                                "RPM curation sync: no trusted GPG key configured for staging repo {} and curation_allow_unverified is not set; refusing UNVERIFIED upstream (0 packages ingested). Set trusted_gpg_key to authenticate the upstream, or curation_allow_unverified=true to opt into unverified ingest.",
+                                staging_id
+                            );
+                            continue;
+                        }
+                        // Explicit opt-in: proceed as "unverified upstream"
+                        // (legacy behavior; no checksum-chain enforcement).
+                        KeylessSync::ProceedUnverified => {
+                            tracing::warn!(
+                                "RPM curation sync: no trusted GPG key configured for staging repo {}; curation_allow_unverified is set, ingesting UNVERIFIED upstream metadata (set trusted_gpg_key to enforce upstream signatures)",
+                                staging_id
+                            );
+                            false
+                        }
+                    },
                 };
 
                 // Parse the primary reference (href + repomd-pinned checksums)
@@ -1414,6 +1470,33 @@ mod tests {
             "nginx must be present after debian decompress+parse"
         );
         assert!(entries.iter().all(|e| e.format == "debian"));
+    }
+
+    // -----------------------------------------------------------------------
+    // #2569 — RPM curation keyless-sync fail-closed default
+    // -----------------------------------------------------------------------
+
+    /// The security-relevant guard: with NO trusted GPG key configured, a
+    /// curation sync must be fail-closed by DEFAULT — it refuses to ingest
+    /// unverified upstream metadata. Only an explicit opt-in
+    /// (`curation_allow_unverified = true`) reverts to the legacy
+    /// unverified-ingest behavior. Before #2569 the keyless path always
+    /// ingested unverified (equivalent to `ProceedUnverified` for both inputs);
+    /// this pins the flipped default.
+    #[test]
+    fn test_keyless_sync_defaults_fail_closed() {
+        // Default (no opt-in) -> refuse (0 packages ingested).
+        assert_eq!(
+            keyless_sync_decision(false),
+            KeylessSync::Refuse,
+            "keyless sync with no opt-in must be fail-closed (refuse), not ingest unverified"
+        );
+        // Explicit opt-in -> proceed as unverified (legacy escape hatch).
+        assert_eq!(
+            keyless_sync_decision(true),
+            KeylessSync::ProceedUnverified,
+            "curation_allow_unverified=true must opt back into unverified ingest"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When a curation source remote has **no `trusted_gpg_key` configured**, the RPM
curation sync (`run_curation_sync_cycle`) ingested upstream metadata
**UNVERIFIED** — the pre-#2567 backward-compat behavior. Now that #2568 has
landed a create/update API for `trusted_gpg_key`, this flips the safe default
to **fail-closed**: a keyless curation sync refuses to ingest unverified
upstream packages unless the repository explicitly opts in.

**Behavior change (keyless path only):**

| trusted key | `curation_allow_unverified` | before | after |
|---|---|---|---|
| none | false / unset (default) | ingest UNVERIFIED | **refuse (0 ingested)** |
| none | true (explicit opt-in) | ingest UNVERIFIED | ingest UNVERIFIED (legacy) |
| set, valid sig | — | verified ingest | verified ingest (unchanged) |
| set, wrong/missing sig | — | 0 ingested | 0 ingested (unchanged) |

The opt-in is a new column `repositories.curation_allow_unverified`
(`BOOLEAN NOT NULL DEFAULT false`), the deliberate, auditable escape hatch for
existing keyless RPM curation repos. It is wired through the repository
create/update API exactly like `trusted_gpg_key` (off the `Repository` model;
written in-tx on create, set-or-leave on update).

**Files**
- `backend/migrations/169_curation_allow_unverified.sql` — new column (reversible via `DROP COLUMN`).
- `backend/src/services/scheduler_service.rs` — fail-closed keyless gate (`keyless_sync_decision`) + query/row plumbing.
- `backend/src/services/repository_service.rs` — persist the opt-in on create/update.
- `backend/src/api/handlers/repositories.rs` — expose the opt-in on the create/update request bodies.

## Regression test (required for `fix/*` PRs)

`services::scheduler_service::tests::test_keyless_sync_defaults_fail_closed`
pins the flipped default: `keyless_sync_decision(false)` must be `Refuse`
(fail-closed), `true` must be `ProceedUnverified`. With the pre-#2569
fail-open logic the `false -> Refuse` assertion fails
(`left: ProceedUnverified, right: Refuse`); with this PR it passes. A DB-backed
roundtrip (`test_curation_allow_unverified_create_update_roundtrip`) covers the
new column's create/update persistence and the fail-closed default.

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo build`, `cargo test`, `cargo clippy -D warnings`, OpenAPI spec test — all green)
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]` (added `curation_allow_unverified` to existing create/update request bodies)
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Closes #2569
