### PR TITLE
fix(proxy): record generic-path proxy downloads and surface proxy counts in analytics

### DIFF
--- a/backend/src/api/handlers/general.rs
+++ b/backend/src/api/handlers/general.rs
@@ -14,3 +14,95 @@ use crate::api::SharedState;
 pub fn router() -> Router<SharedState> {
     Router::new().route("/:repo_key/*path", axum::routing::get(download_artifact))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::api::handlers::test_db_helpers as tdh;
+
+    /// #2705: a proxy download through the generic `/general/{key}/*path`
+    /// route must be recorded in `proxy_download_statistics`, with the same
+    /// semantics as the format-specific proxy paths (first serve counts,
+    /// counting continues on cache hits, HEAD never counts).
+    ///
+    /// Pre-fix, `repositories::download_artifact`'s Remote fallback streamed
+    /// the proxy body but never called `record_proxy_download`, so generic
+    /// remote downloads were invisible to proxy download counting (count
+    /// stayed 0 here). Skips cleanly when DATABASE_URL is unset.
+    #[tokio::test]
+    async fn test_general_remote_proxy_download_is_counted_2705() {
+        use crate::services::proxy_catalog::download_count_by_repo;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "generic").await else {
+            return;
+        };
+        let server = MockServer::start().await;
+        let blob: &[u8] = b"#2705 generic proxy serve marker bytes";
+        Mock::given(method("GET"))
+            .and(path("/files/obj.bin"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(blob))
+            .mount(&server)
+            .await;
+
+        let (state, _cache) = tdh::rewire_remote_proxy(&fx, &server.uri()).await;
+        let auth = tdh::make_auth(fx.user_id, &fx.username);
+        let uri = format!("/{}/files/obj.bin", fx.repo_key);
+
+        // First (cold) serve: 200 + upstream bytes, and the serve is counted.
+        let app = tdh::router_with_auth(super::router(), state.clone(), auth.clone());
+        let (status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+
+        let teardown = || async { fx.teardown().await };
+        if status != axum::http::StatusCode::OK {
+            teardown().await;
+            panic!("expected 200 from generic remote proxy download, got {status}");
+        }
+        if &body[..] != blob {
+            teardown().await;
+            panic!("streamed body must equal upstream bytes");
+        }
+        let first = download_count_by_repo(&fx.pool, fx.repo_id)
+            .await
+            .expect("count query");
+        if first != 1 {
+            teardown().await;
+            panic!(
+                "#2705: first generic proxy serve must record exactly one \
+                 proxy_download_statistics row, got {first} (0 = the pre-fix \
+                 /general/ path never called record_proxy_download)"
+            );
+        }
+
+        // Second serve (cache hit or refetch — either way a real serve):
+        // counting continues, matching the format handlers' semantics.
+        let app = tdh::router_with_auth(super::router(), state.clone(), auth.clone());
+        let (status2, _) = tdh::send(app, tdh::get(uri.clone())).await;
+        let second = download_count_by_repo(&fx.pool, fx.repo_id)
+            .await
+            .expect("count query");
+        if status2 != axum::http::StatusCode::OK || second != 2 {
+            teardown().await;
+            panic!(
+                "second generic proxy serve must count (status {status2}, count {second}, want 200/2)"
+            );
+        }
+
+        // HEAD guard: a HEAD probe serves no bytes and must not count.
+        let app = tdh::router_with_auth(super::router(), state.clone(), auth);
+        let head_req = axum::http::Request::builder()
+            .method(axum::http::Method::HEAD)
+            .uri(uri)
+            .body(axum::body::Body::empty())
+            .expect("build HEAD request");
+        let _ = tdh::send(app, head_req).await;
+        let after_head = download_count_by_repo(&fx.pool, fx.repo_id)
+            .await
+            .expect("count query");
+        teardown().await;
+        assert_eq!(
+            after_head, 2,
+            "HEAD must not increment the proxy download count (is_head guard)"
+        );
+    }
+}

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -6490,7 +6490,7 @@ pub async fn download_artifact(
                 let fetch_path = routing_rules::apply_routing_rules(&path, &rules)
                     .unwrap_or_else(|| path.clone());
 
-                Ok(proxy_helpers::proxy_fetch_streaming(
+                match proxy_helpers::proxy_fetch_streaming(
                     proxy,
                     repo.id,
                     &key,
@@ -6499,8 +6499,29 @@ pub async fn download_artifact(
                     "application/octet-stream",
                 )
                 .await
-                .unwrap_or_else(|e| e)
-                .into_response())
+                {
+                    Ok(response) => {
+                        // #2705: count the proxy serve exactly like the format
+                        // handlers' remote arm (`try_remote_or_virtual_download`)
+                        // does. A proxy-cached object has no `artifacts` row
+                        // (#1280), so `download_stream`'s recorder can never fire
+                        // for this branch — without this call, downloads through
+                        // the generic `/general/` path were invisible to proxy
+                        // download counting. Keyed on `fetch_path` (the cache
+                        // path the streaming tee commits). HEAD-guarded +
+                        // best-effort inside.
+                        proxy_helpers::record_proxy_download(
+                            &state,
+                            repo.id,
+                            &key,
+                            &fetch_path,
+                            &dl_ctx,
+                        )
+                        .await;
+                        Ok(response.into_response())
+                    }
+                    Err(e) => Ok(e.into_response()),
+                }
             } else {
                 Err(AppError::NotFound("Artifact not found".to_string()))
             }

--- a/backend/src/services/analytics_service.rs
+++ b/backend/src/services/analytics_service.rs
@@ -49,6 +49,14 @@ pub struct RepositoryStorageBreakdown {
     pub artifact_count: i64,
     pub storage_bytes: i64,
     pub download_count: i64,
+    /// Downloads served by this repository's remote pull-through proxy
+    /// (`proxy_download_statistics`, #2537/#2704). Proxy-cached objects carry
+    /// no `artifacts` row (#1280), so these serves are counted in a sibling
+    /// table and were previously not readable through any API. Kept separate
+    /// from `download_count` (hosted serves) so existing consumers are
+    /// unaffected; defaults to 0 when deserializing older payloads.
+    #[serde(default)]
+    pub proxy_download_count: i64,
     pub last_upload_at: Option<DateTime<Utc>>,
 }
 
@@ -86,6 +94,12 @@ pub struct GrowthSummary {
 pub struct DownloadTrend {
     pub date: NaiveDate,
     pub download_count: i64,
+    /// Proxy-served (pull-through) downloads for the day, from the sibling
+    /// `proxy_download_statistics` table (#2537/#2704). Additive: hosted
+    /// serves stay in `download_count` unchanged; defaults to 0 when
+    /// deserializing older payloads.
+    #[serde(default)]
+    pub proxy_download_count: i64,
 }
 
 impl AnalyticsService {
@@ -245,6 +259,9 @@ impl AnalyticsService {
                 (SELECT COUNT(*) FROM download_statistics ds
                  JOIN artifacts a2 ON a2.id = ds.artifact_id
                  WHERE a2.repository_id = r.id)::BIGINT as download_count,
+                (SELECT COUNT(*) FROM proxy_download_statistics pds
+                 JOIN proxy_cache_artifacts pca ON pca.id = pds.proxy_cache_id
+                 WHERE pca.repository_id = r.id)::BIGINT as proxy_download_count,
                 MAX(a.created_at) as last_upload_at
             FROM repositories r
             LEFT JOIN artifacts a ON a.repository_id = r.id AND a.is_deleted = false
@@ -379,6 +396,12 @@ impl AnalyticsService {
     }
 
     /// Get download trends (daily counts) for a date range.
+    ///
+    /// Hosted serves (`download_statistics`) and proxy pull-through serves
+    /// (`proxy_download_statistics`, #2537/#2704) are UNIONed by day — the
+    /// union `proxy_catalog::download_count_by_repo`'s docs anticipated —
+    /// and reported as separate fields so existing consumers of
+    /// `download_count` see unchanged values.
     pub async fn get_download_trends(
         &self,
         from: NaiveDate,
@@ -387,12 +410,20 @@ impl AnalyticsService {
         let trends = sqlx::query_as::<_, DownloadTrend>(
             r#"
             SELECT
-                downloaded_at::DATE as date,
-                COUNT(*) as download_count
-            FROM download_statistics
-            WHERE downloaded_at::DATE BETWEEN $1 AND $2
-            GROUP BY downloaded_at::DATE
-            ORDER BY downloaded_at::DATE ASC
+                u.date as date,
+                COALESCE(SUM(u.hosted), 0)::BIGINT as download_count,
+                COALESCE(SUM(u.proxied), 0)::BIGINT as proxy_download_count
+            FROM (
+                SELECT downloaded_at::DATE as date, 1 as hosted, 0 as proxied
+                FROM download_statistics
+                WHERE downloaded_at::DATE BETWEEN $1 AND $2
+                UNION ALL
+                SELECT downloaded_at::DATE as date, 0 as hosted, 1 as proxied
+                FROM proxy_download_statistics
+                WHERE downloaded_at::DATE BETWEEN $1 AND $2
+            ) u
+            GROUP BY u.date
+            ORDER BY u.date ASC
             "#,
         )
         .bind(from)
@@ -536,12 +567,17 @@ mod tests {
             artifact_count: 200,
             storage_bytes: 2_147_483_648,
             download_count: 10000,
+            proxy_download_count: 7,
             last_upload_at: Some(Utc::now()),
         };
         let json = serde_json::to_value(&breakdown).unwrap();
         assert_eq!(json["repository_key"], "maven-central");
         assert_eq!(json["format"], "maven");
         assert_eq!(json["artifact_count"], 200);
+        // #2704: the proxy serve count is an ADDITIVE sibling field; hosted
+        // `download_count` is unchanged.
+        assert_eq!(json["proxy_download_count"], 7);
+        assert_eq!(json["download_count"], 10000);
     }
 
     #[test]
@@ -554,6 +590,7 @@ mod tests {
             artifact_count: 0,
             storage_bytes: 0,
             download_count: 0,
+            proxy_download_count: 0,
             last_upload_at: None,
         };
         let json = serde_json::to_value(&breakdown).unwrap();
@@ -717,10 +754,13 @@ mod tests {
         let trend = DownloadTrend {
             date: NaiveDate::from_ymd_opt(2024, 6, 15).unwrap(),
             download_count: 42,
+            proxy_download_count: 3,
         };
         let json = serde_json::to_value(&trend).unwrap();
         assert_eq!(json["date"], "2024-06-15");
         assert_eq!(json["download_count"], 42);
+        // #2704: proxy serves surface as a separate additive field.
+        assert_eq!(json["proxy_download_count"], 3);
     }
 
     #[test]
@@ -729,5 +769,94 @@ mod tests {
         let trend: DownloadTrend = serde_json::from_str(json).unwrap();
         assert_eq!(trend.date, NaiveDate::from_ymd_opt(2024, 6, 15).unwrap());
         assert_eq!(trend.download_count, 100);
+        // Additive-compat: an older payload without the field defaults to 0.
+        assert_eq!(trend.proxy_download_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // #2704: proxy downloads are readable through the analytics read APIs
+    // (DB-backed; skips cleanly when DATABASE_URL is unset)
+    // -----------------------------------------------------------------------
+
+    /// A recorded proxy serve must be visible via BOTH analytics read
+    /// surfaces: the per-repo `storage/breakdown` `proxy_download_count`
+    /// (exactly 1 for a fresh repo) and the `downloads/trend` daily point.
+    /// Pre-#2704 neither field existed — `proxy_download_statistics` had no
+    /// HTTP-readable surface at all.
+    #[tokio::test]
+    async fn test_analytics_reads_surface_proxy_download_count_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, repo_key, _dir) = tdh::create_repo(&pool, "remote", "generic").await;
+
+        // Record one proxy serve through the canonical recorder (the same
+        // helper the serve paths call), which also ensures the catalog row.
+        crate::services::proxy_catalog::record_proxy_download(
+            &pool,
+            repo_id,
+            "files/obj.bin",
+            "proxy-cache/k/files/obj.bin/__content__",
+            "proxy-cache/k/files/obj.bin/__meta__",
+            None,
+            None,
+            Some("analytics-test"),
+        )
+        .await
+        .expect("record proxy download");
+
+        let service = AnalyticsService::new(pool.clone());
+
+        // Per-repo surface: the fresh repo reports exactly the one proxy
+        // serve, with zero hosted downloads.
+        let breakdown = service
+            .get_storage_breakdown()
+            .await
+            .expect("storage breakdown");
+        let row = breakdown
+            .iter()
+            .find(|b| b.repository_id == repo_id)
+            .expect("fresh repo present in breakdown");
+        let (proxy_count, hosted_count, row_key) = (
+            row.proxy_download_count,
+            row.download_count,
+            row.repository_key.clone(),
+        );
+
+        // Instance trend surface: today's point includes the proxy serve.
+        // (Shared test DB: other tests may add rows concurrently, so assert
+        // presence via >= 1, not an exact count.)
+        let today = chrono::Utc::now().date_naive();
+        let trends = service
+            .get_download_trends(today, today)
+            .await
+            .expect("download trends");
+        let today_proxy = trends
+            .iter()
+            .find(|t| t.date == today)
+            .map(|t| t.proxy_download_count)
+            .unwrap_or(0);
+
+        // Cleanup BEFORE asserting so a failure still leaves the DB clean
+        // (repo delete cascades the catalog + proxy stat rows).
+        let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await;
+
+        assert_eq!(row_key, repo_key);
+        assert_eq!(
+            proxy_count, 1,
+            "per-repo breakdown must surface the recorded proxy serve (#2704)"
+        );
+        assert_eq!(
+            hosted_count, 0,
+            "hosted download_count must be unchanged by proxy serves"
+        );
+        assert!(
+            today_proxy >= 1,
+            "downloads/trend must include today's proxy serve in proxy_download_count (#2704), got {today_proxy}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the proxy download-count pair #2704 / #2705, which together made proxy pull-through serve counting partially blind:

- **#2705 — generic `/general/` proxy path does not record proxy downloads.** The generic download handler (`repositories::download_artifact`, mounted at `/general/{key}/*path`) streamed the remote body via `proxy_helpers::proxy_fetch_streaming` but never called `record_proxy_download`, unlike every format handler's remote arm (`try_remote_or_virtual_download`) and the pypi serve paths. A proxy-cached object has no `artifacts` row (#1280), so no other recorder could fire either: generic remote serves were counted nowhere. The remote fallback now records the serve on success, keyed on the fetch path the cache tee commits, with the same HEAD-guard + best-effort semantics as the format paths.

- **#2704 — proxy first-serve download count is recorded but not readable via the API.** `proxy_download_statistics` (written since #2537 for every proxy serve, first serve included) had no HTTP surface: `admin/downloads`, `analytics/downloads/trend`, and the artifact stats endpoints all read only the hosted `download_statistics` table, and the sole reader (`proxy_catalog::download_count_by_repo`) was not wired to any route. This PR surfaces the recorded counts through the analytics read APIs, additively:
  - `GET /api/v1/admin/analytics/storage/breakdown`: each repository row gains `proxy_download_count` (hosted `download_count` unchanged).
  - `GET /api/v1/admin/analytics/downloads/trend`: each daily point gains `proxy_download_count`, via the hosted/proxy UNION the `download_count_by_repo` docs already anticipated.

Both new JSON fields are additive with `#[serde(default)]`; existing consumers and older payloads are unaffected. No migration; no new sqlx macros (runtime `query_as` only), so the offline build is unchanged.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Details:
- `api::handlers::general::tests::test_general_remote_proxy_download_is_counted_2705` drives the real `/general/{key}/*path` router against a wiremock upstream: first cold serve must record exactly one `proxy_download_statistics` row (fails on `main` with count 0), second serve counts (2), HEAD does not increment. DB-backed; skips cleanly without `DATABASE_URL`.
- `services::analytics_service::tests::test_analytics_reads_surface_proxy_download_count_db` records one proxy serve through the canonical recorder and asserts it is readable via both `get_storage_breakdown` (per-repo `proxy_download_count == 1`, hosted count unchanged at 0) and `get_download_trends` (today's `proxy_download_count >= 1`). Does not compile on `main` (the fields did not exist).
- Additive-compat serialization tests: `proxy_download_count` present in the JSON of both response types and defaults to 0 when deserializing older payloads.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (`cargo nextest run --workspace --lib`: 13717 passed, 6 skipped; fmt + clippy `-D warnings` clean)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations (no new endpoints; existing annotated endpoints gain fields)
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Closes #2704
Closes #2705
