### PR TITLE
fix(migration): populate the packages catalog for imported artifacts

### DIFF
--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -6932,6 +6932,33 @@ pub(crate) fn oci_reference_is_tag(reference: &str) -> bool {
     !reference.contains(':')
 }
 
+/// Total image size derived from a manifest body: `config.size` plus the sum
+/// of `layers[].size`, falling back to the body length when the body is not
+/// JSON. Shared by the live manifest-PUT path and the migration importer
+/// (#2676) so both size the artifact/catalog rows identically.
+pub(crate) fn manifest_total_size(body: &[u8]) -> i64 {
+    if let Ok(manifest_json) = serde_json::from_slice::<serde_json::Value>(body) {
+        let config_size = manifest_json
+            .get("config")
+            .and_then(|c| c.get("size"))
+            .and_then(|s| s.as_i64())
+            .unwrap_or(0);
+        let layers_size: i64 = manifest_json
+            .get("layers")
+            .and_then(|l| l.as_array())
+            .map(|layers| {
+                layers
+                    .iter()
+                    .filter_map(|l| l.get("size").and_then(|s| s.as_i64()))
+                    .sum()
+            })
+            .unwrap_or(0);
+        config_size + layers_size
+    } else {
+        body.len() as i64
+    }
+}
+
 /// Sum of the artifact sizes recorded for an index manifest's child
 /// manifests, used to size the packages-catalog row for a multi-arch tag.
 ///
