### PR TITLE
fix(ldap): sync Active Directory groups to local groups on login

### DIFF
--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -640,6 +640,8 @@ pub async fn ldap_login(
         bind_password.as_deref(),
         &row.user_base_dn,
         &row.user_filter,
+        row.group_base_dn.as_deref(),
+        row.group_filter.as_deref(),
         &row.username_attribute,
         &row.email_attribute,
         &row.display_name_attribute,
@@ -666,6 +668,12 @@ pub async fn ldap_login(
         }
     };
 
+    // Keep copies for the group sync below; the `ldap_user` fields move
+    // into FederatedCredentials.
+    let ldap_dn = ldap_user.dn.clone();
+    let ldap_username = ldap_user.username.clone();
+    let ldap_member_of = ldap_user.groups.clone();
+
     // Sync user to local DB and generate JWT
     let auth_service = AuthService::new(state.db.clone(), Arc::new(state.config.clone()));
     let (user, tokens) = auth_service
@@ -684,6 +692,30 @@ pub async fn ldap_login(
             },
         )
         .await?;
+
+    // Issue #2468: when group sync is configured (group_base_dn and/or
+    // group_filter set), reflect the user's LDAP/AD groups as Artifact
+    // Keeper group memberships through the shared external-group
+    // reconciler (same mechanism as OIDC #1094 / SAML #2333): groups are
+    // auto-created tagged external_source = 'ldap', memberships upserted,
+    // and stale 'ldap'-managed memberships pruned per provider. Non-fatal:
+    // login still succeeds if the directory or DB hiccups.
+    if ldap_svc.group_sync_configured() {
+        let group_names = ldap_svc
+            .resolve_group_names(&ldap_dn, &ldap_username, &ldap_member_of)
+            .await;
+        if let Err(e) =
+            sync_federated_groups_to_local_groups(&state.db, user.id, id, "ldap", &group_names)
+                .await
+        {
+            tracing::warn!(
+                user_id = %user.id,
+                provider_id = %id,
+                error = %e,
+                "Failed to sync LDAP groups to local groups; user login still succeeds"
+            );
+        }
+    }
 
     audit_federated_login(
         &state,
@@ -1221,10 +1253,10 @@ pub(crate) async fn sync_federated_groups_to_local_groups(
             "#,
         )
         .bind(name)
-        .bind(if source == "saml" {
-            format!("Auto-created from SAML group attribute: {name}")
-        } else {
-            format!("Auto-created from OIDC group claim: {name}")
+        .bind(match source {
+            "saml" => format!("Auto-created from SAML group attribute: {name}"),
+            "ldap" => format!("Auto-created from LDAP group: {name}"),
+            _ => format!("Auto-created from OIDC group claim: {name}"),
         })
         .bind(source)
         .bind(provider_id)
@@ -3039,6 +3071,61 @@ mod tests {
             );
 
             cleanup_groups(&pool, &[g1_id, g2_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        // ===================================================================
+        // LDAP variant (#2468) — same reconciler via the "ldap" source from
+        // the ldap_login handler. Groups resolved from AD memberOf / group
+        // search are auto-created tagged external_source = 'ldap' and stale
+        // ldap-managed memberships are pruned on the next login.
+        // ===================================================================
+
+        #[tokio::test]
+        async fn test_ldap_sync_creates_groups_tagged_ldap_and_prunes() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            let provider_id = Uuid::new_v4();
+            let devops = rand_group_name("ldap-devops");
+            let qa = rand_group_name("ldap-qa");
+
+            // First login: user is in both AD groups.
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "ldap",
+                &[devops.clone(), qa.clone()],
+            )
+            .await
+            .expect("first ldap sync");
+
+            let devops_id = group_id_by_name(&pool, &devops).await.expect("devops");
+            let qa_id = group_id_by_name(&pool, &qa).await.expect("qa");
+            assert!(user_is_in_group(&pool, user_id, devops_id).await);
+            assert!(user_is_in_group(&pool, user_id, qa_id).await);
+            assert_eq!(
+                group_external_source(&pool, devops_id).await.as_deref(),
+                Some("ldap")
+            );
+
+            // Second login: dropped from qa in AD -> membership pruned,
+            // devops survives.
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "ldap",
+                std::slice::from_ref(&devops),
+            )
+            .await
+            .expect("second ldap sync");
+            assert!(user_is_in_group(&pool, user_id, devops_id).await);
+            assert!(!user_is_in_group(&pool, user_id, qa_id).await);
+
+            cleanup_groups(&pool, &[devops_id, qa_id]).await;
             cleanup_user(&pool, user_id).await;
         }
 

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -1201,9 +1201,18 @@ pub(crate) async fn sync_oidc_groups_to_local_groups(
 /// Reconcile a federated user's group memberships against the `groups` table.
 ///
 /// For each group name in `idp_groups`:
-/// - Find the group by name; if missing, auto-create it tagged with
-///   `external_source = source` and `external_provider_id = provider_id`.
+/// - Find the group by name **within this provider's namespace** — i.e. only
+///   a group already tagged with `external_source = source` and
+///   `external_provider_id = provider_id` is reused; if missing, auto-create
+///   it with those tags.
 /// - Ensure a `user_group_members` row exists.
+///
+/// A name collision with any group OUTSIDE that namespace — operator-managed
+/// (`external_source IS NULL`) or owned by another source/provider — is
+/// refused and logged instead of granting membership (issue #2759): matching
+/// by name alone would let an IdP-supplied group name (e.g. an AD `cn` from a
+/// low-privilege OU, #2468) attach a federated user to a same-named
+/// privileged local group the operator created.
 ///
 /// Then remove the user from any group that:
 /// - is tagged with this same `external_source` + `external_provider_id`, AND
@@ -1212,7 +1221,7 @@ pub(crate) async fn sync_oidc_groups_to_local_groups(
 /// The prune is scoped to `(source, provider_id)`, so SAML-managed and
 /// OIDC-managed memberships never strip each other, and operator-managed
 /// groups (NULL `external_source`) are never modified by this sync.
-/// (Issues #1094, #2333.)
+/// (Issues #1094, #2333, #2759.)
 pub(crate) async fn sync_federated_groups_to_local_groups(
     pool: &sqlx::PgPool,
     user_id: Uuid,
@@ -1232,23 +1241,30 @@ pub(crate) async fn sync_federated_groups_to_local_groups(
             continue;
         }
 
-        // Find-or-create the group atomically. Concurrent first-logins for
-        // the same brand-new group name from different users would race a
-        // separate SELECT + INSERT, with the loser of the race hitting the
-        // UNIQUE constraint on `groups.name` and aborting the transaction.
-        // ON CONFLICT (name) DO UPDATE … RETURNING id collapses the race
-        // into a single atomic upsert. The `DO UPDATE` (a no-op assignment)
-        // is what makes RETURNING populate for the conflicting row; a plain
-        // DO NOTHING would return zero rows on conflict. Operator-managed
-        // groups (NULL external_source) are reused without modification
-        // because we only assign description/external_source/external_provider_id
-        // when inserting, and the ON CONFLICT branch does not touch those
-        // columns.
-        let (group_id,): (Uuid,) = sqlx::query_as(
+        // Find-or-create the group atomically, scoped to THIS provider's
+        // namespace. Concurrent first-logins for the same brand-new group
+        // name from different users would race a separate SELECT + INSERT,
+        // with the loser of the race hitting the UNIQUE constraint on
+        // `groups.name` and aborting the transaction. ON CONFLICT (name)
+        // DO UPDATE … RETURNING id collapses the race into a single atomic
+        // upsert; the no-op `DO UPDATE` assignment is what makes RETURNING
+        // populate for the conflicting row.
+        //
+        // The DO UPDATE … WHERE clause is the #2759 ownership guard: the
+        // conflicting row is "updated" (and therefore returned) ONLY when it
+        // is already tagged with this same source + provider id. A collision
+        // with an operator-managed group (NULL external_source — the
+        // NULL = $3 comparison is never true) or with a group owned by a
+        // different source/provider returns no row, and membership is
+        // refused below instead of silently attaching the federated user to
+        // a same-named — potentially privileged — local group.
+        let group_id: Option<(Uuid,)> = sqlx::query_as(
             r#"
             INSERT INTO groups (name, description, external_source, external_provider_id)
             VALUES ($1, $2, $3, $4)
             ON CONFLICT (name) DO UPDATE SET name = EXCLUDED.name
+            WHERE groups.external_source = EXCLUDED.external_source
+              AND groups.external_provider_id = EXCLUDED.external_provider_id
             RETURNING id
             "#,
         )
@@ -1260,9 +1276,22 @@ pub(crate) async fn sync_federated_groups_to_local_groups(
         })
         .bind(source)
         .bind(provider_id)
-        .fetch_one(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
+
+        let Some((group_id,)) = group_id else {
+            tracing::warn!(
+                group = %name,
+                source = %source,
+                provider_id = %provider_id,
+                user_id = %user_id,
+                "Refusing to add federated user to name-colliding group not \
+                 managed by this provider (operator-managed or foreign-source \
+                 group of the same name exists); membership not granted (#2759)"
+            );
+            continue;
+        };
 
         sqlx::query(
             r#"
@@ -2838,8 +2867,13 @@ mod tests {
             cleanup_user(&pool, user_id).await;
         }
 
+        /// #2759 contract (flipped from the pre-hardening behaviour, which
+        /// asserted the federated user WAS attached): a name collision with
+        /// an operator-managed group (NULL external_source) must NOT grant
+        /// membership in that group, and the group itself must be left
+        /// untouched.
         #[tokio::test]
-        async fn test_sync_reuses_operator_managed_group_without_modifying_source() {
+        async fn test_sync_never_attaches_federated_user_to_operator_managed_group() {
             let Some(pool) = db_helpers::try_pool().await else {
                 return;
             };
@@ -2864,16 +2898,123 @@ mod tests {
                 std::slice::from_ref(&name),
             )
             .await
-            .expect("sync");
+            .expect("sync must not fail on the collision — it skips the group");
 
-            // The same group id must be reused (not duplicated).
+            // No duplicate group appears (UNIQUE(name)), the operator group
+            // keeps its id and NULL source, and — the point of #2759 — the
+            // federated user is NOT a member of it.
             let found_id = group_id_by_name(&pool, &name).await.expect("found");
             assert_eq!(found_id, preexisting_id);
-            assert!(user_is_in_group(&pool, user_id, found_id).await);
-            // external_source must remain NULL (operator-managed).
             assert!(group_external_source(&pool, found_id).await.is_none());
+            assert!(
+                !user_is_in_group(&pool, user_id, found_id).await,
+                "federated sync must not grant membership in an \
+                 operator-managed group of the same name"
+            );
 
             cleanup_groups(&pool, &[found_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        /// #2759 via the #2468 LDAP path: an AD `cn` from a low-privilege OU
+        /// (mapped cn-only by the LDAP group sync) colliding with a
+        /// privileged operator-managed local group must not grant that
+        /// group's membership — while legitimate ldap-namespaced groups in
+        /// the SAME sync still create and attach normally.
+        #[tokio::test]
+        async fn test_ldap_cn_collision_with_privileged_operator_group_is_refused() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            let provider_id = Uuid::new_v4();
+            let privileged = rand_group_name("developers");
+            let legit = rand_group_name("ldap-contractors");
+
+            let privileged_id = Uuid::new_v4();
+            sqlx::query("INSERT INTO groups (id, name, description) VALUES ($1, $2, $3)")
+                .bind(privileged_id)
+                .bind(&privileged)
+                .bind("operator-managed privileged group")
+                .execute(&pool)
+                .await
+                .expect("create privileged group");
+
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "ldap",
+                &[privileged.clone(), legit.clone()],
+            )
+            .await
+            .expect("sync succeeds; colliding name is skipped, not fatal");
+
+            assert!(
+                !user_is_in_group(&pool, user_id, privileged_id).await,
+                "AD cn collision must not grant the operator-managed \
+                 privileged group"
+            );
+            // The legitimate group from the same sync still works end to end.
+            let legit_id = group_id_by_name(&pool, &legit).await.expect("legit group");
+            assert!(user_is_in_group(&pool, user_id, legit_id).await);
+            assert_eq!(
+                group_external_source(&pool, legit_id).await.as_deref(),
+                Some("ldap")
+            );
+
+            cleanup_groups(&pool, &[privileged_id, legit_id]).await;
+            cleanup_user(&pool, user_id).await;
+        }
+
+        /// #2759 cross-namespace variant: a group owned by a DIFFERENT
+        /// source (or provider) is just as off-limits as an operator-managed
+        /// one — an LDAP sync must not attach to an OIDC-owned group of the
+        /// same name.
+        #[tokio::test]
+        async fn test_sync_never_attaches_to_foreign_source_group() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            let user_id = make_user(&pool).await;
+            let provider_id = Uuid::new_v4();
+            let name = rand_group_name("cross-src");
+
+            // Group owned by an OIDC provider (same provider UUID to prove
+            // the source participates in the namespace, not just the id).
+            let oidc_group_id = Uuid::new_v4();
+            sqlx::query(
+                "INSERT INTO groups (id, name, external_source, external_provider_id) \
+                 VALUES ($1, $2, 'oidc', $3)",
+            )
+            .bind(oidc_group_id)
+            .bind(&name)
+            .bind(provider_id)
+            .execute(&pool)
+            .await
+            .expect("create oidc-owned group");
+
+            sync_federated_groups_to_local_groups(
+                &pool,
+                user_id,
+                provider_id,
+                "ldap",
+                std::slice::from_ref(&name),
+            )
+            .await
+            .expect("sync succeeds; foreign-source collision is skipped");
+
+            assert!(
+                !user_is_in_group(&pool, user_id, oidc_group_id).await,
+                "LDAP sync must not attach to an OIDC-owned group of the same name"
+            );
+            assert_eq!(
+                group_external_source(&pool, oidc_group_id).await.as_deref(),
+                Some("oidc"),
+                "foreign group's ownership tags must be untouched"
+            );
+
+            cleanup_groups(&pool, &[oidc_group_id]).await;
             cleanup_user(&pool, user_id).await;
         }
 

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -1099,6 +1099,8 @@ impl AuthConfigService {
             bind_password.as_deref(),
             &row.user_base_dn,
             &row.user_filter,
+            row.group_base_dn.as_deref(),
+            row.group_filter.as_deref(),
             &row.username_attribute,
             &row.email_attribute,
             &row.display_name_attribute,

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -37,6 +37,14 @@ pub struct LdapConfig {
     pub display_name_attr: String,
     /// Attribute containing group memberships
     pub groups_attr: String,
+    /// Base DN for group searches / scoping (e.g., ou=groups,dc=example,dc=com).
+    /// When set, group synchronization is enabled (issue #2468).
+    pub group_base_dn: Option<String>,
+    /// Group search filter pattern. `{0}`/`{dn}` expand to the user's DN,
+    /// `{1}`/`{username}` to the username.
+    pub group_filter: Option<String>,
+    /// Attribute that names a group (default `cn`).
+    pub group_name_attr: String,
     /// Group DN for admin role mapping
     pub admin_group_dn: Option<String>,
     /// Use STARTTLS
@@ -57,6 +65,9 @@ redacted_debug!(LdapConfig {
     show email_attr,
     show display_name_attr,
     show groups_attr,
+    show group_base_dn,
+    show group_filter,
+    show group_name_attr,
     show admin_group_dn,
     show use_starttls,
     show ca_cert_path,
@@ -76,6 +87,14 @@ impl LdapConfig {
             .map(|v| v == "true" || v == "1")
             .unwrap_or(false);
         (ca_cert_path, no_tls_verify)
+    }
+
+    /// Attribute that names a group, from `LDAP_GROUP_ATTRIBUTE` (default `cn`).
+    fn group_name_attr_from_env() -> String {
+        std::env::var("LDAP_GROUP_ATTRIBUTE")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .unwrap_or_else(|| "cn".to_string())
     }
 
     /// Create LDAP config from application config
@@ -98,6 +117,13 @@ impl LdapConfig {
                 .unwrap_or_else(|_| "cn".to_string()),
             groups_attr: std::env::var("LDAP_GROUPS_ATTR")
                 .unwrap_or_else(|_| "memberOf".to_string()),
+            group_base_dn: std::env::var("LDAP_GROUP_BASE_DN")
+                .ok()
+                .filter(|v| !v.is_empty()),
+            group_filter: std::env::var("LDAP_GROUP_FILTER")
+                .ok()
+                .filter(|v| !v.is_empty()),
+            group_name_attr: Self::group_name_attr_from_env(),
             admin_group_dn: std::env::var("LDAP_ADMIN_GROUP_DN").ok(),
             use_starttls: std::env::var("LDAP_USE_STARTTLS")
                 .map(|v| v == "true" || v == "1")
@@ -181,6 +207,8 @@ impl LdapService {
         bind_password: Option<&str>,
         user_base_dn: &str,
         user_filter: &str,
+        group_base_dn: Option<&str>,
+        group_filter: Option<&str>,
         username_attr: &str,
         email_attr: &str,
         display_name_attr: &str,
@@ -199,6 +227,9 @@ impl LdapService {
             email_attr: email_attr.to_string(),
             display_name_attr: display_name_attr.to_string(),
             groups_attr: groups_attr.to_string(),
+            group_base_dn: group_base_dn.filter(|v| !v.is_empty()).map(String::from),
+            group_filter: group_filter.filter(|v| !v.is_empty()).map(String::from),
+            group_name_attr: LdapConfig::group_name_attr_from_env(),
             admin_group_dn: admin_group_dn.map(String::from),
             use_starttls,
             ca_cert_path,
@@ -571,11 +602,17 @@ impl LdapService {
             .and_then(|v| v.first())
             .cloned();
 
+        // Prefer the exact attribute key (preserves server-returned order for
+        // existing deployments). Active Directory returns large multi-valued
+        // attributes under a ranged key instead (e.g. `memberOf;range=0-1499`,
+        // range retrieval), which the exact lookup misses — fall back to
+        // collecting those values so users in many groups still get their
+        // memberships (issue #2468).
         let groups = entry
             .attrs
             .get(&self.config.groups_attr)
             .cloned()
-            .unwrap_or_default();
+            .unwrap_or_else(|| Self::ranged_attr_values(&entry.attrs, &self.config.groups_attr));
 
         let resolved_username = entry
             .attrs
@@ -696,6 +733,225 @@ impl LdapService {
             .replace('(', "\\28")
             .replace(')', "\\29")
             .replace('\0', "\\00")
+    }
+
+    /// Collect values of a multi-valued attribute returned under Active
+    /// Directory range-retrieval keys (e.g. `memberOf;range=0-1499`).
+    ///
+    /// Keys are matched case-insensitively. Values are sorted for
+    /// deterministic output because `attrs` is an unordered map.
+    fn ranged_attr_values(
+        attrs: &std::collections::HashMap<String, Vec<String>>,
+        name: &str,
+    ) -> Vec<String> {
+        let lname = name.to_ascii_lowercase();
+        let mut out: Vec<String> = attrs
+            .iter()
+            .filter(|(k, _)| {
+                let kl = k.to_ascii_lowercase();
+                kl == lname || (kl.starts_with(&lname) && kl[lname.len()..].starts_with(";range="))
+            })
+            .flat_map(|(_, v)| v.iter().cloned())
+            .collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// Whether group synchronization is configured for this provider
+    /// (issue #2468): a group base DN and/or a group filter is present.
+    pub fn group_sync_configured(&self) -> bool {
+        self.config.group_base_dn.is_some() || self.config.group_filter.is_some()
+    }
+
+    /// Resolve the names of the groups a user belongs to (issue #2468).
+    ///
+    /// Two complementary sources are merged:
+    ///
+    /// 1. The `memberOf` values from the user's own entry (`member_of`) —
+    ///    the Active Directory default, also available on OpenLDAP with the
+    ///    memberOf overlay. Values are group DNs; when `group_base_dn` is
+    ///    configured only DNs under that base are kept, and each DN's first
+    ///    RDN value (the group's `cn`) becomes the group name.
+    /// 2. A group-entry search under `group_base_dn` using the configured
+    ///    `group_filter` (or a default covering RFC 4519 `groupOfNames` /
+    ///    `groupOfUniqueNames`, `posixGroup` and AD `member`). This covers
+    ///    directories without user-side `memberOf`, and lets operators
+    ///    resolve nested AD groups by using the matching-rule-in-chain
+    ///    filter `(member:1.2.840.113556.1.4.1941:={0})`.
+    ///
+    /// Group-search failures are logged and skipped rather than propagated so
+    /// login never breaks on a partially configured directory: whatever came
+    /// from `memberOf` is still returned.
+    pub async fn resolve_group_names(
+        &self,
+        user_dn: &str,
+        username: &str,
+        member_of: &[String],
+    ) -> Vec<String> {
+        let mut names = std::collections::BTreeSet::new();
+
+        for group_dn in member_of {
+            if let Some(base) = &self.config.group_base_dn {
+                if !Self::dn_under_base(group_dn, base) {
+                    continue;
+                }
+            }
+            if let Some(name) = Self::dn_first_rdn_value(group_dn) {
+                names.insert(name);
+            }
+        }
+
+        if self.config.bind_dn.is_some() && self.config.bind_password.is_some() {
+            match self.search_group_names(user_dn, username).await {
+                Ok(found) => names.extend(found),
+                Err(e) => {
+                    tracing::warn!(
+                        user_dn = %user_dn,
+                        error = %e,
+                        "LDAP group search failed; continuing with memberOf-derived groups"
+                    );
+                }
+            }
+        }
+
+        names.into_iter().collect()
+    }
+
+    /// Search group entries the user is a member of and return their names.
+    ///
+    /// Only the group name attribute is requested — never `member` — so
+    /// Active Directory range retrieval on large groups cannot truncate the
+    /// result. Entries missing the name attribute fall back to the first RDN
+    /// value of their DN.
+    async fn search_group_names(&self, user_dn: &str, username: &str) -> Result<Vec<String>> {
+        use ldap3::{Scope, SearchEntry};
+
+        let (bind_dn, bind_pw) = match (&self.config.bind_dn, &self.config.bind_password) {
+            (Some(dn), Some(pw)) => (dn, pw),
+            _ => return Ok(Vec::new()),
+        };
+
+        let search_base = self
+            .config
+            .group_base_dn
+            .as_deref()
+            .unwrap_or(&self.config.base_dn);
+        let filter = self.build_group_filter(user_dn, username);
+
+        let mut ldap = self.connect_and_bind(bind_dn, bind_pw).await?;
+        let (results, _) = ldap
+            .search(
+                search_base,
+                Scope::Subtree,
+                &filter,
+                vec![self.config.group_name_attr.as_str()],
+            )
+            .await
+            .map_err(Self::search_error)?
+            .success()
+            .map_err(Self::search_error)?;
+        ldap.unbind().await.ok();
+
+        let entries: Vec<SearchEntry> = results.into_iter().map(SearchEntry::construct).collect();
+        Ok(Self::group_names_from_entries(
+            &entries,
+            &self.config.group_name_attr,
+        ))
+    }
+
+    /// Map group search entries to group names using the group name
+    /// attribute (case-insensitive), falling back to the first RDN value of
+    /// the entry DN when the attribute is absent.
+    fn group_names_from_entries(entries: &[ldap3::SearchEntry], name_attr: &str) -> Vec<String> {
+        let name_attr = name_attr.to_ascii_lowercase();
+        entries
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .attrs
+                    .iter()
+                    .find(|(k, _)| k.to_ascii_lowercase() == name_attr)
+                    .and_then(|(_, v)| v.first().cloned())
+                    .or_else(|| Self::dn_first_rdn_value(&entry.dn))
+            })
+            .collect()
+    }
+
+    /// Build the LDAP filter that finds the groups a user belongs to.
+    ///
+    /// The configured `group_filter` supports `{0}`/`{dn}` (the user's DN)
+    /// and `{1}`/`{username}` placeholders, all filter-escaped. A configured
+    /// filter without any user placeholder (e.g. `(objectClass=group)`) is
+    /// treated as a group-object class filter and AND-ed with the default
+    /// membership disjunction — matching every group in the base against the
+    /// user would otherwise grant all groups to everyone. Without a
+    /// configured filter the default membership disjunction is used alone.
+    fn build_group_filter(&self, user_dn: &str, username: &str) -> String {
+        let dn = Self::sanitize_ldap_input(user_dn);
+        let uname = Self::sanitize_ldap_input(username);
+        let membership = format!("(|(member={dn})(uniqueMember={dn})(memberUid={uname}))");
+
+        match &self.config.group_filter {
+            Some(f)
+                if f.contains("{0}")
+                    || f.contains("{dn}")
+                    || f.contains("{1}")
+                    || f.contains("{username}") =>
+            {
+                f.replace("{0}", &dn)
+                    .replace("{dn}", &dn)
+                    .replace("{1}", &uname)
+                    .replace("{username}", &uname)
+            }
+            Some(f) => format!("(&{f}{membership})"),
+            None => membership,
+        }
+    }
+
+    /// Extract the value of the first RDN of a DN
+    /// (`CN=devops_,OU=Global,DC=corp,DC=local` → `devops_`).
+    ///
+    /// Handles backslash-escaped characters (e.g. `CN=a\, b,OU=x`) by
+    /// unescaping them into the returned value.
+    fn dn_first_rdn_value(dn: &str) -> Option<String> {
+        let mut first_rdn = String::new();
+        let mut chars = dn.chars();
+        while let Some(c) = chars.next() {
+            match c {
+                '\\' => {
+                    if let Some(escaped) = chars.next() {
+                        first_rdn.push(escaped);
+                    }
+                }
+                ',' => break,
+                _ => first_rdn.push(c),
+            }
+        }
+        let (_, value) = first_rdn.split_once('=')?;
+        let value = value.trim();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value.to_string())
+        }
+    }
+
+    /// Whether `dn` sits under `base` (case-insensitive, tolerant of
+    /// whitespace around RDN separators). An empty base matches everything.
+    fn dn_under_base(dn: &str, base: &str) -> bool {
+        fn normalize(s: &str) -> String {
+            s.split(',')
+                .map(|part| part.trim().to_ascii_lowercase())
+                .collect::<Vec<_>>()
+                .join(",")
+        }
+        let dn = normalize(dn);
+        let base = normalize(base);
+        if base.is_empty() {
+            return true;
+        }
+        dn == base || dn.ends_with(&format!(",{base}"))
     }
 
     /// Check if LDAP is configured and available
@@ -894,6 +1150,9 @@ mod tests {
             email_attr: "mail".to_string(),
             display_name_attr: "cn".to_string(),
             groups_attr: "memberOf".to_string(),
+            group_base_dn: None,
+            group_filter: None,
+            group_name_attr: "cn".to_string(),
             admin_group_dn: Some("cn=admins,ou=groups,dc=example,dc=com".to_string()),
             use_starttls: false,
             ca_cert_path: None,
@@ -1269,6 +1528,8 @@ mod tests {
             Some("password"),
             "ou=users,dc=example,dc=com",
             "(sAMAccountName={username})",
+            Some("ou=groups,dc=example,dc=com"),
+            None,
             "sAMAccountName",
             "mail",
             "displayName",
@@ -1766,6 +2027,288 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extract_user_from_entry_ad_ranged_member_of() {
+        // Active Directory range retrieval: for users with many group
+        // memberships AD returns the attribute under a ranged key
+        // (`memberOf;range=0-1499`) instead of plain `memberOf`. The groups
+        // must still be picked up (issue #2468).
+        use std::collections::HashMap;
+
+        let config = make_test_ldap_config();
+        let svc = make_test_service(config);
+        let entry = ldap3::SearchEntry {
+            dn: "CN=jdoe,OU=Users,DC=corp,DC=local".to_string(),
+            attrs: HashMap::from([
+                ("sAMAccountName".to_string(), vec!["jdoe".to_string()]),
+                (
+                    "memberOf;range=0-1499".to_string(),
+                    vec![
+                        "CN=devops_,OU=Global,DC=corp,DC=local".to_string(),
+                        "CN=qa,OU=Global,DC=corp,DC=local".to_string(),
+                    ],
+                ),
+            ]),
+            bin_attrs: HashMap::new(),
+        };
+        let info = svc.extract_user_from_entry(entry, "jdoe");
+        assert_eq!(
+            info.groups.len(),
+            2,
+            "AD ranged memberOf values must be extracted, got: {:?}",
+            info.groups
+        );
+        assert!(info
+            .groups
+            .contains(&"CN=devops_,OU=Global,DC=corp,DC=local".to_string()));
+    }
+
+    // =======================================================================
+    // Group synchronization (issue #2468): name resolution from AD-shaped
+    // directory data — memberOf DNs, objectClass=group search entries, and
+    // range-retrieval attribute keys.
+    // =======================================================================
+
+    #[test]
+    fn test_dn_first_rdn_value_ad_group_dn() {
+        assert_eq!(
+            LdapService::dn_first_rdn_value("CN=devops_,OU=Global,DC=my_dn,DC=local"),
+            Some("devops_".to_string())
+        );
+        assert_eq!(
+            LdapService::dn_first_rdn_value("cn=developers,ou=groups,dc=example,dc=com"),
+            Some("developers".to_string())
+        );
+        // Escaped comma inside the RDN value stays part of the name.
+        assert_eq!(
+            LdapService::dn_first_rdn_value("CN=Ops\\, Team,OU=Global,DC=corp,DC=local"),
+            Some("Ops, Team".to_string())
+        );
+        assert_eq!(LdapService::dn_first_rdn_value("no-equals-sign"), None);
+        assert_eq!(LdapService::dn_first_rdn_value("CN=,OU=Global"), None);
+    }
+
+    #[test]
+    fn test_dn_under_base_scoping() {
+        // Case-insensitive and whitespace-tolerant, as AD DNs mix casing.
+        assert!(LdapService::dn_under_base(
+            "CN=devops_,OU=Global,DC=my_dn,DC=local",
+            "ou=global,dc=my_dn,dc=local"
+        ));
+        assert!(LdapService::dn_under_base(
+            "CN=qa, OU=Global, DC=my_dn, DC=local",
+            "OU=Global,DC=my_dn,DC=local"
+        ));
+        // A group outside the configured OU must be excluded.
+        assert!(!LdapService::dn_under_base(
+            "CN=other,OU=Elsewhere,DC=my_dn,DC=local",
+            "OU=Global,DC=my_dn,DC=local"
+        ));
+        // Suffix match must respect RDN boundaries.
+        assert!(!LdapService::dn_under_base(
+            "CN=x,OU=NotGlobal,DC=my_dn,DC=local",
+            "OU=Global,DC=my_dn,DC=local"
+        ));
+        assert!(LdapService::dn_under_base("CN=anything,DC=a", ""));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_group_names_from_ad_member_of_scoped_to_base() {
+        // The exact configuration from issue #2468: AD returns memberOf DNs
+        // on the user entry; only groups under LDAP_GROUP_BASE_DN sync, and
+        // the group name is the DN's cn value — not the full DN.
+        let mut config = make_test_ldap_config();
+        config.group_base_dn = Some("OU=Global,DC=my_dn,DC=local".to_string());
+        config.group_filter = Some("(memberOf={0})".to_string());
+        let svc = make_test_service(config);
+        assert!(svc.group_sync_configured());
+
+        // No bind credentials in this config, so only the memberOf path runs.
+        let names = svc
+            .resolve_group_names(
+                "CN=jdoe,OU=Users,DC=my_dn,DC=local",
+                "jdoe",
+                &[
+                    "CN=devops_,OU=Global,DC=my_dn,DC=local".to_string(),
+                    "CN=qa,OU=Global,DC=my_dn,DC=local".to_string(),
+                    // Outside the group base DN: must not sync.
+                    "CN=domain-users,CN=Builtin,DC=my_dn,DC=local".to_string(),
+                ],
+            )
+            .await;
+        assert_eq!(names, vec!["devops_".to_string(), "qa".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_group_names_without_base_uses_all_member_of() {
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(member={0})".to_string());
+        let svc = make_test_service(config);
+
+        let names = svc
+            .resolve_group_names(
+                "uid=jdoe,ou=users,dc=example,dc=com",
+                "jdoe",
+                &[
+                    "cn=developers,ou=groups,dc=example,dc=com".to_string(),
+                    "cn=admins,ou=groups,dc=example,dc=com".to_string(),
+                ],
+            )
+            .await;
+        assert_eq!(names, vec!["admins".to_string(), "developers".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_group_sync_configured_only_with_group_config() {
+        let svc = make_test_service(make_test_ldap_config());
+        assert!(
+            !svc.group_sync_configured(),
+            "no group_base_dn/group_filter -> sync stays off (pre-#2468 behaviour)"
+        );
+
+        let mut config = make_test_ldap_config();
+        config.group_base_dn = Some("ou=groups,dc=example,dc=com".to_string());
+        assert!(make_test_service(config).group_sync_configured());
+
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(member={0})".to_string());
+        assert!(make_test_service(config).group_sync_configured());
+    }
+
+    #[tokio::test]
+    async fn test_build_group_filter_placeholder_substitution_and_escaping() {
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(member={0})".to_string());
+        let svc = make_test_service(config);
+        assert_eq!(
+            svc.build_group_filter("CN=jdoe,OU=Users,DC=corp,DC=local", "jdoe"),
+            "(member=CN=jdoe,OU=Users,DC=corp,DC=local)"
+        );
+
+        // Filter metacharacters in the DN must be escaped (RFC 4515).
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(member={0})".to_string());
+        let svc = make_test_service(config);
+        assert_eq!(
+            svc.build_group_filter("CN=a\\, b(x)*,DC=corp", "j*doe"),
+            "(member=CN=a\\5c, b\\28x\\29\\2a,DC=corp)"
+        );
+
+        // AD nested-group resolution: matching-rule-in-chain passes through.
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(member:1.2.840.113556.1.4.1941:={0})".to_string());
+        let svc = make_test_service(config);
+        assert_eq!(
+            svc.build_group_filter("CN=jdoe,DC=corp", "jdoe"),
+            "(member:1.2.840.113556.1.4.1941:=CN=jdoe,DC=corp)"
+        );
+
+        // {1}/{username} placeholders (posixGroup style).
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(memberUid={1})".to_string());
+        let svc = make_test_service(config);
+        assert_eq!(
+            svc.build_group_filter("uid=jdoe,dc=x", "jdoe"),
+            "(memberUid=jdoe)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_group_filter_static_filter_gets_membership_guard() {
+        // A group-object filter with no user placeholder must NOT match every
+        // group in the base for every user: it is AND-ed with the membership
+        // disjunction instead.
+        let mut config = make_test_ldap_config();
+        config.group_filter = Some("(objectClass=group)".to_string());
+        let svc = make_test_service(config);
+        assert_eq!(
+            svc.build_group_filter("CN=jdoe,DC=corp", "jdoe"),
+            "(&(objectClass=group)(|(member=CN=jdoe,DC=corp)(uniqueMember=CN=jdoe,DC=corp)(memberUid=jdoe)))"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_build_group_filter_default_covers_ad_and_rfc4519() {
+        let mut config = make_test_ldap_config();
+        config.group_base_dn = Some("ou=groups,dc=example,dc=com".to_string());
+        let svc = make_test_service(config);
+        assert_eq!(
+            svc.build_group_filter("uid=jdoe,dc=example,dc=com", "jdoe"),
+            "(|(member=uid=jdoe,dc=example,dc=com)(uniqueMember=uid=jdoe,dc=example,dc=com)(memberUid=jdoe))"
+        );
+    }
+
+    #[test]
+    fn test_group_names_from_entries_ad_shaped() {
+        use std::collections::HashMap;
+
+        // AD-shaped group entries: objectClass=group, member DNs, cn.
+        let entries = vec![
+            ldap3::SearchEntry {
+                dn: "CN=devops_,OU=Global,DC=my_dn,DC=local".to_string(),
+                attrs: HashMap::from([
+                    ("objectClass".to_string(), vec!["group".to_string()]),
+                    ("cn".to_string(), vec!["devops_".to_string()]),
+                    (
+                        "member".to_string(),
+                        vec!["CN=jdoe,OU=Users,DC=my_dn,DC=local".to_string()],
+                    ),
+                ]),
+                bin_attrs: HashMap::new(),
+            },
+            // AD frequently returns attribute keys with server casing; the
+            // lookup must be case-insensitive.
+            ldap3::SearchEntry {
+                dn: "CN=qa,OU=Global,DC=my_dn,DC=local".to_string(),
+                attrs: HashMap::from([("CN".to_string(), vec!["qa".to_string()])]),
+                bin_attrs: HashMap::new(),
+            },
+            // Entry without the name attribute falls back to the DN's RDN.
+            ldap3::SearchEntry {
+                dn: "CN=release-mgrs,OU=Global,DC=my_dn,DC=local".to_string(),
+                attrs: HashMap::new(),
+                bin_attrs: HashMap::new(),
+            },
+        ];
+        assert_eq!(
+            LdapService::group_names_from_entries(&entries, "cn"),
+            vec![
+                "devops_".to_string(),
+                "qa".to_string(),
+                "release-mgrs".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_ranged_attr_values_collects_ad_range_keys() {
+        use std::collections::HashMap;
+        let attrs: HashMap<String, Vec<String>> = HashMap::from([
+            (
+                "memberOf;range=0-1499".to_string(),
+                vec!["CN=b,DC=x".to_string(), "CN=a,DC=x".to_string()],
+            ),
+            ("cn".to_string(), vec!["jdoe".to_string()]),
+        ]);
+        assert_eq!(
+            LdapService::ranged_attr_values(&attrs, "memberOf"),
+            vec!["CN=a,DC=x".to_string(), "CN=b,DC=x".to_string()]
+        );
+        // Case-insensitive plain key match too.
+        let attrs: HashMap<String, Vec<String>> =
+            HashMap::from([("memberof".to_string(), vec!["CN=g,DC=x".to_string()])]);
+        assert_eq!(
+            LdapService::ranged_attr_values(&attrs, "memberOf"),
+            vec!["CN=g,DC=x".to_string()]
+        );
+        // Unrelated attributes never leak in.
+        let attrs: HashMap<String, Vec<String>> = HashMap::from([(
+            "memberOfSomethingElse".to_string(),
+            vec!["CN=g,DC=x".to_string()],
+        )]);
+        assert!(LdapService::ranged_attr_values(&attrs, "memberOf").is_empty());
+    }
+
+    #[tokio::test]
     async fn test_extract_user_from_entry_missing_username_attr() {
         use std::collections::HashMap;
 
@@ -2116,5 +2659,178 @@ mod tests {
             Err(AppError::Config(_)) => {}
             other => panic!("expected Config error without credentials, got {other:?}"),
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // Group search against a mock LDAP server returning AD-shaped group
+    // entries (issue #2468): objectClass=group entries named by cn.
+    // -----------------------------------------------------------------------
+
+    /// Encode a single-byte-length BER TLV (content must stay under 128
+    /// bytes, which the short test DNs guarantee).
+    fn ber(tag: u8, content: &[u8]) -> Vec<u8> {
+        assert!(content.len() < 128, "test BER helper: content too long");
+        let mut out = vec![tag, content.len() as u8];
+        out.extend_from_slice(content);
+        out
+    }
+
+    /// Extract the messageID from a client LDAP frame (single-byte forms).
+    fn ldap_message_id(frame: &[u8]) -> u8 {
+        // SEQUENCE { 0x30 len 0x02 idlen id ... }
+        if frame.len() >= 5 && frame[0] == 0x30 && frame[2] == 0x02 {
+            frame[4]
+        } else {
+            1
+        }
+    }
+
+    /// Spawn a mock LDAP server that accepts a bind, then answers the next
+    /// searchRequest with the given AD-shaped group entries (dn + optional
+    /// `cn` value) followed by searchResultDone.
+    async fn spawn_mock_ldap_group_server(groups: Vec<(String, Option<String>)>) -> u16 {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind mock ldap listener");
+        let port = listener.local_addr().expect("local addr").port();
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                use tokio::io::{AsyncReadExt, AsyncWriteExt};
+                let mut buf = [0u8; 1024];
+
+                // bindRequest -> bindResponse success.
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let bind_id = ldap_message_id(&buf[..n]);
+                let bind_resp = ber(
+                    0x30,
+                    &[
+                        ber(0x02, &[bind_id]),
+                        ber(
+                            0x61,
+                            &[[0x0a, 0x01, 0x00].to_vec(), ber(0x04, b""), ber(0x04, b"")].concat(),
+                        ),
+                    ]
+                    .concat(),
+                );
+                let _ = sock.write_all(&bind_resp).await;
+
+                // searchRequest -> one searchResultEntry per group + done.
+                let n = sock.read(&mut buf).await.unwrap_or(0);
+                let search_id = ldap_message_id(&buf[..n]);
+                for (dn, cn) in &groups {
+                    // partialAttributeList: cn attribute when present.
+                    let attrs = match cn {
+                        Some(value) => ber(
+                            0x30,
+                            &ber(
+                                0x30,
+                                &[ber(0x04, b"cn"), ber(0x31, &ber(0x04, value.as_bytes()))]
+                                    .concat(),
+                            ),
+                        ),
+                        None => ber(0x30, b""),
+                    };
+                    let entry = ber(
+                        0x30,
+                        &[
+                            ber(0x02, &[search_id]),
+                            ber(0x64, &[ber(0x04, dn.as_bytes()), attrs].concat()),
+                        ]
+                        .concat(),
+                    );
+                    let _ = sock.write_all(&entry).await;
+                }
+                let done = ber(
+                    0x30,
+                    &[
+                        ber(0x02, &[search_id]),
+                        ber(
+                            0x65,
+                            &[[0x0a, 0x01, 0x00].to_vec(), ber(0x04, b""), ber(0x04, b"")].concat(),
+                        ),
+                    ]
+                    .concat(),
+                );
+                let _ = sock.write_all(&done).await;
+                let _ = sock.flush().await;
+
+                // Consume a possible unbindRequest before closing.
+                let _ = sock.read(&mut buf).await;
+            }
+        });
+        port
+    }
+
+    #[tokio::test]
+    async fn test_resolve_group_names_via_ad_group_search() {
+        // End-to-end over the wire: an AD-shaped directory where the user
+        // entry carried no usable memberOf, so groups come from the group
+        // search under group_base_dn (objectClass=group entries, named by
+        // cn; the third entry has no cn and falls back to its DN RDN).
+        let port = spawn_mock_ldap_group_server(vec![
+            (
+                "CN=devops_,OU=Global,DC=my_dn,DC=local".to_string(),
+                Some("devops_".to_string()),
+            ),
+            (
+                "CN=qa,OU=Global,DC=my_dn,DC=local".to_string(),
+                Some("qa".to_string()),
+            ),
+            (
+                "CN=release-mgrs,OU=Global,DC=my_dn,DC=local".to_string(),
+                None,
+            ),
+        ])
+        .await;
+
+        let mut config = make_test_ldap_config();
+        config.url = format!("ldap://127.0.0.1:{port}");
+        config.bind_dn = Some("CN=svc,OU=Users,DC=my_dn,DC=local".to_string());
+        config.bind_password = Some("secret".to_string());
+        config.group_base_dn = Some("OU=Global,DC=my_dn,DC=local".to_string());
+        config.group_filter = Some("(member={0})".to_string());
+        let svc = make_test_service(config);
+
+        let names = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            svc.resolve_group_names("CN=jdoe,OU=Users,DC=my_dn,DC=local", "jdoe", &[]),
+        )
+        .await
+        .expect("group search must not hang");
+        assert_eq!(
+            names,
+            vec![
+                "devops_".to_string(),
+                "qa".to_string(),
+                "release-mgrs".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_group_names_search_failure_falls_back_to_member_of() {
+        // Group search that cannot even connect must not fail login-time
+        // resolution: the memberOf-derived names still come back.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind listener");
+        let port = listener.local_addr().expect("local addr").port();
+        drop(listener);
+
+        let mut config = make_test_ldap_config();
+        config.url = format!("ldap://127.0.0.1:{port}");
+        config.bind_dn = Some("CN=svc,DC=my_dn,DC=local".to_string());
+        config.bind_password = Some("secret".to_string());
+        config.group_base_dn = Some("OU=Global,DC=my_dn,DC=local".to_string());
+        let svc = make_test_service(config);
+
+        let names = svc
+            .resolve_group_names(
+                "CN=jdoe,OU=Users,DC=my_dn,DC=local",
+                "jdoe",
+                &["CN=devops_,OU=Global,DC=my_dn,DC=local".to_string()],
+            )
+            .await;
+        assert_eq!(names, vec!["devops_".to_string()]);
     }
 }


### PR DESCRIPTION
## Summary

Closes #2468 — "Can't sync Active Directory groups".
Closes #2759 — federated group reconciler over-grants to operator-managed groups by name (hardening surfaced by red-team review of this PR; shared code, so it also fixes OIDC/SAML).

LDAP group synchronization was configuration-only. `ldap_configs` stores `group_base_dn` / `group_filter` (and `LDAP_GROUP_BASE_DN` / `LDAP_GROUP_FILTER` bootstrap them from the environment), but nothing ever read them back at login: the user's `memberOf` values fed only the `admin_group_dn` role check, and the external-group reconciler used by OIDC (#1094) and SAML (#2333) was never invoked with an `ldap` source. Result: with the documented AD configuration, **no groups were ever created or synced**, exactly as reported.

This PR makes LDAP/AD group sync real, reusing the existing reconciler:

- **Group name resolution** (`LdapService::resolve_group_names`) merges two sources:
  1. `memberOf` DNs from the user's own entry (the Active Directory default; also OpenLDAP with the memberOf overlay), scoped to `group_base_dn` when configured and named by the DN's first RDN value (the group `cn`) — so the issue's exact config (`LDAP_GROUP_BASE_DN=OU=Global,...`, `LDAP_GROUP_ATTRIBUTE=cn`) syncs `devops_` etc. rather than nothing;
  2. a group-entry search under `group_base_dn` using `group_filter` (`{0}`/`{dn}` = user DN, `{1}`/`{username}` = username, filter-escaped). The default filter covers AD `member`, RFC 4519 `member`/`uniqueMember`, and posixGroup `memberUid`; nested AD groups resolve when the operator uses the matching-rule-in-chain filter `(member:1.2.840.113556.1.4.1941:={0})`. A configured filter without a user placeholder (e.g. `(objectClass=group)`) is AND-ed with the membership disjunction so it cannot match every group for every user.
- **AD range retrieval**: users in very many groups get `memberOf;range=0-1499` instead of `memberOf`; those values are now collected too. The group search requests only the group name attribute (never `member`), so range retrieval on large groups cannot truncate results.
- **`ldap_login`** feeds the resolved names through `sync_federated_groups_to_local_groups` with source `ldap`: groups auto-create tagged `external_source = 'ldap'`, memberships upsert, and stale ldap-managed memberships prune scoped to (source, provider) — operator-managed and OIDC/SAML-managed groups are never touched. Sync failures are non-fatal to login (parity with OIDC/SAML).
- **Opt-in by configuration presence**: sync runs only when `group_base_dn` and/or `group_filter` is set, so providers without group configuration keep their exact previous behavior. No migration, no API change (both columns already existed).

Generic (OpenLDAP/RFC 4519) behavior is preserved: the pre-existing `memberOf`-exact-key path, its ordering, the admin-group mapping, and `LDAP_GROUP_ROLE_MAP` are unchanged.

### Reconciler over-grant hardening (#2759)

Red-team review of this PR found a MEDIUM over-grant in the **shared** reconciler (`sync_federated_groups_to_local_groups`) that predates it but is amplified by cn-only AD mapping: the group upsert keyed on `name` alone (`ON CONFLICT (name) DO UPDATE … RETURNING id`) and then unconditionally inserted membership. So a federated group name colliding with a pre-existing **operator-managed** group (`external_source IS NULL`) — or a group owned by a different source/provider — attached the federated user to that foreign group. Concretely, a user in `CN=developers,OU=Contractors` could land in a privileged operator-managed local `developers` group purely by name match.

Fix (shared, so it hardens OIDC #1094 / SAML #2333 / LDAP #2468 alike): the `ON CONFLICT DO UPDATE` now carries a `WHERE groups.external_source = EXCLUDED.external_source AND groups.external_provider_id = EXCLUDED.external_provider_id` guard, so a conflicting row resolves (and returns its id) **only** when it already lives in this provider's namespace. A collision with a `NULL`-source or foreign-source/provider group returns no row; membership is then refused and logged (`#2759`) instead of granted. Auto-created federated groups are still tagged with the correct source/provider, and legitimate federated groups sync exactly as before. No schema change (the `UNIQUE(name)` constraint and existing tags are reused).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_extract_user_from_entry_ad_ranged_member_of` fails on `main` (groups come back empty for an AD ranged `memberOf` key). `test_resolve_group_names_from_ad_member_of_scoped_to_base` and `test_ldap_sync_creates_groups_tagged_ldap_and_prunes` pin the new sync contract end to end; `test_resolve_group_names_via_ad_group_search` exercises the group search over the wire against a mock LDAP server returning AD-shaped (`objectClass=group`, `cn`) entries.

For the #2759 over-grant: `test_sync_never_attaches_federated_user_to_operator_managed_group` (the flipped former-bug test — now asserts the federated user is NOT added to the same-named NULL-source group), `test_ldap_cn_collision_with_privileged_operator_group_is_refused` (AD cn vs privileged operator group refused, while a legit ldap group in the same sync still attaches), and `test_sync_never_attaches_to_foreign_source_group` (LDAP sync refuses an OIDC-owned same-name group). All three fail on the pre-hardening reconciler and pass with the namespace guard.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — DB-backed reconciler test (`external_source = 'ldap'` tagging + prune) and a wire-level mock-LDAP group search test
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally — full `cargo nextest run --workspace --lib` (13830 passed) against a throwaway Postgres; `cargo fmt --check`; `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Notes for reviewers

- The issue also asks about a periodic sync (`LDAP_SYNC_INTERVAL`) and full recursive OU enumeration independent of logins. This PR delivers login-time sync (the same model OIDC and SAML use), which resolves "no AD groups synced"; an interval-driven directory-wide sync would be a separate feature and can be tracked on its own if still wanted.
- `LDAP_GROUP_ATTRIBUTE` (group name attribute) is honored with a `cn` default; there is no `ldap_configs` column for it today, so it stays env-only to keep this migration-free.
