### PR TITLE
fix(hex): keep remote registry an upstream pass-through after first cache

### DIFF
--- a/backend/src/api/handlers/hex.rs
+++ b/backend/src/api/handlers/hex.rs
@@ -324,6 +324,40 @@ async fn package_info(
 ) -> Result<Response, Response> {
     let repo = resolve_hex_repo(&state.db, &repo_key).await?;
 
+    // Remote: the registry resource is upstream's already-signed protobuf —
+    // pass it through regardless of local cache state. This used to be gated
+    // on the local `artifacts` rows being empty, so the first cached tarball
+    // silently flipped the response to the plain-JSON arm below, which the
+    // hex client cannot consume (it gunzips every registry response first,
+    // so it dies in `:zlib.gunzip/1`) — the repo "worked until it cached its
+    // first artifact" (#2658). Cached tarball BYTES still serve locally via
+    // `download_tarball`; only the registry metadata stays a pass-through,
+    // which also keeps the client's pinned upstream signing key valid.
+    if repo.repo_type == RepositoryType::Remote {
+        if let (Some(ref upstream_url), Some(ref proxy)) =
+            (&repo.upstream_url, &state.proxy_service)
+        {
+            let upstream_path = format!("packages/{}", name);
+            let (content, content_type) = proxy_helpers::proxy_fetch_capped(
+                proxy,
+                repo.id,
+                &repo_key,
+                upstream_url,
+                &upstream_path,
+                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+            )
+            .await?;
+            return Ok(Response::builder()
+                .status(StatusCode::OK)
+                .header(
+                    CONTENT_TYPE,
+                    content_type.unwrap_or_else(|| "application/json".to_string()),
+                )
+                .body(Body::from(content))
+                .unwrap());
+        }
+    }
+
     let artifacts = sqlx::query!(
         r#"
         SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256,
@@ -344,32 +378,6 @@ async fn package_info(
     .map_err(super::db_err)?;
 
     if artifacts.is_empty() {
-        // Remote: fetch package metadata from the upstream hex registry.
-        if repo.repo_type == RepositoryType::Remote {
-            if let (Some(ref upstream_url), Some(ref proxy)) =
-                (&repo.upstream_url, &state.proxy_service)
-            {
-                let upstream_path = format!("packages/{}", name);
-                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
-                    proxy,
-                    repo.id,
-                    &repo_key,
-                    upstream_url,
-                    &upstream_path,
-                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-                )
-                .await?;
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(
-                        CONTENT_TYPE,
-                        content_type.unwrap_or_else(|| "application/json".to_string()),
-                    )
-                    .body(Body::from(content))
-                    .unwrap());
-            }
-        }
-
         // Virtual: check every member's `artifacts` table (local or remote
         // cache) before falling back to remote upstream proxy. The previous
         // implementation called `resolve_virtual_metadata` directly, which
@@ -1090,9 +1098,12 @@ async fn list_names(
         return signed_registry_response(&state, repo.id, payload).await;
     }
 
-    // Remote with no local artifacts: proxy the names list from upstream.
-    // hex.pm's /names endpoint returns a signed protobuf payload; pass it through as-is.
-    if names.is_empty() && repo.repo_type == RepositoryType::Remote {
+    // Remote: proxy the names list from upstream regardless of local cache
+    // state. hex.pm's /names endpoint returns a signed protobuf payload; pass
+    // it through as-is. Gating this on the cache being empty made the first
+    // cached artifact flip the response to the JSON arm below, which the hex
+    // client cannot gunzip (#2658).
+    if repo.repo_type == RepositoryType::Remote {
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
@@ -1242,9 +1253,12 @@ async fn list_versions(
         return signed_registry_response(&state, repo.id, payload).await;
     }
 
-    // Remote with no local artifacts: proxy the versions list from upstream.
-    // hex.pm's /versions endpoint returns a signed protobuf payload; pass it through as-is.
-    if artifacts.is_empty() && repo.repo_type == RepositoryType::Remote {
+    // Remote: proxy the versions list from upstream regardless of local cache
+    // state. hex.pm's /versions endpoint returns a signed protobuf payload;
+    // pass it through as-is. Gating this on the cache being empty made the
+    // first cached artifact flip the response to the JSON arm below, which
+    // the hex client cannot gunzip (#2658).
+    if repo.repo_type == RepositoryType::Remote {
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
@@ -3711,6 +3725,104 @@ mod tests {
         );
 
         f.teardown().await;
+    }
+
+    // -----------------------------------------------------------------------
+    // #2658: a Remote hex repo's registry must stay an upstream pass-through
+    // after its first artifact is cached. The old code gated the pass-through
+    // on the local cache being empty, so the first successful `deps.get`
+    // flipped /names, /versions and /packages/{name} to the plain-JSON arm,
+    // which the hex client cannot gunzip — the repo worked exactly once.
+    // -----------------------------------------------------------------------
+
+    /// Distinctive stand-in for upstream's signed+gzipped protobuf registry
+    /// bytes. The assertions only need to tell "upstream bytes passed
+    /// through verbatim" apart from "locally rebuilt JSON".
+    const UPSTREAM_SIGNED_REGISTRY: &[u8] = b"\x1f\x8b\x08upstream-signed-registry-bytes";
+
+    #[tokio::test]
+    async fn test_hex_remote_registry_stays_passthrough_after_first_cache_db() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let Some(fx) = tdh::Fixture::setup("remote", "hex").await else {
+            return;
+        };
+
+        let upstream = MockServer::start().await;
+        for p in ["/versions", "/names", "/packages/phoenix"] {
+            Mock::given(method("GET"))
+                .and(path(p))
+                .respond_with(
+                    ResponseTemplate::new(200)
+                        .set_body_bytes(UPSTREAM_SIGNED_REGISTRY)
+                        .insert_header("content-type", "application/octet-stream"),
+                )
+                .mount(&upstream)
+                .await;
+        }
+        let (state, _cache_dir) = tdh::rewire_remote_proxy(&fx, &upstream.uri()).await;
+
+        let resources = [
+            format!("/{}/versions", fx.repo_key),
+            format!("/{}/names", fx.repo_key),
+            format!("/{}/packages/phoenix", fx.repo_key),
+        ];
+
+        // Before anything is cached: all three registry resources pass
+        // upstream's bytes through (the state the issue calls "works").
+        for uri in &resources {
+            let app = tdh::router_anon(super::router(), state.clone());
+            let (status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+            assert_eq!(status, StatusCode::OK, "{uri} must serve pre-cache");
+            assert_eq!(
+                &body[..],
+                UPSTREAM_SIGNED_REGISTRY,
+                "{uri} must pass upstream bytes through pre-cache"
+            );
+        }
+
+        // Cache one artifact, exactly as the first successful `deps.get`
+        // would leave the repository.
+        let repo = fx.repo_info("remote", Some(&upstream.uri()));
+        tdh::seed_artifact(
+            &state,
+            &fx.pool,
+            &repo,
+            "hex/phoenix/1.7.0/phoenix-1.7.0.tar",
+            "phoenix/1.7.0/phoenix-1.7.0.tar",
+            "phoenix",
+            "1.7.0",
+            "application/octet-stream",
+            bytes::Bytes::from_static(b"cached-tarball-bytes"),
+            fx.user_id,
+        )
+        .await;
+
+        // After caching: the registry must STILL be the upstream
+        // pass-through, not a locally rebuilt JSON document (#2658).
+        for uri in &resources {
+            let app = tdh::router_anon(super::router(), state.clone());
+            let (status, body) = tdh::send(app, tdh::get(uri.clone())).await;
+            assert_eq!(status, StatusCode::OK, "{uri} must serve post-cache");
+            assert_eq!(
+                &body[..],
+                UPSTREAM_SIGNED_REGISTRY,
+                "{uri} must stay an upstream pass-through after the first artifact is cached (#2658)"
+            );
+        }
+
+        // The cached tarball itself still serves from the local cache.
+        let app = tdh::router_anon(super::router(), state.clone());
+        let (status, body) = tdh::send(
+            app,
+            tdh::get(format!("/{}/tarballs/phoenix-1.7.0.tar", fx.repo_key)),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "cached tarball must serve locally");
+        assert_eq!(&body[..], b"cached-tarball-bytes");
+
+        fx.teardown().await;
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #2658.

A Remote (proxy) hex repository served a consumable registry only until it cached
its first artifact. All three registry resources gated the upstream pass-through on
the local cache being empty:

- `GET /hex/{repo}/packages/{name}` — `if artifacts.is_empty() { ... Remote -> proxy }`
- `GET /hex/{repo}/names` — `if names.is_empty() && repo_type == Remote`
- `GET /hex/{repo}/versions` — `if artifacts.is_empty() && repo_type == Remote`

While the cache was empty the handler proxied upstream's already-signed protobuf
(correct). As soon as one artifact was cached the emptiness test failed, the
pass-through was skipped, and the handler fell into the plain-JSON arm. The hex
client gunzips every registry response before anything else, so it died in
`:zlib.gunzip/1` with `:data_error` — the first successful `mix deps.get` broke the
second, with no configuration change and no useful error.

### Change

For `Remote` repositories the three registry resources now pass upstream's
already-signed registry bytes through unconditionally (when an upstream URL and the
proxy service are configured), regardless of local cache state:

- `package_info`: the Remote pass-through is hoisted out of (and above) the
  `artifacts.is_empty()` gate.
- `list_names` / `list_versions`: the `*.is_empty() &&` term is dropped from the
  Remote gate.

Rationale for staying a pass-through rather than emitting a locally signed merged
registry: a Remote repo does not publish a registry signing key (`/public_key`
404s for non-hosted repos), so consumers pin **upstream's** key. Re-signing the
registry after the first cache write would invalidate that pinned key — the same
"works, then breaks" failure in a different coat. Cached tarball **bytes** still
serve locally via `download_tarball`; only the registry metadata remains upstream's.

Behavioral notes:

- A Remote repo with no `upstream_url` (or no proxy service) falls through to the
  previous JSON behavior, unchanged.
- Hosted repos (signed protobuf emission, #2641/#2648) and Virtual repos are
  untouched.
- If the upstream is unreachable, the resources now surface the proxy error for a
  cached repo instead of a locally rebuilt JSON document; that JSON was never
  consumable by the hex client, and the proxy's metadata cache still absorbs
  transient upstream failures.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

`test_hex_remote_registry_stays_passthrough_after_first_cache_db` (wiremock
upstream + DB-backed router test): asserts `/versions`, `/names` and
`/packages/{name}` pass upstream bytes through before caching, seeds one cached
artifact (as the first `deps.get` would), and asserts all three resources are still
byte-identical pass-throughs afterwards — plus that the cached tarball serves
locally. On `main` the post-cache assertion fails with the JSON body
`[{"name":"phoenix","versions":["1.7.0"]}]`; on this branch it passes.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