@@ -6941,7 +6968,11 @@ pub(crate) fn oci_reference_is_tag(reference: &str) -> bool {
 /// so their `artifacts` rows exist by the time the index is tagged). Same
 /// join the `docker_tag` grouping endpoint uses (`fetch_index_child_sizes`
 /// in repositories.rs). Best-effort: sizing must not fail the push.
-async fn index_child_artifact_size_sum(db: &PgPool, repo_id: Uuid, parent_digest: &str) -> i64 {
+pub(crate) async fn index_child_artifact_size_sum(
+    db: &PgPool,
+    repo_id: Uuid,
+    parent_digest: &str,
+) -> i64 {
     sqlx::query_scalar::<_, i64>(
         r#"SELECT COALESCE(SUM(a.size_bytes), 0)::BIGINT
            FROM oci_manifest_refs r
@@ -7107,27 +7138,7 @@ async fn handle_put_manifest(
     }
 
     // Calculate total image size from manifest (config + layers)
-    let total_size: i64 =
-        if let Ok(manifest_json) = serde_json::from_slice::<serde_json::Value>(&body) {
-            let config_size = manifest_json
-                .get("config")
-                .and_then(|c| c.get("size"))
-                .and_then(|s| s.as_i64())
-                .unwrap_or(0);
-            let layers_size: i64 = manifest_json
-                .get("layers")
-                .and_then(|l| l.as_array())
-                .map(|layers| {
-                    layers
-                        .iter()
-                        .filter_map(|l| l.get("size").and_then(|s| s.as_i64()))
-                        .sum()
-                })
-                .unwrap_or(0);
-            config_size + layers_size
-        } else {
-            body.len() as i64
-        };
+    let total_size: i64 = manifest_total_size(&body);
 
     // Also create an artifact record so it appears in the UI
     let artifact_path = format!("v2/{}/manifests/{}", image, reference);

--- a/backend/src/services/artifact_metadata.rs
+++ b/backend/src/services/artifact_metadata.rs
@@ -42,6 +42,7 @@ pub fn parse_name_and_version(
         "helm" | "helm_oci" => parse_helm(filename),
         "npm" | "yarn" | "pnpm" | "bower" => parse_npm(filename, artifact_path),
         "maven" | "gradle" | "sbt" | "ivy" => parse_maven(filename, artifact_path),
+        "nuget" => parse_nuget(filename, artifact_path),
         _ => fallback(filename),
     }
 }
@@ -287,6 +288,52 @@ fn parse_maven(filename: &str, artifact_path: &str) -> ParsedArtifact {
         };
     }
     fallback(filename)
+}
+
+// ---------------------------------------------------------------------------
+// NuGet
+// ---------------------------------------------------------------------------
+
+/// NuGet parser (#2676). Packages are `<id>.<version>.nupkg` where `<id>`
+/// itself contains dots (`Newtonsoft.Json.13.0.3.nupkg`), so the split point
+/// is the first dot whose right-hand side is a valid NuGet version
+/// (2–4 numeric dot-segments plus an optional `-prerelease` suffix) — the
+/// same heuristic the NuGet client uses for folder layouts. Scanning
+/// left-to-right keeps ids with embedded numeric segments intact
+/// (`MyLib.2.Core.1.0.0` → `MyLib.2.Core` @ `1.0.0`, because `2.Core.1.0.0`
+/// is not a valid version). Falls back to the JFrog/Nexus
+/// `<id>/<version>/<filename>` path layout, then to the legacy
+/// filename-as-name behaviour.
+fn parse_nuget(filename: &str, artifact_path: &str) -> ParsedArtifact {
+    if let Some(stem) = filename
+        .strip_suffix(".nupkg")
+        .or_else(|| filename.strip_suffix(".snupkg"))
+    {
+        for (i, _) in stem.match_indices('.') {
+            let (name, rest) = (&stem[..i], &stem[i + 1..]);
+            if !name.is_empty() && is_nuget_version(rest) {
+                return ParsedArtifact {
+                    name: name.to_string(),
+                    version: Some(rest.to_string()),
+                };
+            }
+        }
+    }
+    parse_from_path_segments(artifact_path).unwrap_or_else(|| fallback(filename))
+}
+
+/// True when `s` is a NuGet-shaped version: 2–4 dot-separated numeric parts
+/// with an optional `-<prerelease>` suffix (`1.0.0`, `13.0.3-beta.1`,
+/// `4.7.0.5`). A single bare integer is rejected — package-id segments are
+/// frequently numeric (`MyLib.2`), and NuGet versions always carry at least
+/// `major.minor`.
+fn is_nuget_version(s: &str) -> bool {
+    let core = s.split_once('-').map_or(s, |(core, _pre)| core);
+    let parts: Vec<&str> = core.split('.').collect();
+    (2..=4).contains(&parts.len())
+        && parts
+            .iter()
+            .all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
 }
 
 // ---------------------------------------------------------------------------
@@ -566,5 +613,99 @@ mod tests {
         let garbage = b"not a tarball";
         assert!(extract_artifact_metadata("npm", garbage).is_none());
         assert!(extract_artifact_metadata("helm", garbage).is_none());
+    }
+
+    // -----------------------------------------------------------------
+    // NuGet (#2676)
+    // -----------------------------------------------------------------
+
+    #[test]
+    fn nuget_simple_id() {
+        let p = parse_name_and_version("nuget", "MyPackage.1.0.0.nupkg", "MyPackage.1.0.0.nupkg");
+        assert_eq!(p.name, "MyPackage");
+        assert_eq!(p.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn nuget_dotted_id() {
+        let p = parse_name_and_version(
+            "nuget",
+            "Newtonsoft.Json.13.0.3.nupkg",
+            "Newtonsoft.Json/13.0.3/Newtonsoft.Json.13.0.3.nupkg",
+        );
+        assert_eq!(p.name, "Newtonsoft.Json");
+        assert_eq!(p.version.as_deref(), Some("13.0.3"));
+    }
+
+    #[test]
+    fn nuget_id_with_numeric_segment() {
+        // `2.Core.1.0.0` is not a valid version, so the split lands after
+        // the embedded numeric id segment, not at it.
+        let p = parse_name_and_version(
+            "nuget",
+            "MyLib.2.Core.1.0.0.nupkg",
+            "MyLib.2.Core.1.0.0.nupkg",
+        );
+        assert_eq!(p.name, "MyLib.2.Core");
+        assert_eq!(p.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn nuget_prerelease_version() {
+        let p = parse_name_and_version(
+            "nuget",
+            "MyPackage.1.0.0-beta.1.nupkg",
+            "MyPackage.1.0.0-beta.1.nupkg",
+        );
+        assert_eq!(p.name, "MyPackage");
+        assert_eq!(p.version.as_deref(), Some("1.0.0-beta.1"));
+    }
+
+    #[test]
+    fn nuget_four_part_version() {
+        let p = parse_name_and_version(
+            "nuget",
+            "Legacy.Pkg.4.7.0.5.nupkg",
+            "Legacy.Pkg.4.7.0.5.nupkg",
+        );
+        assert_eq!(p.name, "Legacy.Pkg");
+        assert_eq!(p.version.as_deref(), Some("4.7.0.5"));
+    }
+
+    #[test]
+    fn nuget_unparseable_filename_falls_back_to_path_segments() {
+        let p = parse_name_and_version("nuget", "weird.nupkg", "MyPackage/1.0.0/weird.nupkg");
+        assert_eq!(p.name, "MyPackage");
+        assert_eq!(p.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn nuget_unparseable_everything_falls_back_to_filename() {
+        let p = parse_name_and_version("nuget", "weird.bin", "weird.bin");
+        assert_eq!(p.name, "weird.bin");
+        assert_eq!(p.version, None);
+    }
+
+    #[test]
+    fn nuget_symbols_package() {
+        let p = parse_name_and_version(
+            "nuget",
+            "MyPackage.1.0.0.snupkg",
+            "MyPackage/1.0.0/MyPackage.1.0.0.snupkg",
+        );
+        assert_eq!(p.name, "MyPackage");
+        assert_eq!(p.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn is_nuget_version_shapes() {
+        assert!(is_nuget_version("1.0"));
+        assert!(is_nuget_version("1.0.0"));
+        assert!(is_nuget_version("4.7.0.5"));
+        assert!(is_nuget_version("13.0.3-beta.1"));
+        assert!(!is_nuget_version("2")); // bare integer = id segment, not version
+        assert!(!is_nuget_version("2.Core.1.0.0"));
+        assert!(!is_nuget_version("1.0.0.0.0"));
+        assert!(!is_nuget_version(""));
     }
 }

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -1479,6 +1479,59 @@ impl MigrationWorker {
                 }
 
                 tx.commit().await?;
+
+                // #2676: surface the migrated artifact in the packages
+                // catalog. The web UI's Packages tab reads `packages` /
+                // `package_versions` (via /api/v1/packages), NOT `artifacts`
+                // — every live publish path (nuget, npm, pypi, helm proxy,
+                // the OCI manifest-PUT, the generic upload path) populates
+                // the catalog after its artifact insert, but the import
+                // path only wrote `artifacts` (+ the OCI index tables), so
+                // a migrated repository showed artifacts under an empty
+                // Packages tab. Reuse the exact shared UPSERT path the live
+                // handlers call: it is idempotent (re-running a migration
+                // re-upserts the same rows instead of duplicating them) and
+                // best-effort by contract (a catalog failure must not fail
+                // an item whose content already committed — the wrapper
+                // logs and swallows, mirroring the live paths).
+                if let Some(entry) = migration_catalog_entry(package_type, &oci_role, &parsed) {
+                    let size_bytes = match (&oci_role, &oci_manifest_body) {
+                        // Docker: size the catalog row like the live push —
+                        // config+layers for an image manifest, plus the sum
+                        // of already-imported child manifest sizes for a
+                        // multi-arch index (whose own body carries no
+                        // layers).
+                        (OciRole::Manifest { .. }, Some(body)) => {
+                            let base = crate::api::handlers::oci_v2::manifest_total_size(body);
+                            let child_sum = if matches!(
+                                oci_manifest_class,
+                                Some(crate::api::handlers::oci_v2::ManifestClass::Index)
+                            ) {
+                                crate::api::handlers::oci_v2::index_child_artifact_size_sum(
+                                    &self.db,
+                                    repository_id,
+                                    &computed_digest,
+                                )
+                                .await
+                            } else {
+                                0
+                            };
+                            base.saturating_add(child_sum)
+                        }
+                        _ => content_size as i64,
+                    };
+                    crate::services::package_service::PackageService::new(self.db.clone())
+                        .try_create_or_update_from_artifact(
+                            repository_id,
+                            &entry.name,
+                            &entry.version,
+                            size_bytes,
+                            &sha256_hex,
+                            None,
+                            Some(serde_json::json!({ "format": entry.format })),
+                        )
+                        .await;
+                }
             }
         }
 
@@ -2186,6 +2239,62 @@ fn migration_artifact_path(
             Some(ver) if !ver.is_empty() => format!("{}/{}/{}", parsed_name, ver, filename),
             _ => format!("{}/{}", repo_key, artifact_path),
         },
+    }
+}
+
+/// The `packages`-catalog identity of a migrated artifact, or `None` when
+/// the artifact must not produce a catalog row (#2676).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CatalogEntry {
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) format: String,
+}
+
+/// Decide whether a migrated artifact gets a `packages`/`package_versions`
+/// row and under what identity, mirroring the live publish paths (#2676):
+///
+/// - Docker/OCI: only tag manifests are user-facing versions — the catalog
+///   row is `<image>@<tag>`, exactly like the live manifest-PUT handler.
+///   Digest-addressed child manifests and layer/config blobs are skipped
+///   (mirrors the live path's `oci_reference_is_tag` filter).
+/// - Maven family: skipped. Live maven catalog names are
+///   `groupId:artifactId` and `parse_name_and_version` recovers only the
+///   artifactId, so writing rows here would diverge from the shape the
+///   repository components view expects (follow-up, not in #2676's scope).
+/// - Everything else (helm, nuget, npm, pypi, generic, ...): a row is
+///   written whenever the importer recovered a version, under the same
+///   `(name, version)` the artifact row itself carries.
+pub(crate) fn migration_catalog_entry(
+    package_type: &str,
+    oci_role: &OciRole,
+    parsed: &crate::services::artifact_metadata::ParsedArtifact,
+) -> Option<CatalogEntry> {
+    match oci_role {
+        OciRole::Blob { .. } => None,
+        OciRole::Manifest { image, reference } => {
+            if crate::api::handlers::oci_v2::oci_reference_is_tag(reference) {
+                Some(CatalogEntry {
+                    name: image.clone(),
+                    version: reference.clone(),
+                    format: "docker".to_string(),
+                })
+            } else {
+                None
+            }
+        }
+        OciRole::NotOci => {
+            let pt = package_type.to_lowercase();
+            if matches!(pt.as_str(), "maven" | "gradle" | "sbt" | "ivy") {
+                return None;
+            }
+            let version = parsed.version.clone()?;
+            Some(CatalogEntry {
+                name: parsed.name.clone(),
+                version,
+                format: pt,
+            })
+        }
     }
 }
 
@@ -4939,6 +5048,22 @@ mod tests {
         hex::encode(hasher.finalize())
     }
 
+    /// Build a Docker schema2 image-manifest body over the given config and
+    /// layer bytes. Shared by the import tests so the JSON scaffolding lives
+    /// in one place.
+    fn docker_image_manifest_json(config_bytes: &[u8], layer_bytes: &[u8]) -> String {
+        format!(
+            "{{\"schemaVersion\":2,\
+              \"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\
+              \"config\":{{\"mediaType\":\"application/vnd.docker.container.image.v1+json\",\"size\":{},\"digest\":\"sha256:{}\"}},\
+              \"layers\":[{{\"mediaType\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\",\"size\":{},\"digest\":\"sha256:{}\"}}]}}",
+            config_bytes.len(),
+            sha256_hex_of(config_bytes),
+            layer_bytes.len(),
+            sha256_hex_of(layer_bytes)
+        )
+    }
+
     /// Build a worker + filesystem storage rooted in a fresh temp dir and a
     /// repository row pointing at it. Returns everything a #2457 import test
     /// needs.
@@ -5028,16 +5153,7 @@ mod tests {
         let layer_bytes = bytes::Bytes::from_static(b"layer-bytes-2457");
         let config_hex = sha256_hex_of(&config_bytes);
         let layer_hex = sha256_hex_of(&layer_bytes);
-        let manifest = format!(
-            "{{\"schemaVersion\":2,\
-              \"mediaType\":\"application/vnd.docker.distribution.manifest.v2+json\",\
-              \"config\":{{\"mediaType\":\"application/vnd.docker.container.image.v1+json\",\"size\":{},\"digest\":\"sha256:{}\"}},\
-              \"layers\":[{{\"mediaType\":\"application/vnd.docker.image.rootfs.diff.tar.gzip\",\"size\":{},\"digest\":\"sha256:{}\"}}]}}",
-            config_bytes.len(),
-            config_hex,
-            layer_bytes.len(),
-            layer_hex
-        );
+        let manifest = docker_image_manifest_json(&config_bytes, &layer_bytes);
         let manifest_bytes = bytes::Bytes::from(manifest);
         let manifest_digest = format!("sha256:{}", sha256_hex_of(&manifest_bytes));
 
@@ -5625,5 +5741,284 @@ mod tests {
             .execute(&pool)
             .await
             .expect("cleanup repo");
+    }
+
+    // -----------------------------------------------------------------------
+    // #2676: packages-catalog population (decision logic, pure, no DB)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_catalog_entry_docker_tag_manifest() {
+        let parsed = crate::services::artifact_metadata::ParsedArtifact {
+            name: "manifest.json".to_string(),
+            version: None,
+        };
+        let entry = migration_catalog_entry(
+            "docker",
+            &OciRole::Manifest {
+                image: "org/app".to_string(),
+                reference: "v1.2".to_string(),
+            },
+            &parsed,
+        )
+        .expect("tag manifest must produce a catalog entry");
+        assert_eq!(entry.name, "org/app");
+        assert_eq!(entry.version, "v1.2");
+        assert_eq!(entry.format, "docker");
+    }
+
+    #[test]
+    fn test_catalog_entry_skips_digest_manifests_and_blobs() {
+        let parsed = crate::services::artifact_metadata::ParsedArtifact {
+            name: "manifest.json".to_string(),
+            version: None,
+        };
+        // A digest-addressed child manifest is not a user-facing version
+        // (mirrors the live push path's tag-only filter).
+        assert_eq!(
+            migration_catalog_entry(
+                "docker",
+                &OciRole::Manifest {
+                    image: "app".to_string(),
+                    reference: format!("sha256:{}", "a".repeat(64)),
+                },
+                &parsed,
+            ),
+            None
+        );
+        // Layer/config blobs never surface in the catalog.
+        assert_eq!(
+            migration_catalog_entry(
+                "docker",
+                &OciRole::Blob {
+                    digest: format!("sha256:{}", "b".repeat(64)),
+                },
+                &parsed,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn test_catalog_entry_non_oci_formats() {
+        let parsed = crate::services::artifact_metadata::ParsedArtifact {
+            name: "MyPackage".to_string(),
+            version: Some("1.0.0".to_string()),
+        };
+        // Version recovered => catalog row under the parsed identity, with
+        // the format key lowercased.
+        let entry = migration_catalog_entry("NuGet", &OciRole::NotOci, &parsed)
+            .expect("versioned non-OCI artifact must produce a catalog entry");
+        assert_eq!(entry.name, "MyPackage");
+        assert_eq!(entry.version, "1.0.0");
+        assert_eq!(entry.format, "nuget");
+
+        // No version => no catalog row (`packages.version` is NOT NULL and a
+        // version-less blob is not a package release).
+        let unversioned = crate::services::artifact_metadata::ParsedArtifact {
+            name: "blob.bin".to_string(),
+            version: None,
+        };
+        assert_eq!(
+            migration_catalog_entry("generic", &OciRole::NotOci, &unversioned),
+            None
+        );
+
+        // Maven-family catalog names are `groupId:artifactId`; the parser
+        // only recovers the artifactId, so no row is written (follow-up).
+        assert_eq!(
+            migration_catalog_entry("maven", &OciRole::NotOci, &parsed),
+            None
+        );
+        assert_eq!(
+            migration_catalog_entry("gradle", &OciRole::NotOci, &parsed),
+            None
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // #2676: packages-catalog population on import (DB-gated via try_pool)
+    // -----------------------------------------------------------------------
+
+    /// Count the catalog rows for a repository:
+    /// `(packages rows, package_versions rows)`.
+    async fn catalog_counts(pool: &sqlx::PgPool, repo_id: Uuid) -> (i64, i64) {
+        sqlx::query_as(
+            "SELECT (SELECT COUNT(*) FROM packages WHERE repository_id = $1), \
+                    (SELECT COUNT(*) FROM package_versions pv \
+                     JOIN packages p ON p.id = pv.package_id \
+                     WHERE p.repository_id = $1)",
+        )
+        .bind(repo_id)
+        .fetch_one(pool)
+        .await
+        .expect("count catalog rows")
+    }
+
+    /// The single `(name, version)` catalog row for a repository, if any.
+    async fn single_catalog_row(pool: &sqlx::PgPool, repo_id: Uuid) -> Option<(String, String)> {
+        sqlx::query_as(
+            "SELECT p.name, pv.version FROM packages p \
+             JOIN package_versions pv ON pv.package_id = p.id \
+             WHERE p.repository_id = $1",
+        )
+        .bind(repo_id)
+        .fetch_optional(pool)
+        .await
+        .expect("query catalog")
+    }
+
+    /// Delete the test repository row (cascades to artifacts + catalog rows).
+    async fn cleanup_repo(pool: &sqlx::PgPool, repo_id: Uuid) {
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(pool)
+            .await
+            .expect("cleanup repo");
+    }
+
+    /// A migrated NuGet package must land in `packages`/`package_versions`
+    /// (the tables the web UI's Packages tab reads) exactly like a live
+    /// `nuget push`, and re-running the migration must not duplicate rows.
+    /// Pre-fix, the import wrote only `artifacts` and the tab stayed empty.
+    #[tokio::test]
+    async fn test_nuget_import_populates_package_catalog() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2676-nuget", "nuget").await;
+
+        let path = "MyPackage/1.0.0/MyPackage.1.0.0.nupkg";
+        let mut files = std::collections::HashMap::new();
+        files.insert(
+            path.to_string(),
+            bytes::Bytes::from_static(b"fake nupkg bytes"),
+        );
+
+        transfer_one(&worker, &storage, &files, &repo_key, "nuget", path)
+            .await
+            .expect("nuget transfer must succeed");
+
+        assert_eq!(
+            single_catalog_row(&pool, repo_id).await,
+            Some(("MyPackage".to_string(), "1.0.0".to_string())),
+            "migrated nuget package must appear in the packages catalog"
+        );
+
+        // Re-import (migration re-run) must be idempotent: same single row.
+        transfer_one(&worker, &storage, &files, &repo_key, "nuget", path)
+            .await
+            .expect("nuget re-import must succeed");
+        assert_eq!(
+            catalog_counts(&pool, repo_id).await,
+            (1, 1),
+            "re-running the migration must not duplicate catalog rows"
+        );
+
+        cleanup_repo(&pool, repo_id).await;
+    }
+
+    /// Same guarantee for Helm: the chart identity parsed from
+    /// `<name>-<version>.tgz` must land in the packages catalog.
+    #[tokio::test]
+    async fn test_helm_import_populates_package_catalog() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2676-helm", "helm").await;
+
+        let path = "mychart-1.2.3.tgz";
+        let mut files = std::collections::HashMap::new();
+        files.insert(
+            path.to_string(),
+            bytes::Bytes::from_static(b"not a real tgz - metadata extraction is best-effort"),
+        );
+
+        transfer_one(&worker, &storage, &files, &repo_key, "helm", path)
+            .await
+            .expect("helm transfer must succeed");
+
+        assert_eq!(
+            single_catalog_row(&pool, repo_id).await,
+            Some(("mychart".to_string(), "1.2.3".to_string())),
+            "migrated helm chart must appear in the packages catalog"
+        );
+
+        cleanup_repo(&pool, repo_id).await;
+    }
+
+    /// Docker: importing a tagged image manifest must create a catalog row
+    /// `<image>@<tag>` sized from the manifest's config+layers (mirroring the
+    /// live manifest-PUT), while the by-digest blobs the walker fetches must
+    /// NOT create rows of their own.
+    #[tokio::test]
+    async fn test_docker_import_populates_package_catalog() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2676-docker", "docker").await;
+
+        let config_bytes = bytes::Bytes::from_static(b"{\"os\":\"linux\"}");
+        let layer_bytes = bytes::Bytes::from_static(b"layer-bytes-2676");
+        let config_hex = sha256_hex_of(&config_bytes);
+        let layer_hex = sha256_hex_of(&layer_bytes);
+        let manifest = docker_image_manifest_json(&config_bytes, &layer_bytes);
+        let manifest_bytes = bytes::Bytes::from(manifest);
+
+        // Nexus layout: only the tag is enumerated; the walker fetches the
+        // config/layer blobs by digest.
+        let manifest_path = "v2/hello/manifests/latest".to_string();
+        let mut files = std::collections::HashMap::new();
+        files.insert(manifest_path.clone(), manifest_bytes.clone());
+        files.insert(
+            format!("v2/hello/blobs/sha256:{config_hex}"),
+            config_bytes.clone(),
+        );
+        files.insert(
+            format!("v2/hello/blobs/sha256:{layer_hex}"),
+            layer_bytes.clone(),
+        );
+
+        transfer_one(
+            &worker,
+            &storage,
+            &files,
+            &repo_key,
+            "docker",
+            &manifest_path,
+        )
+        .await
+        .expect("docker manifest import must succeed");
+
+        let row: Option<(String, String, i64)> = sqlx::query_as(
+            "SELECT p.name, pv.version, pv.size_bytes FROM packages p \
+             JOIN package_versions pv ON pv.package_id = p.id \
+             WHERE p.repository_id = $1",
+        )
+        .bind(repo_id)
+        .fetch_optional(&pool)
+        .await
+        .expect("query catalog");
+        let (name, version, size) =
+            row.expect("migrated docker tag must appear in the packages catalog");
+        assert_eq!(name, "hello");
+        assert_eq!(version, "latest");
+        assert_eq!(
+            size,
+            (config_bytes.len() + layer_bytes.len()) as i64,
+            "catalog size must be config+layers, like the live push path"
+        );
+
+        // Exactly one catalog row: the walked-in blobs and the digest child
+        // content must not surface as packages.
+        assert_eq!(catalog_counts(&pool, repo_id).await, (1, 1));
+
+        cleanup_repo(&pool, repo_id).await;
     }
 }


### PR DESCRIPTION
## Summary

Closes #2676

After a Nexus (or Artifactory) migration, imported artifacts appeared under the repository's Artifacts view but the **Packages tab stayed empty** for docker, helm, nuget (and every other format). The Packages tab is backed by `/api/v1/packages`, which reads the `packages` / `package_versions` catalog tables — every live publish path (nuget push, helm upload, docker manifest PUT, npm/pypi/generic upload) populates that catalog after its artifact insert, but the migration importer (`migration_worker::transfer_artifact`) only wrote `artifacts` (+ the OCI index tables), so migrated repositories never got catalog rows.

Changes:

- **`migration_worker.rs`** — after the import transaction commits, the importer now calls the same shared catalog path the live handlers use (`PackageService::try_create_or_update_from_artifact`, an UPSERT, so re-running a migration is idempotent and never duplicates rows). A new pure decision helper `migration_catalog_entry` mirrors the live paths' rules:
  - Docker/OCI: only **tag** manifests produce a catalog row (`<image>@<tag>`); digest-addressed child manifests and layer/config blobs are skipped, exactly like the live manifest-PUT's `oci_reference_is_tag` filter. The row is sized config+layers (plus imported child sizes for a multi-arch index), matching the live push.
  - Non-OCI formats: a row is written whenever the importer recovered a version, under the same `(name, version)` as the artifact row.
  - Maven family is deliberately skipped: live maven catalog names are `groupId:artifactId` and the migration parser only recovers the artifactId, so writing rows would diverge from the shape the components view expects. Left as a follow-up.
- **`artifact_metadata.rs`** — added a NuGet parser. Previously `parse_name_and_version("nuget", ...)` fell through to the filename-as-name/no-version fallback, so migrated NuGet artifacts could never be cataloged (no version) and were stored under the legacy path shape. The parser splits `<id>.<version>.nupkg` at the first dot whose right side is a valid NuGet version (handles dotted ids, embedded numeric id segments, prerelease and 4-part versions, `.snupkg`), falling back to the `<id>/<version>/<file>` path layout. Migrated NuGet artifacts now also land on the canonical `<id>/<version>/<filename>` path the live nuget endpoints look up.
- **`oci_v2.rs`** — extracted the inline config+layers size computation into `manifest_total_size` and widened `index_child_artifact_size_sum` to `pub(crate)` so the importer sizes docker catalog rows identically to the live push (no logic change on the live path).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

DB-gated regression tests (verified failing with the fix disabled, passing with it):
- `test_nuget_import_populates_package_catalog` — migrated `.nupkg` produces `packages`/`package_versions` rows; re-import stays at exactly one row (idempotency).
- `test_helm_import_populates_package_catalog` — migrated chart tgz produces catalog rows.
- `test_docker_import_populates_package_catalog` — migrated tagged manifest produces one `<image>@<tag>` row sized config+layers; walked-in blobs produce none.

Pure unit tests: `migration_catalog_entry` decision matrix (tag vs digest vs blob, maven skip, version-less skip, format lowercasing) and 9 NuGet filename/path parsing cases.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (full `--workspace --lib` suite green against a migrated Postgres, 13,7xx tests)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Notes / follow-ups
- Maven-family catalog population during migration (needs `groupId:artifactId` recovery from the source path) is intentionally out of scope here.
- Previously-completed migrations don't backfill: re-running the migration on the affected repositories (or re-importing) will upsert the catalog rows without duplicating artifacts within the same job.
