### PR TITLE
fix(debian): reject encoded %2f/%5c path separators in proxy paths (defense-in-depth)

### DIFF
--- a/backend/src/api/handlers/debian.rs
+++ b/backend/src/api/handlers/debian.rs
@@ -178,6 +178,57 @@ fn debian_filter_denied(dimension: &str, value: &str) -> Response {
     (StatusCode::NOT_FOUND, "Not found").into_response()
 }
 
+/// Response for a request refused by the #2562 encoded-separator guard. Unlike
+/// a filter miss (404, which hides mirror contents), an encoded path separator
+/// is a malformed request regardless of what the mirror holds, so it is
+/// answered with an explicit 400 that names the reason.
+fn debian_encoded_separator_rejected(path: &str) -> Response {
+    tracing::debug!(
+        path = path,
+        "debian proxy request rejected: encoded path separator (#2562)"
+    );
+    (
+        StatusCode::BAD_REQUEST,
+        "Encoded path separators (%2f/%5c) are not permitted in Debian proxy paths",
+    )
+        .into_response()
+}
+
+/// Detect a percent-encoded path separator (`%2f` = `/`, `%5c` = `\`) anywhere
+/// in a proxy request path, at any percent-decoding layer up to a fixpoint (so
+/// a singly- OR multiply-encoded separator is caught). APT never
+/// percent-encodes path separators, so a hit here is always a path-confusion or
+/// traversal probe rather than a legitimate request. Note this deliberately
+/// does NOT flag other encoded bytes (e.g. an epoch `%3a`), which are legal in
+/// Debian filenames.
+fn has_encoded_path_separator(raw: &str) -> bool {
+    let mut cur = raw.to_string();
+    for _ in 0..8 {
+        let lower = cur.to_ascii_lowercase();
+        if lower.contains("%2f") || lower.contains("%5c") {
+            return true;
+        }
+        if !cur.contains('%') {
+            return false;
+        }
+        match urlencoding::decode(&cur) {
+            Ok(decoded) => {
+                let decoded = decoded.into_owned();
+                if decoded == cur {
+                    // A `%` that is not part of a valid escape — no separator.
+                    return false;
+                }
+                cur = decoded;
+            }
+            // Invalid UTF-8 in an escape: not a decodable separator.
+            Err(_) => return false,
+        }
+    }
+    // Pathological over-encoding: treat as suspicious and let the caller decide
+    // via the normal reject path below (return true so it is refused).
+    true
+}
+
 /// Pre-fetch allow/deny decision for a Debian proxy request. Each dimension is
 /// checked only when supplied (`Some`); an empty allowlist for a dimension
 /// permits everything. Returns a 404 [`Response`] as `Err` when any supplied
