### PR TITLE
fix(migration): create artifacts rows for migrated by-digest child manifests

### DIFF
--- a/backend/.sqlx/query-00c8f4395ef6c70073b562e0ea18d83121ea4154674dd0e1e7c22186fd413d7c.json
+++ b/backend/.sqlx/query-00c8f4395ef6c70073b562e0ea18d83121ea4154674dd0e1e7c22186fd413d7c.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                   block_on_policy_violation, severity_threshold, created_at, updated_at\n            FROM scan_configs\n            WHERE repository_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "block_on_policy_violation",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "severity_threshold",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "00c8f4395ef6c70073b562e0ea18d83121ea4154674dd0e1e7c22186fd413d7c"
+}

--- a/backend/.sqlx/query-01cdcb4d69e0f521d1a09fd8600b4cc5cdefeb537776cdc93ea582944622d067.json
+++ b/backend/.sqlx/query-01cdcb4d69e0f521d1a09fd8600b4cc5cdefeb537776cdc93ea582944622d067.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE artifacts SET quarantine_status = $2 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "01cdcb4d69e0f521d1a09fd8600b4cc5cdefeb537776cdc93ea582944622d067"
+}

--- a/backend/.sqlx/query-01f2c167b0dc4ebe402fabc44df8a614e19455ebaf90b976d4f122a4b85cfb54.json
+++ b/backend/.sqlx/query-01f2c167b0dc4ebe402fabc44df8a614e19455ebaf90b976d4f122a4b85cfb54.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE plugins SET status = 'active', enabled_at = NOW(), updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "01f2c167b0dc4ebe402fabc44df8a614e19455ebaf90b976d4f122a4b85cfb54"
+}

--- a/backend/.sqlx/query-022011961d74cb1743316dd23c275dc1795ca12963ae4717f754a5e5b08ba841.json
+++ b/backend/.sqlx/query-022011961d74cb1743316dd23c275dc1795ca12963ae4717f754a5e5b08ba841.json
@@ -1,0 +1,59 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, plugin_id, event_type, severity, message, details, created_at\n            FROM plugin_events\n            WHERE plugin_id = $1\n            ORDER BY created_at DESC\n            LIMIT $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "event_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "severity",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "details",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "022011961d74cb1743316dd23c275dc1795ca12963ae4717f754a5e5b08ba841"
+}

--- a/backend/.sqlx/query-027da4df8a6b05f7d9ed1157675351b36d776ea05fb7d20efefb42e56122a386.json
+++ b/backend/.sqlx/query-027da4df8a6b05f7d9ed1157675351b36d776ea05fb7d20efefb42e56122a386.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'pub', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "027da4df8a6b05f7d9ed1157675351b36d776ea05fb7d20efefb42e56122a386"
+}

--- a/backend/.sqlx/query-02b2aa46f25b7a58176c418dc2b45a258a49f16166957c28e2cf2cf47d5ae6e3.json
+++ b/backend/.sqlx/query-02b2aa46f25b7a58176c418dc2b45a258a49f16166957c28e2cf2cf47d5ae6e3.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM sync_tasks WHERE status = 'pending'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "02b2aa46f25b7a58176c418dc2b45a258a49f16166957c28e2cf2cf47d5ae6e3"
+}

--- a/backend/.sqlx/query-02d0f2534bed73c81861da9ac7fdc885264cf5eec44c7c0f929c26f5e60925c1.json
+++ b/backend/.sqlx/query-02d0f2534bed73c81861da9ac7fdc885264cf5eec44c7c0f929c26f5e60925c1.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT password_hash, totp_secret, totp_enabled, username FROM users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "username",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "02d0f2534bed73c81861da9ac7fdc885264cf5eec44c7c0f929c26f5e60925c1"
+}

--- a/backend/.sqlx/query-02fbd06b7d8f0194a6e9d06ed3d60c42f0c0728ef3afa9a51cc3fc31f88d1f4a.json
+++ b/backend/.sqlx/query-02fbd06b7d8f0194a6e9d06ed3d60c42f0c0728ef3afa9a51cc3fc31f88d1f4a.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE api_tokens SET created_by_user_id = $1, description = $2 WHERE id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "02fbd06b7d8f0194a6e9d06ed3d60c42f0c0728ef3afa9a51cc3fc31f88d1f4a"
+}

--- a/backend/.sqlx/query-03d8fb98c80708d8f0afe47123bad605de2cffb8f2eb75a2f6139494bdcf5140.json
+++ b/backend/.sqlx/query-03d8fb98c80708d8f0afe47123bad605de2cffb8f2eb75a2f6139494bdcf5140.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT config, config_schema\n        FROM plugins\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "config",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 1,
+        "name": "config_schema",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true,
+      true
+    ]
+  },
+  "hash": "03d8fb98c80708d8f0afe47123bad605de2cffb8f2eb75a2f6139494bdcf5140"
+}

--- a/backend/.sqlx/query-047947938d72f740ef32641dcbac6f491ba1620f70013bae5c8c84963ad12a39.json
+++ b/backend/.sqlx/query-047947938d72f740ef32641dcbac6f491ba1620f70013bae5c8c84963ad12a39.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO peer_instances (id, name, endpoint_url, api_key)\n            VALUES ($1, $2, $3, $4)\n            ON CONFLICT (name) DO UPDATE\n                SET endpoint_url = $3, api_key = $4, updated_at = NOW()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "047947938d72f740ef32641dcbac6f491ba1620f70013bae5c8c84963ad12a39"
+}

--- a/backend/.sqlx/query-04c18ffc790e321c7af9fbde1ccf2e9742d72e74d29a0056edbae56a4527462d.json
+++ b/backend/.sqlx/query-04c18ffc790e321c7af9fbde1ccf2e9742d72e74d29a0056edbae56a4527462d.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, name, token_prefix, scopes, expires_at, last_used_at, created_at\n        FROM api_tokens\n        WHERE user_id = $1 AND revoked_at IS NULL\n        ORDER BY created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "token_prefix",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "scopes",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 4,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "04c18ffc790e321c7af9fbde1ccf2e9742d72e74d29a0056edbae56a4527462d"
+}

--- a/backend/.sqlx/query-071043bdbbf5aed9a508abcad45ef7c9d6f91c030c1ec1cc3efc92c6f1c409eb.json
+++ b/backend/.sqlx/query-071043bdbbf5aed9a508abcad45ef7c9d6f91c030c1ec1cc3efc92c6f1c409eb.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COALESCE(SUM(bytes), 0)::BIGINT as \"usage!\"\n            FROM (\n                SELECT size_bytes AS bytes\n                  FROM artifacts\n                 WHERE repository_id = $1 AND is_deleted = false\n                   AND storage_key NOT LIKE 'proxy-cache/%'\n                UNION ALL\n                SELECT size_bytes AS bytes\n                  FROM proxy_cache_artifacts\n                 WHERE repository_id = $1\n                UNION ALL\n                SELECT size_bytes AS bytes\n                  FROM oci_blobs\n                 WHERE repository_id = $1\n            ) t\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "usage!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "071043bdbbf5aed9a508abcad45ef7c9d6f91c030c1ec1cc3efc92c6f1c409eb"
+}

--- a/backend/.sqlx/query-0729b3c75134db3dbb88baedbaca142975533ac8b9af26f83b3b4b644dbe3460.json
+++ b/backend/.sqlx/query-0729b3c75134db3dbb88baedbaca142975533ac8b9af26f83b3b4b644dbe3460.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.name, a.version as \"version?\", a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.name = $2\n          AND a.is_deleted = false\n        ORDER BY a.created_at ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version?",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "0729b3c75134db3dbb88baedbaca142975533ac8b9af26f83b3b4b644dbe3460"
+}

--- a/backend/.sqlx/query-075cc2a9a4ef91638c8615d4cda8e29786270df288843e821c0b3f49b293cb20.json
+++ b/backend/.sqlx/query-075cc2a9a4ef91638c8615d4cda8e29786270df288843e821c0b3f49b293cb20.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'terraform', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "075cc2a9a4ef91638c8615d4cda8e29786270df288843e821c0b3f49b293cb20"
+}

--- a/backend/.sqlx/query-0762236034cfc356a7406fc1bcf035656b4021f92a42a8afefdab802b4f5e565.json
+++ b/backend/.sqlx/query-0762236034cfc356a7406fc1bcf035656b4021f92a42a8afefdab802b4f5e565.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0762236034cfc356a7406fc1bcf035656b4021f92a42a8afefdab802b4f5e565"
+}

--- a/backend/.sqlx/query-07e3c24be6f66db161ed10e0ecb0b7ec44f8a4c67022c78b67beb05d5fd9b3c4.json
+++ b/backend/.sqlx/query-07e3c24be6f66db161ed10e0ecb0b7ec44f8a4c67022c78b67beb05d5fd9b3c4.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO instance_storage_stats (id, unique_bytes, dedup_scope, computed_at)\n            VALUES (true, $1, $2, now())\n            ON CONFLICT (id) DO UPDATE SET\n                unique_bytes = EXCLUDED.unique_bytes,\n                dedup_scope  = EXCLUDED.dedup_scope,\n                computed_at  = now()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "07e3c24be6f66db161ed10e0ecb0b7ec44f8a4c67022c78b67beb05d5fd9b3c4"
+}

--- a/backend/.sqlx/query-07e3fe821b669760b8acc3976c68f40212765cb49627f355cb3307fb68216f42.json
+++ b/backend/.sqlx/query-07e3fe821b669760b8acc3976c68f40212765cb49627f355cb3307fb68216f42.json
@@ -1,0 +1,92 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE format_handlers\n            SET is_enabled = true, updated_at = NOW()\n            WHERE format_key = $1\n            RETURNING id, format_key, plugin_id,\n                      handler_type as \"handler_type: FormatHandlerType\",\n                      display_name, description, extensions,\n                      is_enabled, priority, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "07e3fe821b669760b8acc3976c68f40212765cb49627f355cb3307fb68216f42"
+}

--- a/backend/.sqlx/query-082ec9783796fa69f09ebc10eeea985a5941e03f3253b5f724c6abc763fab640.json
+++ b/backend/.sqlx/query-082ec9783796fa69f09ebc10eeea985a5941e03f3253b5f724c6abc763fab640.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                r.id, r.repository_id, r.package_name, r.package_version,\n                r.upstream_published_at, r.status, r.requested_at,\n                r.reviewed_by, r.reviewed_at, r.review_reason,\n                r.request_count, r.last_requested_at,\n                repo.key as repository_key\n            FROM age_gate_reviews r\n            INNER JOIN repositories repo ON repo.id = r.repository_id\n            WHERE r.id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "package_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "package_version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "upstream_published_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "requested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "reviewed_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "reviewed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "review_reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "request_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "last_requested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "repository_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "082ec9783796fa69f09ebc10eeea985a5941e03f3253b5f724c6abc763fab640"
+}

--- a/backend/.sqlx/query-084a7d2bf651f0102019a94a426b31351bafddc38cf6262d74bfce0613506e1a.json
+++ b/backend/.sqlx/query-084a7d2bf651f0102019a94a426b31351bafddc38cf6262d74bfce0613506e1a.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO users (id, username, email, display_name, auth_provider, external_id, is_admin, is_active, is_service_account)\n            VALUES ($1, $2, $3, $4, 'ldap', $5, $6, true, false)\n            RETURNING\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "084a7d2bf651f0102019a94a426b31351bafddc38cf6262d74bfce0613506e1a"
+}

--- a/backend/.sqlx/query-08df2123416594d67e01c507ddd721d9711a87115708d0d918519f8340d01572.json
+++ b/backend/.sqlx/query-08df2123416594d67e01c507ddd721d9711a87115708d0d918519f8340d01572.json
@@ -1,0 +1,116 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM signing_keys ORDER BY created_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "key_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "fingerprint",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "key_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "public_key_pem",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "private_key_enc",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 8,
+        "name": "algorithm",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "uid_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "uid_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "rotated_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "08df2123416594d67e01c507ddd721d9711a87115708d0d918519f8340d01572"
+}

--- a/backend/.sqlx/query-08e31e03233abfa07a1e1f3e1fa72dd1a299791f865ccb2900bfa3ccc91c015b.json
+++ b/backend/.sqlx/query-08e31e03233abfa07a1e1f3e1fa72dd1a299791f865ccb2900bfa3ccc91c015b.json
@@ -1,0 +1,102 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, format_key, plugin_id,\n                           handler_type as \"handler_type: FormatHandlerType\",\n                           display_name, description, extensions,\n                           is_enabled, priority, created_at, updated_at\n                    FROM format_handlers\n                    WHERE handler_type = $1 AND is_enabled = true\n                    ORDER BY priority DESC, display_name\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "08e31e03233abfa07a1e1f3e1fa72dd1a299791f865ccb2900bfa3ccc91c015b"
+}

--- a/backend/.sqlx/query-0a041b5e9aef814db159e5bc317896b2485374c37e2a0c9c23d99ea372b816e3.json
+++ b/backend/.sqlx/query-0a041b5e9aef814db159e5bc317896b2485374c37e2a0c9c23d99ea372b816e3.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE external_id = $1 AND auth_provider = 'oidc'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "0a041b5e9aef814db159e5bc317896b2485374c37e2a0c9c23d99ea372b816e3"
+}

--- a/backend/.sqlx/query-0a6c9c37debf5fd91ac5f3903e68b278862093500d871d7ca66324311a1e3dbb.json
+++ b/backend/.sqlx/query-0a6c9c37debf5fd91ac5f3903e68b278862093500d871d7ca66324311a1e3dbb.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT logical_bytes, physical_bytes, unique_bytes, shared_bytes,\n               blob_count, dedup_scope, computed_at\n          FROM repository_storage_stats\n         WHERE repository_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "logical_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "physical_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "unique_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "shared_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "blob_count",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "dedup_scope",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "computed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0a6c9c37debf5fd91ac5f3903e68b278862093500d871d7ca66324311a1e3dbb"
+}

--- a/backend/.sqlx/query-0a72047fbd35cb683832d4cff71c341947e375a6062d7f31abbb3482999e1067.json
+++ b/backend/.sqlx/query-0a72047fbd35cb683832d4cff71c341947e375a6062d7f31abbb3482999e1067.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*)::bigint\n            FROM age_gate_reviews r\n            INNER JOIN repositories repo ON repo.id = r.repository_id\n            WHERE ($1::text IS NULL OR repo.key = $1)\n              AND ($2::text[] IS NULL OR r.status = ANY($2))\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "0a72047fbd35cb683832d4cff71c341947e375a6062d7f31abbb3482999e1067"
+}

--- a/backend/.sqlx/query-0ae76e6ac1be58802e93ef17481fca9e18c6dcbe6982ba4d49e5d866f928df55.json
+++ b/backend/.sqlx/query-0ae76e6ac1be58802e93ef17481fca9e18c6dcbe6982ba4d49e5d866f928df55.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT storage_key FROM artifacts",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0ae76e6ac1be58802e93ef17481fca9e18c6dcbe6982ba4d49e5d866f928df55"
+}

--- a/backend/.sqlx/query-0af50a149ccece8b6b042dd2b3a66e90fda6e7a79482ed9a617045d755ab2530.json
+++ b/backend/.sqlx/query-0af50a149ccece8b6b042dd2b3a66e90fda6e7a79482ed9a617045d755ab2530.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT value FROM repository_config\n            WHERE repository_id = $1 AND key = 'cache_ttl_secs'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "value",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "0af50a149ccece8b6b042dd2b3a66e90fda6e7a79482ed9a617045d755ab2530"
+}

--- a/backend/.sqlx/query-0b5bf965a11eba8f6e96f9acd1615a303a1d067c4015ccf24778738c0fd74336.json
+++ b/backend/.sqlx/query-0b5bf965a11eba8f6e96f9acd1615a303a1d067c4015ccf24778738c0fd74336.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT DISTINCT ON (a.name) a.name, a.version\n            FROM artifacts a\n            WHERE a.repository_id = $1 AND a.is_deleted = false\n            ORDER BY a.name, a.created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "0b5bf965a11eba8f6e96f9acd1615a303a1d067c4015ccf24778738c0fd74336"
+}

--- a/backend/.sqlx/query-0b78b1df55a897dc9f8e28ddf35c97ba8981e294b196da98ff346f31ec4cb4b5.json
+++ b/backend/.sqlx/query-0b78b1df55a897dc9f8e28ddf35c97ba8981e294b196da98ff346f31ec4cb4b5.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT a.name,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.name ILIKE $2\n          AND ($3::text IS NULL OR am.metadata #>> '{composer,type}' = $3)\n        ORDER BY a.name\n        LIMIT $4 OFFSET $5\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "0b78b1df55a897dc9f8e28ddf35c97ba8981e294b196da98ff346f31ec4cb4b5"
+}

--- a/backend/.sqlx/query-0b961012e8839b916a881e1efca27e1a1544bc0a2ecb3a0f503bb6b0ca5bc2e6.json
+++ b/backend/.sqlx/query-0b961012e8839b916a881e1efca27e1a1544bc0a2ecb3a0f503bb6b0ca5bc2e6.json
@@ -1,0 +1,137 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_results (\n                artifact_id, repository_id, scan_type, status, started_at, completed_at,\n                findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                scanner_version, checksum_sha256, source_scan_id, is_reused\n            )\n            VALUES ($1, $2, $3, 'completed', $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, true)\n            RETURNING id, artifact_id, repository_id, scan_type, status,\n                      findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                      scanner_version, error_message, started_at, completed_at, created_at,\n                      is_reused, source_scan_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Timestamptz",
+        "Timestamptz",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Varchar",
+        "Bpchar",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "0b961012e8839b916a881e1efca27e1a1544bc0a2ecb3a0f503bb6b0ca5bc2e6"
+}

--- a/backend/.sqlx/query-0bec50ede42a2312e93249148ccd4deee5139352942e378366966f8a4955083f.json
+++ b/backend/.sqlx/query-0bec50ede42a2312e93249148ccd4deee5139352942e378366966f8a4955083f.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scopes, expires_at FROM api_tokens WHERE token_prefix = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scopes",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 1,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "0bec50ede42a2312e93249148ccd4deee5139352942e378366966f8a4955083f"
+}

--- a/backend/.sqlx/query-0ea7e3fc0757e481f8a2ba5d7f9b9e06793be0d7b469ca016faa30a5007e0aca.json
+++ b/backend/.sqlx/query-0ea7e3fc0757e481f8a2ba5d7f9b9e06793be0d7b469ca016faa30a5007e0aca.json
@@ -1,0 +1,131 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, source_peer_id, target_peer_id,\n                status as \"status: PeerStatus\",\n                latency_ms, bandwidth_estimate_bps,\n                shared_artifacts_count, shared_chunks_count,\n                last_probed_at, last_transfer_at,\n                bytes_transferred_total, transfer_success_count, transfer_failure_count,\n                created_at, updated_at\n            FROM peer_connections\n            WHERE source_peer_id = $1\n              AND ($2::peer_status IS NULL OR status = $2)\n            ORDER BY latency_ms ASC NULLS LAST\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "target_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: PeerStatus",
+        "type_info": {
+          "Custom": {
+            "name": "peer_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "probing",
+                "unreachable",
+                "disabled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "latency_ms",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "bandwidth_estimate_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "shared_artifacts_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "shared_chunks_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_probed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "last_transfer_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "transfer_success_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "transfer_failure_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "peer_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "probing",
+                "unreachable",
+                "disabled"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "0ea7e3fc0757e481f8a2ba5d7f9b9e06793be0d7b469ca016faa30a5007e0aca"
+}

--- a/backend/.sqlx/query-0eccf8d70761b01121cad2f5e9ebcb59abcfc07b8810c5f2ed0b2d5d4e3aa58e.json
+++ b/backend/.sqlx/query-0eccf8d70761b01121cad2f5e9ebcb59abcfc07b8810c5f2ed0b2d5d4e3aa58e.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT version\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND is_deleted = false\n          AND version IS NOT NULL\n        ORDER BY version\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "0eccf8d70761b01121cad2f5e9ebcb59abcfc07b8810c5f2ed0b2d5d4e3aa58e"
+}

--- a/backend/.sqlx/query-10a4ef6d46a9c8d7a86828fbb304bb704dd464d792325ca0b4112f6746ad91b5.json
+++ b/backend/.sqlx/query-10a4ef6d46a9c8d7a86828fbb304bb704dd464d792325ca0b4112f6746ad91b5.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM users WHERE id = $1 AND is_service_account = true",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "10a4ef6d46a9c8d7a86828fbb304bb704dd464d792325ca0b4112f6746ad91b5"
+}

--- a/backend/.sqlx/query-10b74bec8d8f89e5fa64a7307676f2ae640661732b86cdeca224a6a0f346d9b1.json
+++ b/backend/.sqlx/query-10b74bec8d8f89e5fa64a7307676f2ae640661732b86cdeca224a6a0f346d9b1.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            FROM artifacts\n            WHERE id = $1 AND is_deleted = false\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "10b74bec8d8f89e5fa64a7307676f2ae640661732b86cdeca224a6a0f346d9b1"
+}

--- a/backend/.sqlx/query-10f371840323b0f1120b9bcd9af47a92a04bc1c8d817e13db9d69bb83204c4b2.json
+++ b/backend/.sqlx/query-10f371840323b0f1120b9bcd9af47a92a04bc1c8d817e13db9d69bb83204c4b2.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE artifacts SET is_deleted = true WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "10f371840323b0f1120b9bcd9af47a92a04bc1c8d817e13db9d69bb83204c4b2"
+}

--- a/backend/.sqlx/query-111e09516e05188ef845d09448da4e00baeadf8a48eb44cc5231403844753a06.json
+++ b/backend/.sqlx/query-111e09516e05188ef845d09448da4e00baeadf8a48eb44cc5231403844753a06.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO users (id, username, email, display_name, auth_provider, external_id, is_admin, is_active, is_service_account)\n            VALUES ($1, $2, $3, $4, 'oidc', $5, $6, true, false)\n            RETURNING\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "111e09516e05188ef845d09448da4e00baeadf8a48eb44cc5231403844753a06"
+}

--- a/backend/.sqlx/query-112dd54c8bcd917b1e7fd8efb1038834d9ad837b4418a897b67c1d8cb86c5704.json
+++ b/backend/.sqlx/query-112dd54c8bcd917b1e7fd8efb1038834d9ad837b4418a897b67c1d8cb86c5704.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n        ORDER BY a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "112dd54c8bcd917b1e7fd8efb1038834d9ad837b4418a897b67c1d8cb86c5704"
+}

--- a/backend/.sqlx/query-118d963b7b2522799b5be9987a05b1336ff8793030f99d6d8631ad6cf3973ec6.json
+++ b/backend/.sqlx/query-118d963b7b2522799b5be9987a05b1336ff8793030f99d6d8631ad6cf3973ec6.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scan_on_proxy FROM scan_configs WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "118d963b7b2522799b5be9987a05b1336ff8793030f99d6d8631ad6cf3973ec6"
+}

--- a/backend/.sqlx/query-11b4b63ab7e76c8fda991902411b03c6e13ea9f917cec828e28d6efd15da7ee3.json
+++ b/backend/.sqlx/query-11b4b63ab7e76c8fda991902411b03c6e13ea9f917cec828e28d6efd15da7ee3.json
@@ -1,0 +1,37 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.storage_key, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND (\n            CASE WHEN $4 THEN a.name = $2 ELSE LOWER(a.name) = LOWER($2) END\n          )\n          AND a.version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "11b4b63ab7e76c8fda991902411b03c6e13ea9f917cec828e28d6efd15da7ee3"
+}

--- a/backend/.sqlx/query-125c236aa9769ce924dc15703aba0106b2db0c300324c281be084ea28b9e6b52.json
+++ b/backend/.sqlx/query-125c236aa9769ce924dc15703aba0106b2db0c300324c281be084ea28b9e6b52.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.created_at,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.name = $2\n        ORDER BY a.created_at ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "125c236aa9769ce924dc15703aba0106b2db0c300324c281be084ea28b9e6b52"
+}

--- a/backend/.sqlx/query-13b4fe8c9ab0eb9ce9b70b6706a97d7b4300afd4d0412d56b2135cc9e43a40ab.json
+++ b/backend/.sqlx/query-13b4fe8c9ab0eb9ce9b70b6706a97d7b4300afd4d0412d56b2135cc9e43a40ab.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE artifacts SET quarantine_status = 'flagged' WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "13b4fe8c9ab0eb9ce9b70b6706a97d7b4300afd4d0412d56b2135cc9e43a40ab"
+}

--- a/backend/.sqlx/query-140d635c2c1d7fcd00a211b6175493ad28351bdd9538f0eb145e42f5d9f42852.json
+++ b/backend/.sqlx/query-140d635c2c1d7fcd00a211b6175493ad28351bdd9538f0eb145e42f5d9f42852.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE plugins\n        SET status = 'disabled'\n        WHERE id = $1 AND status = 'active'\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "140d635c2c1d7fcd00a211b6175493ad28351bdd9538f0eb145e42f5d9f42852"
+}

--- a/backend/.sqlx/query-1498d03161a03325f27a056592d9f5779c8ea301bc6543dd918449483b22d51e.json
+++ b/backend/.sqlx/query-1498d03161a03325f27a056592d9f5779c8ea301bc6543dd918449483b22d51e.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO signing_keys (id, repository_id, name, key_type, fingerprint, key_id,\n                public_key_pem, private_key_enc, algorithm, uid_name, uid_email, is_active,\n                created_at, created_by, rotated_from)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Bytea",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool",
+        "Timestamptz",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1498d03161a03325f27a056592d9f5779c8ea301bc6543dd918449483b22d51e"
+}

--- a/backend/.sqlx/query-14c1bb286b49b190a2b95665e59f9ada78475ee13972d4dde57f8bb8a4948382.json
+++ b/backend/.sqlx/query-14c1bb286b49b190a2b95665e59f9ada78475ee13972d4dde57f8bb8a4948382.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scan_enabled FROM scan_configs WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "14c1bb286b49b190a2b95665e59f9ada78475ee13972d4dde57f8bb8a4948382"
+}

--- a/backend/.sqlx/query-14c1ddef032721c3a925c35a336a1718d56ae241e77aadb665698a0d3421ac83.json
+++ b/backend/.sqlx/query-14c1ddef032721c3a925c35a336a1718d56ae241e77aadb665698a0d3421ac83.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, repository_id, path, name, version, size_bytes,\n            checksum_sha256, checksum_md5, checksum_sha1,\n            content_type, storage_key, is_deleted, uploaded_by,\n            quarantine_status, quarantine_until,\n            created_at, updated_at\n        FROM artifacts\n        WHERE id = $1 AND repository_id = $2 AND is_deleted = false\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "14c1ddef032721c3a925c35a336a1718d56ae241e77aadb665698a0d3421ac83"
+}

--- a/backend/.sqlx/query-14e8c7f8d34795c3e7e14e624f3cb28aff512ef72bbecb16ff2cd80997e88f87.json
+++ b/backend/.sqlx/query-14e8c7f8d34795c3e7e14e624f3cb28aff512ef72bbecb16ff2cd80997e88f87.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, version, created_at\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n        ORDER BY name, created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "14e8c7f8d34795c3e7e14e624f3cb28aff512ef72bbecb16ff2cd80997e88f87"
+}

--- a/backend/.sqlx/query-158b3007a6c464a6bcee517846f23be5267da20fb6df95256ea45a89a0dcd4b7.json
+++ b/backend/.sqlx/query-158b3007a6c464a6bcee517846f23be5267da20fb6df95256ea45a89a0dcd4b7.json
@@ -1,0 +1,31 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO peer_repo_subscriptions\n                (peer_instance_id, repository_id, sync_enabled, replication_mode, replication_schedule, replication_filter)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            ON CONFLICT (peer_instance_id, repository_id) DO UPDATE SET\n                sync_enabled = $3,\n                replication_mode = $4,\n                replication_schedule = $5,\n                replication_filter = $6\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Bool",
+        {
+          "Custom": {
+            "name": "replication_mode",
+            "kind": {
+              "Enum": [
+                "push",
+                "pull",
+                "mirror",
+                "none"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "158b3007a6c464a6bcee517846f23be5267da20fb6df95256ea45a89a0dcd4b7"
+}

--- a/backend/.sqlx/query-1598f5c91f2aa1414c2bf933523bf85dcd4625f389dd7a4621051803cd30764f.json
+++ b/backend/.sqlx/query-1598f5c91f2aa1414c2bf933523bf85dcd4625f389dd7a4621051803cd30764f.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT a.name, a.version, am.metadata as \"metadata?\"\n            FROM artifacts a\n            LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n            WHERE a.repository_id = $1\n              AND a.is_deleted = false\n              AND LOWER(a.name) = LOWER($2)\n            ORDER BY a.created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "1598f5c91f2aa1414c2bf933523bf85dcd4625f389dd7a4621051803cd30764f"
+}

--- a/backend/.sqlx/query-15fa917c5ced412b660ada632398dc095d8093d7de23eb5e76859338ddd497de.json
+++ b/backend/.sqlx/query-15fa917c5ced412b660ada632398dc095d8093d7de23eb5e76859338ddd497de.json
@@ -1,0 +1,21 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO proxy_cache_artifacts\n            (repository_id, path, storage_key, metadata_key, size_bytes,\n             checksum_sha256, content_type, upstream_url, cached_at, last_accessed_at)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, now(), now())\n        ON CONFLICT (repository_id, path) DO UPDATE SET\n            storage_key      = EXCLUDED.storage_key,\n            metadata_key     = EXCLUDED.metadata_key,\n            size_bytes       = EXCLUDED.size_bytes,\n            checksum_sha256  = EXCLUDED.checksum_sha256,\n            content_type     = EXCLUDED.content_type,\n            upstream_url     = EXCLUDED.upstream_url,\n            cached_at        = now(),\n            last_accessed_at = now()\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "15fa917c5ced412b660ada632398dc095d8093d7de23eb5e76859338ddd497de"
+}

--- a/backend/.sqlx/query-163f70ea906978efb9244ca102b7256becf656f3f13a6cd168f20982484b56e8.json
+++ b/backend/.sqlx/query-163f70ea906978efb9244ca102b7256becf656f3f13a6cd168f20982484b56e8.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'revision' as \"revision?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' IS NOT NULL\n        ORDER BY a.created_at DESC, a.id DESC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "revision?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "163f70ea906978efb9244ca102b7256becf656f3f13a6cd168f20982484b56e8"
+}

--- a/backend/.sqlx/query-1804bfbfff4b2fdb953524a2f43845469f30813ad300af8a90d54e66a36c43a9.json
+++ b/backend/.sqlx/query-1804bfbfff4b2fdb953524a2f43845469f30813ad300af8a90d54e66a36c43a9.json
@@ -1,0 +1,37 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT name, version, created_at\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND name ILIKE $2\n          AND version IS NOT NULL\n        ORDER BY created_at DESC\n        LIMIT $3 OFFSET $4\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "1804bfbfff4b2fdb953524a2f43845469f30813ad300af8a90d54e66a36c43a9"
+}

--- a/backend/.sqlx/query-18cff6b0bc145880c6262c69091dce455fee41a147a5d6a685149adaf65434c5.json
+++ b/backend/.sqlx/query-18cff6b0bc145880c6262c69091dce455fee41a147a5d6a685149adaf65434c5.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE users\n            SET last_login_at = CASE\n                    WHEN last_login_at IS NULL\n                         OR last_login_at < NOW() - INTERVAL '5 minutes'\n                    THEN NOW() ELSE last_login_at\n                END,\n                failed_login_attempts = 0,\n                locked_until = NULL,\n                last_failed_login_at = NULL\n            WHERE id = $1\n              AND (\n                last_login_at IS NULL\n                OR last_login_at < NOW() - INTERVAL '5 minutes'\n                OR failed_login_attempts > 0\n                OR locked_until IS NOT NULL\n                OR last_failed_login_at IS NOT NULL\n              )\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "18cff6b0bc145880c6262c69091dce455fee41a147a5d6a685149adaf65434c5"
+}

--- a/backend/.sqlx/query-19f5a956489a0b5d593db879331416703c57eeccf5741306099737d1313f1023.json
+++ b/backend/.sqlx/query-19f5a956489a0b5d593db879331416703c57eeccf5741306099737d1313f1023.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                   block_on_policy_violation, severity_threshold, created_at, updated_at\n            FROM scan_configs\n            WHERE scan_enabled = true\n            ORDER BY created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "block_on_policy_violation",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "severity_threshold",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "19f5a956489a0b5d593db879331416703c57eeccf5741306099737d1313f1023"
+}

--- a/backend/.sqlx/query-1b81e6176c1baffa5f38f617592c34963ba4c33a023b8ac130d95a2ed35f8e9c.json
+++ b/backend/.sqlx/query-1b81e6176c1baffa5f38f617592c34963ba4c33a023b8ac130d95a2ed35f8e9c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM artifacts WHERE id = $1 AND is_deleted = false)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1b81e6176c1baffa5f38f617592c34963ba4c33a023b8ac130d95a2ed35f8e9c"
+}

--- a/backend/.sqlx/query-1b9435a1ac07dd5f6fdf7cffad0de6fe8f7a193d6eec273a526992a18b93bf83.json
+++ b/backend/.sqlx/query-1b9435a1ac07dd5f6fdf7cffad0de6fe8f7a193d6eec273a526992a18b93bf83.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE id = $1 AND is_service_account = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "1b9435a1ac07dd5f6fdf7cffad0de6fe8f7a193d6eec273a526992a18b93bf83"
+}

--- a/backend/.sqlx/query-1c87008a2b29a9ab431721210ec8e1650319798356f3f938d3a7447423a0964e.json
+++ b/backend/.sqlx/query-1c87008a2b29a9ab431721210ec8e1650319798356f3f938d3a7447423a0964e.json
@@ -1,0 +1,71 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, peer_instance_id, repository_id, sync_enabled,\n                replication_mode::text as replication_mode,\n                replication_schedule,\n                replication_filter,\n                last_replicated_at,\n                created_at\n            FROM peer_repo_subscriptions\n            WHERE peer_instance_id = $1 AND repository_id = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "peer_instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "sync_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "replication_mode",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "replication_schedule",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "replication_filter",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_replicated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      null,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "1c87008a2b29a9ab431721210ec8e1650319798356f3f938d3a7447423a0964e"
+}

--- a/backend/.sqlx/query-1d5b627432768d8ed73d2beb6fdbfd9fde2e8ace85853279fcb7c008d9330c6c.json
+++ b/backend/.sqlx/query-1d5b627432768d8ed73d2beb6fdbfd9fde2e8ace85853279fcb7c008d9330c6c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transfer_sessions\n            SET completed_chunks = (\n                SELECT COUNT(*) FROM transfer_chunks\n                WHERE session_id = $1 AND status = 'completed'\n            ),\n            started_at = COALESCE(started_at, NOW())\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1d5b627432768d8ed73d2beb6fdbfd9fde2e8ace85853279fcb7c008d9330c6c"
+}

--- a/backend/.sqlx/query-1d9569b6573d44a2656256954bc5f3014682eb0bf3f968c2fcad8d2047a5be1e.json
+++ b/backend/.sqlx/query-1d9569b6573d44a2656256954bc5f3014682eb0bf3f968c2fcad8d2047a5be1e.json
@@ -1,0 +1,172 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, name, endpoint_url,\n                status as \"status: InstanceStatus\",\n                region, cache_size_bytes, cache_used_bytes,\n                last_heartbeat_at, last_sync_at, sync_filter,\n                max_bandwidth_bps, sync_window_start, sync_window_end,\n                sync_window_timezone, concurrent_transfers_limit,\n                active_transfers, backoff_until, consecutive_failures,\n                bytes_transferred_total, transfer_failures_total,\n                api_key, is_local,\n                created_at, updated_at\n            FROM peer_instances\n            WHERE name = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: InstanceStatus",
+        "type_info": {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "region",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "cache_size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "cache_used_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_heartbeat_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_sync_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "sync_filter",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "max_bandwidth_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "sync_window_start",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 12,
+        "name": "sync_window_end",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 13,
+        "name": "sync_window_timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "concurrent_transfers_limit",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "active_transfers",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "backoff_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "consecutive_failures",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 19,
+        "name": "transfer_failures_total",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "api_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_local",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 23,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "1d9569b6573d44a2656256954bc5f3014682eb0bf3f968c2fcad8d2047a5be1e"
+}

--- a/backend/.sqlx/query-1d9739f9d79e70530c9337aec2f5c6756157de146062cee04c9c9aa2bb332818.json
+++ b/backend/.sqlx/query-1d9739f9d79e70530c9337aec2f5c6756157de146062cee04c9c9aa2bb332818.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM users WHERE username = $1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1d9739f9d79e70530c9337aec2f5c6756157de146062cee04c9c9aa2bb332818"
+}

--- a/backend/.sqlx/query-1e3944cc8c3034546ea68939999e85128e6eac1b637d7f8592c727d4938cb68e.json
+++ b/backend/.sqlx/query-1e3944cc8c3034546ea68939999e85128e6eac1b637d7f8592c727d4938cb68e.json
@@ -1,0 +1,120 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_findings\n            SET is_acknowledged = true, acknowledged_by = $2,\n                acknowledged_reason = $3, acknowledged_at = NOW()\n            WHERE id = $1\n            RETURNING id, scan_result_id, artifact_id, severity, title, description,\n                      cve_id, affected_component, affected_version, fixed_version,\n                      source, source_url, is_acknowledged, acknowledged_by,\n                      acknowledged_reason, acknowledged_at, created_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "scan_result_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "severity",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "title",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "cve_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "affected_component",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "affected_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "fixed_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "source",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "source_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_acknowledged",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "acknowledged_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "acknowledged_reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "acknowledged_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "1e3944cc8c3034546ea68939999e85128e6eac1b637d7f8592c727d4938cb68e"
+}

