### PR TITLE
fix(proxy): bound buffered metadata across debian/npm/composer/maven/pypi against the shared byte budget (#2684)

### DIFF
--- a/backend/src/api/handlers/composer.rs
+++ b/backend/src/api/handlers/composer.rs
@@ -903,7 +903,7 @@ async fn resolve_v1_provider_metadata(
     let package = composer_v1_base_name(full_name);
 
     // The upstream's own root index decides the protocol.
-    let Ok((root_bytes, _ct)) = proxy_helpers::proxy_fetch_capped(
+    let Ok((root_bytes, _ct, _budget_permit)) = proxy_helpers::proxy_fetch_capped_budgeted(
         proxy,
         repo_id,
         repo_key,
@@ -934,7 +934,7 @@ async fn resolve_v1_provider_metadata(
                 let Some(include_path) = v1_template_path(template, None, include_hash) else {
                     continue;
                 };
-                let Ok((bytes, _ct)) = proxy_helpers::proxy_fetch_capped(
+                let Ok((bytes, _ct, _budget_permit)) = proxy_helpers::proxy_fetch_capped_budgeted(
                     proxy,
                     repo_id,
                     repo_key,
@@ -976,7 +976,7 @@ async fn resolve_v1_provider_metadata(
         return Ok(None);
     };
 
-    match proxy_helpers::proxy_fetch_capped(
+    match proxy_helpers::proxy_fetch_capped_budgeted(
         proxy,
         repo_id,
         repo_key,
@@ -986,7 +986,7 @@ async fn resolve_v1_provider_metadata(
     )
     .await
     {
-        Ok(fetched) => Ok(Some(fetched)),
+        Ok((content, content_type, _budget_permit)) => Ok(Some((content, content_type))),
         Err(resp) if resp.status() == StatusCode::NOT_FOUND => Ok(None),
         Err(e) => Err(e),
     }
@@ -1005,7 +1005,7 @@ async fn fetch_remote_composer_metadata(
     upstream_path: &str,
     full_name: &str,
 ) -> Result<(Bytes, Option<String>), Response> {
-    match proxy_helpers::proxy_fetch_capped(
+    match proxy_helpers::proxy_fetch_capped_budgeted(
         proxy,
         repo_id,
         repo_key,
@@ -1015,7 +1015,7 @@ async fn fetch_remote_composer_metadata(
     )
     .await
     {
-        Ok(fetched) => Ok(fetched),
+        Ok((content, content_type, _budget_permit)) => Ok((content, content_type)),
         Err(resp) if resp.status() == StatusCode::NOT_FOUND => {
             match resolve_v1_provider_metadata(proxy, repo_id, repo_key, upstream_url, full_name)
                 .await?

--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -1301,6 +1301,16 @@ impl<'a> DebianProxy<'a> {
             upstream_url,
             RepositoryFormat::Debian,
         );
+        // #2684: reserve against the process-wide buffered-metadata byte budget
+        // BEFORE buffering the upstream/cached index. Debian must keep buffering
+        // (the index is verified byte-for-byte against the signed `Release`, so
+        // it cannot stream), but the buffer participates in the same shared
+        // bound as every other proxy-metadata format, so N concurrent index
+        // fetches can never drive resident memory past the budget. The permit is
+        // held for the whole fetch + signed-Release verification below.
+        let _budget_permit = proxy_helpers::proxy_metadata_budget()
+            .reserve(proxy_helpers::LARGE_METADATA_MAX_BYTES)
+            .await;
         let (content, upstream_ct) = proxy
             .fetch_artifact_capped(
                 &proxy_repo,
@@ -1365,6 +1375,12 @@ impl<'a> DebianProxy<'a> {
         };
 
         let pseudo_repo = proxy_helpers::build_remote_repo(repo.id, self.repo_key, upstream_url);
+        // #2684: bound the buffered Release/InRelease document against the shared
+        // proxy-metadata byte budget (see `dists`), held across the revalidation
+        // fetch and the signed-release cache update below.
+        let _budget_permit = proxy_helpers::proxy_metadata_budget()
+            .reserve(proxy_helpers::LARGE_METADATA_MAX_BYTES)
+            .await;
         let (content, upstream_ct, changed) = proxy
             .fetch_dists_with_revalidation(
                 &pseudo_repo,

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -1047,15 +1047,16 @@ async fn download(
             if let (Some(ref upstream_url), Some(ref proxy)) =
                 (&repo.upstream_url, &state.proxy_service)
             {
-                let (content, _content_type) = proxy_helpers::proxy_fetch_capped(
-                    proxy,
-                    repo.id,
-                    &repo_key,
-                    upstream_url,
-                    &path,
-                    proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-                )
-                .await?;
+                let (content, _content_type, _budget_permit) =
+                    proxy_helpers::proxy_fetch_capped_budgeted(
+                        proxy,
+                        repo.id,
+                        &repo_key,
+                        upstream_url,
+                        &path,
+                        proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                    )
+                    .await?;
                 return Ok(Response::builder()
                     .status(StatusCode::OK)
                     .header(CONTENT_TYPE, "text/plain")
@@ -1086,15 +1087,16 @@ async fn download(
                     if let (Some(ref upstream_url), Some(ref proxy)) =
                         (&member.upstream_url, &state.proxy_service)
                     {
-                        if let Ok((content, _)) = proxy_helpers::proxy_fetch_capped(
-                            proxy,
-                            member.id,
-                            &member.key,
-                            upstream_url,
-                            &path,
-                            proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
-                        )
-                        .await
+                        if let Ok((content, _, _budget_permit)) =
+                            proxy_helpers::proxy_fetch_capped_budgeted(
+                                proxy,
+                                member.id,
+                                &member.key,
+                                upstream_url,
+                                &path,
+                                proxy_helpers::DEFAULT_METADATA_MAX_BYTES,
+                            )
+                            .await
                         {
                             return Ok(Response::builder()
                                 .status(StatusCode::OK)
@@ -1146,7 +1148,7 @@ async fn fetch_remote_member_metadata(
     }
     let upstream_url = member.upstream_url.as_deref()?;
     let proxy = state.proxy_service.as_ref()?;
-    let (content, _) = proxy_helpers::proxy_fetch_capped(
+    let (content, _, _budget_permit) = proxy_helpers::proxy_fetch_capped_budgeted(
         proxy,
         member.id,
         &member.key,
@@ -1214,7 +1216,7 @@ async fn fetch_maven_metadata_bytes(
         if let (Some(ref upstream_url), Some(ref proxy)) =
             (&repo.upstream_url, &state.proxy_service)
         {
-            let (content, _) = proxy_helpers::proxy_fetch_capped(
+            let (content, _, _budget_permit) = proxy_helpers::proxy_fetch_capped_budgeted(
                 proxy,
                 repo.id,
                 repo_key,

--- a/backend/src/api/handlers/npm.rs
+++ b/backend/src/api/handlers/npm.rs
@@ -1978,15 +1978,16 @@ async fn get_package_metadata(
         if let Some(ref upstream_url) = repo.upstream_url {
             if let Some(ref proxy) = state.proxy_service {
                 let encoded_name = encode_package_name_for_upstream(package_name);
-                let (content, content_type) = proxy_helpers::proxy_fetch_capped(
-                    proxy,
-                    repo.id,
-                    repo_key,
-                    upstream_url,
-                    &encoded_name,
-                    proxy_helpers::LARGE_METADATA_MAX_BYTES,
-                )
-                .await?;
+                let (content, content_type, _budget_permit) =
+                    proxy_helpers::proxy_fetch_capped_budgeted(
+                        proxy,
+                        repo.id,
+                        repo_key,
+                        upstream_url,
+                        &encoded_name,
+                        proxy_helpers::LARGE_METADATA_MAX_BYTES,
+                    )
+                    .await?;
 
                 return rewrite_and_respond_with_age_gate(
                     state,
@@ -2067,7 +2068,7 @@ async fn get_package_metadata(
             };
 
             let encoded_name = encode_package_name_for_upstream(package_name);
-            let result = proxy_helpers::proxy_fetch_capped(
+            let result = proxy_helpers::proxy_fetch_capped_budgeted(
                 proxy,
                 member.id,
                 &member.key,
@@ -2078,7 +2079,7 @@ async fn get_package_metadata(
             .await;
 
             match result {
-                Ok((content, content_type)) => {
+                Ok((content, content_type, _budget_permit)) => {
                     let params =
                         crate::services::age_gate_service::AgeGateRepoParams::from_repository(
                             member,
@@ -2219,7 +2220,7 @@ async fn fetch_remote_packument(
         .as_ref()
         .ok_or_else(|| AppError::NotFound("Package not found".to_string()).into_response())?;
     let encoded_name = encode_package_name_for_upstream(package_name);
-    let (content, _ct) = proxy_helpers::proxy_fetch_capped(
+    let (content, _ct, _budget_permit) = proxy_helpers::proxy_fetch_capped_budgeted(
         proxy,
         repo.id,
         repo_key,
@@ -2310,7 +2311,7 @@ async fn fetch_virtual_packument(
         };
 
         let encoded_name = encode_package_name_for_upstream(package_name);
-        let result = proxy_helpers::proxy_fetch_capped(
+        let result = proxy_helpers::proxy_fetch_capped_budgeted(
             proxy,
             member.id,
             &member.key,
@@ -2321,7 +2322,7 @@ async fn fetch_virtual_packument(
         .await;
 
         match result {
-            Ok((content, _ct)) => {
+            Ok((content, _ct, _budget_permit)) => {
                 let mut json: serde_json::Value =
                     serde_json::from_slice(&content).map_err(|e| {
                         AppError::Internal(format!("Invalid JSON from upstream: {}", e))
@@ -2455,7 +2456,7 @@ async fn npm_publish_time_for_version(
         // Capped like every other buffered packument read (#2181): this runs
         // on the tarball download path, where an unbounded upstream metadata
         // body must not be able to balloon memory.
-        if let Ok((content, _)) = proxy_helpers::proxy_fetch_capped(
+        if let Ok((content, _, _budget_permit)) = proxy_helpers::proxy_fetch_capped_budgeted(
             proxy,
             repo.id,
             &repo.key,

--- a/backend/src/api/handlers/proxy_helpers.rs
+++ b/backend/src/api/handlers/proxy_helpers.rs
@@ -625,6 +625,67 @@ pub async fn proxy_fetch_capped_with_accept(
     .await
 }
 
+/// Budget-reserving sibling of [`proxy_fetch_capped`] (#2684).
+///
+/// Reserves `max` bytes of the process-wide [`proxy_metadata_budget`] BEFORE
+/// buffering the upstream/cached metadata document, then performs the same
+/// capped fetch and returns the held [`OwnedSemaphorePermit`] alongside the
+/// bytes. The caller keeps the reservation for the buffered document's whole
+/// resident lifetime (parse it, then let the permit drop; or ride it on the
+/// response body).
+///
+/// This extends the #2665 RPM bound uniformly to the other buffered-metadata
+/// proxy formats (debian/npm/composer/maven/pypi): the per-request cap already
+/// bounds ONE buffer at `max`, and reserving against the shared budget bounds
+/// the SUM of concurrent buffers process-wide, so N un-rate-limited requests
+/// (including cache hits, which re-buffer independently) can never drive
+/// resident metadata memory past the budget. The reservation is sized to the
+/// cap rather than the (not-yet-known) body length, matching the RPM path, so
+/// the bound holds during the buffering read itself and not only afterwards.
+pub async fn proxy_fetch_capped_budgeted(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    path: &str,
+    max: usize,
+) -> Result<(Bytes, Option<String>, OwnedSemaphorePermit), Response> {
+    let permit = proxy_metadata_budget().reserve(max).await;
+    let (content, content_type) =
+        proxy_fetch_capped(proxy_service, repo_id, repo_key, upstream_url, path, max).await?;
+    Ok((content, content_type, permit))
+}
+
+/// Budget-reserving sibling of [`proxy_fetch_capped_with_cache_key_and_accept`]
+/// (#2684). See [`proxy_fetch_capped_budgeted`] for the reservation semantics;
+/// used by the PyPI simple-index proxy, which negotiates the PEP 691 JSON
+/// representation under a format-qualified cache key.
+#[allow(clippy::too_many_arguments)]
+pub async fn proxy_fetch_capped_with_cache_key_and_accept_budgeted(
+    proxy_service: &ProxyService,
+    repo_id: Uuid,
+    repo_key: &str,
+    upstream_url: &str,
+    fetch_path: &str,
+    cache_path: &str,
+    accept: Option<&str>,
+    max: usize,
+) -> Result<(Bytes, Option<String>, OwnedSemaphorePermit), Response> {
+    let permit = proxy_metadata_budget().reserve(max).await;
+    let (content, content_type) = proxy_fetch_capped_with_cache_key_and_accept(
+        proxy_service,
+        repo_id,
+        repo_key,
+        upstream_url,
+        fetch_path,
+        cache_path,
+        accept,
+        max,
+    )
+    .await?;
+    Ok((content, content_type, permit))
+}
+
 /// Streaming sibling of [`proxy_fetch`] that does NOT buffer the artifact
 /// body in memory (#895). Returns an axum [`Response`] whose body is a
 /// stream the framework drives directly from the upstream HTTP response,
@@ -9082,6 +9143,112 @@ mod tests {
         VERIFIED_STREAMING_CALL_TOKEN,
         "the remote pool `.deb` download (digest-gated cache commit, #2459)"
     );
+
+    // -------------------------------------------------------------------
+    // #2684: buffered-metadata proxy paths reserve against the shared byte
+    // budget.
+    //
+    // #2665 gave the RPM repodata proxy a process-wide byte budget so the
+    // SUM of concurrent buffered metadata is bounded regardless of request
+    // concurrency, but only the RPM path reserved. These pins assert that
+    // the other buffered-metadata formats route their capped metadata
+    // fetches through the BUDGETED helper (`proxy_fetch_capped_budgeted` /
+    // `proxy_fetch_capped_with_cache_key_and_accept_budgeted`), not the
+    // un-budgeted `proxy_fetch_capped(` — a revert would re-introduce the
+    // unbounded-total buffering closed by #2684. The `_budgeted(` token is
+    // NOT a substring of the un-budgeted `proxy_fetch_capped(` token (the
+    // char after `capped` is `_`, not `(`), so each half of the assertion
+    // is independent.
+    // -------------------------------------------------------------------
+
+    /// One pin per buffered-metadata format handler: it MUST call the
+    /// budgeted helper and MUST NOT retain any un-budgeted `proxy_fetch_capped(`
+    /// call. Kept as a macro so the near-identical bodies do not trip the 3%
+    /// duplication gate.
+    macro_rules! budget_pin_test {
+        ($name:ident, $module_file:literal) => {
+            #[test]
+            fn $name() {
+                let src = include_str!($module_file);
+                assert!(
+                    src.contains("proxy_fetch_capped_budgeted(")
+                        || src.contains("proxy_fetch_capped_with_cache_key_and_accept_budgeted("),
+                    "{} MUST route its buffered proxy-metadata fetch through a \
+                     `*_budgeted` helper so it reserves against the shared \
+                     process-wide byte budget (#2684).",
+                    $module_file,
+                );
+                assert!(
+                    !src.contains("proxy_fetch_capped("),
+                    "{} MUST NOT keep an un-budgeted `proxy_fetch_capped(` \
+                     metadata fetch — every buffered-metadata call site must \
+                     reserve against the shared byte budget (#2684).",
+                    $module_file,
+                );
+                assert!(
+                    !src.contains("proxy_fetch_capped_with_cache_key_and_accept("),
+                    "{} MUST NOT keep an un-budgeted \
+                     `proxy_fetch_capped_with_cache_key_and_accept(` metadata \
+                     fetch (#2684).",
+                    $module_file,
+                );
+            }
+        };
+    }
+
+    budget_pin_test!(test_npm_buffered_metadata_reserves_budget_2684, "npm.rs");
+    budget_pin_test!(
+        test_composer_buffered_metadata_reserves_budget_2684,
+        "composer.rs"
+    );
+    budget_pin_test!(
+        test_maven_buffered_metadata_reserves_budget_2684,
+        "maven.rs"
+    );
+    budget_pin_test!(test_pypi_buffered_metadata_reserves_budget_2684, "pypi.rs");
+
+    /// Debian buffers its index directly through `ProxyService` (it verifies
+    /// the bytes against the signed `Release`, so it cannot stream — #2684
+    /// constraint), so its pin asserts it reserves against the shared budget
+    /// via `proxy_metadata_budget()` rather than a `*_budgeted` helper.
+    #[test]
+    fn test_debian_buffered_metadata_reserves_budget_2684() {
+        let src = include_str!("debian.rs");
+        assert!(
+            src.contains("proxy_metadata_budget()"),
+            "debian.rs MUST reserve its buffered dists/Release index against \
+             the shared proxy-metadata byte budget via `proxy_metadata_budget()` \
+             (#2684); debian keeps buffering (signed-Release verification) but \
+             must be bounded like every other format."
+        );
+    }
+
+    /// The named-format buffered-metadata caps (all LARGE-tier) all draw from
+    /// the SAME process-wide budget, so the SUM of concurrent buffers across
+    /// formats — not just per-format — is bounded (#2684). Model that with a
+    /// budget sized to exactly two LARGE caps and prove the third buffer is
+    /// refused until one releases.
+    #[test]
+    fn shared_budget_bounds_sum_across_named_formats_2684() {
+        let cap = LARGE_METADATA_MAX_BYTES;
+        let budget = ProxyMetadataBudget::new(cap * 2);
+        // e.g. an npm packument + a composer packages.json buffering at once.
+        let npm = budget.try_reserve(cap).expect("1st format buffer admitted");
+        let composer = budget.try_reserve(cap).expect("2nd format buffer admitted");
+        // A third format (pypi/maven/debian) buffering concurrently exceeds the
+        // shared budget and is refused until one releases — before #2684 each
+        // format buffered independently with no shared ceiling.
+        assert!(
+            budget.try_reserve(cap).is_none(),
+            "a third concurrent format buffer must not exceed the shared budget"
+        );
+        drop(npm);
+        let pypi = budget
+            .try_reserve(cap)
+            .expect("slot freed for the next format once one releases");
+        drop((composer, pypi));
+        assert_eq!(budget.available_bytes(), cap * 2, "all budget returned");
+    }
 
     // -------------------------------------------------------------------
     // #1215: source-level pins for the remaining shared proxy paths.

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -334,7 +334,7 @@ async fn fetch_remote_simple_root(
 
     let index_path = fetch_pypi_upstream_index_path(&state.db, repo_id).await;
     let (effective_upstream, upstream_path) = pypi_upstream_url_and_path(upstream, "", &index_path);
-    let (content, _content_type) = match proxy_helpers::proxy_fetch_capped(
+    let (content, _content_type, _budget_permit) = match proxy_helpers::proxy_fetch_capped_budgeted(
         proxy,
         repo_id,
         repo_key,
@@ -344,7 +344,7 @@ async fn fetch_remote_simple_root(
     )
     .await
     {
-        Ok(pair) => pair,
+        Ok(triple) => triple,
         Err(_) => return None,
     };
 
@@ -649,10 +649,10 @@ async fn simple_project(
                     &index_path,
                 );
 
-                let (content, content_type) = if wants_json {
+                let (content, content_type, _budget_permit) = if wants_json {
                     // Request the PEP 691 JSON form from upstream, cached under a
                     // format-qualified key so it never collides with the HTML index.
-                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept(
+                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
                         proxy,
                         repo.id,
                         &repo_key,
@@ -664,7 +664,7 @@ async fn simple_project(
                     )
                     .await?
                 } else {
-                    proxy_helpers::proxy_fetch_capped(
+                    proxy_helpers::proxy_fetch_capped_budgeted(
                         proxy,
                         repo.id,
                         &repo_key,
@@ -855,7 +855,7 @@ async fn simple_project(
                     &member_index_path,
                 );
                 let result = if wants_json {
-                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept(
+                    proxy_helpers::proxy_fetch_capped_with_cache_key_and_accept_budgeted(
                         proxy,
                         member.id,
                         &member.key,
@@ -867,7 +867,7 @@ async fn simple_project(
                     )
                     .await
                 } else {
-                    proxy_helpers::proxy_fetch_capped(
+                    proxy_helpers::proxy_fetch_capped_budgeted(
                         proxy,
                         member.id,
                         &member.key,
@@ -879,7 +879,7 @@ async fn simple_project(
                 };
 
                 match result {
-                    Ok((content, content_type)) => {
+                    Ok((content, content_type, _budget_permit)) => {
                         // #2066: apply THIS gated remote member's age gate to its
                         // own contribution before it is merged with local members
                         // below. Locals stay unfiltered (they are not gated);


### PR DESCRIPTION
## Summary

#2665 (PR #2682) added a process-wide `ProxyMetadataBudget` byte-permit
semaphore (`proxy_metadata_budget()`) that bounds the **sum** of bytes the
buffered proxy-metadata path may hold resident across all in-flight requests,
independent of request concurrency. The primitive is format-agnostic, but only
the **RPM** repodata proxy reserved against it. The other buffered-metadata
proxy formats still each buffered the full upstream/cached document with no
shared ceiling: N anonymous, un-rate-limited requests (including cache hits,
which re-buffer independently — the dominant case in #2665) each held up to the
per-request cap, so total resident metadata memory scaled with concurrency,
not with the budget.

This PR routes the remaining buffered-metadata formats through the same shared
budget so the total is bounded uniformly:

- **npm** packument reads (direct + virtual member + tarball-age-gate lookup)
- **composer** `packages.json` / provider-include / `p2` document reads
- **maven** `maven-metadata.xml` and checksum reads (direct + virtual member)
- **pypi** simple-index reads (HTML + PEP 691 JSON, direct + virtual member)
- **debian** `Release`/`InRelease`/`Packages` dists index reads

Two thin budgeted wrappers are added in `proxy_helpers` —
`proxy_fetch_capped_budgeted` and
`proxy_fetch_capped_with_cache_key_and_accept_budgeted` — that reserve `max`
bytes of the shared budget **before** buffering and return the held permit
alongside the bytes, so the caller keeps the reservation for the buffered
document's resident lifetime (parse it, then drop). npm/composer/maven/pypi
call these instead of the un-budgeted `proxy_fetch_capped*` helpers. Debian
buffers directly through `ProxyService` (it verifies the index byte-for-byte
against the signed `Release`, so per the #2684 constraint it must keep
buffering and is **not** streamed) — it reserves inline via
`proxy_metadata_budget()`, held across the fetch and the signed-`Release`
verification.

Reservations are sized to the per-request cap (matching the RPM path), so the
bound holds during the buffering read itself, not just afterward. Legitimate
metadata fetches under the cap are unchanged (same fetch, same bytes, same
headers); only the shared-memory accounting is added. Behaviour is identical
until the process-wide budget (`AK_PROXY_METADATA_BUDGET_BYTES`, default 1 GiB)
is exhausted, at which point further buffers queue (bounded) instead of
admitting unbounded resident memory.

Streaming pass-through (issue item 2) is intentionally **not** included here:
debian is explicitly excluded from streaming (signature verification), and
converting the genuinely pass-through payloads is a larger, separable change.
This PR delivers item 1 (the shared bound) for all named formats.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

In-crate `#[cfg(test)]` tests that run in CI:
- `test_{npm,composer,maven,pypi}_buffered_metadata_reserves_budget_2684` —
  source-level pins asserting each handler routes its buffered-metadata fetch
  through a `*_budgeted` helper and retains **no** un-budgeted
  `proxy_fetch_capped(` call. Verified RED on `main` (each handler used the
  un-budgeted helper) and GREEN here.
- `test_debian_buffered_metadata_reserves_budget_2684` — pins that debian
  reserves against `proxy_metadata_budget()` (it keeps buffering for signature
  verification but is now bounded). RED on `main`.
- `shared_budget_bounds_sum_across_named_formats_2684` — proves the per-format
  caps draw from the SAME budget: with a budget sized to two LARGE caps, a
  third concurrent format buffer is refused until one releases (the exact
  cross-format bound #2684 asks for).
- The existing `proxy_metadata_budget_*` primitive tests (bounds/queues/clamps
  on release) already cover the runtime over-budget-rejected / under-budget-
  admitted behaviour the formats now rely on.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally (`cargo build --lib`, `cargo clippy --workspace
  --all-targets -- -D warnings`, `cargo fmt --check`, and the npm/composer/
  maven/pypi/debian/proxy_helpers/rpm module suites — 1034 tests — all green
  against a throwaway Postgres; jscpd on changed files < 3%)
- [x] No regressions in existing tests

## API Changes
- [x] N/A - no API changes

Closes #2684
