### PR TITLE
fix: require repository admin to update repository security scan config

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -220,7 +220,11 @@ async fn require_repo_fine_grained_action(
 /// fine-grained permission rules exist, matching the inline gate already used
 /// by `set_cache_ttl` / `set_npm_scope_policy` / `invalidate_cache`. Callers
 /// should invoke this AFTER [`require_repo_write_access`] (the tenant gate).
-async fn require_repo_admin(
+///
+/// `pub(crate)` so sibling handler modules with repository-configuration
+/// subresources (e.g. the per-repo scan/security config in `security.rs`,
+/// #2750) can apply the same gate instead of duplicating it.
+pub(crate) async fn require_repo_admin(
     auth: &AuthExtension,
     repo_id: Uuid,
     permission_service: &crate::services::permission_service::PermissionService,

--- a/backend/src/api/handlers/security.rs
+++ b/backend/src/api/handlers/security.rs
@@ -11,7 +11,9 @@ use utoipa::{IntoParams, OpenApi, ToSchema};
 use uuid::Uuid;
 
 use crate::api::handlers::artifacts::check_artifact_visibility;
-use crate::api::handlers::repositories::{require_repo_write_access, require_visible};
+use crate::api::handlers::repositories::{
+    require_repo_admin, require_repo_write_access, require_visible,
+};
 use crate::api::middleware::auth::AuthExtension;
 use crate::api::SharedState;
 use crate::error::{AppError, Result};
@@ -1270,6 +1272,12 @@ async fn update_repo_security(
     let repo_service = RepositoryService::new(state.db.clone());
     let repo = repo_service.get_by_key(&key).await?;
     require_repo_write_access(&auth, &repo, &repo_service).await?;
+    // Scan configuration is a repository supply-chain control (scan_enabled /
+    // block_on_policy_violation / severity_threshold): disabling it must be
+    // repository administration, not artifact publishing. Same admin tier and
+    // fail-closed gate as the configuration subresources fixed in #2745
+    // (#2603 sibling, #2750).
+    require_repo_admin(&auth, repo.id, &state.permission_service).await?;
     let repo = repo.id;
 
     let svc = ScanConfigService::new(state.db.clone());
@@ -1442,6 +1450,13 @@ mod tests {
             body_of("update_repo_security").contains("require_repo_write_access("),
             "update_repo_security must call require_repo_write_access (xtenant)"
         );
+        assert!(
+            body_of("update_repo_security").contains("require_repo_admin("),
+            "update_repo_security must call require_repo_admin (#2750): scan \
+             configuration is a supply-chain control on the repository-admin \
+             tier; `write` (artifact publishing) must not suffice to disable \
+             scanning or the block-on-severity gate"
+        );
         for reader in ["get_repo_security", "list_repo_scans"] {
             assert!(
                 body_of(reader).contains("require_visible("),
@@ -1449,6 +1464,92 @@ mod tests {
                 reader
             );
         }
+    }
+
+    /// DB-backed (#2750, sibling of #2603): a non-admin member holding only
+    /// `write` (developer role via `grant_repo_access`, no fine-grained `admin`
+    /// grant) is DENIED `update_repo_security`, and the denied request must not
+    /// persist a scan config; granting the repository `admin` action lets it
+    /// through; a global admin always passes. Scan configuration gates the
+    /// vulnerability-scanning / block-on-severity supply chain, so write-level
+    /// access (artifact publishing) must not suffice to disable it.
+    #[tokio::test]
+    async fn update_repo_security_requires_repo_admin_db() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (user_id, username) = tdh::create_user(&pool).await;
+        let (repo_id, key, dir) = tdh::create_repo(&pool, "local", "generic").await;
+        // Write-level membership only (developer role): passes the tenant gate.
+        tdh::grant_repo_access(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let auth = tdh::make_auth(user_id, &username);
+
+        // The exploit shape: turn scanning and the block-on-severity gate off.
+        let body = || UpsertScanConfigRequest {
+            scan_enabled: Some(false),
+            block_on_policy_violation: Some(false),
+            ..Default::default()
+        };
+
+        // 1) Write-only member -> 403, and nothing persisted.
+        let denied = update_repo_security(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Path(key.clone()),
+            Json(body()),
+        )
+        .await;
+        assert!(
+            matches!(denied, Err(AppError::Authorization(_))),
+            "write-only member must be denied (403) update_repo_security: {denied:?}"
+        );
+        let persisted = ScanConfigService::new(pool.clone())
+            .get_config(repo_id)
+            .await
+            .expect("get_config");
+        assert!(
+            persisted.is_none(),
+            "denied update_repo_security must not persist a scan config"
+        );
+
+        // 2) Grant repository `admin` -> allowed. Rebuild state so the
+        // permission-service cache (which recorded the pre-grant deny above)
+        // is empty and the new grant is resolved from the database.
+        tdh::grant_repo_admin(&pool, repo_id, user_id).await;
+        let state = tdh::build_state(pool.clone(), dir.to_string_lossy().as_ref());
+        let allowed = update_repo_security(
+            State(state.clone()),
+            Extension(Some(auth.clone())),
+            Path(key.clone()),
+            Json(body()),
+        )
+        .await;
+        assert!(
+            allowed.is_ok(),
+            "repo-admin member must pass update_repo_security: {allowed:?}"
+        );
+
+        // 3) Global admin -> allowed.
+        let admin = tdh::admin_auth(Uuid::new_v4(), "root");
+        let admin_ok = update_repo_security(
+            State(state.clone()),
+            Extension(Some(admin)),
+            Path(key.clone()),
+            Json(UpsertScanConfigRequest {
+                scan_enabled: Some(true),
+                ..Default::default()
+            }),
+        )
+        .await;
+        assert!(
+            admin_ok.is_ok(),
+            "global admin must pass update_repo_security: {admin_ok:?}"
+        );
+
+        tdh::cleanup(&pool, repo_id, user_id).await;
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Admin gate on the GLOBAL security-policy write handlers. The global


### PR DESCRIPTION
## Summary
`PUT /api/v1/repositories/{key}/security` (`update_repo_security` in `backend/src/api/handlers/security.rs`) was gated only by `require_repo_write_access` (the tenant/membership gate). The body (`UpsertScanConfigRequest`) controls `scan_enabled`, `scan_on_upload`, `scan_on_proxy`, `block_on_policy_violation`, and `severity_threshold`, so a repository member holding only `write` (the ability to publish artifacts) could disable the repository's vulnerability scanning and the block-on-severity gate, or raise the threshold — a repository-configuration/supply-chain operation on the same administrative tier as the subresources addressed for #2603 (#2745).

This PR applies the same gate #2745 introduced:

- `update_repo_security` now calls `require_repo_admin(&auth, repo.id, &state.permission_service)` after the existing tenant write gate — fail-closed: global admins bypass, every other caller must hold the repository `admin` action, with no rules-empty fallthrough.
- `require_repo_admin` in `repositories.rs` is widened to `pub(crate)` so sibling handler modules with configuration subresources reuse the one gate instead of duplicating it.
- The `test_repo_security_handlers_enforce_tenant_gate` string-grep guard now also asserts `update_repo_security` calls `require_repo_admin`, so a future edit cannot silently downgrade the handler back to write-level authorization.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`update_repo_security_requires_repo_admin_db` (DB-backed, mirrors #2745's `set_routing_rules_requires_repo_admin_db`):
1. write-only member (developer role, no `admin` grant) → `Err(AppError::Authorization)` (403), and no scan-config row is persisted;
2. after granting the repository `admin` action → allowed;
3. global admin → allowed.

Fails on `main` (before the gate, step 1 observed `Ok(ScanConfigResponse { scan_enabled: false, block_on_policy_violation: false, .. })` — the exploit persisting); passes on this branch.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — DB-backed handler test against a migrated Postgres
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — `cargo build --lib`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo fmt --check`, targeted lib tests (new test + all existing `requires_repo_admin` tests from #2745) all green
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (authorization tier of an existing endpoint only)

Closes #2750