--- a/backend/.sqlx/query-1eb7603bed1c768b519bfdfb195112c6a582048f218bee641f9e395483dfb54f.json
+++ b/backend/.sqlx/query-1eb7603bed1c768b519bfdfb195112c6a582048f218bee641f9e395483dfb54f.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, username, email, password_hash, display_name,\n            auth_provider as \"auth_provider: AuthProvider\",\n            external_id, is_admin, is_active, is_service_account, must_change_password,\n            totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n            failed_login_attempts, locked_until, last_failed_login_at,\n            password_changed_at, last_login_at, created_at, updated_at\n        FROM users\n        WHERE id = $1 AND is_active = true\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "1eb7603bed1c768b519bfdfb195112c6a582048f218bee641f9e395483dfb54f"
+}

--- a/backend/.sqlx/query-1eb8d25ff5c099c3e920860fdcbb665106ede56cebf2491490bf29dd82b0107c.json
+++ b/backend/.sqlx/query-1eb8d25ff5c099c3e920860fdcbb665106ede56cebf2491490bf29dd82b0107c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM download_statistics WHERE artifact_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "1eb8d25ff5c099c3e920860fdcbb665106ede56cebf2491490bf29dd82b0107c"
+}

--- a/backend/.sqlx/query-1eddf57942d2455ce8c9e8e2f051bf8a838d17d878d69a93519900a8af1bd42a.json
+++ b/backend/.sqlx/query-1eddf57942d2455ce8c9e8e2f051bf8a838d17d878d69a93519900a8af1bd42a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE refresh_token_jti\n            SET revoked_at = NOW()\n            WHERE user_id = $1 AND revoked_at IS NULL\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1eddf57942d2455ce8c9e8e2f051bf8a838d17d878d69a93519900a8af1bd42a"
+}

--- a/backend/.sqlx/query-1f64ad593ce568aa3bf2a0a2a589b0845b85dad307bd39fa085a7dd238b1a9e5.json
+++ b/backend/.sqlx/query-1f64ad593ce568aa3bf2a0a2a589b0845b85dad307bd39fa085a7dd238b1a9e5.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT repo_id FROM api_token_repositories WHERE token_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repo_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1f64ad593ce568aa3bf2a0a2a589b0845b85dad307bd39fa085a7dd238b1a9e5"
+}

--- a/backend/.sqlx/query-201f9d338d4a5147e0260dca32c154acb9b5a28e1b68283fbb3c4fcf8e8f5f7f.json
+++ b/backend/.sqlx/query-201f9d338d4a5147e0260dca32c154acb9b5a28e1b68283fbb3c4fcf8e8f5f7f.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                prs.repository_id as repo_id,\n                prs.replication_schedule as schedule,\n                prs.last_replicated_at\n            FROM peer_repo_subscriptions prs\n            JOIN repositories r ON r.id = prs.repository_id\n            WHERE prs.peer_instance_id = $1\n              AND prs.sync_enabled = true\n              AND prs.replication_mode = 'mirror'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "schedule",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_replicated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "201f9d338d4a5147e0260dca32c154acb9b5a28e1b68283fbb3c4fcf8e8f5f7f"
+}

--- a/backend/.sqlx/query-203c2d53c3376349154b749e160c0ab96b7eedfccd0989d3def4c24005d731e7.json
+++ b/backend/.sqlx/query-203c2d53c3376349154b749e160c0ab96b7eedfccd0989d3def4c24005d731e7.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, username, email, password_hash, display_name,\n           auth_provider as \"auth_provider: crate::models::user::AuthProvider\",\n           external_id, is_admin, is_active, is_service_account, must_change_password,\n           totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n           failed_login_attempts, locked_until, last_failed_login_at,\n           password_changed_at, last_login_at, created_at, updated_at\n           FROM users WHERE id = $1 AND is_active = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: crate::models::user::AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "203c2d53c3376349154b749e160c0ab96b7eedfccd0989d3def4c24005d731e7"
+}

--- a/backend/.sqlx/query-22cb86a26afbb0a4928afba385705c08ec3f6c57edd54a773fb384185c9ceecb.json
+++ b/backend/.sqlx/query-22cb86a26afbb0a4928afba385705c08ec3f6c57edd54a773fb384185c9ceecb.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    UPDATE refresh_token_jti\n                    SET consumed_at = NOW()\n                    WHERE jti = $1 AND consumed_at IS NULL\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "22cb86a26afbb0a4928afba385705c08ec3f6c57edd54a773fb384185c9ceecb"
+}

--- a/backend/.sqlx/query-270d2cef6b5246f0805796508afec509f332376ddd607705aa45ec7fec5e2128.json
+++ b/backend/.sqlx/query-270d2cef6b5246f0805796508afec509f332376ddd607705aa45ec7fec5e2128.json
@@ -1,0 +1,90 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, format_key, plugin_id,\n                           handler_type as \"handler_type: FormatHandlerType\",\n                           display_name, description, extensions,\n                           is_enabled, priority, created_at, updated_at\n                    FROM format_handlers\n                    WHERE is_enabled = true\n                    ORDER BY priority DESC, display_name\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "270d2cef6b5246f0805796508afec509f332376ddd607705aa45ec7fec5e2128"
+}

--- a/backend/.sqlx/query-270eae7d8f94f43c9fb707bad15f97638e83c5ac1acf52ea3ee8ab1dde6f2a78.json
+++ b/backend/.sqlx/query-270eae7d8f94f43c9fb707bad15f97638e83c5ac1acf52ea3ee8ab1dde6f2a78.json
@@ -1,0 +1,163 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE users\n            SET display_name = COALESCE($2, display_name),\n                is_active = COALESCE($3, is_active),\n                updated_at = NOW()\n            WHERE id = $1 AND is_service_account = true\n            RETURNING\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "270eae7d8f94f43c9fb707bad15f97638e83c5ac1acf52ea3ee8ab1dde6f2a78"
+}

--- a/backend/.sqlx/query-271a16f2b06dd756f9be24eeadf13dba50cf61b0d1cbf31028a5b38e7d33524c.json
+++ b/backend/.sqlx/query-271a16f2b06dd756f9be24eeadf13dba50cf61b0d1cbf31028a5b38e7d33524c.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n        ORDER BY a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "271a16f2b06dd756f9be24eeadf13dba50cf61b0d1cbf31028a5b38e7d33524c"
+}

--- a/backend/.sqlx/query-2729bc85848caabce58907d4e1b2685259683cc9a38937bc773b9d8c3fda0af0.json
+++ b/backend/.sqlx/query-2729bc85848caabce58907d4e1b2685259683cc9a38937bc773b9d8c3fda0af0.json
@@ -1,0 +1,177 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO peer_instances (name, endpoint_url, region, cache_size_bytes, sync_filter, api_key)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            RETURNING\n                id, name, endpoint_url,\n                status as \"status: InstanceStatus\",\n                region, cache_size_bytes, cache_used_bytes,\n                last_heartbeat_at, last_sync_at, sync_filter,\n                max_bandwidth_bps, sync_window_start, sync_window_end,\n                sync_window_timezone, concurrent_transfers_limit,\n                active_transfers, backoff_until, consecutive_failures,\n                bytes_transferred_total, transfer_failures_total,\n                api_key, is_local,\n                created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: InstanceStatus",
+        "type_info": {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "region",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "cache_size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "cache_used_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_heartbeat_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_sync_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "sync_filter",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "max_bandwidth_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "sync_window_start",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 12,
+        "name": "sync_window_end",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 13,
+        "name": "sync_window_timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "concurrent_transfers_limit",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "active_transfers",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "backoff_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "consecutive_failures",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 19,
+        "name": "transfer_failures_total",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "api_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_local",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 23,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Jsonb",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2729bc85848caabce58907d4e1b2685259683cc9a38937bc773b9d8c3fda0af0"
+}

--- a/backend/.sqlx/query-279921c746b40e74c411891f56f53bba4876feb653bd67958a3142b379291d04.json
+++ b/backend/.sqlx/query-279921c746b40e74c411891f56f53bba4876feb653bd67958a3142b379291d04.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes, checksum_sha256, content_type\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND LOWER(name) = $2\n          AND version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "content_type",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "279921c746b40e74c411891f56f53bba4876feb653bd67958a3142b379291d04"
+}

--- a/backend/.sqlx/query-27a3d57477c57895b9359b0f0b5da753513fb0cb07a105e8fbea0ffe22ee825d.json
+++ b/backend/.sqlx/query-27a3d57477c57895b9359b0f0b5da753513fb0cb07a105e8fbea0ffe22ee825d.json
@@ -1,0 +1,259 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE repositories\n            SET\n                key = COALESCE($2, key),\n                name = COALESCE($3, name),\n                description = COALESCE($4, description),\n                is_public = COALESCE($5, is_public),\n                quota_bytes = COALESCE($6, quota_bytes),\n                upstream_url = COALESCE($7, upstream_url),\n                promotion_only = COALESCE($8, promotion_only),\n                versioning_enabled = COALESCE($9, versioning_enabled),\n                project_id = COALESCE($10, project_id),\n                updated_at = NOW()\n            WHERE id = $1\n            RETURNING\n                id, key, name, description,\n                format as \"format: RepositoryFormat\",\n                repo_type as \"repo_type: RepositoryType\",\n                storage_backend, storage_path, upstream_url,\n                is_public, quota_bytes, promotion_only,\n                replication_priority as \"replication_priority: ReplicationPriority\",\n                curation_enabled, curation_source_repo_id, curation_target_repo_id,\n                curation_default_action, curation_sync_interval_secs, curation_auto_fetch,\n                age_gate_enabled, age_gate_min_age_days, versioning_enabled,\n                project_id, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "format: RepositoryFormat",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_type: RepositoryType",
+        "type_info": {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_backend",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "upstream_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "replication_priority: ReplicationPriority",
+        "type_info": {
+          "Custom": {
+            "name": "replication_priority",
+            "kind": {
+              "Enum": [
+                "immediate",
+                "scheduled",
+                "on_demand",
+                "local_only"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "curation_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "curation_source_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "curation_target_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "curation_default_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "curation_sync_interval_secs",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "curation_auto_fetch",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "age_gate_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "age_gate_min_age_days",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "versioning_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 24,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Bool",
+        "Int8",
+        "Varchar",
+        "Bool",
+        "Bool",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "27a3d57477c57895b9359b0f0b5da753513fb0cb07a105e8fbea0ffe22ee825d"
+}

--- a/backend/.sqlx/query-28c768e68a4087924dc66987aebbdd181986d67d917fc68e2a10d1a2519eed13.json
+++ b/backend/.sqlx/query-28c768e68a4087924dc66987aebbdd181986d67d917fc68e2a10d1a2519eed13.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.version, a.checksum_sha256\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n        ORDER BY a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "28c768e68a4087924dc66987aebbdd181986d67d917fc68e2a10d1a2519eed13"
+}

--- a/backend/.sqlx/query-2918cafbea4ce2e79b1339948fa518de7912ac83dddb784321eb75fe03d74f4c.json
+++ b/backend/.sqlx/query-2918cafbea4ce2e79b1339948fa518de7912ac83dddb784321eb75fe03d74f4c.json
@@ -1,0 +1,55 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND name = $2\n          AND version = $3\n          AND checksum_sha256 = $4\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2918cafbea4ce2e79b1339948fa518de7912ac83dddb784321eb75fe03d74f4c"
+}

--- a/backend/.sqlx/query-295c12f0bfd84767d9975a63011ffa1ce1588d332c035e52372cec9f2f84f6e7.json
+++ b/backend/.sqlx/query-295c12f0bfd84767d9975a63011ffa1ce1588d332c035e52372cec9f2f84f6e7.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT DISTINCT\n                pi.id as node_id,\n                pi.name,\n                pi.endpoint_url,\n                pi.region,\n                pi.status as \"status!: String\"\n            FROM peer_instances pi\n            JOIN peer_repo_subscriptions prs ON prs.peer_instance_id = pi.id\n            WHERE pi.id != $1\n              AND pi.status IN ('online', 'syncing')\n              AND prs.sync_enabled = true\n              AND prs.repository_id IN (\n                  SELECT repository_id FROM peer_repo_subscriptions\n                  WHERE peer_instance_id = $1 AND sync_enabled = true\n              )\n            ORDER BY pi.region, pi.name\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "node_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "region",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status!: String",
+        "type_info": {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "295c12f0bfd84767d9975a63011ffa1ce1588d332c035e52372cec9f2f84f6e7"
+}

--- a/backend/.sqlx/query-2963b690492a56e607a0a6a6e41b26310d6f277148d096791fcd44d1426572fc.json
+++ b/backend/.sqlx/query-2963b690492a56e607a0a6a6e41b26310d6f277148d096791fcd44d1426572fc.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT artifact_id, format, metadata, properties\n        FROM artifact_metadata\n        WHERE artifact_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "properties",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2963b690492a56e607a0a6a6e41b26310d6f277148d096791fcd44d1426572fc"
+}

--- a/backend/.sqlx/query-2a944759e9099f39127761ded659acc311a441431867df5193620660f3650f6a.json
+++ b/backend/.sqlx/query-2a944759e9099f39127761ded659acc311a441431867df5193620660f3650f6a.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE users\n        SET\n            email = COALESCE($2, email),\n            display_name = COALESCE($3, display_name),\n            is_active = COALESCE($4, is_active),\n            is_admin = COALESCE($5, is_admin),\n            privileges_changed_at = CASE WHEN $6 THEN NOW() ELSE privileges_changed_at END,\n            updated_at = NOW()\n        WHERE id = $1\n        RETURNING\n            id, username, email, password_hash, display_name,\n            auth_provider as \"auth_provider: AuthProvider\",\n            external_id, is_admin, is_active, is_service_account, must_change_password,\n            totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n            failed_login_attempts, locked_until, last_failed_login_at,\n            password_changed_at, last_login_at, created_at, updated_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Bool",
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "2a944759e9099f39127761ded659acc311a441431867df5193620660f3650f6a"
+}

--- a/backend/.sqlx/query-2a9afca6023db5aafb991b87cf190d7f368277fa7ca8497a374fd14d9307bd89.json
+++ b/backend/.sqlx/query-2a9afca6023db5aafb991b87cf190d7f368277fa7ca8497a374fd14d9307bd89.json
@@ -1,0 +1,170 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, name, endpoint_url,\n                status as \"status: InstanceStatus\",\n                region, cache_size_bytes, cache_used_bytes,\n                last_heartbeat_at, last_sync_at, sync_filter,\n                max_bandwidth_bps, sync_window_start, sync_window_end,\n                sync_window_timezone, concurrent_transfers_limit,\n                active_transfers, backoff_until, consecutive_failures,\n                bytes_transferred_total, transfer_failures_total,\n                api_key, is_local,\n                created_at, updated_at\n            FROM peer_instances\n            WHERE is_local = true\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: InstanceStatus",
+        "type_info": {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "region",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "cache_size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "cache_used_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_heartbeat_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_sync_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "sync_filter",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "max_bandwidth_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "sync_window_start",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 12,
+        "name": "sync_window_end",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 13,
+        "name": "sync_window_timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "concurrent_transfers_limit",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "active_transfers",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "backoff_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "consecutive_failures",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 19,
+        "name": "transfer_failures_total",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "api_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_local",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 23,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2a9afca6023db5aafb991b87cf190d7f368277fa7ca8497a374fd14d9307bd89"
+}

--- a/backend/.sqlx/query-2aacaf9168963de6823e7e08f7785a067b6f3a6846eff4cc7825087156762f75.json
+++ b/backend/.sqlx/query-2aacaf9168963de6823e7e08f7785a067b6f3a6846eff4cc7825087156762f75.json
@@ -1,0 +1,92 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE format_handlers\n            SET is_enabled = false, updated_at = NOW()\n            WHERE format_key = $1\n            RETURNING id, format_key, plugin_id,\n                      handler_type as \"handler_type: FormatHandlerType\",\n                      display_name, description, extensions,\n                      is_enabled, priority, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "2aacaf9168963de6823e7e08f7785a067b6f3a6846eff4cc7825087156762f75"
+}

--- a/backend/.sqlx/query-2b57c5c71f51bbbc7fbc15741c605f1be94c06991a14511ddbaefb3830ec2925.json
+++ b/backend/.sqlx/query-2b57c5c71f51bbbc7fbc15741c605f1be94c06991a14511ddbaefb3830ec2925.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO users (username, email, password_hash, display_name, auth_provider, is_admin, is_service_account, must_change_password)\n        VALUES ($1, $2, $3, $4, 'local', $5, false, $6)\n        RETURNING\n            id, username, email, password_hash, display_name,\n            auth_provider as \"auth_provider: AuthProvider\",\n            external_id, is_admin, is_active, is_service_account, must_change_password,\n            totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n            failed_login_attempts, locked_until, last_failed_login_at,\n            password_changed_at, last_login_at, created_at, updated_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "2b57c5c71f51bbbc7fbc15741c605f1be94c06991a14511ddbaefb3830ec2925"
+}

--- a/backend/.sqlx/query-2ba2cb964bfe8744c9aaa3479a9c91ac0862a9384de4f7bd90f485850267e531.json
+++ b/backend/.sqlx/query-2ba2cb964bfe8744c9aaa3479a9c91ac0862a9384de4f7bd90f485850267e531.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM scan_results\n            WHERE ($1::uuid IS NULL OR repository_id = $1)\n              AND ($2::uuid IS NULL OR artifact_id = $2)\n              AND ($3::text IS NULL OR status = $3)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2ba2cb964bfe8744c9aaa3479a9c91ac0862a9384de4f7bd90f485850267e531"
+}

--- a/backend/.sqlx/query-2d5d65158cd6ef98d400ebee19b5ca7bea851f868e6d1e320946dd2baa0d788f.json
+++ b/backend/.sqlx/query-2d5d65158cd6ef98d400ebee19b5ca7bea851f868e6d1e320946dd2baa0d788f.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT sk.* FROM signing_keys sk\n            JOIN repository_signing_config rsc ON rsc.signing_key_id = sk.id\n            WHERE rsc.repository_id = $1 AND sk.is_active = true AND rsc.sign_metadata = true\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "key_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "fingerprint",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "key_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "public_key_pem",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "private_key_enc",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 8,
+        "name": "algorithm",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "uid_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "uid_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "rotated_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "2d5d65158cd6ef98d400ebee19b5ca7bea851f868e6d1e320946dd2baa0d788f"
+}

--- a/backend/.sqlx/query-2f79e0e31844f67a89f85972b65199edaaa8533a087bd31e5c83cf8c5ffacd23.json
+++ b/backend/.sqlx/query-2f79e0e31844f67a89f85972b65199edaaa8533a087bd31e5c83cf8c5ffacd23.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*)::BIGINT AS \"count!\"\n        FROM proxy_download_statistics pds\n        JOIN proxy_cache_artifacts pca ON pca.id = pds.proxy_cache_id\n        WHERE pca.repository_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "2f79e0e31844f67a89f85972b65199edaaa8533a087bd31e5c83cf8c5ffacd23"
+}

--- a/backend/.sqlx/query-2fe3b0529ec1816028e1d95e9ad36dcfb3e9cc3bd2f271cb34e2c4fb2ead4600.json
+++ b/backend/.sqlx/query-2fe3b0529ec1816028e1d95e9ad36dcfb3e9cc3bd2f271cb34e2c4fb2ead4600.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT manifest_digest FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manifest_digest",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "2fe3b0529ec1816028e1d95e9ad36dcfb3e9cc3bd2f271cb34e2c4fb2ead4600"
+}

--- a/backend/.sqlx/query-300cb27dcfad2955c8997909576fb6e38434f925cd6074edac165ab89b8205d0.json
+++ b/backend/.sqlx/query-300cb27dcfad2955c8997909576fb6e38434f925cd6074edac165ab89b8205d0.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*) FROM download_statistics\n        WHERE artifact_id = ANY(\n            SELECT id FROM artifacts\n            WHERE repository_id = $1 AND LOWER(name) = LOWER($2) AND is_deleted = false\n        )\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "300cb27dcfad2955c8997909576fb6e38434f925cd6074edac165ab89b8205d0"
+}

--- a/backend/.sqlx/query-304a4857efa6e9a23982de7dde52b124860901530d3820052e7be00401f59b3c.json
+++ b/backend/.sqlx/query-304a4857efa6e9a23982de7dde52b124860901530d3820052e7be00401f59b3c.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT at.id, at.token_hash, at.user_id, at.scopes, at.expires_at,\n                   at.repo_selector, at.revoked_at, at.last_used_at\n            FROM api_tokens at\n            WHERE at.token_prefix = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "token_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scopes",
+        "type_info": "VarcharArray"
+      },
+      {
+        "ordinal": 4,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_selector",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 6,
+        "name": "revoked_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "304a4857efa6e9a23982de7dde52b124860901530d3820052e7be00401f59b3c"
+}

--- a/backend/.sqlx/query-324db57df1629aedb2fccccbea66cd883f5b5a6423619041266ea8ed2a9f5d03.json
+++ b/backend/.sqlx/query-324db57df1629aedb2fccccbea66cd883f5b5a6423619041266ea8ed2a9f5d03.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT password_hash FROM users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "324db57df1629aedb2fccccbea66cd883f5b5a6423619041266ea8ed2a9f5d03"
+}

--- a/backend/.sqlx/query-3274a926e0a9cf404c467762d5f643ddb48487d7945eaa34c28394c9c26a2a14.json
+++ b/backend/.sqlx/query-3274a926e0a9cf404c467762d5f643ddb48487d7945eaa34c28394c9c26a2a14.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'alpine', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3274a926e0a9cf404c467762d5f643ddb48487d7945eaa34c28394c9c26a2a14"
+}

--- a/backend/.sqlx/query-330833f966710f48067550a507d092d35fd4fe7475b7454815873bbe1aa81aa9.json
+++ b/backend/.sqlx/query-330833f966710f48067550a507d092d35fd4fe7475b7454815873bbe1aa81aa9.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT name\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "330833f966710f48067550a507d092d35fd4fe7475b7454815873bbe1aa81aa9"
+}

--- a/backend/.sqlx/query-335a77479e30e412d30b7d9353d655db7174220613bfd498deed36c257b836be.json
+++ b/backend/.sqlx/query-335a77479e30e412d30b7d9353d655db7174220613bfd498deed36c257b836be.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE artifacts\n        SET content_type = $1, updated_at = NOW()\n        WHERE repository_id = $2\n          AND path = $3\n          AND content_type != $1\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "335a77479e30e412d30b7d9353d655db7174220613bfd498deed36c257b836be"
+}

--- a/backend/.sqlx/query-349800e968fcfc2205152be5af01b04616a6dc5fbbc849fcf3cc802b895dd69b.json
+++ b/backend/.sqlx/query-349800e968fcfc2205152be5af01b04616a6dc5fbbc849fcf3cc802b895dd69b.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO refresh_token_jti (jti, user_id, family_id, issued_at, expires_at)\n            VALUES ($1, $2, $3, $4, $5)\n            ON CONFLICT (jti) DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "349800e968fcfc2205152be5af01b04616a6dc5fbbc849fcf3cc802b895dd69b"
+}

--- a/backend/.sqlx/query-351dbfb80c6dfe1933872b3e05050e9d3229f07c9cd160a2bc6aac1537f4ac47.json
+++ b/backend/.sqlx/query-351dbfb80c6dfe1933872b3e05050e9d3229f07c9cd160a2bc6aac1537f4ac47.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COALESCE(SUM(size_bytes), 0)::BIGINT AS \"sum!\"\n        FROM proxy_cache_artifacts\n        WHERE repository_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "sum!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "351dbfb80c6dfe1933872b3e05050e9d3229f07c9cd160a2bc6aac1537f4ac47"
+}

--- a/backend/.sqlx/query-3540b5648376790e380ff93bcce116e898550c5a034f2fad14dd53585986a91e.json
+++ b/backend/.sqlx/query-3540b5648376790e380ff93bcce116e898550c5a034f2fad14dd53585986a91e.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH latest_scan AS (\n                SELECT DISTINCT ON (sr.artifact_id)\n                    sr.artifact_id, sr.id\n                FROM scan_results sr\n                JOIN artifacts a ON a.id = sr.artifact_id\n                WHERE sr.status = 'completed' AND NOT a.is_deleted\n                ORDER BY sr.artifact_id, sr.created_at DESC\n            )\n            SELECT artifact_id AS \"artifact_id!\"\n            FROM latest_scan ls\n            WHERE NOT EXISTS (\n                SELECT 1 FROM scan_packages sp WHERE sp.scan_result_id = ls.id\n            )\n            ORDER BY artifact_id\n            LIMIT $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "artifact_id!",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3540b5648376790e380ff93bcce116e898550c5a034f2fad14dd53585986a91e"
+}

--- a/backend/.sqlx/query-35a00a199cc22f11c558007205e77b97d368ecbe8579f5147297eaf65becc541.json
+++ b/backend/.sqlx/query-35a00a199cc22f11c558007205e77b97d368ecbe8579f5147297eaf65becc541.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO repository_usage_ledger (repository_id, hosted_bytes, proxy_bytes, oci_bytes, updated_at) VALUES ($1, $2, $3, $4, now()) ON CONFLICT (repository_id) DO UPDATE SET hosted_bytes = EXCLUDED.hosted_bytes, proxy_bytes  = EXCLUDED.proxy_bytes, oci_bytes    = EXCLUDED.oci_bytes, updated_at   = now()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "35a00a199cc22f11c558007205e77b97d368ecbe8579f5147297eaf65becc541"
+}

--- a/backend/.sqlx/query-36bb3e51711172a04da296e537bea2bdd0f9f80a1b6a3c59d3286d299cfe80e2.json
+++ b/backend/.sqlx/query-36bb3e51711172a04da296e537bea2bdd0f9f80a1b6a3c59d3286d299cfe80e2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO system_settings (key, value)\n            VALUES ($1, $2)\n            ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = NOW()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "36bb3e51711172a04da296e537bea2bdd0f9f80a1b6a3c59d3286d299cfe80e2"
+}

--- a/backend/.sqlx/query-375122517d1a943fabe4bc0555b1fea0fddfad602e776e0af9a05ae77e4c07ff.json
+++ b/backend/.sqlx/query-375122517d1a943fabe4bc0555b1fea0fddfad602e776e0af9a05ae77e4c07ff.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO repository_signing_config\n                (repository_id, signing_key_id, sign_metadata, sign_packages, require_signatures, updated_at)\n            VALUES ($1, $2, $3, $4, $5, NOW())\n            ON CONFLICT (repository_id) DO UPDATE SET\n                signing_key_id = $2,\n                sign_metadata = $3,\n                sign_packages = $4,\n                require_signatures = $5,\n                updated_at = NOW()\n            RETURNING *\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "signing_key_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "sign_metadata",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "sign_packages",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "require_signatures",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Bool",
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "375122517d1a943fabe4bc0555b1fea0fddfad602e776e0af9a05ae77e4c07ff"
+}

--- a/backend/.sqlx/query-378c5f494301e55a74fbb0618b1e75f994678caea067b1eb2b77a0124135ec64.json
+++ b/backend/.sqlx/query-378c5f494301e55a74fbb0618b1e75f994678caea067b1eb2b77a0124135ec64.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*) as \"count!\"\n        FROM webhook_deliveries\n        WHERE webhook_id = $1\n          AND ($2::boolean IS NULL OR success = $2)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "378c5f494301e55a74fbb0618b1e75f994678caea067b1eb2b77a0124135ec64"
+}

--- a/backend/.sqlx/query-37b3dbfe310fecbbb62c7b3876591b6abe2086fec0c62316897abbf475f0ae45.json
+++ b/backend/.sqlx/query-37b3dbfe310fecbbb62c7b3876591b6abe2086fec0c62316897abbf475f0ae45.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM plugins WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "37b3dbfe310fecbbb62c7b3876591b6abe2086fec0c62316897abbf475f0ae45"
+}

--- a/backend/.sqlx/query-382d64fd08e40e64db4224ce3e9d4c094464f36a2300e13ac7a348e98f530194.json
+++ b/backend/.sqlx/query-382d64fd08e40e64db4224ce3e9d4c094464f36a2300e13ac7a348e98f530194.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_results\n            SET status = 'failed', error_message = $2, completed_at = NOW(),\n                scanner_version = COALESCE($3, scanner_version),\n                started_at = $4\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Varchar",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "382d64fd08e40e64db4224ce3e9d4c094464f36a2300e13ac7a348e98f530194"
+}

--- a/backend/.sqlx/query-3973c8a9d39ccac521986537db08ef69df7b2566130f7c5bb195aca49edd0319.json
+++ b/backend/.sqlx/query-3973c8a9d39ccac521986537db08ef69df7b2566130f7c5bb195aca49edd0319.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes, checksum_sha256, path\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND version = $3\n          AND path = $4\n          AND is_deleted = false\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "path",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3973c8a9d39ccac521986537db08ef69df7b2566130f7c5bb195aca49edd0319"
+}

--- a/backend/.sqlx/query-39fafcaf55e40b0d151cffa6f5be8df4544647d4869a9516564ce836514c87c7.json
+++ b/backend/.sqlx/query-39fafcaf55e40b0d151cffa6f5be8df4544647d4869a9516564ce836514c87c7.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes, checksum_sha256\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND LOWER(name) = LOWER($2)\n          AND version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "39fafcaf55e40b0d151cffa6f5be8df4544647d4869a9516564ce836514c87c7"
+}

--- a/backend/.sqlx/query-3a2f850628e24551b14bc8ae14fb038aff301082415797b86d05a4c2de9893ad.json
+++ b/backend/.sqlx/query-3a2f850628e24551b14bc8ae14fb038aff301082415797b86d05a4c2de9893ad.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT storage_key FROM artifacts WHERE repository_id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3a2f850628e24551b14bc8ae14fb038aff301082415797b86d05a4c2de9893ad"
+}

--- a/backend/.sqlx/query-3a595a63e8541fa30343487618475d272bf73e8713607a43d58a169a40ee4925.json
+++ b/backend/.sqlx/query-3a595a63e8541fa30343487618475d272bf73e8713607a43d58a169a40ee4925.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifacts (\n            id, repository_id, path, name, version, size_bytes,\n            checksum_sha256, checksum_md5, checksum_sha1,\n            content_type, storage_key, uploaded_by\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Bpchar",
+        "Bpchar",
+        "Bpchar",
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3a595a63e8541fa30343487618475d272bf73e8713607a43d58a169a40ee4925"
+}

--- a/backend/.sqlx/query-3df6ff59a318b1b8577d2d46c1f0db76221914ab34473cc60ce025ca31cc70c3.json
+++ b/backend/.sqlx/query-3df6ff59a318b1b8577d2d46c1f0db76221914ab34473cc60ce025ca31cc70c3.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT revoked_at\n                FROM refresh_token_jti\n                WHERE jti = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "revoked_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "3df6ff59a318b1b8577d2d46c1f0db76221914ab34473cc60ce025ca31cc70c3"
+}

--- a/backend/.sqlx/query-3f794ad66ba162d9c00181d42ad8882be17091e1d71567dfc012ff3fdcb8c4b1.json
+++ b/backend/.sqlx/query-3f794ad66ba162d9c00181d42ad8882be17091e1d71567dfc012ff3fdcb8c4b1.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transfer_sessions\n            SET status = 'completed', completed_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3f794ad66ba162d9c00181d42ad8882be17091e1d71567dfc012ff3fdcb8c4b1"
+}

--- a/backend/.sqlx/query-40024411dd6ff36b5ea8bdaf6c59542c0b1912835c02a009940cf079fe477231.json
+++ b/backend/.sqlx/query-40024411dd6ff36b5ea8bdaf6c59542c0b1912835c02a009940cf079fe477231.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT path, size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND LOWER(name) = LOWER($2)\n        ORDER BY path\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "40024411dd6ff36b5ea8bdaf6c59542c0b1912835c02a009940cf079fe477231"
+}

--- a/backend/.sqlx/query-402a0c4fba0c4fe719917dc33317f68a7c506d49eef2781648d78f7c79a2d5ce.json
+++ b/backend/.sqlx/query-402a0c4fba0c4fe719917dc33317f68a7c506d49eef2781648d78f7c79a2d5ce.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM download_statistics",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "402a0c4fba0c4fe719917dc33317f68a7c506d49eef2781648d78f7c79a2d5ce"
+}

--- a/backend/.sqlx/query-41171a9c866be41a1d03c5e37a22db44678caba4be3b846d1b02ccc6de06a8b9.json
+++ b/backend/.sqlx/query-41171a9c866be41a1d03c5e37a22db44678caba4be3b846d1b02ccc6de06a8b9.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE signing_keys SET is_active = false WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "41171a9c866be41a1d03c5e37a22db44678caba4be3b846d1b02ccc6de06a8b9"
+}

--- a/backend/.sqlx/query-4203282367d8d6faf7811f78ab948738383612e88022415a4da239e559c66fc7.json
+++ b/backend/.sqlx/query-4203282367d8d6faf7811f78ab948738383612e88022415a4da239e559c66fc7.json
@@ -1,0 +1,250 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, key, name, description,\n                format as \"format: RepositoryFormat\",\n                repo_type as \"repo_type: RepositoryType\",\n                storage_backend, storage_path, upstream_url,\n                is_public, quota_bytes, promotion_only,\n                replication_priority as \"replication_priority: ReplicationPriority\",\n                curation_enabled, curation_source_repo_id, curation_target_repo_id,\n                curation_default_action, curation_sync_interval_secs, curation_auto_fetch,\n                age_gate_enabled, age_gate_min_age_days, versioning_enabled,\n                project_id, created_at, updated_at\n            FROM repositories\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "format: RepositoryFormat",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_type: RepositoryType",
+        "type_info": {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_backend",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "upstream_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "replication_priority: ReplicationPriority",
+        "type_info": {
+          "Custom": {
+            "name": "replication_priority",
+            "kind": {
+              "Enum": [
+                "immediate",
+                "scheduled",
+                "on_demand",
+                "local_only"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "curation_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "curation_source_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "curation_target_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "curation_default_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "curation_sync_interval_secs",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "curation_auto_fetch",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "age_gate_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "age_gate_min_age_days",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "versioning_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 24,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "4203282367d8d6faf7811f78ab948738383612e88022415a4da239e559c66fc7"
+}

--- a/backend/.sqlx/query-42df15ceb639a6a67239851c14db8c2bcadd83e0fd04b51252992595dc021bab.json
+++ b/backend/.sqlx/query-42df15ceb639a6a67239851c14db8c2bcadd83e0fd04b51252992595dc021bab.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM download_statistics WHERE artifact_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "42df15ceb639a6a67239851c14db8c2bcadd83e0fd04b51252992595dc021bab"
+}

--- a/backend/.sqlx/query-43b8412d5cfdc55c8cbfe7dce7d811ebcde65ca05805be450dd88efb384fc98b.json
+++ b/backend/.sqlx/query-43b8412d5cfdc55c8cbfe7dce7d811ebcde65ca05805be450dd88efb384fc98b.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT peer_instance_id, artifact_id, chunk_bitmap, total_chunks, available_chunks\n        FROM chunk_availability\n        WHERE peer_instance_id = $1 AND artifact_id = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "peer_instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "chunk_bitmap",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 3,
+        "name": "total_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "available_chunks",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "43b8412d5cfdc55c8cbfe7dce7d811ebcde65ca05805be450dd88efb384fc98b"
+}

--- a/backend/.sqlx/query-44463e67a06ea0b636b65fda1afa7e6b9052690eb1ebe63f2bd7a4127ca64c17.json
+++ b/backend/.sqlx/query-44463e67a06ea0b636b65fda1afa7e6b9052690eb1ebe63f2bd7a4127ca64c17.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM peer_instances\n            WHERE ($1::instance_status IS NULL OR status = $1)\n              AND ($2::text IS NULL OR region = $2)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        },
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "44463e67a06ea0b636b65fda1afa7e6b9052690eb1ebe63f2bd7a4127ca64c17"
+}

--- a/backend/.sqlx/query-4488f50c1da0441279d9cc26be9e9cb8340ac68e898091799ddd273fbe1f94db.json
+++ b/backend/.sqlx/query-4488f50c1da0441279d9cc26be9e9cb8340ac68e898091799ddd273fbe1f94db.json
@@ -1,0 +1,187 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, name, endpoint_url,\n                status as \"status: InstanceStatus\",\n                region, cache_size_bytes, cache_used_bytes,\n                last_heartbeat_at, last_sync_at, sync_filter,\n                max_bandwidth_bps, sync_window_start, sync_window_end,\n                sync_window_timezone, concurrent_transfers_limit,\n                active_transfers, backoff_until, consecutive_failures,\n                bytes_transferred_total, transfer_failures_total,\n                api_key, is_local,\n                created_at, updated_at\n            FROM peer_instances\n            WHERE ($1::instance_status IS NULL OR status = $1)\n              AND ($2::text IS NULL OR region = $2)\n            ORDER BY name\n            OFFSET $3\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: InstanceStatus",
+        "type_info": {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "region",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "cache_size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "cache_used_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_heartbeat_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_sync_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "sync_filter",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "max_bandwidth_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "sync_window_start",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 12,
+        "name": "sync_window_end",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 13,
+        "name": "sync_window_timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "concurrent_transfers_limit",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "active_transfers",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "backoff_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "consecutive_failures",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 19,
+        "name": "transfer_failures_total",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "api_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_local",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 23,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        },
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4488f50c1da0441279d9cc26be9e9cb8340ac68e898091799ddd273fbe1f94db"
+}

--- a/backend/.sqlx/query-44baa234fc166ef0e5adaa641f28adf580c20d2fc14ef606fb39fa97b02a3af9.json
+++ b/backend/.sqlx/query-44baa234fc166ef0e5adaa641f28adf580c20d2fc14ef606fb39fa97b02a3af9.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE signing_keys SET last_used_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "44baa234fc166ef0e5adaa641f28adf580c20d2fc14ef606fb39fa97b02a3af9"
+}

--- a/backend/.sqlx/query-44e1d29046a040898327986420d8dab7c8d08fbb618dd45ba4b91da10683f9ed.json
+++ b/backend/.sqlx/query-44e1d29046a040898327986420d8dab7c8d08fbb618dd45ba4b91da10683f9ed.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM roles WHERE name = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "44e1d29046a040898327986420d8dab7c8d08fbb618dd45ba4b91da10683f9ed"
+}

