### PR TITLE
fix(scanner): register tenant scan refcount inside the RAII guard

### DIFF
--- a/backend/src/services/scanner_service.rs
+++ b/backend/src/services/scanner_service.rs
@@ -1188,7 +1188,11 @@ async fn acquire_scan_extraction_permit_from(
     fair_share: usize,
 ) -> ScanExtractionPermit {
     // Register this scan against its tenant and fetch the tenant's semaphore.
-    let tenant_sem = {
+    // The RAII guard is constructed in the SAME no-await critical section as the
+    // refcount bump: if this future is dropped at a later `.await` (permit
+    // acquisition), the guard's `Drop` still decrements the refcount and prunes
+    // the entry, keeping acquire/release symmetric on every exit path (#2595).
+    let (tenant_sem, mut permit) = {
         let mut reg = registry.lock().expect("tenant registry mutex poisoned");
         let entry = reg
             .entry(repository_id)
@@ -1197,7 +1201,15 @@ async fn acquire_scan_extraction_permit_from(
                 refs: 0,
             });
         entry.refs += 1;
-        entry.sem.clone()
+        (
+            entry.sem.clone(),
+            ScanExtractionPermit {
+                repository_id,
+                registry: registry.clone(),
+                _global: None,
+                _tenant: None,
+            },
+        )
     };
 
     // Per-tenant FIRST, then global (consistent ordering => no deadlock).
@@ -1225,12 +1237,9 @@ async fn acquire_scan_extraction_permit_from(
         },
     };
 
-    ScanExtractionPermit {
-        repository_id,
-        registry,
-        _global: global_permit,
-        _tenant: tenant_permit,
-    }
+    permit._global = global_permit;
+    permit._tenant = tenant_permit;
+    permit
 }
 
 /// Process-wired entry point for [`acquire_scan_extraction_permit_from`], using
@@ -10405,6 +10414,64 @@ mod tests {
         assert!(
             registry.lock().unwrap().is_empty(),
             "idle per-tenant entries must be pruned on drop"
+        );
+    }
+
+    /// #2595: dropping the acquire future mid-`.await` (cancellation) must not
+    /// leak the tenant refcount. Before the fix, `refs += 1` ran before the RAII
+    /// guard existed, so a future dropped while parked on the global semaphore
+    /// left a permanent registry entry for the tenant.
+    #[tokio::test]
+    async fn test_scan_extraction_cancelled_acquire_does_not_leak_refcount() {
+        let global = Arc::new(Semaphore::new(1));
+        let registry: TenantExtractionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let fair = 1;
+        let blocker = Uuid::new_v4();
+        let victim = Uuid::new_v4();
+
+        // Saturate the global pool so the next acquire parks on the global await.
+        let held =
+            acquire_scan_extraction_permit_from(blocker, global.clone(), registry.clone(), fair)
+                .await;
+
+        // The victim is within its fair share (fresh tenant), so it reserves its
+        // tenant slot and then blocks at `global.acquire_owned().await`. The
+        // timeout drops the acquire future at exactly that cancellation point.
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(100),
+            acquire_scan_extraction_permit_from(victim, global.clone(), registry.clone(), fair),
+        )
+        .await;
+        assert!(
+            cancelled.is_err(),
+            "victim acquire must still be parked on the global cap"
+        );
+
+        // The dropped future must have unwound its registration: entry pruned.
+        assert!(
+            !registry.lock().unwrap().contains_key(&victim),
+            "cancelled acquire leaked the tenant refcount/registry entry (#2595)"
+        );
+
+        // Normal acquire/release cycle stays symmetric after the cancellation.
+        drop(held);
+        let permit =
+            acquire_scan_extraction_permit_from(victim, global.clone(), registry.clone(), fair)
+                .await;
+        assert_eq!(
+            registry.lock().unwrap().get(&victim).map(|e| e.refs),
+            Some(1),
+            "in-flight scan must be registered with exactly one ref"
+        );
+        drop(permit);
+        assert!(
+            registry.lock().unwrap().is_empty(),
+            "normal acquire/release must prune the tenant entry"
+        );
+        assert_eq!(
+            global.available_permits(),
+            1,
+            "every global permit must be returned"
         );
     }
 


### PR DESCRIPTION
## Summary

Follow-up to the #2555 per-tenant scan-fairness layer. `acquire_scan_extraction_permit_from` bumped the tenant refcount (`entry.refs += 1`) *before* any `.await` and only constructed the `ScanExtractionPermit` RAII guard *after* the semaphore acquisitions. If the acquire future is dropped at one of those await points (cancellation), the guard never exists, `Drop` never runs, and the tenant's registry entry leaks permanently (refcount never returns to 0, entry never pruned).

This PR makes acquire/release symmetric: the guard is now constructed in the **same no-await critical section** as the refcount bump, so a future dropped at any later await still decrements the refcount and prunes the entry via `Drop`. The acquired permits are assigned into the already-live guard afterwards. `Drop` continues to use `saturating_sub`, so the refcount cannot go negative.

Latent per the issue analysis: all production scan triggers dispatch via detached `tokio::spawn` with no cancellation wrapper, so the leak path is currently unreachable — this is hardening so future callers (timeouts, `select!`) can't introduce it.

Fairness semantics from #2555 are unchanged: lone-tenant burst to the full global `N`, per-tenant fair-share floor under contention, tenant-then-global acquire ordering, and idle-entry pruning all still hold (existing tests unchanged and passing).

Closes #2595

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_scan_extraction_cancelled_acquire_does_not_leak_refcount`: saturates the global pool, parks a second tenant's acquire on the global semaphore, drops the future via `tokio::time::timeout`, and asserts the tenant's registry entry is pruned; then verifies a normal acquire/release cycle registers exactly one ref and prunes on drop. Fails on `main` ("cancelled acquire leaked the tenant refcount/registry entry"), passes on this branch.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local gates: `cargo fmt --check` clean, `cargo build --lib` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo nextest run --workspace --lib` 13809 passed / 0 failed.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
