### PR TITLE
perf(proxy): keyset-page remote-cache browsing from the proxy-cache catalog

### DIFF
--- a/.sqlx/query-5451d568eccdbbc0d5068fee50583f05afa302126c47fa372bb3b4291408958b.json
+++ b/.sqlx/query-5451d568eccdbbc0d5068fee50583f05afa302126c47fa372bb3b4291408958b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT EXISTS(\n            SELECT 1 FROM proxy_cache_artifacts WHERE repository_id = $1\n        ) AS \"exists!\"\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5451d568eccdbbc0d5068fee50583f05afa302126c47fa372bb3b4291408958b"
+}

--- a/.sqlx/query-d6d68bd008026dfd081250a4d310452063d11d0150da6f63e063c0586208fad4.json
+++ b/.sqlx/query-d6d68bd008026dfd081250a4d310452063d11d0150da6f63e063c0586208fad4.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT path, size_bytes, checksum_sha256, content_type, cached_at\n        FROM proxy_cache_artifacts\n        WHERE repository_id = $1\n          AND ($2::TEXT IS NULL OR path LIKE $2 ESCAPE '\\')\n          AND ($3::TEXT IS NULL OR path ILIKE $3 ESCAPE '\\')\n          AND ($4::TEXT IS NULL OR path > $4)\n        ORDER BY path\n        LIMIT $5 OFFSET $6\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "content_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "cached_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "d6d68bd008026dfd081250a4d310452063d11d0150da6f63e063c0586208fad4"
+}

--- a/.sqlx/query-e5a3a5a03da22583ac5bdfc0ec650c036b2cb5692da32d85ebb15d11eb8fb9dc.json
+++ b/.sqlx/query-e5a3a5a03da22583ac5bdfc0ec650c036b2cb5692da32d85ebb15d11eb8fb9dc.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*)::BIGINT AS \"count!\"\n        FROM proxy_cache_artifacts\n        WHERE repository_id = $1\n          AND ($2::TEXT IS NULL OR path LIKE $2 ESCAPE '\\')\n          AND ($3::TEXT IS NULL OR path ILIKE $3 ESCAPE '\\')\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e5a3a5a03da22583ac5bdfc0ec650c036b2cb5692da32d85ebb15d11eb8fb9dc"
+}

--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -3833,16 +3833,17 @@ pub struct ListArtifactsQuery {
     ///   referenced layer blobs.  The grouped rows are returned in the
     ///   `docker_tags` array.
     pub group_by: Option<String>,
-    /// Opaque keyset cursor for grouped listings (#2520). Pass the
-    /// `next_cursor` value from the previous response to fetch the next
-    /// page; `page` is ignored while a cursor is present. Supported by
-    /// `group_by=docker_tag` and by `group_by=maven_component` on remote
-    /// repositories; other listing modes ignore it.
+    /// Opaque keyset cursor (#2520, #2519). Pass the `next_cursor` value
+    /// from the previous response to fetch the next page; `page` is ignored
+    /// while a cursor is present. Supported by `group_by=docker_tag`, by
+    /// `group_by=maven_component` on remote repositories, and by the flat
+    /// cached-artifact listing of remote repositories; other listing modes
+    /// ignore it.
     pub cursor: Option<String>,
-    /// Total-count mode for grouped listings (#2520). `count=exact` runs a
-    /// dedicated COUNT query so `pagination.total` is exact; otherwise the
-    /// keyset-paged grouped listings report a cheap lower bound (rows seen
-    /// so far, +1 when another page exists) and `has_more` is the
+    /// Total-count mode for keyset-paged listings (#2520, #2519).
+    /// `count=exact` runs a dedicated COUNT query so `pagination.total` is
+    /// exact; otherwise the keyset-paged listings report a cheap lower bound
+    /// (rows seen so far, +1 when another page exists) and `has_more` is the
     /// authoritative "is there a next page" signal.
     pub count: Option<String>,
 }