--- a/backend/.sqlx/query-4514e0e838e8eb3fb2ec9081f880f73e8e8307aae35f157fd027899b5980814d.json
+++ b/backend/.sqlx/query-4514e0e838e8eb3fb2ec9081f880f73e8e8307aae35f157fd027899b5980814d.json
@@ -1,0 +1,102 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, format_key, plugin_id,\n                           handler_type as \"handler_type: FormatHandlerType\",\n                           display_name, description, extensions,\n                           is_enabled, priority, created_at, updated_at\n                    FROM format_handlers\n                    WHERE handler_type = $1\n                    ORDER BY priority DESC, display_name\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4514e0e838e8eb3fb2ec9081f880f73e8e8307aae35f157fd027899b5980814d"
+}

--- a/backend/.sqlx/query-45ac552b1bfcd28a4eee19d9412157e806a644c2c00d04ec3292cd1d19d83cfc.json
+++ b/backend/.sqlx/query-45ac552b1bfcd28a4eee19d9412157e806a644c2c00d04ec3292cd1d19d83cfc.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE users\n            SET must_change_password = true\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "45ac552b1bfcd28a4eee19d9412157e806a644c2c00d04ec3292cd1d19d83cfc"
+}

--- a/backend/.sqlx/query-46f7b733d867ca95192280cd1cdadf23bfdb6774f386ebda01e2a03648d45a3d.json
+++ b/backend/.sqlx/query-46f7b733d867ca95192280cd1cdadf23bfdb6774f386ebda01e2a03648d45a3d.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.name, a.version, a.size_bytes,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n        ORDER BY a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "46f7b733d867ca95192280cd1cdadf23bfdb6774f386ebda01e2a03648d45a3d"
+}

--- a/backend/.sqlx/query-4811819301a6fb7562af8260fa0a9c66d7ff07e9844ae0cee68ab23dc4a63e0a.json
+++ b/backend/.sqlx/query-4811819301a6fb7562af8260fa0a9c66d7ff07e9844ae0cee68ab23dc4a63e0a.json
@@ -1,0 +1,250 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                r.id, r.key, r.name, r.description,\n                r.format as \"format: RepositoryFormat\",\n                r.repo_type as \"repo_type: RepositoryType\",\n                r.storage_backend, r.storage_path, r.upstream_url,\n                r.is_public, r.quota_bytes, r.promotion_only,\n                r.replication_priority as \"replication_priority: ReplicationPriority\",\n                r.curation_enabled, r.curation_source_repo_id, r.curation_target_repo_id,\n                r.curation_default_action, r.curation_sync_interval_secs, r.curation_auto_fetch,\n                r.age_gate_enabled, r.age_gate_min_age_days, r.versioning_enabled,\n                r.project_id, r.created_at, r.updated_at\n            FROM repositories r\n            INNER JOIN virtual_repo_members vrm ON r.id = vrm.member_repo_id\n            WHERE vrm.virtual_repo_id = $1\n            ORDER BY vrm.priority\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "format: RepositoryFormat",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_type: RepositoryType",
+        "type_info": {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_backend",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "upstream_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "replication_priority: ReplicationPriority",
+        "type_info": {
+          "Custom": {
+            "name": "replication_priority",
+            "kind": {
+              "Enum": [
+                "immediate",
+                "scheduled",
+                "on_demand",
+                "local_only"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "curation_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "curation_source_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "curation_target_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "curation_default_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "curation_sync_interval_secs",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "curation_auto_fetch",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "age_gate_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "age_gate_min_age_days",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "versioning_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 24,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "4811819301a6fb7562af8260fa0a9c66d7ff07e9844ae0cee68ab23dc4a63e0a"
+}

--- a/backend/.sqlx/query-491787dfb4c73973410bce255501b97d58cdd950225b025f49b38d2033d14686.json
+++ b/backend/.sqlx/query-491787dfb4c73973410bce255501b97d58cdd950225b025f49b38d2033d14686.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, name, version, size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND LOWER(name) = LOWER($2)\n          AND version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "491787dfb4c73973410bce255501b97d58cdd950225b025f49b38d2033d14686"
+}

--- a/backend/.sqlx/query-49b4181488fa7c4695859d7d22508d547efa2c94145f8b811f2ee3ff5f1d26fb.json
+++ b/backend/.sqlx/query-49b4181488fa7c4695859d7d22508d547efa2c94145f8b811f2ee3ff5f1d26fb.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.path LIKE $2 || '%' ESCAPE '\\'\n        ORDER BY a.name, a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "49b4181488fa7c4695859d7d22508d547efa2c94145f8b811f2ee3ff5f1d26fb"
+}

--- a/backend/.sqlx/query-4a5b8b10ee6c8245f0c85165d97de37fcbac4f805394077d9774d490e076f150.json
+++ b/backend/.sqlx/query-4a5b8b10ee6c8245f0c85165d97de37fcbac4f805394077d9774d490e076f150.json
@@ -1,0 +1,59 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, content_type, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE '%/' || $2 ESCAPE '\\'\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4a5b8b10ee6c8245f0c85165d97de37fcbac4f805394077d9774d490e076f150"
+}

--- a/backend/.sqlx/query-4a9b49a98b2560b998b804327d823acda2e806f5494c4ea9ae283ca56a4d6c91.json
+++ b/backend/.sqlx/query-4a9b49a98b2560b998b804327d823acda2e806f5494c4ea9ae283ca56a4d6c91.json
@@ -1,0 +1,134 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO plugins (name, version, display_name, description, author, homepage, plugin_type, config_schema)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n        RETURNING\n            id, name, version, display_name, description, author, homepage,\n            status as \"status: PluginStatus\",\n            plugin_type as \"plugin_type: PluginType\",\n            config_schema, installed_at, enabled_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "author",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "homepage",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "status: PluginStatus",
+        "type_info": {
+          "Custom": {
+            "name": "plugin_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "disabled",
+                "error"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "plugin_type: PluginType",
+        "type_info": {
+          "Custom": {
+            "name": "plugin_type",
+            "kind": {
+              "Enum": [
+                "format_handler",
+                "storage_backend",
+                "authentication",
+                "authorization",
+                "webhook",
+                "custom"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "config_schema",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "installed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "enabled_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "plugin_type",
+            "kind": {
+              "Enum": [
+                "format_handler",
+                "storage_backend",
+                "authentication",
+                "authorization",
+                "webhook",
+                "custom"
+              ]
+            }
+          }
+        },
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "4a9b49a98b2560b998b804327d823acda2e806f5494c4ea9ae283ca56a4d6c91"
+}

--- a/backend/.sqlx/query-4aac4e53d44dab9dcffe001689d66686bc4cb2499f4eb68b72438a05eb085ba4.json
+++ b/backend/.sqlx/query-4aac4e53d44dab9dcffe001689d66686bc4cb2499f4eb68b72438a05eb085ba4.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET totp_secret = NULL, totp_enabled = false, totp_backup_codes = NULL, totp_verified_at = NULL WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4aac4e53d44dab9dcffe001689d66686bc4cb2499f4eb68b72438a05eb085ba4"
+}

--- a/backend/.sqlx/query-4abc32c0ce945a98d46af998159f13602b34ebe2b1aca58c6fb2128a79e9e14a.json
+++ b/backend/.sqlx/query-4abc32c0ce945a98d46af998159f13602b34ebe2b1aca58c6fb2128a79e9e14a.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, size_bytes, checksum_sha256, storage_key FROM artifacts WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4abc32c0ce945a98d46af998159f13602b34ebe2b1aca58c6fb2128a79e9e14a"
+}

--- a/backend/.sqlx/query-4ae214e2eaaee22693e4e257955767e4139645a5f7cbef7e8211a66fb3b91c2a.json
+++ b/backend/.sqlx/query-4ae214e2eaaee22693e4e257955767e4139645a5f7cbef7e8211a66fb3b91c2a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO lfs_locks (repository_id, path, ref_name, owner_id, owner_name)\n        VALUES ($1, $2, $3, $4, $5)\n        ON CONFLICT (repository_id, path) DO NOTHING\n        RETURNING id, locked_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "locked_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "4ae214e2eaaee22693e4e257955767e4139645a5f7cbef7e8211a66fb3b91c2a"
+}

--- a/backend/.sqlx/query-4b3d02d4333f4656cd612f3145fe6d4512cdd027ee199a7ca4362700b888d834.json
+++ b/backend/.sqlx/query-4b3d02d4333f4656cd612f3145fe6d4512cdd027ee199a7ca4362700b888d834.json
@@ -1,0 +1,175 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE external_id = $1 AND auth_provider = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "4b3d02d4333f4656cd612f3145fe6d4512cdd027ee199a7ca4362700b888d834"
+}

--- a/backend/.sqlx/query-4b91b34c27b34db150d1ca44088e54dd290ed3ab8961988613227b09ed22bcab.json
+++ b/backend/.sqlx/query-4b91b34c27b34db150d1ca44088e54dd290ed3ab8961988613227b09ed22bcab.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, repository_id, scan_type, status,\n                   findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                   scanner_version, error_message, started_at, completed_at, created_at,\n                   is_reused, source_scan_id\n            FROM scan_results\n            WHERE ($1::uuid IS NULL OR repository_id = $1)\n              AND ($2::uuid IS NULL OR artifact_id = $2)\n              AND ($3::text IS NULL OR status = $3)\n            ORDER BY created_at DESC\n            LIMIT $4 OFFSET $5\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "4b91b34c27b34db150d1ca44088e54dd290ed3ab8961988613227b09ed22bcab"
+}

--- a/backend/.sqlx/query-4e31f5e596bec0a478cd13c9b5339226edf472ead5acf7c1688ce1eabf9fa297.json
+++ b/backend/.sqlx/query-4e31f5e596bec0a478cd13c9b5339226edf472ead5acf7c1688ce1eabf9fa297.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_results\n            SET status = 'not_applicable', error_message = $2, completed_at = NOW(),\n                started_at = $3\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4e31f5e596bec0a478cd13c9b5339226edf472ead5acf7c1688ce1eabf9fa297"
+}

--- a/backend/.sqlx/query-4e7120687b74b6d09cf399380eccc74678f87f0380e5f6802b4b9b87c211fff2.json
+++ b/backend/.sqlx/query-4e7120687b74b6d09cf399380eccc74678f87f0380e5f6802b4b9b87c211fff2.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, storage_key, size_bytes, name\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND LOWER(name) = LOWER($2)\n          AND version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "4e7120687b74b6d09cf399380eccc74678f87f0380e5f6802b4b9b87c211fff2"
+}

--- a/backend/.sqlx/query-4ea526dbf3aea0dc1d38449a8d34658421d499249167ecb43e48f11b7afcbd7e.json
+++ b/backend/.sqlx/query-4ea526dbf3aea0dc1d38449a8d34658421d499249167ecb43e48f11b7afcbd7e.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM plugin_config WHERE plugin_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4ea526dbf3aea0dc1d38449a8d34658421d499249167ecb43e48f11b7afcbd7e"
+}

--- a/backend/.sqlx/query-50293c2e54af11d4c2a553e29b671cef087a159c6ee7182d8ca929ecb748f3b7.json
+++ b/backend/.sqlx/query-50293c2e54af11d4c2a553e29b671cef087a159c6ee7182d8ca929ecb748f3b7.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM users WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "50293c2e54af11d4c2a553e29b671cef087a159c6ee7182d8ca929ecb748f3b7"
+}

--- a/backend/.sqlx/query-50daf5d81586fc47f74f84299501104b56aed22ec7628a951d1f7cc9d5c4442e.json
+++ b/backend/.sqlx/query-50daf5d81586fc47f74f84299501104b56aed22ec7628a951d1f7cc9d5c4442e.json
@@ -1,0 +1,56 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH latest_scans AS (\n                SELECT DISTINCT ON (sr.artifact_id, sr.scan_type) sr.id\n                FROM scan_results sr\n                JOIN artifacts a ON a.id = sr.artifact_id\n                WHERE sr.status = 'completed'\n                  AND NOT a.is_deleted\n                ORDER BY sr.artifact_id, sr.scan_type,\n                         sr.completed_at DESC NULLS LAST, sr.created_at DESC\n            ),\n            latest_findings AS (\n                SELECT sf.severity, sf.is_acknowledged\n                FROM scan_findings sf\n                JOIN latest_scans ls ON ls.id = sf.scan_result_id\n            )\n            SELECT\n                (SELECT COUNT(*) FROM scan_configs WHERE scan_enabled = true) as \"repos_with_scanning!\",\n                (SELECT COUNT(*) FROM scan_results) as \"total_scans!\",\n                COUNT(*) FILTER (WHERE NOT is_acknowledged) as \"total_findings!\",\n                COUNT(*) FILTER (\n                    WHERE severity = 'critical' AND NOT is_acknowledged\n                ) as \"critical_findings!\",\n                COUNT(*) FILTER (\n                    WHERE severity = 'high' AND NOT is_acknowledged\n                ) as \"high_findings!\",\n                (SELECT COUNT(*) FROM repo_security_scores WHERE grade = 'A') as \"repos_grade_a!\",\n                (SELECT COUNT(*) FROM repo_security_scores WHERE grade = 'F') as \"repos_grade_f!\"\n            FROM latest_findings\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repos_with_scanning!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "total_scans!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "total_findings!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "critical_findings!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "high_findings!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "repos_grade_a!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "repos_grade_f!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "50daf5d81586fc47f74f84299501104b56aed22ec7628a951d1f7cc9d5c4442e"
+}

--- a/backend/.sqlx/query-5212054648f616cd1b85bf969e83eced730b8d93fa6ff3d8978d52e08945279d.json
+++ b/backend/.sqlx/query-5212054648f616cd1b85bf969e83eced730b8d93fa6ff3d8978d52e08945279d.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT manifest_digest FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manifest_digest",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5212054648f616cd1b85bf969e83eced730b8d93fa6ff3d8978d52e08945279d"
+}

--- a/backend/.sqlx/query-52301eda1df2a044165a86c5c097cd6459436fcfd721d2f08db9a48e687264a2.json
+++ b/backend/.sqlx/query-52301eda1df2a044165a86c5c097cd6459436fcfd721d2f08db9a48e687264a2.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO plugins (\n                id, name, version, display_name, description, author, homepage, license,\n                status, plugin_type, source_type, source_url, source_ref, wasm_path,\n                manifest, capabilities, resource_limits\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'active', 'format_handler', $9, $10, $11, $12, $13, $14, $15)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "plugin_source_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm_git",
+                "wasm_zip",
+                "wasm_local"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Jsonb",
+        "Jsonb",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "52301eda1df2a044165a86c5c097cd6459436fcfd721d2f08db9a48e687264a2"
+}

--- a/backend/.sqlx/query-53b6fb0dd94cf2e96ec3def1d85312361a257168d0f9f82d3ae9a431b3975f66.json
+++ b/backend/.sqlx/query-53b6fb0dd94cf2e96ec3def1d85312361a257168d0f9f82d3ae9a431b3975f66.json
@@ -1,0 +1,96 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, package_name, package_version,\n                upstream_published_at, status, requested_at,\n                reviewed_by, reviewed_at, review_reason,\n                request_count, last_requested_at,\n                NULL::text as repository_key\n            FROM age_gate_reviews\n            WHERE repository_id = $1 AND package_name = $2 AND package_version = $3\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "package_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "package_version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "upstream_published_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "requested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "reviewed_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "reviewed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "review_reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "request_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "last_requested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "repository_key",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      null
+    ]
+  },
+  "hash": "53b6fb0dd94cf2e96ec3def1d85312361a257168d0f9f82d3ae9a431b3975f66"
+}

--- a/backend/.sqlx/query-53c5967f806cc445df6339f9702825f0970cecf548cee0841074d840a36d949e.json
+++ b/backend/.sqlx/query-53c5967f806cc445df6339f9702825f0970cecf548cee0841074d840a36d949e.json
@@ -1,0 +1,79 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE webhook_deliveries\n        SET\n            response_status = $2,\n            response_body = $3,\n            success = $4,\n            attempts = attempts + 1,\n            delivered_at = CASE WHEN $4 THEN NOW() ELSE delivered_at END\n        WHERE id = $1\n        RETURNING id, webhook_id, event, payload, response_status, response_body, success, attempts, delivered_at, created_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "webhook_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "response_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "response_body",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "success",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "delivered_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "53c5967f806cc445df6339f9702825f0970cecf548cee0841074d840a36d949e"
+}

--- a/backend/.sqlx/query-542f3cfcec215d7c1aca0ea1557ab722e42e195380aa23d49c5eddea96ba5470.json
+++ b/backend/.sqlx/query-542f3cfcec215d7c1aca0ea1557ab722e42e195380aa23d49c5eddea96ba5470.json
@@ -1,0 +1,90 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT id, format_key, plugin_id,\n                           handler_type as \"handler_type: FormatHandlerType\",\n                           display_name, description, extensions,\n                           is_enabled, priority, created_at, updated_at\n                    FROM format_handlers\n                    ORDER BY priority DESC, display_name\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "542f3cfcec215d7c1aca0ea1557ab722e42e195380aa23d49c5eddea96ba5470"
+}

--- a/backend/.sqlx/query-5451d568eccdbbc0d5068fee50583f05afa302126c47fa372bb3b4291408958b.json
+++ b/backend/.sqlx/query-5451d568eccdbbc0d5068fee50583f05afa302126c47fa372bb3b4291408958b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT EXISTS(\n            SELECT 1 FROM proxy_cache_artifacts WHERE repository_id = $1\n        ) AS \"exists!\"\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5451d568eccdbbc0d5068fee50583f05afa302126c47fa372bb3b4291408958b"
+}

--- a/backend/.sqlx/query-5597a21500a6e890bb546e2b55dd37ea91df0693d1d3ab7ca8c8691f07dfec26.json
+++ b/backend/.sqlx/query-5597a21500a6e890bb546e2b55dd37ea91df0693d1d3ab7ca8c8691f07dfec26.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n          AND a.version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5597a21500a6e890bb546e2b55dd37ea91df0693d1d3ab7ca8c8691f07dfec26"
+}

--- a/backend/.sqlx/query-5629c4b0f6b5c081de779d23bb4f739f918a9976a13beca027250a4ca405652f.json
+++ b/backend/.sqlx/query-5629c4b0f6b5c081de779d23bb4f739f918a9976a13beca027250a4ca405652f.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE users\n                SET failed_login_attempts = $2,\n                    locked_until = $3,\n                    last_failed_login_at = $4\n                WHERE id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5629c4b0f6b5c081de779d23bb4f739f918a9976a13beca027250a4ca405652f"
+}

--- a/backend/.sqlx/query-569d30730443801a023b1d0ca18759f61a233bad0b21275f940959eca0b9e902.json
+++ b/backend/.sqlx/query-569d30730443801a023b1d0ca18759f61a233bad0b21275f940959eca0b9e902.json
@@ -1,0 +1,92 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, format_key, plugin_id,\n                   handler_type as \"handler_type: FormatHandlerType\",\n                   display_name, description, extensions,\n                   is_enabled, priority, created_at, updated_at\n            FROM format_handlers\n            WHERE format_key = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "569d30730443801a023b1d0ca18759f61a233bad0b21275f940959eca0b9e902"
+}

--- a/backend/.sqlx/query-56d3e7c656edbbb25ec3cc885ce2be7fd858aa8109e00e8162864765b1fff17c.json
+++ b/backend/.sqlx/query-56d3e7c656edbbb25ec3cc885ce2be7fd858aa8109e00e8162864765b1fff17c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repositories SET updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "56d3e7c656edbbb25ec3cc885ce2be7fd858aa8109e00e8162864765b1fff17c"
+}

--- a/backend/.sqlx/query-586ebe08d9c5e7c8738582a9b9b14ee03e5fa31c7911fa50f249f84983544cd3.json
+++ b/backend/.sqlx/query-586ebe08d9c5e7c8738582a9b9b14ee03e5fa31c7911fa50f249f84983544cd3.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, format, metadata, properties\n            FROM artifact_metadata\n            WHERE artifact_id = $1\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "format",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "586ebe08d9c5e7c8738582a9b9b14ee03e5fa31c7911fa50f249f84983544cd3"
+}

--- a/backend/.sqlx/query-58a32faafa62f301dfae2e9ffe64462a1ba7988ca81b757092cd3328f6da89e3.json
+++ b/backend/.sqlx/query-58a32faafa62f301dfae2e9ffe64462a1ba7988ca81b757092cd3328f6da89e3.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO artifacts (\n                repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_sha1, checksum_md5,\n                content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n            ON CONFLICT (repository_id, path) DO UPDATE SET\n                name = EXCLUDED.name,\n                version = EXCLUDED.version,\n                size_bytes = EXCLUDED.size_bytes,\n                checksum_sha256 = EXCLUDED.checksum_sha256,\n                checksum_sha1 = EXCLUDED.checksum_sha1,\n                checksum_md5 = EXCLUDED.checksum_md5,\n                content_type = EXCLUDED.content_type,\n                storage_key = EXCLUDED.storage_key,\n                uploaded_by = EXCLUDED.uploaded_by,\n                is_deleted = false,\n                updated_at = NOW()\n            RETURNING\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Bpchar",
+        "Bpchar",
+        "Bpchar",
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "58a32faafa62f301dfae2e9ffe64462a1ba7988ca81b757092cd3328f6da89e3"
+}

--- a/backend/.sqlx/query-58ba1f4ab8aecec1dd7dd4a54dcad89e3b6a2dbbc1fe165acc4f35f8d105633f.json
+++ b/backend/.sqlx/query-58ba1f4ab8aecec1dd7dd4a54dcad89e3b6a2dbbc1fe165acc4f35f8d105633f.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT promotion_only FROM repositories WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "58ba1f4ab8aecec1dd7dd4a54dcad89e3b6a2dbbc1fe165acc4f35f8d105633f"
+}

--- a/backend/.sqlx/query-5a26c4999bc79ffd99f284536336d0e4e056b248f669a579605d76b8836c4a7d.json
+++ b/backend/.sqlx/query-5a26c4999bc79ffd99f284536336d0e4e056b248f669a579605d76b8836c4a7d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM virtual_repo_members WHERE virtual_repo_id = $1 AND member_repo_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5a26c4999bc79ffd99f284536336d0e4e056b248f669a579605d76b8836c4a7d"
+}

--- a/backend/.sqlx/query-5a2ce0ca3049f56c4b8b8f7ca596352ea648792105a1272b31f21b14a45818c6.json
+++ b/backend/.sqlx/query-5a2ce0ca3049f56c4b8b8f7ca596352ea648792105a1272b31f21b14a45818c6.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, version FROM artifacts WHERE repository_id = $1 AND path = $2 AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "5a2ce0ca3049f56c4b8b8f7ca596352ea648792105a1272b31f21b14a45818c6"
+}

--- a/backend/.sqlx/query-5a6158dc307db95157f0dce975c9a71f16372d90d015d6c1bf3137c12a335e01.json
+++ b/backend/.sqlx/query-5a6158dc307db95157f0dce975c9a71f16372d90d015d6c1bf3137c12a335e01.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.created_at,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n        ORDER BY a.created_at DESC, a.name DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "5a6158dc307db95157f0dce975c9a71f16372d90d015d6c1bf3137c12a335e01"
+}

--- a/backend/.sqlx/query-5bb304d6e1c528a4489d312e8db7fda86dd57724ea29318c56b1b06c85f166a7.json
+++ b/backend/.sqlx/query-5bb304d6e1c528a4489d312e8db7fda86dd57724ea29318c56b1b06c85f166a7.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                COUNT(*)::bigint as \"total!: i64\",\n                (COUNT(*) FILTER (WHERE expires_at IS NOT NULL AND expires_at < NOW()))::bigint as \"expired!: i64\",\n                (COUNT(*) FILTER (WHERE last_used_at > NOW() - INTERVAL '24 hours'))::bigint as \"used_last_24h!: i64\",\n                (COUNT(*) FILTER (WHERE last_used_at IS NULL))::bigint as \"never_used!: i64\"\n            FROM api_tokens\n            WHERE user_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "total!: i64",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "expired!: i64",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "used_last_24h!: i64",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "never_used!: i64",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "5bb304d6e1c528a4489d312e8db7fda86dd57724ea29318c56b1b06c85f166a7"
+}

--- a/backend/.sqlx/query-5bc6ad57ca5fefc6538f41ee656823261797cc22acd7cc945a77e065d21e3caf.json
+++ b/backend/.sqlx/query-5bc6ad57ca5fefc6538f41ee656823261797cc22acd7cc945a77e065d21e3caf.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO api_tokens (user_id, name, token_hash, token_prefix, scopes, expires_at)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Bpchar",
+        "VarcharArray",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5bc6ad57ca5fefc6538f41ee656823261797cc22acd7cc945a77e065d21e3caf"
+}

--- a/backend/.sqlx/query-5bfc57f3088895f0276077e064008704e2649ec6e2a7070776f4e3a38c701340.json
+++ b/backend/.sqlx/query-5bfc57f3088895f0276077e064008704e2649ec6e2a7070776f4e3a38c701340.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND checksum_sha256 = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "5bfc57f3088895f0276077e064008704e2649ec6e2a7070776f4e3a38c701340"
+}

--- a/backend/.sqlx/query-5c17ced6747db96e8236e52f378cd90bbfdd84d4b9aa0d9ba9111a3cde1c4cd9.json
+++ b/backend/.sqlx/query-5c17ced6747db96e8236e52f378cd90bbfdd84d4b9aa0d9ba9111a3cde1c4cd9.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT MAX(completed_at) as \"last_scan_at\"\n            FROM scan_results\n            WHERE repository_id = $1 AND status = 'completed'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "last_scan_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5c17ced6747db96e8236e52f378cd90bbfdd84d4b9aa0d9ba9111a3cde1c4cd9"
+}

--- a/backend/.sqlx/query-5d5c639f218759b5a85921c67960910c7c5955b1f6ef9e1623809f978234a5df.json
+++ b/backend/.sqlx/query-5d5c639f218759b5a85921c67960910c7c5955b1f6ef9e1623809f978234a5df.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM backups\n            WHERE ($1::backup_status IS NULL OR status = $1)\n              AND ($2::backup_type IS NULL OR backup_type = $2)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "backup_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "backup_type",
+            "kind": {
+              "Enum": [
+                "full",
+                "incremental",
+                "metadata_only",
+                "metadata"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "5d5c639f218759b5a85921c67960910c7c5955b1f6ef9e1623809f978234a5df"
+}

--- a/backend/.sqlx/query-5d7927661894cf8ab505b797c2ea3d384a531f89b0752527f956c1e920b8a9cf.json
+++ b/backend/.sqlx/query-5d7927661894cf8ab505b797c2ea3d384a531f89b0752527f956c1e920b8a9cf.json
@@ -1,0 +1,124 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, repository_id, scan_type, status,\n                   findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                   scanner_version, error_message, started_at, completed_at, created_at,\n                   is_reused, source_scan_id\n            FROM scan_results\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "5d7927661894cf8ab505b797c2ea3d384a531f89b0752527f956c1e920b8a9cf"
+}

--- a/backend/.sqlx/query-5dc183c12b15a3ffc667855cae609fe78c4da972276a694e3eaa56582aac6bff.json
+++ b/backend/.sqlx/query-5dc183c12b15a3ffc667855cae609fe78c4da972276a694e3eaa56582aac6bff.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_connections\n            SET transfer_failure_count = transfer_failure_count + 1,\n                updated_at = NOW()\n            WHERE source_peer_id = $1 AND target_peer_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5dc183c12b15a3ffc667855cae609fe78c4da972276a694e3eaa56582aac6bff"
+}

--- a/backend/.sqlx/query-5dcf60c6d0044a1bd112bcd96ea284135b7512ee20e73b9db5959164c86c3159.json
+++ b/backend/.sqlx/query-5dcf60c6d0044a1bd112bcd96ea284135b7512ee20e73b9db5959164c86c3159.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id AS \"id!: uuid::Uuid\", recipients AS \"recipients!: Vec<String>\"\n        FROM email_subscriptions\n        WHERE enabled = true\n          AND $1 = ANY(event_types)\n          AND (repository_id IS NULL OR repository_id = $2)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!: uuid::Uuid",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "recipients!: Vec<String>",
+        "type_info": "TextArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "5dcf60c6d0044a1bd112bcd96ea284135b7512ee20e73b9db5959164c86c3159"
+}

--- a/backend/.sqlx/query-5e00a3da9032175368e930b9f4f6fb7c87d79dba7a78dd70878318553c8a9780.json
+++ b/backend/.sqlx/query-5e00a3da9032175368e930b9f4f6fb7c87d79dba7a78dd70878318553c8a9780.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, username, email, display_name, is_admin, totp_enabled\n        FROM users\n        WHERE id = $1 AND is_active = true\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "5e00a3da9032175368e930b9f4f6fb7c87d79dba7a78dd70878318553c8a9780"
+}

--- a/backend/.sqlx/query-5e1b0ec0b89c7ff5e9d3c9ee7faecc0bb5d72db2bdae1c8549047ec97810bd7c.json
+++ b/backend/.sqlx/query-5e1b0ec0b89c7ff5e9d3c9ee7faecc0bb5d72db2bdae1c8549047ec97810bd7c.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, username, email, password_hash, display_name,\n            auth_provider as \"auth_provider: AuthProvider\",\n            external_id, is_admin, is_active, is_service_account, must_change_password,\n            totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n            failed_login_attempts, locked_until, last_failed_login_at,\n            password_changed_at, last_login_at, created_at, updated_at\n        FROM users\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "5e1b0ec0b89c7ff5e9d3c9ee7faecc0bb5d72db2bdae1c8549047ec97810bd7c"
+}

--- a/backend/.sqlx/query-5e3ccd9a90225fab7c8a2fdcd888f877f1041b8ebb211ec103ba7cea204bf5b5.json
+++ b/backend/.sqlx/query-5e3ccd9a90225fab7c8a2fdcd888f877f1041b8ebb211ec103ba7cea204bf5b5.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'conan', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5e3ccd9a90225fab7c8a2fdcd888f877f1041b8ebb211ec103ba7cea204bf5b5"
+}

--- a/backend/.sqlx/query-5f04be7b4faa7821726c4967c586431e37f0bfccede6588ff93b3145f6e5a284.json
+++ b/backend/.sqlx/query-5f04be7b4faa7821726c4967c586431e37f0bfccede6588ff93b3145f6e5a284.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE username = $1 AND auth_provider = 'ldap' AND is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "5f04be7b4faa7821726c4967c586431e37f0bfccede6588ff93b3145f6e5a284"
+}

--- a/backend/.sqlx/query-5f76af42b1bc49ce367afc989f73af2261feba1a7edb15658a2b8091b36843f6.json
+++ b/backend/.sqlx/query-5f76af42b1bc49ce367afc989f73af2261feba1a7edb15658a2b8091b36843f6.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT ON (LOWER(name)) name, version,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n        ORDER BY LOWER(name), a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "5f76af42b1bc49ce367afc989f73af2261feba1a7edb15658a2b8091b36843f6"
+}

--- a/backend/.sqlx/query-5fc15186cc994ecaae39dff33922c15297ec9deacb49d2a5c2f67a70e9cd2161.json
+++ b/backend/.sqlx/query-5fc15186cc994ecaae39dff33922c15297ec9deacb49d2a5c2f67a70e9cd2161.json
@@ -1,0 +1,179 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO users (\n                    username, email, display_name, auth_provider,\n                    external_id, is_admin, is_active, is_service_account, must_change_password\n                )\n                VALUES ($1, $2, $3, $4, $5, $6, true, false, false)\n                RETURNING\n                    id, username, email, password_hash, display_name,\n                    auth_provider as \"auth_provider: AuthProvider\",\n                    external_id, is_admin, is_active, is_service_account, must_change_password,\n                    totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                    failed_login_attempts, locked_until, last_failed_login_at,\n                    password_changed_at, last_login_at, created_at, updated_at\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "5fc15186cc994ecaae39dff33922c15297ec9deacb49d2a5c2f67a70e9cd2161"
+}

--- a/backend/.sqlx/query-60571c52dfea6334dae6d3de90ef6dd5d84b9f6c1b0d2d76cb0988b3b9fbba50.json
+++ b/backend/.sqlx/query-60571c52dfea6334dae6d3de90ef6dd5d84b9f6c1b0d2d76cb0988b3b9fbba50.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND checksum_sha256 = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "60571c52dfea6334dae6d3de90ef6dd5d84b9f6c1b0d2d76cb0988b3b9fbba50"
+}

--- a/backend/.sqlx/query-617368dbf6033e900cc2acd5ed0bae166756fb609c97d49f02b8d36afcc46723.json
+++ b/backend/.sqlx/query-617368dbf6033e900cc2acd5ed0bae166756fb609c97d49f02b8d36afcc46723.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM audit_log WHERE created_at < NOW() - make_interval(days => $1)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "617368dbf6033e900cc2acd5ed0bae166756fb609c97d49f02b8d36afcc46723"
+}

--- a/backend/.sqlx/query-6182f5b6c7ce836fc6a5ce7367b0a96e138e64d92e3408b6d7c334b56d57d508.json
+++ b/backend/.sqlx/query-6182f5b6c7ce836fc6a5ce7367b0a96e138e64d92e3408b6d7c334b56d57d508.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'sbt', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6182f5b6c7ce836fc6a5ce7367b0a96e138e64d92e3408b6d7c334b56d57d508"
+}

--- a/backend/.sqlx/query-620837856882f303c882e52e1b2f1d9f218f5b2bb088425370bbc3626002a2ff.json
+++ b/backend/.sqlx/query-620837856882f303c882e52e1b2f1d9f218f5b2bb088425370bbc3626002a2ff.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.created_at\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.name = $2\n          AND a.version = $3\n          AND a.is_deleted = false\n        ORDER BY a.created_at ASC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "620837856882f303c882e52e1b2f1d9f218f5b2bb088425370bbc3626002a2ff"
+}

--- a/backend/.sqlx/query-6248cee682aad0ac4dbe5f7c41d8b4ffee8109365961b2bf7615fcda7f113c05.json
+++ b/backend/.sqlx/query-6248cee682aad0ac4dbe5f7c41d8b4ffee8109365961b2bf7615fcda7f113c05.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transfer_chunks\n            SET status = 'pending', source_peer_id = NULL\n            WHERE session_id = $1 AND chunk_index = $2 AND status = 'failed'\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6248cee682aad0ac4dbe5f7c41d8b4ffee8109365961b2bf7615fcda7f113c05"
+}

--- a/backend/.sqlx/query-627bdd2bae2fbee474ec3cff6682fee9dc5da3e426047d5739e2154dfd2a62ae.json
+++ b/backend/.sqlx/query-627bdd2bae2fbee474ec3cff6682fee9dc5da3e426047d5739e2154dfd2a62ae.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        WITH ensured AS (\n            INSERT INTO proxy_cache_artifacts\n                (repository_id, path, storage_key, metadata_key, size_bytes,\n                 cached_at, last_accessed_at)\n            VALUES ($1, $2, $3, $4, 0, now(), now())\n            ON CONFLICT (repository_id, path) DO UPDATE SET\n                last_accessed_at = now()\n            RETURNING id\n        )\n        INSERT INTO proxy_download_statistics\n            (proxy_cache_id, user_id, ip_address, user_agent)\n        SELECT id, $5, $6, $7 FROM ensured\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "627bdd2bae2fbee474ec3cff6682fee9dc5da3e426047d5739e2154dfd2a62ae"
+}

--- a/backend/.sqlx/query-629d46d34fdcb0800de0649fc384d95357df5b95ef8fe2db84bba2b98e6fa21e.json
+++ b/backend/.sqlx/query-629d46d34fdcb0800de0649fc384d95357df5b95ef8fe2db84bba2b98e6fa21e.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT r.id, r.name, r.description, r.permissions\n        FROM roles r\n        JOIN user_roles ur ON ur.role_id = r.id\n        WHERE ur.user_id = $1\n        ORDER BY r.name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "permissions",
+        "type_info": "TextArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "629d46d34fdcb0800de0649fc384d95357df5b95ef8fe2db84bba2b98e6fa21e"
+}

--- a/backend/.sqlx/query-62e6284ff4d6d4c6b2a86d4d15d3a95d94f4f14f97da4eb55013dc532b4505e1.json
+++ b/backend/.sqlx/query-62e6284ff4d6d4c6b2a86d4d15d3a95d94f4f14f97da4eb55013dc532b4505e1.json
@@ -1,0 +1,113 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, artifact_id, requesting_peer_id, total_size, chunk_size,\n                total_chunks, completed_chunks, checksum_algo, artifact_checksum,\n                status as \"status: SyncStatus\",\n                error_message, created_at, started_at, completed_at\n            FROM transfer_sessions\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "requesting_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "total_size",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "chunk_size",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "total_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "completed_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_algo",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "artifact_checksum",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "status: SyncStatus",
+        "type_info": {
+          "Custom": {
+            "name": "sync_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 13,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "62e6284ff4d6d4c6b2a86d4d15d3a95d94f4f14f97da4eb55013dc532b4505e1"
+}

--- a/backend/.sqlx/query-6325ab25302c5990df434279bdeb6cb3fa7af11f12a2e86e35bcf080509dc97a.json
+++ b/backend/.sqlx/query-6325ab25302c5990df434279bdeb6cb3fa7af11f12a2e86e35bcf080509dc97a.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND name = $2 AND version = $3 AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "6325ab25302c5990df434279bdeb6cb3fa7af11f12a2e86e35bcf080509dc97a"
+}

--- a/backend/.sqlx/query-63b88b4203514f347ff72762b1aca675c401cbdfb0bab4a778e007d4504f1a63.json
+++ b/backend/.sqlx/query-63b88b4203514f347ff72762b1aca675c401cbdfb0bab4a778e007d4504f1a63.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT plugin_id FROM format_handlers WHERE format_key = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "63b88b4203514f347ff72762b1aca675c401cbdfb0bab4a778e007d4504f1a63"
+}

