### PR TITLE
fix: perform a real LDAP bind in the admin test-connection endpoint

### DIFF
--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -1046,30 +1046,100 @@ impl AuthConfigService {
         Ok(Self::ldap_row_to_response(row))
     }
 
-    /// Attempt a TCP connection to the LDAP server to verify reachability.
+    /// Test an LDAP provider configuration end-to-end (#2486).
+    ///
+    /// Runs in two stages:
+    /// 1. SSRF-vet and TCP-probe the configured host/port (unchanged
+    ///    behaviour: generic failure messages, no port-scan oracle).
+    /// 2. If a bind DN and password are stored for this provider, perform a
+    ///    REAL LDAP simple bind with the stored (decrypted) credentials,
+    ///    honouring the configured STARTTLS/TLS settings — the same code
+    ///    path the login flow uses. A rejected bind now reports failure;
+    ///    raw TCP reachability alone is no longer reported as success.
+    ///
+    /// When no service account is configured, only reachability can be
+    /// verified (user auth on such providers is direct-bind, which cannot be
+    /// tested without a user credential), and the message says so
+    /// explicitly.
+    ///
+    /// Note: the bind stage re-dials by hostname via the LDAP client, so a
+    /// DNS rebind between the vetted probe and the bind is a residual — the
+    /// same exposure as the login path, which dials the stored URL on every
+    /// login attempt.
     pub async fn test_ldap_connection(pool: &PgPool, id: Uuid) -> Result<LdapTestResult> {
-        let row = sqlx::query_as::<_, LdapConfigRow>(
-            r#"
-            SELECT id, name, server_url, bind_dn, bind_password_encrypted,
-                   user_base_dn, user_filter, group_base_dn, group_filter,
-                   email_attribute, display_name_attribute, username_attribute,
-                   groups_attribute, admin_group_dn, use_starttls,
-                   is_enabled, priority, created_at, updated_at
-            FROM ldap_configs
-            WHERE id = $1
-            "#,
-        )
-        .bind(id)
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| AppError::Internal(format!("Failed to get LDAP config: {e}")))?
-        .ok_or_else(|| AppError::NotFound(format!("LDAP config {id} not found")))?;
+        let start = std::time::Instant::now();
+        let (row, bind_password) = Self::get_ldap_decrypted(pool, id).await?;
 
         // Parse host and port from server_url (e.g. ldap://host:389 or ldaps://host:636)
-        let url = &row.server_url;
-        let (host, port) = Self::parse_ldap_url(url)?;
+        let (host, port) = Self::parse_ldap_url(&row.server_url)?;
 
-        Self::probe_ldap_endpoint(&host, port).await
+        let probe = Self::probe_ldap_endpoint(&host, port).await?;
+        if !probe.success {
+            return Ok(probe);
+        }
+
+        let has_bind_creds = row.bind_dn.as_deref().is_some_and(|dn| !dn.is_empty())
+            && bind_password.as_deref().is_some_and(|pw| !pw.is_empty());
+        if !has_bind_creds {
+            return Ok(LdapTestResult {
+                success: true,
+                message: format!(
+                    "Connected to {host}:{port}; no bind DN/password configured, \
+                     so credentials were not verified"
+                ),
+                response_time_ms: probe.response_time_ms,
+            });
+        }
+
+        let svc = crate::services::ldap_service::LdapService::from_db_config(
+            pool.clone(),
+            &row.name,
+            &row.server_url,
+            row.bind_dn.as_deref(),
+            bind_password.as_deref(),
+            &row.user_base_dn,
+            &row.user_filter,
+            &row.username_attribute,
+            &row.email_attribute,
+            &row.display_name_attribute,
+            &row.groups_attribute,
+            row.admin_group_dn.as_deref(),
+            row.use_starttls,
+        );
+
+        let bind_result = svc.verify_bind().await;
+        Ok(Self::bind_result_to_test_result(
+            bind_result,
+            start.elapsed().as_millis() as u64,
+        ))
+    }
+
+    /// Map the outcome of the verification bind to the API test result.
+    ///
+    /// Pure helper so the pass/fail decision is unit-testable. Messages stay
+    /// generic: no raw LDAP/OS error text (logged server-side instead) and
+    /// never the bind credentials.
+    fn bind_result_to_test_result(bind_result: Result<()>, elapsed_ms: u64) -> LdapTestResult {
+        match bind_result {
+            Ok(()) => LdapTestResult {
+                success: true,
+                message: "Connection and LDAP bind successful".to_string(),
+                response_time_ms: elapsed_ms,
+            },
+            Err(AppError::Authentication(_)) => LdapTestResult {
+                success: false,
+                message: "LDAP bind rejected: check the bind DN and bind password".to_string(),
+                response_time_ms: elapsed_ms,
+            },
+            Err(e) => {
+                tracing::warn!(target: "security", error = %e, "LDAP test: bind stage failed");
+                LdapTestResult {
+                    success: false,
+                    message: "LDAP connection failed during bind".to_string(),
+                    response_time_ms: elapsed_ms,
+                }
+            }
+        }
     }
 
     /// Resolve, SSRF-vet, and probe a TCP connection to `host:port`.
