### PR TITLE
feat(observability): log server version and git sha at startup

### DIFF
--- a/backend/src/build_info.rs
+++ b/backend/src/build_info.rs
@@ -1,0 +1,63 @@
+//! Build/version metadata baked in at compile time.
+//!
+//! `GIT_SHA` is provided by `build.rs`, which runs `git rev-parse HEAD` (with a
+//! `GIT_SHA` build-env override for out-of-tree builds) and falls back to the
+//! literal `"unknown"` when no git checkout is available — e.g. release
+//! tarballs or CI that builds from an exported source tree. Consumers must
+//! therefore treat `"unknown"` as a valid, non-fatal value.
+
+/// Semantic version of the running build, from `CARGO_PKG_VERSION`.
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Full git commit SHA of the build, or `"unknown"` when built outside a git
+/// checkout. Baked by `build.rs`.
+pub const GIT_SHA: &str = env!("GIT_SHA");
+
+/// Length of the short SHA form, matching the `sha-<commit>` tag emitted by the
+/// Docker Publish workflow so a log line can be matched to an exact image.
+const SHORT_SHA_LEN: usize = 7;
+
+/// Truncate a git SHA to its short form, leaving the `"unknown"` sentinel (and
+/// any value already shorter than the short length) untouched.
+fn shorten(sha: &str) -> &str {
+    if sha == "unknown" || sha.len() < SHORT_SHA_LEN {
+        sha
+    } else {
+        &sha[..SHORT_SHA_LEN]
+    }
+}
+
+/// Short (7-char) git SHA of the build, or `"unknown"` when unavailable.
+pub fn short_sha() -> &'static str {
+    shorten(GIT_SHA)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shortens_a_full_sha() {
+        assert_eq!(shorten("abc1234def5678"), "abc1234");
+    }
+
+    #[test]
+    fn leaves_unknown_untouched() {
+        assert_eq!(shorten("unknown"), "unknown");
+    }
+
+    #[test]
+    fn leaves_short_values_untouched() {
+        assert_eq!(shorten("abc12"), "abc12");
+    }
+
+    #[test]
+    fn exact_length_sha_is_unchanged() {
+        assert_eq!(shorten("abc1234"), "abc1234");
+    }
+
+    #[test]
+    fn version_is_non_empty() {
+        assert!(!VERSION.is_empty());
+    }
+}

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -6,6 +6,7 @@
 mod macros;
 
 pub mod api;
+pub mod build_info;
 pub mod cli;
 pub mod config;
 pub mod db;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -171,7 +171,11 @@ pub async fn run_server(shutdown_token: Option<CancellationToken>) -> Result<()>
     #[cfg(feature = "profiling")]
     tracing::info!("Jemalloc profiling enabled - set _RJEM_MALLOC_CONF=prof:true to activate");
 
-    tracing::info!("Starting Artifact Keeper");
+    tracing::info!(
+        version = artifact_keeper_backend::build_info::VERSION,
+        git = artifact_keeper_backend::build_info::short_sha(),
+        "Starting Artifact Keeper"
+    );
 
     // Connect to database
     let db_pool = db::create_pool(&config).await?;


### PR DESCRIPTION
## Summary

Closes #2597.

The backend startup log line was just `Starting Artifact Keeper` with no build
identity, so support log dumps (e.g. `docker compose logs`) could not be matched
to a running release without guessing from timestamps. This adds the semver
version and short git SHA to that first startup line:

```
INFO artifact_keeper: Starting Artifact Keeper version="1.6.0" git="f857e72"
```

Reuses the existing build-time SHA mechanism — `build.rs` already bakes `GIT_SHA`
via `git rev-parse HEAD` (with a `GIT_SHA` build-env override and a `"unknown"`
fallback for non-git / release-tarball builds), and `handlers/health.rs` already
reads it. No new build mechanism is introduced. A small `build_info` module
exposes `VERSION` / `GIT_SHA` and a tested `short_sha()` helper that truncates to
the 7-char form matching the `sha-<commit>` Docker Publish image tag, leaving the
`"unknown"` sentinel untouched.

No behavior change otherwise; the version was already exposed via the health API,
this only surfaces it in the log stream where triage actually looks.

## Regression test (required for `fix/*` PRs)
- [ ] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [x] N/A — this is not a bug fix

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification:
- `cargo build --lib --bin artifact-keeper` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `cargo test --lib build_info` — 5 passed
- Ran the binary: startup line emitted `version="1.6.0" git="f857e72"` matching `git rev-parse --short HEAD`.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