--- a/backend/.sqlx/query-63f0a9c776c96c58fb5e5a5aa76cb1b06bce4efb332b9a7028be6bcaeaef7b63.json
+++ b/backend/.sqlx/query-63f0a9c776c96c58fb5e5a5aa76cb1b06bce4efb332b9a7028be6bcaeaef7b63.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET last_login_at = NOW() WHERE id = $1 AND (last_login_at IS NULL OR last_login_at < NOW() - INTERVAL '5 minutes')",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "63f0a9c776c96c58fb5e5a5aa76cb1b06bce4efb332b9a7028be6bcaeaef7b63"
+}

--- a/backend/.sqlx/query-64d74040a9e44b58ab00adefefb8fe0562c29a5eced8db9e368f2dc379c6f869.json
+++ b/backend/.sqlx/query-64d74040a9e44b58ab00adefefb8fe0562c29a5eced8db9e368f2dc379c6f869.json
@@ -1,0 +1,139 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, name, version, display_name, description, author, homepage,\n            status as \"status: PluginStatus\",\n            plugin_type as \"plugin_type: PluginType\",\n            config_schema, installed_at, enabled_at\n        FROM plugins\n        WHERE ($1::plugin_status IS NULL OR status = $1)\n          AND ($2::plugin_type IS NULL OR plugin_type = $2)\n        ORDER BY display_name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "author",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "homepage",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "status: PluginStatus",
+        "type_info": {
+          "Custom": {
+            "name": "plugin_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "disabled",
+                "error"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "plugin_type: PluginType",
+        "type_info": {
+          "Custom": {
+            "name": "plugin_type",
+            "kind": {
+              "Enum": [
+                "format_handler",
+                "storage_backend",
+                "authentication",
+                "authorization",
+                "webhook",
+                "custom"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "config_schema",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "installed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "enabled_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "plugin_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "disabled",
+                "error"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "plugin_type",
+            "kind": {
+              "Enum": [
+                "format_handler",
+                "storage_backend",
+                "authentication",
+                "authorization",
+                "webhook",
+                "custom"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "64d74040a9e44b58ab00adefefb8fe0562c29a5eced8db9e368f2dc379c6f869"
+}

--- a/backend/.sqlx/query-657eabca7550243e0a64f264c0b549ca91c76bfb2f648034ca9972808294678f.json
+++ b/backend/.sqlx/query-657eabca7550243e0a64f264c0b549ca91c76bfb2f648034ca9972808294678f.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        UPDATE refresh_token_jti\n                        SET revoked_at = NOW()\n                        WHERE family_id = $1 AND revoked_at IS NULL\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "657eabca7550243e0a64f264c0b549ca91c76bfb2f648034ca9972808294678f"
+}

--- a/backend/.sqlx/query-65a62108487d5e65fead2d0afed251577a6f86ce8559d66fc3ee52f6acbfa834.json
+++ b/backend/.sqlx/query-65a62108487d5e65fead2d0afed251577a6f86ce8559d66fc3ee52f6acbfa834.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO signing_keys (id, repository_id, name, key_type, fingerprint, key_id,\n                public_key_pem, private_key_enc, algorithm, is_active, created_at)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, true, $10)\n            ON CONFLICT DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Bytea",
+        "Varchar",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "65a62108487d5e65fead2d0afed251577a6f86ce8559d66fc3ee52f6acbfa834"
+}

--- a/backend/.sqlx/query-65f5f75262df10e25cbf75173662cde46a4e0ba48bc341ef0ab1938506850d9d.json
+++ b/backend/.sqlx/query-65f5f75262df10e25cbf75173662cde46a4e0ba48bc341ef0ab1938506850d9d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM user_roles WHERE user_id = $1 AND role_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "65f5f75262df10e25cbf75173662cde46a4e0ba48bc341ef0ab1938506850d9d"
+}

--- a/backend/.sqlx/query-65fae74c91f118ebf48b6128d19f30a8d3c953c18eb81e0f9f9ff7beb11cc68d.json
+++ b/backend/.sqlx/query-65fae74c91f118ebf48b6128d19f30a8d3c953c18eb81e0f9f9ff7beb11cc68d.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO transfer_sessions\n                (artifact_id, requesting_peer_id, total_size, chunk_size, total_chunks,\n                 checksum_algo, artifact_checksum, status)\n            VALUES ($1, $2, $3, $4, $5, 'sha256', $6, 'pending')\n            ON CONFLICT (artifact_id, requesting_peer_id) DO UPDATE\n                SET status = 'pending', completed_chunks = 0,\n                    started_at = NULL, completed_at = NULL, error_message = NULL\n            RETURNING\n                id, artifact_id, requesting_peer_id, total_size, chunk_size,\n                total_chunks, completed_chunks, checksum_algo, artifact_checksum,\n                status as \"status: SyncStatus\",\n                error_message, created_at, started_at, completed_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "requesting_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "total_size",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "chunk_size",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "total_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "completed_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_algo",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "artifact_checksum",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "status: SyncStatus",
+        "type_info": {
+          "Custom": {
+            "name": "sync_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 13,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int8",
+        "Int4",
+        "Int4",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "65fae74c91f118ebf48b6128d19f30a8d3c953c18eb81e0f9f9ff7beb11cc68d"
+}

--- a/backend/.sqlx/query-6614b4b457098efe3024979fbd1d42a2ea3b123f1aa9b97d041fa3acac2273ea.json
+++ b/backend/.sqlx/query-6614b4b457098efe3024979fbd1d42a2ea3b123f1aa9b97d041fa3acac2273ea.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO repository_usage_ledger (repository_id) VALUES ($1) ON CONFLICT (repository_id) DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6614b4b457098efe3024979fbd1d42a2ea3b123f1aa9b97d041fa3acac2273ea"
+}

--- a/backend/.sqlx/query-6716ecce9edfc2a61421ecfdefd7158567e8b6b2eac0ac593d164d1210763653.json
+++ b/backend/.sqlx/query-6716ecce9edfc2a61421ecfdefd7158567e8b6b2eac0ac593d164d1210763653.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND name = $2 AND version = $3 AND path = $4 AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "6716ecce9edfc2a61421ecfdefd7158567e8b6b2eac0ac593d164d1210763653"
+}

--- a/backend/.sqlx/query-67977bf72b8fd610a941dda6fb924373e7542b7e80d7f7c0752b6a86ba786729.json
+++ b/backend/.sqlx/query-67977bf72b8fd610a941dda6fb924373e7542b7e80d7f7c0752b6a86ba786729.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.version as \"version?\", a.path, a.size_bytes,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = ANY($1::uuid[])\n          AND a.is_deleted = false\n          AND LOWER(a.name) = $2\n        ORDER BY a.created_at ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "version?",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "67977bf72b8fd610a941dda6fb924373e7542b7e80d7f7c0752b6a86ba786729"
+}

--- a/backend/.sqlx/query-67a4f0e5710f6e6ffa3784656a566dbc0b995574cf8121fd77d77c99f0c716bf.json
+++ b/backend/.sqlx/query-67a4f0e5710f6e6ffa3784656a566dbc0b995574cf8121fd77d77c99f0c716bf.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT manifest_digest, manifest_content_type FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manifest_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "manifest_content_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "67a4f0e5710f6e6ffa3784656a566dbc0b995574cf8121fd77d77c99f0c716bf"
+}

--- a/backend/.sqlx/query-6892ab019207ef45d06e6b918f3885cbbdf65373d2927597e20294d0175547a2.json
+++ b/backend/.sqlx/query-6892ab019207ef45d06e6b918f3885cbbdf65373d2927597e20294d0175547a2.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.name, a.version, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n        ORDER BY a.name, a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "6892ab019207ef45d06e6b918f3885cbbdf65373d2927597e20294d0175547a2"
+}

--- a/backend/.sqlx/query-698d15dbb26cf224b50897439de22464c380ae3cc84809da98753a63145c2ae6.json
+++ b/backend/.sqlx/query-698d15dbb26cf224b50897439de22464c380ae3cc84809da98753a63145c2ae6.json
@@ -1,0 +1,172 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, name, endpoint_url,\n                status as \"status: InstanceStatus\",\n                region, cache_size_bytes, cache_used_bytes,\n                last_heartbeat_at, last_sync_at, sync_filter,\n                max_bandwidth_bps, sync_window_start, sync_window_end,\n                sync_window_timezone, concurrent_transfers_limit,\n                active_transfers, backoff_until, consecutive_failures,\n                bytes_transferred_total, transfer_failures_total,\n                api_key, is_local,\n                created_at, updated_at\n            FROM peer_instances\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: InstanceStatus",
+        "type_info": {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "region",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "cache_size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "cache_used_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_heartbeat_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_sync_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "sync_filter",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "max_bandwidth_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "sync_window_start",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 12,
+        "name": "sync_window_end",
+        "type_info": "Time"
+      },
+      {
+        "ordinal": 13,
+        "name": "sync_window_timezone",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "concurrent_transfers_limit",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 15,
+        "name": "active_transfers",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "backoff_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "consecutive_failures",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 19,
+        "name": "transfer_failures_total",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 20,
+        "name": "api_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 21,
+        "name": "is_local",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 23,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "698d15dbb26cf224b50897439de22464c380ae3cc84809da98753a63145c2ae6"
+}

--- a/backend/.sqlx/query-6a7dc62642891299ae859427693db5ef5682368ae325e6e7ea33044ce85b50d2.json
+++ b/backend/.sqlx/query-6a7dc62642891299ae859427693db5ef5682368ae325e6e7ea33044ce85b50d2.json
@@ -1,0 +1,113 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, name, version, display_name, description, author, homepage,\n            status as \"status: PluginStatus\",\n            plugin_type as \"plugin_type: PluginType\",\n            config_schema, installed_at, enabled_at\n        FROM plugins\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "author",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "homepage",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "status: PluginStatus",
+        "type_info": {
+          "Custom": {
+            "name": "plugin_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "disabled",
+                "error"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 8,
+        "name": "plugin_type: PluginType",
+        "type_info": {
+          "Custom": {
+            "name": "plugin_type",
+            "kind": {
+              "Enum": [
+                "format_handler",
+                "storage_backend",
+                "authentication",
+                "authorization",
+                "webhook",
+                "custom"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 9,
+        "name": "config_schema",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "installed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "enabled_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false,
+      true
+    ]
+  },
+  "hash": "6a7dc62642891299ae859427693db5ef5682368ae325e6e7ea33044ce85b50d2"
+}

--- a/backend/.sqlx/query-6b4311148d7911b5a3983b44a20af6aeaa70952cf43722b2c982d4c75261180d.json
+++ b/backend/.sqlx/query-6b4311148d7911b5a3983b44a20af6aeaa70952cf43722b2c982d4c75261180d.json
@@ -1,0 +1,122 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            FROM artifacts\n            WHERE repository_id = $1\n              AND is_deleted = false\n              AND ($2::text IS NULL OR path LIKE $2)\n              AND ($5::text IS NULL OR LOWER(name) LIKE $5 OR LOWER(path) LIKE $5)\n            ORDER BY path\n            OFFSET $3\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8",
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6b4311148d7911b5a3983b44a20af6aeaa70952cf43722b2c982d4c75261180d"
+}

--- a/backend/.sqlx/query-6bf5f9d4cf1d2ac56f678839c813d886c0b3bf09bf7570fa792fe3865e23de2f.json
+++ b/backend/.sqlx/query-6bf5f9d4cf1d2ac56f678839c813d886c0b3bf09bf7570fa792fe3865e23de2f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET is_admin = COALESCE($2, is_admin), privileges_changed_at = CASE WHEN $3 THEN NOW() ELSE privileges_changed_at END, updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6bf5f9d4cf1d2ac56f678839c813d886c0b3bf09bf7570fa792fe3865e23de2f"
+}

--- a/backend/.sqlx/query-6c785686c4341c7b82301f224828312ac31985000ddb0f498710102b0bd27c4b.json
+++ b/backend/.sqlx/query-6c785686c4341c7b82301f224828312ac31985000ddb0f498710102b0bd27c4b.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n              FROM artifacts\n             WHERE repository_id = $1 AND path = $2 AND is_deleted = false\n               AND storage_key NOT LIKE 'proxy-cache/%'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "6c785686c4341c7b82301f224828312ac31985000ddb0f498710102b0bd27c4b"
+}

--- a/backend/.sqlx/query-6cb1106c2314ccd4f75f47fa62cd92610caab2d0c31b11c85b0c05e8f1c341d2.json
+++ b/backend/.sqlx/query-6cb1106c2314ccd4f75f47fa62cd92610caab2d0c31b11c85b0c05e8f1c341d2.json
@@ -1,0 +1,166 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO users (id, username, email, display_name, auth_provider, external_id, is_admin, is_active, is_service_account)\n            VALUES ($1, $2, $3, $4, 'saml', $5, $6, true, false)\n            RETURNING\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "6cb1106c2314ccd4f75f47fa62cd92610caab2d0c31b11c85b0c05e8f1c341d2"
+}

--- a/backend/.sqlx/query-6cbf81c08dd3a2e908bfad37abff5f8497c854a61eaedb2374d2968dd220ced7.json
+++ b/backend/.sqlx/query-6cbf81c08dd3a2e908bfad37abff5f8497c854a61eaedb2374d2968dd220ced7.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'revision' as \"revision?\",\n               MAX(a.created_at) as \"created_at!\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' IS NOT NULL\n        GROUP BY am.metadata->>'revision'\n        ORDER BY \"created_at!\" DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "revision?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "6cbf81c08dd3a2e908bfad37abff5f8497c854a61eaedb2374d2968dd220ced7"
+}

--- a/backend/.sqlx/query-6d966a3fcdaf15f67eef3f9389b5f056bdf04c218ff0dce69097024d1598b3d4.json
+++ b/backend/.sqlx/query-6d966a3fcdaf15f67eef3f9389b5f056bdf04c218ff0dce69097024d1598b3d4.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, repository_id, path, storage_key, size_bytes,\n               checksum_sha256, content_type\n        FROM proxy_cache_artifacts\n        WHERE repository_id = $1\n          AND ($2::TEXT IS NULL OR path > $2)\n        ORDER BY path\n        LIMIT $3\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_key",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "content_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "6d966a3fcdaf15f67eef3f9389b5f056bdf04c218ff0dce69097024d1598b3d4"
+}

--- a/backend/.sqlx/query-6db7a6f9501ef2bbe33c838c8a7f455a059dcbd600a51a023f08f9fa68e7e09c.json
+++ b/backend/.sqlx/query-6db7a6f9501ef2bbe33c838c8a7f455a059dcbd600a51a023f08f9fa68e7e09c.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO artifacts (\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, uploaded_by\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Bpchar",
+        "Bpchar",
+        "Bpchar",
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6db7a6f9501ef2bbe33c838c8a7f455a059dcbd600a51a023f08f9fa68e7e09c"
+}

--- a/backend/.sqlx/query-6fba916b7e920527469eeb1a860d6e422dc31ba9c5365cf1d1411c316cc34419.json
+++ b/backend/.sqlx/query-6fba916b7e920527469eeb1a860d6e422dc31ba9c5365cf1d1411c316cc34419.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes, checksum_sha256\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "6fba916b7e920527469eeb1a860d6e422dc31ba9c5365cf1d1411c316cc34419"
+}

--- a/backend/.sqlx/query-6ffe0139e3df5e2b6855bb9856b1516852905475e0b3bd62ef257da8e33b06db.json
+++ b/backend/.sqlx/query-6ffe0139e3df5e2b6855bb9856b1516852905475e0b3bd62ef257da8e33b06db.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'hex', $2)\n        ON CONFLICT (artifact_id)\n        DO UPDATE SET metadata = artifact_metadata.metadata || $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6ffe0139e3df5e2b6855bb9856b1516852905475e0b3bd62ef257da8e33b06db"
+}

--- a/backend/.sqlx/query-702704111bc56b9d520afc10b6127193ca8bd8cb607ec2c89cac4070539f611a.json
+++ b/backend/.sqlx/query-702704111bc56b9d520afc10b6127193ca8bd8cb607ec2c89cac4070539f611a.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT repository_id, checksum_sha256\n            FROM artifacts\n            WHERE id = $1 AND is_deleted = false\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "702704111bc56b9d520afc10b6127193ca8bd8cb607ec2c89cac4070539f611a"
+}

--- a/backend/.sqlx/query-704d96cf5be06f974efe55dc336293953e35329363ab069af1dc4fe292577fe4.json
+++ b/backend/.sqlx/query-704d96cf5be06f974efe55dc336293953e35329363ab069af1dc4fe292577fe4.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM signing_keys WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "704d96cf5be06f974efe55dc336293953e35329363ab069af1dc4fe292577fe4"
+}

--- a/backend/.sqlx/query-70b24180f3d16163ec0aa9a692ea92725454eb484c2f4934186c6f6d95917866.json
+++ b/backend/.sqlx/query-70b24180f3d16163ec0aa9a692ea92725454eb484c2f4934186c6f6d95917866.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO backups (backup_type, storage_path, created_by, metadata)\n            VALUES ($1, $2, $3, $4)\n            RETURNING\n                id, backup_type as \"backup_type: BackupType\",\n                status as \"status: BackupStatus\",\n                storage_path, size_bytes, artifact_count,\n                started_at, completed_at, error_message,\n                metadata, created_by, created_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "backup_type: BackupType",
+        "type_info": {
+          "Custom": {
+            "name": "backup_type",
+            "kind": {
+              "Enum": [
+                "full",
+                "incremental",
+                "metadata_only",
+                "metadata"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "status: BackupStatus",
+        "type_info": {
+          "Custom": {
+            "name": "backup_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "artifact_count",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "backup_type",
+            "kind": {
+              "Enum": [
+                "full",
+                "incremental",
+                "metadata_only",
+                "metadata"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "70b24180f3d16163ec0aa9a692ea92725454eb484c2f4934186c6f6d95917866"
+}

--- a/backend/.sqlx/query-71b615195ddb2200f85608587098abc38aaa768ff0b85a92ac790a3c17ab1d3b.json
+++ b/backend/.sqlx/query-71b615195ddb2200f85608587098abc38aaa768ff0b85a92ac790a3c17ab1d3b.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_findings (scan_result_id, artifact_id, severity, title,\n                description, cve_id, affected_component, affected_version, fixed_version,\n                source, source_url)\n            SELECT $1, $2, severity, title, description,\n                   cve_id, affected_component, affected_version, fixed_version,\n                   source, source_url\n            FROM UNNEST(\n                $3::text[],\n                $4::text[],\n                $5::text[],\n                $6::text[],\n                $7::text[],\n                $8::text[],\n                $9::text[],\n                $10::text[],\n                $11::text[]\n            ) AS t(severity, title, description, cve_id, affected_component,\n                   affected_version, fixed_version, source, source_url)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "71b615195ddb2200f85608587098abc38aaa768ff0b85a92ac790a3c17ab1d3b"
+}

--- a/backend/.sqlx/query-71f2f62eeeeb9cdf367d3d874d76270b7ae6b6bd017660d138bfe1a0f6260949.json
+++ b/backend/.sqlx/query-71f2f62eeeeb9cdf367d3d874d76270b7ae6b6bd017660d138bfe1a0f6260949.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT a.version, a.path\n            FROM artifacts a\n            LEFT JOIN age_gate_reviews r\n              ON r.repository_id = a.repository_id\n             AND r.package_name = $2\n             AND r.package_version = a.version\n            WHERE a.repository_id = $1\n              AND a.is_deleted = false\n              AND a.version IS NOT NULL\n              AND a.version <> $3\n              AND LOWER(a.name) = LOWER($2)\n              AND (r.status IS NULL OR r.status = 'approved')\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "71f2f62eeeeb9cdf367d3d874d76270b7ae6b6bd017660d138bfe1a0f6260949"
+}

--- a/backend/.sqlx/query-72a7b01f67ed619686b6a64610ed3a87f89a13c106a89602fa428b8c11b606fe.json
+++ b/backend/.sqlx/query-72a7b01f67ed619686b6a64610ed3a87f89a13c106a89602fa428b8c11b606fe.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM plugins WHERE id = $1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "72a7b01f67ed619686b6a64610ed3a87f89a13c106a89602fa428b8c11b606fe"
+}

--- a/backend/.sqlx/query-72ac0d36aecef4b4deda1a79137587aea7a24ab66c488162ac9c2e2f6d278b29.json
+++ b/backend/.sqlx/query-72ac0d36aecef4b4deda1a79137587aea7a24ab66c488162ac9c2e2f6d278b29.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT a.name, a.version,\n               a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n        ORDER BY a.name, a.version\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "72ac0d36aecef4b4deda1a79137587aea7a24ab66c488162ac9c2e2f6d278b29"
+}

--- a/backend/.sqlx/query-7341e2eb7cfde437182fb89cb9881700b6f29c9b051d7c98e74db37d6ec1eb8e.json
+++ b/backend/.sqlx/query-7341e2eb7cfde437182fb89cb9881700b6f29c9b051d7c98e74db37d6ec1eb8e.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.created_at,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(REPLACE(REPLACE(REPLACE(a.name, '_', '-'), '.', '-'), '--', '-')) = $2\n        ORDER BY a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7341e2eb7cfde437182fb89cb9881700b6f29c9b051d7c98e74db37d6ec1eb8e"
+}

--- a/backend/.sqlx/query-736068016a97784e01e35f8bd21d329453c3b05f021b86489255325d1b26906a.json
+++ b/backend/.sqlx/query-736068016a97784e01e35f8bd21d329453c3b05f021b86489255325d1b26906a.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, webhook_id, event, payload\n        FROM webhook_deliveries\n        WHERE id = $1 AND webhook_id = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "webhook_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "payload",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "736068016a97784e01e35f8bd21d329453c3b05f021b86489255325d1b26906a"
+}

--- a/backend/.sqlx/query-73ea0f5365a96ebed365172f11038662dc165930bf6dc78c89c6c7cf094d3336.json
+++ b/backend/.sqlx/query-73ea0f5365a96ebed365172f11038662dc165930bf6dc78c89c6c7cf094d3336.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT size_bytes, content_type\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "content_type",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "73ea0f5365a96ebed365172f11038662dc165930bf6dc78c89c6c7cf094d3336"
+}

--- a/backend/.sqlx/query-7437aa5f83fa8ac03d71aa130b1aa77dc3d86978e72511f9812ba0b22f82ec94.json
+++ b/backend/.sqlx/query-7437aa5f83fa8ac03d71aa130b1aa77dc3d86978e72511f9812ba0b22f82ec94.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, name, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE $2 ESCAPE '\\'\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7437aa5f83fa8ac03d71aa130b1aa77dc3d86978e72511f9812ba0b22f82ec94"
+}

--- a/backend/.sqlx/query-745d72fa593b6985f9de7093b486941ba5ea0e87522184a392410abcd2c2d987.json
+++ b/backend/.sqlx/query-745d72fa593b6985f9de7093b486941ba5ea0e87522184a392410abcd2c2d987.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT prs.repository_id\n            FROM peer_repo_subscriptions prs\n            JOIN repositories r ON r.id = prs.repository_id\n            WHERE prs.peer_instance_id = $1\n              AND prs.sync_enabled = true\n              AND prs.replication_mode = 'push'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "745d72fa593b6985f9de7093b486941ba5ea0e87522184a392410abcd2c2d987"
+}

--- a/backend/.sqlx/query-74e63b526f5884533e30283239cb311cbab0386748fe0e88e3d8d6f9677d1d98.json
+++ b/backend/.sqlx/query-74e63b526f5884533e30283239cb311cbab0386748fe0e88e3d8d6f9677d1d98.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            FROM artifacts\n            WHERE checksum_sha256 = $1 AND is_deleted = false\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "74e63b526f5884533e30283239cb311cbab0386748fe0e88e3d8d6f9677d1d98"
+}

--- a/backend/.sqlx/query-762e014a2441492256a70ca910a1e865d11a76990e0c3211747ca100d410a8fe.json
+++ b/backend/.sqlx/query-762e014a2441492256a70ca910a1e865d11a76990e0c3211747ca100d410a8fe.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM artifacts WHERE repository_id = $1 AND path = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "762e014a2441492256a70ca910a1e865d11a76990e0c3211747ca100d410a8fe"
+}

--- a/backend/.sqlx/query-76967ce842e4eb1a45636e3344f10320a959d3da01b56d3599af2adbfe7ee3eb.json
+++ b/backend/.sqlx/query-76967ce842e4eb1a45636e3344f10320a959d3da01b56d3599af2adbfe7ee3eb.json
@@ -1,0 +1,113 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, artifact_id, requesting_peer_id, total_size, chunk_size,\n                total_chunks, completed_chunks, checksum_algo, artifact_checksum,\n                status as \"status: SyncStatus\",\n                error_message, created_at, started_at, completed_at\n            FROM transfer_sessions\n            WHERE requesting_peer_id = $1 AND status IN ('pending', 'in_progress')\n            ORDER BY created_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "requesting_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "total_size",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "chunk_size",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "total_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "completed_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_algo",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "artifact_checksum",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "status: SyncStatus",
+        "type_info": {
+          "Custom": {
+            "name": "sync_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 10,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 13,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "76967ce842e4eb1a45636e3344f10320a959d3da01b56d3599af2adbfe7ee3eb"
+}

--- a/backend/.sqlx/query-77b8123fbc8a213d7249ef1b7e934f0e31c8a6c9388674b3019943da7bacd75a.json
+++ b/backend/.sqlx/query-77b8123fbc8a213d7249ef1b7e934f0e31c8a6c9388674b3019943da7bacd75a.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                chunk_index, byte_offset, byte_length, checksum,\n                status as \"status!: String\",\n                source_peer_id\n            FROM transfer_chunks\n            WHERE session_id = $1\n            ORDER BY chunk_index\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "chunk_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "byte_offset",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "byte_length",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status!: String",
+        "type_info": {
+          "Custom": {
+            "name": "sync_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "source_peer_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "77b8123fbc8a213d7249ef1b7e934f0e31c8a6c9388674b3019943da7bacd75a"
+}

--- a/backend/.sqlx/query-78c759c40a5c20d9f330cc953fcacd8d6e0e8df8d119a0f4c748adfde5f378e7.json
+++ b/backend/.sqlx/query-78c759c40a5c20d9f330cc953fcacd8d6e0e8df8d119a0f4c748adfde5f378e7.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT checksum_sha256, version FROM artifacts WHERE repository_id = $1 AND path = $2 AND is_deleted = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "78c759c40a5c20d9f330cc953fcacd8d6e0e8df8d119a0f4c748adfde5f378e7"
+}

--- a/backend/.sqlx/query-7967e163d2ac530dc4f471621380143cb9d9b80d5c8775a5d1d9ffff3e905e0d.json
+++ b/backend/.sqlx/query-7967e163d2ac530dc4f471621380143cb9d9b80d5c8775a5d1d9ffff3e905e0d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE repository_storage_stats\n               SET logical_bytes = 0, physical_bytes = 0, unique_bytes = 0,\n                   shared_bytes = 0, blob_count = 0, dedup_scope = $2,\n                   computed_at = now()\n             WHERE repository_id <> ALL($1)\n               AND (logical_bytes <> 0 OR physical_bytes <> 0 OR blob_count <> 0)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7967e163d2ac530dc4f471621380143cb9d9b80d5c8775a5d1d9ffff3e905e0d"
+}

--- a/backend/.sqlx/query-79a5e64af53bbb79a3e8bbc99f29719a674cb59a33ea69e08d0b87abbb9d9f9e.json
+++ b/backend/.sqlx/query-79a5e64af53bbb79a3e8bbc99f29719a674cb59a33ea69e08d0b87abbb9d9f9e.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM repositories",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "79a5e64af53bbb79a3e8bbc99f29719a674cb59a33ea69e08d0b87abbb9d9f9e"
+}

--- a/backend/.sqlx/query-79aad8b5d9c0640fd982399f030014d668b7ec2358262c9f1e022645decf54b2.json
+++ b/backend/.sqlx/query-79aad8b5d9c0640fd982399f030014d668b7ec2358262c9f1e022645decf54b2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE age_gate_reviews\n            SET status = 'approved', reviewed_by = NULL, reviewed_at = NOW(),\n                review_reason = $2\n            WHERE id = $1 AND status = 'pending'\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "79aad8b5d9c0640fd982399f030014d668b7ec2358262c9f1e022645decf54b2"
+}

--- a/backend/.sqlx/query-7a03b0be9550f585130f4cb8a69bac27ab681a0626352dd303387d1e76cff312.json
+++ b/backend/.sqlx/query-7a03b0be9550f585130f4cb8a69bac27ab681a0626352dd303387d1e76cff312.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_packages (scan_result_id, artifact_id, name,\n                version, purl, license, source_target)\n            SELECT $1, $2, name, version, purl, license, source_target\n            FROM UNNEST(\n                $3::text[],\n                $4::text[],\n                $5::text[],\n                $6::text[],\n                $7::text[]\n            ) AS t(name, version, purl, license, source_target)\n            ON CONFLICT (scan_result_id, name, COALESCE(version, ''))\n                DO UPDATE SET\n                    purl = COALESCE(scan_packages.purl, EXCLUDED.purl),\n                    license = COALESCE(scan_packages.license, EXCLUDED.license),\n                    source_target = COALESCE(scan_packages.source_target,\n                                             EXCLUDED.source_target)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray",
+        "TextArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7a03b0be9550f585130f4cb8a69bac27ab681a0626352dd303387d1e76cff312"
+}

--- a/backend/.sqlx/query-7a8b34de28a9507969fb062574dd08babcf97e0271fe1c622b4207e5cfd43bb4.json
+++ b/backend/.sqlx/query-7a8b34de28a9507969fb062574dd08babcf97e0271fe1c622b4207e5cfd43bb4.json
@@ -1,0 +1,92 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, score, grade, total_findings,\n                   critical_count, high_count, medium_count, low_count,\n                   acknowledged_count, last_scan_at, has_failed_scan, calculated_at\n            FROM repo_security_scores\n            ORDER BY score ASC, critical_count DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "score",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "grade",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "total_findings",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "acknowledged_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "last_scan_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "has_failed_scan",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "calculated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "7a8b34de28a9507969fb062574dd08babcf97e0271fe1c622b4207e5cfd43bb4"
+}

--- a/backend/.sqlx/query-7b09d221ec6cbe157f282f32c3d8fbf828e5ee2c5f133a6a848301db57c52ec4.json
+++ b/backend/.sqlx/query-7b09d221ec6cbe157f282f32c3d8fbf828e5ee2c5f133a6a848301db57c52ec4.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_results\n            SET status = 'completed', findings_count = $2,\n                critical_count = $3, high_count = $4, medium_count = $5,\n                low_count = $6, info_count = $7, completed_at = NOW(),\n                scanner_version = COALESCE($8, scanner_version),\n                started_at = $9,\n                scan_completeness = $10\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Varchar",
+        "Timestamptz",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7b09d221ec6cbe157f282f32c3d8fbf828e5ee2c5f133a6a848301db57c52ec4"
+}

--- a/backend/.sqlx/query-7b5bceef529eeca4b64b9c989349065f01c6e20aba1b8b48f5546e03375d90a7.json
+++ b/backend/.sqlx/query-7b5bceef529eeca4b64b9c989349065f01c6e20aba1b8b48f5546e03375d90a7.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO user_roles (user_id, role_id)\n        VALUES ($1, $2)\n        ON CONFLICT DO NOTHING\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7b5bceef529eeca4b64b9c989349065f01c6e20aba1b8b48f5546e03375d90a7"
+}

--- a/backend/.sqlx/query-7b6a7bda4d3ffdcde532e53ce859903941ed4638d382c48a1d1d976ebbaa4e3a.json
+++ b/backend/.sqlx/query-7b6a7bda4d3ffdcde532e53ce859903941ed4638d382c48a1d1d976ebbaa4e3a.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT a.name\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.metadata->>'repository_url' = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "7b6a7bda4d3ffdcde532e53ce859903941ed4638d382c48a1d1d976ebbaa4e3a"
+}

--- a/backend/.sqlx/query-7b71a0287bbcb5e83ebc130f04496a9d2d27ec78aecf221142af51ad455b0f16.json
+++ b/backend/.sqlx/query-7b71a0287bbcb5e83ebc130f04496a9d2d27ec78aecf221142af51ad455b0f16.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, storage_key, size_bytes, content_type\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "content_type",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "7b71a0287bbcb5e83ebc130f04496a9d2d27ec78aecf221142af51ad455b0f16"
+}

--- a/backend/.sqlx/query-7c129990f94073c8862befddc5472dff4797bef3fe4f57dcb868ddb7b388d5c6.json
+++ b/backend/.sqlx/query-7c129990f94073c8862befddc5472dff4797bef3fe4f57dcb868ddb7b388d5c6.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'conda', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7c129990f94073c8862befddc5472dff4797bef3fe4f57dcb868ddb7b388d5c6"
+}

--- a/backend/.sqlx/query-7ce43cf4b38cd3082888861cda7afc836eeaf9c674e408bf66cab1eeee25d648.json
+++ b/backend/.sqlx/query-7ce43cf4b38cd3082888861cda7afc836eeaf9c674e408bf66cab1eeee25d648.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE users\n                SET email = $1, display_name = $2, is_admin = $3,\n                    last_login_at = NOW(), updated_at = NOW()\n                WHERE id = $4\n                  AND (\n                    email IS DISTINCT FROM $1\n                    OR display_name IS DISTINCT FROM $2\n                    OR is_admin IS DISTINCT FROM $3\n                    OR last_login_at IS NULL\n                    OR last_login_at < NOW() - INTERVAL '5 minutes'\n                  )\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Bool",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7ce43cf4b38cd3082888861cda7afc836eeaf9c674e408bf66cab1eeee25d648"
+}

--- a/backend/.sqlx/query-7dbb6a35fc050a163e128e67ad87f72857d732e411dab2df85a64fa7f8108bd5.json
+++ b/backend/.sqlx/query-7dbb6a35fc050a163e128e67ad87f72857d732e411dab2df85a64fa7f8108bd5.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE repositories\n            SET age_gate_enabled = $2, age_gate_min_age_days = $3, updated_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7dbb6a35fc050a163e128e67ad87f72857d732e411dab2df85a64fa7f8108bd5"
+}

--- a/backend/.sqlx/query-7dd68d1e4ae37e5268b1c32264599068d509f11b96c4c0c5fd346941499138ba.json
+++ b/backend/.sqlx/query-7dd68d1e4ae37e5268b1c32264599068d509f11b96c4c0c5fd346941499138ba.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE repository_signing_config SET signing_key_id = $1, updated_at = NOW() WHERE repository_id = $2 AND signing_key_id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7dd68d1e4ae37e5268b1c32264599068d509f11b96c4c0c5fd346941499138ba"
+}

--- a/backend/.sqlx/query-7f95cafc72ac6fddfb1fe04435c8e1a395600557cd93f22f39de662e9e503f6e.json
+++ b/backend/.sqlx/query-7f95cafc72ac6fddfb1fe04435c8e1a395600557cd93f22f39de662e9e503f6e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'jetbrains', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "7f95cafc72ac6fddfb1fe04435c8e1a395600557cd93f22f39de662e9e503f6e"
+}

--- a/backend/.sqlx/query-8094614706a939e98d6116d06c1a528189206007f9b996a748dcc9623628a587.json
+++ b/backend/.sqlx/query-8094614706a939e98d6116d06c1a528189206007f9b996a748dcc9623628a587.json
@@ -1,0 +1,165 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE users\n                SET\n                    username = $2,\n                    email = $3,\n                    display_name = $4,\n                    is_admin = COALESCE($5, is_admin),\n                    is_active = true,\n                    updated_at = NOW()\n                WHERE id = $1\n                RETURNING\n                    id, username, email, password_hash, display_name,\n                    auth_provider as \"auth_provider: AuthProvider\",\n                    external_id, is_admin, is_active, is_service_account, must_change_password,\n                    totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                    failed_login_attempts, locked_until, last_failed_login_at,\n                    password_changed_at, last_login_at, created_at, updated_at\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "8094614706a939e98d6116d06c1a528189206007f9b996a748dcc9623628a587"
+}

--- a/backend/.sqlx/query-80b5ae80e1d6188f9e970af99cb5414a666bbada2270916640a27d4676585e0f.json
+++ b/backend/.sqlx/query-80b5ae80e1d6188f9e970af99cb5414a666bbada2270916640a27d4676585e0f.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT totp_secret FROM users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "totp_secret",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "80b5ae80e1d6188f9e970af99cb5414a666bbada2270916640a27d4676585e0f"
+}

--- a/backend/.sqlx/query-80c785a598ca81d03d2bd1feb08ad3aa47a5632c0eba01c41a1c1de451c2bd64.json
+++ b/backend/.sqlx/query-80c785a598ca81d03d2bd1feb08ad3aa47a5632c0eba01c41a1c1de451c2bd64.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT auth_provider as \"auth_provider: AuthProvider\"\n            FROM users\n            WHERE username = $1 AND is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "80c785a598ca81d03d2bd1feb08ad3aa47a5632c0eba01c41a1c1de451c2bd64"
+}

--- a/backend/.sqlx/query-816900dcb8d9ebb76cccb63ad65d4291e0bfd4e26f0b88a00bc66e5efba1aeb2.json
+++ b/backend/.sqlx/query-816900dcb8d9ebb76cccb63ad65d4291e0bfd4e26f0b88a00bc66e5efba1aeb2.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO promotion_history (\n            id, artifact_id, source_repo_id, target_repo_id,\n            promoted_by, policy_result, notes\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Jsonb",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "816900dcb8d9ebb76cccb63ad65d4291e0bfd4e26f0b88a00bc66e5efba1aeb2"
+}

