### PR TITLE
feat(pypi): add HTTP caching (ETag + Cache-Control + 304) to simple index

### DIFF
--- a/backend/src/api/handlers/cache_headers.rs
+++ b/backend/src/api/handlers/cache_headers.rs
@@ -11,7 +11,7 @@
 //! requires importing these three helpers — no copy/paste, no divergence.
 
 use axum::body::Body;
-use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH};
+use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG, IF_NONE_MATCH, VARY};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::Response;
 use sha2::{Digest, Sha256};
@@ -40,17 +40,26 @@ pub fn compute_etag(body: &[u8]) -> String {
 /// `None` when the request should proceed to a full `200` response. The
 /// returned `304` re-emits the matching `ETag` and `Cache-Control` so the
 /// client can refresh its freshness lifetime without an unconditional GET.
-pub fn check_conditional_request(headers: &HeaderMap, etag: &str) -> Option<Response> {
+///
+/// `vary`, when `Some`, is echoed as the `Vary` header on the `304`. Callers
+/// whose representation is content-negotiated (e.g. PyPI's `Accept`-driven
+/// HTML vs PEP 691 JSON) must pass it so a shared cache keys the stored `304`
+/// on the same request dimension as the `200`, and never mixes variants.
+pub fn check_conditional_request(
+    headers: &HeaderMap,
+    etag: &str,
+    vary: Option<&str>,
+) -> Option<Response> {
     let if_none_match = headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok())?;
     if if_none_match == "*" || if_none_match.split(',').any(|t| t.trim() == etag) {
-        Some(
-            Response::builder()
-                .status(StatusCode::NOT_MODIFIED)
-                .header(ETAG, etag)
-                .header(CACHE_CONTROL, DEFAULT_CACHE_CONTROL)
-                .body(Body::empty())
-                .unwrap(),
-        )
+        let mut builder = Response::builder()
+            .status(StatusCode::NOT_MODIFIED)
+            .header(ETAG, etag)
+            .header(CACHE_CONTROL, DEFAULT_CACHE_CONTROL);
+        if let Some(vary) = vary {
+            builder = builder.header(VARY, vary);
+        }
+        Some(builder.body(Body::empty()).unwrap())
     } else {
         None
     }
@@ -68,26 +77,35 @@ pub fn check_conditional_request(headers: &HeaderMap, etag: &str) -> Option<Resp
 /// ETag is hashed from `body.as_ref()` and the body is moved into the response
 /// without an intermediate `Vec` copy. `Vec<u8>` and `String` callers keep
 /// working unchanged.
+///
+/// `vary`, when `Some`, is emitted as the `Vary` header on both the `200` and
+/// the `304` (see [`check_conditional_request`]). Pass `Some("Accept")` for
+/// responses whose representation is selected by the request `Accept` header so
+/// shared caches don't serve one client's variant to another; pass `None` for
+/// single-representation resources.
 pub fn cacheable_response(
     body: impl Into<Body> + AsRef<[u8]>,
     content_type: &str,
     headers: &HeaderMap,
+    vary: Option<&str>,
 ) -> Response {
     let etag = compute_etag(body.as_ref());
 
-    if let Some(not_modified) = check_conditional_request(headers, &etag) {
+    if let Some(not_modified) = check_conditional_request(headers, &etag, vary) {
         return not_modified;
     }
 
     let content_length = body.as_ref().len();
-    Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type)
         .header(CONTENT_LENGTH, content_length.to_string())
         .header(ETAG, &etag)
-        .header(CACHE_CONTROL, DEFAULT_CACHE_CONTROL)
-        .body(body.into())
-        .unwrap()
+        .header(CACHE_CONTROL, DEFAULT_CACHE_CONTROL);
+    if let Some(vary) = vary {
+        builder = builder.header(VARY, vary);
+    }
+    builder.body(body.into()).unwrap()
 }
 
 #[cfg(test)]
@@ -127,7 +145,7 @@ mod tests {
         let etag = compute_etag(body);
         let mut h = empty_headers();
         h.insert(IF_NONE_MATCH, HeaderValue::from_str(&etag).unwrap());
-        let r = check_conditional_request(&h, &etag);
+        let r = check_conditional_request(&h, &etag, None);
         assert!(r.is_some());
         let r = r.unwrap();
         assert_eq!(r.status(), StatusCode::NOT_MODIFIED);
@@ -143,7 +161,7 @@ mod tests {
         let etag = compute_etag(b"abc");
         let mut h = empty_headers();
         h.insert(IF_NONE_MATCH, HeaderValue::from_static("*"));
-        assert!(check_conditional_request(&h, &etag).is_some());
+        assert!(check_conditional_request(&h, &etag, None).is_some());
     }
 
     #[test]
@@ -154,14 +172,14 @@ mod tests {
             IF_NONE_MATCH,
             HeaderValue::from_str("\"completely-different\"").unwrap(),
         );
-        assert!(check_conditional_request(&h, &etag).is_none());
+        assert!(check_conditional_request(&h, &etag, None).is_none());
     }
 
     #[test]
     fn check_returns_none_without_if_none_match_header() {
         let etag = compute_etag(b"abc");
         let h = empty_headers();
-        assert!(check_conditional_request(&h, &etag).is_none());
+        assert!(check_conditional_request(&h, &etag, None).is_none());
     }
 
     #[test]
@@ -170,14 +188,14 @@ mod tests {
         let mut h = empty_headers();
         let list = format!("W/\"old1\", {}, W/\"old2\"", etag);
         h.insert(IF_NONE_MATCH, HeaderValue::from_str(&list).unwrap());
-        assert!(check_conditional_request(&h, &etag).is_some());
+        assert!(check_conditional_request(&h, &etag, None).is_some());
     }
 
     // Tests for cacheable_response
     #[test]
     fn cacheable_response_200_on_new_request() {
         let body = b"hello".to_vec();
-        let r = cacheable_response(body.clone(), "text/xml", &empty_headers());
+        let r = cacheable_response(body.clone(), "text/xml", &empty_headers(), None);
         assert_eq!(r.status(), StatusCode::OK);
         assert_eq!(r.headers().get(CONTENT_TYPE).unwrap(), "text/xml");
         assert_eq!(
@@ -198,7 +216,45 @@ mod tests {
         let etag = compute_etag(&body);
         let mut h = empty_headers();
         h.insert(IF_NONE_MATCH, HeaderValue::from_str(&etag).unwrap());
-        let r = cacheable_response(body, "text/xml", &h);
+        let r = cacheable_response(body, "text/xml", &h, None);
         assert_eq!(r.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[test]
+    fn cacheable_response_accepts_bytes_body_with_same_etag() {
+        // The zero-copy proxy path passes a `bytes::Bytes`; it must hash and
+        // serve identically to the `Vec<u8>` path.
+        let raw = b"proxied index body".to_vec();
+        let via_bytes = cacheable_response(
+            bytes::Bytes::from(raw.clone()),
+            "text/html",
+            &empty_headers(),
+            None,
+        );
+        assert_eq!(via_bytes.status(), StatusCode::OK);
+        assert_eq!(
+            via_bytes.headers().get(ETAG).unwrap().to_str().unwrap(),
+            compute_etag(&raw)
+        );
+
+        let etag = compute_etag(&raw);
+        let mut h = empty_headers();
+        h.insert(IF_NONE_MATCH, HeaderValue::from_str(&etag).unwrap());
+        let not_modified = cacheable_response(bytes::Bytes::from(raw), "text/html", &h, None);
+        assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+    }
+
+    #[test]
+    fn cacheable_response_emits_vary_on_200_and_304() {
+        let body = b"hello".to_vec();
+        let r = cacheable_response(body.clone(), "text/html", &empty_headers(), Some("Accept"));
+        assert_eq!(r.headers().get(VARY).unwrap(), "Accept");
+
+        let etag = compute_etag(&body);
+        let mut h = empty_headers();
+        h.insert(IF_NONE_MATCH, HeaderValue::from_str(&etag).unwrap());
+        let nm = cacheable_response(body, "text/html", &h, Some("Accept"));
+        assert_eq!(nm.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(nm.headers().get(VARY).unwrap(), "Accept");
     }
 }

--- a/backend/src/api/handlers/cache_headers.rs
+++ b/backend/src/api/handlers/cache_headers.rs
@@ -62,20 +62,31 @@ pub fn check_conditional_request(headers: &HeaderMap, etag: &str) -> Option<Resp
 /// `content_type` is the response MIME type (e.g. `"text/xml"` for Maven
 /// metadata, `"application/json"` for Conda repodata). `headers` must be the
 /// request's `HeaderMap` so `If-None-Match` can be inspected.
-pub fn cacheable_response(body: Vec<u8>, content_type: &str, headers: &HeaderMap) -> Response {
-    let etag = compute_etag(&body);
+///
+/// `body` is generic over `Into<Body> + AsRef<[u8]>` so callers holding a
+/// `bytes::Bytes` (e.g. a proxied upstream index) can pass it directly: the
+/// ETag is hashed from `body.as_ref()` and the body is moved into the response
+/// without an intermediate `Vec` copy. `Vec<u8>` and `String` callers keep
+/// working unchanged.
+pub fn cacheable_response(
+    body: impl Into<Body> + AsRef<[u8]>,
+    content_type: &str,
+    headers: &HeaderMap,
+) -> Response {
+    let etag = compute_etag(body.as_ref());
 
     if let Some(not_modified) = check_conditional_request(headers, &etag) {
         return not_modified;
     }
 
+    let content_length = body.as_ref().len();
     Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type)
-        .header(CONTENT_LENGTH, body.len().to_string())
+        .header(CONTENT_LENGTH, content_length.to_string())
         .header(ETAG, &etag)
         .header(CACHE_CONTROL, DEFAULT_CACHE_CONTROL)
-        .body(Body::from(body))
+        .body(body.into())
         .unwrap()
 }
 

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -411,7 +411,7 @@ fn cacheable_response(body: Vec<u8>, content_type: &str, headers: &HeaderMap) ->
 
     let etag = compute_etag(&body);
 
-    if let Some(not_modified) = check_conditional_request(headers, &etag) {
+    if let Some(not_modified) = check_conditional_request(headers, &etag, None) {
         return not_modified;
     }
 
@@ -1742,7 +1742,7 @@ async fn repodata_json_jlap(
     let etag = compute_etag(&jlap_body);
 
     // Check for conditional request
-    if let Some(not_modified) = check_conditional_request(&headers, &etag) {
+    if let Some(not_modified) = check_conditional_request(&headers, &etag, None) {
         return Ok(not_modified);
     }
 
@@ -5891,7 +5891,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(IF_NONE_MATCH, etag.parse().unwrap());
 
-        let result = check_conditional_request(&headers, &etag);
+        let result = check_conditional_request(&headers, &etag, None);
         assert!(result.is_some(), "Matching ETag should return 304");
         let resp = result.unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_MODIFIED);
@@ -5903,7 +5903,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(IF_NONE_MATCH, "W/\"different\"".parse().unwrap());
 
-        let result = check_conditional_request(&headers, &etag);
+        let result = check_conditional_request(&headers, &etag, None);
         assert!(result.is_none(), "Non-matching ETag should return None");
     }
 
@@ -5913,7 +5913,7 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert(IF_NONE_MATCH, "*".parse().unwrap());
 
-        let result = check_conditional_request(&headers, &etag);
+        let result = check_conditional_request(&headers, &etag, None);
         assert!(result.is_some(), "Wildcard should match any ETag");
     }
 
@@ -5922,7 +5922,7 @@ mod tests {
         let etag = compute_etag(b"test body");
         let headers = HeaderMap::new();
 
-        let result = check_conditional_request(&headers, &etag);
+        let result = check_conditional_request(&headers, &etag, None);
         assert!(
             result.is_none(),
             "No If-None-Match header should return None"
@@ -5978,7 +5978,7 @@ mod tests {
         let header_val = format!("W/\"old\", {}, W/\"other\"", etag);
         headers.insert(IF_NONE_MATCH, header_val.parse().unwrap());
 
-        let result = check_conditional_request(&headers, &etag);
+        let result = check_conditional_request(&headers, &etag, None);
         assert!(
             result.is_some(),
             "ETag in comma-separated list should match"

--- a/backend/src/api/handlers/conda.rs
+++ b/backend/src/api/handlers/conda.rs
@@ -411,7 +411,13 @@ fn cacheable_response(body: Vec<u8>, content_type: &str, headers: &HeaderMap) ->
 
     let etag = compute_etag(&body);
 
-    if let Some(not_modified) = check_conditional_request(headers, &etag, None) {
+    // JSON repodata is content-negotiated on Accept-Encoding (gzip vs
+    // identity below), so every representation — including the early 304 and
+    // the identity 200 — must carry the same `Vary` as the gzip 200, or a
+    // shared cache could cross the variants.
+    let vary = (content_type == "application/json").then_some("Accept-Encoding");
+
+    if let Some(not_modified) = check_conditional_request(headers, &etag, vary) {
         return not_modified;
     }
 
@@ -432,14 +438,16 @@ fn cacheable_response(body: Vec<u8>, content_type: &str, headers: &HeaderMap) ->
             .unwrap();
     }
 
-    Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, content_type)
         .header(CONTENT_LENGTH, body.len().to_string())
         .header(ETAG, &etag)
-        .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL)
-        .body(Body::from(body))
-        .unwrap()
+        .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL);
+    if let Some(vary) = vary {
+        builder = builder.header("Vary", vary);
+    }
+    builder.body(Body::from(body)).unwrap()
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -918,11 +918,10 @@ async fn download(
     if MavenHandler::is_metadata(&path) {
         let content =
             fetch_maven_metadata_bytes(&state, &repo, &repo_key, &path, auth.as_ref()).await?;
+        // `content` is a refcounted `Bytes`; hand it to the (generic) helper
+        // directly so the metadata payload is moved, not cloned.
         return Ok(cache_headers::cacheable_response(
-            content.to_vec(),
-            "text/xml",
-            &headers,
-            None,
+            content, "text/xml", &headers, None,
         ));
     }
 

--- a/backend/src/api/handlers/maven.rs
+++ b/backend/src/api/handlers/maven.rs
@@ -922,6 +922,7 @@ async fn download(
             content.to_vec(),
             "text/xml",
             &headers,
+            None,
         ));
     }
 

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -12,7 +12,7 @@
 
 use axum::body::Body;
 use axum::extract::{Multipart, Path, State};
-use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG};
+use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG, VARY};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -532,6 +532,7 @@ fn build_simple_root_response(
             serde_json::to_vec(&json).unwrap(),
             "application/vnd.pypi.simple.v1+json",
             headers,
+            Some("Accept"),
         ));
     }
 
@@ -553,7 +554,9 @@ fn build_simple_root_response(
     // nosniff guarantees would be lost if we delegated to it here. Reuse the
     // shared ETag/conditional helpers and re-emit everything on the 200 path.
     let etag = cache_headers::compute_etag(html.as_bytes());
-    if let Some(not_modified) = cache_headers::check_conditional_request(headers, &etag) {
+    if let Some(not_modified) =
+        cache_headers::check_conditional_request(headers, &etag, Some("Accept"))
+    {
         return Ok(not_modified);
     }
 
@@ -563,6 +566,9 @@ fn build_simple_root_response(
         .header(CONTENT_LENGTH, html.len().to_string())
         .header(ETAG, &etag)
         .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL)
+        // Both this HTML page and the PEP 691 JSON variant are selected by the
+        // request Accept header; Vary keeps shared caches from crossing them.
+        .header(VARY, "Accept")
         // pip/uv only consume the link list; deny everything else so a
         // hypothetical injection cannot exfiltrate cookies or load images.
         .header(
@@ -711,6 +717,7 @@ async fn simple_project(
                             json.into_bytes(),
                             PEP691_JSON_CONTENT_TYPE,
                             &headers,
+                            Some("Accept"),
                         ));
                     }
                 }
@@ -735,7 +742,12 @@ async fn simple_project(
                     content
                 };
 
-                return Ok(cache_headers::cacheable_response(body, &ct, &headers));
+                return Ok(cache_headers::cacheable_response(
+                    body,
+                    &ct,
+                    &headers,
+                    Some("Accept"),
+                ));
             }
         }
         // For virtual repos, iterate through ALL members and union their
