### PR TITLE
fix(npm): fan hosted-publish packument invalidation out to all replicas

### DIFF
--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -7260,6 +7260,187 @@ mod tests {
         );
     }
 
+    /// #2490: a hosted publish must invalidate the computed-packument cache
+    /// on EVERY replica, not only the one that handled the publish.
+    ///
+    /// Simulates two replicas as two process-local `SharedState`s sharing one
+    /// database: replica B warms its virtual-repo packument cache (both the
+    /// full and the abbreviated/corgi Accept variants — the two documents one
+    /// `npm pack`/`npm install` resolves), replica A publishes a new version
+    /// with a `canary` dist-tag, and replica B — whose cached entries would
+    /// otherwise serve the pre-publish packument as *fresh* for the whole
+    /// fresh TTL (300 s here) — must converge through the Postgres NOTIFY
+    /// fanout within seconds, coherently across both variants. Also asserts
+    /// read-your-writes on the publishing replica itself, immediately and
+    /// without polling. Skips when no test database is configured.
+    #[tokio::test]
+    async fn test_publish_invalidates_virtual_packument_across_replicas() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        use crate::services::cache_invalidation;
+
+        let Some(fx) = tdh::Fixture::setup("local", "npm").await else {
+            return;
+        };
+        let repo = fx.repo_info("local", None);
+
+        // A virtual repo with the hosted repo as its only member: reads go
+        // through the virtual (cached), publishes to the hosted member.
+        let (virtual_id, virtual_key, virtual_dir) =
+            tdh::create_repo(&fx.pool, "virtual", "npm").await;
+        sqlx::query(
+            "INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority) \
+             VALUES ($1, $2, 1)",
+        )
+        .bind(virtual_id)
+        .bind(fx.repo_id)
+        .execute(&fx.pool)
+        .await
+        .expect("insert virtual member");
+
+        // "Replica B": its own in-process packument cache over the same
+        // database, with its cross-replica invalidation listener running.
+        let state_b = tdh::build_state(fx.pool.clone(), fx.storage_dir.to_str().unwrap());
+        let shutdown = tokio_util::sync::CancellationToken::new();
+        let _listener_b = cache_invalidation::start_cache_invalidation_listener(
+            fx.pool.clone(),
+            cache_invalidation::CacheInvalidationHandles {
+                repo_cache: state_b.repo_cache.clone(),
+                permission_service: state_b.permission_service.clone(),
+                npm_packument_cache: state_b.npm_packument_cache.clone(),
+            },
+            shutdown.clone(),
+        )
+        .await;
+
+        // v1.0.0 exists before the caches are warmed.
+        let path = "widget/1.0.0/widget-1.0.0.tgz";
+        tdh::seed_artifact(
+            &fx.state,
+            &fx.pool,
+            &repo,
+            &format!("npm/{path}"),
+            path,
+            "widget",
+            "1.0.0",
+            "application/gzip",
+            Bytes::from_static(b"tgz"),
+            fx.user_id,
+        )
+        .await;
+
+        let base_url = "http://localhost";
+        let full_headers = HeaderMap::new();
+        let mut corgi_headers = HeaderMap::new();
+        corgi_headers.insert(
+            axum::http::header::ACCEPT,
+            "application/vnd.npm.install-v1+json".parse().unwrap(),
+        );
+
+        async fn packument_json(
+            state: &SharedState,
+            repo_key: &str,
+            base_url: &str,
+            headers: &HeaderMap,
+        ) -> serde_json::Value {
+            let resp =
+                super::get_package_metadata_cached(state, repo_key, "widget", base_url, headers)
+                    .await
+                    .unwrap_or_else(|r| panic!("packument read failed: HTTP {}", r.status()));
+            let bytes = axum::body::to_bytes(resp.into_body(), 8 * 1024 * 1024)
+                .await
+                .expect("read packument body");
+            serde_json::from_slice(&bytes).expect("parse packument json")
+        }
+
+        // Warm replica B's cache in BOTH Accept variants and prove the warm
+        // state: without an invalidation these entries serve as fresh for the
+        // whole 300 s fresh TTL.
+        for headers in [&full_headers, &corgi_headers] {
+            let json = packument_json(&state_b, &virtual_key, base_url, headers).await;
+            assert!(
+                json["versions"]["1.0.0"].is_object(),
+                "warmed packument must contain the seeded version"
+            );
+        }
+        let warm_key = packument_cache::cache_key(&virtual_key, "widget", false, false, base_url);
+        assert!(
+            state_b
+                .npm_packument_cache
+                .as_ref()
+                .expect("test state has the packument cache enabled")
+                .lookup(&warm_key)
+                .await
+                .is_some(),
+            "replica B's virtual packument must be cached before the publish"
+        );
+
+        // Replica A publishes 2.0.0 with a `canary` dist-tag.
+        let tarball_b64 = base64::engine::general_purpose::STANDARD.encode(b"tgz2");
+        let publish_body = serde_json::json!({
+            "name": "widget",
+            "versions": { "2.0.0": { "name": "widget", "version": "2.0.0" } },
+            "_attachments": { "widget-2.0.0.tgz": { "data": tarball_b64 } },
+            "dist-tags": { "canary": "2.0.0" }
+        });
+        let published = super::publish_package(
+            &fx.state,
+            Some(tdh::make_auth(fx.user_id, &fx.username)),
+            &fx.repo_key,
+            "widget",
+            &HeaderMap::new(),
+            Bytes::from(serde_json::to_vec(&publish_body).expect("serialize publish body")),
+        )
+        .await;
+        assert!(
+            published.is_ok(),
+            "publish should succeed: {:?}",
+            published.err().map(|r| r.status())
+        );
+
+        // Read-your-writes on the publishing replica: immediate, no polling.
+        let json_a = packument_json(&fx.state, &virtual_key, base_url, &full_headers).await;
+
+        // Replica B must converge via the NOTIFY fanout well before the
+        // 300 s fresh TTL; poll briefly for the asynchronous delivery. Both
+        // Accept variants must agree (the incoherence that split `npm pack`'s
+        // printed filename from its written bytes in #2490).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        let mut converged = false;
+        while std::time::Instant::now() < deadline {
+            let full = packument_json(&state_b, &virtual_key, base_url, &full_headers).await;
+            let corgi = packument_json(&state_b, &virtual_key, base_url, &corgi_headers).await;
+            if [&full, &corgi].iter().all(|json| {
+                json["versions"]["2.0.0"].is_object() && json["dist-tags"]["canary"] == "2.0.0"
+            }) {
+                converged = true;
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+
+        // Tear down before asserting so a failure never leaks DB state.
+        shutdown.cancel();
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(virtual_id)
+            .execute(&fx.pool)
+            .await
+            .expect("delete virtual repo");
+        let _ = std::fs::remove_dir_all(&virtual_dir);
+        fx.teardown().await;
+
+        assert!(
+            json_a["versions"]["2.0.0"].is_object() && json_a["dist-tags"]["canary"] == "2.0.0",
+            "publishing replica must read its own write immediately, got {:?}",
+            json_a["dist-tags"]
+        );
+        assert!(
+            converged,
+            "replica B must see 2.0.0 and dist-tags.canary coherently in both \
+             Accept variants within seconds of the publish (would take up to \
+             the fresh TTL + per-variant SWR reads without the fanout, #2490)"
+        );
+    }
+
     /// #2022: a direct `npm publish` to a `promotion_only` repository must be
     /// rejected with 409 CONFLICT; the same publish to a normal repository must
     /// still succeed. Skips when no test database is configured.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -862,9 +862,10 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         .store(setup_required, std::sync::atomic::Ordering::Relaxed);
     let state = Arc::new(app_state);
 
-    // Fan out authorization-cache invalidations from other replicas via
-    // Postgres LISTEN/NOTIFY (migration 142 triggers +
-    // services/cache_invalidation.rs). Awaited so the initial LISTEN and the
+    // Fan out authorization-cache and npm computed-packument invalidations
+    // from other replicas via Postgres LISTEN/NOTIFY (migration 142 triggers
+    // + services/cache_invalidation.rs; the packument event is emitted
+    // application-side on local npm writes, #2490). Awaited so the initial LISTEN and the
     // conservative startup flush complete before requests are served; if the
     // connection fails the spawned task retries with backoff while requests
     // proceed under TTL-bound staleness.
@@ -874,6 +875,7 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
         cache_invalidation::CacheInvalidationHandles {
             repo_cache: state.repo_cache.clone(),
             permission_service: state.permission_service.clone(),
+            npm_packument_cache: state.npm_packument_cache.clone(),
         },
         runtime_shutdown_token.clone(),
     )