--- a/backend/.sqlx/query-82472aef24ab4890a08aabd31cd214e7563465f0f4ea4c0586cf3194094cd5bb.json
+++ b/backend/.sqlx/query-82472aef24ab4890a08aabd31cd214e7563465f0f4ea4c0586cf3194094cd5bb.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT size_bytes, storage_key FROM oci_blobs WHERE repository_id = $1 AND digest = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "82472aef24ab4890a08aabd31cd214e7563465f0f4ea4c0586cf3194094cd5bb"
+}

--- a/backend/.sqlx/query-826876770a727889a8e9e9a8a5fa701db10c729936e4779b00210f835daeb6eb.json
+++ b/backend/.sqlx/query-826876770a727889a8e9e9a8a5fa701db10c729936e4779b00210f835daeb6eb.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO artifact_metadata (artifact_id, format, metadata, properties)\n            VALUES ($1, $2, $3, $4)\n            ON CONFLICT (artifact_id) DO UPDATE SET\n                format = EXCLUDED.format,\n                metadata = EXCLUDED.metadata,\n                properties = EXCLUDED.properties\n            RETURNING id, artifact_id, format, metadata, properties\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "format",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Jsonb",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "826876770a727889a8e9e9a8a5fa701db10c729936e4779b00210f835daeb6eb"
+}

--- a/backend/.sqlx/query-8321d2faee6323bc351edfc1a15f3d62212d919c37e85ebf3293d2cebb6eb89f.json
+++ b/backend/.sqlx/query-8321d2faee6323bc351edfc1a15f3d62212d919c37e85ebf3293d2cebb6eb89f.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM signing_keys WHERE repository_id = $1 ORDER BY created_at DESC",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "key_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "fingerprint",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "key_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "public_key_pem",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "private_key_enc",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 8,
+        "name": "algorithm",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "uid_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "uid_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "rotated_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "8321d2faee6323bc351edfc1a15f3d62212d919c37e85ebf3293d2cebb6eb89f"
+}

--- a/backend/.sqlx/query-847683a32c89c2c81f5e08a605be8c5a857ff44c17547ef0340dfc7c863d237f.json
+++ b/backend/.sqlx/query-847683a32c89c2c81f5e08a605be8c5a857ff44c17547ef0340dfc7c863d237f.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO artifact_metadata (artifact_id, format, metadata)\n            VALUES ($1, 'alpine', $2)\n            ON CONFLICT (artifact_id)\n            DO UPDATE SET metadata = artifact_metadata.metadata || $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "847683a32c89c2c81f5e08a605be8c5a857ff44c17547ef0340dfc7c863d237f"
+}

--- a/backend/.sqlx/query-86b1d9930d209c103cf51d0a8f16a2782f3725a44f25e47358f7b824b5b7c807.json
+++ b/backend/.sqlx/query-86b1d9930d209c103cf51d0a8f16a2782f3725a44f25e47358f7b824b5b7c807.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scopes FROM api_tokens WHERE token_prefix = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scopes",
+        "type_info": "VarcharArray"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "86b1d9930d209c103cf51d0a8f16a2782f3725a44f25e47358f7b824b5b7c807"
+}

--- a/backend/.sqlx/query-86bcd2a00a72a469e0457f7ac538fc774844e2c6534dfe56924f9f8a162f3b50.json
+++ b/backend/.sqlx/query-86bcd2a00a72a469e0457f7ac538fc774844e2c6534dfe56924f9f8a162f3b50.json
@@ -1,0 +1,113 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, backup_type as \"backup_type: BackupType\",\n                status as \"status: BackupStatus\",\n                storage_path, size_bytes, artifact_count,\n                started_at, completed_at, error_message,\n                metadata, created_by, created_at\n            FROM backups\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "backup_type: BackupType",
+        "type_info": {
+          "Custom": {
+            "name": "backup_type",
+            "kind": {
+              "Enum": [
+                "full",
+                "incremental",
+                "metadata_only",
+                "metadata"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "status: BackupStatus",
+        "type_info": {
+          "Custom": {
+            "name": "backup_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "artifact_count",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "86bcd2a00a72a469e0457f7ac538fc774844e2c6534dfe56924f9f8a162f3b50"
+}

--- a/backend/.sqlx/query-879dfe51645b1ed5a6705c1d127abdb6800c8267f86dee4d8a7eca2041212d5b.json
+++ b/backend/.sqlx/query-879dfe51645b1ed5a6705c1d127abdb6800c8267f86dee4d8a7eca2041212d5b.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT unique_bytes FROM instance_storage_stats WHERE id = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "unique_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "879dfe51645b1ed5a6705c1d127abdb6800c8267f86dee4d8a7eca2041212d5b"
+}

--- a/backend/.sqlx/query-87a2d66a7d76cb4cca35cede1822ad1cba8a63d4b9af44428ddd805ac9c8fed1.json
+++ b/backend/.sqlx/query-87a2d66a7d76cb4cca35cede1822ad1cba8a63d4b9af44428ddd805ac9c8fed1.json
@@ -1,0 +1,102 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                st.id, st.peer_instance_id, st.artifact_id,\n                st.status as \"status: SyncStatus\",\n                st.priority, st.bytes_transferred, st.error_message,\n                st.started_at, st.completed_at, st.created_at,\n                a.storage_key, a.size_bytes as artifact_size\n            FROM sync_tasks st\n            JOIN artifacts a ON a.id = st.artifact_id\n            WHERE st.peer_instance_id = $1\n              AND st.status = 'pending'\n            ORDER BY st.priority DESC, st.created_at\n            LIMIT $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "peer_instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: SyncStatus",
+        "type_info": {
+          "Custom": {
+            "name": "sync_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "bytes_transferred",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "artifact_size",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "87a2d66a7d76cb4cca35cede1822ad1cba8a63d4b9af44428ddd805ac9c8fed1"
+}

--- a/backend/.sqlx/query-889df665f807e2b2ce87d61ca9303d80d8a2d9833db36ab7dc3b569852be07e9.json
+++ b/backend/.sqlx/query-889df665f807e2b2ce87d61ca9303d80d8a2d9833db36ab7dc3b569852be07e9.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM download_statistics WHERE artifact_id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "889df665f807e2b2ce87d61ca9303d80d8a2d9833db36ab7dc3b569852be07e9"
+}

--- a/backend/.sqlx/query-8913ef9bf47d05f10a6a84e399a2efd110e6ea96bd082bf74332232e8d93371e.json
+++ b/backend/.sqlx/query-8913ef9bf47d05f10a6a84e399a2efd110e6ea96bd082bf74332232e8d93371e.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE artifacts SET is_deleted = true, updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8913ef9bf47d05f10a6a84e399a2efd110e6ea96bd082bf74332232e8d93371e"
+}

--- a/backend/.sqlx/query-8ba9bece0a883fb927a2d9eabdc99d9b95708271545eac2e0c18821249d51fa3.json
+++ b/backend/.sqlx/query-8ba9bece0a883fb927a2d9eabdc99d9b95708271545eac2e0c18821249d51fa3.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'chef', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8ba9bece0a883fb927a2d9eabdc99d9b95708271545eac2e0c18821249d51fa3"
+}

--- a/backend/.sqlx/query-8d2aa0c023a10b56cb38adfbc590365e12bb6e0a1476759a2cd6c43bd2cab939.json
+++ b/backend/.sqlx/query-8d2aa0c023a10b56cb38adfbc590365e12bb6e0a1476759a2cd6c43bd2cab939.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE external_id = $1 AND auth_provider = 'ldap'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "8d2aa0c023a10b56cb38adfbc590365e12bb6e0a1476759a2cd6c43bd2cab939"
+}

--- a/backend/.sqlx/query-8d7899e89c5a216e8ef327e99db43a67b6f8ddede271d7563b2a3bea8823d776.json
+++ b/backend/.sqlx/query-8d7899e89c5a216e8ef327e99db43a67b6f8ddede271d7563b2a3bea8823d776.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(hosted_bytes + proxy_bytes + oci_bytes, 0)::BIGINT as \"t!\"\n                     FROM repository_usage_ledger WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "t!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "8d7899e89c5a216e8ef327e99db43a67b6f8ddede271d7563b2a3bea8823d776"
+}

--- a/backend/.sqlx/query-8d94112016a55e4ba7a2c0130aa32908e56298f48256d2d85f4e7e27accef983.json
+++ b/backend/.sqlx/query-8d94112016a55e4ba7a2c0130aa32908e56298f48256d2d85f4e7e27accef983.json
@@ -1,0 +1,250 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            r.id, r.key, r.name, r.description,\n            r.format as \"format: RepositoryFormat\",\n            r.repo_type as \"repo_type: RepositoryType\",\n            r.storage_backend, r.storage_path, r.upstream_url,\n            r.is_public, r.quota_bytes, r.promotion_only,\n            r.replication_priority as \"replication_priority: ReplicationPriority\",\n            r.curation_enabled, r.curation_source_repo_id, r.curation_target_repo_id,\n            r.curation_default_action, r.curation_sync_interval_secs, r.curation_auto_fetch,\n            r.age_gate_enabled, r.age_gate_min_age_days, r.versioning_enabled,\n            r.project_id, r.created_at, r.updated_at\n        FROM repositories r\n        INNER JOIN virtual_repo_members vrm ON r.id = vrm.member_repo_id\n        WHERE vrm.virtual_repo_id = $1\n        ORDER BY vrm.priority\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "format: RepositoryFormat",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_type: RepositoryType",
+        "type_info": {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_backend",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "upstream_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "replication_priority: ReplicationPriority",
+        "type_info": {
+          "Custom": {
+            "name": "replication_priority",
+            "kind": {
+              "Enum": [
+                "immediate",
+                "scheduled",
+                "on_demand",
+                "local_only"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "curation_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "curation_source_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "curation_target_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "curation_default_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "curation_sync_interval_secs",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "curation_auto_fetch",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "age_gate_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "age_gate_min_age_days",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "versioning_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 24,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "8d94112016a55e4ba7a2c0130aa32908e56298f48256d2d85f4e7e27accef983"
+}

--- a/backend/.sqlx/query-8d9cd78e3c8f84ffc010cf398bcac510638d1bf1cd9cc8ca06de501ecfb85b90.json
+++ b/backend/.sqlx/query-8d9cd78e3c8f84ffc010cf398bcac510638d1bf1cd9cc8ca06de501ecfb85b90.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE peer_instances\n                SET status = $2, updated_at = NOW()\n                WHERE id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8d9cd78e3c8f84ffc010cf398bcac510638d1bf1cd9cc8ca06de501ecfb85b90"
+}

--- a/backend/.sqlx/query-8df0a6cc9b9f81fa728673d26104d7169cc06423648bfa9e51fa4d81b78a184c.json
+++ b/backend/.sqlx/query-8df0a6cc9b9f81fa728673d26104d7169cc06423648bfa9e51fa4d81b78a184c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE plugins SET status = 'disabled', updated_at = NOW() WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8df0a6cc9b9f81fa728673d26104d7169cc06423648bfa9e51fa4d81b78a184c"
+}

--- a/backend/.sqlx/query-8e0f35a69c82bf6d8cff1586c091fea907096b8829e3eb7e6d2602bdbc62302f.json
+++ b/backend/.sqlx/query-8e0f35a69c82bf6d8cff1586c091fea907096b8829e3eb7e6d2602bdbc62302f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET totp_enabled = true, totp_backup_codes = $2, totp_verified_at = $3 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8e0f35a69c82bf6d8cff1586c091fea907096b8829e3eb7e6d2602bdbc62302f"
+}

--- a/backend/.sqlx/query-8ead7a7250a7087d4cc714cdf61fb2b6b3d81ab6bd6db12e3c7bd2d02eaf7295.json
+++ b/backend/.sqlx/query-8ead7a7250a7087d4cc714cdf61fb2b6b3d81ab6bd6db12e3c7bd2d02eaf7295.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                u.id,\n                u.username,\n                u.display_name,\n                u.is_active,\n                COALESCE(t.cnt, 0) as \"token_count!: i64\",\n                u.created_at,\n                u.updated_at\n            FROM users u\n            LEFT JOIN (\n                SELECT user_id, COUNT(*) as cnt\n                FROM api_tokens\n                WHERE revoked_at IS NULL\n                GROUP BY user_id\n            ) t ON t.user_id = u.id\n            WHERE u.is_service_account = true\n              AND ($1 OR u.is_active = true)\n            ORDER BY u.created_at DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "token_count!: i64",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      null,
+      false,
+      false
+    ]
+  },
+  "hash": "8ead7a7250a7087d4cc714cdf61fb2b6b3d81ab6bd6db12e3c7bd2d02eaf7295"
+}

--- a/backend/.sqlx/query-90ce7179df54ce68fcd01d59205966e4d410bd8a2d12cc27f88b0eed485af69a.json
+++ b/backend/.sqlx/query-90ce7179df54ce68fcd01d59205966e4d410bd8a2d12cc27f88b0eed485af69a.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND checksum_sha256 = $2 AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "90ce7179df54ce68fcd01d59205966e4d410bd8a2d12cc27f88b0eed485af69a"
+}

--- a/backend/.sqlx/query-9295150ea98ba5d940de2ff28adcd6c9df48e527d14cb2835a89034041b8a773.json
+++ b/backend/.sqlx/query-9295150ea98ba5d940de2ff28adcd6c9df48e527d14cb2835a89034041b8a773.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM repositories WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9295150ea98ba5d940de2ff28adcd6c9df48e527d14cb2835a89034041b8a773"
+}

--- a/backend/.sqlx/query-92db700224bd280009c0385cb469f99e5eac7b3b4390ba189a14f0958079d41e.json
+++ b/backend/.sqlx/query-92db700224bd280009c0385cb469f99e5eac7b3b4390ba189a14f0958079d41e.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM repositories",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "92db700224bd280009c0385cb469f99e5eac7b3b4390ba189a14f0958079d41e"
+}

--- a/backend/.sqlx/query-931211e8556bd965b5a4ed9e2f744ed0c514e13802f65eb028646a7201cbc74c.json
+++ b/backend/.sqlx/query-931211e8556bd965b5a4ed9e2f744ed0c514e13802f65eb028646a7201cbc74c.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'packageRevision' as \"pkg_revision?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'revision' = $4\n          AND am.metadata->>'packageId' = $5\n          AND am.metadata->>'type' = 'package'\n          AND am.metadata->>'packageRevision' IS NOT NULL\n        ORDER BY a.created_at DESC, a.id DESC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pkg_revision?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "931211e8556bd965b5a4ed9e2f744ed0c514e13802f65eb028646a7201cbc74c"
+}

--- a/backend/.sqlx/query-933ad60da7dd5b21a5b17cc55da708346bbe8ee55eb7a3452d43e4a8d9a9ecb6.json
+++ b/backend/.sqlx/query-933ad60da7dd5b21a5b17cc55da708346bbe8ee55eb7a3452d43e4a8d9a9ecb6.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM repository_signing_config WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "signing_key_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "sign_metadata",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "sign_packages",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "require_signatures",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "933ad60da7dd5b21a5b17cc55da708346bbe8ee55eb7a3452d43e4a8d9a9ecb6"
+}

--- a/backend/.sqlx/query-93b3ad73e22c9ce9d635690b20ef3969b35252376bf90f317ae938b4d3af7d95.json
+++ b/backend/.sqlx/query-93b3ad73e22c9ce9d635690b20ef3969b35252376bf90f317ae938b4d3af7d95.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM oci_tags WHERE repository_id = $1 AND name = $2 AND tag = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "93b3ad73e22c9ce9d635690b20ef3969b35252376bf90f317ae938b4d3af7d95"
+}

--- a/backend/.sqlx/query-944a1b3809e9c39a7ca8787b64aeead46947eb6ae6901092ae0e705a7b5a2427.json
+++ b/backend/.sqlx/query-944a1b3809e9c39a7ca8787b64aeead46947eb6ae6901092ae0e705a7b5a2427.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n                 FROM proxy_cache_artifacts WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "944a1b3809e9c39a7ca8787b64aeead46947eb6ae6901092ae0e705a7b5a2427"
+}

--- a/backend/.sqlx/query-946423a6cd51f909804877030ce535fe8802ae71b6923114b3a46c17a6b9c14c.json
+++ b/backend/.sqlx/query-946423a6cd51f909804877030ce535fe8802ae71b6923114b3a46c17a6b9c14c.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.path, a.checksum_sha256, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.name = $2\n          AND a.version = $3\n          AND a.is_deleted = false\n        ORDER BY a.path\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "946423a6cd51f909804877030ce535fe8802ae71b6923114b3a46c17a6b9c14c"
+}

--- a/backend/.sqlx/query-95217d46149146e27c79b8dcad33641e987bad28340d1acd1f3c72909597c132.json
+++ b/backend/.sqlx/query-95217d46149146e27c79b8dcad33641e987bad28340d1acd1f3c72909597c132.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM lfs_locks WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "95217d46149146e27c79b8dcad33641e987bad28340d1acd1f3c72909597c132"
+}

--- a/backend/.sqlx/query-9531a50645ba16c088a58c698116d18c9db4ea866d6538ba41eb357bcd482224.json
+++ b/backend/.sqlx/query-9531a50645ba16c088a58c698116d18c9db4ea866d6538ba41eb357bcd482224.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) FROM format_handlers WHERE is_enabled = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9531a50645ba16c088a58c698116d18c9db4ea866d6538ba41eb357bcd482224"
+}

--- a/backend/.sqlx/query-95924ac7251345836011b3c0ffeaf8df6c5691b4b8358f6c8d6d2b486175b44d.json
+++ b/backend/.sqlx/query-95924ac7251345836011b3c0ffeaf8df6c5691b4b8358f6c8d6d2b486175b44d.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE id = $1 AND is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "95924ac7251345836011b3c0ffeaf8df6c5691b4b8358f6c8d6d2b486175b44d"
+}

--- a/backend/.sqlx/query-9780131fb180f6f4836183a416101e7e5c58e66e0f6f5b342f5ebbcb2a3fb398.json
+++ b/backend/.sqlx/query-9780131fb180f6f4836183a416101e7e5c58e66e0f6f5b342f5ebbcb2a3fb398.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND name = $2 AND version = $3 AND path LIKE '%.mod' AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9780131fb180f6f4836183a416101e7e5c58e66e0f6f5b342f5ebbcb2a3fb398"
+}

--- a/backend/.sqlx/query-979176e335b1eee831d7fc5c13860ec880048ef23a7ae1dedcd21b7fbe591071.json
+++ b/backend/.sqlx/query-979176e335b1eee831d7fc5c13860ec880048ef23a7ae1dedcd21b7fbe591071.json
@@ -1,0 +1,120 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, scan_result_id, artifact_id, severity, title, description,\n                   cve_id, affected_component, affected_version, fixed_version,\n                   source, source_url, is_acknowledged, acknowledged_by,\n                   acknowledged_reason, acknowledged_at, created_at\n            FROM scan_findings\n            WHERE scan_result_id = $1\n            ORDER BY\n                CASE severity\n                    WHEN 'critical' THEN 0\n                    WHEN 'high' THEN 1\n                    WHEN 'medium' THEN 2\n                    WHEN 'low' THEN 3\n                    WHEN 'info' THEN 4\n                END,\n                created_at DESC\n            LIMIT $2 OFFSET $3\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "scan_result_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "severity",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "title",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "cve_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "affected_component",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "affected_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "fixed_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "source",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "source_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_acknowledged",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "acknowledged_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "acknowledged_reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "acknowledged_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "979176e335b1eee831d7fc5c13860ec880048ef23a7ae1dedcd21b7fbe591071"
+}

--- a/backend/.sqlx/query-980cd8bca4296062cf418f95309607ff65e7435d84ce01b955e2b7180ddca330.json
+++ b/backend/.sqlx/query-980cd8bca4296062cf418f95309607ff65e7435d84ce01b955e2b7180ddca330.json
@@ -1,0 +1,97 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE format_handlers\n            SET display_name = COALESCE($2, display_name),\n                description = COALESCE($3, description),\n                extensions = COALESCE($4, extensions),\n                is_enabled = COALESCE($5, is_enabled),\n                priority = COALESCE($6, priority),\n                updated_at = NOW()\n            WHERE format_key = $1\n            RETURNING id, format_key, plugin_id,\n                      handler_type as \"handler_type: FormatHandlerType\",\n                      display_name, description, extensions,\n                      is_enabled, priority, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Varchar",
+        "Text",
+        "TextArray",
+        "Bool",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "980cd8bca4296062cf418f95309607ff65e7435d84ce01b955e2b7180ddca330"
+}

--- a/backend/.sqlx/query-98877dd90bb9af69391472f80a26788917a57d735af7ec1ebfe267fe61f4508b.json
+++ b/backend/.sqlx/query-98877dd90bb9af69391472f80a26788917a57d735af7ec1ebfe267fe61f4508b.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_connections\n            SET transfer_success_count = transfer_success_count + 1,\n                bytes_transferred_total = bytes_transferred_total + $3,\n                last_transfer_at = NOW(), updated_at = NOW()\n            WHERE source_peer_id = $1 AND target_peer_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "98877dd90bb9af69391472f80a26788917a57d735af7ec1ebfe267fe61f4508b"
+}

--- a/backend/.sqlx/query-98cdc24c9284cdd9edcc103a47c781c5b3bc13b9cdb8ac560fb2cc780de84683.json
+++ b/backend/.sqlx/query-98cdc24c9284cdd9edcc103a47c781c5b3bc13b9cdb8ac560fb2cc780de84683.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE plugins\n            SET version = $2, manifest = $3, capabilities = $4, resource_limits = $5, updated_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Jsonb",
+        "Jsonb",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "98cdc24c9284cdd9edcc103a47c781c5b3bc13b9cdb8ac560fb2cc780de84683"
+}

--- a/backend/.sqlx/query-990621bb5e971a715abd79ff2b4ad40b6b91544a2088ff7fcfb7f806f65ba233.json
+++ b/backend/.sqlx/query-990621bb5e971a715abd79ff2b4ad40b6b91544a2088ff7fcfb7f806f65ba233.json
@@ -1,0 +1,132 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_results\n            SET status = 'completed',\n                completed_at = NOW(),\n                findings_count = $2,\n                critical_count = $3,\n                high_count = $4,\n                medium_count = $5,\n                low_count = $6,\n                info_count = $7,\n                is_reused = true,\n                source_scan_id = $8,\n                scanner_version = $9\n            WHERE id = $1 AND status = 'running'\n            RETURNING id, artifact_id, repository_id, scan_type, status,\n                      findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                      scanner_version, error_message, started_at, completed_at, created_at,\n                      is_reused, source_scan_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "990621bb5e971a715abd79ff2b4ad40b6b91544a2088ff7fcfb7f806f65ba233"
+}

--- a/backend/.sqlx/query-9976822f68b8add4c577ed02f809bca84867a23878282048e6d8bf3bb3405680.json
+++ b/backend/.sqlx/query-9976822f68b8add4c577ed02f809bca84867a23878282048e6d8bf3bb3405680.json
@@ -1,0 +1,97 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                r.id, r.repository_id, r.package_name, r.package_version,\n                r.upstream_published_at, r.status, r.requested_at,\n                r.reviewed_by, r.reviewed_at, r.review_reason,\n                r.request_count, r.last_requested_at,\n                repo.key as repository_key\n            FROM age_gate_reviews r\n            INNER JOIN repositories repo ON repo.id = r.repository_id\n            WHERE ($1::text IS NULL OR repo.key = $1)\n              AND ($2::text[] IS NULL OR r.status = ANY($2))\n            ORDER BY r.last_requested_at DESC\n            OFFSET $3 LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "package_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "package_version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "upstream_published_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "requested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "reviewed_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 8,
+        "name": "reviewed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "review_reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "request_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "last_requested_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "repository_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "TextArray",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9976822f68b8add4c577ed02f809bca84867a23878282048e6d8bf3bb3405680"
+}

--- a/backend/.sqlx/query-99a3d913761f89fbdbe776eb3199d1eb1a6347bda28846f359b4c7e6e2b56e02.json
+++ b/backend/.sqlx/query-99a3d913761f89fbdbe776eb3199d1eb1a6347bda28846f359b4c7e6e2b56e02.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'cocoapods', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "99a3d913761f89fbdbe776eb3199d1eb1a6347bda28846f359b4c7e6e2b56e02"
+}

--- a/backend/.sqlx/query-99a98f8e6c403934df235670d05d58acc88c7fb986f64f09001a192d53e7e570.json
+++ b/backend/.sqlx/query-99a98f8e6c403934df235670d05d58acc88c7fb986f64f09001a192d53e7e570.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, username, email, password_hash, display_name,\n                       auth_provider as \"auth_provider: crate::models::user::AuthProvider\",\n                       external_id, is_admin, is_active, is_service_account, must_change_password,\n                       totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                       failed_login_attempts, locked_until, last_failed_login_at,\n                       password_changed_at, last_login_at, created_at, updated_at\n                       FROM users WHERE id = $1 AND is_active = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: crate::models::user::AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "99a98f8e6c403934df235670d05d58acc88c7fb986f64f09001a192d53e7e570"
+}

--- a/backend/.sqlx/query-9ad0f5c339b92f530f7b7846db5534409c101a2ec8bae1e997c0ca38ec93a184.json
+++ b/backend/.sqlx/query-9ad0f5c339b92f530f7b7846db5534409c101a2ec8bae1e997c0ca38ec93a184.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT manifest_digest, manifest_content_type FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2 LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "manifest_digest",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "manifest_content_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "9ad0f5c339b92f530f7b7846db5534409c101a2ec8bae1e997c0ca38ec93a184"
+}

--- a/backend/.sqlx/query-9b11ee0f9615dae0f6a64ff6db930921e1d3e67d57792f91fe591e9c6ec44ac0.json
+++ b/backend/.sqlx/query-9b11ee0f9615dae0f6a64ff6db930921e1d3e67d57792f91fe591e9c6ec44ac0.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND version = $3\n          AND path LIKE '%.mod'\n          AND is_deleted = false\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9b11ee0f9615dae0f6a64ff6db930921e1d3e67d57792f91fe591e9c6ec44ac0"
+}

--- a/backend/.sqlx/query-9bc8cce911ed1e936b53b596da3fb3551cb18ff7eb0237171a17bd9ca67e661d.json
+++ b/backend/.sqlx/query-9bc8cce911ed1e936b53b596da3fb3551cb18ff7eb0237171a17bd9ca67e661d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM users",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9bc8cce911ed1e936b53b596da3fb3551cb18ff7eb0237171a17bd9ca67e661d"
+}

--- a/backend/.sqlx/query-9bda52f99e8edfc6e225a149bd4cbcb6e2c9df1bb5e0664a9658bace3c1c16ae.json
+++ b/backend/.sqlx/query-9bda52f99e8edfc6e225a149bd4cbcb6e2c9df1bb5e0664a9658bace3c1c16ae.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                pc.target_peer_id as node_id,\n                pi.endpoint_url,\n                pc.latency_ms,\n                pc.bandwidth_estimate_bps,\n                COALESCE(ca.available_chunks, 0) as \"available_chunks!: i32\"\n            FROM peer_connections pc\n            JOIN peer_instances pi ON pi.id = pc.target_peer_id\n            LEFT JOIN chunk_availability ca\n                ON ca.peer_instance_id = pc.target_peer_id AND ca.artifact_id = $2\n            WHERE pc.source_peer_id = $1\n              AND pc.status = 'active'\n              AND pi.status IN ('online', 'syncing')\n            ORDER BY pc.latency_ms ASC NULLS LAST\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "node_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "endpoint_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "latency_ms",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "bandwidth_estimate_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "available_chunks!: i32",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      null
+    ]
+  },
+  "hash": "9bda52f99e8edfc6e225a149bd4cbcb6e2c9df1bb5e0664a9658bace3c1c16ae"
+}

--- a/backend/.sqlx/query-9c7830951c41928de217750415b8fb1b79f883be4852cb94a0f3fe55aef35033.json
+++ b/backend/.sqlx/query-9c7830951c41928de217750415b8fb1b79f883be4852cb94a0f3fe55aef35033.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE api_tokens SET repo_selector = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Jsonb",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9c7830951c41928de217750415b8fb1b79f883be4852cb94a0f3fe55aef35033"
+}

--- a/backend/.sqlx/query-9cee8f416f4694c27a285269bffcd459c3ea8cf1023738a66b5a9b90d0ab1478.json
+++ b/backend/.sqlx/query-9cee8f416f4694c27a285269bffcd459c3ea8cf1023738a66b5a9b90d0ab1478.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH latest_status AS (\n                SELECT DISTINCT ON (sr.artifact_id, sr.scan_type) sr.status\n                FROM scan_results sr\n                JOIN artifacts a ON a.id = sr.artifact_id\n                WHERE a.repository_id = $1\n                  AND NOT a.is_deleted\n                ORDER BY sr.artifact_id, sr.scan_type,\n                         sr.completed_at DESC NULLS LAST, sr.created_at DESC\n            )\n            SELECT EXISTS (\n                SELECT 1 FROM latest_status WHERE status = 'failed'\n            ) AS \"has_failed!\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "has_failed!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9cee8f416f4694c27a285269bffcd459c3ea8cf1023738a66b5a9b90d0ab1478"
+}

--- a/backend/.sqlx/query-9e56e5c5d9339c0f5224125994ae74822e434be987869952d2a2c00a4d957c0c.json
+++ b/backend/.sqlx/query-9e56e5c5d9339c0f5224125994ae74822e434be987869952d2a2c00a4d957c0c.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM user_roles WHERE user_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9e56e5c5d9339c0f5224125994ae74822e434be987869952d2a2c00a4d957c0c"
+}

--- a/backend/.sqlx/query-9e8804da49121b1302c96a92e8368be8e98ee290bd08a2052eb59290d4f27d5b.json
+++ b/backend/.sqlx/query-9e8804da49121b1302c96a92e8368be8e98ee290bd08a2052eb59290d4f27d5b.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                ca.peer_instance_id,\n                ca.available_chunks,\n                ca.total_chunks,\n                ca.chunk_bitmap\n            FROM chunk_availability ca\n            JOIN peer_instances pi ON pi.id = ca.peer_instance_id\n            WHERE ca.artifact_id = $1\n              AND ca.peer_instance_id != $2\n              AND ca.available_chunks > 0\n              AND pi.status IN ('online', 'syncing')\n            ORDER BY ca.available_chunks DESC\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "peer_instance_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "available_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "total_chunks",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "chunk_bitmap",
+        "type_info": "Bytea"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "9e8804da49121b1302c96a92e8368be8e98ee290bd08a2052eb59290d4f27d5b"
+}

--- a/backend/.sqlx/query-9eb22f2aa82ea693ce70a78c0bead5eae18c45f8460848716b322998a838e27d.json
+++ b/backend/.sqlx/query-9eb22f2aa82ea693ce70a78c0bead5eae18c45f8460848716b322998a838e27d.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM plugins WHERE name = $1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9eb22f2aa82ea693ce70a78c0bead5eae18c45f8460848716b322998a838e27d"
+}

--- a/backend/.sqlx/query-9ede0571d4ffe7ff2adb3103e9688f01947678213884dc8ee067b8302b70d563.json
+++ b/backend/.sqlx/query-9ede0571d4ffe7ff2adb3103e9688f01947678213884dc8ee067b8302b70d563.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT scan_on_upload FROM scan_configs WHERE repository_id = $1 AND scan_enabled = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9ede0571d4ffe7ff2adb3103e9688f01947678213884dc8ee067b8302b70d563"
+}

--- a/backend/.sqlx/query-9f18a5190d27c528ede61b0a1a8c066cf94e10fe252df49a45f50f56e2750b47.json
+++ b/backend/.sqlx/query-9f18a5190d27c528ede61b0a1a8c066cf94e10fe252df49a45f50f56e2750b47.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT ON (LOWER(a.name)) a.name, a.version, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n        ORDER BY LOWER(a.name), a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "9f18a5190d27c528ede61b0a1a8c066cf94e10fe252df49a45f50f56e2750b47"
+}

--- a/backend/.sqlx/query-9f2aeefbe59fca7e6a021cd198078f7e6f4a3b235cfed6980ae41fee3ec051c4.json
+++ b/backend/.sqlx/query-9f2aeefbe59fca7e6a021cd198078f7e6f4a3b235cfed6980ae41fee3ec051c4.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO transfer_chunks\n                    (session_id, chunk_index, byte_offset, byte_length, checksum, status)\n                VALUES ($1, $2, $3, $4, '', 'pending')\n                ON CONFLICT (session_id, chunk_index) DO NOTHING\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Int8",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "9f2aeefbe59fca7e6a021cd198078f7e6f4a3b235cfed6980ae41fee3ec051c4"
+}

--- a/backend/.sqlx/query-a03a4889fe2b688e46bd7a80e57f08371c3d0989d5f809d57392a637a46bc65a.json
+++ b/backend/.sqlx/query-a03a4889fe2b688e46bd7a80e57f08371c3d0989d5f809d57392a637a46bc65a.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT key, value\n        FROM system_settings\n        WHERE key IN (\n            'allow_anonymous_download',\n            'max_upload_size_bytes',\n            'retention_days',\n            'audit_retention_days',\n            'backup_retention_count',\n            'edge_stale_threshold_minutes'\n        )\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "value",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "a03a4889fe2b688e46bd7a80e57f08371c3d0989d5f809d57392a637a46bc65a"
+}

--- a/backend/.sqlx/query-a0446b0aafec3e5c6c9066d39abc38ab826decd2265d8d10734e9c4ceb9ac035.json
+++ b/backend/.sqlx/query-a0446b0aafec3e5c6c9066d39abc38ab826decd2265d8d10734e9c4ceb9ac035.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE peer_instances SET\n            max_bandwidth_bps = COALESCE($2, max_bandwidth_bps),\n            sync_window_start = COALESCE($3, sync_window_start),\n            sync_window_end = COALESCE($4, sync_window_end),\n            sync_window_timezone = COALESCE($5, sync_window_timezone),\n            concurrent_transfers_limit = COALESCE($6, concurrent_transfers_limit),\n            updated_at = NOW()\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Time",
+        "Time",
+        "Varchar",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a0446b0aafec3e5c6c9066d39abc38ab826decd2265d8d10734e9c4ceb9ac035"
+}

--- a/backend/.sqlx/query-a21880b257a1451337554c830fff3e552d423c2d235697f150ff085a084abf8c.json
+++ b/backend/.sqlx/query-a21880b257a1451337554c830fff3e552d423c2d235697f150ff085a084abf8c.json
@@ -1,0 +1,59 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.name, a.version, a.size_bytes, a.checksum_sha256, a.created_at,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n        ORDER BY a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a21880b257a1451337554c830fff3e552d423c2d235697f150ff085a084abf8c"
+}

--- a/backend/.sqlx/query-a3dc8399e9d07b5fe6f0217c5eb09491960c9059cc64626fcf1fcfb53a9ee1a3.json
+++ b/backend/.sqlx/query-a3dc8399e9d07b5fe6f0217c5eb09491960c9059cc64626fcf1fcfb53a9ee1a3.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM plugin_hooks WHERE plugin_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a3dc8399e9d07b5fe6f0217c5eb09491960c9059cc64626fcf1fcfb53a9ee1a3"
+}

--- a/backend/.sqlx/query-a40ced3710b05c27b17fd1fdd920b4321001d50a4df382bb81369493f4504c9c.json
+++ b/backend/.sqlx/query-a40ced3710b05c27b17fd1fdd920b4321001d50a4df382bb81369493f4504c9c.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE sync_tasks\n            SET\n                status = $2,\n                bytes_transferred = COALESCE($3, bytes_transferred),\n                error_message = $4,\n                started_at = COALESCE($5, started_at),\n                completed_at = COALESCE($6, completed_at)\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "sync_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        },
+        "Int8",
+        "Text",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a40ced3710b05c27b17fd1fdd920b4321001d50a4df382bb81369493f4504c9c"
+}

--- a/backend/.sqlx/query-a48a69d7d50d8b3bb84e6efb3ac9deb17c09a4a1e8a47d4eb937e3cca5b866fb.json
+++ b/backend/.sqlx/query-a48a69d7d50d8b3bb84e6efb3ac9deb17c09a4a1e8a47d4eb937e3cca5b866fb.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND path = $2 AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "a48a69d7d50d8b3bb84e6efb3ac9deb17c09a4a1e8a47d4eb937e3cca5b866fb"
+}

--- a/backend/.sqlx/query-a51690ce7f78dece37b2241a4a97f47804343e1af8f564ac63a1591d4aeb814f.json
+++ b/backend/.sqlx/query-a51690ce7f78dece37b2241a4a97f47804343e1af8f564ac63a1591d4aeb814f.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND version = $3\n          AND is_deleted = false\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "a51690ce7f78dece37b2241a4a97f47804343e1af8f564ac63a1591d4aeb814f"
+}

--- a/backend/.sqlx/query-a5cb1f79f5cc097952af072dd6fd95738b6d08bc32daea71e59b8894325b8d97.json
+++ b/backend/.sqlx/query-a5cb1f79f5cc097952af072dd6fd95738b6d08bc32daea71e59b8894325b8d97.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a5cb1f79f5cc097952af072dd6fd95738b6d08bc32daea71e59b8894325b8d97"
+}

--- a/backend/.sqlx/query-a6a62528235e33f98389e4cd755356b9300d7bae45ef9827b39071970f825853.json
+++ b/backend/.sqlx/query-a6a62528235e33f98389e4cd755356b9300d7bae45ef9827b39071970f825853.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'swift', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a6a62528235e33f98389e4cd755356b9300d7bae45ef9827b39071970f825853"
+}

--- a/backend/.sqlx/query-a742f798cea5da8bebaca77ae57af1bb003b3164d21f32c1b278f58705c98147.json
+++ b/backend/.sqlx/query-a742f798cea5da8bebaca77ae57af1bb003b3164d21f32c1b278f58705c98147.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.name, a.version, a.size_bytes, a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n        ORDER BY a.created_at DESC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "a742f798cea5da8bebaca77ae57af1bb003b3164d21f32c1b278f58705c98147"
+}

