### PR TITLE
fix(repositories): correct virtual-repo total aggregation and allow member edits

### DIFF
--- a/backend/src/api/handlers/repositories.rs
+++ b/backend/src/api/handlers/repositories.rs
@@ -2262,6 +2262,19 @@ pub async fn list_repositories(
         std::collections::HashMap::new()
     };
 
+    // #2785: the batched per-repo SUM above keys off `repository_id`, which is
+    // (near) empty for a virtual repo — it owns no artifact rows, only member
+    // links. Overwrite each virtual repo's figure with the union of its
+    // resolvable members so the listing total matches the child repos. Virtual
+    // repos are rare, so this touches at most a handful of rows per page.
+    let mut storage_map = storage_map;
+    for r in &repos {
+        if r.repo_type == RepositoryType::Virtual {
+            let combined = service.get_virtual_storage_usage(r.id).await?;
+            storage_map.insert(r.id, combined);
+        }
+    }
+
     // Batch fetch which repos have a trusted GPG key configured (#2568) so the
     // listing reports `has_trusted_gpg_key` accurately without an N+1. The key
     // material is never selected — only its presence.
@@ -2773,7 +2786,9 @@ pub async fn get_repository(
     let service = RepositoryService::new(state.db.clone());
     let repo = service.get_by_key(&key).await?;
     require_visible(&repo, &auth, &service).await?;
-    let storage_used = service.get_storage_usage(repo.id).await?;
+    // #2785: virtual repos report the union of their members' contents, not
+    // their own (empty) rows, so the displayed total matches the child repos.
+    let storage_used = service.get_display_storage_usage(&repo).await?;
     let auth_type =
         crate::services::upstream_auth::get_upstream_auth_type(&state.db, repo.id).await?;
 
@@ -3354,7 +3369,8 @@ pub async fn update_repository(
         cache.remove(&repo.key);
     }
 
-    let storage_used = service.get_storage_usage(repo.id).await?;
+    // #2785: virtual repos report the union of their members' contents.
+    let storage_used = service.get_display_storage_usage(&repo).await?;
 
     state.event_bus.emit_repository_event(
         "repository.updated",
@@ -7887,47 +7903,14 @@ pub async fn remove_virtual_member(
     Ok(())
 }
 
-/// Compare the input set of (member_key, member_id) pairs against the
-/// `RETURNING` set produced by the bulk UNNEST UPDATE, and surface any
-/// missing ids as a 404 listing the affected member keys.
+/// Replace the full member set of a virtual repository (add / remove / reorder).
 ///
-/// `returned` is the slice of `member_repo_id`s that the UPDATE actually
-/// matched. If its length equals the requested count, every requested
-/// (virtual_repo_id, member_repo_id) row was present and updated, and we
-/// return Ok(()). Otherwise some member row was deleted between the
-/// resolve pass and the UPDATE (TOCTOU). The error message lists the
-/// requested keys whose ids did not appear in `returned`, in the order
-/// they were submitted, so the caller can retry with a fresh resolve.
-///
-/// Pure: does not touch the database or any handler state. Lives at
-/// module scope so unit tests can exercise the TOCTOU branch without
-/// running the full handler.
-pub(crate) fn detect_bulk_update_misses<'a, I>(
-    virtual_repo_key: &str,
-    requested: I,
-    returned: &[Uuid],
-) -> Result<()>
-where
-    I: IntoIterator<Item = (&'a str, Uuid)>,
-{
-    let requested: Vec<(&str, Uuid)> = requested.into_iter().collect();
-    if requested.len() == returned.len() {
-        return Ok(());
-    }
-    let returned_set: std::collections::HashSet<Uuid> = returned.iter().copied().collect();
-    let missing: Vec<&str> = requested
-        .iter()
-        .filter(|(_, id)| !returned_set.contains(id))
-        .map(|(key, _)| *key)
-        .collect();
-    Err(AppError::NotFound(format!(
-        "members no longer exist on virtual repository {}: {}",
-        virtual_repo_key,
-        missing.join(", ")
-    )))
-}
-
-/// Update priorities for all members (bulk reorder)
+/// #2785: this is the "edit the members after creation" operation. The body is
+/// the complete desired member list; members not listed are removed, listed
+/// members that are not yet present are added, and priorities are refreshed.
+/// The prior implementation only reordered members that already existed and
+/// returned 404 for any member not already present, so adding a member through
+/// an edit form failed.
 #[utoipa::path(
     put,
     path = "/{key}/members",
@@ -7939,9 +7922,10 @@ where
     request_body = UpdateVirtualMembersRequest,
     security(("bearer_auth" = [])),
     responses(
-        (status = 200, description = "Members updated", body = VirtualMembersListResponse),
-        (status = 400, description = "Repository is not virtual"),
+        (status = 200, description = "Members replaced with the supplied set", body = VirtualMembersListResponse),
+        (status = 400, description = "Repository is not virtual, or a member is invalid"),
         (status = 401, description = "Authentication required"),
+        (status = 403, description = "Insufficient permissions"),
         (status = 404, description = "Repository not found"),
     )
 )]