@@ -318,7 +369,19 @@ fn repo_remote_upstream(repo: &RepoInfo) -> Option<&str> {
 /// be silently stripped. Escapes above the base (scheme/host/port/prefix
 /// change) are refused too.
 #[allow(clippy::result_large_err)]
-fn normalized_debian_relpath(base_url: &str, relative: &str) -> Result<String, Response> {
+fn normalized_debian_relpath(
+    base_url: &str,
+    relative: &str,
+    allow_encoded_separators: bool,
+) -> Result<String, Response> {
+    // #2562 defense-in-depth: reject an encoded path separator (%2f/%5c) before
+    // it can be forwarded opaquely upstream. reqwest keeps `%2f` encoded (it is
+    // NOT split into a segment), so such a request is gated as one opaque
+    // segment yet a nonstandard upstream that decodes it could still traverse.
+    // APT never encodes separators, so this never blocks a legitimate path.
+    if !allow_encoded_separators && has_encoded_path_separator(relative) {
+        return Err(debian_encoded_separator_rejected(relative));
+    }
     if relative.bytes().any(|b| b <= 0x20 || b == 0x7f) {
         return Err(debian_filter_denied("path", relative));
     }
@@ -356,9 +419,10 @@ fn normalized_dists_parts(
     base_url: &str,
     distribution: &str,
     raw_suffix: &str,
+    allow_encoded_separators: bool,
 ) -> Result<(String, String), Response> {
     let relative = format!("dists/{}/{}", distribution, raw_suffix);
-    let norm = normalized_debian_relpath(base_url, &relative)?;
+    let norm = normalized_debian_relpath(base_url, &relative, allow_encoded_separators)?;
     let mut it = norm.splitn(3, '/');
     match it.next() {
         Some("dists") => {}
@@ -384,7 +448,12 @@ fn gate_debian_dists(
     distribution: &str,
     raw_suffix: &str,
 ) -> Result<(), Response> {
-    let (dist, suffix) = normalized_dists_parts(base_url, distribution, raw_suffix)?;
+    let (dist, suffix) = normalized_dists_parts(
+        base_url,
+        distribution,
+        raw_suffix,
+        filter.allow_encoded_separators,
+    )?;
     debian_filter_decision(
         filter,
         Some(&dist),
@@ -405,7 +474,7 @@ fn gate_debian_pool(
     path: &str,
 ) -> Result<(), Response> {
     let relative = format!("pool/{}/{}", component, path);
-    let norm = normalized_debian_relpath(base_url, &relative)?;
+    let norm = normalized_debian_relpath(base_url, &relative, filter.allow_encoded_separators)?;
     let mut it = norm.splitn(3, '/');
     match it.next() {
         Some("pool") => {}
@@ -448,7 +517,12 @@ async fn enforce_by_hash_arch(
     if filter.architectures.is_empty() {
         return Ok(());
     }
-    let (ndist, suffix) = normalized_dists_parts(upstream_url, distribution, raw_suffix)?;
+    let (ndist, suffix) = normalized_dists_parts(
+        upstream_url,
+        distribution,
+        raw_suffix,
+        filter.allow_encoded_separators,
+    )?;
     if !suffix.contains("by-hash/") {
         return Ok(());
     }
@@ -3304,10 +3378,10 @@ mod tests {
                 .to_string();
             // A control byte is refused up front (belt); otherwise parity holds.
             if raw.bytes().any(|b| b <= 0x20 || b == 0x7f) {
-                assert!(normalized_debian_relpath(TEST_BASE, raw).is_err());
+                assert!(normalized_debian_relpath(TEST_BASE, raw, false).is_err());
             } else {
                 assert_eq!(
-                    normalized_debian_relpath(TEST_BASE, raw).unwrap(),
+                    normalized_debian_relpath(TEST_BASE, raw, false).unwrap(),
                     expected,
                     "gate input must equal reqwest fetch path for: {raw:?}"
                 );
@@ -3361,16 +3435,98 @@ mod tests {
     }
 
     #[test]
+    fn test_has_encoded_path_separator() {
+        // Encoded forward slash / backslash, any case, any decode layer.
+        assert!(has_encoded_path_separator("main%2f..%2fcontrib"));
+        assert!(has_encoded_path_separator("main%2F..%2Fcontrib"));
+        assert!(has_encoded_path_separator("a%5cb"));
+        assert!(has_encoded_path_separator("a%5Cb"));
+        // Double-encoded (axum decodes once -> %2f reaches the fixpoint scan).
+        assert!(has_encoded_path_separator("main%252f..%252fcontrib"));
+        // Legitimate Debian paths: real separators and an epoch colon are fine.
+        assert!(!has_encoded_path_separator("main/binary-amd64/Packages.gz"));
+        assert!(!has_encoded_path_separator("gcc_4%3a10.2.1-1_amd64.deb"));
+        assert!(!has_encoded_path_separator("0ad_1_arm64%252edeb"));
+        assert!(!has_encoded_path_separator("Release"));
+    }
+
+    #[test]
+    fn test_gate_dists_rejects_encoded_separator_with_400() {
+        // Default filter (allow_encoded_separators = false) rejects an encoded
+        // separator in the dists path with a clear 400 (#2562).
+        let filter = DebianRepositoryConfig::default();
+        let resp = gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main%2f..%2fcontrib/binary-amd64/Packages.gz",
+        )
+        .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // An encoded separator smuggled through the distribution segment is also
+        // caught (the whole relative path is scanned).
+        let resp = gate_debian_dists(&filter, TEST_BASE, "book%2f..worm", "Release").unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // A legitimate path (real separators, epoch colon) still passes.
+        assert!(gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main/binary-amd64/Packages.gz"
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_gate_dists_encoded_separator_opt_out() {
+        // With the per-repo opt-out on, the encoded separator is no longer
+        // rejected by the #2562 guard (it then flows to the normal gate, which
+        // for an empty allowlist permits it).
+        let filter = DebianRepositoryConfig {
+            allow_encoded_separators: true,
+            ..Default::default()
+        };
+        assert!(gate_debian_dists(
+            &filter,
+            TEST_BASE,
+            "bookworm",
+            "main%2f..%2fcontrib/binary-amd64/Packages.gz",
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn test_gate_pool_rejects_encoded_separator_with_400() {
+        let filter = DebianRepositoryConfig::default();
+        let resp = gate_debian_pool(
+            &filter,
+            TEST_BASE,
+            "main",
+            "0/0ad/..%2f..%2f..%2fetc%2fpasswd",
+        )
+        .unwrap_err();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        // Legitimate pool path with an epoch-colon filename still passes.
+        assert!(gate_debian_pool(
+            &filter,
+            TEST_BASE,
+            "main",
+            "g/gcc/gcc_4%3a10.2.1-1_amd64.deb"
+        )
+        .is_ok());
+    }
+
+    #[test]
     fn test_normalized_relpath_rejects_control_bytes_and_escape() {
         // Raw control byte (tab/LF/CR/space) refused up front.
         for bad in ["main/\t/Packages", "main/\n/Packages", "main/ /Packages"] {
             assert!(
-                normalized_debian_relpath(TEST_BASE, bad).is_err(),
+                normalized_debian_relpath(TEST_BASE, bad, false).is_err(),
                 "should reject control/ws: {bad:?}"
             );
         }
         // Escape above the base path is refused.
-        assert!(normalized_debian_relpath(TEST_BASE, "../../etc/passwd").is_err());
+        assert!(normalized_debian_relpath(TEST_BASE, "../../etc/passwd", false).is_err());
     }
 
     #[test]

--- a/backend/src/formats/debian.rs
+++ b/backend/src/formats/debian.rs
@@ -135,6 +135,14 @@ pub struct DebianRepositoryConfig {
     /// rather than silently advertising content the proxy would then block.
     #[serde(default, deserialize_with = "deserialize_vec_string_or_null")]
     pub package_queries: Vec<String>,
+    /// Defense-in-depth (#2562): when `false` (the default) a proxy request
+    /// whose path carries a percent-encoded path separator (`%2f` = `/`,
+    /// `%5c` = `\`, at any decode layer) is rejected with 400 before any
+    /// upstream fetch. APT never percent-encodes path separators, so this only
+    /// ever blocks path-confusion/traversal probes; set it `true` to opt out
+    /// for a nonstandard upstream that genuinely requires encoded separators.
+    #[serde(default)]
+    pub allow_encoded_separators: bool,
 }
 
 /// Partial-update patch for [`DebianRepositoryConfig`]. Fields left absent are
@@ -163,6 +171,8 @@ pub struct DebianConfigPatch {
     pub package_fetch_strategy: Option<DebianPackageFetchStrategy>,
     #[serde(default)]
     pub package_queries: Option<Vec<String>>,
+    #[serde(default)]
+    pub allow_encoded_separators: Option<bool>,
 }
 
 impl DebianConfigPatch {
@@ -197,6 +207,9 @@ impl DebianConfigPatch {
         }
         if let Some(v) = self.package_queries {
             base.package_queries = v;
+        }
+        if let Some(v) = self.allow_encoded_separators {
+            base.allow_encoded_separators = v;
         }
         base
     }
@@ -1968,6 +1981,38 @@ Size: 100
             vec!["main".to_string(), "contrib".to_string()]
         );
         assert_eq!(merged.architectures, vec!["amd64".to_string()]);
+    }
+
+    #[test]
+    fn test_allow_encoded_separators_defaults_to_reject() {
+        // #2562: the guard is on by default (allow flag false) so the
+        // defense-in-depth is active without any operator action.
+        assert!(!DebianRepositoryConfig::default().allow_encoded_separators);
+        // Absent in JSON -> false (reject). Set true -> honored.
+        let cfg: DebianRepositoryConfig = serde_json::from_str("{}").unwrap();
+        assert!(!cfg.allow_encoded_separators);
+        let cfg: DebianRepositoryConfig =
+            serde_json::from_str(r#"{"allow_encoded_separators": true}"#).unwrap();
+        assert!(cfg.allow_encoded_separators);
+    }
+
+    #[test]
+    fn test_config_patch_toggles_allow_encoded_separators() {
+        let base = DebianRepositoryConfig::default();
+        assert!(!base.allow_encoded_separators);
+        let patch = DebianConfigPatch {
+            allow_encoded_separators: Some(true),
+            ..Default::default()
+        };
+        let merged = patch.apply_to(base);
+        assert!(merged.allow_encoded_separators);
+        // A patch that omits the field preserves the stored value.
+        let base = DebianRepositoryConfig {
+            allow_encoded_separators: true,
+            ..Default::default()
+        };
+        let merged = DebianConfigPatch::default().apply_to(base);
+        assert!(merged.allow_encoded_separators);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Defense-in-depth for the Debian remote proxy: reject a request whose path carries
a **percent-encoded path separator** (`%2f` = `/`, `%5c` = `\`) before it is
forwarded upstream.

Today an encoded separator survives the proxy path gate as a single opaque
segment. `normalized_debian_relpath` resolves the fetch path with the same
WHATWG URL parser reqwest uses, and that parser keeps `%2f`/`%5c` **encoded**
inside a path segment (it does not split them into `/`), so `main%2f..%2fcontrib`
is gated as one segment (which passes an empty/permissive allowlist) and reqwest
forwards the literal `%2f` upstream. Against any standard APT origin/CDN this is a
harmless 404 (Apache `AllowEncodedSlashes` defaults `Off`; encoded slashes are not
treated as separators), but a nonstandard upstream that both decodes `%2f` **and**
resolves `..` server-side could be steered off-path. APT never percent-encodes
path separators, so rejecting them costs nothing for legitimate traffic.

The guard lives at the single chokepoint every gated proxy path already funnels
through (`normalized_debian_relpath`, reached by both `gate_debian_dists` and
`gate_debian_pool`), so `dists/*`, `pool/*`, the static `Release`/`InRelease`/
`Release.gpg` routes, the by-hash arch cross-check, and virtual-member fan-out are
all covered. The scan collapses percent-encoding to a fixpoint, so a singly- or
multiply-encoded separator (`%252f`) is caught, while other encoded bytes that are
legal in Debian filenames (e.g. an epoch `%3a`) are left untouched. A refused
request returns an explicit **400** naming the reason (not the filter's 404, which
is reserved for hiding mirror contents).

Configurable per repository via a new `allow_encoded_separators` flag on the Debian
remote config. It defaults to `false` (guard **on**), so the hardening is active
without operator action; an operator with a genuinely nonstandard upstream can set
it `true` to opt out.

Origin: info note from the #2460/#2558 round-3 red-team (not exploitable on standard
origins). Closes #2562.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

New unit tests (fail before the guard existed, pass after):
- `test_has_encoded_path_separator` — detector: `%2f`/`%5c` (any case, single/double
  encoded) flagged; real separators, epoch `%3a`, and `%252edeb` are not.
- `test_gate_dists_rejects_encoded_separator_with_400` — encoded separator in the
  dists path (and smuggled via the distribution segment) → 400; legit path → ok.
- `test_gate_dists_encoded_separator_opt_out` — with `allow_encoded_separators=true`
  the guard stands down.
- `test_gate_pool_rejects_encoded_separator_with_400` — pool traversal probe → 400;
  epoch-colon filename → ok.
- `test_allow_encoded_separators_defaults_to_reject` /
  `test_config_patch_toggles_allow_encoded_separators` — default is reject; patch
  merge honors/preserves the flag.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes (additive optional config field only; no migration)
