### PR TITLE
fix(maven): match camelCase storageKey in flat-key files[] attribution (#2706)

### DIFF
--- a/backend/migrations/172_maven_flat_object_attribution_metadata_files_casing.sql
+++ b/backend/migrations/172_maven_flat_object_attribution_metadata_files_casing.sql
@@ -1,0 +1,77 @@
+-- Re-run migration 163's metadata-`files[]` backfill with the correct key
+-- spelling, qualified by storage backend (#2706).
+--
+-- Migration 163 category (2) attributed row-less GAV-grouped companion files
+-- (`.pom`, `.module`, `-sources.jar`, `-javadoc.jar`) by reading each parent
+-- artifact's metadata `files[]` array element as `elem->>'storage_key'`
+-- (snake_case). The GAV-grouped upload handler (#418) has ALWAYS serialized
+-- those entries with a camelCase `"storageKey"` (matching every other reader of
+-- this array: `repositories.rs` reads `sizeBytes`/`extension`, `sbom.rs` reads
+-- `storageKey`). The spelling never matched real data, so category (2) inserted
+-- ZERO rows and every legacy row-less companion still fails closed with 404 on
+-- cloud backends after upgrading to >= 1.5.7 -- the primary `.jar`/`.aar`
+-- resolves (live row) while its `.pom`/`.module` 404s, breaking dependency
+-- resolution for those GAVs.
+--
+-- The read-time layer 2 lookup (`OWNER_BY_METADATA_FILES_SQL`) is corrected in
+-- the same change to match `COALESCE(f->>'storageKey', f->>'storage_key')`, so
+-- companions whose parent row is still live resolve directly. This migration
+-- persists the attribution for companions whose parent row was later
+-- soft-deleted (where the live-row-only layer 2 no longer matches), and derives
+-- their checksum/signature sidecars, exactly as 163 intended.
+--
+-- Isolation is preserved (#2504/#2574/#2584/#2671):
+--   * Cloud repositories only (`storage_backend <> 'filesystem'`) and LIVE
+--     parents only (`is_deleted = false`), as in 163.
+--   * Single-owner only, qualified by the physical object identity
+--     (storage_backend, storage_key): a key referenced by two repositories on
+--     the SAME backend stays ambiguous and UNATTRIBUTED, so it fails closed
+--     (404 read / 403 write) for both tenants. Two repositories on DIFFERENT
+--     backends do not collide (#2671).
+--   * `ON CONFLICT (storage_backend, storage_key) DO NOTHING`: never overwrites
+--     an existing attribution (a live-row `primary_row`, an earlier claim, or a
+--     rollup) -- it only fills in the genuinely-missing metadata-`files[]` rows.
+--
+-- Replay-safe: pure INSERT ... ON CONFLICT DO NOTHING against the post-168
+-- `(storage_backend, storage_key)` primary key; re-running is a no-op.
+
+-- (2') Companion files recorded in a live parent artifact's metadata `files[]`
+--      array, keyed on the real camelCase `storageKey` (with a snake_case
+--      fallback), qualified by the owning repository's backend.
+INSERT INTO maven_flat_object_owner (storage_backend, storage_key, repository_id, source)
+SELECT r.storage_backend,
+       COALESCE(elem->>'storageKey', elem->>'storage_key') AS storage_key,
+       MIN(a.repository_id::text)::uuid,
+       'metadata_files'
+FROM artifact_metadata am
+JOIN artifacts a ON a.id = am.artifact_id
+JOIN repositories r ON r.id = a.repository_id
+CROSS JOIN LATERAL jsonb_array_elements(
+    CASE WHEN jsonb_typeof(am.metadata->'files') = 'array'
+         THEN am.metadata->'files'
+         ELSE '[]'::jsonb END
+) AS elem
+WHERE a.is_deleted = false
+  AND r.storage_backend <> 'filesystem'
+  AND COALESCE(elem->>'storageKey', elem->>'storage_key') LIKE 'maven/%'
+GROUP BY r.storage_backend, COALESCE(elem->>'storageKey', elem->>'storage_key')
+HAVING COUNT(DISTINCT a.repository_id) = 1
+ON CONFLICT (storage_backend, storage_key) DO NOTHING;
+
+-- (3') Derived checksum/signature sidecars for the metadata-`files[]` keys
+--      attributed above (or already present): `.sha1`, `.md5`, `.sha256`, `.asc`
+--      inherit the base object's owner and backend. Base keys that already carry
+--      a sidecar suffix are skipped. Existing sidecars are left untouched.
+INSERT INTO maven_flat_object_owner (storage_backend, storage_key, repository_id, source)
+SELECT o.storage_backend,
+       o.storage_key || s.suffix,
+       o.repository_id,
+       'derived_checksum'
+FROM maven_flat_object_owner o
+CROSS JOIN (VALUES ('.sha1'), ('.md5'), ('.sha256'), ('.asc')) AS s(suffix)
+WHERE o.source = 'metadata_files'
+  AND o.storage_key NOT LIKE '%.sha1'
+  AND o.storage_key NOT LIKE '%.md5'
+  AND o.storage_key NOT LIKE '%.sha256'
+  AND o.storage_key NOT LIKE '%.asc'
+ON CONFLICT (storage_backend, storage_key) DO NOTHING;

--- a/backend/src/services/maven_flat_attribution.rs
+++ b/backend/src/services/maven_flat_attribution.rs
@@ -61,6 +61,12 @@ const OWNER_BY_ARTIFACT_ROW_SQL: &str = "SELECT DISTINCT a.repository_id FROM ar
 /// `files[]` array lists this key (legacy GAV-grouped uploads whose companion
 /// files have no row of their own), restricted to repositories on `$2`. LIMIT 2
 /// for the same ambiguity test.
+///
+/// The GAV-grouped upload handler serializes each `files[]` entry with a
+/// camelCase `"storageKey"` (matching every other reader of this array --
+/// `repositories.rs`'s `sizeBytes`/`extension`, `sbom.rs`'s `storageKey`), so
+/// the lookup keys on `storageKey` and falls back to the legacy snake_case
+/// `storage_key` only for any rows written in that spelling (#2706).
 const OWNER_BY_METADATA_FILES_SQL: &str = "SELECT DISTINCT a.repository_id \
      FROM artifact_metadata am \
      JOIN artifacts a ON a.id = am.artifact_id \
@@ -70,7 +76,7 @@ const OWNER_BY_METADATA_FILES_SQL: &str = "SELECT DISTINCT a.repository_id \
        AND jsonb_typeof(am.metadata->'files') = 'array' \
        AND EXISTS ( \
          SELECT 1 FROM jsonb_array_elements(am.metadata->'files') f \
-         WHERE f->>'storage_key' = $1) \
+         WHERE COALESCE(f->>'storageKey', f->>'storage_key') = $1) \
      LIMIT 2";
 
 /// The attribution table (backfilled legacy keys + write-time claims). The
@@ -429,6 +435,126 @@ mod tests {
         .execute(pool)
         .await
         .expect("seed artifact");
+    }
+
+    /// Seed a live parent artifact in `repo_id` plus an `artifact_metadata` row
+    /// whose `files[]` array lists one row-less companion at `companion_key`,
+    /// shaped EXACTLY as the GAV-grouped upload handler writes it (camelCase
+    /// `"storageKey"`, #418).
+    async fn seed_metadata_files_camel(pool: &PgPool, repo_id: Uuid, companion_key: &str) {
+        let parent_path = format!("com/acme/meta/1.0/meta-1.0-{}.jar", Uuid::new_v4());
+        let parent_key = format!("maven/{parent_path}");
+        seed_artifact(pool, repo_id, &parent_path, &parent_key).await;
+        let (artifact_id,): (Uuid,) =
+            sqlx::query_as("SELECT id FROM artifacts WHERE storage_key = $1")
+                .bind(&parent_key)
+                .fetch_one(pool)
+                .await
+                .expect("fetch parent artifact id");
+        let metadata = serde_json::json!({
+            "files": [{
+                "path": "com/acme/meta/1.0/meta-1.0.pom",
+                "storageKey": companion_key,
+                "sizeBytes": 200,
+                "sha256": "0".repeat(64),
+                "extension": "pom"
+            }]
+        });
+        sqlx::query(
+            "INSERT INTO artifact_metadata (artifact_id, format, metadata) \
+             VALUES ($1, 'maven', $2) \
+             ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2",
+        )
+        .bind(artifact_id)
+        .bind(&metadata)
+        .execute(pool)
+        .await
+        .expect("seed artifact_metadata");
+    }
+
+    /// #2706: a row-less GAV-grouped companion recorded in a live parent's
+    /// metadata `files[]` array resolves to the parent's repository. The upload
+    /// handler writes those entries with a camelCase `"storageKey"`; the layer-2
+    /// lookup keyed on snake_case `storage_key` never matched real data, so the
+    /// companion failed closed (404) for its genuine owner on cloud backends.
+    ///
+    /// This test seeds the array in the real (camelCase) shape and asserts the
+    /// owner now resolves. It FAILS against the pre-fix `f->>'storage_key'`
+    /// lookup (returns `None`) and PASSES against
+    /// `COALESCE(f->>'storageKey', f->>'storage_key')`.
+    #[tokio::test]
+    async fn test_attributed_owner_from_metadata_files_camelcase_2706() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        set_repo_backend(&pool, repo_a, "s3").await;
+        // The parent primary `.jar` has a live row; the `.pom` companion is
+        // row-less and only recorded in the parent's metadata `files[]`.
+        let parent_key = format!("maven/com/acme/meta/1.0/meta-1.0-{}.jar", Uuid::new_v4());
+        seed_artifact(&pool, repo_a, "com/acme/meta/1.0/meta-1.0.jar", &parent_key).await;
+        let companion = format!("maven/com/acme/meta/1.0/meta-1.0-{}.pom", Uuid::new_v4());
+        seed_metadata_files_camel(&pool, repo_a, &companion).await;
+
+        // The companion has no row of its own (layer (a) misses), so this only
+        // resolves via the metadata `files[]` layer (b).
+        assert_eq!(
+            attributed_owner(&pool, "s3", &companion)
+                .await
+                .expect("query"),
+            Some(repo_a),
+            "camelCase storageKey companion must resolve to the parent's repository"
+        );
+        // And its genuine owner may read it on cloud.
+        assert!(flat_key_readable(&pool, repo_a, "s3", &companion).await);
+
+        tdh::cleanup(&pool, repo_a, Uuid::nil()).await;
+    }
+
+    /// #2706 fail-closed guard: the casing fix must MATCH real data, not loosen
+    /// isolation. A companion listed (camelCase) in the metadata `files[]` of two
+    /// repositories on the SAME backend is ambiguous and stays UNATTRIBUTED (404
+    /// for both), and a foreign repository can never read another repo's
+    /// unambiguously-owned companion.
+    #[tokio::test]
+    async fn test_metadata_files_camelcase_still_fails_closed_2706() {
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (repo_a, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        let (repo_b, _, _) = tdh::create_repo(&pool, "local", "maven").await;
+        set_repo_backend(&pool, repo_a, "s3").await;
+        set_repo_backend(&pool, repo_b, "s3").await;
+
+        // Foreign case: a companion owned unambiguously by repo_b is NOT
+        // readable by repo_a (the #2504 hole stays closed).
+        let owned = format!("maven/com/acme/meta/1.0/owned-1.0-{}.pom", Uuid::new_v4());
+        seed_metadata_files_camel(&pool, repo_b, &owned).await;
+        assert_eq!(
+            attributed_owner(&pool, "s3", &owned).await.expect("query"),
+            Some(repo_b)
+        );
+        assert!(flat_key_readable(&pool, repo_b, "s3", &owned).await);
+        assert!(
+            !flat_key_readable(&pool, repo_a, "s3", &owned).await,
+            "a foreign repo must not read another repo's owned companion"
+        );
+
+        // Ambiguous case: the SAME companion key listed by two repos on the SAME
+        // backend resolves to neither -- fails closed for both tenants.
+        let shared = format!("maven/com/acme/meta/1.0/shared-1.0-{}.pom", Uuid::new_v4());
+        seed_metadata_files_camel(&pool, repo_a, &shared).await;
+        seed_metadata_files_camel(&pool, repo_b, &shared).await;
+        assert_eq!(
+            attributed_owner(&pool, "s3", &shared).await.expect("query"),
+            None,
+            "a companion listed by two same-backend repos is ambiguous -> unattributed"
+        );
+        assert!(!flat_key_readable(&pool, repo_a, "s3", &shared).await);
+        assert!(!flat_key_readable(&pool, repo_b, "s3", &shared).await);
+
+        tdh::cleanup(&pool, repo_b, Uuid::nil()).await;
+        tdh::cleanup(&pool, repo_a, Uuid::nil()).await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Row-less Maven flat-key attribution (added in #2585 for #2574/#2584) resolves a
legacy GAV-grouped companion (`.pom`, `.module`, `-sources.jar`, `-javadoc.jar`)
by looking it up in the parent artifact's metadata `files[]` array. Both the
read-time layer-2 query (`OWNER_BY_METADATA_FILES_SQL` in
`services/maven_flat_attribution.rs`) and migration 163's `metadata_files`
backfill matched `f->>'storage_key'` (snake_case), but the GAV-grouped upload
handler has always serialized those entries with camelCase `"storageKey"` — the
same spelling every other reader of this array uses (`repositories.rs`
`sizeBytes`/`extension`, `sbom.rs` `storageKey`). The spelling never matched real
data, so on cloud backends (S3/GCS/Azure):

- Read layer-2 never resolved an owner from `files[]`.
- Migration 163 category (2) inserted zero rows (`elem->>'storage_key'` is NULL
  for every real element, so nothing passed the `LIKE 'maven/%'` filter).

Net effect: after upgrading to ≥ 1.5.7, every legacy row-less companion that
#2585 was designed to keep serving still 404s — the primary `.jar`/`.aar`
resolves via its live row while its `.pom`/`.module` 404s, breaking dependency
resolution for those GAVs.

This change matches the real written data; it does **not** loosen isolation:

- Read-time: layer 2 now keys on `COALESCE(f->>'storageKey', f->>'storage_key')`
  — the camelCase the handler writes, with a snake_case fallback for any legacy
  rows. Single-owner and same-backend ambiguity checks are unchanged, so an
  ambiguous or foreign key still fails closed (404 read / 403 write), preserving
  #2504/#2574/#2584/#2716 and the #2671 backend qualification.
- Migration 172 re-runs 163's `metadata_files` backfill with the corrected
  spelling, qualified by `(storage_backend, storage_key)` (the post-#2671
  schema), single-owner-per-backend only, `ON CONFLICT DO NOTHING` (never
  overwrites an existing attribution), plus the derived checksum/signature
  sidecars for the newly-attributed keys. This persists attribution for
  companions whose parent row was later soft-deleted (where the live-row-only
  read layer no longer matches).

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Two unit tests added in `maven_flat_attribution.rs`:

- `test_attributed_owner_from_metadata_files_camelcase_2706` — seeds a live
  parent + `artifact_metadata` `files[]` in the real camelCase shape and asserts
  the row-less companion resolves to the parent's repository. FAILS on the
  pre-fix snake_case lookup (`None`), PASSES after (`Some(owner)`).
- `test_metadata_files_camelcase_still_fails_closed_2706` — a companion owned
  unambiguously by repo B is not readable by repo A, and a companion listed by
  two same-backend repos is ambiguous → unattributed (404 for both). Proves the
  casing fix matches data without widening any read.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local verification (authoritative): `cargo build --lib` clean;
`cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt
--check` clean; `cargo test --lib maven_flat_attribution` 13/13 pass. Migrations
apply cleanly through 172. Direct SQL against the real writer shape:
`storage_key` matches 0 rows, `COALESCE(storageKey, storage_key)` matches 1.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [ ] N/A - no API changes

Migration 172 is a forward-only, idempotent (`ON CONFLICT DO NOTHING`) data
backfill, consistent with migrations 163/168; it adds attribution rows only and
never removes or overwrites existing ones, so a replay is a no-op.

Closes #2706