@@ -7965,19 +7949,37 @@ pub async fn update_virtual_members(
         ));
     }
 
+    // Gate the whole operation on repo-admin of the virtual PARENT up front.
+    // Editing the member list is administration of the parent; doing this here
+    // (not only inside the per-member loop) means an empty desired set — "remove
+    // all members" — is still authorized rather than silently ungated.
+    require_repo_access(&auth, virtual_repo.id)?;
+    let has_repo_admin = if auth.is_admin {
+        false
+    } else {
+        state
+            .permission_service
+            .check_permission(auth.user_id, "repository", virtual_repo.id, "admin", false)
+            .await?
+    };
+    if !member_mutation_admin_allowed(auth.is_admin, has_repo_admin) {
+        return Err(AppError::Authorization(
+            "Insufficient permissions to manage members of this repository".to_string(),
+        ));
+    }
+
     // Resolve every member_repo lookup up front. Reads do not need
-    // transactional protection and resolving first means a bad key fails
-    // fast with 404 before the UPDATE runs.
+    // transactional protection and resolving first means a bad key fails fast
+    // with 404 before the reconcile runs.
     //
-    // Per-member defensive checks also run during the resolve pass:
-    //   - authz: the caller must have rights on each member repo, not just
-    //     the virtual parent (issue #913).
-    //   - self-membership / cycle detection (issue #915): the current
-    //     contract is "update existing rows only" so neither can be
-    //     introduced today, but the checks remain so a future contract
-    //     extension to upsert missing rows cannot slip a cycle in.
-    let mut resolved_member_ids: Vec<Uuid> = Vec::with_capacity(payload.members.len());
-    let mut priorities: Vec<i32> = Vec::with_capacity(payload.members.len());
+    // Per-member defensive checks run during the resolve pass:
+    //   - authz: the caller must have rights on each member repo, not just the
+    //     virtual parent (issue #913).
+    //   - self-membership / cycle detection (issue #915): now that the endpoint
+    //     can insert new edges these are load-bearing, not merely defensive.
+    //   - format match: the member's format must match the virtual repo, the
+    //     same invariant `add_virtual_member` enforces.
+    let mut desired: Vec<(Uuid, i32)> = Vec::with_capacity(payload.members.len());
     for member in &payload.members {
         let member_repo = service.get_by_key(&member.member_key).await?;
         authorize_virtual_member_mutation(
@@ -7995,6 +7997,12 @@ pub async fn update_virtual_members(
             ));
         }
 
+        if member_repo.format != virtual_repo.format {
+            return Err(AppError::Validation(
+                "Member repository format must match virtual repository format".to_string(),
+            ));
+        }
+
         if member_repo.repo_type == RepositoryType::Virtual
             && service
                 .would_create_cycle(virtual_repo.id, member_repo.id)
@@ -8006,40 +8014,16 @@ pub async fn update_virtual_members(
             )));
         }
 
-        resolved_member_ids.push(member_repo.id);
-        priorities.push(member.priority);
+        desired.push((member_repo.id, member.priority));
     }
 
