### PR TITLE
fix(proxy): sanitize filename in Content-Disposition per RFC 6266

### DIFF
--- a/backend/src/api/download_response.rs
+++ b/backend/src/api/download_response.rs
@@ -16,6 +16,50 @@ use crate::storage::{PresignedUrl, PresignedUrlSource, StorageBackend};
 /// Header to indicate how the artifact was served
 pub const X_ARTIFACT_STORAGE: &str = "x-artifact-storage";
 
+/// Build a safe `Content-Disposition: attachment` header value for a
+/// caller/artifact-supplied filename, per RFC 6266 / RFC 5987 (#2654).
+///
+/// The suggested download name can originate in untrusted content (e.g. a
+/// `Chart.yaml` `name` inside an uploaded archive), so it must never be
+/// interpolated into the header verbatim. This helper:
+///
+/// - **strips control characters** (including CR/LF), so a crafted name can
+///   never split or inject response headers;
+/// - always emits an ASCII `filename="…"` form with `"` and `\` escaped per
+///   the quoted-string grammar (non-ASCII bytes collapse to `_` there); and
+/// - when the name contains non-ASCII characters, additionally emits
+///   `filename*=UTF-8''<percent-encoded>` so modern clients recover the exact
+///   UTF-8 name while legacy clients fall back to the ASCII form.
+///
+/// The returned string is always a valid `HeaderValue`.
+pub(crate) fn content_disposition_attachment(filename: &str) -> String {
+    // Drop control characters (incl. CR, LF, NUL, tab) up front so nothing that
+    // could break the header survives into either rendered form.
+    let cleaned: String = filename.chars().filter(|c| !c.is_control()).collect();
+
+    // RFC 6266 quoted-string ASCII fallback: non-ASCII -> '_', escape '\' and '"'.
+    let mut ascii = String::with_capacity(cleaned.len());
+    for c in cleaned.chars() {
+        match c {
+            _ if !c.is_ascii() => ascii.push('_'),
+            '"' | '\\' => {
+                ascii.push('\\');
+                ascii.push(c);
+            }
+            _ => ascii.push(c),
+        }
+    }
+
+    if cleaned.is_ascii() {
+        format!("attachment; filename=\"{ascii}\"")
+    } else {
+        // RFC 5987 extended value carries the exact UTF-8 name for clients that
+        // support it; the ASCII `filename` above remains for those that don't.
+        let encoded = urlencoding::encode(&cleaned);
+        format!("attachment; filename=\"{ascii}\"; filename*=UTF-8''{encoded}")
+    }
+}
+
 /// Download response that can be either a redirect or streamed content
 pub enum DownloadResponse {
     /// 302 redirect to presigned URL
@@ -91,10 +135,8 @@ impl IntoResponse for DownloadResponse {
                     .header(X_ARTIFACT_STORAGE, "proxy");
 
                 if let Some(name) = filename {
-                    builder = builder.header(
-                        "Content-Disposition",
-                        format!("attachment; filename=\"{}\"", name),
-                    );
+                    builder = builder
+                        .header("Content-Disposition", content_disposition_attachment(&name));
                 }
 
                 builder.body(Body::from(data)).unwrap()
@@ -216,6 +258,45 @@ mod tests {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
     use bytes::Bytes;
+
+    #[test]
+    fn test_content_disposition_attachment_plain_ascii_unchanged() {
+        // Normal names (incl. spaces) still render the familiar quoted form.
+        assert_eq!(
+            content_disposition_attachment("pkg-1.0.0.tgz"),
+            "attachment; filename=\"pkg-1.0.0.tgz\""
+        );
+        assert_eq!(
+            content_disposition_attachment("my package 1.0.tgz"),
+            "attachment; filename=\"my package 1.0.tgz\""
+        );
+    }
+
+    #[test]
+    fn test_content_disposition_attachment_strips_crlf() {
+        // #2654: CR/LF must never survive into the header value.
+        let v = content_disposition_attachment("a\r\nSet-Cookie: x=1.tgz");
+        assert!(!v.contains('\r') && !v.contains('\n'), "v = {v:?}");
+        assert_eq!(v, "attachment; filename=\"aSet-Cookie: x=1.tgz\"");
+    }
+
+    #[test]
+    fn test_content_disposition_attachment_escapes_quote_and_backslash() {
+        let v = content_disposition_attachment("a\"b\\c.tgz");
+        assert_eq!(v, "attachment; filename=\"a\\\"b\\\\c.tgz\"");
+    }
+
+    #[test]
+    fn test_content_disposition_attachment_non_ascii_uses_rfc5987() {
+        // Non-ASCII names emit both an ASCII fallback (non-ASCII -> '_') and the
+        // RFC 5987 extended, percent-encoded parameter.
+        let v = content_disposition_attachment("naïve-café.tgz");
+        assert!(v.starts_with("attachment; filename=\""), "v = {v:?}");
+        assert!(v.contains("filename*=UTF-8''"), "v = {v:?}");
+        assert!(!v.contains('ï') && !v.contains('é'), "v = {v:?}");
+        // Percent-encoded UTF-8 bytes for the accented characters are present.
+        assert!(v.contains("%C3%AF") && v.contains("%C3%A9"), "v = {v:?}");
+    }
 
     #[test]
     fn test_redirect_constructor() {

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -8,7 +8,7 @@ use futures::StreamExt;
 use sqlx::PgPool;
 use uuid::Uuid;
 
-use crate::api::download_response::try_presigned_redirect;
+use crate::api::download_response::{content_disposition_attachment, try_presigned_redirect};
 use crate::api::handlers::error_helpers::{map_db_err, map_storage_err};
 use crate::api::AppState;
 use crate::error::AppError;
@@ -830,10 +830,7 @@ pub(crate) fn build_streaming_response_with_disposition(
         builder = builder.header("content-length", len);
     }
     if let Some(fname) = filename {
-        builder = builder.header(
-            "content-disposition",
-            format!("attachment; filename=\"{}\"", fname),
-        );
+        builder = builder.header("content-disposition", content_disposition_attachment(fname));
     }
     let body = axum::body::Body::from_stream(
         result
@@ -4510,10 +4507,7 @@ pub(crate) fn build_download_response(
         .header("Content-Type", ct)
         .header("Content-Length", content.len().to_string());
     if let Some(fname) = filename {
-        builder = builder.header(
-            "Content-Disposition",
-            format!("attachment; filename=\"{}\"", fname),
-        );
+        builder = builder.header("Content-Disposition", content_disposition_attachment(fname));
     }
     builder.body(axum::body::Body::from(content)).unwrap()
 }
@@ -6919,6 +6913,34 @@ mod tests {
         );
         let cd = resp.headers().get("Content-Disposition").unwrap();
         assert_eq!(cd, "attachment; filename=\"pkg-1.0.0.tgz\"");
+    }
+
+    #[test]
+    fn test_build_download_response_filename_crlf_and_quote_not_injectable() {
+        // #2654: a crafted filename carrying CRLF, a double quote, and a
+        // non-ASCII char must not inject/split the Content-Disposition header.
+        let resp = build_download_response(
+            Bytes::from_static(b"x"),
+            None,
+            "application/octet-stream",
+            Some("evil\"\r\nSet-Cookie: pwn=1\r\n名前.tgz"),
+        );
+        let cd = resp
+            .headers()
+            .get("Content-Disposition")
+            .unwrap()
+            .to_str()
+            .expect("header value must be valid (no raw control bytes)");
+
+        // No raw CR/LF survived into the header value.
+        assert!(!cd.contains('\r') && !cd.contains('\n'), "cd = {cd:?}");
+        // The injected header name did not leak as a standalone header.
+        assert!(resp.headers().get("Set-Cookie").is_none());
+        // The embedded double quote is backslash-escaped in the quoted-string.
+        assert!(cd.contains("filename=\"evil\\\""), "cd = {cd:?}");
+        // Non-ASCII name triggers the RFC 5987 extended form (percent-encoded).
+        assert!(cd.contains("filename*=UTF-8''"), "cd = {cd:?}");
+        assert!(!cd.contains('名'), "raw non-ASCII must not appear: {cd:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`build_download_response` (and its siblings `build_streaming_response_with_disposition` in `proxy_helpers.rs` and `DownloadResponse::into_response` in `download_response.rs`) interpolated a caller/artifact-supplied filename straight into the `Content-Disposition` header:

```rust
format!("attachment; filename=\"{}\"", fname)
```

A crafted filename — one carrying `CR`/`LF`, a `"`, or non-ASCII bytes — could break or inject the response header, and an invalid `HeaderValue` then made the builder `.unwrap()` **panic** (dropped connection / 500). Such names are reachable from untrusted content (e.g. a helm `Chart.yaml` `name` inside an uploaded archive), so the value must never be interpolated verbatim.

## Fix

New shared helper `content_disposition_attachment(filename)` (in `download_response.rs`), applied at all three interpolation sites, builds an **RFC 6266 / RFC 5987**-correct value:

- **strips control characters** (incl. `CR`/`LF`) so a name can never split or inject the header;
- always emits an ASCII `filename="…"` form with `"` and `\` escaped per the quoted-string grammar (non-ASCII collapses to `_` there);
- for non-ASCII names, additionally emits `filename*=UTF-8''<percent-encoded>` so modern clients recover the exact UTF-8 name while legacy clients fall back to the ASCII form.

The header value is now always a valid `HeaderValue`, so the builder no longer panics on hostile input. **Download bytes are unchanged — only header construction is touched.** Reuses the existing `urlencoding` dependency for the percent-encoding.

## Regression test (required for `fix/*` PRs)

`test_build_download_response_filename_crlf_and_quote_not_injectable` drives the unchanged public `build_download_response` with `evil"\r\nSet-Cookie: pwn=1\r\n名前.tgz`.

- **Fails on `main`:** panics at the builder `.unwrap()` with `http::Error(InvalidHeaderValue)`.
- **Passes here:** no raw `CR`/`LF` in the value, no leaked `Set-Cookie` header, `"` escaped, non-ASCII routed through `filename*=UTF-8''`.

Plus direct unit tests on the helper (plain ASCII unchanged, CRLF stripped, quote/backslash escaped, non-ASCII → RFC 5987). All existing normal-filename tests are unaffected.

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2654