--- a/backend/src/services/cache_invalidation.rs
+++ b/backend/src/services/cache_invalidation.rs
@@ -17,6 +17,15 @@
 //! each received [`InvalidationEvent`] onto the existing process-local
 //! invalidation helpers.
 //!
+//! The same channel also carries the npm computed-packument invalidation
+//! (#2490). Unlike the trigger-emitted kinds above, that event is published
+//! application-side ([`notify_npm_packument_invalidated`]) by the replica
+//! that handled a local npm write (publish, dist-tag change, artifact
+//! delete): only the application knows the affected package name and the set
+//! of virtual repositories whose computed packument changed with it, and the
+//! emit happens after the write's local invalidation, so a receiving replica
+//! always recomputes from committed state.
+//!
 //! Postgres notifications are delivered only to sessions that are currently
 //! listening, so this is a best-effort latency optimisation layered on top of
 //! the existing TTLs, not a consistency proof: on listener startup and on
@@ -37,6 +46,7 @@ use uuid::Uuid;
 
 use crate::api::RepoCache;
 use crate::services::auth_service;
+use crate::services::npm_packument_cache::NpmPackumentCache;
 use crate::services::permission_service::PermissionService;
 
 /// Upper bound for the reconnect backoff. Long enough to avoid hammering a
@@ -72,6 +82,20 @@ pub enum InvalidationEvent {
     /// design: the whole permission cache is flushed (30 s TTL, so the
     /// refill burst is bounded); fine-grained keys can come later if needed.
     PermissionsChanged,
+    /// A local npm write (publish, dist-tag change, artifact delete) changed
+    /// the computed packument for `package` (#2490). `repo_keys` lists the
+    /// hosting repository and every virtual repository containing it; each
+    /// replica drops all of its cached packument variants (full/corgi ×
+    /// gzip/identity × base URL) for those keys, so a publish handled by one
+    /// replica is immediately visible through every replica instead of only
+    /// converging per-variant via stale-while-revalidate reads.
+    ///
+    /// Emitted application-side by [`notify_npm_packument_invalidated`], not
+    /// by a migration-142 trigger.
+    NpmPackumentInvalidated {
+        repo_keys: Vec<String>,
+        package: String,
+    },
 }
 
 /// Versioned wrapper matching the exact JSON the triggers emit.