-    // Single-statement bulk update via UNNEST(uuid[], int4[]). This is atomic
-    // by construction in Postgres: the entire statement either succeeds and
-    // updates every matching row, or fails and updates none.
-    //
-    // The service runs the UPDATE inside a transaction that first takes the
-    // process-wide member-graph advisory lock (B2). Without that lock, two
-    // concurrent PUTs over an overlapping member set acquire row locks in
-    // planner-scan order and can deadlock on the shared row, which Postgres
-    // only breaks after `deadlock_timeout`; under a race loop that surfaces
-    // as multi-second stalls that exhaust the client timeout. The lock
-    // serialises every member-graph mutation so the UPDATEs never contend.
-    //
-    // RETURNING gives us the set of member_repo_ids that actually matched
-    // the (virtual_repo_id, member_repo_id) predicate. If that set is
-    // smaller than the input set, some member row was deleted between the
-    // resolve pass and the UPDATE (TOCTOU), and we surface a 404 listing
-    // the missing keys so the caller can retry with a fresh resolution.
-    let updated = service
-        .update_virtual_member_priorities(virtual_repo.id, &resolved_member_ids, &priorities)
+    // Reconcile the membership to exactly `desired` in one advisory-locked
+    // transaction (remove absent, insert new, refresh priorities). The service
+    // takes the process-wide member-graph advisory lock so this never contends
+    // with a concurrent add/remove/reorder.
+    service
+        .set_virtual_members(virtual_repo.id, &desired)
         .await?;
-
-    detect_bulk_update_misses(
-        &virtual_repo.key,
-        payload
-            .members
-            .iter()
-            .map(|m| m.member_key.as_str())
-            .zip(resolved_member_ids.iter().copied()),
-        &updated,
-    )?;
 
     // Return updated list. Pass the same auth context so the listing is
     // filtered to caller-visible members consistently.
@@ -11232,136 +11216,6 @@ mod tests {
         assert_eq!(req.members[1].member_key, "repo-b");
         assert_eq!(req.members[1].priority, 2);
     }
