### PR TITLE
perf(rpm): serve repodata from a fingerprint-validated cached render

### DIFF
--- a/.sqlx/query-034c5ed9ea81ad352d0a4c455b1ae39358c09b6dfae94af6f3e40d60277704b7.json
+++ b/.sqlx/query-034c5ed9ea81ad352d0a4c455b1ae39358c09b6dfae94af6f3e40d60277704b7.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.updated_at, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n          AND a.path LIKE '%.rpm'\n        ORDER BY a.name, a.version, a.path, a.id\n        ",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.updated_at, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = ANY($1) AND a.is_deleted = false\n          AND a.path LIKE '%.rpm'\n        ORDER BY a.name, a.version, a.path, a.id\n        ",
   "describe": {
     "columns": [
       {
@@ -51,7 +51,7 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid"
+        "UuidArray"
       ]
     },
     "nullable": [
@@ -66,5 +66,5 @@
       false
     ]
   },
-  "hash": "f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f"
+  "hash": "034c5ed9ea81ad352d0a4c455b1ae39358c09b6dfae94af6f3e40d60277704b7"
 }

--- a/.sqlx/query-b27f5013af43d7ffbf97be0e9ff0f8f8940b46cff8a980ef1cd22e79ff825533.json
+++ b/.sqlx/query-b27f5013af43d7ffbf97be0e9ff0f8f8940b46cff8a980ef1cd22e79ff825533.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*) AS \"live_rpm_count!\", MAX(a.updated_at) AS latest_update\n        FROM artifacts a\n        WHERE a.repository_id = ANY($1) AND a.is_deleted = false\n          AND a.path LIKE '%.rpm'\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "live_rpm_count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "latest_update",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "b27f5013af43d7ffbf97be0e9ff0f8f8940b46cff8a980ef1cd22e79ff825533"
+}

--- a/backend/src/api/handlers/rpm.rs
+++ b/backend/src/api/handlers/rpm.rs
@@ -35,6 +35,7 @@ use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
 use crate::api::SharedState;
 use crate::models::repository::RepositoryType;
+use crate::services::rpm_repodata_cache::{RenderedRepodata, RepodataFingerprint};
 use crate::services::signing_service::SigningService;
 
 // ---------------------------------------------------------------------------