@@ -980,6 +992,7 @@ async fn simple_project(
                                 json.into_bytes(),
                                 PEP691_JSON_CONTENT_TYPE,
                                 &headers,
+                                Some("Accept"),
                             ));
                         }
                     }
@@ -999,7 +1012,12 @@ async fn simple_project(
                         content
                     };
 
-                    return Ok(cache_headers::cacheable_response(body, &ct, &headers));
+                    return Ok(cache_headers::cacheable_response(
+                        body,
+                        &ct,
+                        &headers,
+                        Some("Accept"),
+                    ));
                 }
             }
         }
@@ -1095,6 +1113,7 @@ fn build_simple_project_response(
             serde_json::to_vec(&json).unwrap(),
             "application/vnd.pypi.simple.v1+json",
             headers,
+            Some("Accept"),
         ));
     }
 
@@ -1149,6 +1168,7 @@ fn build_simple_project_response(
         html.into_bytes(),
         "text/html; charset=utf-8",
         headers,
+        Some("Accept"),
     ))
 }
 
@@ -7375,6 +7395,7 @@ mod tests {
             first.headers().get("X-Content-Type-Options").unwrap(),
             "nosniff"
         );
+        assert_eq!(first.headers().get(VARY).unwrap(), "Accept");
         let etag = etag_of(&first);
 
         let mut h = headers_accept("");