--- a/backend/.sqlx/query-a79e81d3fbe3b706bbd022a4891a748780ba6b5caf888d7841ee344050711984.json
+++ b/backend/.sqlx/query-a79e81d3fbe3b706bbd022a4891a748780ba6b5caf888d7841ee344050711984.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'packageRevision' as \"pkg_revision?\",\n               MAX(a.created_at) as \"created_at!\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'revision' = $4\n          AND am.metadata->>'packageId' = $5\n          AND am.metadata->>'type' = 'package'\n          AND am.metadata->>'packageRevision' IS NOT NULL\n        GROUP BY am.metadata->>'packageRevision'\n        ORDER BY \"created_at!\" DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pkg_revision?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "a79e81d3fbe3b706bbd022a4891a748780ba6b5caf888d7841ee344050711984"
+}

--- a/backend/.sqlx/query-a84247e5c60726f7fff094f8a14b4db439efc78790e6aef5710c3eebcc764399.json
+++ b/backend/.sqlx/query-a84247e5c60726f7fff094f8a14b4db439efc78790e6aef5710c3eebcc764399.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM artifacts\n            WHERE is_deleted = false\n              AND name ILIKE $1\n              AND ($2::uuid[] IS NULL OR repository_id = ANY($2))\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "a84247e5c60726f7fff094f8a14b4db439efc78790e6aef5710c3eebcc764399"
+}

--- a/backend/.sqlx/query-a9966554bf61c7a05cc7e1c58dbb8cf91112c75aea4be0d043650283650908ec.json
+++ b/backend/.sqlx/query-a9966554bf61c7a05cc7e1c58dbb8cf91112c75aea4be0d043650283650908ec.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM peer_repo_subscriptions WHERE peer_instance_id = $1 AND repository_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a9966554bf61c7a05cc7e1c58dbb8cf91112c75aea4be0d043650283650908ec"
+}

--- a/backend/.sqlx/query-aa83e571290daeb70fc403821a4273c0ef8e85fed96159e1bd5c0bcb50e2c9c3.json
+++ b/backend/.sqlx/query-aa83e571290daeb70fc403821a4273c0ef8e85fed96159e1bd5c0bcb50e2c9c3.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO chunk_availability\n                (peer_instance_id, artifact_id, chunk_bitmap, total_chunks, available_chunks)\n            VALUES ($1, $2, $3, $4, $5)\n            ON CONFLICT (peer_instance_id, artifact_id) DO UPDATE\n                SET chunk_bitmap = $3, available_chunks = $5, updated_at = NOW()\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Bytea",
+        "Int4",
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "aa83e571290daeb70fc403821a4273c0ef8e85fed96159e1bd5c0bcb50e2c9c3"
+}

--- a/backend/.sqlx/query-aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182.json
+++ b/backend/.sqlx/query-aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(DISTINCT a.name)\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND ($2 = '' OR a.name ILIKE '%' || $2 || '%')\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "aaedcabcafb76d5c573603c4be2e6e177560d993714f07bc9739754de2eb2182"
+}

--- a/backend/.sqlx/query-ab12ba1b68115d4d61e21ce81b837478b14541257eabb20d301c055f48b89bf5.json
+++ b/backend/.sqlx/query-ab12ba1b68115d4d61e21ce81b837478b14541257eabb20d301c055f48b89bf5.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, size_bytes, checksum_sha256,\n               checksum_md5, checksum_sha1,\n               content_type, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "ab12ba1b68115d4d61e21ce81b837478b14541257eabb20d301c055f48b89bf5"
+}

--- a/backend/.sqlx/query-ab4717210b7d122dcc27b5b9ee2b81e4e672426ef3c4c463c78991f1f6a65393.json
+++ b/backend/.sqlx/query-ab4717210b7d122dcc27b5b9ee2b81e4e672426ef3c4c463c78991f1f6a65393.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT checksum_sha256, version FROM artifacts WHERE repository_id = $1 AND path = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "ab4717210b7d122dcc27b5b9ee2b81e4e672426ef3c4c463c78991f1f6a65393"
+}

--- a/backend/.sqlx/query-acbee9d5ca125de4511599ae505c60be9807bb8a018106f70b67298d618a6cd6.json
+++ b/backend/.sqlx/query-acbee9d5ca125de4511599ae505c60be9807bb8a018106f70b67298d618a6cd6.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifacts (\n            repository_id, path, name, version, size_bytes,\n            checksum_sha256, content_type, storage_key, uploaded_by\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Bpchar",
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "acbee9d5ca125de4511599ae505c60be9807bb8a018106f70b67298d618a6cd6"
+}

--- a/backend/.sqlx/query-ae603c04660f8f7af24922f47b85cbd8b8a3c8b693d1949f5c6cda95a3415947.json
+++ b/backend/.sqlx/query-ae603c04660f8f7af24922f47b85cbd8b8a3c8b693d1949f5c6cda95a3415947.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n                 FROM oci_blobs WHERE repository_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ae603c04660f8f7af24922f47b85cbd8b8a3c8b693d1949f5c6cda95a3415947"
+}

--- a/backend/.sqlx/query-aecc9727d512567ad9037f6a1ebeaeea4a40ba29e705ce32fbb56ce208334c9e.json
+++ b/backend/.sqlx/query-aecc9727d512567ad9037f6a1ebeaeea4a40ba29e705ce32fbb56ce208334c9e.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE users\n            SET is_active = false, updated_at = NOW()\n            WHERE auth_provider = $1\n              AND is_active = true\n              AND external_id IS NOT NULL\n              AND external_id != ALL($2)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        },
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "aecc9727d512567ad9037f6a1ebeaeea4a40ba29e705ce32fbb56ce208334c9e"
+}

--- a/backend/.sqlx/query-aef90b7e0492852ad9485cd60626f4709478b819a349c7bc64623086bb88122f.json
+++ b/backend/.sqlx/query-aef90b7e0492852ad9485cd60626f4709478b819a349c7bc64623086bb88122f.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, locked_at, owner_name\n        FROM lfs_locks\n        WHERE repository_id = $1\n        ORDER BY locked_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "locked_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "owner_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "aef90b7e0492852ad9485cd60626f4709478b819a349c7bc64623086bb88122f"
+}

--- a/backend/.sqlx/query-af06d488d04f6fe600a71bd2454a529fae0a3e8624d2478ddc85864980809f72.json
+++ b/backend/.sqlx/query-af06d488d04f6fe600a71bd2454a529fae0a3e8624d2478ddc85864980809f72.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT EXISTS(SELECT 1 FROM oci_tags WHERE repository_id = $1 AND manifest_digest = $2)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "exists",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "af06d488d04f6fe600a71bd2454a529fae0a3e8624d2478ddc85864980809f72"
+}

--- a/backend/.sqlx/query-af381b4b4f84117fd42e711ff164a9ef9407fb1f96feb762b40b9da9a36aa8a7.json
+++ b/backend/.sqlx/query-af381b4b4f84117fd42e711ff164a9ef9407fb1f96feb762b40b9da9a36aa8a7.json
@@ -1,0 +1,30 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO artifacts (repository_id, path, name, version, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by)\n           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n           ON CONFLICT (repository_id, path) DO UPDATE SET\n             version = EXCLUDED.version,\n             size_bytes = EXCLUDED.size_bytes,\n             checksum_sha256 = EXCLUDED.checksum_sha256,\n             content_type = EXCLUDED.content_type,\n             storage_key = EXCLUDED.storage_key,\n             uploaded_by = EXCLUDED.uploaded_by,\n             is_deleted = false,\n             updated_at = NOW()\n           RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Int8",
+        "Bpchar",
+        "Varchar",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "af381b4b4f84117fd42e711ff164a9ef9407fb1f96feb762b40b9da9a36aa8a7"
+}

--- a/backend/.sqlx/query-af419117e164590483da93d45925b1f9461ad796dfa1e4672e0cd996202f506a.json
+++ b/backend/.sqlx/query-af419117e164590483da93d45925b1f9461ad796dfa1e4672e0cd996202f506a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO age_gate_reviews (\n                repository_id, package_name, package_version,\n                upstream_published_at, status\n            )\n            SELECT $1, $2, v, p, 'pending'\n            FROM UNNEST($3::text[], $4::timestamptz[]) AS t(v, p)\n            ON CONFLICT (repository_id, package_name, package_version)\n            DO UPDATE SET\n                request_count = age_gate_reviews.request_count + 1,\n                last_requested_at = NOW(),\n                upstream_published_at = COALESCE(EXCLUDED.upstream_published_at, age_gate_reviews.upstream_published_at)\n            WHERE age_gate_reviews.last_requested_at < $5\n            RETURNING id AS \"id!\", (request_count = 1) AS \"is_new!\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "is_new!",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "TextArray",
+        "TimestamptzArray",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "af419117e164590483da93d45925b1f9461ad796dfa1e4672e0cd996202f506a"
+}

--- a/backend/.sqlx/query-af67dd3f269be8e98e2f7af3f6be07b49d3be3ac0d5f5b204a80d7e65064b94d.json
+++ b/backend/.sqlx/query-af67dd3f269be8e98e2f7af3f6be07b49d3be3ac0d5f5b204a80d7e65064b94d.json
@@ -1,0 +1,141 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, backup_type as \"backup_type: BackupType\",\n                status as \"status: BackupStatus\",\n                storage_path, size_bytes, artifact_count,\n                started_at, completed_at, error_message,\n                metadata, created_by, created_at\n            FROM backups\n            WHERE ($1::backup_status IS NULL OR status = $1)\n              AND ($2::backup_type IS NULL OR backup_type = $2)\n            ORDER BY created_at DESC\n            OFFSET $3\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "backup_type: BackupType",
+        "type_info": {
+          "Custom": {
+            "name": "backup_type",
+            "kind": {
+              "Enum": [
+                "full",
+                "incremental",
+                "metadata_only",
+                "metadata"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "status: BackupStatus",
+        "type_info": {
+          "Custom": {
+            "name": "backup_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "artifact_count",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 10,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 11,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "backup_status",
+            "kind": {
+              "Enum": [
+                "pending",
+                "in_progress",
+                "completed",
+                "failed",
+                "cancelled"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "backup_type",
+            "kind": {
+              "Enum": [
+                "full",
+                "incremental",
+                "metadata_only",
+                "metadata"
+              ]
+            }
+          }
+        },
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "af67dd3f269be8e98e2f7af3f6be07b49d3be3ac0d5f5b204a80d7e65064b94d"
+}

--- a/backend/.sqlx/query-b0cc37dbf1ae9b664e6cc326ef528838adac152497064b75e5721c9f4646a1a0.json
+++ b/backend/.sqlx/query-b0cc37dbf1ae9b664e6cc326ef528838adac152497064b75e5721c9f4646a1a0.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'composer', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b0cc37dbf1ae9b664e6cc326ef528838adac152497064b75e5721c9f4646a1a0"
+}

--- a/backend/.sqlx/query-b1382113ba5b3d7cef6f68f143c694ba98a7d7d3c73673edc6cf11b2532969fb.json
+++ b/backend/.sqlx/query-b1382113ba5b3d7cef6f68f143c694ba98a7d7d3c73673edc6cf11b2532969fb.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_instances\n            SET\n                last_heartbeat_at = NOW(),\n                cache_used_bytes = $2,\n                status = $3,\n                updated_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b1382113ba5b3d7cef6f68f143c694ba98a7d7d3c73673edc6cf11b2532969fb"
+}

--- a/backend/.sqlx/query-b20930c60991998742298cdbd679688356deac260e84dc5738ec400bee583224.json
+++ b/backend/.sqlx/query-b20930c60991998742298cdbd679688356deac260e84dc5738ec400bee583224.json
@@ -1,0 +1,75 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_configs (repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                                      block_on_policy_violation, severity_threshold)\n            VALUES ($1, $2, $3, $4, $5, $6)\n            ON CONFLICT (repository_id)\n            DO UPDATE SET\n                scan_enabled = EXCLUDED.scan_enabled,\n                scan_on_upload = EXCLUDED.scan_on_upload,\n                scan_on_proxy = EXCLUDED.scan_on_proxy,\n                block_on_policy_violation = EXCLUDED.block_on_policy_violation,\n                severity_threshold = EXCLUDED.severity_threshold,\n                updated_at = NOW()\n            RETURNING id, repository_id, scan_enabled, scan_on_upload, scan_on_proxy,\n                      block_on_policy_violation, severity_threshold, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "scan_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_on_upload",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 4,
+        "name": "scan_on_proxy",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "block_on_policy_violation",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "severity_threshold",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Bool",
+        "Bool",
+        "Bool",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b20930c60991998742298cdbd679688356deac260e84dc5738ec400bee583224"
+}

--- a/backend/.sqlx/query-b480e22b6f44452ed3999ea6ec2bbf893c8306f8cd6f5a47a54d7ae76a4a67bc.json
+++ b/backend/.sqlx/query-b480e22b6f44452ed3999ea6ec2bbf893c8306f8cd6f5a47a54d7ae76a4a67bc.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT totp_secret, totp_enabled, totp_backup_codes, username FROM users WHERE id = $1 AND is_active = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 2,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "username",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "b480e22b6f44452ed3999ea6ec2bbf893c8306f8cd6f5a47a54d7ae76a4a67bc"
+}

--- a/backend/.sqlx/query-b50efb2160cf8b8ae8eff42fba054d8fc7433670f9224bba7f0cf739f56cf684.json
+++ b/backend/.sqlx/query-b50efb2160cf8b8ae8eff42fba054d8fc7433670f9224bba7f0cf739f56cf684.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT\n            a.name,\n            a.version as \"version?\",\n            am.metadata->>'version' as \"meta_version?\",\n            am.metadata->>'user' as \"meta_user?\",\n            am.metadata->>'channel' as \"meta_channel?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name LIKE $2\n        ORDER BY a.name, a.version\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version?",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "meta_version?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "meta_user?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "meta_channel?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "b50efb2160cf8b8ae8eff42fba054d8fc7433670f9224bba7f0cf739f56cf684"
+}

--- a/backend/.sqlx/query-b611fcf150bdaaaf11192ac371d28202665c225a1c1b356f8858ff21c11fe017.json
+++ b/backend/.sqlx/query-b611fcf150bdaaaf11192ac371d28202665c225a1c1b356f8858ff21c11fe017.json
@@ -1,0 +1,164 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO users (\n                id, username, email, display_name, auth_provider,\n                is_admin, is_active, is_service_account, must_change_password\n            )\n            VALUES ($1, $2, $3, $4, 'local', false, true, true, false)\n            RETURNING\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "b611fcf150bdaaaf11192ac371d28202665c225a1c1b356f8858ff21c11fe017"
+}

--- a/backend/.sqlx/query-b6554ca8b92f79b964fbbf18d007ae3c4b4a46c88084814252052f1609797ec5.json
+++ b/backend/.sqlx/query-b6554ca8b92f79b964fbbf18d007ae3c4b4a46c88084814252052f1609797ec5.json
@@ -1,0 +1,121 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            FROM artifacts\n            WHERE is_deleted = false\n              AND name ILIKE $1\n              AND ($2::uuid[] IS NULL OR repository_id = ANY($2))\n            ORDER BY name\n            OFFSET $3\n            LIMIT $4\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "UuidArray",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "b6554ca8b92f79b964fbbf18d007ae3c4b4a46c88084814252052f1609797ec5"
+}

--- a/backend/.sqlx/query-b6b4d503503dc5e1b4cf270a56fff91db1def08c817d805e52bc959e2def04c2.json
+++ b/backend/.sqlx/query-b6b4d503503dc5e1b4cf270a56fff91db1def08c817d805e52bc959e2def04c2.json
@@ -1,0 +1,334 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO repositories (\n                key, name, description, format, repo_type,\n                storage_backend, storage_path, upstream_url,\n                is_public, quota_bytes, promotion_only, versioning_enabled,\n                project_id\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\n            RETURNING\n                id, key, name, description,\n                format as \"format: RepositoryFormat\",\n                repo_type as \"repo_type: RepositoryType\",\n                storage_backend, storage_path, upstream_url,\n                is_public, quota_bytes, promotion_only,\n                replication_priority as \"replication_priority: ReplicationPriority\",\n                curation_enabled, curation_source_repo_id, curation_target_repo_id,\n                curation_default_action, curation_sync_interval_secs, curation_auto_fetch,\n                age_gate_enabled, age_gate_min_age_days, versioning_enabled,\n                project_id, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "format: RepositoryFormat",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_type: RepositoryType",
+        "type_info": {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_backend",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "upstream_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "replication_priority: ReplicationPriority",
+        "type_info": {
+          "Custom": {
+            "name": "replication_priority",
+            "kind": {
+              "Enum": [
+                "immediate",
+                "scheduled",
+                "on_demand",
+                "local_only"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "curation_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "curation_source_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "curation_target_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "curation_default_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "curation_sync_interval_secs",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "curation_auto_fetch",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "age_gate_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "age_gate_min_age_days",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "versioning_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 24,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar",
+        "Text",
+        {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        },
+        {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Bool",
+        "Int8",
+        "Bool",
+        "Bool",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "b6b4d503503dc5e1b4cf270a56fff91db1def08c817d805e52bc959e2def04c2"
+}

--- a/backend/.sqlx/query-b6ed3d03ed6d7a799d81d0d782e8190a7cea5d7fc7166348e8aff094a9e38a4f.json
+++ b/backend/.sqlx/query-b6ed3d03ed6d7a799d81d0d782e8190a7cea5d7fc7166348e8aff094a9e38a4f.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO oci_blobs (repository_id, digest, size_bytes, storage_key) VALUES ($1, $2, $3, $4) ON CONFLICT (repository_id, digest) DO UPDATE SET pending_delete_at = NULL",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b6ed3d03ed6d7a799d81d0d782e8190a7cea5d7fc7166348e8aff094a9e38a4f"
+}

--- a/backend/.sqlx/query-b6f2cb71d744e292a728b61c98e051a6447e0398b1a5848ec6907bd57a3353aa.json
+++ b/backend/.sqlx/query-b6f2cb71d744e292a728b61c98e051a6447e0398b1a5848ec6907bd57a3353aa.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'file' as \"file?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND am.metadata->>'type' = 'package'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' = $6\n          AND am.metadata->>'packageId' = $7\n          AND am.metadata->>'packageRevision' = $8\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "file?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b6f2cb71d744e292a728b61c98e051a6447e0398b1a5848ec6907bd57a3353aa"
+}

--- a/backend/.sqlx/query-b751410fcbb82ce95beedf171ca4d16d9bf3328389a4d3aff7d10a5774ba14ca.json
+++ b/backend/.sqlx/query-b751410fcbb82ce95beedf171ca4d16d9bf3328389a4d3aff7d10a5774ba14ca.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND name = $2 AND version = $3 AND path LIKE '%.zip' AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "b751410fcbb82ce95beedf171ca4d16d9bf3328389a4d3aff7d10a5774ba14ca"
+}

--- a/backend/.sqlx/query-b758017fde8a50ea273ac5a09fc18d4074440f2f4443b8a0a6dfd477305360d7.json
+++ b/backend/.sqlx/query-b758017fde8a50ea273ac5a09fc18d4074440f2f4443b8a0a6dfd477305360d7.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM scan_findings WHERE scan_result_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b758017fde8a50ea273ac5a09fc18d4074440f2f4443b8a0a6dfd477305360d7"
+}

--- a/backend/.sqlx/query-b77419411cb6ad0c1ae336e57991a8f2649f1c85af1337c825a343c919af3dc3.json
+++ b/backend/.sqlx/query-b77419411cb6ad0c1ae336e57991a8f2649f1c85af1337c825a343c919af3dc3.json
@@ -1,0 +1,108 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO format_handlers (format_key, plugin_id, handler_type, display_name, description, extensions, priority)\n            VALUES ($1, $2, $3, $4, $5, $6, $7)\n            RETURNING id, format_key, plugin_id,\n                      handler_type as \"handler_type: FormatHandlerType\",\n                      display_name, description, extensions,\n                      is_enabled, priority, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "format_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "plugin_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "extensions",
+        "type_info": "TextArray"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "priority",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Uuid",
+        {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        },
+        "Varchar",
+        "Text",
+        "TextArray",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b77419411cb6ad0c1ae336e57991a8f2649f1c85af1337c825a343c919af3dc3"
+}

--- a/backend/.sqlx/query-b7866836c756096b2ebc23e667b8b96aa5fa543f06a2c55ef3e966eb9148f23b.json
+++ b/backend/.sqlx/query-b7866836c756096b2ebc23e667b8b96aa5fa543f06a2c55ef3e966eb9148f23b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\" FROM transfer_chunks\n            WHERE session_id = $1 AND status != 'completed'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "b7866836c756096b2ebc23e667b8b96aa5fa543f06a2c55ef3e966eb9148f23b"
+}

--- a/backend/.sqlx/query-b826ba6e31ace21cfe32a00c3b26bbaf611931f3ca58620aabaf996a40caa373.json
+++ b/backend/.sqlx/query-b826ba6e31ace21cfe32a00c3b26bbaf611931f3ca58620aabaf996a40caa373.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM format_handlers WHERE format_key = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b826ba6e31ace21cfe32a00c3b26bbaf611931f3ca58620aabaf996a40caa373"
+}

--- a/backend/.sqlx/query-b8b2c0021165b3819a31c01b2e5e57742799c4f35807271a9ad953abc1051b80.json
+++ b/backend/.sqlx/query-b8b2c0021165b3819a31c01b2e5e57742799c4f35807271a9ad953abc1051b80.json
@@ -1,0 +1,250 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, key, name, description,\n                format as \"format: RepositoryFormat\",\n                repo_type as \"repo_type: RepositoryType\",\n                storage_backend, storage_path, upstream_url,\n                is_public, quota_bytes, promotion_only,\n                replication_priority as \"replication_priority: ReplicationPriority\",\n                curation_enabled, curation_source_repo_id, curation_target_repo_id,\n                curation_default_action, curation_sync_interval_secs, curation_auto_fetch,\n                age_gate_enabled, age_gate_min_age_days, versioning_enabled,\n                project_id, created_at, updated_at\n            FROM repositories\n            WHERE key = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "format: RepositoryFormat",
+        "type_info": {
+          "Custom": {
+            "name": "repository_format",
+            "kind": {
+              "Enum": [
+                "maven",
+                "gradle",
+                "npm",
+                "pypi",
+                "nuget",
+                "go",
+                "rubygems",
+                "docker",
+                "helm",
+                "rpm",
+                "debian",
+                "conan",
+                "cargo",
+                "generic",
+                "podman",
+                "buildx",
+                "oras",
+                "wasm_oci",
+                "helm_oci",
+                "poetry",
+                "conda",
+                "yarn",
+                "bower",
+                "pnpm",
+                "chocolatey",
+                "powershell",
+                "terraform",
+                "opentofu",
+                "alpine",
+                "conda_native",
+                "composer",
+                "hex",
+                "cocoapods",
+                "swift",
+                "pub",
+                "sbt",
+                "chef",
+                "puppet",
+                "ansible",
+                "gitlfs",
+                "vscode",
+                "jetbrains",
+                "huggingface",
+                "mlmodel",
+                "cran",
+                "vagrant",
+                "opkg",
+                "p2",
+                "bazel",
+                "protobuf",
+                "incus",
+                "lxc"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 5,
+        "name": "repo_type: RepositoryType",
+        "type_info": {
+          "Custom": {
+            "name": "repository_type",
+            "kind": {
+              "Enum": [
+                "local",
+                "remote",
+                "virtual",
+                "staging"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_backend",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "storage_path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "upstream_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_public",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "promotion_only",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "replication_priority: ReplicationPriority",
+        "type_info": {
+          "Custom": {
+            "name": "replication_priority",
+            "kind": {
+              "Enum": [
+                "immediate",
+                "scheduled",
+                "on_demand",
+                "local_only"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 13,
+        "name": "curation_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "curation_source_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "curation_target_repo_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "curation_default_action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "curation_sync_interval_secs",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 18,
+        "name": "curation_auto_fetch",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 19,
+        "name": "age_gate_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 20,
+        "name": "age_gate_min_age_days",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 21,
+        "name": "versioning_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 22,
+        "name": "project_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 23,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 24,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "b8b2c0021165b3819a31c01b2e5e57742799c4f35807271a9ad953abc1051b80"
+}

--- a/backend/.sqlx/query-b975d1bbbf76f4d957478dcd3e634d3f6df7963a6eea450b0e476505239157f4.json
+++ b/backend/.sqlx/query-b975d1bbbf76f4d957478dcd3e634d3f6df7963a6eea450b0e476505239157f4.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'go', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b975d1bbbf76f4d957478dcd3e634d3f6df7963a6eea450b0e476505239157f4"
+}

--- a/backend/.sqlx/query-b9d877b561e22a14df12f0b9368fce7522598b64b422106f6f391121343b3b86.json
+++ b/backend/.sqlx/query-b9d877b561e22a14df12f0b9368fce7522598b64b422106f6f391121343b3b86.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, path, name, version, size_bytes,\n                   checksum_sha256, checksum_md5, checksum_sha1,\n                   content_type, storage_key, is_deleted, uploaded_by,\n                   quarantine_status, quarantine_until,\n                   created_at, updated_at\n            FROM artifacts\n            WHERE id = $1 AND is_deleted = false\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "b9d877b561e22a14df12f0b9368fce7522598b64b422106f6f391121343b3b86"
+}

--- a/backend/.sqlx/query-b9f14eec157fb105d92d282a5f063913543603ba88bec3ac224434e01bc84974.json
+++ b/backend/.sqlx/query-b9f14eec157fb105d92d282a5f063913543603ba88bec3ac224434e01bc84974.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_connections\n            SET status = 'unreachable', updated_at = NOW()\n            WHERE source_peer_id = $1 AND target_peer_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b9f14eec157fb105d92d282a5f063913543603ba88bec3ac224434e01bc84974"
+}

--- a/backend/.sqlx/query-bb29e1c6c59e6ea4c846c86353bf706e558312151d15c979c4a366d0aeb542b1.json
+++ b/backend/.sqlx/query-bb29e1c6c59e6ea4c846c86353bf706e558312151d15c979c4a366d0aeb542b1.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, version\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND left(md5(name), 3) = $2\n          AND (\n            quarantine_status IS NULL\n            OR quarantine_status NOT IN ('quarantined', 'rejected')\n            OR (\n              quarantine_status = 'quarantined'\n              AND quarantine_until IS NOT NULL\n              AND quarantine_until <= NOW()\n            )\n          )\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "bb29e1c6c59e6ea4c846c86353bf706e558312151d15c979c4a366d0aeb542b1"
+}

--- a/backend/.sqlx/query-bba5b44be999420534ef47a9aaae58a9297ffa80bb66e56a46ce3818d2e886fe.json
+++ b/backend/.sqlx/query-bba5b44be999420534ef47a9aaae58a9297ffa80bb66e56a46ce3818d2e886fe.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT DISTINCT a.version\n                FROM artifacts a\n                INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id\n                WHERE vrm.virtual_repo_id = $1\n                  AND a.name = $2\n                  AND a.is_deleted = false\n                  AND a.version IS NOT NULL\n                ORDER BY a.version\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "bba5b44be999420534ef47a9aaae58a9297ffa80bb66e56a46ce3818d2e886fe"
+}

--- a/backend/.sqlx/query-bd05540b7540897c7ce884042b061789cd8ccd2122d48b7bddf06ce91b1aba62.json
+++ b/backend/.sqlx/query-bd05540b7540897c7ce884042b061789cd8ccd2122d48b7bddf06ce91b1aba62.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM webhooks WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bd05540b7540897c7ce884042b061789cd8ccd2122d48b7bddf06ce91b1aba62"
+}

--- a/backend/.sqlx/query-bd2260e545cb9bf9c2de722a9229685c54d4e7738768732e069ad3f16483e5e3.json
+++ b/backend/.sqlx/query-bd2260e545cb9bf9c2de722a9229685c54d4e7738768732e069ad3f16483e5e3.json
@@ -1,0 +1,124 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, repository_id, scan_type, status,\n                   findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                   scanner_version, error_message, started_at, completed_at, created_at,\n                   is_reused, source_scan_id\n            FROM scan_results\n            WHERE id = $1\n            FOR SHARE\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "bd2260e545cb9bf9c2de722a9229685c54d4e7738768732e069ad3f16483e5e3"
+}

--- a/backend/.sqlx/query-bdcd1a9851d29a5f5c9d15d3eff05196ff48fb8d2f622939ab5190c6574fdee8.json
+++ b/backend/.sqlx/query-bdcd1a9851d29a5f5c9d15d3eff05196ff48fb8d2f622939ab5190c6574fdee8.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*) as \"count!\"\n        FROM users\n        WHERE ($1::text IS NULL OR username ILIKE $1 OR email ILIKE $1 OR display_name ILIKE $1)\n          AND ($2::boolean IS NULL OR is_active = $2)\n          AND ($3::boolean IS NULL OR is_admin = $3)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "bdcd1a9851d29a5f5c9d15d3eff05196ff48fb8d2f622939ab5190c6574fdee8"
+}

--- a/backend/.sqlx/query-bf1229d219c3f9ee20cb52d8b73d6a37dae9513efb79f35b591ca59e5d1b7239.json
+++ b/backend/.sqlx/query-bf1229d219c3f9ee20cb52d8b73d6a37dae9513efb79f35b591ca59e5d1b7239.json
@@ -1,0 +1,165 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            id, username, email, password_hash, display_name,\n            auth_provider as \"auth_provider: AuthProvider\",\n            external_id, is_admin, is_active, is_service_account, must_change_password,\n            totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n            failed_login_attempts, locked_until, last_failed_login_at,\n            password_changed_at, last_login_at, created_at, updated_at\n        FROM users\n        WHERE ($1::text IS NULL OR username ILIKE $1 OR email ILIKE $1 OR display_name ILIKE $1)\n          AND ($2::boolean IS NULL OR is_active = $2)\n          AND ($3::boolean IS NULL OR is_admin = $3)\n        ORDER BY username\n        OFFSET $4\n        LIMIT $5\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool",
+        "Bool",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "bf1229d219c3f9ee20cb52d8b73d6a37dae9513efb79f35b591ca59e5d1b7239"
+}

--- a/backend/.sqlx/query-bf3caba50ceec756f28f5bc463ce98e6e3e178a3c6046f2b37c81e227e6fa9b5.json
+++ b/backend/.sqlx/query-bf3caba50ceec756f28f5bc463ce98e6e3e178a3c6046f2b37c81e227e6fa9b5.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            COUNT(*) as \"download_count!\",\n            MIN(downloaded_at) as first_downloaded,\n            MAX(downloaded_at) as last_downloaded\n        FROM download_statistics\n        WHERE artifact_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "download_count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "first_downloaded",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "last_downloaded",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "bf3caba50ceec756f28f5bc463ce98e6e3e178a3c6046f2b37c81e227e6fa9b5"
+}

--- a/backend/.sqlx/query-bfba99300202448b3393474afc67a1eeb29f14aa4e4eec264810eff615b15c12.json
+++ b/backend/.sqlx/query-bfba99300202448b3393474afc67a1eeb29f14aa4e4eec264810eff615b15c12.json
@@ -1,0 +1,175 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE users\n            SET is_active = true, updated_at = NOW()\n            WHERE external_id = $1 AND auth_provider = $2\n            RETURNING\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "bfba99300202448b3393474afc67a1eeb29f14aa4e4eec264810eff615b15c12"
+}

--- a/backend/.sqlx/query-bfce00bef037f11faed40dbb747b72dd8ce186e7efb36b8ade8b4afc921870c4.json
+++ b/backend/.sqlx/query-bfce00bef037f11faed40dbb747b72dd8ce186e7efb36b8ade8b4afc921870c4.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO peer_connections (source_peer_id, target_peer_id, status)\n            VALUES ($1, $2, 'active')\n            ON CONFLICT (source_peer_id, target_peer_id) DO NOTHING\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "bfce00bef037f11faed40dbb747b72dd8ce186e7efb36b8ade8b4afc921870c4"
+}

--- a/backend/.sqlx/query-c1179bf00d6a5e2a4053668a02541ca2974f97f3e4bb56a72ad789156f47da79.json
+++ b/backend/.sqlx/query-c1179bf00d6a5e2a4053668a02541ca2974f97f3e4bb56a72ad789156f47da79.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE users SET totp_secret = $2 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c1179bf00d6a5e2a4053668a02541ca2974f97f3e4bb56a72ad789156f47da79"
+}

--- a/backend/.sqlx/query-c13277b2c39c8178dcde9d65f8340f697fb97a041956ea2aee12b30557c86303.json
+++ b/backend/.sqlx/query-c13277b2c39c8178dcde9d65f8340f697fb97a041956ea2aee12b30557c86303.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n          AND a.version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c13277b2c39c8178dcde9d65f8340f697fb97a041956ea2aee12b30557c86303"
+}

--- a/backend/.sqlx/query-c1ac096c425e915cf48ef5d5ac7f2c8238403fe5e4672585cfb6b2a7987f9b4d.json
+++ b/backend/.sqlx/query-c1ac096c425e915cf48ef5d5ac7f2c8238403fe5e4672585cfb6b2a7987f9b4d.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(DISTINCT a.name)\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.name ILIKE $2\n          AND ($3::text IS NULL OR am.metadata #>> '{composer,type}' = $3)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c1ac096c425e915cf48ef5d5ac7f2c8238403fe5e4672585cfb6b2a7987f9b4d"
+}

--- a/backend/.sqlx/query-c2dd55f8fddfe90abac5f38fdab6204ca5dfd40a8716e3d9916ad72d0c7744d2.json
+++ b/backend/.sqlx/query-c2dd55f8fddfe90abac5f38fdab6204ca5dfd40a8716e3d9916ad72d0c7744d2.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transfer_sessions\n            SET status = 'failed', error_message = $2, completed_at = NOW()\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c2dd55f8fddfe90abac5f38fdab6204ca5dfd40a8716e3d9916ad72d0c7744d2"
+}

--- a/backend/.sqlx/query-c2f3678ba7030d21cd06fa525a92a4db95c26df57e5b365a65ff6ee0afa98ba2.json
+++ b/backend/.sqlx/query-c2f3678ba7030d21cd06fa525a92a4db95c26df57e5b365a65ff6ee0afa98ba2.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT repository_id FROM peer_repo_subscriptions WHERE peer_instance_id = $1 AND sync_enabled = true",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c2f3678ba7030d21cd06fa525a92a4db95c26df57e5b365a65ff6ee0afa98ba2"
+}

--- a/backend/.sqlx/query-c32fa0960026fb6b9f33c4f5ec28f77df9ac797ace64586e8b3ee4a03ef2861e.json
+++ b/backend/.sqlx/query-c32fa0960026fb6b9f33c4f5ec28f77df9ac797ace64586e8b3ee4a03ef2861e.json
@@ -1,0 +1,121 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO peer_connections\n                (source_peer_id, target_peer_id, status, latency_ms,\n                 bandwidth_estimate_bps, last_probed_at)\n            VALUES ($1, $2, 'active', $3, $4, NOW())\n            ON CONFLICT (source_peer_id, target_peer_id) DO UPDATE\n                SET status = 'active', latency_ms = $3,\n                    bandwidth_estimate_bps = COALESCE($4, peer_connections.bandwidth_estimate_bps),\n                    last_probed_at = NOW(), updated_at = NOW()\n            RETURNING\n                id, source_peer_id, target_peer_id,\n                status as \"status: PeerStatus\",\n                latency_ms, bandwidth_estimate_bps,\n                shared_artifacts_count, shared_chunks_count,\n                last_probed_at, last_transfer_at,\n                bytes_transferred_total, transfer_success_count, transfer_failure_count,\n                created_at, updated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "source_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "target_peer_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "status: PeerStatus",
+        "type_info": {
+          "Custom": {
+            "name": "peer_status",
+            "kind": {
+              "Enum": [
+                "active",
+                "probing",
+                "unreachable",
+                "disabled"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 4,
+        "name": "latency_ms",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "bandwidth_estimate_bps",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "shared_artifacts_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "shared_chunks_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "last_probed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "last_transfer_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 10,
+        "name": "bytes_transferred_total",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 11,
+        "name": "transfer_success_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 12,
+        "name": "transfer_failure_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Int4",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c32fa0960026fb6b9f33c4f5ec28f77df9ac797ace64586e8b3ee4a03ef2861e"
+}

--- a/backend/.sqlx/query-c48a1b8fc9889658fcf4bd063a5f86c49cf9ce9a7fb9703352d1f7c997707c8a.json
+++ b/backend/.sqlx/query-c48a1b8fc9889658fcf4bd063a5f86c49cf9ce9a7fb9703352d1f7c997707c8a.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE peer_repo_subscriptions SET last_replicated_at = NOW() WHERE peer_instance_id = $1 AND repository_id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c48a1b8fc9889658fcf4bd063a5f86c49cf9ce9a7fb9703352d1f7c997707c8a"
+}

--- a/backend/.sqlx/query-c757e2510e8bd19ab425511f5a85ac8947a11608aa656d6c79f2e57fdd8cf105.json
+++ b/backend/.sqlx/query-c757e2510e8bd19ab425511f5a85ac8947a11608aa656d6c79f2e57fdd8cf105.json
@@ -1,0 +1,79 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, webhook_id, event, payload, response_status, response_body, success, attempts, delivered_at, created_at\n        FROM webhook_deliveries\n        WHERE webhook_id = $1\n          AND ($2::boolean IS NULL OR success = $2)\n        ORDER BY created_at DESC\n        OFFSET $3\n        LIMIT $4\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "webhook_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "payload",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "response_status",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "response_body",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "success",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 7,
+        "name": "attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "delivered_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 9,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "c757e2510e8bd19ab425511f5a85ac8947a11608aa656d6c79f2e57fdd8cf105"
+}

--- a/backend/.sqlx/query-c7a9900df41b74b39a10e5d8fe85b589c6534ba077c2323c51b6e34e83ed1cc6.json
+++ b/backend/.sqlx/query-c7a9900df41b74b39a10e5d8fe85b589c6534ba077c2323c51b6e34e83ed1cc6.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, format, metadata, properties\n            FROM artifact_metadata\n            WHERE artifact_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "format",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "properties",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c7a9900df41b74b39a10e5d8fe85b589c6534ba077c2323c51b6e34e83ed1cc6"
+}

