### PR TITLE
fix(upload): stream common artifact upload routes instead of buffering (#2517)

### DIFF
--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -2110,7 +2110,7 @@ async fn upload(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((repo_key, path)): Path<(String, String)>,
     headers: HeaderMap,
-    body: Bytes,
+    body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: read-scoped API tokens were being accepted on
     // this push endpoint. Require the write scope before doing any work.
@@ -2154,6 +2154,14 @@ async fn upload(
         .storage_for_repo(&repo.storage_location())
         .map_err(|e| e.into_response())?;
 
+    // Stream the request body to a bounded scratch file, computing
+    // SHA-256/SHA-1/MD5 in one pass — never buffering the artifact in memory
+    // (#2517). All three branches below (checksum sidecar, maven-metadata.xml,
+    // and the artifact itself) store from the staged file. The stager enforces
+    // `max_upload_size_bytes` mid-stream (413 on breach).
+    let (staged, digests) =
+        proxy_helpers::stage_stream_content_addressed(&state, body.into_data_stream()).await?;
+
     // If this is a checksum file (.sha1, .md5, .sha256), just store it and return.
     // These row-less puts create no artifact row, so attribution is committed
     // here -- only after the object bytes are durably written (#2574, V3b).
@@ -2161,7 +2169,9 @@ async fn upload(
         // Atomically claim the flat key BEFORE writing its bytes: exactly one
         // concurrent first-publisher wins, the rest are refused, so the stored
         // bytes and the attributed owner can never disagree (#2586). Release the
-        // freshly-inserted claim if the put itself fails (V3b).
+        // freshly-inserted claim if the put itself fails (V3b). The staged
+        // stream is opened first so a local scratch-file failure never claims.
+        let stream = proxy_helpers::open_staged_upload_stream(&staged).await?;
         let claim = crate::services::maven_flat_attribution::claim_flat_key_for_write(
             &state.db,
             repo.id,
@@ -2170,7 +2180,7 @@ async fn upload(
         )
         .await
         .map_err(|e| e.into_response())?;
-        if let Err(e) = storage.put(&storage_key, body).await {
+        if let Err(e) = storage.put_stream(&storage_key, stream).await {
             release_flat_key_claim_best_effort(
                 &state.db,
                 claim,
@@ -2191,7 +2201,9 @@ async fn upload(
     // claim-on-write-success rule as the checksum branch (#2574, V3b).
     if MavenHandler::is_metadata(&path) {
         // Row-less metadata put: atomic claim-gate before the write, same as the
-        // checksum branch (#2586); release on put failure (V3b).
+        // checksum branch (#2586); release on put failure (V3b). Staged stream
+        // opened first so a local scratch-file failure never claims.
+        let stream = proxy_helpers::open_staged_upload_stream(&staged).await?;
         let claim = crate::services::maven_flat_attribution::claim_flat_key_for_write(
             &state.db,
             repo.id,
@@ -2200,7 +2212,7 @@ async fn upload(
         )
         .await
         .map_err(|e| e.into_response())?;
-        if let Err(e) = storage.put(&storage_key, body).await {
+        if let Err(e) = storage.put_stream(&storage_key, stream).await {
             release_flat_key_claim_best_effort(
                 &state.db,
                 claim,
@@ -2221,17 +2233,15 @@ async fn upload(
     let coords = MavenHandler::parse_coordinates(&path)
         .map_err(|e| AppError::Validation(format!("Invalid Maven path: {}", e)).into_response())?;
 
-    // Compute checksums for the canonical artifact row. Maven checksum
-    // sidecars are stored separately, but the artifact ledger should still
-    // carry the common digests so checksum search, replication, and API
-    // responses have the same fidelity as generic uploads.
-    let mut hasher = Sha256::new();
-    hasher.update(&body);
-    let checksum_sha256 = format!("{:x}", hasher.finalize());
-    let checksum_sha1 = compute_checksum(&body, ChecksumType::Sha1);
-    let checksum_md5 = compute_checksum(&body, ChecksumType::Md5);
+    // Content digests for the canonical artifact row come from the single
+    // streaming stage pass. Maven checksum sidecars are stored separately, but
+    // the artifact ledger still carries the common digests so checksum search,
+    // replication, and API responses have the same fidelity as generic uploads.
+    let checksum_sha256 = digests.sha256.clone();
+    let checksum_sha1 = digests.sha1.clone();
+    let checksum_md5 = digests.md5.clone();
 
-    let size_bytes = body.len() as i64;
+    let size_bytes = staged.size_bytes();
     let ct = content_type_for_path(&path);
 
     // Check for active (non-deleted) duplicate
@@ -2277,7 +2287,9 @@ async fn upload(
     // concurrent first-publishers of the same key exactly one proceeds and the
     // other is refused (#2586). This runs after coordinate parsing + the
     // duplicate check, so an invalid/aborted request never claims (V3b); if the
-    // put fails, the freshly-inserted claim is released below.
+    // put fails, the freshly-inserted claim is released below. The staged
+    // stream is opened first so a local scratch-file failure never claims.
+    let stream = proxy_helpers::open_staged_upload_stream(&staged).await?;
     let flat_key_claim = crate::services::maven_flat_attribution::claim_flat_key_for_write(
         &state.db,
         repo.id,
@@ -2287,8 +2299,9 @@ async fn upload(
     .await
     .map_err(|e| e.into_response())?;
 
-    // Store file in object storage regardless of grouping outcome
-    if let Err(e) = storage.put(&storage_key, body.clone()).await {
+    // Store file in object storage regardless of grouping outcome — streamed
+    // from the staged scratch file, not a heap buffer (#2517).
+    if let Err(e) = storage.put_stream(&storage_key, stream).await {
         release_flat_key_claim_best_effort(
             &state.db,
             flat_key_claim,
@@ -2300,18 +2313,34 @@ async fn upload(
         return Err(map_storage_err(e));
     }
 
-    // Build metadata JSON for this physical Maven file.
+    // Build metadata JSON for this physical Maven file. `parse_metadata` only
+    // inspects the body for POM files (small XML); every other maven file (jars,
+    // ...) derives its metadata from the coordinates alone. Read the small POM
+    // back from the staged file; skip the read entirely for everything else so a
+    // large artifact is never materialised in memory.
     let handler = MavenHandler::new();
-    let mut file_metadata = crate::formats::FormatHandler::parse_metadata(&handler, &path, &body)
-        .await
-        .unwrap_or_else(|_| {
-            serde_json::json!({
-                "groupId": coords.group_id,
-                "artifactId": coords.artifact_id,
-                "version": coords.version,
-                "extension": coords.extension,
-            })
-        });
+    let pom_bytes = if MavenHandler::is_pom(&path) {
+        Bytes::from(
+            tokio::fs::read(staged.path())
+                .await
+                .map_err(|e| proxy_helpers::internal_error("Reading staged POM", e))?,
+        )
+    } else {
+        Bytes::new()
+    };
+    // Scratch file no longer needed once the object is stored and any POM read.
+    drop(staged);
+    let mut file_metadata =
+        crate::formats::FormatHandler::parse_metadata(&handler, &path, &pom_bytes)
+            .await
+            .unwrap_or_else(|_| {
+                serde_json::json!({
+                    "groupId": coords.group_id,
+                    "artifactId": coords.artifact_id,
+                    "version": coords.version,
+                    "extension": coords.extension,
+                })
+            });
 
     let name = coords.artifact_id.clone();
     let package_name = maven_package_name(&coords);
@@ -4605,7 +4634,7 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((repo_key.to_string(), path.to_string())),
             axum::http::HeaderMap::new(),
-            bytes::Bytes::copy_from_slice(body),
+            axum::body::Body::from(body.to_vec()),
         )
         .await
         .expect("upload must succeed");

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -15940,6 +15940,206 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------
+    // Multipart staging helpers (#2517): the upload pipeline spools form-file
+    // fields to a bounded scratch file, computing SHA-256/SHA-1/MD5 in one
+    // pass, and never buffers the artifact in memory. These tests drive the
+    // extractors directly with hand-built multipart bodies.
+    // ---------------------------------------------------------------------
+
+    fn staging_test_state() -> crate::api::SharedState {
+        use std::sync::Arc;
+        let pool = sqlx::PgPool::connect_lazy("postgres://fake:fake@localhost/fake")
+            .expect("connect_lazy should not fail");
+        let storage: Arc<dyn crate::storage::StorageBackend> = Arc::new(
+            crate::storage::filesystem::FilesystemStorage::new("/tmp/test-repo-staging"),
+        );
+        let registry = Arc::new(crate::storage::StorageRegistry::new(
+            std::collections::HashMap::new(),
+            "filesystem".to_string(),
+        ));
+        Arc::new(crate::api::AppState::new(
+            crate::config::Config::test_config(),
+            pool,
+            storage,
+            registry,
+        ))
+    }
+
+    /// Build a real `axum::extract::Multipart` from a raw multipart body, the
+    /// same way the framework would for an incoming request.
+    async fn multipart_from_body(boundary: &str, body: &str) -> Multipart {
+        use axum::extract::FromRequest;
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/")
+            .header(
+                header::CONTENT_TYPE,
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        Multipart::from_request(req, &())
+            .await
+            .expect("multipart extractor")
+    }
+
+    #[tokio::test]
+    async fn test_stage_multipart_file_spools_to_scratch_with_digests() {
+        let state = staging_test_state();
+        let body = concat!(
+            "--XB\r\n",
+            "Content-Disposition: form-data; name=\"file\"; filename=\"abc.bin\"\r\n",
+            "\r\n",
+            "abc\r\n",
+            "--XB--\r\n"
+        );
+        let mp = multipart_from_body("XB", body).await;
+
+        let (staged, digests, filename) = stage_multipart_file(&state, mp)
+            .await
+            .expect("staging should succeed");
+        assert_eq!(filename, "abc.bin");
+        assert_eq!(staged.size_bytes(), 3);
+        // Well-known digests of the ASCII string "abc": all three computed in
+        // the single spooling pass.
+        assert_eq!(
+            digests.sha256,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+        assert_eq!(digests.sha1, "a9993e364706816aba3e25717850c26c9cd0d89d");
+        assert_eq!(digests.md5, "900150983cd24fb0d6963f7d28e17f72");
+        // The bytes live in the scratch file, ready to be re-streamed.
+        let on_disk = tokio::fs::read(staged.path()).await.unwrap();
+        assert_eq!(on_disk, b"abc");
+    }
+
+    #[tokio::test]
+    async fn test_stage_multipart_file_requires_a_file_field() {
+        let state = staging_test_state();
+        let body = concat!(
+            "--XB\r\n",
+            "Content-Disposition: form-data; name=\"path\"\r\n",
+            "\r\n",
+            "just/a/path\r\n",
+            "--XB--\r\n"
+        );
+        let mp = multipart_from_body("XB", body).await;
+        let resp = match stage_multipart_file(&state, mp).await {
+            Ok(_) => panic!("form without a file field must be rejected"),
+            Err(resp) => resp,
+        };
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_stage_multipart_file_and_path_reads_fields_in_any_order() {
+        let state = staging_test_state();
+        // `path` arrives BEFORE the file field: order must not matter.
+        let body = concat!(
+            "--XB\r\n",
+            "Content-Disposition: form-data; name=\"path\"\r\n",
+            "\r\n",
+            "docs/dir/\r\n",
+            "--XB\r\n",
+            "Content-Disposition: form-data; name=\"file\"; filename=\"guide.pdf\"\r\n",
+            "\r\n",
+            "pdfbytes\r\n",
+            "--XB--\r\n"
+        );
+        let mp = multipart_from_body("XB", body).await;
+        let (staged, digests, filename, custom_path) = stage_multipart_file_and_path(&state, mp)
+            .await
+            .expect("staging should succeed");
+        assert_eq!(filename, "guide.pdf");
+        assert_eq!(custom_path.as_deref(), Some("docs/dir/"));
+        assert_eq!(staged.size_bytes(), 8);
+        assert_eq!(digests.sha256.len(), 64);
+        let on_disk = tokio::fs::read(staged.path()).await.unwrap();
+        assert_eq!(on_disk, b"pdfbytes");
+    }
+
+    #[tokio::test]
+    async fn test_stage_multipart_file_and_path_requires_file() {
+        let state = staging_test_state();
+        let body = concat!(
+            "--XB\r\n",
+            "Content-Disposition: form-data; name=\"path\"\r\n",
+            "\r\n",
+            "docs/dir/\r\n",
+            "--XB--\r\n"
+        );
+        let mp = multipart_from_body("XB", body).await;
+        let resp = match stage_multipart_file_and_path(&state, mp).await {
+            Ok(_) => panic!("path-only form must be rejected"),
+            Err(resp) => resp,
+        };
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // ---------------------------------------------------------------------
+    // The multipart upload handlers gate on auth BEFORE reading the form:
+    // anonymous callers get 401 and read-scoped API tokens get 403. In
+    // neither case is the (lazily-connected, never-dialed) database touched,
+    // so these run without a live Postgres.
+    // ---------------------------------------------------------------------
+
+    /// Drive BOTH multipart upload handlers with the given auth and assert
+    /// they short-circuit with the expected status.
+    async fn assert_multipart_handlers_reject(auth: Option<AuthExtension>, want: StatusCode) {
+        let state = staging_test_state();
+        let form = "--XB\r\n\
+                    Content-Disposition: form-data; name=\"file\"; filename=\"x.bin\"\r\n\
+                    \r\n\
+                    x\r\n\
+                    --XB--\r\n";
+
+        let mp = multipart_from_body("XB", form).await;
+        let resp = upload_artifact_multipart(
+            State(state.clone()),
+            Extension(auth.clone()),
+            Path("generic-repo".to_string()),
+            HeaderMap::new(),
+            mp,
+        )
+        .await
+        .expect_err("multipart upload must be rejected");
+        assert_eq!(resp.status(), want, "upload_artifact_multipart");
+
+        let mp = multipart_from_body("XB", form).await;
+        let resp = upload_artifact_multipart_with_path(
+            State(state),
+            Extension(auth),
+            Path(("generic-repo".to_string(), "a/b.bin".to_string())),
+            HeaderMap::new(),
+            mp,
+        )
+        .await
+        .expect_err("multipart upload with path must be rejected");
+        assert_eq!(resp.status(), want, "upload_artifact_multipart_with_path");
+    }
+
+    #[tokio::test]
+    async fn test_multipart_upload_handlers_reject_anonymous() {
+        assert_multipart_handlers_reject(None, StatusCode::UNAUTHORIZED).await;
+    }
+
+    #[tokio::test]
+    async fn test_multipart_upload_handlers_reject_read_scoped_token() {
+        let auth = AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "reader".to_string(),
+            email: "reader@example.com".to_string(),
+            is_admin: false,
+            is_api_token: true,
+            is_service_account: false,
+            scopes: Some(vec!["read".to_string()]),
+            allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
+        };
+        assert_multipart_handlers_reject(Some(auth), StatusCode::FORBIDDEN).await;
+    }
+
+    // ---------------------------------------------------------------------
     // Security: composed paths must be rejected by validate_artifact_path
     //
     // Regression for the gap found in #1322's security review:

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -5589,10 +5589,10 @@ pub async fn upload_artifact(
     Extension(auth): Extension<Option<AuthExtension>>,
     Path((key, path)): Path<(String, String)>,
     headers: HeaderMap,
-    body: Bytes,
-) -> Result<(StatusCode, Json<ArtifactResponse>)> {
-    let auth = require_auth(auth)?;
-    auth.require_scope("write")?;
+    body: Body,
+) -> std::result::Result<Response, Response> {
+    let auth = require_auth(auth).map_err(|e| e.into_response())?;
+    auth.require_scope("write").map_err(|e| e.into_response())?;
 
     // Validate the composed artifact path against traversal, null bytes,
     // backslashes, percent-encoded traversal, absolute paths, etc. This
@@ -5601,68 +5601,149 @@ pub async fn upload_artifact(
     // Filesystem storage's `key_to_path` would strip `..` segments, but S3
     // and other object backends would happily accept `../etc/passwd`.
     upload_service::validate_artifact_path(&path)
-        .map_err(|e| AppError::Validation(e.to_string()))?;
+        .map_err(|e| AppError::Validation(e.to_string()).into_response())?;
 
+    let (repo_service, repo) = authorize_generic_upload(&state, &auth, &key).await?;
+
+    // Stream the request body straight to a bounded scratch file, computing
+    // SHA-256/SHA-1/MD5 in a single pass — the whole artifact is never buffered
+    // in memory (#2517). The stager enforces `max_upload_size_bytes` mid-stream
+    // (413 on breach) instead of relying on a request-body-limit layer.
+    let (staged, digests) =
+        proxy_helpers::stage_stream_content_addressed(&state, body.into_data_stream()).await?;
+
+    persist_generic_staged_upload(
+        &state,
+        &auth,
+        &repo_service,
+        &repo,
+        key,
+        path,
+        &headers,
+        staged,
+        digests,
+    )
+    .await
+}
+
+/// Authorize a generic artifact write: resolve the repository and enforce the
+/// write gates shared by the raw-`PUT` and multipart upload entry points, before
+/// any request body is consumed.
+async fn authorize_generic_upload(
+    state: &SharedState,
+    auth: &AuthExtension,
+    key: &str,
+) -> std::result::Result<(RepositoryService, crate::models::repository::Repository), Response> {
     let repo_service = RepositoryService::new(state.db.clone());
-    let repo = repo_service.get_by_key(&key).await?;
-    require_repo_write_access(&auth, &repo, &repo_service).await?;
+    let repo = repo_service
+        .get_by_key(key)
+        .await
+        .map_err(|e| e.into_response())?;
+    require_repo_write_access(auth, &repo, &repo_service)
+        .await
+        .map_err(|e| e.into_response())?;
     // Fine-grained write gate (#2321 G2): the tenant gate above admits any
     // grantee (incl. a read-only one) and any authed caller on a public repo,
     // collapsing read/write. Require the `write` action when rules exist, the
     // same block `upload.rs::create_session` applies to the chunked path.
-    require_repo_fine_grained_action(&auth, repo.id, "write", &state.permission_service).await?;
+    require_repo_fine_grained_action(auth, repo.id, "write", &state.permission_service)
+        .await
+        .map_err(|e| e.into_response())?;
 
     // Reject direct uploads to promotion-only repositories. Such repos accept
     // artifacts only via the promotion path (staging -> promotion -> approval);
     // the promotion service writes through its own path and is unaffected. This
     // applies to all callers including admins.
-    if crate::api::handlers::proxy_helpers::promotion_only_blocks_direct_upload(
-        repo.promotion_only,
-        auth.is_admin,
-    ) {
+    if proxy_helpers::promotion_only_blocks_direct_upload(repo.promotion_only, auth.is_admin) {
         return Err(AppError::Authorization(
             "Direct uploads are disabled for this repository; publish via promotion".to_string(),
-        ));
+        )
+        .into_response());
     }
 
-    // Verify declared checksums against actual content before storing anything.
+    Ok((repo_service, repo))
+}
+
+/// Finish a generic artifact upload from an already-staged scratch file (#2517).
+///
+/// The raw-`PUT` and multipart entry points authorize the request and stream the
+/// body to a bounded scratch file (computing the content digests in one pass);
+/// this shared tail verifies declared checksums, runs any WASM format plugin,
+/// derives the artifact coordinates, and persists via the streaming service
+/// method — never buffering the whole artifact in memory.
+#[allow(clippy::too_many_arguments)]
+async fn persist_generic_staged_upload(
+    state: &SharedState,
+    auth: &AuthExtension,
+    repo_service: &RepositoryService,
+    repo: &crate::models::repository::Repository,
+    key: String,
+    path: String,
+    headers: &HeaderMap,
+    staged: proxy_helpers::StagedUpload,
+    digests: crate::services::artifact_service::ContentDigests,
+) -> std::result::Result<Response, Response> {
+    // Verify declared checksums against the digests computed while staging —
+    // same semantics as the old `verify_checksums(&body, ...)`, but with no
+    // extra pass over the body.
     let declared_sha256 = headers
         .get("x-checksum-sha256")
         .and_then(|v| v.to_str().ok());
     let declared_sha1 = headers.get("x-checksum-sha1").and_then(|v| v.to_str().ok());
     let declared_md5 = headers.get("x-checksum-md5").and_then(|v| v.to_str().ok());
-    ArtifactService::verify_checksums(&body, declared_sha256, declared_sha1, declared_md5)?;
+    ArtifactService::verify_declared_digests(
+        &digests,
+        declared_sha256,
+        declared_sha1,
+        declared_md5,
+    )
+    .map_err(|e| e.into_response())?;
 
-    let storage = state.storage_for_repo(&repo.storage_location())?;
+    let storage = state
+        .storage_for_repo(&repo.storage_location())
+        .map_err(|e| e.into_response())?;
     let artifact_service = state.create_artifact_service(storage);
 
     // Extract name from path
     let name = path.split('/').next_back().unwrap_or(&path).to_string();
 
     // Check if this repo has a WASM plugin format handler
-    let format_key = repo_service.get_format_key(repo.id).await?;
+    let format_key = repo_service
+        .get_format_key(repo.id)
+        .await
+        .map_err(|e| e.into_response())?;
     let mut wasm_metadata = None;
 
     if let (Some(ref fk), Some(ref registry)) = (&format_key, &state.plugin_registry) {
         if registry.has_format(fk).await {
-            // Run WASM plugin validate + parse_metadata
-            match registry.execute_validate(fk, &path, &body).await {
+            // WASM-PLUGIN-INPUT (#2517 product decision): format plugins receive
+            // the whole artifact body by value across the WASM ABI. A repo with a
+            // registered WASM format handler therefore still materialises the
+            // staged file here, preserving the exact pre-existing plugin-input
+            // semantics rather than silently feeding the plugin a truncated view.
+            // Bounding this to a prefix read — or extending the plugin ABI to
+            // accept a stream/path so large plugin-backed formats also stay
+            // off-heap — is a separate product/ABI decision, deliberately left
+            // out of this streaming conversion. The common (non-plugin) generic
+            // upload never reaches this branch and streams end-to-end.
+            let plugin_body = tokio::fs::read(staged.path())
+                .await
+                .map_err(|e| proxy_helpers::internal_error("Reading staged upload", e))?;
+            match registry.execute_validate(fk, &path, &plugin_body).await {
                 Ok(Ok(())) => {}
                 Ok(Err(validation_err)) => {
-                    return Err(crate::error::AppError::Validation(
-                        validation_err.to_string(),
-                    ));
+                    return Err(AppError::Validation(validation_err.to_string()).into_response());
                 }
                 Err(e) => {
                     tracing::error!("WASM plugin validate error for {}: {}", fk, e);
-                    return Err(crate::error::AppError::Internal(format!(
-                        "Plugin error: {}",
-                        e
-                    )));
+                    return Err(AppError::Internal(format!("Plugin error: {}", e)).into_response());
                 }
             }
 
-            match registry.execute_parse_metadata(fk, &path, &body).await {
+            match registry
+                .execute_parse_metadata(fk, &path, &plugin_body)
+                .await
+            {
                 Ok(meta) => {
                     wasm_metadata = Some(meta);
                 }
@@ -5718,38 +5799,49 @@ pub async fn upload_artifact(
         .map(|m| m.content_type.clone())
         .unwrap_or_else(|| resolve_upload_content_type(declared_content_type, &path));
 
-    // No pre-cleanup here: this generic upload endpoint (and the multipart
-    // variants that delegate to it) persists through
-    // `artifact_service::upload_with_sync_options`, whose release-immutability
-    // backstop must SEE any soft-deleted tombstone at this coordinate — purging
-    // it first would hide a release-immutability swap (DELETE + re-upload of
-    // DIFFERENT bytes to a released coordinate, the exploited path). The
-    // service's `ON CONFLICT (repository_id, path) DO UPDATE ... is_deleted =
-    // false` resurrects the tombstone for the allowed cases (identical-bytes
-    // republish / mutable index files), so the UNIQUE(repository_id, path)
-    // constraint is still satisfied without the manual purge.
+    // No pre-cleanup here: this generic upload endpoint persists through
+    // `artifact_service::upload_stream_with_sync_options`, whose
+    // release-immutability backstop must SEE any soft-deleted tombstone at this
+    // coordinate — purging it first would hide a release-immutability swap
+    // (DELETE + re-upload of DIFFERENT bytes to a released coordinate, the
+    // exploited path). The service's `ON CONFLICT (repository_id, path) DO UPDATE
+    // ... is_deleted = false` resurrects the tombstone for the allowed cases
+    // (identical-bytes republish / mutable index files), so the
+    // UNIQUE(repository_id, path) constraint is still satisfied without the
+    // manual purge.
 
+    let size_bytes = staged.size_bytes();
+    let content_stream = proxy_helpers::open_staged_upload_stream(&staged).await?;
     let artifact = artifact_service
-        .upload_with_sync_options(
+        .upload_stream_with_sync_options(
             repo.id,
             &path,
             &name,
             version.as_deref(),
             &content_type,
-            body,
+            content_stream,
+            digests,
+            size_bytes,
             Some(auth.user_id),
-            !is_replication_request(&headers),
+            !is_replication_request(headers),
         )
-        .await?;
+        .await
+        .map_err(|e| e.into_response())?;
+    // Scratch file no longer needed once the service has consumed the stream.
+    drop(staged);
 
-    let downloads = artifact_service.get_download_stats(artifact.id).await?;
+    let downloads = artifact_service
+        .get_download_stats(artifact.id)
+        .await
+        .map_err(|e| e.into_response())?;
     let metadata_json = wasm_metadata.map(|m| m.to_json());
 
     // #2367: echo the revision this upload landed at for versioned repos.
     let (revision, version_label) = if versioning_active {
         artifact_service
             .latest_version_info(repo.id, &artifact.path)
-            .await?
+            .await
+            .map_err(|e| e.into_response())?
             .map(|(rev, label)| (Some(rev), label))
             .unwrap_or((None, None))
     } else {
@@ -5779,7 +5871,8 @@ pub async fn upload_artifact(
             revision,
             version_label,
         }),
-    ))
+    )
+        .into_response())
 }
 
 /// Resolve the Content-Type for a generic artifact upload.
@@ -5817,19 +5910,30 @@ async fn upload_artifact_multipart_with_path(
     Path((key, path)): Path<(String, String)>,
     headers: HeaderMap,
     multipart: Multipart,
-) -> Result<(StatusCode, Json<ArtifactResponse>)> {
-    let (body, filename) = extract_multipart_file(multipart).await?;
+) -> std::result::Result<Response, Response> {
+    let auth = require_auth(auth).map_err(|e| e.into_response())?;
+    auth.require_scope("write").map_err(|e| e.into_response())?;
+    let (repo_service, repo) = authorize_generic_upload(&state, &auth, &key).await?;
+
+    let (staged, digests, filename) = stage_multipart_file(&state, multipart).await?;
     let artifact_path = if path.is_empty() || path == "/" {
         filename
     } else {
         path
     };
-    upload_artifact(
-        State(state),
-        Extension(auth),
-        Path((key, artifact_path)),
-        headers,
-        body,
+    upload_service::validate_artifact_path(&artifact_path)
+        .map_err(|e| AppError::Validation(e.to_string()).into_response())?;
+
+    persist_generic_staged_upload(
+        &state,
+        &auth,
+        &repo_service,
+        &repo,
+        key,
+        artifact_path,
+        &headers,
+        staged,
+        digests,
     )
     .await
 }
@@ -5851,15 +5955,27 @@ async fn upload_artifact_multipart(
     Path(key): Path<String>,
     headers: HeaderMap,
     multipart: Multipart,
-) -> Result<(StatusCode, Json<ArtifactResponse>)> {
-    let (body, filename, custom_path) = extract_multipart_file_and_path(multipart).await?;
+) -> std::result::Result<Response, Response> {
+    let auth = require_auth(auth).map_err(|e| e.into_response())?;
+    auth.require_scope("write").map_err(|e| e.into_response())?;
+    let (repo_service, repo) = authorize_generic_upload(&state, &auth, &key).await?;
+
+    let (staged, digests, filename, custom_path) =
+        stage_multipart_file_and_path(&state, multipart).await?;
     let artifact_path = compose_artifact_path(custom_path.as_deref(), &filename);
-    upload_artifact(
-        State(state),
-        Extension(auth),
-        Path((key, artifact_path)),
-        headers,
-        body,
+    upload_service::validate_artifact_path(&artifact_path)
+        .map_err(|e| AppError::Validation(e.to_string()).into_response())?;
+
+    persist_generic_staged_upload(
+        &state,
+        &auth,
+        &repo_service,
+        &repo,
+        key,
+        artifact_path,
+        &headers,
+        staged,
+        digests,
     )
     .await
 }
@@ -5889,76 +6005,87 @@ fn compose_artifact_path(custom_path: Option<&str>, filename: &str) -> String {
     }
 }
 
-/// Extract the first file field from a multipart form.
-async fn extract_multipart_file(mut multipart: Multipart) -> Result<(Bytes, String)> {
+/// Stream the first file field of a multipart form to a bounded scratch file,
+/// computing SHA-256/SHA-1/MD5 in one pass (#2517). Never buffers the field in
+/// memory. Returns the staged scratch handle, its content digests, and the
+/// original filename.
+async fn stage_multipart_file(
+    state: &SharedState,
+    mut multipart: Multipart,
+) -> std::result::Result<
+    (
+        proxy_helpers::StagedUpload,
+        crate::services::artifact_service::ContentDigests,
+        String,
+    ),
+    Response,
+> {
     while let Some(field) = multipart
         .next_field()
         .await
-        .map_err(|e| AppError::Validation(format!("Invalid multipart data: {e}")))?
+        .map_err(|e| AppError::Validation(format!("Invalid multipart data: {e}")).into_response())?
     {
         // Accept any field that has a filename (i.e. a file upload)
-        let filename = field.file_name().map(|s| s.to_string());
-        if let Some(filename) = filename {
-            #[allow(clippy::disallowed_methods)]
-            // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-            let data: Bytes = field
-                .bytes()
-                .await
-                .map_err(|e| AppError::Validation(format!("Failed to read file: {e}")))?;
-            return Ok((data, filename));
+        if let Some(filename) = field.file_name().map(|s| s.to_string()) {
+            let (staged, digests) =
+                proxy_helpers::stage_upload_field_content_addressed(state, field).await?;
+            return Ok((staged, digests, filename));
         }
     }
-    Err(AppError::Validation(
-        "No file field found in multipart form".to_string(),
-    ))
+    Err(AppError::Validation("No file field found in multipart form".to_string()).into_response())
 }
 
-/// Extract both a file field and an optional `path` text field from a
-/// multipart form.
+/// Streaming variant of the file+path extractor (#2517): spool the file field
+/// to a bounded scratch file (digests in one pass) and read the small optional
+/// `path` text field.
 ///
-/// Iterates the full form: a file field (one with a `filename`) yields the
-/// body and original filename; a `path` field (any non-file field named
-/// `path`) yields the requested artifact path. Either may appear in any
-/// order. Returns an error if no file is found.
-async fn extract_multipart_file_and_path(
+/// Iterates the full form: a file field (one with a `filename`) is staged; a
+/// `path` field (any non-file field named `path`) yields the requested artifact
+/// path. Either may appear in any order. Returns an error if no file is found.
+async fn stage_multipart_file_and_path(
+    state: &SharedState,
     mut multipart: Multipart,
-) -> Result<(Bytes, String, Option<String>)> {
-    let mut file: Option<(Bytes, String)> = None;
+) -> std::result::Result<
+    (
+        proxy_helpers::StagedUpload,
+        crate::services::artifact_service::ContentDigests,
+        String,
+        Option<String>,
+    ),
+    Response,
+> {
+    let mut file = None;
     let mut custom_path: Option<String> = None;
 
     while let Some(field) = multipart
         .next_field()
         .await
-        .map_err(|e| AppError::Validation(format!("Invalid multipart data: {e}")))?
+        .map_err(|e| AppError::Validation(format!("Invalid multipart data: {e}")).into_response())?
     {
         let filename = field.file_name().map(|s| s.to_string());
         let name = field.name().map(|s| s.to_string());
         if let Some(filename) = filename {
             // File upload field
             if file.is_none() {
-                #[allow(clippy::disallowed_methods)]
-                // STREAMING-EXEMPT: upload handler buffers one bounded multipart field (capped by DefaultBodyLimit); tracked for incremental-hash put_stream conversion in a later #1608 phase
-                let data: Bytes = field
-                    .bytes()
-                    .await
-                    .map_err(|e| AppError::Validation(format!("Failed to read file: {e}")))?;
-                file = Some((data, filename));
+                let (staged, digests) =
+                    proxy_helpers::stage_upload_field_content_addressed(state, field).await?;
+                file = Some((staged, digests, filename));
             }
         } else if name.as_deref() == Some("path") {
-            // Custom path text field
-            let value = field
-                .text()
-                .await
-                .map_err(|e| AppError::Validation(format!("Failed to read path field: {e}")))?;
+            // Custom path text field (small; read as text)
+            let value = field.text().await.map_err(|e| {
+                AppError::Validation(format!("Failed to read path field: {e}")).into_response()
+            })?;
             custom_path = Some(value);
         }
     }
 
     match file {
-        Some((body, filename)) => Ok((body, filename, custom_path)),
-        None => Err(AppError::Validation(
-            "No file field found in multipart form".to_string(),
-        )),
+        Some((staged, digests, filename)) => Ok((staged, digests, filename, custom_path)),
+        None => Err(
+            AppError::Validation("No file field found in multipart form".to_string())
+                .into_response(),
+        ),
     }
 }
 
@@ -11292,7 +11419,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"ORIGINAL-RELEASE-BYTES"),
+            Body::from(Bytes::from_static(b"ORIGINAL-RELEASE-BYTES")),
         )
         .await;
         assert!(up.is_ok(), "initial publish must succeed: {up:?}");
@@ -11315,11 +11442,12 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"SWAPPED-MALICIOUS-BYTES"),
+            Body::from(Bytes::from_static(b"SWAPPED-MALICIOUS-BYTES")),
         )
         .await;
-        assert!(
-            matches!(swap, Err(AppError::Conflict(_))),
+        assert_eq!(
+            swap.as_ref().err().map(|r| r.status()),
+            Some(StatusCode::CONFLICT),
             "DELETE + re-upload of DIFFERENT bytes to a released coordinate must 409, got: {swap:?}"
         );
 
@@ -11384,7 +11512,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"RELEASE-BYTES"),
+            Body::from(Bytes::from_static(b"RELEASE-BYTES")),
         )
         .await
         .expect("initial publish must succeed");
@@ -11436,7 +11564,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path2.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"NORMAL-REPO-BYTES"),
+            Body::from(Bytes::from_static(b"NORMAL-REPO-BYTES")),
         )
         .await
         .expect("publish to normal repo must succeed");
@@ -11482,7 +11610,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            body.clone(),
+            Body::from(body.clone()),
         )
         .await
         .expect("publish jar");
@@ -11499,7 +11627,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            body.clone(),
+            Body::from(body.clone()),
         )
         .await;
         assert!(
@@ -11514,7 +11642,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), meta.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"<metadata>v1</metadata>"),
+            Body::from(Bytes::from_static(b"<metadata>v1</metadata>")),
         )
         .await
         .expect("publish metadata");
@@ -11531,7 +11659,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), meta.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"<metadata>v2-updated</metadata>"),
+            Body::from(Bytes::from_static(b"<metadata>v2-updated</metadata>")),
         )
         .await;
         assert!(
@@ -12117,11 +12245,12 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((key.clone(), "pkg/1.0.0/pkg.bin".to_string())),
             HeaderMap::new(),
-            Bytes::from_static(b"BYTES"),
+            Body::from(Bytes::from_static(b"BYTES")),
         )
         .await;
-        assert!(
-            matches!(denied, Err(AppError::Authorization(_))),
+        assert_eq!(
+            denied.as_ref().err().map(|r| r.status()),
+            Some(StatusCode::FORBIDDEN),
             "read-only grantee must be denied write, got: {denied:?}"
         );
 
@@ -12131,7 +12260,7 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((key.clone(), "pkg/1.0.0/pkg.bin".to_string())),
             HeaderMap::new(),
-            Bytes::from_static(b"BYTES"),
+            Body::from(Bytes::from_static(b"BYTES")),
         )
         .await;
         assert!(allowed.is_ok(), "write grant must upload, got: {allowed:?}");
@@ -12146,7 +12275,7 @@ mod tests {
             Extension(Some(admin)),
             Path((key.clone(), "pkg/2.0.0/pkg.bin".to_string())),
             HeaderMap::new(),
-            Bytes::from_static(b"BYTES"),
+            Body::from(Bytes::from_static(b"BYTES")),
         )
         .await;
         assert!(admin_ok.is_ok(), "admin must bypass, got: {admin_ok:?}");
@@ -12170,11 +12299,12 @@ mod tests {
             Extension(Some(tdh::make_auth(user_id, &username))),
             Path((pub_key.clone(), "pub/1.0.0/pub.bin".to_string())),
             HeaderMap::new(),
-            Bytes::from_static(b"BYTES"),
+            Body::from(Bytes::from_static(b"BYTES")),
         )
         .await;
-        assert!(
-            matches!(nonmember_pub, Err(AppError::Authorization(_))),
+        assert_eq!(
+            nonmember_pub.as_ref().err().map(|r| r.status()),
+            Some(StatusCode::FORBIDDEN),
             "non-member must be denied write on a public repo with a write rule, got: {nonmember_pub:?}"
         );
 
@@ -12209,7 +12339,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"BYTES"),
+            Body::from(Bytes::from_static(b"BYTES")),
         )
         .await
         .expect("publish must succeed with write+delete grant");
@@ -15884,16 +16014,17 @@ mod tests {
             Extension(Some(auth)),
             Path((fx.repo_key.clone(), composed)),
             HeaderMap::new(),
-            Bytes::from_static(b"payload-should-never-be-stored"),
+            Body::from(Bytes::from_static(b"payload-should-never-be-stored")),
         )
         .await;
 
         let err = result.expect_err("traversal path must be rejected");
         // AppError::Validation maps to 400 Bad Request via IntoResponse
-        // (see error.rs status_and_code). Pinning the variant here is
-        // equivalent and avoids reaching into a private method.
-        assert!(
-            matches!(err, AppError::Validation(_)),
+        // (see error.rs status_and_code); the streaming upload handler returns
+        // that as a fully-formed Response, so assert on its status.
+        assert_eq!(
+            err.status(),
+            StatusCode::BAD_REQUEST,
             "traversal path must surface as Validation (400), got {err:?}",
         );
 
@@ -15929,14 +16060,16 @@ mod tests {
             Extension(Some(auth.clone())),
             Path((fx.repo_key.clone(), "foo/bar.txt".to_string())),
             HeaderMap::new(),
-            Bytes::from_static(b"directwrite"),
+            Body::from(Bytes::from_static(b"directwrite")),
         )
         .await;
 
         let err = blocked.expect_err("admin direct upload to promotion_only repo must be blocked");
-        // AppError::Authorization maps to 403 Forbidden (see error.rs).
-        assert!(
-            matches!(err, AppError::Authorization(_)),
+        // AppError::Authorization maps to 403 Forbidden (see error.rs); the
+        // streaming upload handler returns that as a fully-formed Response.
+        assert_eq!(
+            err.status(),
+            StatusCode::FORBIDDEN,
             "admin direct upload to promotion_only repo must surface as Authorization (403), got {err:?}",
         );
 
@@ -15947,16 +16080,16 @@ mod tests {
             .await
             .expect("clear promotion_only");
 
-        let (status, _) = upload_artifact(
+        let resp = upload_artifact(
             State(fx.state.clone()),
             Extension(Some(auth)),
             Path((fx.repo_key.clone(), "foo/bar.txt".to_string())),
             HeaderMap::new(),
-            Bytes::from_static(b"directwrite"),
+            Body::from(Bytes::from_static(b"directwrite")),
         )
         .await
         .expect("admin upload to a normal repo must succeed");
-        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(resp.status(), StatusCode::CREATED);
 
         fx.teardown().await;
     }
@@ -17658,7 +17791,7 @@ mod tests {
                 Extension(auth.clone()),
                 Path((key.clone(), p.clone())),
                 HeaderMap::new(),
-                Bytes::from_static(b"TARBALL-BYTES"),
+                Body::from(Bytes::from_static(b"TARBALL-BYTES")),
             )
             .await
             .expect("publish must succeed");
@@ -17791,7 +17924,7 @@ mod tests {
             Extension(auth.clone()),
             Path((key.clone(), path.clone())),
             HeaderMap::new(),
-            Bytes::from_static(b"GENERIC-BYTES"),
+            Body::from(Bytes::from_static(b"GENERIC-BYTES")),
         )
         .await
         .expect("publish must succeed");

--- a/backend/src/api/handlers/terraform.rs
+++ b/backend/src/api/handlers/terraform.rs
@@ -34,7 +34,13 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, put};
 use axum::Extension;
 use axum::Router;
+// `Bytes` and the `sha2` digest types are now only referenced by the unit
+// tests: the upload handlers stream the body and take their digests from the
+// shared staging primitive (#2517), so gate these imports to test builds to
+// keep the production build free of unused-import warnings.
+#[cfg(test)]
 use bytes::Bytes;
+#[cfg(test)]
 use sha2::{Digest, Sha256};
 use sqlx::PgPool;
 use tracing::info;
@@ -600,7 +606,7 @@ async fn upload_module(
         String,
         String,
     )>,
-    body: Bytes,
+    body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = require_auth_basic_scope(auth, "terraform", "write")?.user_id;
@@ -630,33 +636,26 @@ async fn upload_module(
             .into_response());
     }
 
-    // Compute SHA256
-    let mut hasher = Sha256::new();
-    hasher.update(&body);
-    let checksum = format!("{:x}", hasher.finalize());
+    // Stream the request body to a bounded scratch file, computing the content
+    // digests in one pass — never buffering the module archive in memory
+    // (#2517). The stager enforces `max_upload_size_bytes` mid-stream.
+    let (staged, digests) =
+        proxy_helpers::stage_stream_content_addressed(&state, body.into_data_stream()).await?;
+    let checksum = digests.sha256.clone();
+    let size_bytes = staged.size_bytes();
 
-    let size_bytes = body.len() as i64;
     let artifact_path = build_module_artifact_path(&namespace, &name, &provider, &version);
     let storage_key = format!(
         "terraform/modules/{}/{}/{}/{}.tar.gz",
         namespace, name, provider, version
     );
-    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
-        .await?;
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
 
-    // Store the file
-    let storage = state
-        .storage_for_repo(&repo.storage_location())
-        .map_err(|e| e.into_response())?;
-    storage.put(&storage_key, body).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    // Store the file, streamed from the staged scratch file.
+    // `put_artifact_stream` runs the cross-repo write guard (#2584) before
+    // writing, then streams the object to storage.
+    proxy_helpers::put_artifact_stream(&state, &repo, &storage_key, staged).await?;
 
     // Insert artifact record
     let artifact_id = sqlx::query_scalar!(
@@ -1108,7 +1107,7 @@ async fn upload_provider(
         String,
         String,
     )>,
-    body: Bytes,
+    body: Body,
 ) -> Result<Response, Response> {
     // GHSA-vvc3-h39c-mrq5: enforce token scope before processing.
     let user_id = require_auth_basic_scope(auth, "terraform", "write")?.user_id;
@@ -1147,30 +1146,23 @@ async fn upload_provider(
 
     super::cleanup_soft_deleted_artifact(&state.db, repo.id, &artifact_path).await;
 
-    // Compute SHA256
-    let mut hasher = Sha256::new();
-    hasher.update(&body);
-    let checksum = format!("{:x}", hasher.finalize());
+    // Stream the request body to a bounded scratch file, computing the content
+    // digests in one pass — never buffering the provider archive in memory
+    // (#2517). The stager enforces `max_upload_size_bytes` mid-stream.
+    let (staged, digests) =
+        proxy_helpers::stage_stream_content_addressed(&state, body.into_data_stream()).await?;
+    let checksum = digests.sha256.clone();
+    let size_bytes = staged.size_bytes();
 
-    let size_bytes = body.len() as i64;
     let storage_key = format!(
         "terraform/providers/{}/{}/{}/terraform-provider-{}_{}.zip",
         namespace, type_name, version, type_name, platform
     );
-    proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
-        .await?;
 
-    // Store the file
-    let storage = state
-        .storage_for_repo(&repo.storage_location())
-        .map_err(|e| e.into_response())?;
-    storage.put(&storage_key, body).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Storage error: {}", e),
-        )
-            .into_response()
-    })?;
+    // Store the file, streamed from the staged scratch file.
+    // `put_artifact_stream` runs the cross-repo write guard (#2584) before
+    // writing, then streams the object to storage.
+    proxy_helpers::put_artifact_stream(&state, &repo, &storage_key, staged).await?;
 
     // Insert artifact record
     let artifact_id = sqlx::query_scalar!(

--- a/backend/src/services/artifact_service.rs
+++ b/backend/src/services/artifact_service.rs
@@ -388,6 +388,48 @@ impl ArtifactService {
         Ok(())
     }
 
+    /// Verify client-declared `x-checksum-*` headers against digests already
+    /// computed by the streaming stage pass, without re-reading the body.
+    ///
+    /// Semantically identical to [`Self::verify_checksums`] (same case-insensitive
+    /// comparison, same per-algorithm error messages) but takes the precomputed
+    /// [`ContentDigests`] instead of a full in-memory buffer. The streaming
+    /// upload path computes SHA-256/SHA-1/MD5 in a single pass while spooling the
+    /// body to scratch (#2517), so this makes the extra hashing passes that
+    /// `verify_checksums` performed unnecessary.
+    pub fn verify_declared_digests(
+        digests: &ContentDigests,
+        declared_sha256: Option<&str>,
+        declared_sha1: Option<&str>,
+        declared_md5: Option<&str>,
+    ) -> Result<()> {
+        if let Some(declared) = declared_sha256 {
+            if !declared.eq_ignore_ascii_case(&digests.sha256) {
+                return Err(AppError::Validation(format!(
+                    "SHA-256 checksum mismatch: declared {} but actual content hashes to {}",
+                    declared, digests.sha256
+                )));
+            }
+        }
+        if let Some(declared) = declared_sha1 {
+            if !declared.eq_ignore_ascii_case(&digests.sha1) {
+                return Err(AppError::Validation(format!(
+                    "SHA-1 checksum mismatch: declared {} but actual content hashes to {}",
+                    declared, digests.sha1
+                )));
+            }
+        }
+        if let Some(declared) = declared_md5 {
+            if !declared.eq_ignore_ascii_case(&digests.md5) {
+                return Err(AppError::Validation(format!(
+                    "MD5 checksum mismatch: declared {} but actual content hashes to {}",
+                    declared, digests.md5
+                )));
+            }
+        }
+        Ok(())
+    }
+
     /// Generate content-addressable storage key from checksum
     pub fn storage_key_from_checksum(checksum: &str) -> String {
         // Use first 4 chars for directory sharding: ab/cd/abcd...
@@ -2724,6 +2766,57 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(err.contains(declared));
         assert!(err.contains(&actual_sha256));
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_declared_digests (#2517): the streaming upload path verifies
+    // declared `x-checksum-*` headers against the digests computed in the single
+    // staging pass. It must be byte-for-byte equivalent to the old buffered
+    // `verify_checksums`.
+    // -----------------------------------------------------------------------
+
+    fn digests_of(data: &[u8]) -> ContentDigests {
+        let mut h = MultiHasher::new();
+        h.update(data);
+        h.finalize()
+    }
+
+    #[test]
+    fn test_verify_declared_digests_matches_verify_checksums() {
+        let data = vec![0x5Au8; 200_000];
+        let d = digests_of(&data);
+        // All three declared and correct (mixed case) -> Ok, same as buffered.
+        assert!(ArtifactService::verify_checksums(
+            &data,
+            Some(&d.sha256.to_uppercase()),
+            Some(&d.sha1),
+            Some(&d.md5.to_uppercase()),
+        )
+        .is_ok());
+        assert!(ArtifactService::verify_declared_digests(
+            &d,
+            Some(&d.sha256.to_uppercase()),
+            Some(&d.sha1),
+            Some(&d.md5.to_uppercase()),
+        )
+        .is_ok());
+        // None declared -> Ok (nothing to check).
+        assert!(ArtifactService::verify_declared_digests(&d, None, None, None).is_ok());
+    }
+
+    #[test]
+    fn test_verify_declared_digests_rejects_each_mismatch() {
+        let d = digests_of(b"streamed artifact body");
+        // Wrong SHA-256.
+        let e = ArtifactService::verify_declared_digests(&d, Some("deadbeef"), None, None)
+            .unwrap_err()
+            .to_string();
+        assert!(e.contains("SHA-256"));
+        assert!(e.contains(&d.sha256));
+        // Wrong SHA-1.
+        assert!(ArtifactService::verify_declared_digests(&d, None, Some("00"), None).is_err());
+        // Wrong MD5.
+        assert!(ArtifactService::verify_declared_digests(&d, None, None, Some("ff")).is_err());
     }
 
     // -----------------------------------------------------------------------

--- a/backend/tests/streaming_invariant.rs
+++ b/backend/tests/streaming_invariant.rs
@@ -62,18 +62,28 @@ use std::path::{Path, PathBuf};
 ///     progress — the row is gone.
 ///
 /// Net: 31 -> 30 (+1 npm, -1 pypi, -1 remote_instances).
+///
+/// PF-005 (#2517) streamed the generic multipart upload extractors
+/// (`stage_multipart_file` / `stage_multipart_file_and_path`) onto the shared
+/// content-addressed staging primitive, deleting both `Field::bytes()` reads in
+/// repositories.rs: the repositories.rs row is removed, 30 -> 28.
+///
+/// Reconciliation (independent of PF-005): the RPM curation-sync merges (#2567 /
+/// #2599) added a third capped-metadata buffer site in scheduler_service.rs
+/// (an upstream repo-index gz-decode, not an artifact blob) without updating
+/// this allowlist. Reconciled here to match the current source: 2 -> 3, so the
+/// total is 28 + 1 = 29.
 const ALLOWLIST: &[(&str, usize)] = &[
     ("src/api/handlers/goproxy.rs", 1),
     ("src/api/handlers/npm.rs", 6),
     ("src/api/handlers/oci_v2.rs", 1),
     ("src/api/handlers/plugins.rs", 2),
     ("src/api/handlers/proxy_helpers.rs", 2),
-    ("src/api/handlers/repositories.rs", 2),
     ("src/api/middleware/rate_limit.rs", 1),
     ("src/main.rs", 1),
     ("src/services/artifactory_client.rs", 1),
     ("src/services/nexus_client.rs", 1),
-    ("src/services/scheduler_service.rs", 2),
+    ("src/services/scheduler_service.rs", 3),
     ("src/storage/azure.rs", 4),
     ("src/storage/gcs.rs", 4),
     ("src/storage/s3.rs", 2),
@@ -427,9 +437,198 @@ fn streaming_invariant_exempt_sites_match_allowlist() {
 
     let total: usize = actual_marks.values().sum();
     assert_eq!(
-        total, 30,
-        "expected 30 exempt sites after #1608 Phase 4b + #2491 reconciliation \
-         (npm packument cache +1; pypi and remote_instances streamed to storage, \
-         -1 each); got {total}"
+        total, 29,
+        "expected 29 exempt sites after #1608 Phase 4b + #2491 reconciliation \
+         + PF-005 (#2517) generic multipart streaming (repositories.rs -2) \
+         + RPM curation-sync reconciliation (scheduler_service.rs +1); got {total}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// PF-005 (#2517): `body: Bytes` blob-upload extractor guard.
+// ---------------------------------------------------------------------------
+
+/// Per-file count of `body: Bytes` request-body extractors that ALSO perform a
+/// blob storage write in the same function — i.e. artifact-upload routes that
+/// buffer the whole body on the heap before writing it to storage.
+///
+/// The clippy `disallowed-methods` gate and the `.bytes()` / `to_bytes` scan
+/// above cannot see a `body: Bytes` axum extractor: it is an ordinary typed
+/// handler argument resolved by axum, with no gated method call. This ratchet
+/// closes that gap — any handler that takes `body: Bytes` and, in the same fn,
+/// calls a blob storage write (`storage.put(`, `put_stream(`,
+/// `put_artifact_stream(`, `upload[_stream]_with_sync_options(`) must be listed
+/// here with a justification, and the list must trend to zero as routes stream.
+///
+/// Control-plane / JSON routes that take `body: Bytes` for auth-before-parse
+/// (post-#1438, e.g. `create_repository`) are NOT matched: they perform no blob
+/// storage write in-fn, so they never appear here.
+///
+/// PF-005 (#2517) Phase 1 streamed the four "common" buffered blob routes
+/// (`repositories::upload_artifact` generic PUT, `maven::upload`, and
+/// `terraform::upload_module` + `upload_provider`), removing them from this
+/// list. The remainder are the long-tail format handlers (tracked for later
+/// PF-005 phases) plus two intentional small-body sinks that stay:
+///   * `oci_v2::handle_put_manifest` — an OCI *manifest* is a small bounded JSON
+///     document (blobs upload via the streamed `/blobs/uploads` path), and
+///   * `proxy_helpers::put_artifact_bytes` — the shared buffered helper the
+///     long-tail light-format handlers still call; it goes away when they do.
+const RAW_BODY_BLOB_ALLOWLIST: &[(&str, usize)] = &[
+    ("src/api/handlers/cocoapods.rs", 1),
+    ("src/api/handlers/composer.rs", 1),
+    ("src/api/handlers/conan.rs", 2),
+    ("src/api/handlers/debian.rs", 1),
+    ("src/api/handlers/gitlfs.rs", 1),
+    ("src/api/handlers/goproxy.rs", 2),
+    ("src/api/handlers/jetbrains.rs", 1),
+    ("src/api/handlers/oci_v2.rs", 1),
+    ("src/api/handlers/proxy_helpers.rs", 1),
+    ("src/api/handlers/sbt.rs", 1),
+    ("src/api/handlers/swift.rs", 1),
+    ("src/api/handlers/vscode.rs", 1),
+];
+
+/// Blob storage-write call fragments (matched after collapsing all whitespace,
+/// so a `storage\n    .put(` method chain split across lines is still found).
+const BLOB_WRITE_TOKENS: &[&str] = &[
+    "storage.put(",
+    ".put_stream(",
+    "put_artifact_stream(",
+    "upload_with_sync_options(",
+    "upload_stream_with_sync_options(",
+];
+
+/// `{ .. }` span of the function whose signature contains byte offset
+/// `sig_pos` (a `body: Bytes` match): the first `{` at/after `sig_pos` opens the
+/// fn body; brace-match to its close. Returns `(open, close)` byte offsets into
+/// `masked`, or `None` if unbalanced. Handler return types contain no `{`, so
+/// the first brace after the signature is always the body opener.
+fn fn_body_span(masked: &str, sig_pos: usize) -> Option<(usize, usize)> {
+    let bytes = masked.as_bytes();
+    let open = masked[sig_pos..].find('{').map(|o| sig_pos + o)?;
+    let mut depth = 0i32;
+    let mut j = open;
+    while j < bytes.len() {
+        match bytes[j] {
+            b'{' => depth += 1,
+            b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((open, j));
+                }
+            }
+            _ => {}
+        }
+        j += 1;
+    }
+    None
+}
+
+/// Byte offsets of every standalone `body: Bytes` parameter in masked code (any
+/// run of spaces between `body:` and `Bytes`, with both `body` and `Bytes` whole
+/// words).
+fn raw_body_bytes_positions(masked: &str) -> Vec<usize> {
+    let b = masked.as_bytes();
+    let mut out = Vec::new();
+    let mut from = 0usize;
+    while let Some(rel) = masked[from..].find("body:") {
+        let at = from + rel;
+        from = at + "body:".len();
+        // `body` must be a whole word (previous char not an identifier char).
+        let prev_ok = at == 0 || !(b[at - 1].is_ascii_alphanumeric() || b[at - 1] == b'_');
+        if !prev_ok {
+            continue;
+        }
+        let rest = masked[from..].trim_start();
+        if let Some(after) = rest.strip_prefix("Bytes") {
+            // `Bytes` must be a whole word too (next char not identifier char).
+            let next_ok = after
+                .chars()
+                .next()
+                .map(|c| !(c.is_alphanumeric() || c == '_'))
+                .unwrap_or(true);
+            if next_ok {
+                out.push(at);
+            }
+        }
+    }
+    out
+}
+
+#[test]
+fn streaming_invariant_no_new_buffered_blob_upload_routes() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let src = root.join("src");
+    let mut files = Vec::new();
+    collect_rs_files(&src, &mut files);
+    files.sort();
+
+    let allow: BTreeMap<&str, usize> = RAW_BODY_BLOB_ALLOWLIST.iter().copied().collect();
+    let mut actual: BTreeMap<String, usize> = BTreeMap::new();
+
+    for file in &files {
+        let raw = std::fs::read_to_string(file).expect("read source file");
+        let rel = file
+            .strip_prefix(&root)
+            .unwrap()
+            .to_string_lossy()
+            .replace('\\', "/");
+
+        // Whole-file test scaffold: skip entirely.
+        if raw.lines().any(|l| l.trim_start().starts_with(FILE_EXEMPT)) {
+            continue;
+        }
+
+        let masked = code_mask(&raw);
+        let test = test_lines(&masked);
+
+        let mut count = 0usize;
+        for pos in raw_body_bytes_positions(&masked) {
+            let line = masked[..pos].bytes().filter(|&c| c == b'\n').count() + 1;
+            if test.contains(&line) {
+                continue;
+            }
+            let Some((open, close)) = fn_body_span(&masked, pos) else {
+                continue;
+            };
+            let body: String = masked[open..close].split_whitespace().collect();
+            if BLOB_WRITE_TOKENS.iter().any(|t| body.contains(t)) {
+                count += 1;
+            }
+        }
+        if count > 0 {
+            actual.insert(rel, count);
+        }
+    }
+
+    let expected: BTreeMap<String, usize> =
+        allow.iter().map(|(k, v)| (k.to_string(), *v)).collect();
+
+    if actual != expected {
+        let mut diff = String::new();
+        for (k, v) in &expected {
+            match actual.get(k) {
+                Some(a) if a == v => {}
+                Some(a) => diff.push_str(&format!("  {k}: allowlist={v} actual={a}\n")),
+                None => diff.push_str(&format!(
+                    "  {k}: allowlist={v} actual=0 (route streamed — shrink RAW_BODY_BLOB_ALLOWLIST)\n"
+                )),
+            }
+        }
+        for (k, a) in &actual {
+            if !expected.contains_key(k) {
+                diff.push_str(&format!(
+                    "  {k}: allowlist=<absent> actual={a} (new buffered blob-upload route)\n"
+                ));
+            }
+        }
+        panic!(
+            "`body: Bytes` blob-upload routes no longer match the allowlist (PF-005, #2517).\n\
+             A handler that takes `body: Bytes` AND writes that body to storage in the same fn \
+             buffers the whole artifact in memory. Convert it to the streaming staging primitives \
+             (`stage_stream_content_addressed` + `upload_stream_with_sync_options` / \
+             `put_artifact_stream`) and shrink the list; or — if the body is genuinely small and \
+             bounded — add it with a justification.\n{diff}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

PF-005 (#2517): the common upload routes took the request body as a `Bytes`
extractor, buffering the whole artifact (up to the 10 GiB default limit) on the
heap before writing it to storage — a per-request multi-GiB heap allocation that
OOMs the pod well before the global concurrency cap sheds load.

This converts the buffered blob-upload routes to the existing content-addressed
streaming primitives (`stage_stream_content_addressed` +
`upload_stream_with_sync_options` / `put_artifact_stream`), mirroring the routes
already streamed under #1608 (pypi/nuget/chef/oci_v2). The body is spooled to a
bounded scratch file with SHA-256/SHA-1/MD5 computed in a single pass; it is
never held whole in memory.

Routes converted:
- `repositories::upload_artifact` (generic `PUT /{key}/artifacts/*path`) and both
  multipart entry points (`POST .../artifacts` and `.../artifacts/*path`). The
  two `Field::bytes()` extractors are replaced by streaming stagers
  (`stage_multipart_file` / `stage_multipart_file_and_path`), and auth /
  authorization now runs **before** the body is consumed.
- `maven::upload` (artifact branch + checksum-sidecar / `maven-metadata.xml`
  branches). Row checksums come from the staged digests; the small POM is read
  back from the staged file only for POM uploads (jars never materialise).
- `terraform::upload_module` and `terraform::upload_provider`.

Also adds `ArtifactService::verify_declared_digests`, which checks client
`x-checksum-*` headers against the staged digests with no extra pass (replacing
`verify_checksums(&body, ...)`).

**Scope caution honoured:** only artifact-blob routes were converted. The ~14
remaining `body: Bytes` blob sites (long-tail format handlers + two intentional
small-body sinks — the OCI *manifest* JSON PUT and the shared
`put_artifact_bytes` helper) are tracked in the new guard's allowlist for later
PF-005 phases. Control-plane / JSON `body: Bytes` routes (post-#1438
auth-before-parse) are untouched.

**WASM plugin input — product decision, unchanged here:** a repo with a
registered WASM *format handler* still materialises the staged file to feed the
plugin, preserving exact plugin-input semantics. Bounding that to a prefix read,
or extending the plugin ABI to accept a stream/path, is a separate
product/ABI decision and is deliberately out of scope. The common (non-plugin)
generic upload streams end-to-end.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`tests/streaming_invariant.rs` gains `streaming_invariant_no_new_buffered_blob_upload_routes`:
a source-scan guard (the clippy `disallowed-methods` gate cannot see a `body: Bytes`
extractor) that fails if any handler takes `body: Bytes` **and** writes a blob to
storage in the same fn. It fails on the pre-conversion routes (verified locally
by reverting a route to its buffered form) and passes on this PR.

## Test Checklist
- [x] Unit tests added/updated (`verify_declared_digests` parity + mismatch tests)
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo build`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --test streaming_invariant`, `cargo fmt --all --check` — all clean)
- [x] No regressions in existing tests (existing `repositories`/`maven` upload unit tests updated for the new `Result<Response, Response>` signatures)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (same paths, status codes, and response bodies; extractor type only)

Closes #2517