### PR TITLE
fix(auth): expose local-login availability to the login UI when SSO is enabled

### DIFF
--- a/backend/src/api/handlers/auth.rs
+++ b/backend/src/api/handlers/auth.rs
@@ -1023,6 +1023,10 @@ mod tests {
         let Some(pool) = tdh::try_pool().await else {
             return;
         };
+        // Serialize against other tests that seed enabled SSO providers
+        // (e.g. the system-config local-login matrix, #2621) — the
+        // enabled-provider lookup is a whole-database question.
+        let _guard = tdh::sso_provider_serial_lock().await;
         let dir = std::env::temp_dir().join(format!("ph-sso-{}", Uuid::new_v4()));
         let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
         let uid = Uuid::new_v4();

--- a/backend/src/api/handlers/system_config.rs
+++ b/backend/src/api/handlers/system_config.rs
@@ -15,6 +15,7 @@ use utoipa::{OpenApi, ToSchema};
 
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
+use crate::services::auth_config_service::AuthConfigService;
 
 /// Router for the system configuration endpoint.
 ///
@@ -72,6 +73,35 @@ pub struct AuthConfig {
     /// Whether SAML SSO is configured (derived from the SSO admin settings in the DB,
     /// but for this endpoint we report whether the OIDC issuer is set as a proxy).
     pub sso_enabled: bool,
+    /// Whether the login UI should offer the local username/password form
+    /// (issue #2621). `true` when no SSO provider is enabled; with SSO
+    /// enabled it is `true` only when the operator explicitly opted in via
+    /// `ALLOW_LOCAL_ADMIN_LOGIN=true` and has not enforced strict SSO-only
+    /// via `SSO_DISABLE_ADMIN_BREAK_GLASS`. Display-only: the login endpoint
+    /// independently enforces the same policy server-side
+    /// (`api::handlers::auth::local_login_gate`), so this flag never grants
+    /// access by itself. LDAP is separate — the UI shows the credentials form
+    /// for enabled LDAP providers regardless of this flag.
+    pub local_login_enabled: bool,
+}
+
+/// Whether the local username/password login form should be offered to the
+/// (pre-authentication) login UI. Mirrors the *operator-visible* subset of the
+/// login-time policy in `api::handlers::auth::local_login_gate`:
+///
+/// * No SSO provider enabled → local login is the only way in, always `true`.
+/// * SSO enabled → `true` only when `ALLOW_LOCAL_ADMIN_LOGIN=true` was set
+///   and `SSO_DISABLE_ADMIN_BREAK_GLASS` (which takes precedence, #2018) is
+///   not. The quiet default admin break-glass (#443) is intentionally *not*
+///   advertised here: absent the explicit opt-in, the form stays hidden so
+///   SSO-first deployments don't present password fields that reject every
+///   non-admin (#350 / #2621).
+fn local_login_form_enabled(
+    sso_enabled: bool,
+    allow_local_admin_login: bool,
+    disable_admin_break_glass: bool,
+) -> bool {
+    !sso_enabled || (allow_local_admin_login && !disable_admin_break_glass)
 }
 
 /// Runtime configuration values.
@@ -158,10 +188,27 @@ pub async fn get_system_config(
 
     // Public-safe fields: always returned. Login UI needs to know which
     // providers are available before the user authenticates.
+    //
+    // `local_login_enabled` uses the same enabled-provider source of truth as
+    // the login-time policy (`AuthConfigService::list_enabled_providers`, see
+    // `enforce_local_login_sso_policy` in handlers::auth) rather than the env
+    // proxies above, so the advertised form matches what the login endpoint
+    // will actually accept. On a lookup error we fail toward showing the form
+    // (matching the login page's own fail-safe); the login endpoint still
+    // enforces the policy server-side, so this is display-only either way.
+    let sso_provider_enabled = AuthConfigService::list_enabled_providers(&state.db)
+        .await
+        .map(|providers| !providers.is_empty())
+        .unwrap_or(false);
     let auth_config = AuthConfig {
         oidc_enabled: config.oidc_issuer.is_some(),
         ldap_enabled: config.ldap_url.is_some(),
         sso_enabled: config.oidc_issuer.is_some(),
+        local_login_enabled: local_login_form_enabled(
+            sso_provider_enabled,
+            config.allow_local_admin_login,
+            config.sso_disable_admin_break_glass,
+        ),
     };
 
     // Non-admin / anonymous callers receive only the public-safe subset. The
@@ -277,6 +324,7 @@ mod tests {
                 oidc_enabled: false,
                 ldap_enabled: false,
                 sso_enabled: false,
+                local_login_enabled: true,
             },
             oidc_issuer: None,
             permissions: Some(PermissionsConfig {
@@ -344,6 +392,7 @@ mod tests {
                 oidc_enabled: true,
                 ldap_enabled: true,
                 sso_enabled: true,
+                local_login_enabled: false,
             },
             oidc_issuer: Some("https://auth.example.com".to_string()),
             permissions: Some(PermissionsConfig {
@@ -424,11 +473,13 @@ mod tests {
             oidc_enabled: true,
             ldap_enabled: false,
             sso_enabled: true,
+            local_login_enabled: true,
         };
         let json = serde_json::to_string(&auth).unwrap();
         assert!(json.contains("\"oidc_enabled\":true"));
         assert!(json.contains("\"ldap_enabled\":false"));
         assert!(json.contains("\"sso_enabled\":true"));
+        assert!(json.contains("\"local_login_enabled\":true"));
     }
 
     #[test]
@@ -448,6 +499,7 @@ mod tests {
                 oidc_enabled: true,
                 ldap_enabled: false,
                 sso_enabled: true,
+                local_login_enabled: false,
             },
             ..minimal_response()
         };
@@ -775,5 +827,123 @@ mod tests {
         assert_eq!(obj["search_engine"], "database");
         assert_eq!(obj["scanners"]["trivy_enabled"], false);
         assert_eq!(obj["permissions"]["enforcement_enabled"], true);
+    }
+
+    // -----------------------------------------------------------------------
+    // local_login_form_enabled — public local-login affordance (issue #2621)
+    //
+    // Full matrix. The flag only *advertises* the form; enforcement lives in
+    // handlers::auth::local_login_gate, so nothing here can widen access.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_local_login_form_no_sso_always_enabled() {
+        // Without SSO, local login is the only way in — the form must be
+        // offered regardless of either flag.
+        for allow in [false, true] {
+            for strict in [false, true] {
+                assert!(local_login_form_enabled(false, allow, strict));
+            }
+        }
+    }
+
+    #[test]
+    fn test_local_login_form_sso_requires_explicit_opt_in() {
+        // SSO enabled + ALLOW_LOCAL_ADMIN_LOGIN unset/false: the form stays
+        // hidden (the quiet #443 admin break-glass is not advertised).
+        for strict in [false, true] {
+            assert!(!local_login_form_enabled(true, false, strict));
+        }
+    }
+
+    #[test]
+    fn test_local_login_form_sso_with_flag_enabled() {
+        // The #2621 case: OIDC/SSO enabled AND ALLOW_LOCAL_ADMIN_LOGIN=true
+        // must advertise the local login form.
+        assert!(local_login_form_enabled(true, true, false));
+    }
+
+    #[test]
+    fn test_local_login_form_strict_sso_overrides_flag() {
+        // SSO_DISABLE_ADMIN_BREAK_GLASS (#2018) takes precedence: even with
+        // the opt-in flag set, strict SSO-only hides the form because the
+        // login endpoint would reject every local credential anyway.
+        assert!(!local_login_form_enabled(true, true, true));
+    }
+
+    /// DB-backed (#2621): the handler must compute `auth.local_login_enabled`
+    /// from the *enabled-provider* source of truth (same as the login gate)
+    /// combined with the ALLOW_LOCAL_ADMIN_LOGIN / strict-SSO config flags.
+    #[tokio::test]
+    async fn test_handler_local_login_enabled_matrix_db() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        // Serialize against other tests that seed enabled SSO providers —
+        // list_enabled_providers is a whole-database question.
+        let _guard = tdh::sso_provider_serial_lock().await;
+        let provider = format!("sysconfig-2621-ldap-{}", uuid::Uuid::new_v4());
+
+        // Only assert the "no SSO -> form offered" case when no other
+        // enabled provider exists (a prior suite may have left rows behind).
+        let preexisting = !AuthConfigService::list_enabled_providers(&pool)
+            .await
+            .expect("list providers")
+            .is_empty();
+        if !preexisting {
+            let state = tdh::build_state(pool.clone(), "/tmp/sysconfig-2621");
+            let obj = call_handler(state, None).await;
+            assert_eq!(
+                obj["auth"]["local_login_enabled"], true,
+                "no SSO providers: local login form must be offered"
+            );
+        }
+
+        // Enable one provider (LDAP row keeps the seed minimal; the gate and
+        // this endpoint treat any enabled provider type identically).
+        sqlx::query(
+            "INSERT INTO ldap_configs (name, server_url, user_base_dn, is_enabled) \
+             VALUES ($1, 'ldap://test.invalid', 'dc=test', true)",
+        )
+        .bind(&provider)
+        .execute(&pool)
+        .await
+        .expect("seed enabled LDAP provider");
+
+        // SSO enabled + flag unset (default): form hidden — this is the
+        // pre-#2621 behaviour and must not change.
+        let state = tdh::build_state(pool.clone(), "/tmp/sysconfig-2621");
+        let obj = call_handler(state, None).await;
+        assert_eq!(
+            obj["auth"]["local_login_enabled"], false,
+            "SSO enabled without ALLOW_LOCAL_ADMIN_LOGIN: form must stay hidden"
+        );
+
+        // SSO enabled + ALLOW_LOCAL_ADMIN_LOGIN=true: the broken case from
+        // issue #2621 — the form must now be advertised.
+        let state = tdh::build_state_with(pool.clone(), "/tmp/sysconfig-2621", |c| {
+            c.allow_local_admin_login = true;
+        });
+        let obj = call_handler(state, None).await;
+        assert_eq!(
+            obj["auth"]["local_login_enabled"], true,
+            "SSO enabled with ALLOW_LOCAL_ADMIN_LOGIN=true: form must be offered"
+        );
+
+        // Strict SSO-only (#2018) wins over the opt-in flag.
+        let state = tdh::build_state_with(pool.clone(), "/tmp/sysconfig-2621", |c| {
+            c.allow_local_admin_login = true;
+            c.sso_disable_admin_break_glass = true;
+        });
+        let obj = call_handler(state, None).await;
+        assert_eq!(
+            obj["auth"]["local_login_enabled"], false,
+            "strict SSO-only must hide the form even with the opt-in flag"
+        );
+
+        let _ = sqlx::query("DELETE FROM ldap_configs WHERE name = $1")
+            .bind(&provider)
+            .execute(&pool)
+            .await;
     }
 }

--- a/backend/src/api/handlers/test_db_helpers.rs
+++ b/backend/src/api/handlers/test_db_helpers.rs
@@ -149,6 +149,55 @@ pub async fn blob_gc_serial_lock() -> BlobGcSerialGuard {
     BlobGcSerialGuard { _conn: Some(conn) }
 }
 
+/// Advisory-lock key for [`sso_provider_serial_lock`] (#2621).
+///
+/// Distinct from the other test lock keys and from the application advisory
+/// locks, so the SSO-provider test cluster serializes only against itself.
+const SSO_PROVIDER_TEST_LOCK_KEY: i64 = 0x5350_2621; // "SP" + issue #2621
+
+/// Cross-process serialization guard for tests that seed *enabled* SSO
+/// providers (#2621).
+///
+/// `AuthConfigService::list_enabled_providers` answers a WHOLE-database
+/// question ("is any SSO provider enabled?") that both the local-login policy
+/// gate and the public system-config affordance consult. Under `cargo
+/// nextest`'s process-per-test parallelism, one test's freshly-seeded enabled
+/// provider flips a peer test's "no SSO configured" baseline mid-assert. A
+/// Postgres *session* advisory lock — mirroring [`scan_dedup_serial_lock`] —
+/// makes every such test contend for one key, so only one runs its seed →
+/// assert → cleanup critical section at a time. The lock releases when the
+/// guard drops (connection closes), including on panic.
+pub struct SsoProviderSerialGuard {
+    _conn: Option<sqlx::PgConnection>,
+}
+
+/// Acquire the process-wide SSO-provider test lock, blocking until it is free.
+///
+/// Returns an inert guard (no lock held) when `DATABASE_URL` is unset or the
+/// database is unreachable, mirroring [`try_pool`] so DB-free environments
+/// still no-op cleanly. Call this as the first line of any DB-backed test
+/// that seeds or asserts on enabled SSO providers and bind the result for the
+/// whole test body.
+pub async fn sso_provider_serial_lock() -> SsoProviderSerialGuard {
+    use sqlx::Connection;
+    let Ok(url) = std::env::var("DATABASE_URL") else {
+        return SsoProviderSerialGuard { _conn: None };
+    };
+    let mut conn = match sqlx::PgConnection::connect(&url).await {
+        Ok(c) => c,
+        Err(_) => return SsoProviderSerialGuard { _conn: None },
+    };
+    if sqlx::query("SELECT pg_advisory_lock($1)")
+        .bind(SSO_PROVIDER_TEST_LOCK_KEY)
+        .execute(&mut conn)
+        .await
+        .is_err()
+    {
+        return SsoProviderSerialGuard { _conn: None };
+    }
+    SsoProviderSerialGuard { _conn: Some(conn) }
+}
+
 /// Build a lazily-connecting pool that never actually opens a connection
 /// unless a query is issued. Useful for DB-free unit tests of code paths that
 /// short-circuit before touching the database.
@@ -277,6 +326,17 @@ fn cfg(storage_path: &str) -> Config {
 }
 
 pub fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
+    build_state_with(pool, storage_path, |_| {})
+}
+
+/// Like [`build_state`], but lets the caller adjust the test `Config` before
+/// the state is built (e.g. toggling auth-policy flags such as
+/// `allow_local_admin_login`).
+pub fn build_state_with(
+    pool: PgPool,
+    storage_path: &str,
+    mutate: impl FnOnce(&mut Config),
+) -> SharedState {
     let storage: Arc<dyn crate::storage::StorageBackend> = Arc::new(
         crate::storage::filesystem::FilesystemStorage::new(storage_path),
     );
@@ -284,7 +344,9 @@ pub fn build_state(pool: PgPool, storage_path: &str) -> SharedState {
         std::collections::HashMap::new(),
         "filesystem".to_string(),
     ));