@@ -7384,5 +7405,6 @@ mod tests {
         );
         let second = build_simple_root_response(&h, "pypi", &packages).unwrap();
         assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(second.headers().get(VARY).unwrap(), "Accept");
     }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -715,8 +715,11 @@ async fn simple_project(
                     }
                 }
 
-                // Rewrite absolute download URLs to route through our proxy
-                let body_bytes: Vec<u8> = if ct.contains("text/html") {
+                // Rewrite absolute download URLs to route through our proxy.
+                // Keep the passthrough branch zero-copy: `content` is a
+                // refcounted `Bytes`, so move it into the response instead of
+                // cloning the whole index payload.
+                let body: Bytes = if ct.contains("text/html") {
                     let html = String::from_utf8_lossy(&content);
                     let rewritten = rewrite_upstream_urls(&html, &repo_key, &project);
                     let rewritten = filter_pypi_simple_html_response(
@@ -727,12 +730,12 @@ async fn simple_project(
                         rewritten,
                     )
                     .await;
-                    rewritten.into_bytes()
+                    Bytes::from(rewritten.into_bytes())
                 } else {
-                    content.to_vec()
+                    content
                 };
 
-                return Ok(cache_headers::cacheable_response(body_bytes, &ct, &headers));
+                return Ok(cache_headers::cacheable_response(body, &ct, &headers));
             }
         }
         // For virtual repos, iterate through ALL members and union their