@@ -2103,6 +2173,48 @@ mod tests {
     fn test_parse_ldap_url_invalid_port() {
         let result = AuthConfigService::parse_ldap_url("ldap://myhost:notaport");
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // bind_result_to_test_result (#2486): the test-connection endpoint must
+    // report the TRUE bind outcome, with generic credential-free messages.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_bind_result_mapping_success() {
+        let res = AuthConfigService::bind_result_to_test_result(Ok(()), 12);
+        assert!(res.success);
+        assert_eq!(res.message, "Connection and LDAP bind successful");
+        assert_eq!(res.response_time_ms, 12);
+    }
+
+    #[test]
+    fn test_bind_result_mapping_rejected_bind_is_failure() {
+        // A rejected bind (bad bind DN/password) must NOT report success —
+        // this is the exact bug in #2486, where TCP reachability alone was
+        // reported as "Connection Successful".
+        let res = AuthConfigService::bind_result_to_test_result(
+            Err(AppError::Authentication("Invalid credentials".into())),
+            7,
+        );
+        assert!(!res.success);
+        assert!(res.message.contains("bind DN"));
+        assert_eq!(res.response_time_ms, 7);
+    }
+
+    #[test]
+    fn test_bind_result_mapping_connection_error_is_generic() {
+        // Connection-level details (raw OS/TLS errors) stay server-side.
+        let res = AuthConfigService::bind_result_to_test_result(
+            Err(AppError::Internal(
+                "LDAP connection failed: os error 111 secret-internal-detail".into(),
+            )),
+            3,
+        );
+        assert!(!res.success);
+        assert!(!res.message.contains("secret-internal-detail"));
+        assert!(!res.message.contains("os error"));
+        assert_eq!(res.message, "LDAP connection failed during bind");
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -708,6 +708,36 @@ impl LdapService {
         &self.config.url
     }
 
+    /// Verify the configured service-account credentials via a real LDAP
+    /// simple bind (admin "test connection" flow, #2486).
+    ///
+    /// Unlike [`check_health`], which is a liveness probe that silently
+    /// passes when no service account is configured, this method exists to
+    /// answer "are these settings actually valid?": it connects with the
+    /// configured TLS/STARTTLS settings, performs a simple bind with the
+    /// configured bind DN and password, then unbinds. Error classification
+    /// (via [`Self::connect_and_bind`]) distinguishes a credential rejection
+    /// (`AppError::Authentication`) from connection-level failures
+    /// (`AppError::Internal`), and never includes the bind password.
+    pub async fn verify_bind(&self) -> Result<()> {
+        let (bind_dn, bind_pw) = match (&self.config.bind_dn, &self.config.bind_password) {
+            (Some(dn), Some(pw)) if !dn.is_empty() => (dn.clone(), pw.clone()),
+            _ => {
+                return Err(AppError::Config(
+                    "LDAP bind credentials not configured".into(),
+                ))
+            }
+        };
+        let mut ldap = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            self.connect_and_bind(&bind_dn, &bind_pw),
+        )
+        .await
+        .map_err(|_| AppError::Internal("LDAP connection test timed out".into()))??;
+        ldap.unbind().await.ok();
+        Ok(())
+    }
+
     /// Probe LDAP connectivity by attempting a service-account bind.
     ///
     /// If a service account is configured, performs a real bind to verify
@@ -1955,5 +1985,136 @@ mod tests {
         let result = svc.check_health().await;
         // Should fail on empty URL check before attempting bind
         assert!(result.is_err());
+    }
+
+    // -----------------------------------------------------------------------
+    // verify_bind (#2486): the admin test-connection flow must perform a real
+    // LDAP bind and report its true outcome, not just TCP reachability.
+    // -----------------------------------------------------------------------
+
+    /// LDAP resultCode for a bindResponse.
+    const LDAP_RC_SUCCESS: u8 = 0x00;
+    /// invalidCredentials (49).
+    const LDAP_RC_INVALID_CREDENTIALS: u8 = 0x31;
+
+    /// Spawn a minimal mock LDAP server on 127.0.0.1 that answers the first
+    /// request with a BER-encoded bindResponse (messageID 1) carrying the
+    /// given resultCode, then drains the connection. This is a server that is
+    /// perfectly REACHABLE over TCP — exactly the case where the old
+    /// TCP-probe-only test reported "Connection Successful" regardless of
+    /// whether the bind credentials were valid.
+    async fn spawn_mock_ldap_server(result_code: u8) -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock ldap listener");
+        let port = listener.local_addr().expect("local addr").port();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = [0u8; 512];
+                // Read the client's bindRequest (single small frame).
+                let _ = sock.read(&mut buf).await;
+                // SEQUENCE { messageID 1, [APPLICATION 1] bindResponse {
+                //   resultCode <rc>, matchedDN "", diagnosticMessage "" } }
+                let resp = [
+                    0x30,
+                    0x0c,
+                    0x02,
+                    0x01,
+                    0x01,
+                    0x61,
+                    0x07,
+                    0x0a,
+                    0x01,
+                    result_code,
+                    0x04,
+                    0x00,
+                    0x04,
+                    0x00,
+                ];
+                let _ = sock.write_all(&resp).await;
+                let _ = sock.flush().await;
+                // Consume a possible unbindRequest before closing.
+                let _ = sock.read(&mut buf).await;
+            }
+        });
+        port
+    }
+
+    fn make_verify_bind_service(
+        port: u16,
+        bind_dn: Option<&str>,
+        bind_pw: Option<&str>,
+    ) -> LdapService {
+        let mut config = make_test_ldap_config();
+        config.url = format!("ldap://127.0.0.1:{port}");
+        config.bind_dn = bind_dn.map(String::from);
+        config.bind_password = bind_pw.map(String::from);
+        make_test_service(config)
+    }
+
+    #[tokio::test]
+    async fn test_verify_bind_rejected_credentials_reports_failure() {
+        // The server accepts the TCP connection but rejects the bind: the
+        // old reachability-only test reported success here (#2486); the
+        // real bind must surface an authentication failure.
+        let port = spawn_mock_ldap_server(LDAP_RC_INVALID_CREDENTIALS).await;
+        let svc = make_verify_bind_service(
+            port,
+            Some("cn=wrong,dc=example,dc=com"),
+            Some("bad-password"),
+        );
+
+        match svc.verify_bind().await {
+            Err(AppError::Authentication(msg)) => {
+                // The error must never leak the credentials being tested.
+                assert!(!msg.contains("bad-password"));
+                assert!(!msg.contains("cn=wrong"));
+            }
+            other => panic!("expected Authentication error for rejected bind, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_bind_accepted_credentials_reports_success() {
+        let port = spawn_mock_ldap_server(LDAP_RC_SUCCESS).await;
+        let svc = make_verify_bind_service(
+            port,
+            Some("cn=admin,dc=example,dc=com"),
+            Some("correct-password"),
+        );
+
+        svc.verify_bind()
+            .await
+            .expect("bind accepted by server should verify");
+    }
+
+    #[tokio::test]
+    async fn test_verify_bind_unreachable_server_is_connection_error() {
+        // Reserve an ephemeral port, then drop the listener so the connect
+        // is refused: this must classify as a connection-level error, not a
+        // credential rejection.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+
+        let svc =
+            make_verify_bind_service(port, Some("cn=admin,dc=example,dc=com"), Some("password"));
+
+        match svc.verify_bind().await {
+            Err(AppError::Internal(_)) => {}
+            other => panic!("expected Internal error for unreachable server, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_verify_bind_without_credentials_is_config_error() {
+        let svc = make_verify_bind_service(1, None, None);
+        match svc.verify_bind().await {
+            Err(AppError::Config(_)) => {}
+            other => panic!("expected Config error without credentials, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## Summary

The SSO admin "test LDAP connection" endpoint (`POST /api/v1/admin/sso/ldap/{id}/test`) only opened a raw TCP connection to the configured host/port. It never spoke LDAP and never used the stored bind DN / bind password, so any TCP-reachable server reported "Connection Successful" even with completely wrong credentials (#2486).

This change makes the test report the true outcome:

- **Stage 1 (unchanged):** the existing SSRF-vetted TCP probe, with the same generic failure messages (no port-scan oracle).
- **Stage 2 (new):** if a bind DN and password are stored for the provider, a real LDAP simple bind is performed with the stored (decrypted) credentials, honoring the configured STARTTLS/TLS settings — via the same `LdapService` client path the login flow uses (`LdapService::verify_bind`, built on the existing `connect_and_bind`).
- A rejected bind now returns `success: false` with a generic, credential-free message ("LDAP bind rejected: check the bind DN and bind password"). Connection/TLS failures during the bind stage are reported generically and logged server-side.
- Providers with no service account configured report success with an explicit note that only reachability was verified (user auth on such providers is direct-bind, which cannot be tested without a user credential).

No schema changes, no new sqlx macros, no API shape changes (`LdapTestResult` unchanged).

Closes #2486

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_verify_bind_rejected_credentials_reports_failure` spins up a minimal mock LDAP server that accepts the TCP connection but answers the bind with `invalidCredentials(49)` — exactly the server shape the old code reported as "Connection Successful" — and asserts the test path surfaces an authentication failure that never contains the credentials. Companion tests cover the accepted-bind, unreachable-server, and no-credentials paths, plus pure unit tests for the bind-outcome → API-result mapping (including that raw OS/LDAP error text is not leaked to the response).

## Test Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (`cargo nextest run --workspace --lib`: 13758 passed, 0 failed)

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
