### PR TITLE
ci: enforce the Trivy CRITICAL/HIGH scan policy on container publication

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -489,12 +489,18 @@ jobs:
           # backend-alpine digest output skipped while alpine builds are suspended.
 
       # --- Trivy CVE scanning ---
-      # --ignore-unfixed: only fail on CVEs with available patches.
-      # Unpatched UBI base image CVEs (Red Hat's responsibility) are still
-      # reported in SARIF for visibility but don't block the build.
-      # Trivy scans upload SARIF to GitHub Security tab for visibility.
-      # exit-code: 0 means scan results are informational — unfixed base image
-      # CVEs (Red Hat's responsibility) should not block image publishing.
+      # These scans ENFORCE (#2609): a CRITICAL or HIGH CVE with an available
+      # fix fails this job, and the merge-* jobs `need` this job, so no tag is
+      # published from a failing scan. The exception paths, in order:
+      #   * --ignore-unfixed: CVEs with no released fix (typically UBI base
+      #     image CVEs that are Red Hat's responsibility) are reported in
+      #     SARIF for visibility but do not block publication.
+      #   * .trivyignore: per-CVE accepted exceptions, each justified in that
+      #     file. This is the documented way to unblock a publish while a fix
+      #     is pending.
+      # All three scan steps run to completion (`if: always()` on the later
+      # ones) so a failing image never hides findings in the others, and the
+      # SARIF uploads below also run on failure.
       # NOTE: trivy binary extracted from official GHCR image because the
       # aquasecurity/trivy GitHub repo was wiped (no releases/tags).
       - name: Install Trivy
@@ -515,7 +521,7 @@ jobs:
           # Suppress residual CVEs in the bundled trivy/grype CLI binaries that
           # have no fixed tool release yet (justified per-CVE in .trivyignore).
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       - name: Trivy scan - OpenSCAP
@@ -528,7 +534,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       - name: Trivy scan - Scanner Adapter
@@ -541,7 +547,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       # Alpine scan skipped while alpine builds are suspended.
@@ -555,7 +561,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
-          exit-code: '0'
+          exit-code: '1'
           skip-setup-trivy: true
 
       - name: Upload Backend Trivy SARIF
@@ -664,13 +670,12 @@ jobs:
           echo "## Container Security Scan Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Trivy CVE Scan" >> $GITHUB_STEP_SUMMARY
-          # These scans run with `exit-code: 0`: they report, they do not gate.
-          # Findings land in code scanning and in the uploaded SARIF. Saying
-          # otherwise here would be the same kind of unearned claim this
-          # workflow's other guards exist to remove. Making the policy real is
-          # tracked separately.
+          # This claim is earned (#2609): the scan steps run with
+          # `exit-code: 1` and every merge-* job `needs` this job, so a
+          # CRITICAL/HIGH fixable finding fails the scan and no tag is
+          # published. Keep this text and that wiring in sync.
           echo "- **Scope**: CRITICAL and HIGH severity, fixed CVEs only (\`.trivyignore\` documents accepted exceptions)" >> $GITHUB_STEP_SUMMARY