@@ -313,9 +314,36 @@ struct RpmArtifact {
 /// repodata must never describe those as packages (#2590). Delta RPMs
 /// (`.drpm`) are also excluded — they belong in `prestodelta` metadata,
 /// which we do not generate, not in `primary.xml`.
-async fn list_rpm_artifacts(
+/// The repositories a repodata response for `repo` describes: the repo
+/// itself for Hosted (Local/Staging) repos, or the member repo ids for
+/// Virtual repos — otherwise `repomd.xml`/`primary.xml.gz` advertise
+/// `packages="0"` and `dnf` treats the aggregate repo as empty even though
+/// the members hold packages (#1780).
+///
+/// Sorted so the id set is canonical: `fetch_virtual_members` orders by
+/// `vrm.priority`, which is not a total order, and both the fingerprint
+/// comparison (#2521) and the render must not depend on member visit order
+/// for the output (and therefore the detached signature) to be reproducible
+/// (#2636).
+async fn repodata_repo_ids(
     db: &sqlx::PgPool,
-    repo_id: uuid::Uuid,
+    repo: &RepoInfo,
+) -> Result<Vec<uuid::Uuid>, Response> {
+    if repo.repo_type != RepositoryType::Virtual {
+        return Ok(vec![repo.id]);
+    }
+    let members = proxy_helpers::fetch_virtual_members(db, repo.id).await?;
+    let mut ids: Vec<uuid::Uuid> = members.iter().map(|m| m.id).collect();
+    ids.sort_unstable();
+    Ok(ids)
+}
+
+/// Collect the RPM artifacts a repodata response should describe, in a
+/// deterministic total order (`ORDER BY name, version, path, id`) so
+/// unchanged state always renders byte-identical documents (#2636).
+async fn collect_repodata_artifacts(
+    db: &sqlx::PgPool,
+    repo_ids: &[uuid::Uuid],
 ) -> Result<Vec<RpmArtifact>, Response> {
     let rows = sqlx::query!(
         r#"
@@ -323,11 +351,11 @@ async fn list_rpm_artifacts(
                a.storage_key, a.updated_at, am.metadata as "metadata?"
         FROM artifacts a
         LEFT JOIN artifact_metadata am ON am.artifact_id = a.id
-        WHERE a.repository_id = $1 AND a.is_deleted = false
+        WHERE a.repository_id = ANY($1) AND a.is_deleted = false
           AND a.path LIKE '%.rpm'
         ORDER BY a.name, a.version, a.path, a.id
         "#,
-        repo_id
+        repo_ids
     )
     .fetch_all(db)
     .await
@@ -349,45 +377,82 @@ async fn list_rpm_artifacts(
         .collect())
 }
 
-/// Collect the RPM artifacts a repodata response should describe.
+/// The current [`RepodataFingerprint`] for `repo_ids`: one aggregate query
+/// (count + latest `updated_at` over the live `.rpm` rows — an index scan
+/// with no row transfer and no metadata join), revalidated on every repodata
+/// request so a publish/delete/promotion is visible on the very next read.
 ///
-/// For Hosted (Local/Staging) repos this is just the repo's own artifacts.
-/// For Virtual repos the metadata must reflect the union of every member
-/// repo's packages — otherwise `repomd.xml`/`primary.xml.gz` advertise
-/// `packages="0"` and `dnf` treats the aggregate repo as empty even though
-/// the members hold packages (#1780). We resolve the member repo IDs via
-/// `fetch_virtual_members` and concatenate each member's artifact list.
-///
-/// The result is sorted into the same deterministic total order
-/// `list_rpm_artifacts` returns. Concatenating per-member lists inherits
-/// `fetch_virtual_members`' `ORDER BY vrm.priority`, which is not a total
-/// order — members sharing a priority can be visited in either order — so the
-/// merged list needed its own ordering for the render (and therefore the
-/// detached signature) to be reproducible (#2636).
-async fn collect_repodata_artifacts(
+/// The `.rpm` scoping matches `collect_repodata_artifacts` exactly: the
+/// fingerprint must move if and only if the rendered row set can change.
+async fn repodata_fingerprint(
     db: &sqlx::PgPool,
-    repo: &RepoInfo,
-) -> Result<Vec<RpmArtifact>, Response> {
-    if repo.repo_type != RepositoryType::Virtual {
-        return list_rpm_artifacts(db, repo.id).await;
-    }
+    repo_ids: Vec<uuid::Uuid>,
+) -> Result<RepodataFingerprint, Response> {
+    let row = sqlx::query!(
+        r#"
+        SELECT COUNT(*) AS "live_rpm_count!", MAX(a.updated_at) AS latest_update
+        FROM artifacts a
+        WHERE a.repository_id = ANY($1) AND a.is_deleted = false
+          AND a.path LIKE '%.rpm'
+        "#,
+        &repo_ids
+    )
+    .fetch_one(db)
+    .await
+    .map_err(super::db_err)?;
 
-    let members = proxy_helpers::fetch_virtual_members(db, repo.id).await?;
-    let mut artifacts = Vec::new();
-    for member in &members {
-        artifacts.extend(list_rpm_artifacts(db, member.id).await?);
-    }
-    artifacts.sort_by(|a, b| {
-        (&a.name, &a.version, &a.path, &a.id).cmp(&(&b.name, &b.version, &b.path, &b.id))
-    });
-    Ok(artifacts)
+    Ok(RepodataFingerprint {
+        repo_ids,
+        live_rpm_count: row.live_rpm_count,
+        latest_update: row.latest_update,
+    })
+}
+
+/// Serve the rendered repodata set for `repo` through the fingerprint-
+/// validated cache (#2521): a warm request costs the fingerprint query plus
+/// a refcount clone of the prebuilt bytes; a state change re-renders exactly
+/// once (concurrent misses coalesce on a per-repo single-flight lock). The
+/// O(repo) generation itself runs on the blocking pool so large renders do
+/// not stall the async runtime.
+async fn cached_repodata(
+    state: &SharedState,
+    repo: &RepoInfo,
+) -> Result<std::sync::Arc<RenderedRepodata>, Response> {
+    let repo_ids = repodata_repo_ids(&state.db, repo).await?;
+    // Captured BEFORE the artifact rows are fetched: a write racing the
+    // render can only make the stored entry look older than its content, so
+    // the next request re-renders — never serves stale bytes as fresh.
+    let fingerprint = repodata_fingerprint(&state.db, repo_ids).await?;
+    let db = state.db.clone();
+    let ids = fingerprint.repo_ids.clone();
+    state
+        .rpm_repodata_cache
+        .get_or_render(repo.id, fingerprint, || async move {
+            let artifacts = collect_repodata_artifacts(&db, &ids).await?;
+            tokio::task::spawn_blocking(move || render_repodata(&artifacts))
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "RPM repodata render task failed");
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "Failed to render repository metadata",
+                    )
+                        .into_response()
+                })
+        })
+        .await
 }
 
 // ---------------------------------------------------------------------------
-// Shared repomd.xml generation
+// Shared repodata rendering
 // ---------------------------------------------------------------------------
 
-fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
+/// Render the complete repodata set for one repository state: `repomd.xml`
+/// plus every compressed index document its checksums describe. Rendering
+/// them together (instead of per endpoint, per request) is what lets the
+/// cache serve coherent, immutable bytes for the whole set (#2521) — and the
+/// gzipped siblings are byproducts `repomd.xml` had to build anyway.
+fn render_repodata(artifacts: &[RpmArtifact]) -> RenderedRepodata {
     // Generate primary.xml content and compute both the compressed (gzipped)
     // and uncompressed (open) sha256 + sizes. DNF/createrepo clients expect a
     // top-level <revision> plus per-<data> <open-checksum>/<open-size> elements
@@ -426,7 +491,7 @@ fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
     // the same defect (#2652).
     let timestamp = metadata_epoch(artifacts.iter().map(|a| a.updated_at)).timestamp();
 
-    format!(
+    let repomd_xml = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <repomd xmlns="http://linux.duke.edu/metadata/repo" xmlns:rpm="http://linux.duke.edu/metadata/rpm">
   <revision>{timestamp}</revision>
@@ -481,7 +546,22 @@ fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
         other_open_size = other_open_size,
         updateinfo_size = updateinfo_gz.len(),
         updateinfo_open_size = updateinfo_open_size,
-    )
+    );
+
+    RenderedRepodata {
+        repomd_xml: Bytes::from(repomd_xml),
+        primary_gz: Bytes::from(primary_gz),
+        filelists_gz: Bytes::from(filelists_gz),
+        other_gz: Bytes::from(other_gz),
+    }
+}
+
+/// Test-facing shim retaining the original `repomd.xml`-only signature; the
+/// handlers serve [`render_repodata`] output through the cache.
+#[cfg(test)]
+fn generate_repomd_xml_content(artifacts: &[RpmArtifact]) -> String {
+    String::from_utf8(render_repodata(artifacts).repomd_xml.to_vec())
+        .expect("repomd.xml is valid UTF-8")
 }
 
 // ---------------------------------------------------------------------------