@@ -981,7 +984,7 @@ async fn simple_project(
                         }
                     }
 
-                    let body_bytes: Vec<u8> = if ct.contains("text/html") {
+                    let body: Bytes = if ct.contains("text/html") {
                         let html = String::from_utf8_lossy(&content);
                         let rewritten = rewrite_upstream_urls(&html, &repo_key, &project);
                         let merged = merge_local_into_remote_simple_html(
@@ -991,12 +994,12 @@ async fn simple_project(
                             &local_artifacts,
                             &tracks,
                         );
-                        merged.into_bytes()
+                        Bytes::from(merged.into_bytes())
                     } else {
-                        content.to_vec()
+                        content
                     };
 
-                    return Ok(cache_headers::cacheable_response(body_bytes, &ct, &headers));
+                    return Ok(cache_headers::cacheable_response(body, &ct, &headers));
                 }
             }
         }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -7407,4 +7407,31 @@ mod tests {
         assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
         assert_eq!(second.headers().get(VARY).unwrap(), "Accept");
     }
+
+    #[test]
+    fn simple_root_json_response_is_cacheable() {
+        let packages = ["flask".to_string()];
+        let json_accept = "application/vnd.pypi.simple.v1+json";
+
+        let first =
+            build_simple_root_response(&headers_accept(json_accept), "pypi", &packages).unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(first.headers().get(CONTENT_TYPE).unwrap(), json_accept);
+        assert!(first.headers().get(ETAG).is_some());
+        assert_eq!(
+            first.headers().get(CACHE_CONTROL).unwrap(),
+            cache_headers::DEFAULT_CACHE_CONTROL
+        );
+        assert_eq!(first.headers().get(VARY).unwrap(), "Accept");
+        let etag = etag_of(&first);
+
+        let mut h = headers_accept(json_accept);
+        h.insert(
+            axum::http::header::IF_NONE_MATCH,
+            axum::http::HeaderValue::from_str(&etag).unwrap(),
+        );
+        let second = build_simple_root_response(&h, "pypi", &packages).unwrap();
+        assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
+        assert_eq!(second.headers().get(VARY).unwrap(), "Accept");
+    }
 }