-          echo "- **Policy**: reporting only — findings are uploaded to code scanning and do NOT block publication" >> $GITHUB_STEP_SUMMARY
+          echo "- **Policy**: enforced — a CRITICAL/HIGH CVE with an available fix fails this job, and the merge jobs depend on it, so publication is blocked" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend**: $([ -f backend-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **OpenSCAP**: $([ -f openscap-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
           echo "- **Scanner Adapter**: $([ -f scanner-adapter-trivy.sarif ] && echo 'Scanned' || echo 'Skipped')" >> $GITHUB_STEP_SUMMARY
@@ -687,7 +692,11 @@ jobs:
   merge-backend:
     name: Backend Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-backend]
+    # `scan-containers` is a real gate (#2609): a CRITICAL/HIGH fixable CVE in
+    # ANY of the three images blocks ALL tag publication, because the scan job
+    # scans them together. `.trivyignore` is the exception path if one image
+    # must ship while another is being fixed.
+    needs: [publish-preflight, build-backend, scan-containers]
     permissions:
       contents: read
       packages: write
@@ -831,7 +840,8 @@ jobs:
   merge-openscap:
     name: OpenSCAP Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-openscap]
+    # Gated on the container scan; see merge-backend (#2609).
+    needs: [publish-preflight, build-openscap, scan-containers]
     permissions:
       contents: read
       packages: write
@@ -955,7 +965,8 @@ jobs:
   merge-scanner-adapter:
     name: Scanner Adapter Multi-Arch Manifest
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-scanner-adapter]
+    # Gated on the container scan; see merge-backend (#2609).
+    needs: [publish-preflight, build-scanner-adapter, scan-containers]
     permissions:
       contents: read
       packages: write
@@ -1204,7 +1215,8 @@ jobs:
     # Alpine builds suspended; the multi-arch manifest job follows them.
     if: false
     runs-on: ubuntu-latest
-    needs: [publish-preflight, build-backend-alpine]
+    # Gated on the container scan; see merge-backend (#2609).
+    needs: [publish-preflight, build-backend-alpine, scan-containers]
     permissions:
       contents: read
       packages: write

--- a/backend/tests/workflow_scan_gate_tests.rs
+++ b/backend/tests/workflow_scan_gate_tests.rs
@@ -1,0 +1,174 @@
+//! Contract tests for the container-scan publication gate (#2609).
+//!
+//! `.github/workflows/docker-publish.yml` states a policy: CRITICAL/HIGH
+//! CVEs with an available fix block image publication, with `.trivyignore`
+//! as the documented exception path. These tests pin the two pieces of
+//! wiring that make that claim true, so neither can be loosened silently:
+//!
+//!   1. every Trivy scan step runs with `exit-code: '1'` (findings fail the
+//!      Security Scan job instead of being informational), and
+//!   2. every `merge-*` job `needs: scan-containers` (a failing scan stops
+//!      tag publication, not just the scan job itself).
+//!
+//! They parse the workflow YAML directly; no network, no Docker, no DB.
+
+use serde_yaml::Value;
+use std::path::Path;
+
+fn load_docker_publish_workflow() -> Value {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join(".github")
+        .join("workflows")
+        .join("docker-publish.yml");
+    let raw = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", path.display()));
+    serde_yaml::from_str(&raw).expect("docker-publish.yml is not valid YAML")
+}
+
+fn jobs(workflow: &Value) -> &serde_yaml::Mapping {
+    workflow
+        .get("jobs")
+        .and_then(Value::as_mapping)
+        .expect("workflow has a `jobs` mapping")
+}
+
+/// All steps across all jobs that invoke the aquasecurity/trivy-action,
+/// keyed as (job name, step name).
+fn trivy_scan_steps(workflow: &Value) -> Vec<(String, String, Value)> {
+    let mut found = Vec::new();
+    for (job_name, job) in jobs(workflow) {
+        let Some(steps) = job.get("steps").and_then(Value::as_sequence) else {
+            continue;
+        };
+        for step in steps {
+            let uses = step.get("uses").and_then(Value::as_str).unwrap_or("");
+            if uses.starts_with("aquasecurity/trivy-action@") {
+                let step_name = step
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or("<unnamed>")
+                    .to_string();
+                found.push((
+                    job_name.as_str().unwrap_or("<job>").to_string(),
+                    step_name,
+                    step.clone(),
+                ));
+            }
+        }
+    }
+    found
+}
+
+/// Wiring half 1: a CRITICAL/HIGH fixable finding must FAIL the scan step.
+/// `exit-code: '0'` is exactly the report-but-don't-enforce regression #2609
+/// closed; if a scan needs to be unblocked, the exception path is a justified
+/// `.trivyignore` entry, not a global exit-code downgrade.
+#[test]
+fn trivy_scan_steps_enforce_via_exit_code() {
+    let workflow = load_docker_publish_workflow();
+    let steps = trivy_scan_steps(&workflow);
+    assert!(
+        !steps.is_empty(),
+        "expected trivy-action scan steps in docker-publish.yml; \
+         if the scanner moved, move this contract test with it"
+    );
+    for (job, name, step) in &steps {
+        let with = step.get("with").expect("trivy step has `with`");
+        let exit_code = with.get("exit-code").and_then(Value::as_str);
+        assert_eq!(
+            exit_code,
+            Some("1"),
+            "{job} / {name}: Trivy must run with exit-code '1' so policy \
+             violations fail the scan (#2609); use .trivyignore for exceptions"
+        );
+        // The stated scope of the policy: fixable CRITICAL/HIGH only.
+        assert_eq!(
+            with.get("severity").and_then(Value::as_str),
+            Some("CRITICAL,HIGH"),
+            "{job} / {name}: severity scope drifted from the stated policy"
+        );
+        assert_eq!(
+            with.get("ignore-unfixed").and_then(Value::as_bool),
+            Some(true),
+            "{job} / {name}: ignore-unfixed keeps unfixable base-image CVEs \
+             report-only; removing it changes the stated policy"
+        );
+        assert_eq!(
+            with.get("trivyignores").and_then(Value::as_str),
+            Some(".trivyignore"),
+            "{job} / {name}: .trivyignore is the documented exception path"
+        );
+    }
+}
+
+/// Wiring half 2: publication must DEPEND on the scan. Without this edge a
+/// red Security Scan job is a bystander — the merge jobs still push tags.
+#[test]
+fn merge_jobs_depend_on_container_scan() {
+    let workflow = load_docker_publish_workflow();
+    let mut merge_jobs = 0;
+    for (job_name, job) in jobs(&workflow) {
+        let job_name = job_name.as_str().unwrap_or("<job>");
+        if !job_name.starts_with("merge-") {
+            continue;
+        }
+        merge_jobs += 1;
+        let needs: Vec<&str> = job
+            .get("needs")
+            .and_then(Value::as_sequence)
+            .map(|s| s.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        assert!(
+            needs.contains(&"scan-containers"),
+            "{job_name}: must `need` scan-containers so a policy-violating \
+             image is never published (#2609); needs = {needs:?}"
+        );
+    }
+    assert!(
+        merge_jobs >= 3,
+        "expected the backend/openscap/scanner-adapter merge jobs; \
+         if publication jobs were renamed, move this contract test with them"
+    );
+}
+
+/// The scan job itself must cover every image the merge jobs publish: each
+/// active (non-`if: false`) merge job's build dependency is also a dependency
+/// of scan-containers, so nothing is published unscanned.
+#[test]
+fn scan_job_covers_all_actively_published_builds() {
+    let workflow = load_docker_publish_workflow();
+    let all_jobs = jobs(&workflow);
+    let scan_needs: Vec<&str> = all_jobs
+        .get(Value::from("scan-containers"))
+        .and_then(|j| j.get("needs"))
+        .and_then(Value::as_sequence)
+        .map(|s| s.iter().filter_map(Value::as_str).collect())
+        .expect("scan-containers job with `needs` exists");
+
+    for (job_name, job) in all_jobs {
+        let job_name = job_name.as_str().unwrap_or("<job>");
+        if !job_name.starts_with("merge-") {
+            continue;
+        }
+        // Suspended jobs (`if: false`, e.g. the alpine variant) publish
+        // nothing, so their build inputs need no scan coverage yet.
+        if job.get("if").and_then(Value::as_bool) == Some(false) {
+            continue;
+        }
+        let needs: Vec<&str> = job
+            .get("needs")
+            .and_then(Value::as_sequence)
+            .map(|s| s.iter().filter_map(Value::as_str).collect())
+            .unwrap_or_default();
+        for dep in needs {
+            if dep.starts_with("build-") {
+                assert!(
+                    scan_needs.contains(&dep),
+                    "{job_name} publishes {dep} output, but scan-containers \
+                     does not scan it (needs = {scan_needs:?})"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2609.

Decision (per the issue's Direction): **Option 1 — enforce.** The Trivy scan in `docker-publish.yml` now gates publication instead of only reporting:

- All Trivy scan steps run with `exit-code: '1'` (was `'0'`), so a CRITICAL/HIGH CVE **with an available fix** fails the Security Scan job. `ignore-unfixed: true` stays: unfixable base-image CVEs remain report-only (SARIF/code scanning). `.trivyignore` remains the documented per-CVE exception path.
- `merge-backend`, `merge-openscap`, `merge-scanner-adapter` (and the suspended `merge-backend-alpine`) now `need: scan-containers`, so no tag is published from a failing scan. Previously a red scan job was a bystander — the merge jobs published regardless.
- The step summary now states the enforced policy, so workflow behaviour and summary text agree (they were deliberately de-coupled by #2604, which fixed the text but not the behaviour).
- The later scan steps keep `if: always()` and the SARIF uploads keep `if: always()`, so a failing image never hides findings in the others and results still land in code scanning on a red run.

### Burndown (issue precondition for Option 1)

Verified the enforcement does not block the next publish: all three current `:dev` images were scanned locally with the exact enforced configuration (`--severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore --exit-code 1`, Trivy 0.71.2):

| Image | Fixable CRITICAL/HIGH | Exit code |
|---|---|---|
| `artifact-keeper-backend:dev` | 0 | 0 |
| `artifact-keeper-openscap:dev` | 0 | 0 |
| `artifact-keeper-scanner-adapter:dev` | 0 | 0 |

The residual scanner-CLI CVEs are already covered by justified `.trivyignore` entries, so the backlog is empty.

### Behaviour change worth knowing

Because `scan-containers` scans all three images in one job, a CRITICAL/HIGH fixable CVE in **any** image now blocks **all** tag publication (and a failed openscap/adapter build now transitively blocks the backend manifest). That is the fail-closed reading of the issue's "publication depends on the scan result"; `.trivyignore` is the escape hatch if one image must ship while another is being fixed. Splitting the scan job per image would decouple this and can be a follow-up if it ever bites.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`backend/tests/workflow_scan_gate_tests.rs` parses `docker-publish.yml` and pins the two wiring halves (scan steps enforce via `exit-code: '1'` + stated severity/ignore-unfixed/trivyignore scope; every `merge-*` job needs `scan-containers`; every actively-published build is scanned). On `main` two of the three tests fail (`exit-code` and the missing `needs` edge); on this branch all three pass. No network/Docker/DB needed.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification:
- `cargo fmt --check` — clean
- `cargo build --lib` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace --lib` — pass
- `cargo test --test workflow_scan_gate_tests` — 3/3 pass (2/3 fail against `main`'s workflow, as intended)
- `actionlint` on the workflow — finding set identical to `main` (only pre-existing custom-runner-label/shellcheck notes)
- Gap replication: scanning a known-vulnerable image with the workflow's previous config reported `Total: 2 (HIGH: 2)` yet exited 0; the same scan with `exit-code 1` exits 1.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