@@ -88,6 +112,9 @@ pub struct InvalidationEnvelope {
 pub struct CacheInvalidationHandles {
     pub repo_cache: RepoCache,
     pub permission_service: Arc<PermissionService>,
+    /// npm computed-packument cache (#2490). `None` when the cache is
+    /// disabled; the event is then a no-op on this replica.
+    pub npm_packument_cache: Option<Arc<NpmPackumentCache>>,
 }
 
 /// Parse one notification payload into an [`InvalidationEvent`].
@@ -133,11 +160,25 @@ pub async fn apply_invalidation_event(
         InvalidationEvent::PermissionsChanged => {
             handles.permission_service.invalidate_cache();
         }
+        InvalidationEvent::NpmPackumentInvalidated { repo_keys, package } => {
+            if let Some(cache) = handles.npm_packument_cache.as_ref() {
+                for repo_key in repo_keys {
+                    cache.invalidate_package(repo_key, package).await;
+                }
+            }
+        }
     }
 }
 
 /// Conservatively flush every cache family this module manages. Used on
 /// listener startup, on reconnect, and on any payload that fails to parse.
+///
+/// The npm computed-packument cache is deliberately NOT flushed here: a
+/// missed [`InvalidationEvent::NpmPackumentInvalidated`] is a bounded,
+/// non-authorization staleness (the entry ages out of its fresh window and
+/// stale-while-revalidate converges it — the pre-#2490 behavior), whereas
+/// flushing every cached packument on each listener reconnect would trade a
+/// database blip for a cold-cache burst of upstream registry refetches.
 pub async fn conservative_flush_all(handles: &CacheInvalidationHandles) {
     let flushed_token_entries = auth_service::flush_all_api_token_cache_entries();
     handles.repo_cache.write().await.clear();
@@ -167,6 +208,72 @@ pub async fn handle_notification_payload(handles: &CacheInvalidationHandles, pay
                 "unparseable cache-invalidation payload; conservatively flushing caches"
             );
             conservative_flush_all(handles).await;
+        }
+    }
+}
+
+/// Soft bound on one NOTIFY payload. Postgres rejects payloads over 8000
+/// bytes; chunking well under that keeps a package contained in many virtual
+/// repositories from ever producing an undeliverable notification.
+const NOTIFY_PAYLOAD_SOFT_MAX_BYTES: usize = 6000;
+
+/// Serialize one [`InvalidationEvent::NpmPackumentInvalidated`] envelope for
+/// `repo_keys`/`package`, chunking `repo_keys` so every payload stays under
+/// [`NOTIFY_PAYLOAD_SOFT_MAX_BYTES`]. Pure so the chunking contract is unit
+/// testable; by construction each payload round-trips through
+/// [`parse_invalidation_payload`].
+pub fn npm_packument_invalidation_payloads(repo_keys: &[String], package: &str) -> Vec<String> {
+    let serialize = |keys: &[String]| -> String {
+        serde_json::to_string(&InvalidationEnvelope {
+            v: CACHE_INVALIDATION_VERSION,
+            event: InvalidationEvent::NpmPackumentInvalidated {
+                repo_keys: keys.to_vec(),
+                package: package.to_string(),
+            },
+        })
+        .expect("npm packument invalidation envelope must serialize")
+    };
+    let mut payloads = Vec::new();
+    let mut chunk: Vec<String> = Vec::new();
+    for key in repo_keys {
+        chunk.push(key.clone());
+        // A single repo key (<= 255 chars) plus a package name (<= 214) can
+        // never exceed the bound on its own, so an oversized chunk always
+        // has a previous key to flush.
+        if chunk.len() > 1 && serialize(&chunk).len() > NOTIFY_PAYLOAD_SOFT_MAX_BYTES {
+            let overflow = chunk.pop().expect("chunk has at least two entries");
+            payloads.push(serialize(&chunk));
+            chunk = vec![overflow];
+        }
+    }
+    if !chunk.is_empty() {
+        payloads.push(serialize(&chunk));
+    }
+    payloads
+}
+
+/// Publish an [`InvalidationEvent::NpmPackumentInvalidated`] for
+/// `repo_keys`/`package` on [`CACHE_INVALIDATION_CHANNEL`], so every
+/// listening replica drops its process-local computed-packument entries
+/// (#2490). Best-effort by design, matching the module's posture: on failure
+/// the local invalidation the caller already performed stands, and other
+/// replicas converge through stale-while-revalidate within their TTL bounds
+/// (the pre-#2490 behavior).
+pub async fn notify_npm_packument_invalidated(pool: &PgPool, repo_keys: &[String], package: &str) {
+    for payload in npm_packument_invalidation_payloads(repo_keys, package) {
+        if let Err(e) = sqlx::query("SELECT pg_notify($1, $2)")
+            .bind(CACHE_INVALIDATION_CHANNEL)
+            .bind(&payload)
+            .execute(pool)
+            .await
+        {
+            counter!("ak_cache_invalidation_notify_errors_total").increment(1);
+            tracing::warn!(
+                error = %e,
+                package,
+                "failed to publish npm packument invalidation; \
+                 other replicas converge via stale-while-revalidate"
+            );
         }
     }
 }