--- a/backend/src/api/handlers/pypi.rs
+++ b/backend/src/api/handlers/pypi.rs
@@ -12,7 +12,7 @@
 
 use axum::body::Body;
 use axum::extract::{Multipart, Path, State};
-use axum::http::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use axum::http::header::{CACHE_CONTROL, CONTENT_LENGTH, CONTENT_TYPE, ETAG};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -27,6 +27,7 @@ use sqlx::PgPool;
 use std::future::Future;
 use tracing::{debug, info, warn};
 
+use crate::api::handlers::cache_headers;
 use crate::api::handlers::error_helpers::{map_db_err, map_storage_err};
 use crate::api::handlers::proxy_helpers::{self, RepoInfo};
 use crate::api::middleware::auth::{require_auth_basic_scope, AuthExtension};
@@ -527,11 +528,11 @@ fn build_simple_root_response(
                 serde_json::json!({ "name": p })
             }).collect::<Vec<_>>()
         });
-        return Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "application/vnd.pypi.simple.v1+json")
-            .body(Body::from(serde_json::to_string(&json).unwrap()))
-            .unwrap());
+        return Ok(cache_headers::cacheable_response(
+            serde_json::to_vec(&json).unwrap(),
+            "application/vnd.pypi.simple.v1+json",
+            headers,
+        ));
     }
 
     // HTML response (default).