--- a/backend/.sqlx/query-c859fcdfed67c131ceb91c6d7b10a85c0a08aa14ed597cc7dfea51aa27ef6a1f.json
+++ b/backend/.sqlx/query-c859fcdfed67c131ceb91c6d7b10a85c0a08aa14ed597cc7dfea51aa27ef6a1f.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_findings (\n                scan_result_id, artifact_id, severity, title, description,\n                cve_id, affected_component, affected_version, fixed_version,\n                source, source_url\n            )\n            SELECT $1, $2, severity, title, description,\n                   cve_id, affected_component, affected_version, fixed_version,\n                   source, source_url\n            FROM scan_findings\n            WHERE scan_result_id = $3\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c859fcdfed67c131ceb91c6d7b10a85c0a08aa14ed597cc7dfea51aa27ef6a1f"
+}

--- a/backend/.sqlx/query-c86eab3878c3aef7512b70e4bba538e769e740ae44d1fa94212ba26b5753d3a2.json
+++ b/backend/.sqlx/query-c86eab3878c3aef7512b70e4bba538e769e740ae44d1fa94212ba26b5753d3a2.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.name, a.version, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.metadata->>'is_binary' = 'true'\n        ORDER BY a.name, a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "c86eab3878c3aef7512b70e4bba538e769e740ae44d1fa94212ba26b5753d3a2"
+}

--- a/backend/.sqlx/query-c88d26fb4ac95c434e7e6c35fc9d778bf96a7fc78bc493abee8cfe9ee1680505.json
+++ b/backend/.sqlx/query-c88d26fb4ac95c434e7e6c35fc9d778bf96a7fc78bc493abee8cfe9ee1680505.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT am.metadata->>'file' as \"file?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND am.metadata->>'type' = 'recipe'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' = $6\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "file?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "c88d26fb4ac95c434e7e6c35fc9d778bf96a7fc78bc493abee8cfe9ee1680505"
+}

--- a/backend/.sqlx/query-c8ff07a0a985186e9ec1e99f542346c264432a1b99509ef1fe26846ebdae67a2.json
+++ b/backend/.sqlx/query-c8ff07a0a985186e9ec1e99f542346c264432a1b99509ef1fe26846ebdae67a2.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, MAX(created_at) AS \"updated_at!\"\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n        GROUP BY name\n        ORDER BY name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "updated_at!",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "c8ff07a0a985186e9ec1e99f542346c264432a1b99509ef1fe26846ebdae67a2"
+}

--- a/backend/.sqlx/query-c9419fcbadb9ed1c14a30b8d5acc51c38287f1867837e037ba1704964b74bc3d.json
+++ b/backend/.sqlx/query-c9419fcbadb9ed1c14a30b8d5acc51c38287f1867837e037ba1704964b74bc3d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'cargo', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "c9419fcbadb9ed1c14a30b8d5acc51c38287f1867837e037ba1704964b74bc3d"
+}

--- a/backend/.sqlx/query-c9dd75b7f7bb10a421633b81afba11794c29d7e881a014d4c4baae3f06edb54a.json
+++ b/backend/.sqlx/query-c9dd75b7f7bb10a421633b81afba11794c29d7e881a014d4c4baae3f06edb54a.json
@@ -1,0 +1,174 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE auth_provider = $1 AND is_active = true\n            ORDER BY username\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "c9dd75b7f7bb10a421633b81afba11794c29d7e881a014d4c4baae3f06edb54a"
+}

--- a/backend/.sqlx/query-c9e098a4468c99c18893d0cf2558a760bd82addd72e41fc62d5fd99085f69836.json
+++ b/backend/.sqlx/query-c9e098a4468c99c18893d0cf2558a760bd82addd72e41fc62d5fd99085f69836.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, locked_at, owner_name\n        FROM lfs_locks\n        WHERE repository_id = $1\n          AND id = $2\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "locked_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "owner_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c9e098a4468c99c18893d0cf2558a760bd82addd72e41fc62d5fd99085f69836"
+}

--- a/backend/.sqlx/query-caf0389fc4b6d5f66fd19f0869070f1a6a1eb89ae9034172257b3e54779a8cc6.json
+++ b/backend/.sqlx/query-caf0389fc4b6d5f66fd19f0869070f1a6a1eb89ae9034172257b3e54779a8cc6.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT hosted_bytes FROM repository_usage_ledger WHERE repository_id = $1 FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "hosted_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "caf0389fc4b6d5f66fd19f0869070f1a6a1eb89ae9034172257b3e54779a8cc6"
+}

--- a/backend/.sqlx/query-cb435986464f574cee7739b8ae44cdec92182aded467642cf53e67eb5cb961a5.json
+++ b/backend/.sqlx/query-cb435986464f574cee7739b8ae44cdec92182aded467642cf53e67eb5cb961a5.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM peer_instances WHERE status = 'online'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "cb435986464f574cee7739b8ae44cdec92182aded467642cf53e67eb5cb961a5"
+}

--- a/backend/.sqlx/query-cb8171dd853ccc267c3d7e3b5538a576ecbe2111d9fe81e9bfedf8fb4f25a670.json
+++ b/backend/.sqlx/query-cb8171dd853ccc267c3d7e3b5538a576ecbe2111d9fe81e9bfedf8fb4f25a670.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2) ON CONFLICT DO NOTHING",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cb8171dd853ccc267c3d7e3b5538a576ecbe2111d9fe81e9bfedf8fb4f25a670"
+}

--- a/backend/.sqlx/query-cbb7fc902dd898da8b804267796ee3b15d130b48c927712a6c1b85d40585453f.json
+++ b/backend/.sqlx/query-cbb7fc902dd898da8b804267796ee3b15d130b48c927712a6c1b85d40585453f.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE age_gate_reviews r\n            SET status = 'approved', reviewed_by = NULL, reviewed_at = NOW(),\n                review_reason = $1\n            FROM repositories repo\n            WHERE r.repository_id = repo.id\n              AND r.status = 'pending'\n              AND repo.age_gate_enabled = true\n              AND r.upstream_published_at IS NOT NULL\n              AND NOW() - r.upstream_published_at >= make_interval(days => repo.age_gate_min_age_days)\n            RETURNING r.id AS \"id!\", r.repository_id AS \"repository_id!\"\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id!",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id!",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "cbb7fc902dd898da8b804267796ee3b15d130b48c927712a6c1b85d40585453f"
+}

--- a/backend/.sqlx/query-cd1f678443f57f494d8b0eaba29dea248ef82910f8aa448ec2713eca6bedf277.json
+++ b/backend/.sqlx/query-cd1f678443f57f494d8b0eaba29dea248ef82910f8aa448ec2713eca6bedf277.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT token_id, repo_id FROM api_token_repositories WHERE token_id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "token_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repo_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "cd1f678443f57f494d8b0eaba29dea248ef82910f8aa448ec2713eca6bedf277"
+}

--- a/backend/.sqlx/query-cf4c6343363b9b57dedf3c975574fc6af224a9ab10827f09dea8d9dbda2d9607.json
+++ b/backend/.sqlx/query-cf4c6343363b9b57dedf3c975574fc6af224a9ab10827f09dea8d9dbda2d9607.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO plugin_events (plugin_id, event_type, severity, message, details)\n            VALUES ($1, $2, $3, $4, $5)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Varchar",
+        "Text",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cf4c6343363b9b57dedf3c975574fc6af224a9ab10827f09dea8d9dbda2d9607"
+}

--- a/backend/.sqlx/query-cf88107c6e3da24160d06cbbaa2dab2e89af4ecb6c1ef4ec108cc0d3535654e8.json
+++ b/backend/.sqlx/query-cf88107c6e3da24160d06cbbaa2dab2e89af4ecb6c1ef4ec108cc0d3535654e8.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.storage_key\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.path LIKE '%/' || $2 ESCAPE '\\'\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "cf88107c6e3da24160d06cbbaa2dab2e89af4ecb6c1ef4ec108cc0d3535654e8"
+}

--- a/backend/.sqlx/query-cfce0385dee0a43e734a2e9149bd03808e36ab861c27a70a5351d0bcfe5d9cd1.json
+++ b/backend/.sqlx/query-cfce0385dee0a43e734a2e9149bd03808e36ab861c27a70a5351d0bcfe5d9cd1.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO api_token_repositories (token_id, repo_id) VALUES ($1, $2)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cfce0385dee0a43e734a2e9149bd03808e36ab861c27a70a5351d0bcfe5d9cd1"
+}

--- a/backend/.sqlx/query-d1414e9e8370b009f5f38e3a91d253b544d4d44679d1997248bb0f10c3f59c3e.json
+++ b/backend/.sqlx/query-d1414e9e8370b009f5f38e3a91d253b544d4d44679d1997248bb0f10c3f59c3e.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, repo_selector FROM api_tokens WHERE id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repo_selector",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "d1414e9e8370b009f5f38e3a91d253b544d4d44679d1997248bb0f10c3f59c3e"
+}

--- a/backend/.sqlx/query-d15467732d290257e1b8e07e72d4bc5b245f8fa989370376367ab55e3f498ee2.json
+++ b/backend/.sqlx/query-d15467732d290257e1b8e07e72d4bc5b245f8fa989370376367ab55e3f498ee2.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transfer_chunks\n            SET status = 'completed', checksum = $3, source_peer_id = $4,\n                downloaded_at = NOW(), attempts = attempts + 1\n            WHERE session_id = $1 AND chunk_index = $2 AND status != 'completed'\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d15467732d290257e1b8e07e72d4bc5b245f8fa989370376367ab55e3f498ee2"
+}

--- a/backend/.sqlx/query-d194328e871b566d2fbdb45a1daaf32c98ed1da608e9ce800a1d9707385bc5c0.json
+++ b/backend/.sqlx/query-d194328e871b566d2fbdb45a1daaf32c98ed1da608e9ce800a1d9707385bc5c0.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM refresh_token_jti WHERE expires_at < $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d194328e871b566d2fbdb45a1daaf32c98ed1da608e9ce800a1d9707385bc5c0"
+}

--- a/backend/.sqlx/query-d1af1d67854cce10e9ff0dddcfd3a813c923fe0df58cf10b82f8ac23b4057001.json
+++ b/backend/.sqlx/query-d1af1d67854cce10e9ff0dddcfd3a813c923fe0df58cf10b82f8ac23b4057001.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, checksum_sha256\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d1af1d67854cce10e9ff0dddcfd3a813c923fe0df58cf10b82f8ac23b4057001"
+}

--- a/backend/.sqlx/query-d2254e9918a5c4a9ea96e4b7f31cfed8c46e0dc93575e250519847bd9e2d136f.json
+++ b/backend/.sqlx/query-d2254e9918a5c4a9ea96e4b7f31cfed8c46e0dc93575e250519847bd9e2d136f.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT a.version, a.path, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.name = $2\n          AND a.is_deleted = false\n          AND a.version IS NOT NULL\n        ORDER BY a.version\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "d2254e9918a5c4a9ea96e4b7f31cfed8c46e0dc93575e250519847bd9e2d136f"
+}

--- a/backend/.sqlx/query-d26130daa478befad3f957631c791529e1bc8377cbdec09951982d07b3c5ffd0.json
+++ b/backend/.sqlx/query-d26130daa478befad3f957631c791529e1bc8377cbdec09951982d07b3c5ffd0.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE username = $1 AND is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "d26130daa478befad3f957631c791529e1bc8377cbdec09951982d07b3c5ffd0"
+}

--- a/backend/.sqlx/query-d40c26aea3772243eb9b8b6edbbf704c82efcf729fd3f0300c60fcebe8b4bdde.json
+++ b/backend/.sqlx/query-d40c26aea3772243eb9b8b6edbbf704c82efcf729fd3f0300c60fcebe8b4bdde.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT path, size_bytes, checksum_sha256\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path LIKE $2 || '%' ESCAPE '\\'\n        ORDER BY path\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d40c26aea3772243eb9b8b6edbbf704c82efcf729fd3f0300c60fcebe8b4bdde"
+}

--- a/backend/.sqlx/query-d50ad8ef23948188712a3c780dd2c338f92fa8de7947a3173d1bedf0a0d0804f.json
+++ b/backend/.sqlx/query-d50ad8ef23948188712a3c780dd2c338f92fa8de7947a3173d1bedf0a0d0804f.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO promotion_history (\n                id, artifact_id, source_repo_id, target_repo_id,\n                promoted_by, policy_result, notes\n            )\n            VALUES ($1, $2, $3, $4, $5, $6, $7)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Jsonb",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d50ad8ef23948188712a3c780dd2c338f92fa8de7947a3173d1bedf0a0d0804f"
+}

--- a/backend/.sqlx/query-d527e4b377ac1fe18e52ebc5f7626119cd1d579876c079a4554f659a79b5ddb6.json
+++ b/backend/.sqlx/query-d527e4b377ac1fe18e52ebc5f7626119cd1d579876c079a4554f659a79b5ddb6.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            COUNT(*) as \"count!\",\n            COALESCE(SUM(size_bytes), 0)::BIGINT as \"size!\"\n        FROM artifacts\n        WHERE is_deleted = false\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "size!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null,
+      null
+    ]
+  },
+  "hash": "d527e4b377ac1fe18e52ebc5f7626119cd1d579876c079a4554f659a79b5ddb6"
+}

--- a/backend/.sqlx/query-d6d68bd008026dfd081250a4d310452063d11d0150da6f63e063c0586208fad4.json
+++ b/backend/.sqlx/query-d6d68bd008026dfd081250a4d310452063d11d0150da6f63e063c0586208fad4.json
@@ -1,0 +1,51 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT path, size_bytes, checksum_sha256, content_type, cached_at\n        FROM proxy_cache_artifacts\n        WHERE repository_id = $1\n          AND ($2::TEXT IS NULL OR path LIKE $2 ESCAPE '\\')\n          AND ($3::TEXT IS NULL OR path ILIKE $3 ESCAPE '\\')\n          AND ($4::TEXT IS NULL OR path > $4)\n        ORDER BY path\n        LIMIT $5 OFFSET $6\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "checksum_sha256",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "content_type",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "cached_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "d6d68bd008026dfd081250a4d310452063d11d0150da6f63e063c0586208fad4"
+}

--- a/backend/.sqlx/query-d74c5e1b1399cde46aa9634037604be76282cce604edd173b351ee4159e1905e.json
+++ b/backend/.sqlx/query-d74c5e1b1399cde46aa9634037604be76282cce604edd173b351ee4159e1905e.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            FROM artifacts\n            WHERE repository_id = $1 AND path = $2 AND is_deleted = false\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "d74c5e1b1399cde46aa9634037604be76282cce604edd173b351ee4159e1905e"
+}

--- a/backend/.sqlx/query-d79de8bd44c1f180124de77cbcacf4eb772136088fc06d81e13ccadd3a9e62ea.json
+++ b/backend/.sqlx/query-d79de8bd44c1f180124de77cbcacf4eb772136088fc06d81e13ccadd3a9e62ea.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT handler_type as \"handler_type: FormatHandlerType\" FROM format_handlers WHERE format_key = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "handler_type: FormatHandlerType",
+        "type_info": {
+          "Custom": {
+            "name": "format_handler_type",
+            "kind": {
+              "Enum": [
+                "core",
+                "wasm"
+              ]
+            }
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d79de8bd44c1f180124de77cbcacf4eb772136088fc06d81e13ccadd3a9e62ea"
+}

--- a/backend/.sqlx/query-d7b1ed4a3a070a5e1b884c876044bb1d45f56344b33c653c3a96192765816f8e.json
+++ b/backend/.sqlx/query-d7b1ed4a3a070a5e1b884c876044bb1d45f56344b33c653c3a96192765816f8e.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE artifacts SET is_deleted = true, updated_at = NOW() WHERE repository_id = $1 AND path = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d7b1ed4a3a070a5e1b884c876044bb1d45f56344b33c653c3a96192765816f8e"
+}

--- a/backend/.sqlx/query-d89933fead6fc343ade0d0bd8526cd610163d6c0d2445170d4287bbf3f3ab2ac.json
+++ b/backend/.sqlx/query-d89933fead6fc343ade0d0bd8526cd610163d6c0d2445170d4287bbf3f3ab2ac.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND LOWER(name) = LOWER($2)\n          AND version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "d89933fead6fc343ade0d0bd8526cd610163d6c0d2445170d4287bbf3f3ab2ac"
+}

--- a/backend/.sqlx/query-d9e55ee7285dd90f446308569571a6d93780ecf0bc9c2ba00ae54c01418e2d73.json
+++ b/backend/.sqlx/query-d9e55ee7285dd90f446308569571a6d93780ecf0bc9c2ba00ae54c01418e2d73.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_instances\n            SET status = 'offline'\n            WHERE status = 'online'\n              AND last_heartbeat_at < NOW() - make_interval(mins => $1)\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d9e55ee7285dd90f446308569571a6d93780ecf0bc9c2ba00ae54c01418e2d73"
+}

--- a/backend/.sqlx/query-da025ba1ad46815d5e96051fe2f9280022fcdbf5ae59761d019274e0c4fb8322.json
+++ b/backend/.sqlx/query-da025ba1ad46815d5e96051fe2f9280022fcdbf5ae59761d019274e0c4fb8322.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM plugin_events WHERE plugin_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "da025ba1ad46815d5e96051fe2f9280022fcdbf5ae59761d019274e0c4fb8322"
+}

--- a/backend/.sqlx/query-da16b39f9feafe83d9a9442fae47131c3d17f21dd81c69f371574cfae86c6b76.json
+++ b/backend/.sqlx/query-da16b39f9feafe83d9a9442fae47131c3d17f21dd81c69f371574cfae86c6b76.json
@@ -1,0 +1,104 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO repo_security_scores (repository_id, score, grade, total_findings,\n                critical_count, high_count, medium_count, low_count,\n                acknowledged_count, last_scan_at, has_failed_scan, calculated_at)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW())\n            ON CONFLICT (repository_id)\n            DO UPDATE SET\n                score = EXCLUDED.score,\n                grade = EXCLUDED.grade,\n                total_findings = EXCLUDED.total_findings,\n                critical_count = EXCLUDED.critical_count,\n                high_count = EXCLUDED.high_count,\n                medium_count = EXCLUDED.medium_count,\n                low_count = EXCLUDED.low_count,\n                acknowledged_count = EXCLUDED.acknowledged_count,\n                last_scan_at = EXCLUDED.last_scan_at,\n                has_failed_scan = EXCLUDED.has_failed_scan,\n                calculated_at = NOW()\n            RETURNING id, repository_id, score, grade, total_findings,\n                      critical_count, high_count, medium_count, low_count,\n                      acknowledged_count, last_scan_at, has_failed_scan, calculated_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "score",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "grade",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "total_findings",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "acknowledged_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "last_scan_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "has_failed_scan",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "calculated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Bpchar",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Int4",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "da16b39f9feafe83d9a9442fae47131c3d17f21dd81c69f371574cfae86c6b76"
+}

--- a/backend/.sqlx/query-dabfa9f345152ab93a5d0b5e41395570ddb6107b8dd6ad614052b656bafd9aa2.json
+++ b/backend/.sqlx/query-dabfa9f345152ab93a5d0b5e41395570ddb6107b8dd6ad614052b656bafd9aa2.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            WITH latest_scans AS (\n                SELECT DISTINCT ON (sr.artifact_id, sr.scan_type) sr.id\n                FROM scan_results sr\n                JOIN artifacts a ON a.id = sr.artifact_id\n                WHERE a.repository_id = $1\n                  AND NOT a.is_deleted\n                  AND sr.status = 'completed'\n                ORDER BY sr.artifact_id, sr.scan_type,\n                         sr.completed_at DESC NULLS LAST, sr.created_at DESC\n            )\n            SELECT\n                COUNT(*) FILTER (WHERE severity = 'critical' AND NOT is_acknowledged) as \"critical!\",\n                COUNT(*) FILTER (WHERE severity = 'high' AND NOT is_acknowledged) as \"high!\",\n                COUNT(*) FILTER (WHERE severity = 'medium' AND NOT is_acknowledged) as \"medium!\",\n                COUNT(*) FILTER (WHERE severity = 'low' AND NOT is_acknowledged) as \"low!\",\n                COUNT(*) FILTER (WHERE is_acknowledged) as \"acknowledged!\",\n                COUNT(*) as \"total!\"\n            FROM scan_findings\n            WHERE scan_result_id IN (SELECT id FROM latest_scans)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "critical!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "high!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 2,
+        "name": "medium!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "low!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 4,
+        "name": "acknowledged!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "total!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    ]
+  },
+  "hash": "dabfa9f345152ab93a5d0b5e41395570ddb6107b8dd6ad614052b656bafd9aa2"
+}

--- a/backend/.sqlx/query-db22727136649faed8dd71f8026c6ada167a7f446afb11f511cd38632dc575d8.json
+++ b/backend/.sqlx/query-db22727136649faed8dd71f8026c6ada167a7f446afb11f511cd38632dc575d8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                INSERT INTO repository_storage_stats\n                    (repository_id, logical_bytes, physical_bytes, unique_bytes,\n                     shared_bytes, blob_count, dedup_scope, computed_at)\n                VALUES ($1, $2, $3, $4, $5, $6, $7, now())\n                ON CONFLICT (repository_id) DO UPDATE SET\n                    logical_bytes  = EXCLUDED.logical_bytes,\n                    physical_bytes = EXCLUDED.physical_bytes,\n                    unique_bytes   = EXCLUDED.unique_bytes,\n                    shared_bytes   = EXCLUDED.shared_bytes,\n                    blob_count     = EXCLUDED.blob_count,\n                    dedup_scope    = EXCLUDED.dedup_scope,\n                    computed_at    = now()\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Int8",
+        "Int8",
+        "Int8",
+        "Int8",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "db22727136649faed8dd71f8026c6ada167a7f446afb11f511cd38632dc575d8"
+}

--- a/backend/.sqlx/query-db4acd3e1f52d3da23359a512b78b819d892cd632a550488f5e6b4ae32ccb8be.json
+++ b/backend/.sqlx/query-db4acd3e1f52d3da23359a512b78b819d892cd632a550488f5e6b4ae32ccb8be.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, package_version, status\n            FROM age_gate_reviews\n            WHERE repository_id = $1 AND package_name = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "package_version",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "status",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "db4acd3e1f52d3da23359a512b78b819d892cd632a550488f5e6b4ae32ccb8be"
+}

--- a/backend/.sqlx/query-dc641d586968cce243a87654e1cafaee052af9dfcc26e6fa259e7035d4a7f43b.json
+++ b/backend/.sqlx/query-dc641d586968cce243a87654e1cafaee052af9dfcc26e6fa259e7035d4a7f43b.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, path, locked_at, owner_name\n            FROM lfs_locks\n            WHERE repository_id = $1 AND path = $2\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "locked_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 3,
+        "name": "owner_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dc641d586968cce243a87654e1cafaee052af9dfcc26e6fa259e7035d4a7f43b"
+}

--- a/backend/.sqlx/query-dc6ef049572a2894a3a46bb16801a4476364e403ffd5774010f06c05d1086adb.json
+++ b/backend/.sqlx/query-dc6ef049572a2894a3a46bb16801a4476364e403ffd5774010f06c05d1086adb.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_repo_subscriptions\n            SET replication_mode = $3\n            WHERE peer_instance_id = $1 AND repository_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        {
+          "Custom": {
+            "name": "replication_mode",
+            "kind": {
+              "Enum": [
+                "push",
+                "pull",
+                "mirror",
+                "none"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dc6ef049572a2894a3a46bb16801a4476364e403ffd5774010f06c05d1086adb"
+}

--- a/backend/.sqlx/query-dc7506358286224b6fb49cfcc68f9ad3d96bbd1125cf33e263a47efc2fe9e6a0.json
+++ b/backend/.sqlx/query-dc7506358286224b6fb49cfcc68f9ad3d96bbd1125cf33e263a47efc2fe9e6a0.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            a.id,\n            a.path,\n            a.size_bytes,\n            a.created_at\n        FROM artifacts a\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND ($2 = '' OR a.path LIKE $2 || '%')\n        ORDER BY a.path\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dc7506358286224b6fb49cfcc68f9ad3d96bbd1125cf33e263a47efc2fe9e6a0"
+}

--- a/backend/.sqlx/query-dccdc286e940c0304813996e9b035f92e2d5a8e40d5486fb8d9d3a5254b963ad.json
+++ b/backend/.sqlx/query-dccdc286e940c0304813996e9b035f92e2d5a8e40d5486fb8d9d3a5254b963ad.json
@@ -1,0 +1,41 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, storage_key, size_bytes\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dccdc286e940c0304813996e9b035f92e2d5a8e40d5486fb8d9d3a5254b963ad"
+}

--- a/backend/.sqlx/query-dcd19181852770c85e075b687d53839c98f1acfe55b040bf52d56d5d04a659cd.json
+++ b/backend/.sqlx/query-dcd19181852770c85e075b687d53839c98f1acfe55b040bf52d56d5d04a659cd.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, path, size_bytes, checksum_sha256, storage_key\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n          AND path = $2\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dcd19181852770c85e075b687d53839c98f1acfe55b040bf52d56d5d04a659cd"
+}

--- a/backend/.sqlx/query-dd3765b62f2c3900320c27077d5452df5fa223283d0bce5bb2f36fac27908bd6.json
+++ b/backend/.sqlx/query-dd3765b62f2c3900320c27077d5452df5fa223283d0bce5bb2f36fac27908bd6.json
@@ -1,0 +1,127 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_results (artifact_id, repository_id, scan_type, status, started_at, checksum_sha256)\n            VALUES ($1, $2, $3, 'running', NOW(), $4)\n            RETURNING id, artifact_id, repository_id, scan_type, status,\n                      findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                      scanner_version, error_message, started_at, completed_at, created_at,\n                      is_reused, source_scan_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "dd3765b62f2c3900320c27077d5452df5fa223283d0bce5bb2f36fac27908bd6"
+}

--- a/backend/.sqlx/query-de3230de507ca1e11d2ca40bef8a5b8470628ddbaa454af4f49f6fe6953f9014.json
+++ b/backend/.sqlx/query-de3230de507ca1e11d2ca40bef8a5b8470628ddbaa454af4f49f6fe6953f9014.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT username FROM users WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "username",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "de3230de507ca1e11d2ca40bef8a5b8470628ddbaa454af4f49f6fe6953f9014"
+}

--- a/backend/.sqlx/query-de5528ad97803f42cd1a281eb2eee09434af8478c599552bbe839f430e12deda.json
+++ b/backend/.sqlx/query-de5528ad97803f42cd1a281eb2eee09434af8478c599552bbe839f430e12deda.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE plugins\n        SET config = $2\n        WHERE id = $1\n        RETURNING config_schema\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "config_schema",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "de5528ad97803f42cd1a281eb2eee09434af8478c599552bbe839f430e12deda"
+}

--- a/backend/.sqlx/query-dedddf6839b1bbb75aace02c7bd956c09efba1baeba3ba7d4c946c34210e5867.json
+++ b/backend/.sqlx/query-dedddf6839b1bbb75aace02c7bd956c09efba1baeba3ba7d4c946c34210e5867.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes, checksum_sha256\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND version = $3\n          AND is_deleted = false\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "dedddf6839b1bbb75aace02c7bd956c09efba1baeba3ba7d4c946c34210e5867"
+}

--- a/backend/.sqlx/query-dfe4d82a8a76c3192df7bc065e6b6c6544a0b55ee2809c46089063d1f6227a2b.json
+++ b/backend/.sqlx/query-dfe4d82a8a76c3192df7bc065e6b6c6544a0b55ee2809c46089063d1f6227a2b.json
@@ -1,0 +1,35 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.version, a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND a.name = $2\n        ORDER BY a.created_at ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "dfe4d82a8a76c3192df7bc065e6b6c6544a0b55ee2809c46089063d1f6227a2b"
+}

--- a/backend/.sqlx/query-e0b0b0e430dfeeea13e3cf70bd7bd6e10b2858c5f2cee2bcaa4671b24b744e23.json
+++ b/backend/.sqlx/query-e0b0b0e430dfeeea13e3cf70bd7bd6e10b2858c5f2cee2bcaa4671b24b744e23.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM proxy_cache_artifacts WHERE storage_key = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e0b0b0e430dfeeea13e3cf70bd7bd6e10b2858c5f2cee2bcaa4671b24b744e23"
+}

--- a/backend/.sqlx/query-e3f14da710ce8bb017355fd4d23f79e9b9a1aa3c111962ce5699fe19be8c064c.json
+++ b/backend/.sqlx/query-e3f14da710ce8bb017355fd4d23f79e9b9a1aa3c111962ce5699fe19be8c064c.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COUNT(*) as \"count!\"\n            FROM artifacts\n            WHERE repository_id = $1\n              AND is_deleted = false\n              AND ($2::text IS NULL OR path LIKE $2)\n              AND ($3::text IS NULL OR LOWER(name) LIKE $3 OR LOWER(path) LIKE $3)\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e3f14da710ce8bb017355fd4d23f79e9b9a1aa3c111962ce5699fe19be8c064c"
+}

--- a/backend/.sqlx/query-e3f30aa9e183801bd38ffa013f70a531ae36f0e99a9e67389ee5c1b44b549dd8.json
+++ b/backend/.sqlx/query-e3f30aa9e183801bd38ffa013f70a531ae36f0e99a9e67389ee5c1b44b549dd8.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                SELECT consumed_at, revoked_at, family_id\n                FROM refresh_token_jti\n                WHERE jti = $1\n                ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "consumed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 1,
+        "name": "revoked_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 2,
+        "name": "family_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "e3f30aa9e183801bd38ffa013f70a531ae36f0e99a9e67389ee5c1b44b549dd8"
+}

--- a/backend/.sqlx/query-e3ff56c317454630e9cf4d5d2a452b4e0ee67acfe10227dbaee6c2fa1218344b.json
+++ b/backend/.sqlx/query-e3ff56c317454630e9cf4d5d2a452b4e0ee67acfe10227dbaee6c2fa1218344b.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, repository_id, path, name, version, size_bytes,\n                checksum_sha256, checksum_md5, checksum_sha1,\n                content_type, storage_key, is_deleted, uploaded_by,\n                quarantine_status, quarantine_until,\n                created_at, updated_at\n            FROM artifacts\n            WHERE id = $1 AND repository_id = $2 AND is_deleted = false\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 6,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "checksum_md5",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "checksum_sha1",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "content_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "is_deleted",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 13,
+        "name": "quarantine_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 14,
+        "name": "quarantine_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "e3ff56c317454630e9cf4d5d2a452b4e0ee67acfe10227dbaee6c2fa1218344b"
+}

--- a/backend/.sqlx/query-e441aa00b0250e832fed586db91da1bcacb322c809ce0a084352bb5f4f08cbfb.json
+++ b/backend/.sqlx/query-e441aa00b0250e832fed586db91da1bcacb322c809ce0a084352bb5f4f08cbfb.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.version, a.size_bytes, a.checksum_sha256,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND LOWER(a.name) = LOWER($2)\n          AND a.version = $3\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "e441aa00b0250e832fed586db91da1bcacb322c809ce0a084352bb5f4f08cbfb"
+}

--- a/backend/.sqlx/query-e471f8dc2adefe9eed40e31ef143181ccaa1a1d1dcadc659f19a5ff3bc9505ce.json
+++ b/backend/.sqlx/query-e471f8dc2adefe9eed40e31ef143181ccaa1a1d1dcadc659f19a5ff3bc9505ce.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE peer_connections SET\n                shared_artifacts_count = (\n                    SELECT COUNT(DISTINCT ec1.artifact_id)\n                    FROM peer_cache_entries ec1\n                    JOIN peer_cache_entries ec2\n                        ON ec1.artifact_id = ec2.artifact_id\n                    WHERE ec1.peer_instance_id = $1 AND ec2.peer_instance_id = $2\n                ),\n                shared_chunks_count = (\n                    SELECT COALESCE(SUM(\n                        LEAST(ca1.available_chunks, ca2.available_chunks)\n                    ), 0)\n                    FROM chunk_availability ca1\n                    JOIN chunk_availability ca2\n                        ON ca1.artifact_id = ca2.artifact_id\n                    WHERE ca1.peer_instance_id = $1 AND ca2.peer_instance_id = $2\n                ),\n                updated_at = NOW()\n            WHERE source_peer_id = $1 AND target_peer_id = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e471f8dc2adefe9eed40e31ef143181ccaa1a1d1dcadc659f19a5ff3bc9505ce"
+}

--- a/backend/.sqlx/query-e4e027e4f8a6845938030dba25b54984770f449642e49e52d4444f6b583fbfad.json
+++ b/backend/.sqlx/query-e4e027e4f8a6845938030dba25b54984770f449642e49e52d4444f6b583fbfad.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, size_bytes\n            FROM artifacts\n            WHERE repository_id = $1\n              AND is_deleted = false\n              AND checksum_sha256 = $2\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "e4e027e4f8a6845938030dba25b54984770f449642e49e52d4444f6b583fbfad"
+}

--- a/backend/.sqlx/query-e54d1364b9e54f3dff67eb697c6f323746d6a20f4c17ebc4f1ad847ea55bb4f9.json
+++ b/backend/.sqlx/query-e54d1364b9e54f3dff67eb697c6f323746d6a20f4c17ebc4f1ad847ea55bb4f9.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE transfer_chunks\n            SET status = 'failed', last_error = $3, attempts = attempts + 1\n            WHERE session_id = $1 AND chunk_index = $2\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e54d1364b9e54f3dff67eb697c6f323746d6a20f4c17ebc4f1ad847ea55bb4f9"
+}

--- a/backend/.sqlx/query-e5785d82d0f2cb638dcc7ccb56e35b4c81b63c432d6f67b36bfa4d65c80bc7f6.json
+++ b/backend/.sqlx/query-e5785d82d0f2cb638dcc7ccb56e35b4c81b63c432d6f67b36bfa4d65c80bc7f6.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT name, version\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n        ORDER BY name, created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "e5785d82d0f2cb638dcc7ccb56e35b4c81b63c432d6f67b36bfa4d65c80bc7f6"
+}

--- a/backend/.sqlx/query-e5a3a5a03da22583ac5bdfc0ec650c036b2cb5692da32d85ebb15d11eb8fb9dc.json
+++ b/backend/.sqlx/query-e5a3a5a03da22583ac5bdfc0ec650c036b2cb5692da32d85ebb15d11eb8fb9dc.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT COUNT(*)::BIGINT AS \"count!\"\n        FROM proxy_cache_artifacts\n        WHERE repository_id = $1\n          AND ($2::TEXT IS NULL OR path LIKE $2 ESCAPE '\\')\n          AND ($3::TEXT IS NULL OR path ILIKE $3 ESCAPE '\\')\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e5a3a5a03da22583ac5bdfc0ec650c036b2cb5692da32d85ebb15d11eb8fb9dc"
+}

--- a/backend/.sqlx/query-e61a853db737412b5b6bc5d1c863e76ead3f98ce0c3b258af477dec97e0c506e.json
+++ b/backend/.sqlx/query-e61a853db737412b5b6bc5d1c863e76ead3f98ce0c3b258af477dec97e0c506e.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT ON (LOWER(name)) name, version\n        FROM artifacts\n        WHERE repository_id = $1\n          AND is_deleted = false\n        ORDER BY LOWER(name), created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "e61a853db737412b5b6bc5d1c863e76ead3f98ce0c3b258af477dec97e0c506e"
+}

--- a/backend/.sqlx/query-e73bbba52979f82096c5efd14dd5c6dfdb9d950a7feb871b82eb3253120e0198.json
+++ b/backend/.sqlx/query-e73bbba52979f82096c5efd14dd5c6dfdb9d950a7feb871b82eb3253120e0198.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT COALESCE(SUM(size_bytes), 0)::BIGINT as \"bytes!\"\n              FROM artifacts\n             WHERE repository_id = $1 AND is_deleted = false\n               AND storage_key NOT LIKE 'proxy-cache/%'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "bytes!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "e73bbba52979f82096c5efd14dd5c6dfdb9d950a7feb871b82eb3253120e0198"
+}

--- a/backend/.sqlx/query-e885810e8cdc718361ace6f114c75a4bb6244a29ea1629ea73152ea22b72e81c.json
+++ b/backend/.sqlx/query-e885810e8cdc718361ace6f114c75a4bb6244a29ea1629ea73152ea22b72e81c.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO proxy_cache_artifacts\n            (repository_id, path, storage_key, metadata_key, size_bytes,\n             checksum_sha256, content_type, cached_at, last_accessed_at)\n        VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())\n        ON CONFLICT (repository_id, path) DO UPDATE SET\n            last_accessed_at = now()\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Int8",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e885810e8cdc718361ace6f114c75a4bb6244a29ea1629ea73152ea22b72e81c"
+}

--- a/backend/.sqlx/query-e8ad345903aa7759da76f703d11b67e00e70a97b897e2591bfdbac2641ce5452.json
+++ b/backend/.sqlx/query-e8ad345903aa7759da76f703d11b67e00e70a97b897e2591bfdbac2641ce5452.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM artifacts WHERE repository_id = $1 AND LOWER(name) = LOWER($2) AND version = $3 AND is_deleted = false",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e8ad345903aa7759da76f703d11b67e00e70a97b897e2591bfdbac2641ce5452"
+}

--- a/backend/.sqlx/query-e986cc010617f88a30a3a9fb2bca1e198b44fd654649edeb7c7097be95f16dff.json
+++ b/backend/.sqlx/query-e986cc010617f88a30a3a9fb2bca1e198b44fd654649edeb7c7097be95f16dff.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'nuget', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "e986cc010617f88a30a3a9fb2bca1e198b44fd654649edeb7c7097be95f16dff"
+}

