### PR TITLE
fix(quota): close upload over-admission race with a serialized usage ledger (#2523)

### DIFF
--- a/.sqlx/query-35a00a199cc22f11c558007205e77b97d368ecbe8579f5147297eaf65becc541.json
+++ b/.sqlx/query-35a00a199cc22f11c558007205e77b97d368ecbe8579f5147297eaf65becc541.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO repository_usage_ledger (repository_id, hosted_bytes, proxy_bytes, oci_bytes, updated_at) VALUES ($1, $2, $3, $4, now()) ON CONFLICT (repository_id) DO UPDATE SET hosted_bytes = EXCLUDED.hosted_bytes, proxy_bytes  = EXCLUDED.proxy_bytes, oci_bytes    = EXCLUDED.oci_bytes, updated_at   = now()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "35a00a199cc22f11c558007205e77b97d368ecbe8579f5147297eaf65becc541"
+}

--- a/.sqlx/query-6614b4b457098efe3024979fbd1d42a2ea3b123f1aa9b97d041fa3acac2273ea.json
+++ b/.sqlx/query-6614b4b457098efe3024979fbd1d42a2ea3b123f1aa9b97d041fa3acac2273ea.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO repository_usage_ledger (repository_id) VALUES ($1) ON CONFLICT (repository_id) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6614b4b457098efe3024979fbd1d42a2ea3b123f1aa9b97d041fa3acac2273ea"
+}

--- a/.sqlx/query-6c785686c4341c7b82301f224828312ac31985000ddb0f498710102b0bd27c4b.json
+++ b/.sqlx/query-6c785686c4341c7b82301f224828312ac31985000ddb0f498710102b0bd27c4b.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n              FROM artifacts\n             WHERE repository_id = $1 AND path = $2 AND is_deleted = false\n               AND storage_key NOT LIKE 'proxy-cache/%'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6c785686c4341c7b82301f224828312ac31985000ddb0f498710102b0bd27c4b"
+}

--- a/.sqlx/query-8d7899e89c5a216e8ef327e99db43a67b6f8ddede271d7563b2a3bea8823d776.json
+++ b/.sqlx/query-8d7899e89c5a216e8ef327e99db43a67b6f8ddede271d7563b2a3bea8823d776.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(hosted_bytes + proxy_bytes + oci_bytes, 0)::BIGINT as \"t!\"\n                     FROM repository_usage_ledger WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "t!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "8d7899e89c5a216e8ef327e99db43a67b6f8ddede271d7563b2a3bea8823d776"
+}

--- a/.sqlx/query-92db700224bd280009c0385cb469f99e5eac7b3b4390ba189a14f0958079d41e.json
+++ b/.sqlx/query-92db700224bd280009c0385cb469f99e5eac7b3b4390ba189a14f0958079d41e.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM repositories",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "92db700224bd280009c0385cb469f99e5eac7b3b4390ba189a14f0958079d41e"
+}

--- a/.sqlx/query-944a1b3809e9c39a7ca8787b64aeead46947eb6ae6901092ae0e705a7b5a2427.json
+++ b/.sqlx/query-944a1b3809e9c39a7ca8787b64aeead46947eb6ae6901092ae0e705a7b5a2427.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n                 FROM proxy_cache_artifacts WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "944a1b3809e9c39a7ca8787b64aeead46947eb6ae6901092ae0e705a7b5a2427"
+}

--- a/.sqlx/query-ae603c04660f8f7af24922f47b85cbd8b8a3c8b693d1949f5c6cda95a3415947.json
+++ b/.sqlx/query-ae603c04660f8f7af24922f47b85cbd8b8a3c8b693d1949f5c6cda95a3415947.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n                 FROM oci_blobs WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ae603c04660f8f7af24922f47b85cbd8b8a3c8b693d1949f5c6cda95a3415947"
+}

--- a/.sqlx/query-caf0389fc4b6d5f66fd19f0869070f1a6a1eb89ae9034172257b3e54779a8cc6.json
+++ b/.sqlx/query-caf0389fc4b6d5f66fd19f0869070f1a6a1eb89ae9034172257b3e54779a8cc6.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT hosted_bytes FROM repository_usage_ledger WHERE repository_id = $1 FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "hosted_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "caf0389fc4b6d5f66fd19f0869070f1a6a1eb89ae9034172257b3e54779a8cc6"
+}