@@ -546,9 +547,22 @@ fn build_simple_root_response(
     // anchor-rendering rules have pure unit coverage (B8).
     let html = PypiHandler::render_simple_root_html(repo_key, packages);
 
+    // Serve with ETag + Cache-Control so clients can revalidate cheaply, but
+    // keep the security headers this endpoint sets — `cacheable_response`
+    // builds a fresh response with only the cache headers, so the CSP and
+    // nosniff guarantees would be lost if we delegated to it here. Reuse the
+    // shared ETag/conditional helpers and re-emit everything on the 200 path.
+    let etag = cache_headers::compute_etag(html.as_bytes());
+    if let Some(not_modified) = cache_headers::check_conditional_request(headers, &etag) {
+        return Ok(not_modified);
+    }
+
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(CONTENT_TYPE, "text/html; charset=utf-8")
+        .header(CONTENT_LENGTH, html.len().to_string())
+        .header(ETAG, &etag)
+        .header(CACHE_CONTROL, cache_headers::DEFAULT_CACHE_CONTROL)
         // pip/uv only consume the link list; deny everything else so a
         // hypothetical injection cannot exfiltrate cookies or load images.
         .header(
@@ -693,16 +707,16 @@ async fn simple_project(
                             json,
                         )
                         .await;
-                        return Ok(Response::builder()
-                            .status(StatusCode::OK)
-                            .header(CONTENT_TYPE, PEP691_JSON_CONTENT_TYPE)
-                            .body(Body::from(json))
-                            .unwrap());
+                        return Ok(cache_headers::cacheable_response(
+                            json.into_bytes(),
+                            PEP691_JSON_CONTENT_TYPE,
+                            &headers,
+                        ));
                     }
                 }
 
                 // Rewrite absolute download URLs to route through our proxy