-    Arc::new(AppState::new(cfg(storage_path), pool, storage, registry))
+    let mut config = cfg(storage_path);
+    mutate(&mut config);
+    Arc::new(AppState::new(config, pool, storage, registry))
 }
 
 pub async fn create_user(pool: &PgPool) -> (Uuid, String) {


### PR DESCRIPTION
## Summary

Fixes #2621: with OIDC configured and `ALLOW_LOCAL_ADMIN_LOGIN="true"`, the login page shows only the "Sign in with SSO" button — the username/password form for the local admin account never appears.

Root cause is on the backend's discovery surface, not the login endpoint. `POST /api/v1/auth/login` already honors the policy (`local_login_gate` in `handlers/auth.rs`), but the backend exposed no public signal for whether the local credentials form should be offered. The web login page therefore falls back to a heuristic — hide the form whenever a redirect provider (OIDC/SAML) is enabled and no LDAP provider exists — which cannot see `ALLOW_LOCAL_ADMIN_LOGIN`. The web code carries an explicit TODO to "make precise once the backend exposes a public `local_auth_enabled` flag"; this PR adds that flag.

Changes:

- `GET /api/v1/system/config` (`auth` object, public-safe tier) gains `local_login_enabled`:
  - no SSO provider enabled → `true` (unchanged behavior — local login is the only way in);
  - SSO enabled → `true` only when `ALLOW_LOCAL_ADMIN_LOGIN=true` and `SSO_DISABLE_ADMIN_BREAK_GLASS` is not set; strict SSO-only takes precedence over the opt-in flag.
- The flag is computed from the same enabled-provider source of truth as the login-time policy (`AuthConfigService::list_enabled_providers`), so the advertised form always matches what the login endpoint will accept.
- `test_db_helpers`: new `build_state_with` (config-mutating variant of `build_state`) and a `sso_provider_serial_lock` advisory-lock guard. The guard also fixes a pre-existing parallel-test hazard: `test_enforce_local_login_sso_policy_db` and the new matrix test both seed enabled providers and assert on the whole-database "any provider enabled?" question, and collide without serialization.

This change is display-only and cannot widen access in any configuration: the login endpoint independently enforces the same policy server-side (`local_login_gate`, unchanged in this PR), and the new field only ever reads `true` under SSO when the operator explicitly set `ALLOW_LOCAL_ADMIN_LOGIN=true`. The quiet default admin break-glass (#443) is intentionally not advertised, so SSO-first deployments keep their current login page.

A follow-up in `artifact-keeper-web` is needed to consume `auth.local_login_enabled` on the login page (replacing the provider-list heuristic from #350).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_handler_local_login_enabled_matrix_db` seeds an enabled SSO provider and asserts the full matrix against the real handler + database; it cannot pass on `main` (the field does not exist there). The pure policy matrix is covered DB-free by the four `test_local_login_form_*` tests.

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Matrix evidence (all via `GET /api/v1/system/config` → `auth.local_login_enabled`):

| SSO provider enabled | `ALLOW_LOCAL_ADMIN_LOGIN` | `SSO_DISABLE_ADMIN_BREAK_GLASS` | result |
|---|---|---|---|
| no | any | any | `true` (unchanged) |
| yes | unset/false | any | `false` (unchanged — form stays hidden) |
| yes | `true` | unset/false | `true` (the #2621 fix) |
| yes | `true` | `true` | `false` (strict SSO-only wins) |

Full workspace lib suite: 13720 passed / 0 failed / 6 skipped (nextest, DB-backed). `cargo fmt --check`, `cargo clippy --workspace -- -D warnings` clean. `test_openapi_spec_is_valid` passes.

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

No new endpoint; one additive field on the existing `AuthConfig` schema (`ToSchema` derived, docs included). No migration.

Closes #2621
