### PR TITLE
fix(rpm): exclude non-.rpm objects from repodata listings

### DIFF
--- a/.sqlx/query-f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f.json
+++ b/.sqlx/query-f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.updated_at, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n        ORDER BY a.name, a.version, a.path, a.id\n        ",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.updated_at, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n          AND a.path LIKE '%.rpm'\n        ORDER BY a.name, a.version, a.path, a.id\n        ",
   "describe": {
     "columns": [
       {
@@ -66,5 +66,5 @@
       false
     ]
   },
-  "hash": "c8bf6d407a918f252604042bc99771308da0a1aabe2a377339c7996d931198f5"
+  "hash": "f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f"
 }

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -306,6 +306,13 @@ struct RpmArtifact {
 /// and the detached signature would not match the served document (#2636).
 /// `(name, version, path)` is the order Debian's package index already uses;
 /// `id` is unique, so appending it makes the order total.
+///
+/// Only actual `.rpm` package objects (including `.src.rpm`) are listed: the
+/// generic chunked upload flow can place arbitrary companions (signature
+/// sidecars, checksum files, `.repo` snippets) in an RPM repository, and
+/// repodata must never describe those as packages (#2590). Delta RPMs
+/// (`.drpm`) are also excluded — they belong in `prestodelta` metadata,
+/// which we do not generate, not in `primary.xml`.
 async fn list_rpm_artifacts(
     db: &sqlx::PgPool,
     repo_id: uuid::Uuid,
@@ -317,6 +324,7 @@ async fn list_rpm_artifacts(
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
         WHERE a.repository_id = $1 AND a.is_deleted = false
+          AND a.path LIKE '%.rpm'
         ORDER BY a.name, a.version, a.path, a.id
         "#,
         repo_id
@@ -2981,6 +2989,95 @@ mod tests {
             .await
             .ok();
         f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #2590: repodata must describe only actual `.rpm` packages. The generic
+    // chunked upload flow can place arbitrary objects (signature sidecars,
+    // checksum files, `.repo` snippets) into an RPM repository; those must
+    // not leak into primary.xml/filelists.xml/other.xml, or dnf/yum trip on
+    // metadata entries that are not packages.
+    // -----------------------------------------------------------------------
+
+    /// Insert an arbitrary (non-`.rpm`) object row into the fixture repo,
+    /// mimicking what the generic upload flow stores.
+    async fn insert_repo_object(f: &tdh::Fixture, path: &str, name: &str) {
+        sqlx::query(
+            r#"
+            INSERT INTO artifacts (
+                repository_id, path, name, size_bytes,
+                checksum_sha256, content_type, storage_key, uploaded_by
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            "#,
+        )
+        .bind(f.repo_id)
+        .bind(path)
+        .bind(name)
+        .bind(64i64)
+        .bind("1111111111111111111111111111111111111111111111111111111111111111")
+        .bind("application/octet-stream")
+        .bind(path)
+        .bind(f.user_id)
+        .execute(&f.pool)
+        .await
+        .expect("insert non-rpm repo object");
+    }
+
+    #[tokio::test]
+    async fn test_rpm_repodata_excludes_non_rpm_objects() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+
+        // Two real packages: a binary RPM and a source RPM (both must stay).
+        insert_rpm_artifact(&f, "realpkg").await;
+        insert_repo_object(&f, "packages/realpkg-1.0-1.src.rpm", "realpkg-src").await;
+        // Non-package companions the generic flow can store (all must go).
+        insert_repo_object(&f, "packages/realpkg-1.0-1.x86_64.rpm.asc", "realpkg-sig").await;
+        insert_repo_object(&f, "realpkg-1.0-1.x86_64.rpm.sha256", "realpkg-sum").await;
+        insert_repo_object(&f, "test.repo", "test-repo").await;
+
+        // The query helper itself must only return the package rows.
+        let listed = super::list_rpm_artifacts(&f.pool, f.repo_id)
+            .await
+            .expect("list_rpm_artifacts");
+        let paths: Vec<&str> = listed.iter().map(|a| a.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec![
+                "packages/realpkg-1.0-1.x86_64.rpm",
+                "packages/realpkg-1.0-1.src.rpm",
+            ],
+            "list_rpm_artifacts must return only .rpm package objects"
+        );
+
+        // End to end: primary.xml must describe exactly the two packages.
+        let (status, body) = get_repodata(&f, "primary.xml.gz").await;
+        assert_eq!(status, StatusCode::OK);
+        let mut decoder = GzDecoder::new(&body[..]);
+        let mut primary = String::new();
+        decoder
+            .read_to_string(&mut primary)
+            .expect("decompress primary.xml.gz");
+
+        f.teardown().await;
+
+        assert!(
+            primary.contains("packages=\"2\""),
+            "primary.xml must count only the .rpm packages, got: {primary}"
+        );
+        assert!(primary.contains("realpkg-1.0-1.x86_64.rpm"));
+        assert!(primary.contains("realpkg-1.0-1.src.rpm"));
+        for junk in [".rpm.asc", ".rpm.sha256", "test.repo"] {
+            assert!(
+                !primary.contains(junk),
+                "non-package object {junk} leaked into primary.xml: {primary}"
+            );
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2590 (follow-up to #2580 / #2587).

`list_rpm_artifacts` selected **every** artifact in the repository regardless of
extension, so non-`.rpm` objects placed in an RPM repo through the generic
chunked upload flow (signature sidecars like `.rpm.asc`, checksum files like
`.rpm.sha256`, `.repo` snippets, arbitrary companions) leaked into the
generated repodata — `primary.xml`, `filelists.xml` and `other.xml` described
them as packages, inflating `packages="N"` and handing dnf/yum metadata entries
that are not installable packages.

### Fix

One-line filter in the `list_rpm_artifacts` query:

- `AND a.path LIKE '%.rpm'` — only actual RPM package objects are listed.
- `.src.rpm` still matches the suffix, so source RPMs are **not** dropped.
- `.drpm` (delta RPM) does not match and stays excluded deliberately: deltas
  belong in `prestodelta` metadata (which we do not generate), never in
  `primary.xml`.
- Virtual-repo aggregation (`collect_repodata_artifacts`) funnels through the
  same helper, so member-repo listings inherit the filter.
- The deterministic `(name, version, path, id)` total order from #2636 is
  untouched — filtering does not reorder, so the repomd signature contract is
  unaffected.

`.sqlx` offline cache regenerated for the changed `sqlx::query!`
(`cargo sqlx prepare --workspace -- --all-targets` against a migrated DB).

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_rpm_repodata_excludes_non_rpm_objects` (DB-backed, `rpm.rs`) seeds a
hosted RPM repo with a binary `.rpm`, a `.src.rpm`, and three non-package
objects (`.rpm.asc`, `.rpm.sha256`, `test.repo`), then asserts:

1. `list_rpm_artifacts` returns exactly the two package paths, and
2. the served `repodata/primary.xml.gz` reports `packages="2"`, contains both
   package locations, and contains none of the non-package objects.

**Fails on `main`** — the listing came back with all five objects:

```
left:  ["packages/realpkg-1.0-1.x86_64.rpm", "packages/realpkg-1.0-1.x86_64.rpm.asc",
        "packages/realpkg-1.0-1.src.rpm", "realpkg-1.0-1.x86_64.rpm.sha256", "test.repo"]
right: ["packages/realpkg-1.0-1.x86_64.rpm", "packages/realpkg-1.0-1.src.rpm"]
```

**Passes with the fix** (and the `.src.rpm` leg guards against over-filtering).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local gates (DB-backed, migrated throwaway Postgres):
- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --lib rpm::tests` — 131 passed / 0 failed (new test included)
- full `--workspace --lib` suite — pass (see PR checks once CI drains)
- duplication: `rpm.rs` is on the `.jscpd.json` format-handler exemption list

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