@@ -289,6 +396,7 @@ mod tests {
     use super::*;
     use crate::api::CachedRepo;
     use crate::services::auth_service;
+    use crate::services::npm_packument_cache;
 
     /// The permission service needs a pool at construction time but these
     /// tests never touch the database: `connect_lazy` defers any real
@@ -303,6 +411,26 @@ mod tests {
         CacheInvalidationHandles {
             repo_cache: Arc::new(RwLock::new(HashMap::new())),
             permission_service: lazy_permission_service(),
+            npm_packument_cache: None,
+        }
+    }
+
+    /// An in-process packument cache with a generous fresh window, so a
+    /// still-cached entry can only disappear through an invalidation.
+    fn in_process_packument_cache() -> Arc<npm_packument_cache::NpmPackumentCache> {
+        Arc::new(npm_packument_cache::NpmPackumentCache::new(
+            Arc::new(npm_packument_cache::InProcessPackumentCache::new(
+                std::time::Duration::from_secs(600),
+            )),
+            std::time::Duration::from_secs(300),
+        ))
+    }
+
+    fn cached_packument_entry() -> npm_packument_cache::CachedPackument {
+        npm_packument_cache::CachedPackument {
+            bytes: bytes::Bytes::from_static(b"{}"),
+            content_type: "application/json".to_string(),
+            content_encoding: None,
         }
     }
 
@@ -352,6 +480,10 @@ mod tests {
                 key: "repo-a".to_string(),
             },
             InvalidationEvent::PermissionsChanged,
+            InvalidationEvent::NpmPackumentInvalidated {
+                repo_keys: vec!["npm-local".to_string(), "npm-virtual".to_string()],
+                package: "@acme/webapp".to_string(),
+            },
         ];
         for event in events {
             let payload = serde_json::to_string(&InvalidationEnvelope {
@@ -376,6 +508,15 @@ mod tests {
         assert_eq!(
             parse_invalidation_payload(r#"{"v":1,"kind":"permissions_changed"}"#),
             Ok(InvalidationEvent::PermissionsChanged)
+        );
+        assert_eq!(
+            parse_invalidation_payload(
+                r#"{"v":1,"kind":"npm_packument_invalidated","repo_keys":["npm-local","npm-virtual"],"package":"@acme/webapp"}"#
+            ),
+            Ok(InvalidationEvent::NpmPackumentInvalidated {
+                repo_keys: vec!["npm-local".to_string(), "npm-virtual".to_string()],
+                package: "@acme/webapp".to_string(),
+            })
         );
     }
 
@@ -472,6 +613,129 @@ mod tests {
         assert!(
             auth_service::is_user_api_tokens_invalidated_after(user_id, cached_before_event),
             "cache entries older than the event must be rejected on hit"
+        );
+    }
+
+    /// #2490: applying the npm event must drop every cached variant of the
+    /// package in every listed repo key, and nothing else.
+    #[tokio::test]
+    async fn applying_npm_packument_invalidated_evicts_listed_repo_keys_only() {
+        let cache = in_process_packument_cache();
+        let mut handles = test_handles();
+        handles.npm_packument_cache = Some(cache.clone());
+
+        // Both Accept variants of the target package in the hosting repo and
+        // a containing virtual, plus two bystanders (other package, other
+        // repo).
+        let mut targeted = Vec::new();
+        for repo_key in ["npm-local", "npm-virtual"] {
+            for abbreviated in [false, true] {
+                let key = npm_packument_cache::cache_key(
+                    repo_key,
+                    "@acme/webapp",
+                    abbreviated,
+                    false,
+                    "http://a",
+                );
+                cache.store(&key, cached_packument_entry()).await;
+                targeted.push(key);
+            }
+        }
+        let bystanders = [
+            npm_packument_cache::cache_key("npm-virtual", "other-pkg", false, false, "http://a"),
+            npm_packument_cache::cache_key("npm-other", "@acme/webapp", false, false, "http://a"),
+        ];
+        for key in &bystanders {
+            cache.store(key, cached_packument_entry()).await;
+        }
+
+        apply_invalidation_event(
+            &handles,
+            &InvalidationEvent::NpmPackumentInvalidated {
+                repo_keys: vec!["npm-local".to_string(), "npm-virtual".to_string()],
+                package: "@acme/webapp".to_string(),
+            },
+        )
+        .await;
+
+        for key in &targeted {
+            assert!(
+                cache.lookup(key).await.is_none(),
+                "cached variant must be evicted by the cross-replica event: {key}"
+            );
+        }
+        for key in &bystanders {
+            assert!(
+                cache.lookup(key).await.is_some(),
+                "unrelated cache entries must survive a targeted eviction: {key}"
+            );
+        }
+    }
+
+    /// A replica with the packument cache disabled must apply the event as a
+    /// no-op, not panic or flush other caches.
+    #[tokio::test]
+    async fn applying_npm_packument_invalidated_without_cache_is_a_noop() {
+        let handles = test_handles();
+        warm_repo_cache(&handles, "repo-bystander").await;
+
+        apply_invalidation_event(
+            &handles,
+            &InvalidationEvent::NpmPackumentInvalidated {
+                repo_keys: vec!["npm-local".to_string()],
+                package: "widget".to_string(),
+            },
+        )
+        .await;
+
+        assert!(repo_cache_contains(&handles, "repo-bystander").await);
+    }
+
+    // -- npm payload chunking -------------------------------------------------
+
+    /// Every emitted payload must stay under the Postgres NOTIFY bound, parse
+    /// back, and together cover exactly the input repo keys in order.
+    #[test]
+    fn npm_payloads_chunk_under_the_notify_bound_and_round_trip() {
+        let repo_keys: Vec<String> = (0..200).map(|i| format!("npm-virtual-{i:0>200}")).collect();
+        let payloads = npm_packument_invalidation_payloads(&repo_keys, "@acme/webapp");
+
+        assert!(
+            payloads.len() > 1,
+            "200 x ~200-byte keys must not fit one payload"
+        );
+        let mut reassembled = Vec::new();
+        for payload in &payloads {
+            assert!(
+                payload.len() <= NOTIFY_PAYLOAD_SOFT_MAX_BYTES,
+                "payload of {} bytes exceeds the soft bound",
+                payload.len()
+            );
+            match parse_invalidation_payload(payload) {
+                Ok(InvalidationEvent::NpmPackumentInvalidated { repo_keys, package }) => {
+                    assert_eq!(package, "@acme/webapp");
+                    reassembled.extend(repo_keys);
+                }
+                other => panic!("chunked payload must parse back to the npm event, got {other:?}"),
+            }
+        }
+        assert_eq!(
+            reassembled, repo_keys,
+            "chunking must preserve every repo key exactly once, in order"
+        );
+    }
+
+    #[test]
+    fn npm_payloads_single_chunk_for_the_common_case() {
+        let repo_keys = vec!["npm-local".to_string(), "npm-virtual".to_string()];
+        let payloads = npm_packument_invalidation_payloads(&repo_keys, "widget");
+        assert_eq!(payloads.len(), 1);
+        assert_eq!(
+            parse_invalidation_payload(&payloads[0]),
+            Ok(InvalidationEvent::NpmPackumentInvalidated {
+                repo_keys,
+                package: "widget".to_string(),
+            })
         );
     }
 

--- a/backend/src/services/npm_packument_cache.rs
+++ b/backend/src/services/npm_packument_cache.rs
@@ -1205,9 +1205,17 @@ impl NpmPackumentCache {
 }
 
 /// Drop every cached variant of `package` in the repository AND in every
-/// virtual repository containing it. Shared by the local-write invalidation
-/// path (publish, dist-tag change, delete) and the upstream feed consumer
-/// (#2249), so "a package changed" means the same thing from both directions.
+/// virtual repository containing it, then fan the invalidation out to every
+/// other replica over the Postgres `LISTEN`/`NOTIFY` channel (#2490).
+///
+/// Without the fanout, a hosted publish handled by one replica leaves the
+/// other replicas' process-local entries serving the pre-publish packument
+/// as *fresh* for the whole fresh window, and each (replica × Accept variant
+/// × encoding × base URL) entry only converges when its own SWR refresh is
+/// triggered by a read — so successive reads through a load balancer can
+/// disagree about the same dist-tag for hours. The fanout also bumps the
+/// receiving replicas' invalidation generations, so their in-flight computes
+/// started before this write cannot re-install pre-write data.
 pub async fn invalidate_package_and_virtuals(
     db: &sqlx::PgPool,
     cache: &NpmPackumentCache,
@@ -1215,10 +1223,17 @@ pub async fn invalidate_package_and_virtuals(
     repo_key: &str,
     package: &str,
 ) {
+    let mut repo_keys = vec![repo_key.to_string()];
     cache.invalidate_package(repo_key, package).await;
     for virtual_key in virtual_repo_keys(db, repo_id).await {
         cache.invalidate_package(&virtual_key, package).await;
+        repo_keys.push(virtual_key);
     }
+    // After the local invalidation, so the emitting replica's own delivery is
+    // an idempotent no-op and receiving replicas recompute from the already
+    // committed write.
+    crate::services::cache_invalidation::notify_npm_packument_invalidated(db, &repo_keys, package)
+        .await;
 }
 
 /// Keys of every virtual repository containing `repo_id` as a member.

--- a/backend/tests/cache_invalidation_fanout_tests.rs
+++ b/backend/tests/cache_invalidation_fanout_tests.rs
@@ -200,6 +200,7 @@ fn fresh_handles(pool: &PgPool) -> CacheInvalidationHandles {
     CacheInvalidationHandles {
         repo_cache: Arc::new(RwLock::new(HashMap::new())),
         permission_service: Arc::new(PermissionService::new(pool.clone())),
+        npm_packument_cache: None,
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #2490.

After a hosted npm publish (or dist-tag change / artifact delete), the computed-packument cache was only invalidated on the replica that handled the write. Other replicas kept serving their process-local entries for the virtual repo as *fresh* for the whole fresh TTL, and past that each `(replica x full/corgi x gzip/identity x base URL)` variant only converged when its own stale-while-revalidate refresh was triggered by a read. In multi-replica deployments this left successive reads disagreeing about the same dist-tag for hours, including inside a single `npm pack`/`npm install` invocation (the printed-filename vs written-bytes split reported in #2490).

This wires the npm computed-packument invalidation into the existing cross-replica cache-invalidation fanout (`services/cache_invalidation.rs`, Postgres `LISTEN`/`NOTIFY`, the same channel the migration-142 auth-cache triggers use):

- `invalidate_package_and_virtuals` (the shared local-write invalidation path used by publish, dist-tag put/delete, and REST artifact delete) now publishes an `npm_packument_invalidated` event carrying the hosting repo key, every containing virtual repo key, and the package name, after performing its local invalidation.
- Every replica's existing invalidation listener applies the event with the same `invalidate_package` helper the originating replica calls locally, dropping all cached variants at once and bumping the per-package invalidation generation (so in-flight computes started before the write cannot re-install pre-write data on receiving replicas either).
- The event is emitted application-side (only the application knows the package name and the virtual-repo membership), chunked to stay under the Postgres NOTIFY payload bound, and best-effort: on failure the local invalidation stands and other replicas converge through the existing SWR/TTL bounds, exactly the pre-change behavior. The npm cache is deliberately excluded from the listener's conservative reconnect flush: a missed event is bounded, non-authorization staleness, while flushing on every reconnect would trade a database blip for a cold-cache burst of upstream refetches.

The cache design itself (SWR, fresh/stale windows, optional shared Redis backend) is unchanged; this only adds the missing cross-replica invalidation signal, mirroring how the auth caches already stay coherent. Deployments with the optional Redis backend get the same benefit for their always-warm local layers, and the generation bump narrows the documented cross-replica store race window.

Not covered here (separate concern): the proxied-upstream feed consumer (#2249) still invalidates only the replica holding the consumer lock; that path has no local write and is tracked separately.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_publish_invalidates_virtual_packument_across_replicas` (backend/src/api/handlers/npm.rs) simulates two replicas as two process-local states over one database: replica B warms its virtual-repo packument cache in both Accept variants, replica A publishes a new version with a `canary` dist-tag, and replica B must serve the new version and dist-tag coherently in both variants within seconds (it converges in ~0.3 s with the fanout; without it the test times out because B's entries stay "fresh" for the 300 s TTL — verified failing with the emit disabled). The test also asserts immediate read-your-writes on the publishing replica.

Unit tests in `services/cache_invalidation.rs` cover the new event: payload round-trip and exact wire shape, targeted eviction across listed repo keys with bystander survival, no-op application when the cache is disabled, and NOTIFY payload chunking (size bound + lossless reassembly).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