-
-    // -------------------------------------------------------------------
-    // detect_bulk_update_misses (issue #912 TOCTOU detection)
-    //
-    // The bulk UPDATE ... FROM UNNEST(...) RETURNING produces the set of
-    // member_repo_ids that actually matched. If a member row was deleted
-    // between the resolve pass and the UPDATE, the RETURNING set is
-    // smaller than the input. The handler converts that gap into a 404
-    // listing the requested keys that are no longer present. The
-    // detection logic is a pure function over (requested, returned)
-    // pairs so the entire branch is unit-testable without a database.
-    // -------------------------------------------------------------------
-
-    #[test]
-    fn test_detect_bulk_update_misses_all_present_returns_ok() {
-        // Happy path: every requested id is in the RETURNING set, so the
-        // branch returns Ok(()) and the handler proceeds to list members.
-        let id_a = Uuid::new_v4();
-        let id_b = Uuid::new_v4();
-        let requested = [("repo-a", id_a), ("repo-b", id_b)];
-        let returned = vec![id_b, id_a];
-        let result = detect_bulk_update_misses("v-repo", requested.iter().copied(), &returned);
-        assert!(result.is_ok(), "all-present must return Ok, got {result:?}");
-    }
-
-    #[test]
-    fn test_detect_bulk_update_misses_empty_inputs_returns_ok() {
-        // Edge case: empty payload and empty RETURNING. The handler
-        // does not currently call the helper with an empty input but
-        // the contract should still be Ok(()) so a future caller that
-        // passes-through an empty request does not 404 spuriously.
-        let result = detect_bulk_update_misses("v-repo", std::iter::empty::<(&str, Uuid)>(), &[]);
-        assert!(result.is_ok(), "empty input must return Ok, got {result:?}");
-    }
-
-    #[test]
-    fn test_detect_bulk_update_misses_single_missing_returns_404() {
-        // The most common TOCTOU shape: one member was deleted between
-        // resolve and UPDATE. Helper must surface that one key in a 404.
-        let id_a = Uuid::new_v4();
-        let id_b = Uuid::new_v4();
-        let requested = [("repo-a", id_a), ("repo-b", id_b)];
-        // Only id_a came back. id_b was deleted.
-        let returned = vec![id_a];
-        let err = detect_bulk_update_misses("v-repo", requested.iter().copied(), &returned)
-            .expect_err("single missing must be Err");
-        match err {
-            AppError::NotFound(msg) => {
-                assert!(
-                    msg.contains("repo-b"),
-                    "missing key must appear in error message, got: {msg}"
-                );
-                assert!(
-                    !msg.contains("repo-a"),
-                    "present key must not appear in error message, got: {msg}"
-                );
-                assert!(
-                    msg.contains("v-repo"),
-                    "virtual repo key must appear in error message, got: {msg}"
-                );
-            }
-            other => panic!("expected NotFound, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_detect_bulk_update_misses_all_missing_returns_404_with_every_key() {
-        // Worst case: the entire member set was deleted while the
-        // PUT was in flight. Every requested key must appear in the 404.
-        let id_a = Uuid::new_v4();
-        let id_b = Uuid::new_v4();
-        let id_c = Uuid::new_v4();
-        let requested = [("a", id_a), ("b", id_b), ("c", id_c)];
-        let returned: Vec<Uuid> = vec![];
-        let err = detect_bulk_update_misses("v-repo", requested.iter().copied(), &returned)
-            .expect_err("all-missing must be Err");
-        match err {
-            AppError::NotFound(msg) => {
-                for key in ["a", "b", "c"] {
-                    assert!(
-                        msg.contains(key),
-                        "missing key '{key}' must appear in error, got: {msg}"
-                    );
-                }
-            }
-            other => panic!("expected NotFound, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn test_detect_bulk_update_misses_preserves_submission_order() {
-        // The 404 message lists missing keys in the order the caller
-        // submitted them, NOT in RETURNING order or set-iteration order.
-        // This is load-bearing: callers diff the missing list against
-        // their own submission order to figure out which retry to make.
-        let id1 = Uuid::new_v4();
-        let id2 = Uuid::new_v4();
-        let id3 = Uuid::new_v4();
-        let id4 = Uuid::new_v4();
-        // Submit in order [first, second, third, fourth]; second and
-        // fourth get deleted between resolve and UPDATE.
-        let requested = [
-            ("first", id1),
-            ("second", id2),
-            ("third", id3),
-            ("fourth", id4),
-        ];
-        let returned = vec![id1, id3];
-        let err = detect_bulk_update_misses("v-repo", requested.iter().copied(), &returned)
-            .expect_err("partial-missing must be Err");
-        match err {
-            AppError::NotFound(msg) => {
-                let second_pos = msg.find("second").expect("'second' must appear");
-                let fourth_pos = msg.find("fourth").expect("'fourth' must appear");
-                assert!(
-                    second_pos < fourth_pos,
-                    "missing keys must be listed in submission order; got: {msg}"
-                );
-            }
-            other => panic!("expected NotFound, got {other:?}"),
-        }
-    }
-
-    // Note: the original `test_update_virtual_members_resolution_preserves_order`
-    // unit test was removed during code review. It exercised
-    // `Vec::iter().map().collect()` and `serde_json::from_str`, neither of
-    // which touches the single-statement `UPDATE ... FROM UNNEST(...)`
-    // bulk update or the RETURNING-set comparison that fixes the #912 bug.
-    // A real DB-backed regression test (including a concurrent-PUT race)
-    // lives in `backend/tests/virtual_members_atomicity_test.rs`.
 
     #[test]
     fn test_virtual_member_response_serialization() {

--- a/backend/src/services/repository_service.rs
+++ b/backend/src/services/repository_service.rs
@@ -1578,6 +1578,170 @@ impl RepositoryService {
         Ok(usage)
     }
 
+    /// Storage figure to DISPLAY for `repo` (issue #2785).
+    ///
+    /// A virtual repository owns no `artifacts` / `proxy_cache_artifacts` /
+    /// `oci_blobs` rows of its own — its content is whatever resolves through
+    /// its members. A plain `get_storage_usage(virtual_id)` therefore reports
+    /// the virtual's *own* rows (effectively zero) even though browsing the
+    /// virtual surfaces real member data, so the detail view showed a total
+    /// that did not match the combined total of its child repos. For a virtual
+    /// repo we instead sum over the union of its resolvable member contents;
+    /// every other repo type keeps the existing per-repo figure unchanged.
+    pub async fn get_display_storage_usage(&self, repo: &Repository) -> Result<i64> {
+        if repo.repo_type == RepositoryType::Virtual {
+            self.get_virtual_storage_usage(repo.id).await
+        } else {
+            self.get_storage_usage(repo.id).await
+        }
+    }
+
+    /// Combined storage figure for a virtual repository: the union of the
+    /// contents of every non-virtual member reachable through the membership
+    /// graph (issue #2785).
+    ///
+    /// The membership graph is walked with a recursive CTE bounded by
+    /// [`MAX_VIRTUAL_DEPTH`] so a nested virtual member contributes its own
+    /// leaves. Leaf (non-virtual) repositories are collected DISTINCT, so a
+    /// repository reachable through two different members is counted once
+    /// (union semantics) rather than double-counted. The per-leaf sum reuses
+    /// the same three components as [`Self::get_storage_usage`]
+    /// (`artifacts` + `proxy_cache_artifacts` + `oci_blobs`), keeping the
+    /// virtual total consistent with the sum of what each member reports on
+    /// its own.
+    ///
+    /// Uses the dynamic query API (not the `query!` macro) so this path does
+    /// not depend on an updated offline SQLx cache, matching the convention
+    /// used by the cycle-detection walk.
+    pub async fn get_virtual_storage_usage(&self, virtual_repo_id: Uuid) -> Result<i64> {
+        let usage: i64 = sqlx::query_scalar(
+            r#"
+            WITH RECURSIVE reachable(repo_id, depth) AS (
+                SELECT vrm.member_repo_id, 1
+                  FROM virtual_repo_members vrm
+                 WHERE vrm.virtual_repo_id = $1
+              UNION
+                SELECT vrm.member_repo_id, reachable.depth + 1
+                  FROM reachable
+                  JOIN repositories parent
+                    ON parent.id = reachable.repo_id
+                   AND parent.repo_type = 'virtual'
+                  JOIN virtual_repo_members vrm
+                    ON vrm.virtual_repo_id = reachable.repo_id
+                 WHERE reachable.depth < $2
+            ),
+            leaves AS (
+                SELECT DISTINCT reachable.repo_id AS id
+                  FROM reachable
+                  JOIN repositories leaf ON leaf.id = reachable.repo_id
+                 WHERE leaf.repo_type <> 'virtual'
+            )
+            SELECT COALESCE(SUM(bytes), 0)::BIGINT
+            FROM (
+                SELECT size_bytes AS bytes
+                  FROM artifacts
+                 WHERE repository_id IN (SELECT id FROM leaves)
+                   AND is_deleted = false
+                   AND storage_key NOT LIKE 'proxy-cache/%'
+                UNION ALL
+                SELECT size_bytes AS bytes
+                  FROM proxy_cache_artifacts
+                 WHERE repository_id IN (SELECT id FROM leaves)
+                UNION ALL
+                SELECT size_bytes AS bytes
+                  FROM oci_blobs
+                 WHERE repository_id IN (SELECT id FROM leaves)
+            ) t
+            "#,
+        )
+        .bind(virtual_repo_id)
+        .bind(MAX_VIRTUAL_DEPTH as i32)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(usage)
+    }
+
+    /// Reconcile the FULL member set of a virtual repository to exactly
+    /// `desired` (issue #2785 defect B).
+    ///
+    /// Editing a virtual repository after creation must be able to add and
+    /// remove members, not merely reorder the ones added at create time. This
+    /// replaces the membership with exactly the `(member_repo_id, priority)`
+    /// pairs in `desired`, in a single transaction guarded by the same
+    /// process-wide member-graph advisory lock that `add_virtual_member` and
+    /// `update_virtual_member_priorities` take (so it never contends with a
+    /// concurrent membership mutation):
+    ///
+    ///   * members not present in `desired` are removed;
+    ///   * members already present have their priority updated;
+    ///   * new members are inserted.
+    ///
+    /// An empty `desired` removes every member. Caller-side authorization
+    /// (repo-admin on the virtual parent + token-scope / cycle / format checks
+    /// per member) is enforced by the handler before this runs.
+    pub async fn set_virtual_members(
+        &self,
+        virtual_repo_id: Uuid,
+        desired: &[(Uuid, i32)],
+    ) -> Result<()> {
+        let member_ids: Vec<Uuid> = desired.iter().map(|(id, _)| *id).collect();
+        let priorities: Vec<i32> = desired.iter().map(|(_, p)| *p).collect();
+
+        let mut tx = self
+            .db
+            .begin()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(VIRTUAL_MEMBER_GRAPH_LOCK_KEY)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Remove members that are no longer in the desired set. `<> ALL($2)`
+        // over an empty array is TRUE for every row, so an empty desired set
+        // clears the membership.
+        sqlx::query(
+            r#"
+            DELETE FROM virtual_repo_members
+             WHERE virtual_repo_id = $1
+               AND member_repo_id <> ALL($2::uuid[])
+            "#,
+        )
+        .bind(virtual_repo_id)
+        .bind(&member_ids)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        // Upsert the desired members: insert the new ones, refresh the
+        // priority of the ones that already existed.
+        sqlx::query(
+            r#"
+            INSERT INTO virtual_repo_members (virtual_repo_id, member_repo_id, priority)
+            SELECT $1, m.member_repo_id, m.priority
+              FROM UNNEST($2::uuid[], $3::int4[]) AS m(member_repo_id, priority)
+            ON CONFLICT (virtual_repo_id, member_repo_id)
+            DO UPDATE SET priority = EXCLUDED.priority
+            "#,
+        )
+        .bind(virtual_repo_id)
+        .bind(&member_ids)
+        .bind(&priorities)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| AppError::Database(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| AppError::Database(e.to_string()))?;
+
+        Ok(())
+    }
+
     /// Check if an upload of `additional_bytes` would be permitted under the
     /// repository's storage quota.
     ///
@@ -4298,6 +4462,292 @@ mod tests {
             assert_eq!(usage, 3_500, "artifacts + proxy catalog only");
 
             cleanup_repo(&pool, repo.id).await;
+        }
+
+        /// Build a `create` request for a VIRTUAL repository of the given
+        /// format (the shared `make_create_req` builds a Local repo).
+        fn make_virtual_req(suffix: &str, format: RepositoryFormat) -> CreateRepositoryRequest {
+            CreateRepositoryRequest {
+                repo_type: RepositoryType::Virtual,
+                ..make_create_req(suffix, format)
+            }
+        }
+
+        /// #2785 defect A: a virtual repository's displayed storage total must
+        /// equal the combined total of its member (child) repositories. The
+        /// pre-fix per-repo figure is computed from the virtual's OWN rows,
+        /// which are empty, so it reported 0 while the members held real data.
+        #[tokio::test]
+        async fn test_virtual_storage_usage_sums_members_2785() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+
+            let virt = service
+                .create(make_virtual_req(
+                    &format!("{suffix}v"),
+                    RepositoryFormat::Docker,
+                ))
+                .await
+                .expect("create virtual");
+            let m1 = service
+                .create(make_create_req(
+                    &format!("{suffix}m1"),
+                    RepositoryFormat::Docker,
+                ))
+                .await
+                .expect("create m1");
+            let m2 = service
+                .create(make_create_req(
+                    &format!("{suffix}m2"),
+                    RepositoryFormat::Docker,
+                ))
+                .await
+                .expect("create m2");
+
+            // m1: a manifest artifact (700) + a 500k layer. m2: a 250k layer.
+            insert_artifact(
+                &pool,
+                m1.id,
+                "img/manifests/1.0",
+                "oci-manifests/sha256:aa",
+                700,
+            )
+            .await;
+            insert_oci_blob(
+                &pool,
+                m1.id,
+                &format!("sha256:{}", Uuid::new_v4().simple()),
+                500_000,
+            )
+            .await;
+            insert_oci_blob(
+                &pool,
+                m2.id,
+                &format!("sha256:{}", Uuid::new_v4().simple()),
+                250_000,
+            )
+            .await;
+
+            service
+                .add_virtual_member(virt.id, m1.id, Some(1))
+                .await
+                .expect("add m1");
+            service
+                .add_virtual_member(virt.id, m2.id, Some(2))
+                .await
+                .expect("add m2");
+
+            let m1_usage = service.get_storage_usage(m1.id).await.expect("m1 usage");
+            let m2_usage = service.get_storage_usage(m2.id).await.expect("m2 usage");
+            assert_eq!(m1_usage, 500_700);
+            assert_eq!(m2_usage, 250_000);
+
+            // Pre-fix behaviour the customer saw: the virtual owns no artifact
+            // rows, so the plain per-repo figure is 0 despite the members
+            // holding 750,700 bytes of resolvable content.
+            assert_eq!(
+                service.get_storage_usage(virt.id).await.expect("virt own"),
+                0,
+                "virtual repo owns no artifact/blob rows of its own"
+            );
+
+            // Fix: the combined figure equals the sum of the members, and the
+            // display helper routes a virtual repo through that union.
+            let combined = service
+                .get_virtual_storage_usage(virt.id)
+                .await
+                .expect("virtual combined");
+            assert_eq!(
+                combined,
+                m1_usage + m2_usage,
+                "virtual total = sum of members"
+            );
+            assert_eq!(
+                service
+                    .get_display_storage_usage(&virt)
+                    .await
+                    .expect("display"),
+                combined,
+                "display helper unions members for a virtual repo"
+            );
+            // A non-virtual repo keeps its own per-repo figure via the helper.
+            assert_eq!(
+                service
+                    .get_display_storage_usage(&m1)
+                    .await
+                    .expect("display m1"),
+                m1_usage
+            );
+
+            cleanup_repo(&pool, virt.id).await;
+            cleanup_repo(&pool, m1.id).await;
+            cleanup_repo(&pool, m2.id).await;
+        }
+
+        /// #2785 defect A (union semantics): a leaf repository reachable through
+        /// more than one path in a nested membership graph is counted ONCE, and
+        /// nested virtual members contribute their own leaves.
+        #[tokio::test]
+        async fn test_virtual_storage_usage_dedups_diamond_2785() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+
+            // leaf B holds 1000 bytes; A is a virtual containing B; V is a
+            // virtual containing BOTH A and B (a diamond: V -> A -> B, V -> B).
+            let leaf = service
+                .create(make_create_req(
+                    &format!("{suffix}b"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create leaf");
+            let a = service
+                .create(make_virtual_req(
+                    &format!("{suffix}a"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create a");
+            let v = service
+                .create(make_virtual_req(
+                    &format!("{suffix}v"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create v");
+
+            insert_artifact(
+                &pool,
+                leaf.id,
+                "pkg/1",
+                &format!("cas/ab/cd/{}", Uuid::new_v4()),
+                1_000,
+            )
+            .await;
+
+            service
+                .add_virtual_member(a.id, leaf.id, Some(1))
+                .await
+                .expect("a->b");
+            service
+                .add_virtual_member(v.id, a.id, Some(1))
+                .await
+                .expect("v->a");
+            service
+                .add_virtual_member(v.id, leaf.id, Some(2))
+                .await
+                .expect("v->b");
+
+            // B counted once despite two reachable paths.
+            assert_eq!(
+                service
+                    .get_virtual_storage_usage(v.id)
+                    .await
+                    .expect("v combined"),
+                1_000,
+                "leaf reachable via two paths counts once (union)"
+            );
+
+            cleanup_repo(&pool, v.id).await;
+            cleanup_repo(&pool, a.id).await;
+            cleanup_repo(&pool, leaf.id).await;
+        }
+
+        /// #2785 defect B: a virtual repository's member list is editable after
+        /// creation — `set_virtual_members` adds, removes, and reorders members
+        /// to match exactly the supplied set (the pre-fix PUT endpoint only
+        /// reordered members that already existed).
+        #[tokio::test]
+        async fn test_set_virtual_members_edits_after_create_2785() {
+            let Some(pool) = tdh::try_pool().await else {
+                return;
+            };
+            let service = RepositoryService::new(pool.clone());
+            let suffix = format!("{}", uuid::Uuid::new_v4().simple());
+
+            let virt = service
+                .create(make_virtual_req(
+                    &format!("{suffix}v"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create virtual");
+            let a = service
+                .create(make_create_req(
+                    &format!("{suffix}a"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create a");
+            let b = service
+                .create(make_create_req(
+                    &format!("{suffix}b"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create b");
+            let c = service
+                .create(make_create_req(
+                    &format!("{suffix}c"),
+                    RepositoryFormat::Generic,
+                ))
+                .await
+                .expect("create c");
+
+            // Created with member A only.
+            service
+                .add_virtual_member(virt.id, a.id, Some(1))
+                .await
+                .expect("add a");
+
+            let ids = |repos: &[Repository]| repos.iter().map(|r| r.id).collect::<Vec<_>>();
+
+            // Edit: add B and reprioritise A. get_virtual_members orders by priority.
+            service
+                .set_virtual_members(virt.id, &[(a.id, 5), (b.id, 2)])
+                .await
+                .expect("reconcile add");
+            assert_eq!(
+                ids(&service.get_virtual_members(virt.id).await.expect("list")),
+                vec![b.id, a.id],
+                "B (prio 2) then A (prio 5) after add + reprioritise"
+            );
+
+            // Edit: replace the whole set with C only (removes A and B).
+            service
+                .set_virtual_members(virt.id, &[(c.id, 1)])
+                .await
+                .expect("reconcile replace");
+            assert_eq!(
+                ids(&service.get_virtual_members(virt.id).await.expect("list")),
+                vec![c.id],
+                "membership replaced with exactly {{C}}"
+            );
+
+            // Edit: empty set clears every member.
+            service
+                .set_virtual_members(virt.id, &[])
+                .await
+                .expect("reconcile empty");
+            assert!(
+                service
+                    .get_virtual_members(virt.id)
+                    .await
+                    .expect("list")
+                    .is_empty(),
+                "empty desired set clears membership"
+            );
+
+            cleanup_repo(&pool, virt.id).await;
+            cleanup_repo(&pool, a.id).await;
+            cleanup_repo(&pool, b.id).await;
+            cleanup_repo(&pool, c.id).await;
         }
 
         /// PF-007 (#2523): after inserts across all three components the


### PR DESCRIPTION
## Summary

Fixes two virtual-repository defects reported against 1.6.0 (#2785):

**A. Reported total did not match the combined total of the child repos.**
A virtual repository owns no `artifacts` / `proxy_cache_artifacts` / `oci_blobs`
rows of its own — its content is whatever resolves through its members. Both the
repository detail view (`get_repository`) and the listing (`list_repositories`)
computed `storage_used_bytes` from rows keyed on the virtual repo's *own*
`repository_id`, which is empty, so a virtual repo reported ~0 bytes even though
browsing it surfaced real member data. The figure never matched the sum of the
child repositories.

Fix: for a virtual repository the displayed figure is now the union of its
resolvable member contents. `RepositoryService::get_virtual_storage_usage`
walks the membership graph with a recursive CTE (bounded by `MAX_VIRTUAL_DEPTH`),
collects the DISTINCT set of non-virtual leaf repositories (so a leaf reachable
through several paths counts once, and nested virtual members contribute their
own leaves), and sums the same three storage components `get_storage_usage`
already uses. `get_display_storage_usage` routes virtual repos through the union
and leaves every other repo type unchanged. The detail, update, and listing
handlers use it.

**B. A virtual repository could not be edited after creation.**
`PUT /repositories/{key}/members` only *reordered members that already existed*:
it updated priorities of present rows and returned 404 for any member key not
already present. Editing the member list (adding or removing a member) through
that endpoint failed. Add/remove were only possible one row at a time via
separate POST/DELETE calls.

Fix: `PUT /repositories/{key}/members` now replaces the full member set. The
body is the complete desired list; members not listed are removed, new members
are inserted, and priorities are refreshed — all in one advisory-locked
transaction (`RepositoryService::set_virtual_members`) that takes the same
process-wide member-graph lock as the other membership mutations. Authorization
is preserved and strengthened: repo-admin on the virtual parent is now enforced
up front (so an empty "remove all" set is still gated), each desired member
still passes the per-member token-scope, self-membership, format-match, and
cycle checks. The obsolete reorder-only TOCTOU helper (`detect_bulk_update_misses`)
and its unit tests were removed; the service-level reorder method it fronted is
retained (still exercised by the atomicity integration tests).

Closes #2785.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Added DB-backed tests in `repository_service` (`tests::db`):
- `test_virtual_storage_usage_sums_members_2785` — a virtual with two members of
  known size reports the combined total; also pins the pre-fix bug
  (`get_storage_usage(virtual) == 0`) alongside the fix.
- `test_virtual_storage_usage_dedups_diamond_2785` — a leaf reachable through two
  paths (V→A→B and V→B) counts once (union semantics; nested-virtual recursion).
- `test_set_virtual_members_edits_after_create_2785` — after create with one
  member, reconcile adds a member + reprioritises, then replaces the whole set,
  then clears it.

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

Local (throwaway Postgres, migrations applied): `cargo fmt --check`, `cargo build
--lib` (SQLX_OFFLINE), `cargo clippy --workspace --all-targets -D warnings`, the 3
new tests + existing `virtual_member` / `get_storage_usage` / `update_virtual_members`
/ router / openapi tests all green. New SQL uses the dynamic query API (no `query!`
macro), so no offline SQLx cache regeneration is required.

## API Changes
- [x] New endpoints have `#[utoipa::path]` annotations
- [x] Request/response types have `#[derive(ToSchema)]`
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — N/A, no schema change
- [ ] N/A - no API changes

The `PUT /repositories/{key}/members` semantics change from "reorder existing" to
"replace member set"; the `#[utoipa::path]` summary/responses were updated
accordingly. No schema migration.

## Cherry-pick note (release/1.6.x)
Every virtual-repo function this PR touches or depends on
(`get_storage_usage`, `add_virtual_member`, `update_virtual_member_priorities`,
`get_virtual_members`, the `update_virtual_members` handler,
`member_mutation_admin_allowed`, and the `get_repository` / `update_repository`
storage lines) is byte-identical between `main` and `v1.6.0`, so this applies
cleanly onto `release/1.6.x`.