@@ -502,13 +582,12 @@ async fn repomd_xml(
         return Ok(resp);
     }
 
-    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
-    let xml = generate_repomd_xml_content(&artifacts);
+    let rendered = cached_repodata(&state, &repo).await?;
 
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "application/xml")
-        .body(Body::from(xml))
+        .body(Body::from(rendered.repomd_xml.clone()))
         .unwrap())
 }
 
@@ -534,8 +613,12 @@ async fn repomd_xml_asc(
         return Ok(resp);
     }
 
-    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
-    let repomd_content = generate_repomd_xml_content(&artifacts);
+    // Sign the same cached bytes `repomd.xml` serves: the signature and the
+    // document are two requests, and both must render identically from
+    // unchanged state (#2636). The shared cache entry makes that literal —
+    // one render, one byte sequence, two endpoints.
+    let rendered = cached_repodata(&state, &repo).await?;
+    let repomd_content = rendered.repomd_xml.clone();
 
     let signing_svc = SigningService::new(state.db.clone(), &state.config.jwt_secret);
     // #2636: this endpoint must emit a real detached OpenPGP signature — the
@@ -559,7 +642,7 @@ async fn repomd_xml_asc(
         resp
     })?;
     let armored = signing_svc
-        .sign_openpgp_detached_with_key(&key, repomd_content.as_bytes())
+        .sign_openpgp_detached_with_key(&key, &repomd_content)
         .await
         .map_err(|e| {
             // A key that cannot sign is a server-side failure, not a missing
@@ -678,10 +761,8 @@ async fn primary_xml_gz(
         return Ok(resp);
     }
 
-    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
-
-    let primary_xml = generate_primary_xml(&artifacts);
-    let gz = gzip_bytes(primary_xml.as_bytes());
+    let rendered = cached_repodata(&state, &repo).await?;
+    let gz = rendered.primary_gz.clone();
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -712,10 +793,8 @@ async fn filelists_xml_gz(
         return Ok(resp);
     }
 
-    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
-
-    let filelists_xml = generate_filelists_xml(&artifacts);
-    let gz = gzip_bytes(filelists_xml.as_bytes());
+    let rendered = cached_repodata(&state, &repo).await?;
+    let gz = rendered.filelists_gz.clone();
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -741,10 +820,8 @@ async fn other_xml_gz(
         return Ok(resp);
     }
 
-    let artifacts = collect_repodata_artifacts(&state.db, &repo).await?;
-
-    let other_xml = generate_other_xml(&artifacts);
-    let gz = gzip_bytes(other_xml.as_bytes());
+    let rendered = cached_repodata(&state, &repo).await?;
+    let gz = rendered.other_gz.clone();
 
     Ok(Response::builder()
         .status(StatusCode::OK)
@@ -3042,9 +3119,9 @@ mod tests {
         insert_repo_object(&f, "test.repo", "test-repo").await;
 
         // The query helper itself must only return the package rows.
-        let listed = super::list_rpm_artifacts(&f.pool, f.repo_id)
+        let listed = super::collect_repodata_artifacts(&f.pool, &[f.repo_id])
             .await
-            .expect("list_rpm_artifacts");
+            .expect("collect_repodata_artifacts");
         let paths: Vec<&str> = listed.iter().map(|a| a.path.as_str()).collect();
         assert_eq!(
             paths,
@@ -3052,7 +3129,7 @@ mod tests {
                 "packages/realpkg-1.0-1.x86_64.rpm",
                 "packages/realpkg-1.0-1.src.rpm",
             ],
-            "list_rpm_artifacts must return only .rpm package objects"
+            "collect_repodata_artifacts must return only .rpm package objects"
         );
 
         // End to end: primary.xml must describe exactly the two packages.
@@ -3145,6 +3222,87 @@ mod tests {
         .execute(&f.pool)
         .await
         .expect("insert rpm artifact");
+    }
+
+    // -----------------------------------------------------------------------
+    // #2521 (PF-004): repodata requests must serve a prebuilt cached render.
+    // Before the fix every /repodata/* request refetched all live .rpm rows
+    // and regenerated + regzipped the whole document set in the request path
+    // (repomd.xml built primary/filelists/other/updateinfo just to hash
+    // them), so one dnf refresh cost O(repo) work five times over.
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_rpm_repodata_warm_requests_serve_one_cached_render() {
+        use flate2::read::GzDecoder;
+        use std::io::Read;
+
+        let Some(f) = tdh::Fixture::setup("local", "rpm").await else {
+            return;
+        };
+        insert_rpm_artifact(&f, "alpha").await;
+        insert_rpm_artifact(&f, "beta").await;
+
+        let renders_before = f.state.rpm_repodata_cache.renders();
+
+        // A full dnf-style refresh (manifest + all three indexes) plus a
+        // repeat of the manifest: five requests against unchanged state.
+        let (st, repomd) = get_repodata(&f, "repomd.xml").await;
+        assert_eq!(st, StatusCode::OK);
+        let (st, primary) = get_repodata(&f, "primary.xml.gz").await;
+        assert_eq!(st, StatusCode::OK);
+        let (st, _filelists) = get_repodata(&f, "filelists.xml.gz").await;
+        assert_eq!(st, StatusCode::OK);
+        let (st, _other) = get_repodata(&f, "other.xml.gz").await;
+        assert_eq!(st, StatusCode::OK);
+        let (st, repomd_again) = get_repodata(&f, "repomd.xml").await;
+        assert_eq!(st, StatusCode::OK);
+
+        assert_eq!(
+            f.state.rpm_repodata_cache.renders() - renders_before,
+            1,
+            "five repodata requests against unchanged state must cost exactly \
+             one O(repo) render"
+        );
+        assert_eq!(repomd, repomd_again, "warm manifest must be byte-identical");
+
+        // Coherence across the set: the checksum repomd.xml advertises for
+        // primary.xml.gz must be the checksum of the bytes the sibling
+        // endpoint actually served — they come from the same render.
+        let repomd_text = String::from_utf8(repomd.to_vec()).expect("repomd utf8");
+        let primary_sha = super::sha256_hex(&primary);
+        assert!(
+            repomd_text.contains(&primary_sha),
+            "repomd.xml must advertise the checksum of the served primary.xml.gz \
+             (expected {primary_sha} in: {repomd_text})"
+        );
+
+        // A one-artifact mutation rotates the fingerprint: exactly one new
+        // render, and the served metadata reflects the change immediately
+        // (no TTL window — the fingerprint is revalidated per request).
+        insert_rpm_artifact(&f, "gamma").await;
+        let (st, primary_after) = get_repodata(&f, "primary.xml.gz").await;
+        assert_eq!(st, StatusCode::OK);
+        assert_eq!(
+            f.state.rpm_repodata_cache.renders() - renders_before,
+            2,
+            "one artifact mutation must cause exactly one re-render"
+        );
+        let mut decoder = GzDecoder::new(&primary_after[..]);
+        let mut primary_xml = String::new();
+        decoder
+            .read_to_string(&mut primary_xml)
+            .expect("decompress primary.xml.gz");
+        assert!(
+            primary_xml.contains("<name>gamma</name>"),
+            "post-mutation metadata must include the new package: {primary_xml}"
+        );
+        assert!(
+            primary_xml.contains("packages=\"3\""),
+            "post-mutation metadata must count all three packages: {primary_xml}"
+        );
+
+        f.teardown().await;
     }
 
     /// The end-to-end contract `dnf repo_gpgcheck=1` enforces: the signature

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -20,6 +20,7 @@ use crate::services::plugin_registry::PluginRegistry;
 use crate::services::proxy_service::ProxyService;
 use crate::services::quality_check_service::QualityCheckService;
 use crate::services::repository_service::RepositoryService;
+use crate::services::rpm_repodata_cache::RpmRepodataCache;
 use crate::services::scanner_service::ScannerService;
 use crate::services::smtp_service::SmtpService;
 use crate::services::wasm_plugin_service::WasmPluginService;
@@ -139,6 +140,12 @@ pub struct AppState {
     /// can evict just the entries belonging to a specific
     /// `(repo_key, distribution)` when the underlying Release flips.
     pub signed_release_cache_index: SignedReleaseCacheIndex,
+    /// Fingerprint-validated cache of rendered RPM repodata sets (#2521):
+    /// warm `repomd.xml` / `primary.xml.gz` / `filelists.xml.gz` /
+    /// `other.xml.gz` requests serve prebuilt bytes validated by one cheap
+    /// aggregate query instead of refetching every artifact row and
+    /// regenerating + recompressing the whole document set per request.
+    pub rpm_repodata_cache: Arc<RpmRepodataCache>,
     /// Concurrency cap for bcrypt-bound auth work (login, password verify,
     /// API token verify). `None` when `auth_max_concurrency == 0`, in which
     /// case auth runs without a process-wide cap (legacy behaviour).
@@ -205,6 +212,7 @@ impl AppState {
             npm_packument_cache,
             signed_release_cache: Arc::new(RwLock::new(HashMap::new())),
             signed_release_cache_index: Arc::new(RwLock::new(HashMap::new())),
+            rpm_repodata_cache: Arc::new(RpmRepodataCache::new()),
             auth_semaphore,
         }
     }
@@ -250,6 +258,7 @@ impl AppState {
             npm_packument_cache,
             signed_release_cache: Arc::new(RwLock::new(HashMap::new())),
             signed_release_cache_index: Arc::new(RwLock::new(HashMap::new())),
+            rpm_repodata_cache: Arc::new(RpmRepodataCache::new()),
             auth_semaphore,
         }
     }

--- a/backend/src/services/mod.rs
+++ b/backend/src/services/mod.rs
@@ -64,6 +64,7 @@ pub mod repo_selector_service;
 pub mod repository_label_service;
 pub mod repository_service;
 pub mod routing_rules;
+pub mod rpm_repodata_cache;
 pub mod saml_service;
 pub mod sbom_service;
 pub mod scan_config_service;

--- a/backend/src/services/rpm_repodata_cache.rs
+++ b/backend/src/services/rpm_repodata_cache.rs
@@ -1,0 +1,465 @@
+//! Revision-validated cache for rendered RPM repodata (#2521, PF-004).
+//!
+//! Every hosted/virtual RPM repodata request used to fetch **every** live
+//! `.rpm` row (plus its metadata JSON) and rebuild the full document set in
+//! the request path: `repomd.xml` alone generated primary, filelists, other
+//! and updateinfo XML, gzipped all four and hashed all eight variants — then
+//! threw everything but the manifest away. A single `dnf makecache` issues
+//! `repomd.xml` + `primary.xml.gz` + `filelists.xml.gz` + `other.xml.gz`
+//! (and `repomd.xml.asc` when `repo_gpgcheck=1`), so one client refresh cost
+//! O(repo) work five times over, and N concurrent CI jobs multiplied it.
+//!
+//! This cache stores the *complete rendered set* for a repository, keyed by a
+//! [`RepodataFingerprint`] of the repository state the render was built from.
+//! A request now:
+//!
+//! 1. computes the fingerprint with one cheap aggregate query
+//!    (`COUNT(*)` + `MAX(updated_at)` over the repo's live `.rpm` rows —
+//!    no row transfer, no metadata join);
+//! 2. serves the cached bytes when the fingerprint matches (warm path:
+//!    zero full-catalog queries, zero XML/gzip/hash work);
+//! 3. otherwise renders once under a per-repository single-flight lock, so
+//!    100 concurrent cold refreshes of the same state cause one render, and
+//!    stores the set under the new fingerprint.
+//!
+//! Correctness / staleness model: the fingerprint is revalidated against the
+//! database on **every** request, so a change is visible on the very next
+//! read (no TTL window, and read-your-writes holds per replica even in
+//! multi-replica deployments — each replica revalidates independently).
+//! Publish adds a live row (count and max both move), delete removes one
+//! (count moves), promotion inserts into the target repo (count moves), and
+//! there is no un-delete path in the artifact service. The fingerprint is
+//! captured *before* the rows are fetched, so a write racing a render can
+//! only make the stored entry look older than it is — the next request
+//! observes a fingerprint mismatch and re-renders. Over-invalidation is
+//! possible; serving stale bytes as fresh is not.
+//!
+//! Determinism (#2636 contract): a cached set is by construction a pure
+//! function of repository state, and `repomd.xml.asc` signs the *same cached
+//! bytes* `repomd.xml` serves. Sibling documents (`primary.xml.gz`, …) come
+//! from the same render as the `repomd.xml` that advertises their checksums,
+//! so a client that fetches the set against unchanged state always sees
+//! coherent checksums.
+//!
+//! Bounds: entry count and total byte budget are both capped; eviction is
+//! oldest-render-first. One entry per repository, so the worst case is
+//! `min(MAX_ENTRIES, active RPM repos)` rendered sets. Follow-ups tracked on
+//! #2521: a durable cross-replica object store for prebuilt revisions and the
+//! same treatment for the PyPI/Helm/Composer root indexes.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use tokio::sync::{Mutex, RwLock};
+use uuid::Uuid;
+
+/// Soft cap on cached repositories. Each repository holds exactly one entry
+/// (its current revision), so this bounds the number of distinct RPM repos
+/// kept warm per process.
+pub const RPM_REPODATA_CACHE_MAX_ENTRIES: usize = 32;
+
+/// Total byte budget across all cached entries. Large repositories produce
+/// multi-MiB compressed indexes; the budget keeps the worst case bounded
+/// regardless of entry count. Oldest entries are evicted first when the
+/// budget is exceeded (the newest entry is always retained, so a single
+/// over-budget repository still gets warm-request behaviour).
+pub const RPM_REPODATA_CACHE_MAX_BYTES: usize = 256 * 1024 * 1024;
+
+/// Identity of the repository state a rendered set was built from.
+///
+/// * `repo_ids` — the sorted set of repositories the render covers (one id
+///   for hosted repos, the member ids for virtual repos), so a virtual
+///   membership change rotates the fingerprint even when counts collide.
+/// * `live_rpm_count` — live `.rpm` rows across `repo_ids`; moves on upload,
+///   delete and promotion.
+/// * `latest_update` — `MAX(updated_at)` over those rows; moves on upload
+///   and on any row-touching mutation. `None` for an empty repository.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RepodataFingerprint {
+    pub repo_ids: Vec<Uuid>,
+    pub live_rpm_count: i64,
+    pub latest_update: Option<DateTime<Utc>>,
+}
+
+/// One immutable rendered repodata set: the manifest plus the compressed
+/// index documents its checksums describe. `Bytes` so a warm hit clones a
+/// refcount, not the payload.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RenderedRepodata {
+    pub repomd_xml: Bytes,
+    pub primary_gz: Bytes,
+    pub filelists_gz: Bytes,
+    pub other_gz: Bytes,
+}
+
+impl RenderedRepodata {
+    fn total_bytes(&self) -> usize {
+        self.repomd_xml.len()
+            + self.primary_gz.len()
+            + self.filelists_gz.len()
+            + self.other_gz.len()
+    }
+}
+
+struct CacheEntry {
+    fingerprint: RepodataFingerprint,
+    rendered: Arc<RenderedRepodata>,
+    rendered_at: Instant,
+}
+
+/// Fingerprint-validated, single-flight cache of rendered RPM repodata sets,
+/// keyed by the serving repository's id.
+pub struct RpmRepodataCache {
+    entries: RwLock<HashMap<Uuid, CacheEntry>>,
+    /// Per-repository render locks: concurrent misses for one repo coalesce
+    /// behind a single render instead of each paying the O(repo) build.
+    /// Guarded by a std `Mutex` (never held across an await).
+    render_locks: std::sync::Mutex<HashMap<Uuid, Arc<Mutex<()>>>>,
+    /// Number of full renders performed. Observability + the test hook that
+    /// proves warm requests do not rebuild.
+    renders: AtomicU64,
+    max_entries: usize,
+    max_bytes: usize,
+}
+
+impl Default for RpmRepodataCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RpmRepodataCache {
+    pub fn new() -> Self {
+        Self::with_limits(RPM_REPODATA_CACHE_MAX_ENTRIES, RPM_REPODATA_CACHE_MAX_BYTES)
+    }
+
+    pub fn with_limits(max_entries: usize, max_bytes: usize) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            render_locks: std::sync::Mutex::new(HashMap::new()),
+            renders: AtomicU64::new(0),
+            max_entries: max_entries.max(1),
+            max_bytes,
+        }
+    }
+
+    /// Total full renders performed since startup.
+    pub fn renders(&self) -> u64 {
+        self.renders.load(Ordering::Relaxed)
+    }
+
+    /// The cached set for `repo_id`, but only when it was rendered from
+    /// exactly the state `fingerprint` describes.
+    pub async fn lookup(
+        &self,
+        repo_id: Uuid,
+        fingerprint: &RepodataFingerprint,
+    ) -> Option<Arc<RenderedRepodata>> {
+        let entries = self.entries.read().await;
+        let entry = entries.get(&repo_id)?;
+        if entry.fingerprint == *fingerprint {
+            Some(entry.rendered.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Serve the set for `(repo_id, fingerprint)`, rendering at most once per
+    /// state change: a fingerprint hit returns the cached bytes; concurrent
+    /// misses for one repository coalesce behind a per-repo lock, and every
+    /// waiter re-checks the cache before rendering so exactly one of them
+    /// pays the O(repo) build.
+    ///
+    /// A render failure is returned to the caller and caches nothing, so the
+    /// next request retries.
+    pub async fn get_or_render<E, F, Fut>(
+        &self,
+        repo_id: Uuid,
+        fingerprint: RepodataFingerprint,
+        render: F,
+    ) -> Result<Arc<RenderedRepodata>, E>
+    where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = Result<RenderedRepodata, E>>,
+    {
+        if let Some(hit) = self.lookup(repo_id, &fingerprint).await {
+            return Ok(hit);
+        }
+        let lock = self.render_lock(repo_id);
+        let _guard = lock.lock().await;
+        // Re-check: the leader that held the lock may have rendered exactly
+        // this state while we waited.
+        if let Some(hit) = self.lookup(repo_id, &fingerprint).await {
+            return Ok(hit);
+        }
+        let rendered = Arc::new(render().await?);
+        self.renders.fetch_add(1, Ordering::Relaxed);
+        self.insert(repo_id, fingerprint, rendered.clone()).await;
+        Ok(rendered)
+    }
+
+    /// The per-repository render lock, creating it on first use and sweeping
+    /// locks no longer held by anyone so the map stays bounded by the number
+    /// of concurrently-rendering repositories.
+    fn render_lock(&self, repo_id: Uuid) -> Arc<Mutex<()>> {
+        let mut locks = self
+            .render_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks.retain(|id, lock| *id == repo_id || Arc::strong_count(lock) > 1);
+        locks.entry(repo_id).or_default().clone()
+    }
+
+    async fn insert(
+        &self,
+        repo_id: Uuid,
+        fingerprint: RepodataFingerprint,
+        rendered: Arc<RenderedRepodata>,
+    ) {
+        let mut entries = self.entries.write().await;
+        entries.insert(
+            repo_id,
+            CacheEntry {
+                fingerprint,
+                rendered,
+                rendered_at: Instant::now(),
+            },
+        );
+        // Enforce the entry cap and the byte budget, oldest render first. The
+        // just-inserted entry is the newest, so it survives unless it is the
+        // only one left — a single over-budget repository still gets cached.
+        loop {
+            let over_entries = entries.len() > self.max_entries;
+            let total: usize = entries.values().map(|e| e.rendered.total_bytes()).sum();
+            let over_bytes = total > self.max_bytes && entries.len() > 1;
+            if !over_entries && !over_bytes {
+                break;
+            }
+            let Some(oldest) = entries
+                .iter()
+                .max_by_key(|(_, e)| e.rendered_at.elapsed())
+                .map(|(id, _)| *id)
+            else {
+                break;
+            };
+            entries.remove(&oldest);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    fn fp(count: i64, secs: i64, repo_ids: Vec<Uuid>) -> RepodataFingerprint {
+        RepodataFingerprint {
+            repo_ids,
+            live_rpm_count: count,
+            latest_update: chrono::DateTime::from_timestamp(secs, 0),
+        }
+    }
+
+    fn rendered(tag: &str) -> RenderedRepodata {
+        RenderedRepodata {
+            repomd_xml: Bytes::copy_from_slice(format!("repomd-{tag}").as_bytes()),
+            primary_gz: Bytes::copy_from_slice(format!("primary-{tag}").as_bytes()),
+            filelists_gz: Bytes::copy_from_slice(format!("filelists-{tag}").as_bytes()),
+            other_gz: Bytes::copy_from_slice(format!("other-{tag}").as_bytes()),
+        }
+    }
+
+    #[tokio::test]
+    async fn matching_fingerprint_serves_cached_set_without_rerender() {
+        let cache = RpmRepodataCache::new();
+        let repo = Uuid::new_v4();
+        let calls = AtomicUsize::new(0);
+
+        for _ in 0..5 {
+            let out = cache
+                .get_or_render::<(), _, _>(repo, fp(3, 100, vec![repo]), || async {
+                    calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(rendered("v1"))
+                })
+                .await
+                .unwrap();
+            assert_eq!(out.repomd_xml, Bytes::from_static(b"repomd-v1"));
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "five warm requests must cost exactly one render"
+        );
+        assert_eq!(cache.renders(), 1);
+    }
+
+    #[tokio::test]
+    async fn changed_fingerprint_rerenders_and_replaces_entry() {
+        let cache = RpmRepodataCache::new();
+        let repo = Uuid::new_v4();
+
+        cache
+            .get_or_render::<(), _, _>(repo, fp(3, 100, vec![repo]), || async {
+                Ok(rendered("v1"))
+            })
+            .await
+            .unwrap();
+        // One-artifact mutation: count and latest_update both move.
+        let out = cache
+            .get_or_render::<(), _, _>(repo, fp(4, 200, vec![repo]), || async {
+                Ok(rendered("v2"))
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.repomd_xml, Bytes::from_static(b"repomd-v2"));
+        assert_eq!(
+            cache.renders(),
+            2,
+            "one mutation causes exactly one re-render"
+        );
+
+        // The old revision is gone; the new one is served.
+        assert!(cache.lookup(repo, &fp(3, 100, vec![repo])).await.is_none());
+        assert!(cache.lookup(repo, &fp(4, 200, vec![repo])).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn virtual_member_set_change_rotates_fingerprint() {
+        let a = Uuid::new_v4();
+        let b = Uuid::new_v4();
+        // Same counts and timestamps, different member sets: must not match.
+        assert_ne!(fp(3, 100, vec![a]), fp(3, 100, vec![a, b]));
+        assert_eq!(fp(3, 100, vec![a, b]), fp(3, 100, vec![a, b]));
+    }
+
+    #[tokio::test]
+    async fn concurrent_cold_requests_coalesce_to_one_render() {
+        let cache = Arc::new(RpmRepodataCache::new());
+        let repo = Uuid::new_v4();
+        let calls = Arc::new(AtomicUsize::new(0));
+
+        let tasks: Vec<_> = (0..50)
+            .map(|_| {
+                let cache = cache.clone();
+                let calls = calls.clone();
+                tokio::spawn(async move {
+                    cache
+                        .get_or_render::<(), _, _>(repo, fp(3, 100, vec![repo]), || async move {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+                            Ok(rendered("v1"))
+                        })
+                        .await
+                        .unwrap()
+                })
+            })
+            .collect();
+        for task in tasks {
+            let out = task.await.unwrap();
+            assert_eq!(out.repomd_xml, Bytes::from_static(b"repomd-v1"));
+        }
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "50 concurrent cold refreshes of one state must cause exactly one render"
+        );
+    }
+
+    #[tokio::test]
+    async fn render_failure_caches_nothing_and_next_request_retries() {
+        let cache = RpmRepodataCache::new();
+        let repo = Uuid::new_v4();
+
+        let err = cache
+            .get_or_render::<&str, _, _>(repo, fp(3, 100, vec![repo]), || async { Err("db down") })
+            .await
+            .unwrap_err();
+        assert_eq!(err, "db down");
+        assert_eq!(cache.renders(), 0);
+
+        // The lock was released and nothing was cached: the retry renders.
+        let out = cache
+            .get_or_render::<&str, _, _>(repo, fp(3, 100, vec![repo]), || async {
+                Ok(rendered("v1"))
+            })
+            .await
+            .unwrap();
+        assert_eq!(out.repomd_xml, Bytes::from_static(b"repomd-v1"));
+        assert_eq!(cache.renders(), 1);
+    }
+
+    #[tokio::test]
+    async fn entry_cap_evicts_oldest_repository() {
+        let cache = RpmRepodataCache::with_limits(2, usize::MAX);
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let third = Uuid::new_v4();
+
+        for (i, repo) in [first, second, third].into_iter().enumerate() {
+            cache
+                .get_or_render::<(), _, _>(repo, fp(1, 100, vec![repo]), || async move {
+                    Ok(rendered(&format!("v{i}")))
+                })
+                .await
+                .unwrap();
+            // Distinct rendered_at ordering even on coarse clocks.
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        assert!(
+            cache
+                .lookup(first, &fp(1, 100, vec![first]))
+                .await
+                .is_none(),
+            "oldest entry must be evicted at the cap"
+        );
+        assert!(cache
+            .lookup(second, &fp(1, 100, vec![second]))
+            .await
+            .is_some());
+        assert!(cache
+            .lookup(third, &fp(1, 100, vec![third]))
+            .await
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn byte_budget_evicts_oldest_but_keeps_newest() {
+        // Each rendered set from `rendered()` is ~40 bytes; budget of 100
+        // holds two sets but not three.
+        let cache = RpmRepodataCache::with_limits(usize::MAX, 100);
+        let first = Uuid::new_v4();
+        let second = Uuid::new_v4();
+        let third = Uuid::new_v4();
+
+        for repo in [first, second, third] {
+            cache
+                .get_or_render::<(), _, _>(repo, fp(1, 100, vec![repo]), || async move {
+                    Ok(rendered("vv"))
+                })
+                .await
+                .unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        }
+
+        assert!(
+            cache
+                .lookup(first, &fp(1, 100, vec![first]))
+                .await
+                .is_none(),
+            "oldest entry must be evicted when over the byte budget"
+        );
+        assert!(
+            cache
+                .lookup(third, &fp(1, 100, vec![third]))
+                .await
+                .is_some(),
+            "the newest entry must always survive"
+        );
+    }
+}


### PR DESCRIPTION
Closes #2521

## Summary

RPM repodata endpoints (`repomd.xml`, `repomd.xml.asc`, `primary.xml.gz`, `filelists.xml.gz`, `other.xml.gz`) rebuilt the **entire repository's** package metadata inside every request: each request fetched all live `.rpm` rows plus their metadata JSON, regenerated the XML documents, gzipped them and hashed every variant — `repomd.xml` alone built all four sub-documents just to embed their checksums, and each sibling endpoint repeated the full flow. A single `dnf makecache` therefore cost O(repo) work five times over, and concurrent CI refreshes multiplied it (PF-004).

This PR makes the five endpoints serve a **complete rendered repodata set** cached per repository and validated by a repository-state fingerprint (sorted covered repo ids + live `.rpm` count + `MAX(updated_at)`), recomputed with one cheap aggregate query per request:

- **Warm requests** serve prebuilt immutable bytes: no full-catalog query, no XML/gzip/hash work. The fingerprint is revalidated on every request, so a publish/delete/promotion is visible on the very next read (no TTL window; read-your-writes holds per replica in multi-replica deployments).
- **Concurrent cold refreshes coalesce**: misses for one repository share a per-repo single-flight lock, so 100 concurrent refreshes of one state cause one render, which runs on the blocking pool instead of the async runtime.
- **Coherence and determinism are preserved (#2636)**: `repomd.xml.asc` signs the exact cached bytes `repomd.xml` serves, and the compressed siblings come from the same render as the manifest that advertises their checksums. The fingerprint is captured before rows are fetched, so a racing write can only cause an extra re-render, never stale-served-as-fresh.
- **Bounded**: entry-count cap and a total byte budget, oldest-render-first eviction; the newest entry always survives.

Measured (statement-logged Postgres, identical test sequence on both trees):

| sequence | base | this PR |
|---|---|---|
| 2× `repomd.xml` (unchanged state) | 2 full-catalog selects | 1 full-catalog select |
| 6-request dnf-style flow incl. one mutation | 6 full-catalog selects | 2 full-catalog selects (initial + post-mutation render) + 6 cheap aggregates |

Scoped to RPM — the highest-impact format in PF-004 (five endpoints, four sub-documents per manifest render). The PyPI `/simple/`, Helm `index.yaml` and Composer root indexes named in the same issue are follow-ups, as is a durable cross-replica object store for prebuilt revisions.

Refs #2521

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

`services::rpm_repodata_cache` unit tests cover fingerprint hit/miss, single-flight coalescing (50 concurrent misses → 1 render), render-failure retry, entry-cap and byte-budget eviction, and member-set fingerprint rotation. The DB-backed handler test `test_rpm_repodata_warm_requests_serve_one_cached_render` proves a five-request dnf-style refresh costs exactly one O(repo) render, that `repomd.xml` advertises the checksum of the bytes the sibling endpoint actually served, and that a one-artifact mutation causes exactly one re-render with correct content. Full lib suite: 13826 passed, 0 failed (DB-backed, cargo nextest). The existing deterministic-signing suite (`test_repomd_asc_*`, byte-stability tests) passes unchanged.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes