### PR TITLE
fix(security): bump bundled grype to v0.116.0 to clear CVE-2026-56852 (#2749)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -4,7 +4,7 @@
 #
 # * Every entry below is a Go-dependency CVE compiled INTO one of the vendored
 #   scanner CLIs that AK images ship and invoke:
-#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.115.0, backend images)
+#     - /usr/local/bin/grype  (ghcr.io/anchore/grype:v0.116.0, backend images)
 #     - /usr/local/bin/trivy  (ghcr.io/aquasecurity/trivy:0.72.0,
 #       scanner-adapter image only — the backend images do NOT bundle trivy)
 #   Both are short-lived CLI subprocesses the services shell out to. They are
@@ -23,7 +23,7 @@
 #   every build), or in the UBI/Alpine base OS packages. Only
 #   vendored-scanner-binary CVEs that have no fixed *tool release* are listed.
 #
-# * Both tools are pinned to the latest upstream release (grype v0.115.0,
+# * Both tools are pinned to the latest upstream release (grype v0.116.0,
 #   trivy 0.72.0, bumped for #2391). For the CVEs below the dependency fix
 #   exists upstream but no tagged tool release has been rebuilt against it
 #   yet (or, where noted, no upstream fix exists at all). They drop off
@@ -39,8 +39,8 @@
 # Trivy tracker: ghcr.io/aquasecurity/trivy tags (GitHub repo has no releases)
 
 # ---------------------------------------------------------------------------
-# grype v0.115.0 binary — Go stdlib @ go1.26.3
-# Fixed in Go 1.26.4/1.26.5 (1.25.11/1.25.12). grype v0.115.0 (latest) is
+# grype v0.116.0 binary — Go stdlib @ go1.26.3
+# Fixed in Go 1.26.4/1.26.5 (1.25.11/1.25.12). grype v0.116.0 (latest) is
 # still built with go1.26.3. Drops off when grype ships a release built on
 # Go >= 1.26.5. (CVE-2026-39822 / CVE-2026-42505 also cover the trivy 0.72.0
 # binary, which is built with go1.26.4.)
@@ -51,10 +51,10 @@ CVE-2026-42505
 CVE-2026-42507
 
 # ---------------------------------------------------------------------------
-# grype v0.115.0 binary — github.com/docker/docker @ v28.5.2+incompatible
+# grype v0.116.0 binary — github.com/docker/docker @ v28.5.2+incompatible
 # CVE-2026-41567 / -41568 / -42306: NO upstream-fixed docker release exists yet
 # (FixedVersion=none). CVE-2026-33997 / -34040 are fixed in docker 29.3.1 but
-# grype v0.115.0 (latest) has not rebuilt against it. Code path: grype's
+# grype v0.116.0 (latest) has not rebuilt against it. Code path: grype's
 # Docker engine client for `docker:` image sources; the backend invokes grype
 # against on-disk artifacts/SBOMs, not the Docker daemon.
 CVE-2026-33997

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -174,12 +174,15 @@ RUN find /mnt/rootfs -xdev -perm /6000 -type f -exec chmod a-s {} + && \
 # binary's HIGH-severity Go-dependency CVEs and ~150 MB of image size with no
 # functional loss. See issues #1544 and #2088.
 #
-# Grype is pinned to v0.115.0, the latest upstream release. It is rebuilt
+# Grype is pinned to v0.116.0, the latest upstream release. It is rebuilt
 # against fixed containerd/go-git/x-crypto versions (clearing those CVEs from
-# v0.114.0), but still bundles Go 1.26.3 stdlib and docker v28.5.2; those
-# residual CVEs have no fixed grype release yet and are documented/suppressed
-# in /.trivyignore rather than "bumped away". Re-evaluate on every bump (#2391).
-FROM ghcr.io/anchore/grype:v0.115.0 AS grype-bin
+# v0.114.0) and bumps golang.org/x/text to v0.39.0, clearing CVE-2026-56852
+# (infinite loop in norm.Iter on invalid UTF-8) that the v0.115.0 binary
+# carried via x/text v0.38.0 (#2749). It still bundles Go 1.26.3 stdlib and
+# docker v28.5.2; those residual CVEs have no fixed grype release yet and are
+# documented/suppressed in /.trivyignore rather than "bumped away".
+# Re-evaluate on every bump (#2391).
+FROM ghcr.io/anchore/grype:v0.116.0 AS grype-bin
 
 # ---------- Stage 5b: Pre-seed the Grype vulnerability DB ----------
 # Populates the Grype DB at build time so the image works on egress-restricted


### PR DESCRIPTION
## Summary

Weekly container scan (`Scheduled Container Scan`, run
[29729085563](https://github.com/artifact-keeper/artifact-keeper/actions/runs/29729085563))
reported **1 CRITICAL/HIGH-with-fix** finding in the **Backend** image
(OpenSCAP: 0). The finding is **CVE-2026-56852** — an infinite loop in
`golang.org/x/text` `norm.Iter` on input containing invalid UTF-8 bytes —
carried by the **bundled `grype` CLI** (`/usr/local/bin/grype`), which
`docker/Dockerfile.backend` pins to `ghcr.io/anchore/grype:v0.115.0`. That
grype release is built against `golang.org/x/text v0.38.0`; the fix is in
`x/text v0.39.0`.

This bumps the grype pin to the latest upstream release **v0.116.0**, which is
rebuilt against `golang.org/x/text v0.39.0`, removing the vulnerable package
from the binary. This is the minimal, self-contained bump — no Rust code or
`Cargo.lock` change.

| | |
|---|---|
| CVE | CVE-2026-56852 |
| Package | `golang.org/x/text` (compiled into the bundled grype CLI) |
| Installed | v0.38.0 (grype v0.115.0) |
| Fixed | 0.39.0 (grype v0.116.0) |
| Files changed | `docker/Dockerfile.backend` (grype pin) + `.trivyignore` (version-reference comments only) |

grype v0.116.0 introduces **no new CRITICAL/HIGH** beyond the existing
`.trivyignore` residual set — the Go-stdlib (`go1.26.3`) and `docker/docker`
(`v28.5.2`) CVEs are unchanged and already suppressed/justified there. Only the
version-reference comments in `.trivyignore` were updated (the CVE suppression
list is untouched).

## Verification

Both grype binaries were extracted from their official images and scanned with
Trivy `0.69.3` (the version CI's Install-Trivy step pins), `rootfs
--severity CRITICAL,HIGH --ignore-unfixed`. The runtime image copies this exact
binary verbatim (`COPY --from=grype-bin /grype /usr/local/bin/`), so the scanned
artifact is byte-identical to what ships.

**Before — grype v0.115.0:**
```
CVE-2026-56852  golang.org/x/text  v0.38.0  ->  0.39.0   (norm.Iter infinite loop on invalid UTF-8)
```

**After — grype v0.116.0:**
```
x/text findings: 0        # CVE-2026-56852 gone (x/text bumped to v0.39.0)
```

**After — full CRITICAL/HIGH set vs `.trivyignore` (CI-exact: `--severity CRITICAL,HIGH --ignore-unfixed --ignorefile .trivyignore`):**
```
count: 0                  # every residual CRIT/HIGH already suppressed; no new alerts
```

grype v0.116.0 `go.mod` confirms `golang.org/x/text v0.39.0` (v0.115.0 pinned
v0.38.0).

Note on the SARIF severity label: the uploaded SARIF shows CVE-2026-56852 as
`UNKNOWN`/`note` at the current DB snapshot, yet it was counted as a
CRITICAL/HIGH-with-fix at scan time (2026-07-20) — a Trivy DB severity
reconciliation between the CI run and today. Regardless of the label, the bump
removes the vulnerable `x/text v0.38.0` from the binary entirely, so the finding
cannot recur.

## Regression test (required for `fix/*` PRs)
- [x] N/A — the regression guard is the existing weekly `Scheduled Container Scan` (Trivy) workflow, which is exactly what surfaced this finding; there is no unit-testable logic in a bundled third-party CLI's transitive Go dependency.

## Test Checklist
- [x] Manually tested locally (Trivy 0.69.3 scan of the extracted grype binary, before/after — evidence above)
- [x] No regressions in existing tests (Docker-pin/comment-only change; no Rust code touched)

## API Changes
- [x] N/A - no API changes

---

Milestone: 1.6.1. Cherry-picks cleanly onto `release/1.6.x` — both changed
files are byte-identical at `v1.6.0` (819cff0) and main HEAD in the touched
regions.

Closes #2749