@@ -4138,6 +4139,8 @@ pub async fn list_artifacts(
             &key,
             query.path_prefix.as_deref(),
             query.q.as_deref(),
+            query.cursor.as_deref(),
+            count_exact,
             page,
             per_page,
         )
@@ -4256,32 +4259,60 @@ pub async fn list_artifacts(
 
 /// List the artifacts a remote (proxy) repository has cached.
 ///
-/// Proxy-cached items are not in the `artifacts` table (#1280), so they are
-/// reconstructed from the storage backend by [`ProxyService::list_cached_artifacts`].
-/// Each entry is mapped to an [`ArtifactResponse`]; entries carry no DB id,
+/// Proxy-cached items are not in the `artifacts` table (#1280). Since
+/// migration 159 they ARE indexed in the `proxy_cache_artifacts` catalog
+/// (written at sidecar-commit time, lazily backfilled on cache hit), so the
+/// listing pages straight out of that catalog with a `path` keyset — O(page)
+/// DB rows per request, no storage I/O (PF-002 / #2519). Each entry is
+/// mapped to an [`ArtifactResponse`]; entries carry no DB artifact id,
 /// version, or download count, so those fields take their natural defaults
 /// (a deterministic synthetic id derived from `repo_key + path`, `None`
-/// version, zero downloads). Filtering and pagination happen in-process over
-/// the recovered set, since there is no DB query to push them into. See #1548
-/// and web #424.
+/// version, zero downloads). See #1548 and web #424.
+///
+/// Legacy fallback: a repository whose cache predates the catalog and has
+/// not been touched since (zero catalog rows) still reconstructs the listing
+/// from the storage backend the old way — a whole-prefix `storage.list`
+/// call, O(total cached objects) per request. That path disappears for a
+/// repo as soon as one entry is cataloged (any cache write or hit). Bulk
+/// storage->catalog reconciliation for cold legacy caches is follow-up work
+/// tracked on #2270.
+#[allow(clippy::too_many_arguments)]
 async fn list_remote_cached_artifacts(
     state: &SharedState,
     repo: &crate::models::repository::Repository,
     key: &str,
     path_prefix: Option<&str>,
     q: Option<&str>,
+    cursor: Option<&str>,
+    count_exact: bool,
     page: u32,
     per_page: u32,
 ) -> Result<Json<ArtifactListResponse>> {
-    // Two-phase listing (#1571): first recover just the cached path strings
-    // (no sidecar reads), filter + slice them to the requested page, and only
-    // then load sidecars for that page. Both listing filters are path-based,
-    // so paging on the paths is exact and avoids the previous O(N) sidecar
-    // read on every request. The trade-off is that `total` counts paths whose
-    // sidecar may since have gone missing (a half-written / legacy cache
-    // write); such a path is still dropped from the returned page, matching
-    // the old per-entry skip, but is no longer pre-excluded from the count —
-    // an acceptable approximation in exchange for O(page) reads.
+    if crate::services::proxy_catalog::has_rows(&state.db, repo.id).await? {
+        return list_remote_cached_from_catalog(
+            state,
+            repo,
+            key,
+            path_prefix,
+            q,
+            cursor,
+            count_exact,
+            page,
+            per_page,
+        )
+        .await;
+    }
+
+    // Legacy two-phase listing (#1571) for pre-catalog caches: first recover
+    // just the cached path strings (no sidecar reads), filter + slice them to
+    // the requested page, and only then load sidecars for that page. Both
+    // listing filters are path-based, so paging on the paths is exact and
+    // avoids the previous O(N) sidecar read on every request. The trade-off
+    // is that `total` counts paths whose sidecar may since have gone missing
+    // (a half-written / legacy cache write); such a path is still dropped
+    // from the returned page, matching the old per-entry skip, but is no
+    // longer pre-excluded from the count — an acceptable approximation in
+    // exchange for O(page) reads.
     let proxy = state.proxy_service.as_deref();
     let paths = match proxy {
         Some(proxy) => proxy.list_cached_paths(&repo.key).await,
@@ -4315,6 +4346,142 @@ async fn list_remote_cached_artifacts(
         next_cursor: None,
         has_more: None,
     }))
+}
+
+/// Page a remote repository's cached-artifact listing out of the
+/// `proxy_cache_artifacts` catalog (PF-002 / #2519), replacing the per-request
+/// whole-prefix `storage.list` enumeration with an indexed keyset query that
+/// examines O(page) rows.
+///
+/// Paging mirrors the #2520 grouped-listing contract: an opaque `?cursor=`
+/// (the previous response's `next_cursor`, keyed on the last `path`) takes
+/// precedence; without a cursor, legacy `page=N` addressing still works via
+/// OFFSET. `has_more` is authoritative (fetched as `per_page + 1` rows);
+/// `pagination.total` is a cheap lower bound unless the client opts into
+/// `?count=exact`. Filters keep the legacy semantics: `path_prefix` is a
+/// starts-with match, `q` a case-insensitive substring match, both applied
+/// as escaped `LIKE` patterns so user-supplied `%`/`_` match literally.
+#[allow(clippy::too_many_arguments)]
+async fn list_remote_cached_from_catalog(
+    state: &SharedState,
+    repo: &crate::models::repository::Repository,
+    key: &str,
+    path_prefix: Option<&str>,
+    q: Option<&str>,
+    cursor: Option<&str>,
+    count_exact: bool,
+    page: u32,
+    per_page: u32,
+) -> Result<Json<ArtifactListResponse>> {
+    use crate::services::proxy_catalog;
+
+    // The cached-listing cursor is single-key (`path`); the shared two-part
+    // cursor codec is reused with an empty second component so all listing
+    // cursors stay one opaque format.
+    let keyset = decode_cursor_param(cursor)?;
+    let after_path = keyset.as_ref().map(|(path, _)| path.as_str());
+    let offset = if after_path.is_some() {
+        0
+    } else {
+        i64::from(page.saturating_sub(1)) * i64::from(per_page)
+    };
+
+    let prefix_like = path_prefix
+        .filter(|p| !p.is_empty())
+        .map(|p| format!("{}%", super::escape_like_literal(p)));
+    let q_like = q
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("%{}%", super::escape_like_literal(s)));
+
+    let mut rows = proxy_catalog::browse_page(
+        &state.db,
+        repo.id,
+        prefix_like.as_deref(),
+        q_like.as_deref(),
+        after_path,
+        offset,
+        i64::from(per_page) + 1,
+    )
+    .await?;
+    let has_more = rows.len() > per_page as usize;
+    rows.truncate(per_page as usize);
+    let next_cursor = if has_more {
+        rows.last().map(|r| encode_keyset_cursor(&r.path, ""))
+    } else {
+        None
+    };
+
+    let exact_total = if count_exact {
+        Some(
+            proxy_catalog::browse_count(
+                &state.db,
+                repo.id,
+                prefix_like.as_deref(),
+                q_like.as_deref(),
+            )
+            .await?,
+        )
+    } else {
+        None
+    };
+    let total = grouped_listing_total(exact_total, offset, rows.len(), has_more);
+
+    let items = rows
+        .iter()
+        .map(|row| build_catalog_artifact_response(row, key))
+        .collect();
+
+    Ok(Json(ArtifactListResponse {
+        items,
+        pagination: Pagination {
+            page,
+            per_page,
+            total,
+            total_pages: grouped_total_pages(total, per_page),
+        },
+        components: None,
+        docker_tags: None,
+        next_cursor,
+        has_more: Some(has_more),
+    }))
+}
+
+/// Map a `proxy_cache_artifacts` catalog row to the listing's
+/// [`ArtifactResponse`], mirroring [`build_cached_artifact_response`]'s
+/// sidecar mapping: same deterministic synthetic id, `analyzable: false`,
+/// and the `application/octet-stream` content-type default. A transient
+/// placeholder row awaiting its tee refresh (see
+/// `proxy_catalog::record_proxy_download`) surfaces with size 0 and an empty
+/// checksum until the authoritative upsert lands.
+fn build_catalog_artifact_response(
+    row: &crate::services::proxy_catalog::ProxyCacheBrowseRow,
+    repo_key: &str,
+) -> ArtifactResponse {
+    let name = row.path.rsplit('/').next().unwrap_or(&row.path).to_string();
+    ArtifactResponse {
+        id: cached_artifact_id(repo_key, &row.path),
+        repository_key: repo_key.to_string(),
+        path: row.path.clone(),
+        name,
+        version: None,
+        size_bytes: row.size_bytes,
+        checksum_sha256: row.checksum_sha256.clone().unwrap_or_default(),
+        content_type: row
+            .content_type
+            .clone()
+            .unwrap_or_else(|| "application/octet-stream".to_string()),
+        download_count: 0,
+        created_at: row.cached_at,
+        metadata: None,
+        // Same rationale as the sidecar-recovered path: synthetic id, no
+        // `artifacts` row, so SBOM/scan cannot resolve the object.
+        analyzable: false,
+        cache_cached_at: Some(row.cached_at),
+        cache_expires_at: None,
+        revision: None,
+        version_label: None,
+    }
 }
 
 /// Apply the listing's `path_prefix` and `q` filters to the recovered proxy