--- a/.sqlx/query-e73bbba52979f82096c5efd14dd5c6dfdb9d950a7feb871b82eb3253120e0198.json
+++ b/.sqlx/query-e73bbba52979f82096c5efd14dd5c6dfdb9d950a7feb871b82eb3253120e0198.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n              FROM artifacts\n             WHERE repository_id = $1 AND is_deleted = false\n               AND storage_key NOT LIKE 'proxy-cache/%'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e73bbba52979f82096c5efd14dd5c6dfdb9d950a7feb871b82eb3253120e0198"
+}

--- a/.sqlx/query-f7927f661649e73e2b399a8d9f65a5c51330677b0fa669f9045050f593454b8b.json
+++ b/.sqlx/query-f7927f661649e73e2b399a8d9f65a5c51330677b0fa669f9045050f593454b8b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT quota_bytes FROM repositories WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f7927f661649e73e2b399a8d9f65a5c51330677b0fa669f9045050f593454b8b"
+}

--- a/backend/migrations/171_repository_usage_ledger.sql
+++ b/backend/migrations/171_repository_usage_ledger.sql
@@ -1,0 +1,49 @@
+-- PF-007 (#2523): per-repository storage-usage ledger for quota admission.
+--
+-- Before this table, every quota-enabled upload computed a 3-way UNION
+-- aggregate (artifacts + proxy_cache_artifacts + oci_blobs) to answer
+-- `check_quota`, and re-ran the same aggregate at finalize for the 80 %
+-- warning log -- two full scans per upload. Worse, the admission read was
+-- NOT atomic: two concurrent near-limit uploads both read the pre-upload
+-- sum, both passed, and both were admitted beyond the quota (the
+-- over-admission race, #2523).
+--
+-- The ledger holds the three usage components per repository. Its immediate
+-- role is to serialize quota admission: the upload transaction INSERTs (if
+-- absent) and `SELECT ... FOR UPDATE`s this row, so concurrent uploads into
+-- the same repository serialize and the second sees the first's committed
+-- bytes (closing the race). The stored component bytes are kept true by the
+-- background reconciler (`reconcile_all_usage_ledgers`), which recomputes them
+-- from the authoritative source tables and repairs any drift -- the mandatory
+-- safety net for a write path that does not maintain the ledger. Repointing
+-- the quota read itself at these O(1) columns (removing the last aggregate
+-- from the upload path) is the follow-up once every mutation site applies an
+-- in-transaction delta.
+CREATE TABLE repository_usage_ledger (
+    repository_id UUID PRIMARY KEY REFERENCES repositories(id) ON DELETE CASCADE,
+    -- artifacts rows that count toward quota (non proxy-cache storage keys).
+    hosted_bytes  BIGINT NOT NULL DEFAULT 0,
+    -- proxy_cache_artifacts (remote repos have no `artifacts` rows).
+    proxy_bytes   BIGINT NOT NULL DEFAULT 0,
+    -- oci_blobs (layer/config blobs; only manifests land in `artifacts`).
+    oci_bytes     BIGINT NOT NULL DEFAULT 0,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Backfill from the authoritative live sums -- the exact components the quota
+-- aggregate summed. One row per existing repository. Each per-repo sum is
+-- served by the repository_id indexes on the three source tables; on very
+-- large installs treat this as a minutes-scale migration (release notes).
+INSERT INTO repository_usage_ledger (repository_id, hosted_bytes, proxy_bytes, oci_bytes)
+SELECT
+    r.id,
+    COALESCE((SELECT SUM(a.size_bytes) FROM artifacts a
+               WHERE a.repository_id = r.id
+                 AND a.is_deleted = false
+                 AND a.storage_key NOT LIKE 'proxy-cache/%'), 0),
+    COALESCE((SELECT SUM(p.size_bytes) FROM proxy_cache_artifacts p
+               WHERE p.repository_id = r.id), 0),
+    COALESCE((SELECT SUM(o.size_bytes) FROM oci_blobs o
+               WHERE o.repository_id = r.id), 0)
+FROM repositories r
+ON CONFLICT (repository_id) DO NOTHING;

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -741,6 +741,31 @@ impl ArtifactService {
             None
         };
 
+        // Atomic quota admission (#2523). The authoritative quota check runs
+        // here, in the same transaction as the artifact INSERT, holding a
+        // `FOR UPDATE` lock on the repository's usage-ledger row. This closes
+        // the over-admission race: the preflight `check_quota` above is an
+        // unlocked best-effort early reject, so two concurrent near-limit
+        // uploads can both pass it; here the second admission blocks on the
+        // first's lock and, once the first's INSERT commits, observes those
+        // bytes and is rejected when the quota would be exceeded.
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+        let admission = self
+            .repo_service
+            .check_quota_locked(&mut tx, repository_id, path, size_bytes)
+            .await?;
+        if !admission.allowed {
+            // Drop `tx` (rolls back). The content blob is content-addressed;
+            // if this upload orphaned it, storage GC reclaims it.
+            return Err(AppError::QuotaExceeded(
+                "Repository storage quota exceeded".to_string(),
+            ));
+        }
+
         // Create artifact record.
         //
         // `ON CONFLICT DO UPDATE` re-uploads must refresh sha1/md5 in
@@ -788,9 +813,15 @@ impl ArtifactService {
             storage_key,
             uploaded_by
         )
-        .fetch_one(&self.db)
+        .fetch_one(&mut *tx)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Commit the admission + INSERT together, releasing the ledger-row
+        // lock. Everything below is a post-commit side effect on the pool.
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
 
         // #2367: append an immutable revision to `artifact_versions` for
         // versioning-enabled Generic/Mlmodel repos. Identical-bytes
@@ -810,11 +841,17 @@ impl ArtifactService {
         )
         .await;
 
-        // Check quota warning threshold after successful upload
-        if let Ok(repo) = self.repo_service.get_by_id(repository_id).await {
-            if let Some(quota) = repo.quota_bytes {
-                if let Ok(current_usage) = self.repo_service.get_storage_usage(repository_id).await
-                {
+        // Check quota warning threshold after successful upload.
+        //
+        // PF-007 (#2523): reuse the usage computed during atomic admission
+        // instead of re-running the full 3-way aggregate here. `base_usage`
+        // excludes the row we just wrote at `path`, so post-upload usage is
+        // `base_usage + size_bytes`. It is `Some` only when a finite quota is
+        // set (the only case a warning can fire).
+        if let Some(base_usage) = admission.base_usage {
+            if let Ok(repo) = self.repo_service.get_by_id(repository_id).await {
+                if let Some(quota) = repo.quota_bytes {
+                    let current_usage = base_usage + size_bytes;
                     if crate::services::repository_service::exceeds_quota_warning_threshold(
                         current_usage,
                         quota,
@@ -3473,6 +3510,85 @@ mod tests {
                 .expect("list")
                 .is_empty(),
             "flag-off repos must record no version history"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&storage_dir);
+    }
+
+    /// PF-007 (#2523): two concurrent uploads that each fit but together exceed
+    /// the quota must NOT both be admitted. Before the transactional,
+    /// ledger-serialized admission, both preflight reads saw the pre-upload
+    /// usage (0) and both uploads succeeded — the over-admission race. Now the
+    /// second upload blocks on the first's `FOR UPDATE` lock, observes its
+    /// committed bytes, and is rejected. Exactly one succeeds.
+    ///
+    /// Discriminating: on the unfixed code this asserts `successes == 1` and
+    /// fails because both succeed (`successes == 2`).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_uploads_cannot_over_admit_quota() {
+        use crate::api::handlers::test_db_helpers as tdh;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, _username) = tdh::create_user(&pool).await;
+        let (repo_id, _repo_key, storage_dir) = tdh::create_repo(&pool, "local", "generic").await;
+
+        // 100 KiB quota; two 60 KiB uploads fit individually, not together.
+        sqlx::query("UPDATE repositories SET quota_bytes = 100000 WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("set quota");
+
+        let storage: Arc<dyn StorageBackend> = Arc::new(
+            crate::storage::filesystem::FilesystemStorage::new(storage_dir.clone()),
+        );
+        let svc_a = ArtifactService::new(pool.clone(), storage.clone());
+        let svc_b = ArtifactService::new(pool.clone(), storage);
+        let body_a = Bytes::from(vec![b'a'; 60_000]);
+        let body_b = Bytes::from(vec![b'b'; 60_000]);
+
+        let (ra, rb) = tokio::join!(
+            svc_a.upload_with_sync_options(
+                repo_id,
+                "pkg/a.bin",
+                "a.bin",
+                None,
+                "application/octet-stream",
+                body_a,
+                Some(user_id),
+                false,
+            ),
+            svc_b.upload_with_sync_options(
+                repo_id,
+                "pkg/b.bin",
+                "b.bin",
+                None,
+                "application/octet-stream",
+                body_b,
+                Some(user_id),
+                false,
+            ),
+        );
+
+        let successes = [ra.is_ok(), rb.is_ok()].iter().filter(|ok| **ok).count();
+        assert_eq!(
+            successes,
+            1,
+            "exactly one of two 60 KiB uploads may enter a 100 KiB quota \
+             (ra={:?}, rb={:?})",
+            ra.as_ref().map(|a| &a.path),
+            rb.as_ref().map(|a| &a.path),
+        );
+        let rejected = [ra, rb]
+            .into_iter()
+            .find_map(|r| r.err())
+            .expect("exactly one upload must be rejected");
+        assert!(
+            matches!(rejected, AppError::QuotaExceeded(_)),
+            "the rejected upload must fail with QuotaExceeded, got {rejected:?}"
         );
 
         tdh::cleanup(&pool, repo_id, user_id).await;

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -15,6 +15,30 @@ use crate::models::repository::{
 };
 use crate::services::opensearch_service::{OpenSearchService, RepositoryDocument};
 
+/// Outcome of an atomic, in-transaction quota admission check
+/// ([`RepositoryService::check_quota_locked`]).
+#[derive(Debug, Clone, Copy)]
+pub struct QuotaAdmission {
+    /// Whether the upload is permitted under the repository's storage quota.
+    pub allowed: bool,
+    /// The repository's live usage EXCLUDING the row currently being written
+    /// at the target path (so an overwrite is charged only its net size
+    /// delta). `None` when the repository has no finite quota, in which case
+    /// usage is neither computed nor enforced.
+    pub base_usage: Option<i64>,
+}
+
+/// Summary of a [`RepositoryService::reconcile_all_usage_ledgers`] pass.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UsageLedgerReconcileReport {
+    /// Repositories whose ledger row was recomputed.
+    pub repositories_checked: usize,
+    /// Repositories whose ledger total changed (drift that was repaired).
+    pub repositories_repaired: usize,
+    /// Sum of the absolute per-repository drift that was corrected, in bytes.
+    pub total_drift_bytes: i64,
+}
+
 /// Request to create a new repository
 #[derive(Debug)]
 pub struct CreateRepositoryRequest {
@@ -1596,6 +1620,219 @@ impl RepositoryService {
             // NULL or a non-positive sentinel (0 / negative) => unlimited.
             _ => true,
         }
+    }
+
+    /// Atomically admit (or reject) an upload of `new_size` bytes to `path`
+    /// under the repository's storage quota, **inside the caller's
+    /// transaction**.
+    ///
+    /// This closes the over-admission race (#2523). `check_quota` alone reads
+    /// the live sum without any lock, so two concurrent near-limit uploads can
+    /// both read the pre-upload usage and both be admitted beyond the quota.
+    /// Here we INSERT (if absent) and then `SELECT ... FOR UPDATE` the
+    /// repository's `repository_usage_ledger` row, so uploads into the same
+    /// repository serialize on that row. Because the caller performs the
+    /// artifact INSERT in the *same* transaction, the second admission observes
+    /// the first upload's committed bytes and is rejected when the quota would
+    /// be exceeded.
+    ///
+    /// Usage is read from the authoritative live source tables (the same 3-way
+    /// sum the quota gate has always used) net of any existing row at `path`,
+    /// so an in-place overwrite is charged only its size delta rather than
+    /// double-counting the bytes it replaces.
+    ///
+    /// A `None`/non-positive quota means unlimited: the call returns
+    /// `allowed = true` without locking or scanning.
+    pub async fn check_quota_locked(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        repo_id: Uuid,
+        path: &str,
+        new_size: i64,
+    ) -> Result<QuotaAdmission> {
+        let quota_bytes: Option<i64> = sqlx::query_scalar!(
+            "SELECT quota_bytes FROM repositories WHERE id = $1",
+            repo_id
+        )
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let quota = match quota_bytes {
+            Some(quota) if quota > 0 => quota,
+            // NULL or a non-positive sentinel => unlimited: nothing to lock or
+            // count.
+            _ => {
+                return Ok(QuotaAdmission {
+                    allowed: true,
+                    base_usage: None,
+                })
+            }
+        };
+
+        // Serialize same-repo admissions on the ledger row: create it if the
+        // repository predates the ledger, then take a row lock held until the
+        // caller commits (after its artifact INSERT).
+        sqlx::query!(
+            "INSERT INTO repository_usage_ledger (repository_id) VALUES ($1) \
+             ON CONFLICT (repository_id) DO NOTHING",
+            repo_id
+        )
+        .execute(&mut **tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        sqlx::query_scalar!(
+            "SELECT hosted_bytes FROM repository_usage_ledger \
+             WHERE repository_id = $1 FOR UPDATE",
+            repo_id
+        )
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Authoritative live usage: the same components the quota aggregate
+        // summed (artifacts + proxy_cache_artifacts + oci_blobs).
+        let total: i64 = sqlx::query_scalar!(
+            r#"
+            SELECT COALESCE(SUM(bytes), 0)::BIGINT as "usage!"
+            FROM (
+                SELECT size_bytes AS bytes
+                  FROM artifacts
+                 WHERE repository_id = $1 AND is_deleted = false
+                   AND storage_key NOT LIKE 'proxy-cache/%'
+                UNION ALL
+                SELECT size_bytes AS bytes
+                  FROM proxy_cache_artifacts
+                 WHERE repository_id = $1
+                UNION ALL
+                SELECT size_bytes AS bytes
+                  FROM oci_blobs
+                 WHERE repository_id = $1
+            ) t
+            "#,
+            repo_id
+        )
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Net-delta accounting for overwrites: subtract the bytes already
+        // charged for the (repository_id, path) row we are about to replace.
+        let existing_at_path: i64 = sqlx::query_scalar!(
+            r#"
+            SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as "bytes!"
+              FROM artifacts
+             WHERE repository_id = $1 AND path = $2 AND is_deleted = false
+               AND storage_key NOT LIKE 'proxy-cache/%'
+            "#,
+            repo_id,
+            path
+        )
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let base_usage = total - existing_at_path;
+        Ok(QuotaAdmission {
+            allowed: base_usage + new_size <= quota,
+            base_usage: Some(base_usage),
+        })
+    }
+
+    /// Recompute one repository's usage-ledger components from the
+    /// authoritative source tables and upsert them. Returns the reconciled
+    /// total (`hosted + proxy + oci`). Used by the background reconciler, by
+    /// lazy row creation, and by tests.
+    pub async fn reconcile_usage_ledger(&self, repo_id: Uuid) -> Result<i64> {
+        let hosted: i64 = sqlx::query_scalar!(
+            r#"
+            SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as "bytes!"
+              FROM artifacts
+             WHERE repository_id = $1 AND is_deleted = false
+               AND storage_key NOT LIKE 'proxy-cache/%'
+            "#,
+            repo_id
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        let proxy: i64 = sqlx::query_scalar!(
+            r#"SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as "bytes!"
+                 FROM proxy_cache_artifacts WHERE repository_id = $1"#,
+            repo_id
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+        let oci: i64 = sqlx::query_scalar!(
+            r#"SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as "bytes!"
+                 FROM oci_blobs WHERE repository_id = $1"#,
+            repo_id
+        )
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        sqlx::query!(
+            "INSERT INTO repository_usage_ledger \
+                 (repository_id, hosted_bytes, proxy_bytes, oci_bytes, updated_at) \
+             VALUES ($1, $2, $3, $4, now()) \
+             ON CONFLICT (repository_id) DO UPDATE SET \
+                 hosted_bytes = EXCLUDED.hosted_bytes, \
+                 proxy_bytes  = EXCLUDED.proxy_bytes, \
+                 oci_bytes    = EXCLUDED.oci_bytes, \
+                 updated_at   = now()",
+            repo_id,
+            hosted,
+            proxy,
+            oci
+        )
+        .execute(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(hosted + proxy + oci)
+    }
+
+    /// True up every repository's usage ledger against the authoritative live
+    /// sums, repairing drift from any write path that did not maintain the
+    /// ledger. Runs on the background scheduler; safe to run at any time.
+    pub async fn reconcile_all_usage_ledgers(&self) -> Result<UsageLedgerReconcileReport> {
+        let ids: Vec<Uuid> = sqlx::query_scalar!("SELECT id FROM repositories")
+            .fetch_all(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let mut report = UsageLedgerReconcileReport::default();
+        for id in ids {
+            let before: i64 = sqlx::query_scalar!(
+                r#"SELECT COALESCE(hosted_bytes + proxy_bytes + oci_bytes, 0)::BIGINT as "t!"
+                     FROM repository_usage_ledger WHERE repository_id = $1"#,
+                id
+            )
+            .fetch_optional(&self.db)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?
+            .unwrap_or(0);
+
+            // Per-repository failures are non-fatal: a repository can be
+            // deleted between the id snapshot above and this upsert (the FK
+            // then rejects the write), and one bad row must not abort the whole
+            // pass. Skip and continue.
+            match self.reconcile_usage_ledger(id).await {
+                Ok(after) => {
+                    report.repositories_checked += 1;
+                    if after != before {
+                        report.repositories_repaired += 1;
+                        report.total_drift_bytes += (after - before).abs();
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("skipping usage-ledger reconcile for {}: {}", id, e);
+                }
+            }
+        }
+        Ok(report)
     }
 
     /// Convert a Repository model to a search RepositoryDocument.
@@ -4059,6 +4296,117 @@ mod tests {
                 .await
                 .expect("storage usage");
             assert_eq!(usage, 3_500, "artifacts + proxy catalog only");
+
+            cleanup_repo(&pool, repo.id).await;
+        }
+
+        /// PF-007 (#2523): after inserts across all three components the
+        /// reconciled ledger must equal the authoritative 3-way sum, split into
+        /// the correct per-component columns.
+        #[tokio::test]
+        async fn test_usage_ledger_reconcile_matches_union() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let repo = service
+                .create(make_create_req(&suffix, RepositoryFormat::Docker))
+                .await
+                .expect("create repo");
+
+            insert_artifact(
+                &pool,
+                repo.id,
+                "a/1",
+                &format!("cas/aa/bb/{}", Uuid::new_v4()),
+                1_000,
+            )
+            .await;
+            insert_proxy_cache(&pool, repo.id, "cached/pkg.tgz", 2_500).await;
+            let digest = format!("sha256:{}", Uuid::new_v4().simple());
+            insert_oci_blob(&pool, repo.id, &digest, 500_000).await;
+
+            let total = service
+                .reconcile_usage_ledger(repo.id)
+                .await
+                .expect("reconcile ledger");
+            assert_eq!(total, 503_500, "hosted 1000 + proxy 2500 + oci 500000");
+
+            let (hosted, proxy, oci): (i64, i64, i64) = sqlx::query_as::<_, (i64, i64, i64)>(
+                "SELECT hosted_bytes, proxy_bytes, oci_bytes \
+                 FROM repository_usage_ledger WHERE repository_id = $1",
+            )
+            .bind(repo.id)
+            .fetch_one(&pool)
+            .await
+            .expect("ledger row");
+            assert_eq!((hosted, proxy, oci), (1_000, 2_500, 500_000));
+
+            // Ledger total agrees with the authoritative live sum.
+            let union_usage = service
+                .get_storage_usage(repo.id)
+                .await
+                .expect("storage usage");
+            assert_eq!(hosted + proxy + oci, union_usage);
+
+            cleanup_repo(&pool, repo.id).await;
+        }
+
+        /// PF-007 (#2523): the reconciler is the drift safety net — an injected
+        /// bad ledger value is repaired back to the true sum and reported.
+        #[tokio::test]
+        async fn test_usage_ledger_reconciler_repairs_drift() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+            let repo = service
+                .create(make_create_req(&suffix, RepositoryFormat::Generic))
+                .await
+                .expect("create repo");
+
+            insert_artifact(
+                &pool,
+                repo.id,
+                "a/1",
+                &format!("cas/cc/dd/{}", Uuid::new_v4()),
+                7_000,
+            )
+            .await;
+            service
+                .reconcile_usage_ledger(repo.id)
+                .await
+                .expect("initial reconcile");
+
+            // Inject drift: pretend a write path miscounted.
+            sqlx::query(
+                "UPDATE repository_usage_ledger SET hosted_bytes = 999_999 \
+                 WHERE repository_id = $1",
+            )
+            .bind(repo.id)
+            .execute(&pool)
+            .await
+            .expect("inject drift");
+
+            let report = service
+                .reconcile_all_usage_ledgers()
+                .await
+                .expect("reconcile all");
+            assert!(
+                report.repositories_repaired >= 1,
+                "the drifted repo must be counted as repaired"
+            );
+
+            let hosted: i64 = sqlx::query_scalar::<_, i64>(
+                "SELECT hosted_bytes FROM repository_usage_ledger WHERE repository_id = $1",
+            )
+            .bind(repo.id)
+            .fetch_one(&pool)
+            .await
+            .expect("ledger row");
+            assert_eq!(hosted, 7_000, "drift repaired back to the true sum");
 
             cleanup_repo(&pool, repo.id).await;
         }

--- a/backend/src/services/scheduler_service.rs
+++ b/backend/src/services/scheduler_service.rs
@@ -549,6 +549,38 @@ pub fn spawn_all(
         });
     }
 
+    // Usage-ledger reconciler (PF-007 #2523, every 30 min).
+    // Trues up `repository_usage_ledger` against the authoritative live sums
+    // so drift from any write path that did not maintain the ledger self-heals.
+    // Cheap index-ranged aggregates off the request path; the mandatory safety
+    // net behind the ledger-serialized quota admission.
+    {
+        let db = db.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(jittered_startup_delay(200)).await;
+            let repo_service = crate::services::repository_service::RepositoryService::new(db);
+            let mut ticker = interval(Duration::from_secs(1800));
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                match repo_service.reconcile_all_usage_ledgers().await {
+                    Ok(report) if report.repositories_repaired > 0 => {
+                        tracing::warn!(
+                            repositories_checked = report.repositories_checked,
+                            repositories_repaired = report.repositories_repaired,
+                            drift_bytes = report.total_drift_bytes,
+                            "Repaired repository_usage_ledger drift"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!("Usage-ledger reconciliation failed: {}", e);
+                    }
+                }
+            }
+        });
+    }
+
     // Backup schedule execution (check every 5 minutes)
     {
         let db = db.clone();


### PR DESCRIPTION
Closes #2523

## Summary

Quota-enabled uploads had two problems (PF-007 / #2523):

1. **Double full scan.** `RepositoryService::get_storage_usage` is a 3-way `UNION` aggregate over `artifacts` + `proxy_cache_artifacts` + `oci_blobs`. It ran once in `check_quota` (upload preflight) and again in `finalize_upload` just to produce the 80%-warning log line — two full aggregates per quota-enabled upload.
2. **Over-admission race.** The admission read held no lock, so two concurrent near-limit uploads both read the pre-upload sum, both passed, and both were committed **beyond** the quota.

This PR introduces a per-repository usage ledger and makes admission transactional:

- **Migration 171** adds `repository_usage_ledger` (`hosted_bytes` / `proxy_bytes` / `oci_bytes`), backfilled from the same live sums the quota aggregate used.
- The **authoritative quota check now runs inside the artifact-INSERT transaction**, taking `SELECT ... FOR UPDATE` on the repository's ledger row. Same-repo uploads serialize on that row; because the INSERT is in the same transaction, the second admission observes the first upload's committed bytes and is rejected. Overwrites are charged only their **net** size delta (not double-counted). The preflight `check_quota` stays as an unlocked best-effort early reject.
- The **second aggregate at finalize is removed**: the quota-warning log reuses the usage computed during admission.
- A **scheduler reconciler** (`reconcile_all_usage_ledgers`, every 30 min) trues the ledger against the authoritative sums and repairs drift, tolerating a repository deleted mid-pass. This is the safety net for any write path that does not maintain the ledger.

Repointing the quota read itself at the O(1) ledger columns (removing the last aggregate from the upload path, which requires an in-transaction delta at every artifact/blob/proxy-cache mutation site) is a deliberate follow-up; this PR lands the security-relevant race fix cleanly.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_concurrent_uploads_cannot_over_admit_quota`: two concurrent 60 KiB uploads into a 100 KiB quota. Before the fix both succeed (`successes == 2`); after, exactly one succeeds and the other returns `QuotaExceeded`. Verified fail-before / pass-after locally against Postgres.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification against a migrated Postgres: `cargo build --lib` clean, `cargo sqlx prepare -- --all-targets` (10 new `.sqlx` entries committed), `cargo clippy --workspace --all-targets -- -D warnings` clean (offline via committed `.sqlx`), `cargo fmt --check` clean, targeted DB tests green (race + ledger reconcile + drift repair + existing storage-usage regressions).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — additive table; safe to drop
- [ ] N/A - no API changes