### PR TITLE
fix(storage): repo-scoped cloud storage keys for Maven/sbt objects

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,14 @@ STORAGE_PATH=/var/lib/artifact-keeper/artifacts
 # or "migration" (reads both formats during migration).
 # STORAGE_PATH_FORMAT=native
 
+# Storage key scheme for path-addressed format objects (Maven/sbt) on shared
+# cloud backends (S3/GCS/Azure): "repo-scoped" (default) writes
+# {format}/{repository_id}/{path} so keys can never collide across
+# repositories; "flat" keeps the legacy {format}/{path} layout. Reads fall
+# back to the flat key, so existing objects stay readable either way.
+# Filesystem storage is unaffected (already isolated per repository).
+# STORAGE_KEY_SCHEME=repo-scoped
+
 # --- S3 Storage (when STORAGE_BACKEND=s3) ---
 # S3_BUCKET=my-artifacts
 # S3_REGION=us-east-1

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -944,6 +944,23 @@ async fn download(
         // to (#2504, #2574 — the same ownership rule as the write guard).
         // Foreign-owned and unattributed keys fall through to the row-gated
         // computed-checksum path below.
+        // #2624: new sidecar writes on cloud land at the repo-scoped key,
+        // which embeds this repository's id and therefore needs no catalog
+        // attribution gate — it cannot name another repository's object.
+        let key_scheme = crate::storage::StorageKeyScheme::from_env();
+        if checksum_compute_eligible(&repo.repo_type) {
+            if let Some(scoped_key) =
+                key_scheme.scoped_read_key(&repo.storage_backend, "maven", repo.id, &path)
+            {
+                if let Ok(content) = storage.get(&scoped_key).await {
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(CONTENT_TYPE, "text/plain")
+                        .body(Body::from(content))
+                        .unwrap());
+                }
+            }
+        }
         let checksum_storage_key = format!("maven/{}", path);
         if checksum_compute_eligible(&repo.repo_type)
             && crate::services::maven_flat_attribution::flat_key_readable(
@@ -970,8 +987,25 @@ async fn download(
         // is served only to its attributed owner (#2504, #2574).
         if base_path.contains("-SNAPSHOT") {
             if let Some(resolved) = resolve_snapshot_artifact(&state.db, repo.id, base_path).await {
-                let resolved_checksum_key =
-                    format!("maven/{}.{}", resolved.path, checksum_suffix(checksum_type));
+                let resolved_sidecar_path =
+                    format!("{}.{}", resolved.path, checksum_suffix(checksum_type));
+                // Repo-scoped candidate first (#2624): physically owned by
+                // this repository, no attribution gate needed.
+                if let Some(scoped_key) = key_scheme.scoped_read_key(
+                    &repo.storage_backend,
+                    "maven",
+                    repo.id,
+                    &resolved_sidecar_path,
+                ) {
+                    if let Ok(content) = storage.get(&scoped_key).await {
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, "text/plain")
+                            .body(Body::from(content))
+                            .unwrap());
+                    }
+                }
+                let resolved_checksum_key = format!("maven/{}", resolved_sidecar_path);
                 if crate::services::maven_flat_attribution::flat_key_readable(
                     &state.db,
                     repo.id,
@@ -1125,6 +1159,48 @@ async fn fetch_remote_member_metadata(
     std::str::from_utf8(&content).ok().map(|s| s.to_string())
 }
 
+/// Read a Local/Staging virtual member's stored metadata document at `path`.
+///
+/// Tries the member's repo-scoped key first (#2624) — the key embeds the
+/// member's repository id, so it is physically owned and needs no catalog
+/// attribution gate — then falls back to the legacy flat `maven/{path}` key.
+/// On shared cloud namespaces the flat key is served only when the catalog
+/// attributes it to the member (#2504, #2574). Scoped to `member.id`, both
+/// reads compose with the #1804 member authorization done by the caller.
+async fn read_member_stored_metadata(
+    state: &SharedState,
+    member: &crate::models::repository::Repository,
+    path: &str,
+) -> Option<String> {
+    let member_storage = state.storage_for_repo(&member.storage_location()).ok()?;
+    if let Some(scoped_key) = crate::storage::StorageKeyScheme::from_env().scoped_read_key(
+        &member.storage_backend,
+        "maven",
+        member.id,
+        path,
+    ) {
+        if let Ok(content) = member_storage.get(&scoped_key).await {
+            if let Ok(s) = std::str::from_utf8(&content) {
+                return Some(s.to_string());
+            }
+        }
+    }
+    let member_storage_key = format!("maven/{}", path);
+    if crate::services::maven_flat_attribution::flat_key_readable(
+        &state.db,
+        member.id,
+        &member.storage_backend,
+        &member_storage_key,
+    )
+    .await
+    {
+        if let Ok(content) = member_storage.get(&member_storage_key).await {
+            return std::str::from_utf8(&content).ok().map(|s| s.to_string());
+        }
+    }
+    None
+}
+
 async fn fetch_maven_metadata_bytes(
     state: &SharedState,
     repo: &RepoInfo,
@@ -1266,34 +1342,13 @@ async fn fetch_maven_metadata_bytes(
             let mut member_docs: Vec<String> = Vec::new();
             for chunk in members.chunks(proxy_helpers::MAX_VIRTUAL_FANOUT) {
                 let batch = futures::future::join_all(chunk.iter().map(|member| async {
-                    // Unanchored `maven/<path>` read: sound on filesystem
-                    // (physical isolation), or on a shared cloud namespace only
-                    // when the key is attributed to THIS member repository
-                    // (#2504, #2574). Scoped to `member.id`, it composes with the
-                    // #1804 member-authorization done by the caller.
-                    let member_storage_key = format!("maven/{}", path);
+                    // Stored-document read: repo-scoped key first, then the
+                    // attribution-gated legacy flat key (#2624, #2504, #2574);
+                    // see `read_member_stored_metadata`.
                     if member.repo_type == RepositoryType::Remote {
                         fetch_remote_member_metadata(state, member, path).await
-                    } else if crate::services::maven_flat_attribution::flat_key_readable(
-                        &state.db,
-                        member.id,
-                        &member.storage_backend,
-                        &member_storage_key,
-                    )
-                    .await
-                    {
-                        match state.storage_for_repo(&member.storage_location()) {
-                            Ok(member_storage) => {
-                                member_storage.get(&member_storage_key).await.ok().and_then(
-                                    |content| {
-                                        std::str::from_utf8(&content).ok().map(|s| s.to_string())
-                                    },
-                                )
-                            }
-                            Err(_) => None,
-                        }
                     } else {
-                        None
+                        read_member_stored_metadata(state, member, path).await
                     }
                 }))
                 .await;
@@ -1325,30 +1380,14 @@ async fn fetch_maven_metadata_bytes(
                             entries.extend(parse_snapshot_versions_xml(&xml_str));
                         }
                     } else {
-                        // Unanchored `maven/<path>` read: sound on filesystem
-                        // (physical isolation); on a shared cloud namespace only
-                        // when the key is attributed to THIS member repository
-                        // (#2504, #2574). Otherwise rely on the row-scoped
-                        // snapshot entries below. Scoped to `member.id`, it
-                        // composes with the #1804 member authorization.
-                        let member_storage_key = format!("maven/{}", path);
-                        if crate::services::maven_flat_attribution::flat_key_readable(
-                            &state.db,
-                            member.id,
-                            &member.storage_backend,
-                            &member_storage_key,
-                        )
-                        .await
+                        // Stored-document read: repo-scoped key first, then the
+                        // attribution-gated legacy flat key (#2624, #2504,
+                        // #2574); see `read_member_stored_metadata`. A miss
+                        // falls through to the row-scoped snapshot entries.
+                        if let Some(xml_str) =
+                            read_member_stored_metadata(state, member, path).await
                         {
-                            if let Ok(member_storage) =
-                                state.storage_for_repo(&member.storage_location())
-                            {
-                                if let Ok(content) = member_storage.get(&member_storage_key).await {
-                                    if let Ok(xml_str) = std::str::from_utf8(&content) {
-                                        entries.extend(parse_snapshot_versions_xml(xml_str));
-                                    }
-                                }
-                            }
+                            entries.extend(parse_snapshot_versions_xml(&xml_str));
                         }
                         entries.extend(
                             collect_snapshot_entries(
@@ -1394,6 +1433,18 @@ async fn fetch_maven_metadata_bytes(
     // repository (#2504, #2574). This keeps a deliberately-uploaded verbatim
     // document authoritative for its owner instead of degrading to the dynamic
     // generation below, while foreign/unattributed keys fall through.
+    // Repo-scoped candidate first (#2624): the key embeds this repository's
+    // id, so no attribution gate is needed for it.
+    if let Some(scoped_key) = crate::storage::StorageKeyScheme::from_env().scoped_read_key(
+        &repo.storage_backend,
+        "maven",
+        repo.id,
+        path,
+    ) {
+        if let Ok(content) = storage.get(&scoped_key).await {
+            return Ok(content);
+        }
+    }
     let meta_storage_key = format!("maven/{}", path);
     if crate::services::maven_flat_attribution::flat_key_readable(
         &state.db,
@@ -1812,6 +1863,28 @@ async fn serve_artifact(
             // attributes the key to this repository (#2504, #2574 — the same
             // ownership rule as the write guard). A foreign-owned or
             // unattributed key 404s rather than serving another repo's bytes.
+            // Repo-scoped candidate first (#2624): row-less sidecars written
+            // under the scoped scheme (checksums, verbatim metadata) live at
+            // `maven/{repo.id}/{path}`. The key embeds this repository's id,
+            // so it needs no attribution gate.
+            if repo.repo_type == RepositoryType::Local || repo.repo_type == RepositoryType::Staging
+            {
+                if let Some(scoped_key) = crate::storage::StorageKeyScheme::from_env()
+                    .scoped_read_key(&repo.storage_backend, "maven", repo.id, path)
+                {
+                    let storage = state
+                        .storage_for_repo(&repo.storage_location())
+                        .map_err(|e| e.into_response())?;
+                    if let Ok(stream) = storage.get_stream(&scoped_key).await {
+                        let ct = content_type_for_path(path);
+                        return Ok(Response::builder()
+                            .status(StatusCode::OK)
+                            .header(CONTENT_TYPE, ct)
+                            .body(Body::from_stream(stream))
+                            .unwrap());
+                    }
+                }
+            }
             let legacy_storage_key = format!("maven/{}", path);
             if (repo.repo_type == RepositoryType::Local
                 || repo.repo_type == RepositoryType::Staging)
@@ -2133,10 +2206,24 @@ async fn upload(
     .unwrap_or(false);
     proxy_helpers::reject_direct_upload_if_promotion_only(promotion_only, auth.is_admin)?;
 
-    let storage_key = format!("maven/{}", path);
+    // #2624: on shared cloud namespaces new objects are written under a
+    // repository-scoped key (`maven/{repository_id}/{path}`) so the physical
+    // key can never collide with — or be claimed by — another repository.
+    // Filesystem backends and the `STORAGE_KEY_SCHEME=flat` opt-out keep the
+    // legacy `maven/{path}` shape. Existing objects are untouched: their
+    // artifact rows still carry the flat key they were written under, and the
+    // derived-read sites fall back to the flat key.
+    let storage_key = crate::storage::StorageKeyScheme::from_env().write_key(
+        &repo.storage_backend,
+        "maven",
+        repo.id,
+        &path,
+    );
     // Guard every flat-key write before it reaches storage (#2584). On a shared
     // cloud namespace this refuses to overwrite a *different* repository's object
-    // living at this exact key (403). It is a READ-ONLY check: it must not
+    // living at this exact key (403). A repo-scoped key embeds this repository's
+    // id and can never be foreign-owned, so the guard passes trivially there.
+    // It is a READ-ONLY check: it must not
     // attribute the key here, because this runs before the bytes are written and
     // before coordinate parsing/validation that can still reject the request --
     // claiming here would flip ownership of a foreign *unattributed* key on any
@@ -2851,7 +2938,10 @@ mod tests {
     // build_maven_storage_key
     // -----------------------------------------------------------------------
 
-    /// Build the Maven storage key from a raw path.
+    /// Build the LEGACY flat Maven storage key from a raw path — the shape
+    /// used on repo-isolated (filesystem) backends and under
+    /// `STORAGE_KEY_SCHEME=flat`. Cloud writes under the default repo-scoped
+    /// scheme use `StorageKeyScheme::write_key` instead (#2624).
     fn build_maven_storage_key(path: &str) -> String {
         format!("maven/{}", path)
     }
@@ -3834,6 +3924,203 @@ mod tests {
         assert_eq!(version_count, 1);
 
         fx.teardown().await;
+    }
+
+    /// #2624: on a shared cloud namespace (registered "s3" backend) Maven
+    /// uploads must write REPO-SCOPED storage keys (`maven/{repo_id}/{path}`)
+    /// so the same coordinate in two repositories can never collide on one
+    /// physical object — and every read path (row-anchored artifact download,
+    /// row-less checksum sidecar, verbatim maven-metadata.xml) must resolve
+    /// the scoped object back.
+    #[tokio::test]
+    async fn test_cloud_upload_uses_repo_scoped_key_2624() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "maven").await;
+        sqlx::query(
+            "UPDATE repositories SET storage_backend = 's3', storage_path = key WHERE id = $1",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("set cloud backend");
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (state, mem) = tdh::build_state_with_cloud(pool.clone(), "s3");
+        let router =
+            tdh::router_with_auth(super::router(), state, tdh::make_auth(user_id, &username));
+
+        // -- Artifact upload lands at the repo-scoped key, and ONLY there.
+        let path = "com/example/scoped2624/demo/1.0.0/demo-1.0.0.jar";
+        let jar = bytes::Bytes::from_static(b"scoped-jar-bytes-2624");
+        let (status, body) = tdh::send(
+            router.clone(),
+            tdh::put(format!("/{repo_key}/{path}"), jar.clone()),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "PUT failed: {}",
+            String::from_utf8_lossy(&body)
+        );
+
+        let scoped_key = format!("maven/{repo_id}/{path}");
+        let db_key: String = sqlx::query_scalar(
+            "SELECT storage_key FROM artifacts WHERE repository_id = $1 AND path = $2",
+        )
+        .bind(repo_id)
+        .bind(path)
+        .fetch_one(&pool)
+        .await
+        .expect("artifact row");
+        assert_eq!(
+            db_key, scoped_key,
+            "artifact row must record the repo-scoped physical key"
+        );
+        {
+            let objects = mem.objects.lock().unwrap();
+            assert!(
+                objects.contains_key(&scoped_key),
+                "bytes must live at the repo-scoped key"
+            );
+            assert!(
+                !objects.contains_key(&format!("maven/{path}")),
+                "the legacy flat key must NOT be written"
+            );
+        }
+
+        // -- Row-anchored download resolves the recorded scoped key.
+        let (status, body) =
+            tdh::send(router.clone(), tdh::get(format!("/{repo_key}/{path}"))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, jar);
+
+        // -- Row-less checksum sidecar: stored scoped, served via the scoped
+        //    read candidate (no attribution row needed).
+        let sha1_path = format!("{path}.sha1");
+        let sha1 = bytes::Bytes::from_static(b"da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        let (status, _) = tdh::send(
+            router.clone(),
+            tdh::put(format!("/{repo_key}/{sha1_path}"), sha1.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert!(mem
+            .objects
+            .lock()
+            .unwrap()
+            .contains_key(&format!("maven/{repo_id}/{sha1_path}")));
+        let (status, body) =
+            tdh::send(router.clone(), tdh::get(format!("/{repo_key}/{sha1_path}"))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, sha1);
+
+        // -- Verbatim maven-metadata.xml round-trips through the scoped key.
+        let meta_path = "com/example/scoped2624/demo/maven-metadata.xml";
+        let meta = bytes::Bytes::from_static(
+            b"<metadata><groupId>com.example.scoped2624</groupId>\
+              <artifactId>demo</artifactId><versioning><versions>\
+              <version>1.0.0</version></versions></versioning></metadata>",
+        );
+        let (status, _) = tdh::send(
+            router.clone(),
+            tdh::put(format!("/{repo_key}/{meta_path}"), meta.clone()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::CREATED);
+        assert!(mem
+            .objects
+            .lock()
+            .unwrap()
+            .contains_key(&format!("maven/{repo_id}/{meta_path}")));
+        let (status, body) =
+            tdh::send(router.clone(), tdh::get(format!("/{repo_key}/{meta_path}"))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, meta);
+
+        let _ = sqlx::query("DELETE FROM maven_flat_object_owner WHERE repository_id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+        tdh::cleanup(&pool, repo_id, user_id).await;
+    }
+
+    /// #2624 back-compat: objects stored under the LEGACY flat scheme
+    /// (`maven/{path}`) must stay readable after the repo-scoped scheme takes
+    /// over new writes — row-anchored artifacts through the storage_key their
+    /// row recorded, and row-less sidecars through the attribution-gated flat
+    /// fallback (owner inherited from the base artifact row). Nothing is
+    /// re-keyed or stranded.
+    #[tokio::test]
+    async fn test_cloud_legacy_flat_keys_still_served_2624() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use axum::http::StatusCode;
+
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "local", "maven").await;
+        sqlx::query(
+            "UPDATE repositories SET storage_backend = 's3', storage_path = key WHERE id = $1",
+        )
+        .bind(repo_id)
+        .execute(&pool)
+        .await
+        .expect("set cloud backend");
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (state, mem) = tdh::build_state_with_cloud(pool.clone(), "s3");
+        let router =
+            tdh::router_with_auth(super::router(), state, tdh::make_auth(user_id, &username));
+
+        // Seed a pre-scheme artifact: bytes at the FLAT key, row recording it.
+        let path = "com/example/legacy2624/old/1.0.0/old-1.0.0.jar";
+        let flat_key = format!("maven/{path}");
+        let jar = bytes::Bytes::from_static(b"legacy-flat-jar-bytes-2624");
+        mem.objects
+            .lock()
+            .unwrap()
+            .insert(flat_key.clone(), jar.clone());
+        sqlx::query(
+            "INSERT INTO artifacts \
+             (repository_id, path, name, version, size_bytes, checksum_sha256, \
+              content_type, storage_key, uploaded_by) \
+             VALUES ($1, $2, 'old', '1.0.0', $3, $4, 'application/java-archive', $5, $6)",
+        )
+        .bind(repo_id)
+        .bind(path)
+        .bind(jar.len() as i64)
+        .bind("ab".repeat(32))
+        .bind(&flat_key)
+        .bind(user_id)
+        .execute(&pool)
+        .await
+        .expect("seed legacy artifact row");
+
+        // Row-anchored read: served through the row's recorded flat key.
+        let (status, body) =
+            tdh::send(router.clone(), tdh::get(format!("/{repo_key}/{path}"))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, jar);
+
+        // Row-less legacy sidecar at the flat key: the scoped candidate
+        // misses, and the flat fallback serves it because attribution
+        // inherits the base artifact row's owner (#2504/#2574 rules intact).
+        let sha1_flat_key = format!("{flat_key}.sha1");
+        let sha1 = bytes::Bytes::from_static(b"cafebabecafebabecafebabecafebabecafebabe");
+        mem.objects
+            .lock()
+            .unwrap()
+            .insert(sha1_flat_key, sha1.clone());
+        let (status, body) =
+            tdh::send(router.clone(), tdh::get(format!("/{repo_key}/{path}.sha1"))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, sha1);
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
     }
 
     /// Direct Maven uploads bypass the generic ArtifactService upload path, so

--- a/backend/src/api/handlers/maven_proxy.rs
+++ b/backend/src/api/handlers/maven_proxy.rs
@@ -167,6 +167,27 @@ pub(crate) async fn maven_local_fetch_storage_fallback(
     // (#2504, #2574 — the same ownership rule as the write guard). A database
     // error fails closed (404) rather than risking a foreign read.
     if !crate::storage::backend_is_repo_isolated(&location.backend) {
+        // Repo-scoped candidate first (#2624): row-less companions written
+        // under the scoped scheme live at `maven/{repo_id}/{path}`. The key
+        // embeds the requesting repository's id, so it is physically owned
+        // and needs no catalog attribution.
+        if let Some(scoped_key) = crate::storage::StorageKeyScheme::from_env().scoped_read_key(
+            &location.backend,
+            "maven",
+            repo_id,
+            artifact_path,
+        ) {
+            let storage = state.storage_for_repo_or_500(location)?;
+            if let Ok(stream) = storage.get_stream(&scoped_key).await {
+                return Ok(StreamingFetchResult {
+                    body: stream,
+                    content_type: None,
+                    content_length: None,
+                    // Row-less companion object: not anchored to an artifact row.
+                    artifact_id: None,
+                });
+            }
+        }
         let flat_key = format!("maven/{}", artifact_path);
         let owned = crate::services::maven_flat_attribution::attributed_owner(
             db,

--- a/backend/src/api/handlers/sbt.rs
+++ b/backend/src/api/handlers/sbt.rs
@@ -268,8 +268,17 @@ async fn upload_artifact(
         "application/java-archive"
     };
 
-    // Store the file
-    let storage_key = format!("sbt/{}", artifact_path);
+    // Store the file. #2624: on shared cloud namespaces new objects embed the
+    // repository id (`sbt/{repository_id}/{path}`) so keys can never collide
+    // across repositories; filesystem backends and STORAGE_KEY_SCHEME=flat
+    // keep the legacy `sbt/{path}` shape. Downloads read the row-recorded
+    // storage_key, so objects written under either scheme stay readable.
+    let storage_key = crate::storage::StorageKeyScheme::from_env().write_key(
+        &repo.storage_backend,
+        "sbt",
+        repo.id,
+        &artifact_path,
+    );
     proxy_helpers::guard_cross_repo_write(&state, repo.id, &repo.storage_backend, &storage_key)
         .await?;
     let storage = state

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -287,6 +287,75 @@ pub fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
     Arc::new(AppState::new(cfg(storage_path), pool, storage, registry))
 }
 
+/// Minimal in-memory [`crate::storage::StorageBackend`] double for tests that
+/// need a registered *cloud* backend (shared flat namespace) instead of the
+/// per-repo-rooted filesystem storage `build_state` provides. Missing keys
+/// return a "not found" storage error, matching how handlers detect misses.
+#[derive(Default)]
+pub struct MemStorage {
+    pub objects: std::sync::Mutex<std::collections::HashMap<String, Bytes>>,
+}
+
+#[async_trait::async_trait]
+impl crate::storage::StorageBackend for MemStorage {
+    async fn put(&self, key: &str, content: Bytes) -> crate::error::Result<()> {
+        self.objects
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), content);
+        Ok(())
+    }
+
+    async fn get(&self, key: &str) -> crate::error::Result<Bytes> {
+        self.objects
+            .lock()
+            .unwrap()
+            .get(key)
+            .cloned()
+            .ok_or_else(|| crate::error::AppError::Storage(format!("Key not found: {key}")))
+    }
+
+    async fn exists(&self, key: &str) -> crate::error::Result<bool> {
+        Ok(self.objects.lock().unwrap().contains_key(key))
+    }
+
+    async fn delete(&self, key: &str) -> crate::error::Result<()> {
+        self.objects.lock().unwrap().remove(key);
+        Ok(())
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        stream: futures::stream::BoxStream<'static, crate::error::Result<Bytes>>,
+    ) -> crate::error::Result<crate::storage::PutStreamResult> {
+        crate::storage::buffered_put_stream_fallback(self, key, stream).await
+    }
+}
+
+/// Like [`build_state`], but the registry carries an in-memory backend
+/// registered under `backend_name` (e.g. `"s3"`), simulating a shared cloud
+/// namespace. Returns the state plus the backing [`MemStorage`] so tests can
+/// assert exactly which physical keys were written (#2624).
+pub fn build_state_with_cloud(pool: PgPool, backend_name: &str) -> (SharedState, Arc<MemStorage>) {
+    let mem = Arc::new(MemStorage::default());
+    let mut backends: std::collections::HashMap<String, Arc<dyn crate::storage::StorageBackend>> =
+        std::collections::HashMap::new();
+    backends.insert(backend_name.to_string(), mem.clone());
+    let registry = Arc::new(crate::storage::StorageRegistry::new(
+        backends,
+        backend_name.to_string(),
+    ));
+    let storage: Arc<dyn crate::storage::StorageBackend> = mem.clone();
+    let state = Arc::new(AppState::new(
+        cfg("/tmp/ak-cloud-test-unused"),
+        pool,
+        storage,
+        registry,
+    ));
+    (state, mem)
+}
+
 pub async fn create_user(pool: &PgPool) -> (Uuid, String) {
     let id = Uuid::new_v4();
     let username = format!("ph-test-u-{}", id);

--- a/backend/src/storage/keys.rs
+++ b/backend/src/storage/keys.rs
@@ -1,4 +1,4 @@
-//! Shared storage-key prefixes.
+//! Shared storage-key prefixes and the repository-scoped key scheme.
 //!
 //! OCI objects are stored under fixed key prefixes that are referenced from
 //! several independent sites: the write path that produces the keys, the
@@ -6,6 +6,96 @@
 //! sites build keys with these constants; the SQL sites still have to embed
 //! the literal (Postgres cannot read Rust constants) but pin themselves to
 //! the constant with compile-time assertions so the two can never drift.
+//!
+//! [`StorageKeyScheme`] (#2624) governs whether path-addressed format objects
+//! on shared cloud namespaces embed the owning repository's id in their
+//! storage key (`{format}/{repository_id}/{path}`, the same shape the
+//! rpm/alpine/incus handlers already use) or keep the legacy flat
+//! `{format}/{path}` namespace.
+
+use uuid::Uuid;
+
+/// How path-addressed format objects are keyed on shared cloud namespaces
+/// (S3/GCS/Azure).
+///
+/// Selected by the `STORAGE_KEY_SCHEME` environment variable:
+/// `repo-scoped` (default) or `flat` (the pre-#2624 layout).
+///
+/// Filesystem backends are exempt either way: [`super::registry`] roots a
+/// fresh `FilesystemStorage` at each repository's `storage_path`, so their
+/// key space is already physically per-repository and scoping the key again
+/// would only churn the on-disk layout.
+///
+/// Rollout/back-compat contract (#2624):
+/// - Row-anchored reads always use the `artifacts.storage_key` recorded at
+///   write time, so objects written under either scheme stay readable
+///   without any migration.
+/// - Derived (row-less) reads try the scoped candidate first and then fall
+///   back to the legacy flat key, gated by the same #2504/#2574 attribution
+///   rules as before.
+/// - The scoped segment is the repository **UUID** (never reused, unlike the
+///   repository key), so a scoped key is physically attributable to exactly
+///   one repository for all time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum StorageKeyScheme {
+    /// `{format}/{repository_id}/{path}` on shared cloud namespaces (default).
+    #[default]
+    RepoScoped,
+    /// Legacy flat `{format}/{path}` shared namespace.
+    Flat,
+}
+
+impl StorageKeyScheme {
+    /// Load from the `STORAGE_KEY_SCHEME` environment variable.
+    pub fn from_env() -> Self {
+        match std::env::var("STORAGE_KEY_SCHEME")
+            .unwrap_or_default()
+            .to_lowercase()
+            .as_str()
+        {
+            "flat" | "legacy" => Self::Flat,
+            _ => Self::RepoScoped,
+        }
+    }
+
+    /// The storage key new `{format_prefix}` objects are written to for
+    /// `repository_id` on `storage_backend`.
+    ///
+    /// Repo-isolated (filesystem) backends and the [`Flat`](Self::Flat)
+    /// scheme keep the legacy `{format}/{path}` key; shared cloud namespaces
+    /// under [`RepoScoped`](Self::RepoScoped) embed the repository id.
+    pub fn write_key(
+        self,
+        storage_backend: &str,
+        format_prefix: &str,
+        repository_id: Uuid,
+        path: &str,
+    ) -> String {
+        self.scoped_read_key(storage_backend, format_prefix, repository_id, path)
+            .unwrap_or_else(|| format!("{format_prefix}/{path}"))
+    }
+
+    /// The repo-scoped candidate a derived (row-less) read should try BEFORE
+    /// the legacy flat key, or `None` when writes for this backend/scheme go
+    /// to the flat key anyway.
+    ///
+    /// The returned key embeds `repository_id`, so serving it back to that
+    /// same repository needs no catalog attribution check — the key cannot
+    /// name another repository's object.
+    pub fn scoped_read_key(
+        self,
+        storage_backend: &str,
+        format_prefix: &str,
+        repository_id: Uuid,
+        path: &str,
+    ) -> Option<String> {
+        if self == Self::RepoScoped && !super::registry::backend_is_repo_isolated(storage_backend) {
+            Some(format!("{format_prefix}/{repository_id}/{path}"))
+        } else {
+            None
+        }
+    }
+}
 
 /// Storage-key prefix for OCI image manifest objects: `oci-manifests/`.
 ///
@@ -60,5 +150,90 @@ mod tests {
         // The SQL literals in the lifecycle cascade and storage GC orphan
         // predicate hard-code this exact value; keep them in sync.
         assert_eq!(OCI_MANIFEST_STORAGE_PREFIX, "oci-manifests/");
+    }
+
+    // -- StorageKeyScheme (#2624) -------------------------------------------
+
+    const REPO_A: Uuid = Uuid::from_u128(0x1111_2222_3333_4444_5555_6666_7777_8888);
+    const REPO_B: Uuid = Uuid::from_u128(0x9999_aaaa_bbbb_cccc_dddd_eeee_ffff_0000);
+
+    #[test]
+    fn repo_scoped_write_key_embeds_repository_id_on_cloud() {
+        let key = StorageKeyScheme::RepoScoped.write_key(
+            "s3",
+            "maven",
+            REPO_A,
+            "com/example/lib/1.0/lib-1.0.jar",
+        );
+        assert_eq!(
+            key,
+            format!("maven/{REPO_A}/com/example/lib/1.0/lib-1.0.jar")
+        );
+    }
+
+    #[test]
+    fn repo_scoped_write_key_keeps_flat_key_on_filesystem() {
+        // Filesystem backends are already rooted per-repository; the key
+        // stays in the legacy shape so existing directory trees are reused.
+        let key = StorageKeyScheme::RepoScoped.write_key(
+            "filesystem",
+            "maven",
+            REPO_A,
+            "com/example/lib/1.0/lib-1.0.jar",
+        );
+        assert_eq!(key, "maven/com/example/lib/1.0/lib-1.0.jar");
+    }
+
+    #[test]
+    fn flat_scheme_write_key_is_legacy_shape_everywhere() {
+        for backend in ["s3", "gcs", "azure", "filesystem"] {
+            let key = StorageKeyScheme::Flat.write_key(
+                backend,
+                "maven",
+                REPO_A,
+                "com/example/lib/1.0/lib-1.0.jar",
+            );
+            assert_eq!(key, "maven/com/example/lib/1.0/lib-1.0.jar");
+        }
+    }
+
+    #[test]
+    fn scoped_keys_of_two_repositories_can_never_collide() {
+        // The scheme's whole point (#2624/#2586): the same coordinate in two
+        // repositories resolves to two distinct physical objects.
+        let path = "com/example/lib/1.0/lib-1.0.jar";
+        let a = StorageKeyScheme::RepoScoped.write_key("s3", "maven", REPO_A, path);
+        let b = StorageKeyScheme::RepoScoped.write_key("s3", "maven", REPO_B, path);
+        assert_ne!(a, b);
+        assert!(a.contains(&REPO_A.to_string()));
+        assert!(b.contains(&REPO_B.to_string()));
+    }
+
+    #[test]
+    fn scoped_read_key_matches_write_key_on_cloud() {
+        let path = "com/example/lib/maven-metadata.xml";
+        let scoped = StorageKeyScheme::RepoScoped
+            .scoped_read_key("gcs", "maven", REPO_A, path)
+            .expect("cloud backend under repo-scoped scheme yields a candidate");
+        assert_eq!(
+            scoped,
+            StorageKeyScheme::RepoScoped.write_key("gcs", "maven", REPO_A, path)
+        );
+    }
+
+    #[test]
+    fn scoped_read_key_is_none_when_writes_are_flat() {
+        let path = "com/example/lib/maven-metadata.xml";
+        assert!(StorageKeyScheme::RepoScoped
+            .scoped_read_key("filesystem", "maven", REPO_A, path)
+            .is_none());
+        assert!(StorageKeyScheme::Flat
+            .scoped_read_key("s3", "maven", REPO_A, path)
+            .is_none());
+    }
+
+    #[test]
+    fn default_scheme_is_repo_scoped() {
+        assert_eq!(StorageKeyScheme::default(), StorageKeyScheme::RepoScoped);
     }
 }

--- a/backend/src/storage/mod.rs
+++ b/backend/src/storage/mod.rs
@@ -8,6 +8,7 @@ pub mod path_format;
 pub mod registry;
 pub mod s3;
 
+pub use keys::StorageKeyScheme;
 pub use path_format::StoragePathFormat;
 pub use registry::{backend_is_repo_isolated, StorageLocation, StorageRegistry};
 


### PR DESCRIPTION
## Summary

Closes #2624.

On S3/GCS/Azure, Maven (and sbt/Ivy) objects were stored under a flat `maven/{path}` / `sbt/{path}` key with no repository identifier — the layout the reporter observed (`artifacts/maven/com/...` instead of the documented `artifacts/maven/{repository_id}/com/...`). Beyond the docs mismatch, the flat namespace is the structural root of the cross-repository key-collision class that #2504/#2574/#2584/#2716 mitigated catalog-side: the same coordinate in two repositories names one physical object.

This PR introduces a repository-scoped storage key scheme and applies it to the Maven family (the formats still on flat keys with the reported symptom):

- **New writes on cloud backends** go to `{format}/{repository_id}/{path}` (e.g. `maven/6b9f.../com/example/lib/1.0/lib-1.0.jar`) — the same shape the rpm/alpine/incus handlers already use. The repository **UUID** is used (not the reusable repository key), so a key is physically attributable to exactly one repository for all time and two repositories can never collide on a key.
- **`STORAGE_KEY_SCHEME`** env flag selects the scheme: `repo-scoped` (default) or `flat` (legacy layout opt-out). Documented in `.env.example`.
- **Filesystem backends are exempt**: the registry already roots each repository at its own directory, so scoping the key again would only churn the on-disk layout. Their behavior (and every existing filesystem test) is unchanged.

### Back-compat: no migration, nothing stranded

- Row-anchored reads (artifact downloads, presigned redirects, scanner, GC, backup) always use the `artifacts.storage_key` recorded at write time — old rows keep their flat keys, new rows record scoped keys, so objects written under either scheme stay readable with **no re-keying migration**.
- Derived (row-less) reads — stored checksum sidecars, verbatim `maven-metadata.xml`, virtual-member stored metadata, the legacy hosted fallback, and the virtual-member companion fallback — now try the repo-scoped candidate first (needs no attribution gate: the key embeds the reader's repository id) and then fall back to the legacy flat key under the **unchanged** #2504/#2574 attribution rules.
- The #2584 write guard and the #2716 atomic first-claim gate still run on every write, now keyed by the scoped key; they pass trivially for scoped keys (never foreign-owned) and keep protecting any remaining flat-key writes under `STORAGE_KEY_SCHEME=flat`.

Known residual (pre-existing class, unchanged): a mutable coordinate re-published across the scheme transition (SNAPSHOT re-deploy, metadata/sidecar rewrite) leaves its superseded flat object as an unreferenced ghost, the same ghost class as #1570; it is never served (reads prefer the scoped/row key). Promotion/approval copy paths keep referencing the source object's key as before; extending the scoped scheme to the remaining flat-key formats and to promotion-time re-keying can follow up under the #2586 structural plan.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_cloud_upload_uses_repo_scoped_key_2624` (DB-backed, in-memory cloud registry) uploads through the real router against an `s3`-backed repository and asserts the artifact row records `maven/{repo_id}/{path}`, the bytes live at exactly that key (and NOT at the flat key), and the row-anchored download, row-less checksum sidecar, and verbatim `maven-metadata.xml` all round-trip. Verified it fails against the pre-fix behavior (running it under `STORAGE_KEY_SCHEME=flat`, which is the old write path, fails at "artifact row must record the repo-scoped physical key").

`test_cloud_legacy_flat_keys_still_served_2624` pins the back-compat contract: pre-scheme objects at flat keys — both row-anchored artifacts and row-less attribution-gated sidecars — are still served after the scheme takes over new writes.

`storage::keys` unit tests pin the scheme itself: scoped shape on cloud, flat on filesystem/opt-out, read/write candidate agreement, and that two repositories' scoped keys can never collide.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