@@ -11976,6 +12143,157 @@ mod tests {
         );
 
         tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// PF-002 (#2519): the remote cached-artifact listing pages out of the
+    /// `proxy_cache_artifacts` catalog — exact page contents and an
+    /// authoritative `has_more` across a full cursor walk — WITHOUT touching
+    /// the storage backend. Nothing is written to storage here (and the test
+    /// state has no proxy service), so the pre-#2519 whole-prefix
+    /// enumeration path would return an empty listing: this test fails
+    /// against the old implementation.
+    #[tokio::test]
+    async fn remote_cached_listing_pages_from_catalog_2519() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::proxy_catalog;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "remote", "generic").await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let repo = RepositoryService::new(pool.clone())
+            .get_by_key(&key)
+            .await
+            .expect("remote repo");
+
+        // Seed 25 catalog rows. No object is written to storage, so any code
+        // path that still enumerates the storage prefix sees zero entries.
+        let total = 25usize;
+        for i in 0..total {
+            let p = format!("pkg/obj-{i:03}.bin");
+            proxy_catalog::upsert(
+                &pool,
+                repo_id,
+                &p,
+                &format!("proxy-cache/{key}/{p}/__content__"),
+                &format!("proxy-cache/{key}/{p}/__cache_meta__.json"),
+                10 + i as i64,
+                Some("f00d"),
+                Some("application/x-test"),
+                None,
+            )
+            .await
+            .expect("seed catalog row");
+        }
+
+        // Full cursor walk: 10 + 10 + 5, has_more true/true/false, and the
+        // concatenated pages equal the seeded set exactly (no gaps, no dups).
+        let mut cursor: Option<String> = None;
+        let mut walked: Vec<String> = Vec::new();
+        let mut hops = 0;
+        loop {
+            let resp = list_remote_cached_artifacts(
+                &state,
+                &repo,
+                &key,
+                None,
+                None,
+                cursor.as_deref(),
+                false,
+                1,
+                10,
+            )
+            .await
+            .expect("catalog-paged listing")
+            .0;
+            assert!(resp.items.len() <= 10, "page bounded by per_page");
+            walked.extend(resp.items.iter().map(|i| i.path.clone()));
+            hops += 1;
+            match (resp.has_more, hops) {
+                (Some(true), 1 | 2) => {
+                    cursor = resp.next_cursor.clone();
+                    assert!(cursor.is_some(), "has_more page carries next_cursor");
+                }
+                (Some(false), 3) => {
+                    assert!(resp.next_cursor.is_none(), "last page has no cursor");
+                    assert_eq!(resp.items.len(), 5, "final short page");
+                    break;
+                }
+                (hm, n) => panic!("unexpected has_more={hm:?} on page {n}"),
+            }
+        }
+        let expected: Vec<String> = (0..total).map(|i| format!("pkg/obj-{i:03}.bin")).collect();
+        assert_eq!(walked, expected, "cursor walk yields every row in order");
+
+        // Response mapping mirrors the sidecar path: synthetic id semantics,
+        // not analyzable, catalog timestamp surfaced as cache_cached_at.
+        let first =
+            list_remote_cached_artifacts(&state, &repo, &key, None, None, None, false, 1, 10)
+                .await
+                .expect("first page")
+                .0;
+        let item = &first.items[0];
+        assert_eq!(item.path, "pkg/obj-000.bin");
+        assert_eq!(item.name, "obj-000.bin");
+        assert_eq!(item.size_bytes, 10);
+        assert_eq!(item.checksum_sha256, "f00d");
+        assert_eq!(item.content_type, "application/x-test");
+        assert!(!item.analyzable);
+        assert!(item.cache_cached_at.is_some());
+        assert_eq!(item.id, cached_artifact_id(&key, "pkg/obj-000.bin"));
+
+        // Legacy page=N addressing still works without a cursor, and
+        // `count=exact` opts into the exact total (default is a lower bound
+        // with authoritative has_more).
+        let page3 =
+            list_remote_cached_artifacts(&state, &repo, &key, None, None, None, true, 3, 10)
+                .await
+                .expect("page 3")
+                .0;
+        assert_eq!(
+            page3
+                .items
+                .iter()
+                .map(|i| i.path.as_str())
+                .collect::<Vec<_>>(),
+            expected[20..]
+                .iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(page3.pagination.total, 25, "count=exact total");
+        assert_eq!(page3.has_more, Some(false));
+
+        // The substring filter keeps its legacy case-insensitive semantics.
+        let filtered = list_remote_cached_artifacts(
+            &state,
+            &repo,
+            &key,
+            None,
+            Some("OBJ-013"),
+            None,
+            false,
+            1,
+            10,
+        )
+        .await
+        .expect("filtered")
+        .0;
+        assert_eq!(
+            filtered
+                .items
+                .iter()
+                .map(|i| i.path.as_str())
+                .collect::<Vec<_>>(),
+            ["pkg/obj-013.bin"]
+        );
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .expect("cleanup repo");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/backend/src/services/proxy_catalog.rs
+++ b/backend/src/services/proxy_catalog.rs
@@ -161,6 +161,121 @@ pub async fn sum_by_repo(db: &PgPool, repository_id: Uuid) -> Result<i64> {
     Ok(sum)
 }
 
+/// One catalog row as surfaced by the remote-repository browse listing
+/// (PF-002 / #2519). Unlike [`ProxyCacheEntry`] this carries `cached_at`, so
+/// the listing can render the cache timestamp without reading the storage
+/// sidecar for each page item.
+#[derive(Debug, Clone)]
+pub struct ProxyCacheBrowseRow {
+    pub path: String,
+    pub size_bytes: i64,
+    pub checksum_sha256: Option<String>,
+    pub content_type: Option<String>,
+    pub cached_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Whether ANY catalog row exists for the repository. O(1) via the
+/// `(repository_id, path)` unique index. The browse listing uses this to
+/// decide between catalog-backed keyset paging (PF-002 / #2519) and the
+/// legacy storage-prefix reconstruction for pre-catalog caches that have no
+/// rows yet.
+pub async fn has_rows(db: &PgPool, repository_id: Uuid) -> Result<bool> {
+    let exists = sqlx::query_scalar!(
+        r#"
+        SELECT EXISTS(
+            SELECT 1 FROM proxy_cache_artifacts WHERE repository_id = $1
+        ) AS "exists!"
+        "#,
+        repository_id
+    )
+    .fetch_one(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(exists)
+}
+
+/// One keyset page of the remote-repository browse listing (PF-002 / #2519),
+/// ordered by `path` and examining O(page) rows via the `(repository_id,
+/// path)` unique index — never the whole cached set.
+///
+/// `prefix_like` / `q_like` are complete, pre-escaped `LIKE` patterns (the
+/// caller appends/wraps `%` around `escape_like_literal` output) matched
+/// under `ESCAPE '\'`; `q_like` matches case-insensitively (`ILIKE`),
+/// mirroring the legacy in-memory substring filter. `after_path` is the last
+/// path of the previous page (exclusive keyset bound); `offset` supports the
+/// legacy `page=N` addressing when no cursor is supplied (pass 0 with a
+/// cursor). The caller passes `limit = per_page + 1` and uses the extra row
+/// as the authoritative `has_more` signal (#2520 pattern).
+pub async fn browse_page(
+    db: &PgPool,
+    repository_id: Uuid,
+    prefix_like: Option<&str>,
+    q_like: Option<&str>,
+    after_path: Option<&str>,
+    offset: i64,
+    limit: i64,
+) -> Result<Vec<ProxyCacheBrowseRow>> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT path, size_bytes, checksum_sha256, content_type, cached_at
+        FROM proxy_cache_artifacts
+        WHERE repository_id = $1
+          AND ($2::TEXT IS NULL OR path LIKE $2 ESCAPE '\')
+          AND ($3::TEXT IS NULL OR path ILIKE $3 ESCAPE '\')
+          AND ($4::TEXT IS NULL OR path > $4)
+        ORDER BY path
+        LIMIT $5 OFFSET $6
+        "#,
+        repository_id,
+        prefix_like,
+        q_like,
+        after_path,
+        limit,
+        offset,
+    )
+    .fetch_all(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| ProxyCacheBrowseRow {
+            path: r.path,
+            size_bytes: r.size_bytes,
+            checksum_sha256: r.checksum_sha256,
+            content_type: r.content_type,
+            cached_at: r.cached_at,
+        })
+        .collect())
+}
+
+/// Exact match count for [`browse_page`]'s filters, behind the listing's
+/// explicit `?count=exact` opt-in (#2520 pattern): the default response
+/// reports a cheap lower-bound total plus an authoritative `has_more`.
+pub async fn browse_count(
+    db: &PgPool,
+    repository_id: Uuid,
+    prefix_like: Option<&str>,
+    q_like: Option<&str>,
+) -> Result<i64> {
+    let count = sqlx::query_scalar!(
+        r#"
+        SELECT COUNT(*)::BIGINT AS "count!"
+        FROM proxy_cache_artifacts
+        WHERE repository_id = $1
+          AND ($2::TEXT IS NULL OR path LIKE $2 ESCAPE '\')
+          AND ($3::TEXT IS NULL OR path ILIKE $3 ESCAPE '\')
+        "#,
+        repository_id,
+        prefix_like,
+        q_like,
+    )
+    .fetch_one(db)
+    .await
+    .map_err(|e| AppError::Database(e.to_string()))?;
+    Ok(count)
+}
+
 /// Keyset-paged catalog listing for one repository, ordered by `path`
 /// (#2270 visibility / PF-002 seam). `after` is the last path from the previous
 /// page (exclusive); pass `None` for the first page.
@@ -513,6 +628,162 @@ mod tests {
             next.iter().map(|e| e.path.as_str()).collect::<Vec<_>>(),
             ["c/3"]
         );
+        cleanup_repo(&pool, repo).await;
+    }
+
+    /// PF-002 (#2519): the browse page must return exact contents across a
+    /// full keyset walk, with each call bounded by `limit` — it must never
+    /// hand the caller the whole cached set at once.
+    #[tokio::test]
+    async fn test_browse_page_keyset_walk_is_bounded_and_exact() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let repo = insert_repo(&pool).await;
+        let total = 25usize;
+        let per_page = 10usize;
+        for i in 0..total {
+            let p = format!("pkg/obj-{i:03}.bin");
+            upsert(
+                &pool,
+                repo,
+                &p,
+                &format!("proxy-cache/{}/{p}/__content__", repo.simple()),
+                "m",
+                i as i64,
+                Some("c"),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        let mut walked: Vec<String> = Vec::new();
+        let mut after: Option<String> = None;
+        let mut pages = 0;
+        loop {
+            let rows = browse_page(
+                &pool,
+                repo,
+                None,
+                None,
+                after.as_deref(),
+                0,
+                (per_page + 1) as i64,
+            )
+            .await
+            .unwrap();
+            // Bounded: never more than per_page + 1 rows per call, even
+            // though 25 rows exist.
+            assert!(rows.len() <= per_page + 1, "page is bounded by limit");
+            let has_more = rows.len() > per_page;
+            let page_rows = &rows[..rows.len().min(per_page)];
+            walked.extend(page_rows.iter().map(|r| r.path.clone()));
+            pages += 1;
+            match (has_more, pages) {
+                (true, 1 | 2) => {} // first two pages are full with more behind
+                (false, 3) => break,
+                (hm, n) => panic!("unexpected has_more={hm} on page {n}"),
+            }
+            after = page_rows.last().map(|r| r.path.clone());
+        }
+
+        let expected: Vec<String> = (0..total).map(|i| format!("pkg/obj-{i:03}.bin")).collect();
+        assert_eq!(walked, expected, "full walk yields every row exactly once");
+        assert_eq!(browse_count(&pool, repo, None, None).await.unwrap(), 25);
+        cleanup_repo(&pool, repo).await;
+    }
+
+    /// PF-002 (#2519): prefix + substring filters match the legacy in-memory
+    /// semantics (prefix = starts_with, `q` = case-insensitive substring) and
+    /// LIKE metacharacters in user input match literally.
+    #[tokio::test]
+    async fn test_browse_page_filters_and_like_escaping() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let repo = insert_repo(&pool).await;
+        // Paths are all-lowercase and same-case so the asserted relative
+        // order is identical under any database collation (C vs linguistic);
+        // case-insensitivity is exercised through the QUERY side below.
+        for p in ["a/one.whl", "a/two.whl", "b/100%_done.whl", "b/100xy.whl"] {
+            upsert(
+                &pool,
+                repo,
+                p,
+                &format!("proxy-cache/{}/{p}/__content__", repo.simple()),
+                "m",
+                1,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        }
+        let escape = |s: &str| {
+            let mut out = String::new();
+            for ch in s.chars() {
+                if matches!(ch, '\\' | '%' | '_') {
+                    out.push('\\');
+                }
+                out.push(ch);
+            }
+            out
+        };
+
+        // Prefix filter: starts_with semantics.
+        let rows = browse_page(&pool, repo, Some("a/%"), None, None, 0, 10)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.iter().map(|r| r.path.as_str()).collect::<Vec<_>>(),
+            ["a/one.whl", "a/two.whl"]
+        );
+
+        // Substring filter is case-insensitive, like the legacy
+        // `to_lowercase().contains()` filter: an upper-cased needle still
+        // matches the lower-cased stored path.
+        let rows = browse_page(&pool, repo, None, Some("%TWO%"), None, 0, 10)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.iter().map(|r| r.path.as_str()).collect::<Vec<_>>(),
+            ["a/two.whl"]
+        );
+
+        // `%` / `_` in user input match literally once escaped: `100%_`
+        // must match only the literal path, not wildcard onto `100xy`.
+        let q = format!("%{}%", escape("100%_"));
+        let rows = browse_page(&pool, repo, None, Some(&q), None, 0, 10)
+            .await
+            .unwrap();
+        assert_eq!(
+            rows.iter().map(|r| r.path.as_str()).collect::<Vec<_>>(),
+            ["b/100%_done.whl"]
+        );
+        assert_eq!(
+            browse_count(&pool, repo, None, Some(&q)).await.unwrap(),
+            1,
+            "count applies the same escaped filters as the page"
+        );
+        cleanup_repo(&pool, repo).await;
+    }
+
+    /// `has_rows` distinguishes a cataloged repo from a pre-catalog (or empty)
+    /// one, which is what gates the legacy storage-listing fallback.
+    #[tokio::test]
+    async fn test_has_rows_gates_catalog_vs_fallback() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let repo = insert_repo(&pool).await;
+        assert!(!has_rows(&pool, repo).await.unwrap(), "empty catalog");
+        upsert(&pool, repo, "p", "proxy-k", "m", 1, None, None, None)
+            .await
+            .unwrap();
+        assert!(has_rows(&pool, repo).await.unwrap(), "cataloged repo");
         cleanup_repo(&pool, repo).await;
     }
 


### PR DESCRIPTION
## Summary

Closes #2519 (PF-002).

Browsing a remote (proxy) repository's cached artifacts enumerated the **entire** `proxy-cache/<repo>/` storage prefix on every request: `list_remote_cached_artifacts` called `ProxyService::list_cached_paths`, which does a whole-prefix `storage.list` (~2 keys per cached object), then lowercased/filtered/sorted the full path vector in process before slicing out one page. At 1M cached objects that is ~2M key allocations plus an O(N log N) sort per page, per concurrent user, with cloud LIST latency/cost inside interactive UI requests.

This PR pages the listing straight out of the `proxy_cache_artifacts` catalog (migration 159, written transactionally at sidecar-commit time and lazily backfilled on cache hit), so a browse request examines O(page) indexed rows and performs **no storage I/O**:

- `services/proxy_catalog.rs`: new `browse_page` (keyset on `path` via the `(repository_id, path)` unique index, `LIMIT per_page + 1`, optional escaped `LIKE`/`ILIKE` filters), `browse_count`, and `has_rows`.
- `api/handlers/repositories.rs`: the remote branch of `GET /api/v1/repositories/{key}/artifacts` now serves from the catalog, adopting the #2520 keyset contract already shipped for grouped listings: opaque `?cursor=` (`next_cursor` in the response), authoritative `has_more`, legacy `page=N` still honored via OFFSET when no cursor is passed, and `pagination.total` as a cheap lower bound unless the client opts into `?count=exact`. Filter semantics are unchanged (`path_prefix` = starts-with, `q` = case-insensitive substring; `%`/`_` in user input are LIKE-escaped and match literally). Response shape is additive only (`next_cursor`/`has_more` fields already existed).

Compatibility fallback: a repository with **zero** catalog rows (a cache that predates migration 159 and has not been written/hit since) still uses the previous storage-prefix reconstruction, so nothing disappears from the UI; the fallback retires per-repo on the first cataloged entry.

Follow-ups, out of scope here (tracked on #2270 / noted on #2519):
- cursor-batched storage→catalog reconciliation for cold legacy caches;
- PyPI root recovery still lists the `simple/` prefix (`proxy_service.rs`);
- `StorageBackend::list` still returns one `Vec<String>` for maintenance callers.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`repositories::tests::remote_cached_listing_pages_from_catalog_2519` seeds 25 catalog rows with **no objects in storage** and walks the listing by cursor (10/10/5, `has_more` true/true/false, exact contents, `count=exact`, legacy `page=3`, case-insensitive `q`). Against the previous implementation the listing comes back empty (it only knew how to enumerate storage), so the test fails on `main` and passes here. `proxy_catalog` unit tests additionally cover the bounded keyset walk, filter semantics, LIKE-metacharacter escaping, and the `has_rows` fallback gate.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local: `cargo build --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, `cargo nextest run --workspace --lib` (one pre-existing, unrelated failure also present on the base commit: `npm_scope_policy_put_get_round_trip_db` asserts a DB row order without an ORDER BY), `cargo sqlx prepare --workspace -- --all-targets` (3 new query files checked in).

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

No new endpoints, types, or migrations; the existing `cursor`/`count` query params and `next_cursor`/`has_more` response fields (#2520) are now also honored by the remote flat listing, with doc comments updated accordingly.