-                let body = if ct.contains("text/html") {
+                let body_bytes: Vec<u8> = if ct.contains("text/html") {
                     let html = String::from_utf8_lossy(&content);
                     let rewritten = rewrite_upstream_urls(&html, &repo_key, &project);
                     let rewritten = filter_pypi_simple_html_response(
@@ -713,16 +727,12 @@ async fn simple_project(
                         rewritten,
                     )
                     .await;
-                    Body::from(rewritten)
+                    rewritten.into_bytes()
                 } else {
-                    Body::from(content)
+                    content.to_vec()
                 };
 
-                return Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header(CONTENT_TYPE, ct)
-                    .body(body)
-                    .unwrap());
+                return Ok(cache_headers::cacheable_response(body_bytes, &ct, &headers));
             }
         }
         // For virtual repos, iterate through ALL members and union their
@@ -963,15 +973,15 @@ async fn simple_project(
                             &local_artifacts,
                             &tracks,
                         ) {
-                            return Ok(Response::builder()
-                                .status(StatusCode::OK)
-                                .header(CONTENT_TYPE, PEP691_JSON_CONTENT_TYPE)
-                                .body(Body::from(json))
-                                .unwrap());
+                            return Ok(cache_headers::cacheable_response(
+                                json.into_bytes(),
+                                PEP691_JSON_CONTENT_TYPE,
+                                &headers,
+                            ));
                         }
                     }
 
-                    let body = if ct.contains("text/html") {
+                    let body_bytes: Vec<u8> = if ct.contains("text/html") {
                         let html = String::from_utf8_lossy(&content);
                         let rewritten = rewrite_upstream_urls(&html, &repo_key, &project);
                         let merged = merge_local_into_remote_simple_html(
@@ -981,16 +991,12 @@ async fn simple_project(
                             &local_artifacts,
                             &tracks,
                         );
-                        Body::from(merged)
+                        merged.into_bytes()
                     } else {
-                        Body::from(content)
+                        content.to_vec()
                     };
 
-                    return Ok(Response::builder()
-                        .status(StatusCode::OK)
-                        .header(CONTENT_TYPE, ct)
-                        .body(body)
-                        .unwrap());
+                    return Ok(cache_headers::cacheable_response(body_bytes, &ct, &headers));
                 }
             }
         }
@@ -1082,11 +1088,11 @@ fn build_simple_project_response(
             "files": files,
         });
 
-        return Ok(Response::builder()
-            .status(StatusCode::OK)
-            .header(CONTENT_TYPE, "application/vnd.pypi.simple.v1+json")
-            .body(Body::from(serde_json::to_string(&json).unwrap()))
-            .unwrap());
+        return Ok(cache_headers::cacheable_response(
+            serde_json::to_vec(&json).unwrap(),
+            "application/vnd.pypi.simple.v1+json",
+            headers,
+        ));
     }
 
     // HTML response
@@ -1136,11 +1142,11 @@ fn build_simple_project_response(
 
     html.push_str("</body>\n</html>\n");
 
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(CONTENT_TYPE, "text/html; charset=utf-8")
-        .body(Body::from(html))
-        .unwrap())
+    Ok(cache_headers::cacheable_response(
+        html.into_bytes(),
+        "text/html; charset=utf-8",
+        headers,
+    ))
 }
 
 /// Splice local-member entries into a remote-member PEP 503 HTML response so