--- a/backend/.sqlx/query-e9dbc0f5ade116181a1f7aeb39e644a2dddaf0aeb35d58be058dce481a2d52d3.json
+++ b/backend/.sqlx/query-e9dbc0f5ade116181a1f7aeb39e644a2dddaf0aeb35d58be058dce481a2d52d3.json
@@ -1,0 +1,24 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    SELECT a.created_at\n                    FROM artifacts a\n                    INNER JOIN virtual_repo_members vrm ON a.repository_id = vrm.member_repo_id\n                    WHERE vrm.virtual_repo_id = $1\n                      AND a.name = $2\n                      AND a.version = $3\n                      AND a.is_deleted = false\n                    ORDER BY a.created_at ASC\n                    LIMIT 1\n                    ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e9dbc0f5ade116181a1f7aeb39e644a2dddaf0aeb35d58be058dce481a2d52d3"
+}

--- a/backend/.sqlx/query-eb72ac73ee4cd8b20fb35255b4ff30fc3a5798344d4df941969be4108f5c3a8a.json
+++ b/backend/.sqlx/query-eb72ac73ee4cd8b20fb35255b4ff30fc3a5798344d4df941969be4108f5c3a8a.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO scan_results\n                (artifact_id, repository_id, scan_type, status, error_message,\n                 started_at, completed_at, checksum_sha256)\n            VALUES ($1, $2, $3, 'not_applicable', $4, NOW(), NOW(), $5)\n            RETURNING id, artifact_id, repository_id, scan_type, status,\n                      findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                      scanner_version, error_message, started_at, completed_at, created_at,\n                      is_reused, source_scan_id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Text",
+        "Bpchar"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "eb72ac73ee4cd8b20fb35255b4ff30fc3a5798344d4df941969be4108f5c3a8a"
+}

--- a/backend/.sqlx/query-ebcc4a2a9f656fef5f4499c83882de8063db0dd278c5d07d567c7759c501634c.json
+++ b/backend/.sqlx/query-ebcc4a2a9f656fef5f4499c83882de8063db0dd278c5d07d567c7759c501634c.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.name, a.version, a.size_bytes,\n               am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n        ORDER BY a.name, a.created_at DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "ebcc4a2a9f656fef5f4499c83882de8063db0dd278c5d07d567c7759c501634c"
+}

--- a/backend/.sqlx/query-ec2ec815992abb0cde2242319e0924e73238ec7beef8ae93a4c8f76280cc7744.json
+++ b/backend/.sqlx/query-ec2ec815992abb0cde2242319e0924e73238ec7beef8ae93a4c8f76280cc7744.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT am.metadata->>'packageId' as \"package_id?\"\n        FROM artifacts a\n        JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND am.format = 'conan'\n          AND a.name = $2\n          AND a.version = $3\n          AND am.metadata->>'user' = $4\n          AND am.metadata->>'channel' = $5\n          AND am.metadata->>'revision' = $6\n          AND am.metadata->>'type' = 'package'\n          AND am.metadata->>'packageId' IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "package_id?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "ec2ec815992abb0cde2242319e0924e73238ec7beef8ae93a4c8f76280cc7744"
+}

--- a/backend/.sqlx/query-ec34f84e3212fbd955e6278e0d3670e4aa7f116777bddc6439123bd505f30c66.json
+++ b/backend/.sqlx/query-ec34f84e3212fbd955e6278e0d3670e4aa7f116777bddc6439123bd505f30c66.json
@@ -1,0 +1,29 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT version, created_at\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND is_deleted = false\n          AND version IS NOT NULL\n        ORDER BY created_at DESC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      true,
+      false
+    ]
+  },
+  "hash": "ec34f84e3212fbd955e6278e0d3670e4aa7f116777bddc6439123bd505f30c66"
+}

--- a/backend/.sqlx/query-ed379d747d009b0b496a3002cf1b10f97fc2838334e06e029e3ed6edbbf80dc2.json
+++ b/backend/.sqlx/query-ed379d747d009b0b496a3002cf1b10f97fc2838334e06e029e3ed6edbbf80dc2.json
@@ -1,0 +1,127 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, repository_id, scan_type, status,\n                   findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                   scanner_version, error_message, started_at, completed_at, created_at,\n                   is_reused, source_scan_id\n            FROM scan_results\n            WHERE checksum_sha256 = $1\n              AND scan_type = $2\n              AND status = 'completed'\n              AND completed_at > NOW() - (\n                  CASE WHEN findings_count = 0 THEN $4 ELSE $3 END || ' days'\n              )::interval\n            ORDER BY completed_at DESC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bpchar",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "ed379d747d009b0b496a3002cf1b10f97fc2838334e06e029e3ed6edbbf80dc2"
+}

--- a/backend/.sqlx/query-ee1c6848cc1ad8adf719457d357e1c369bbb133db854a9b19ad1ef9733f04e1b.json
+++ b/backend/.sqlx/query-ee1c6848cc1ad8adf719457d357e1c369bbb133db854a9b19ad1ef9733f04e1b.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        UPDATE plugins\n        SET status = 'active', enabled_at = NOW()\n        WHERE id = $1 AND status = 'disabled'\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ee1c6848cc1ad8adf719457d357e1c369bbb133db854a9b19ad1ef9733f04e1b"
+}

--- a/backend/.sqlx/query-f16e1411c15add5fb08be2c511ff157ec9c31653a5599140c59e738e32c5feb2.json
+++ b/backend/.sqlx/query-f16e1411c15add5fb08be2c511ff157ec9c31653a5599140c59e738e32c5feb2.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE age_gate_reviews\n            SET status = 'approved', reviewed_by = $2, reviewed_at = NOW(),\n                review_reason = $3\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f16e1411c15add5fb08be2c511ff157ec9c31653a5599140c59e738e32c5feb2"
+}

--- a/backend/.sqlx/query-f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f.json
+++ b/backend/.sqlx/query-f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f.json
@@ -1,0 +1,70 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT a.id, a.path, a.name, a.version, a.size_bytes, a.checksum_sha256,\n               a.storage_key, a.updated_at, am.metadata as \"metadata?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1 AND a.is_deleted = false\n          AND a.path LIKE '%.rpm'\n        ORDER BY a.name, a.version, a.path, a.id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "path",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 5,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 8,
+        "name": "metadata?",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f20218b6f10c33838ed9c99d64062b34267996a18df2bc8b1e0929c08cf8795f"
+}

--- a/backend/.sqlx/query-f249094e6008e20e1fb46241834e7f0fab474fce61673112de9bbb4cdfeda9dc.json
+++ b/backend/.sqlx/query-f249094e6008e20e1fb46241834e7f0fab474fce61673112de9bbb4cdfeda9dc.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM signing_keys WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "key_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "fingerprint",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "key_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "public_key_pem",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "private_key_enc",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 8,
+        "name": "algorithm",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "uid_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "uid_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "rotated_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "f249094e6008e20e1fb46241834e7f0fab474fce61673112de9bbb4cdfeda9dc"
+}

--- a/backend/.sqlx/query-f268518dd100c787b29549a0370c9982bb4e5dc3efc2835fa056462d01c0cc9e.json
+++ b/backend/.sqlx/query-f268518dd100c787b29549a0370c9982bb4e5dc3efc2835fa056462d01c0cc9e.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT * FROM signing_keys WHERE id = $1 FOR UPDATE",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "key_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "fingerprint",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "key_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "public_key_pem",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "private_key_enc",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 8,
+        "name": "algorithm",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "uid_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "uid_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "rotated_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "f268518dd100c787b29549a0370c9982bb4e5dc3efc2835fa056462d01c0cc9e"
+}

--- a/backend/.sqlx/query-f2b7c2bdb2a3c63ecbce9e3bedda84952b315e13924252713815dcd4bb976396.json
+++ b/backend/.sqlx/query-f2b7c2bdb2a3c63ecbce9e3bedda84952b315e13924252713815dcd4bb976396.json
@@ -1,0 +1,161 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE external_id = $1 AND auth_provider = 'saml'\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "f2b7c2bdb2a3c63ecbce9e3bedda84952b315e13924252713815dcd4bb976396"
+}

--- a/backend/.sqlx/query-f301c2a38f0dc7123cf6863b298b2d6fb1c502054fd032f566e96e1a284c7c0d.json
+++ b/backend/.sqlx/query-f301c2a38f0dc7123cf6863b298b2d6fb1c502054fd032f566e96e1a284c7c0d.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT a.name,\n               MAX(a.version) as \"max_version?\",\n               MAX(am.metadata::text) as \"metadata_text?\"\n        FROM artifacts a\n        LEFT JOIN artifact_metadata am ON am.artifact_id = a.id\n        WHERE a.repository_id = $1\n          AND a.is_deleted = false\n          AND ($2 = '' OR a.name ILIKE '%' || $2 || '%')\n        GROUP BY a.name\n        ORDER BY a.name\n        LIMIT $3\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "max_version?",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "metadata_text?",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "f301c2a38f0dc7123cf6863b298b2d6fb1c502054fd032f566e96e1a284c7c0d"
+}

--- a/backend/.sqlx/query-f49b33a3da20939933cfeec947ddfe5ad6f27fba04d317518ed5f00ddc22c6ca.json
+++ b/backend/.sqlx/query-f49b33a3da20939933cfeec947ddfe5ad6f27fba04d317518ed5f00ddc22c6ca.json
@@ -1,0 +1,119 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT * FROM signing_keys\n            WHERE repository_id = $1 AND name = $2 AND is_active = true\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "key_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "fingerprint",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "key_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "public_key_pem",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "private_key_enc",
+        "type_info": "Bytea"
+      },
+      {
+        "ordinal": 8,
+        "name": "algorithm",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "uid_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "uid_email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "expires_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "created_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 15,
+        "name": "rotated_from",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 16,
+        "name": "last_used_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true,
+      false,
+      false,
+      true,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "f49b33a3da20939933cfeec947ddfe5ad6f27fba04d317518ed5f00ddc22c6ca"
+}

--- a/backend/.sqlx/query-f4bcdf3811cf803d0bac625f205ee409ca6a7fe7247008ffce4effcb4d6b3b3b.json
+++ b/backend/.sqlx/query-f4bcdf3811cf803d0bac625f205ee409ca6a7fe7247008ffce4effcb4d6b3b3b.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT key AS repository_key, repo_type::text AS repository_type\n            FROM repositories\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "repository_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_type",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      null
+    ]
+  },
+  "hash": "f4bcdf3811cf803d0bac625f205ee409ca6a7fe7247008ffce4effcb4d6b3b3b"
+}

--- a/backend/.sqlx/query-f4dec45a47bb441da5ef55a085682d1c4a8c45474593202c47cbf43ba3137322.json
+++ b/backend/.sqlx/query-f4dec45a47bb441da5ef55a085682d1c4a8c45474593202c47cbf43ba3137322.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM api_tokens WHERE expires_at IS NOT NULL AND expires_at < NOW()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "f4dec45a47bb441da5ef55a085682d1c4a8c45474593202c47cbf43ba3137322"
+}

--- a/backend/.sqlx/query-f62c6ac7908b15e8a774c1ffea89518c970e3ead364b5a23d1f3d1b88188ffed.json
+++ b/backend/.sqlx/query-f62c6ac7908b15e8a774c1ffea89518c970e3ead364b5a23d1f3d1b88188ffed.json
@@ -1,0 +1,118 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_findings\n            SET is_acknowledged = false, acknowledged_by = NULL,\n                acknowledged_reason = NULL, acknowledged_at = NULL\n            WHERE id = $1\n            RETURNING id, scan_result_id, artifact_id, severity, title, description,\n                      cve_id, affected_component, affected_version, fixed_version,\n                      source, source_url, is_acknowledged, acknowledged_by,\n                      acknowledged_reason, acknowledged_at, created_at\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "scan_result_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "severity",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "title",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 6,
+        "name": "cve_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "affected_component",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 8,
+        "name": "affected_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "fixed_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 10,
+        "name": "source",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 11,
+        "name": "source_url",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "is_acknowledged",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "acknowledged_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 14,
+        "name": "acknowledged_reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 15,
+        "name": "acknowledged_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "f62c6ac7908b15e8a774c1ffea89518c970e3ead364b5a23d1f3d1b88188ffed"
+}

--- a/backend/.sqlx/query-f7155d6276a8819c663b8c7a809ca4f39c5c2e473025b7bb73c4269dbe92c38d.json
+++ b/backend/.sqlx/query-f7155d6276a8819c663b8c7a809ca4f39c5c2e473025b7bb73c4269dbe92c38d.json
@@ -1,0 +1,128 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, artifact_id, repository_id, scan_type, status,\n                   findings_count, critical_count, high_count, medium_count, low_count, info_count,\n                   scanner_version, error_message, started_at, completed_at, created_at,\n                   is_reused, source_scan_id\n            FROM scan_results\n            WHERE artifact_id = $1\n              AND checksum_sha256 = $2\n              AND scan_type = $3\n              AND status = 'completed'\n              AND completed_at > NOW() - (\n                  CASE WHEN findings_count = 0 THEN $5 ELSE $4 END || ' days'\n              )::interval\n            ORDER BY completed_at DESC\n            LIMIT 1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "artifact_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 3,
+        "name": "scan_type",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "findings_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "info_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 11,
+        "name": "scanner_version",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 12,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "started_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 14,
+        "name": "completed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 16,
+        "name": "is_reused",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 17,
+        "name": "source_scan_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bpchar",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "f7155d6276a8819c663b8c7a809ca4f39c5c2e473025b7bb73c4269dbe92c38d"
+}

--- a/backend/.sqlx/query-f717fd4b2e1511582c10912d11747b68d5006a6f2eb6e9623ca47503bbc0b86c.json
+++ b/backend/.sqlx/query-f717fd4b2e1511582c10912d11747b68d5006a6f2eb6e9623ca47503bbc0b86c.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            INSERT INTO age_gate_reviews (\n                repository_id, package_name, package_version,\n                upstream_published_at, status\n            )\n            VALUES ($1, $2, $3, $4, 'pending')\n            ON CONFLICT (repository_id, package_name, package_version)\n            DO UPDATE SET\n                request_count = age_gate_reviews.request_count + 1,\n                last_requested_at = NOW(),\n                upstream_published_at = COALESCE(EXCLUDED.upstream_published_at, age_gate_reviews.upstream_published_at)\n            RETURNING id\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "f717fd4b2e1511582c10912d11747b68d5006a6f2eb6e9623ca47503bbc0b86c"
+}

--- a/backend/.sqlx/query-f7927f661649e73e2b399a8d9f65a5c51330677b0fa669f9045050f593454b8b.json
+++ b/backend/.sqlx/query-f7927f661649e73e2b399a8d9f65a5c51330677b0fa669f9045050f593454b8b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT quota_bytes FROM repositories WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "quota_bytes",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "f7927f661649e73e2b399a8d9f65a5c51330677b0fa669f9045050f593454b8b"
+}

--- a/backend/.sqlx/query-f7ca89fa86dee3a69abab05bcef202cc1ef168106384a7d085149d39c9559766.json
+++ b/backend/.sqlx/query-f7ca89fa86dee3a69abab05bcef202cc1ef168106384a7d085149d39c9559766.json
@@ -1,0 +1,94 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, repository_id, score, grade, total_findings,\n                   critical_count, high_count, medium_count, low_count,\n                   acknowledged_count, last_scan_at, has_failed_scan, calculated_at\n            FROM repo_security_scores\n            WHERE repository_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "repository_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "score",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "grade",
+        "type_info": "Bpchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "total_findings",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "critical_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "high_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 7,
+        "name": "medium_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 8,
+        "name": "low_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 9,
+        "name": "acknowledged_count",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 10,
+        "name": "last_scan_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 11,
+        "name": "has_failed_scan",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 12,
+        "name": "calculated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "f7ca89fa86dee3a69abab05bcef202cc1ef168106384a7d085149d39c9559766"
+}

--- a/backend/.sqlx/query-f80df5178e36f1c0d65fcf466d296264e015b44bcf460d1c00ea6709ed7ba784.json
+++ b/backend/.sqlx/query-f80df5178e36f1c0d65fcf466d296264e015b44bcf460d1c00ea6709ed7ba784.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, storage_key, size_bytes, checksum_sha256\n        FROM artifacts\n        WHERE repository_id = $1\n          AND name = $2\n          AND version = $3\n          AND path LIKE '%.zip'\n          AND is_deleted = false\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "storage_key",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "size_bytes",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "checksum_sha256",
+        "type_info": "Bpchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "f80df5178e36f1c0d65fcf466d296264e015b44bcf460d1c00ea6709ed7ba784"
+}

--- a/backend/.sqlx/query-f843865709e4c13cf4a30e716eeebe3d37c9bd944e120688671d951938ef4fd7.json
+++ b/backend/.sqlx/query-f843865709e4c13cf4a30e716eeebe3d37c9bd944e120688671d951938ef4fd7.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE scan_results\n            SET inventory_status = $2\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f843865709e4c13cf4a30e716eeebe3d37c9bd944e120688671d951938ef4fd7"
+}

--- a/backend/.sqlx/query-f87a9f913dfc50aa5f34673e5884c50a03c47d8e2d8860c60c6767bdb19dc636.json
+++ b/backend/.sqlx/query-f87a9f913dfc50aa5f34673e5884c50a03c47d8e2d8860c60c6767bdb19dc636.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE peer_instances\n                SET status = $2, last_sync_at = NOW(), updated_at = NOW()\n                WHERE id = $1\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        {
+          "Custom": {
+            "name": "instance_status",
+            "kind": {
+              "Enum": [
+                "online",
+                "offline",
+                "syncing",
+                "degraded"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "f87a9f913dfc50aa5f34673e5884c50a03c47d8e2d8860c60c6767bdb19dc636"
+}

--- a/backend/.sqlx/query-fa42be3b82d7f4b30955a009e12d20a87925a0435ef29acd6d2ae60dbf85b935.json
+++ b/backend/.sqlx/query-fa42be3b82d7f4b30955a009e12d20a87925a0435ef29acd6d2ae60dbf85b935.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM peer_instances WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fa42be3b82d7f4b30955a009e12d20a87925a0435ef29acd6d2ae60dbf85b935"
+}

--- a/backend/.sqlx/query-fc86719b2fc991ee25f6be20c5320f7f0b2f800e1aa47636becee1eccea42ceb.json
+++ b/backend/.sqlx/query-fc86719b2fc991ee25f6be20c5320f7f0b2f800e1aa47636becee1eccea42ceb.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, name, version FROM artifacts WHERE id = ANY($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "version",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "fc86719b2fc991ee25f6be20c5320f7f0b2f800e1aa47636becee1eccea42ceb"
+}

--- a/backend/.sqlx/query-fcbc7eb1a74f6ac7eab7b13b1f901fe71addce4dc80109c2361962fad6b63ddc.json
+++ b/backend/.sqlx/query-fcbc7eb1a74f6ac7eab7b13b1f901fe71addce4dc80109c2361962fad6b63ddc.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO signing_key_audit (signing_key_id, action, performed_by, details) VALUES ($1, $2, $3, $4)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Varchar",
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fcbc7eb1a74f6ac7eab7b13b1f901fe71addce4dc80109c2361962fad6b63ddc"
+}

--- a/backend/.sqlx/query-fcd74938872a3ac9b854154bb52ad8be4bdcef9f5219528005104630fedeed51.json
+++ b/backend/.sqlx/query-fcd74938872a3ac9b854154bb52ad8be4bdcef9f5219528005104630fedeed51.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO artifact_metadata (artifact_id, format, metadata)\n        VALUES ($1, 'vscode', $2)\n        ON CONFLICT (artifact_id) DO UPDATE SET metadata = $2\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Jsonb"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fcd74938872a3ac9b854154bb52ad8be4bdcef9f5219528005104630fedeed51"
+}

--- a/backend/.sqlx/query-fe0ee8fd4643c19fd52fd291dd172f172b57d8b25d90659f4540f78046a89ad0.json
+++ b/backend/.sqlx/query-fe0ee8fd4643c19fd52fd291dd172f172b57d8b25d90659f4540f78046a89ad0.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT name\n        FROM artifacts\n        WHERE repository_id = $1 AND is_deleted = false\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fe0ee8fd4643c19fd52fd291dd172f172b57d8b25d90659f4540f78046a89ad0"
+}

--- a/backend/.sqlx/query-fe6d259321ba086abb5cf2b3279f786c2f39fd969eb76ae7c0a02a1ea69e1cc4.json
+++ b/backend/.sqlx/query-fe6d259321ba086abb5cf2b3279f786c2f39fd969eb76ae7c0a02a1ea69e1cc4.json
@@ -1,0 +1,159 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                id, username, email, password_hash, display_name,\n                auth_provider as \"auth_provider: AuthProvider\",\n                external_id, is_admin, is_active, is_service_account, must_change_password,\n                totp_secret, totp_enabled, totp_backup_codes, totp_verified_at,\n                failed_login_attempts, locked_until, last_failed_login_at,\n                password_changed_at, last_login_at, created_at, updated_at\n            FROM users\n            WHERE username = '_ak_scanner'\n              AND is_service_account = true\n              AND is_active = true\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "email",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "password_hash",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 4,
+        "name": "display_name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 5,
+        "name": "auth_provider: AuthProvider",
+        "type_info": {
+          "Custom": {
+            "name": "auth_provider",
+            "kind": {
+              "Enum": [
+                "local",
+                "ldap",
+                "saml",
+                "oidc",
+                "ci"
+              ]
+            }
+          }
+        }
+      },
+      {
+        "ordinal": 6,
+        "name": "external_id",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 7,
+        "name": "is_admin",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 8,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 9,
+        "name": "is_service_account",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 10,
+        "name": "must_change_password",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 11,
+        "name": "totp_secret",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "totp_enabled",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 13,
+        "name": "totp_backup_codes",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 14,
+        "name": "totp_verified_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "failed_login_attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 16,
+        "name": "locked_until",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "last_failed_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 18,
+        "name": "password_changed_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 19,
+        "name": "last_login_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 20,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 21,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      false,
+      false
+    ]
+  },
+  "hash": "fe6d259321ba086abb5cf2b3279f786c2f39fd969eb76ae7c0a02a1ea69e1cc4"
+}

--- a/backend/.sqlx/query-fec7fa5d959e05a7ea04a10cd3e0bb6596f4f7524cfb0dda3bb9713ae38a240b.json
+++ b/backend/.sqlx/query-fec7fa5d959e05a7ea04a10cd3e0bb6596f4f7524cfb0dda3bb9713ae38a240b.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT is_enabled FROM format_handlers WHERE format_key = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "is_enabled",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "fec7fa5d959e05a7ea04a10cd3e0bb6596f4f7524cfb0dda3bb9713ae38a240b"
+}

--- a/backend/.sqlx/query-ff9b7421ab62d3081831ccec44d02c0fea323face3bce2fa915bbcf5853e60fb.json
+++ b/backend/.sqlx/query-ff9b7421ab62d3081831ccec44d02c0fea323face3bce2fa915bbcf5853e60fb.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE age_gate_reviews\n            SET status = 'rejected', reviewed_by = $2, reviewed_at = NOW(),\n                review_reason = $3\n            WHERE id = $1\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ff9b7421ab62d3081831ccec44d02c0fea323face3bce2fa915bbcf5853e60fb"
+}

--- a/backend/src/api/handlers/oci_v2.rs
+++ b/backend/src/api/handlers/oci_v2.rs
@@ -6993,6 +6993,71 @@ pub(crate) async fn index_child_artifact_size_sum(
     })
 }
 
+/// Upsert the `artifacts` row that makes a Docker/OCI manifest visible to the
+/// subsystems that enumerate the `artifacts` table (UI/download, GC, quota,
+/// scanning).
+///
+/// This is the single source of truth for a manifest's `artifacts` row. Two
+/// callers share it so a migrated manifest is enumerated identically to a
+/// natively-pushed one:
+///   * the live manifest-PUT path ([`handle_put_manifest`]) records the tag or
+///     by-digest manifest a client pushes;
+///   * the migration referenced-content walk
+///     ([`crate::services::oci_referenced_content`]) records the by-digest
+///     *child* manifests of a migrated multi-arch index. A native `docker push`
+///     writes one `artifacts` row per manifest, but the importer previously
+///     registered only the OCI index tables for those children, so GC / quota /
+///     scanning under-counted them (#2576).
+///
+/// The row is keyed on `(repository_id, path)` with `path =
+/// v2/<image>/manifests/<reference>` (the reference is the digest for a
+/// by-digest child), so a re-push / re-migration upserts in place instead of
+/// duplicating. Returns the artifact id.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn upsert_manifest_artifact<'e, E>(
+    executor: E,
+    repo_id: Uuid,
+    image: &str,
+    reference: &str,
+    digest: &str,
+    content_type: &str,
+    storage_key: &str,
+    total_size: i64,
+    uploaded_by: Option<Uuid>,
+) -> Result<Uuid, sqlx::Error>
+where
+    E: sqlx::PgExecutor<'e>,
+{
+    let artifact_path = format!("v2/{}/manifests/{}", image, reference);
+    let artifact_name = format!("{}:{}", image, reference);
+    let checksum = digest.strip_prefix("sha256:").unwrap_or(digest);
+    sqlx::query_scalar!(
+        r#"INSERT INTO artifacts (repository_id, path, name, version, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+           ON CONFLICT (repository_id, path) DO UPDATE SET
+             version = EXCLUDED.version,
+             size_bytes = EXCLUDED.size_bytes,
+             checksum_sha256 = EXCLUDED.checksum_sha256,
+             content_type = EXCLUDED.content_type,
+             storage_key = EXCLUDED.storage_key,
+             uploaded_by = EXCLUDED.uploaded_by,
+             is_deleted = false,
+             updated_at = NOW()
+           RETURNING id"#,
+        repo_id,
+        artifact_path,
+        artifact_name,
+        Some(reference),
+        total_size,
+        checksum,
+        content_type,
+        storage_key,
+        uploaded_by,
+    )
+    .fetch_one(executor)
+    .await
+}
+
 async fn handle_put_manifest(
     state: &SharedState,
     headers: &HeaderMap,
@@ -7140,45 +7205,41 @@ async fn handle_put_manifest(
     // Calculate total image size from manifest (config + layers)
     let total_size: i64 = manifest_total_size(&body);
 
-    // Also create an artifact record so it appears in the UI
+    // Also create an artifact record so it appears in the UI (and so GC /
+    // quota / scanning, which enumerate the `artifacts` table, see this
+    // manifest). Shared with the migration import path via
+    // `upsert_manifest_artifact` so a pushed and a migrated manifest are
+    // recorded identically.
     let artifact_path = format!("v2/{}/manifests/{}", image, reference);
-    let artifact_name = format!("{}:{}", image, reference);
     let checksum = digest.strip_prefix("sha256:").unwrap_or(&digest);
 
-    match sqlx::query_scalar!(
-        r#"INSERT INTO artifacts (repository_id, path, name, version, size_bytes, checksum_sha256, content_type, storage_key, uploaded_by)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-           ON CONFLICT (repository_id, path) DO UPDATE SET
-             version = EXCLUDED.version,
-             size_bytes = EXCLUDED.size_bytes,
-             checksum_sha256 = EXCLUDED.checksum_sha256,
-             content_type = EXCLUDED.content_type,
-             storage_key = EXCLUDED.storage_key,
-             uploaded_by = EXCLUDED.uploaded_by,
-             is_deleted = false,
-             updated_at = NOW()
-           RETURNING id"#,
+    match upsert_manifest_artifact(
+        &state.db,
         repo_id,
-        artifact_path,
-        artifact_name,
-        Some(reference),
+        &image,
+        reference,
+        &digest,
+        &content_type,
+        &manifest_key,
         total_size,
-        checksum,
-        content_type,
-        manifest_key,
         Some(claims.sub),
     )
-    .fetch_one(&state.db)
     .await
     {
         Ok(artifact_id) => {
             crate::services::quarantine_service::apply_upload_hold_hosted(
-                &state.db, repo_id, artifact_id,
+                &state.db,
+                repo_id,
+                artifact_id,
             )
             .await;
         }
         Err(e) => {
-            tracing::error!("Failed to upsert artifact record for {}: {}", artifact_path, e);
+            tracing::error!(
+                "Failed to upsert artifact record for {}: {}",
+                artifact_path,
+                e
+            );
         }
     }
 

--- a/backend/src/services/oci_referenced_content.rs
+++ b/backend/src/services/oci_referenced_content.rs
@@ -49,8 +49,8 @@ use uuid::Uuid;
 
 use crate::api::handlers::oci_v2::{
     blob_storage_key, classify_manifest, extract_blob_refs, extract_child_digests,
-    manifest_storage_key, persist_tag_and_refs_in_tx, resolve_manifest_content_type,
-    stored_media_type_for, ManifestClass,
+    manifest_storage_key, manifest_total_size, persist_tag_and_refs_in_tx,
+    resolve_manifest_content_type, stored_media_type_for, upsert_manifest_artifact, ManifestClass,
 };
 use crate::services::migration_service::MigrationError;
 use crate::services::oci_manifest_refs_backfill::MAX_INDEX_MANIFEST_BYTES;
@@ -249,6 +249,28 @@ pub(crate) async fn walk_and_register_referenced_content(
             &content_type,
             &class,
             &body,
+        )
+        .await?;
+
+        // #2576: record the by-digest child manifest in `artifacts` too. A
+        // native `docker push` writes one `artifacts` row per manifest; the
+        // importer previously registered only the OCI index tables for these
+        // children, so GC / quota / scanning (which enumerate `artifacts`)
+        // under-counted the per-arch children of a migrated multi-arch index.
+        // Uses the SAME shared upsert as the live push path, keyed on
+        // (repository_id, path) so a re-migration upserts in place. `None`
+        // uploader: an imported manifest has no pushing user. Runs on the item
+        // transaction, so the row commits atomically with the tag/refs.
+        upsert_manifest_artifact(
+            &mut **tx,
+            repo_id,
+            image,
+            &digest,
+            &digest,
+            &content_type,
+            &manifest_storage_key(&digest),
+            manifest_total_size(&body),
+            None,
         )
         .await?;
 
@@ -914,6 +936,166 @@ mod tests {
             assert!(row.is_some(), "child {d} registered");
             assert!(storage.exists(&manifest_storage_key(&d)).await.unwrap());
         }
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// #2576: every by-digest child manifest of a migrated multi-arch index
+    /// gets an `artifacts` row (path `v2/<image>/manifests/<digest>`, checksum
+    /// = the manifest digest, size = config+layers) so GC / quota / scanning —
+    /// which enumerate the `artifacts` table — see the children, exactly as a
+    /// native `docker push` records one row per manifest.
+    #[tokio::test]
+    async fn walker_creates_artifacts_row_per_child_manifest() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        let cfg_a = bytes::Bytes::from_static(b"{\"arch\":\"amd64\"}");
+        let cfg_b = bytes::Bytes::from_static(b"{\"arch\":\"arm64\"}");
+        let layer = bytes::Bytes::from_static(b"shared-layer");
+        let child_a = image_manifest(&cfg_a, &[&layer]);
+        let child_b = image_manifest(&cfg_b, &[&layer]);
+        let index = index_manifest(&[&child_a, &child_b]);
+
+        let mut src = DigestSource::new();
+        for b in [&cfg_a, &cfg_b, &layer] {
+            src.blobs.insert(sha256_digest(b), b.clone());
+        }
+        for m in [&child_a, &child_b] {
+            src.manifests.insert(sha256_digest(m), m.clone());
+        }
+        let client: Arc<dyn SourceRegistry> = Arc::new(src);
+
+        let mut tx = pool.begin().await.unwrap();
+        walk_and_register_referenced_content(
+            &mut tx,
+            &storage,
+            &client,
+            tmp.path(),
+            repo_id,
+            "app",
+            "app",
+            &ManifestClass::Index,
+            &index,
+            &WalkCaps::default(),
+        )
+        .await
+        .expect("index walk");
+        tx.commit().await.unwrap();
+
+        // Both children now have an `artifacts` row keyed by the live-push path
+        // shape, with the digest as checksum and the config+layer size.
+        for (m, cfg) in [(&child_a, &cfg_a), (&child_b, &cfg_b)] {
+            let d = sha256_digest(m);
+            let checksum = d.strip_prefix("sha256:").unwrap();
+            let path = format!("v2/app/manifests/{d}");
+            let row: Option<(String, i64, String)> = sqlx::query_as(
+                "SELECT checksum_sha256, size_bytes, storage_key \
+                 FROM artifacts \
+                 WHERE repository_id = $1 AND path = $2 AND is_deleted = false",
+            )
+            .bind(repo_id)
+            .bind(&path)
+            .fetch_optional(&pool)
+            .await
+            .unwrap();
+            let (got_checksum, got_size, got_key) = row.expect("child artifacts row exists");
+            assert_eq!(got_checksum, checksum, "checksum = manifest digest");
+            assert_eq!(
+                got_size,
+                (cfg.len() + layer.len()) as i64,
+                "size = config + layers"
+            );
+            assert_eq!(
+                got_key,
+                manifest_storage_key(&d),
+                "storage key = manifest key"
+            );
+        }
+
+        // The children are enumerable via `artifacts` (what GC/quota/scan scan).
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM artifacts \
+             WHERE repository_id = $1 AND path LIKE 'v2/app/manifests/sha256:%' AND is_deleted = false",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(count.0, 2, "one artifacts row per by-digest child manifest");
+
+        sqlx::query("DELETE FROM repositories WHERE id = $1")
+            .bind(repo_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+    }
+
+    /// #2576: re-migrating the same index must not duplicate the child
+    /// `artifacts` rows — the upsert is idempotent on (repository_id, path).
+    #[tokio::test]
+    async fn walker_child_artifacts_rows_are_idempotent_on_remigration() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (storage, tmp, repo_id) = setup(&pool).await;
+
+        let cfg = bytes::Bytes::from_static(b"{\"arch\":\"amd64\"}");
+        let layer = bytes::Bytes::from_static(b"a-layer");
+        let child = image_manifest(&cfg, &[&layer]);
+        let index = index_manifest(&[&child]);
+
+        let build_src = || {
+            let mut src = DigestSource::new();
+            for b in [&cfg, &layer] {
+                src.blobs.insert(sha256_digest(b), b.clone());
+            }
+            src.manifests.insert(sha256_digest(&child), child.clone());
+            Arc::new(src) as Arc<dyn SourceRegistry>
+        };
+
+        // Migrate twice, as a re-run would.
+        for _ in 0..2 {
+            let client = build_src();
+            let mut tx = pool.begin().await.unwrap();
+            walk_and_register_referenced_content(
+                &mut tx,
+                &storage,
+                &client,
+                tmp.path(),
+                repo_id,
+                "app",
+                "app",
+                &ManifestClass::Index,
+                &index,
+                &WalkCaps::default(),
+            )
+            .await
+            .expect("index walk");
+            tx.commit().await.unwrap();
+        }
+
+        let d = sha256_digest(&child);
+        let path = format!("v2/app/manifests/{d}");
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM artifacts WHERE repository_id = $1 AND path = $2")
+                .bind(repo_id)
+                .bind(&path)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(
+            count.0, 1,
+            "re-migration upserts in place, no duplicate row"
+        );
+
         sqlx::query("DELETE FROM repositories WHERE id = $1")
             .bind(repo_id)
             .execute(&pool)


### PR DESCRIPTION
## Summary

Closes #2576.

When a multi-arch image (image index / manifest list) is migrated, its
by-digest **child** manifests were registered only in the OCI index tables
(`oci_tags`, `oci_manifest_refs`/`manifest_blob_refs`, `oci_blobs`) — they got
**no `artifacts` row**. A native `docker push` writes one `artifacts` row per
manifest (the referenced-content walk models a push), so the importer diverged
from the push path for children. Any subsystem that enumerates the `artifacts`
table — GC, quota/accounting, scanning, the download/UI listing — therefore
under-counted the per-arch children of a migrated multi-arch image.

Root cause: `oci_referenced_content::walk_and_register_referenced_content`
registers each child manifest via `persist_tag_and_refs_in_tx` (tag + refs) and
its blobs into `oci_blobs`, but never inserted the child's `artifacts` row. The
top-level tagged manifest gets its row in `migration_worker`; the children were
the gap.

Fix:
- Extract the manifest `artifacts`-row upsert used by the live manifest-PUT
  path (`handle_put_manifest`) into a single shared helper,
  `oci_v2::upsert_manifest_artifact`, keyed on `(repository_id, path)` with
  `path = v2/<image>/manifests/<reference>`.
- The migration referenced-content walk now calls that same helper for every
  by-digest child manifest it registers, inside the item transaction, so the
  row commits atomically with the tag/refs (fail-closed) and is attributed to
  the correct repository, sized as `config + layers` (same as the live push),
  and carries the manifest digest as `checksum_sha256`.
- Idempotent: the upsert is `ON CONFLICT (repository_id, path) DO UPDATE`, so
  re-migration refreshes the row in place instead of duplicating it.

No new SQL text (the shared helper reuses the existing INSERT), so the sqlx
offline cache is unchanged and no migration is required. Children are attributed
per-arch exactly as a native push records them, and are not double-counted with
their parent index (the index's own `artifacts` row is sized from the index body
only). As a side benefit, `index_child_artifact_size_sum` — which sizes the
migrated multi-arch tag's Packages-catalog row by joining child `artifacts`
rows — now returns the correct total instead of 0.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added to `oci_referenced_content::tests`:
- `walker_creates_artifacts_row_per_child_manifest` — migrates a 2-arch index
  and asserts each child gets an `artifacts` row (correct path, digest checksum,
  config+layer size, manifest storage key) enumerable by the GC/quota/scan
  query shape. Fails on `main` (no child row), passes here.
- `walker_child_artifacts_rows_are_idempotent_on_remigration` — re-migrating the
  same index leaves exactly one row per child (no duplication).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local (throwaway Postgres): `cargo build --lib`, `cargo fmt --check`,
`cargo clippy --workspace --all-targets -- -D warnings` all clean; the 12
`oci_referenced_content` tests and 312 `oci_v2` handler tests pass; jscpd on the
changed files reports no duplication.

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