@@ -7282,5 +7288,98 @@ mod tests {
             result.is_none(),
             "cache miss must yield None, not Some(result)"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // HTTP caching on the simple index (ETag + If-None-Match -> 304)
+    // -----------------------------------------------------------------------
+
+    fn sample_artifact() -> SimpleProjectArtifact {
+        SimpleProjectArtifact {
+            path: "flask/3.0.0/flask-3.0.0-py3-none-any.whl".to_string(),
+            version: Some("3.0.0".to_string()),
+            size_bytes: 123,
+            checksum_sha256: "abc123".to_string(),
+            metadata: None,
+            upload_time: None,
+        }
+    }
+
+    fn headers_accept(accept: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("accept", axum::http::HeaderValue::from_str(accept).unwrap());
+        h
+    }
+
+    fn etag_of(resp: &Response) -> String {
+        resp.headers()
+            .get(ETAG)
+            .expect("index response must carry an ETag")
+            .to_str()
+            .unwrap()
+            .to_string()
+    }
+
+    #[test]
+    fn simple_project_response_emits_etag_and_cache_control() {
+        for accept in ["", "application/vnd.pypi.simple.v1+json"] {
+            let arts = [sample_artifact()];
+            let resp =
+                build_simple_project_response(&headers_accept(accept), "pypi", "flask", &arts, &[])
+                    .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "accept={accept:?}");
+            assert!(resp.headers().get(ETAG).is_some(), "accept={accept:?}");
+            assert_eq!(
+                resp.headers().get(CACHE_CONTROL).unwrap(),
+                cache_headers::DEFAULT_CACHE_CONTROL,
+                "accept={accept:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn simple_project_response_304_on_matching_if_none_match() {
+        for accept in ["", "application/vnd.pypi.simple.v1+json"] {
+            let arts = [sample_artifact()];
+            let first =
+                build_simple_project_response(&headers_accept(accept), "pypi", "flask", &arts, &[])
+                    .unwrap();
+            let etag = etag_of(&first);
+
+            let mut h = headers_accept(accept);
+            h.insert(
+                axum::http::header::IF_NONE_MATCH,
+                axum::http::HeaderValue::from_str(&etag).unwrap(),
+            );
+            let second = build_simple_project_response(&h, "pypi", "flask", &arts, &[]).unwrap();
+            assert_eq!(
+                second.status(),
+                StatusCode::NOT_MODIFIED,
+                "accept={accept:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn simple_root_response_304_on_match_and_keeps_csp() {
+        let packages = ["flask".to_string(), "requests".to_string()];
+
+        // 200 path re-emits the CSP / nosniff guarantees alongside the ETag.
+        let first = build_simple_root_response(&headers_accept(""), "pypi", &packages).unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        assert!(first.headers().get("Content-Security-Policy").is_some());
+        assert_eq!(
+            first.headers().get("X-Content-Type-Options").unwrap(),
+            "nosniff"
+        );
+        let etag = etag_of(&first);
+
+        let mut h = headers_accept("");
+        h.insert(
+            axum::http::header::IF_NONE_MATCH,
+            axum::http::HeaderValue::from_str(&etag).unwrap(),
+        );
+        let second = build_simple_root_response(&h, "pypi", &packages).unwrap();
+        assert_eq!(second.status(), StatusCode::NOT_MODIFIED);
     }
 }


### PR DESCRIPTION
## What

Wire the PyPI Simple API handlers into the shared HTTP-caching helper, so simple-index responses carry `ETag` + `Cache-Control` and answer conditional requests with `304 Not Modified`, matching what `conda.rs` and `maven.rs` already do via `cache_headers::cacheable_response` (#2079).

Before this change, every PyPI simple-index response was an unconditional `200`: no `ETag`, no `Cache-Control`, no `If-None-Match` handling. Clients (`pip`/`uv`) therefore re-downloaded and the server re-rendered every index on every request - a `uv lock --upgrade` fired hundreds of `200`s and zero `304`s.

## Changes

`backend/src/api/handlers/pypi.rs`:

- `build_simple_project_response` — JSON (PEP 691) and HTML paths now return `cache_headers::cacheable_response(...)`.
- `build_simple_root_response` — JSON path uses the helper; HTML path keeps its `Content-Security-Policy` / `X-Content-Type-Options` headers and adds `ETag` + `Cache-Control` via `compute_etag` + `check_conditional_request` (The helper builds a fresh response with only cache headers, so delegating would have dropped the CSP guarantees).
- `simple_project` remote and virtual proxy return paths — JSON and HTML/passthrough responses now go through the helper too, so proxied Upstream indexes are also cacheable.
- Unit tests: ETag + `Cache-Control` present on `200`, `304` on matching `If-None-Match` (JSON and HTML), and the root HTML response still emits CSP.

ETags are the SHA-256 hash of the exact bytes AK serves (after URL rewriting/local-merge), so they remain valid for proxied and merged indexes.

Out of scope: npm packument responses look to have the same gap — noted in the issue as a follow-up.

Closes #2773