### PR TITLE
fix(ldap): per-provider LDAPS TLS skip-verify and custom CA options

### DIFF
--- a/backend/migrations/174_ldap_configs_tls_options.sql
+++ b/backend/migrations/174_ldap_configs_tls_options.sql
@@ -1,0 +1,27 @@
+-- #2782 (LDAPS TLS trust options, per provider): surface the LDAP TLS trust
+-- controls in the per-provider SSO configuration instead of only the global
+-- `LDAP_INSECURE_TLS` / `LDAP_CA_CERT_PATH` environment variables.
+--
+-- Two new columns on `ldap_configs`:
+--
+--   * `insecure_skip_verify` — opt-in toggle to skip TLS certificate
+--     verification for LDAPS/STARTTLS (matches Harbor's "insecure skip
+--     verify"). Defaults FALSE (secure-by-default); verification stays on
+--     unless an operator explicitly turns it off for this provider. When
+--     true, the login and test-connection paths log a loud warning.
+--
+--   * `ca_certificate` — inline PEM CA certificate/chain trusted for this
+--     provider's LDAPS/STARTTLS handshake, so a customer using a private CA
+--     no longer has to import the whole chain into the host trust store or
+--     mount a file and set an env var. NULL/empty means "use the system trust
+--     store (plus any `LDAP_CA_CERT_PATH` fallback)".
+--
+-- The global environment variables continue to work as a fallback so existing
+-- deployments are unaffected: the effective skip-verify is
+-- `insecure_skip_verify OR LDAP_INSECURE_TLS`, and the inline `ca_certificate`
+-- takes precedence over the env-configured CA path when both are present.
+--
+-- Reversible: DROP COLUMN restores the pre-#2782 shape.
+ALTER TABLE ldap_configs
+    ADD COLUMN IF NOT EXISTS insecure_skip_verify BOOLEAN NOT NULL DEFAULT false,
+    ADD COLUMN IF NOT EXISTS ca_certificate TEXT;

--- a/backend/src/api/handlers/sso.rs
+++ b/backend/src/api/handlers/sso.rs
@@ -648,6 +648,8 @@ pub async fn ldap_login(
         &row.groups_attribute,
         row.admin_group_dn.as_deref(),
         row.use_starttls,
+        row.insecure_skip_verify,
+        row.ca_certificate.as_deref(),
     );
 
     // Authenticate against LDAP. A bind/credential failure is the LDAP

--- a/backend/src/api/handlers/sso_admin.rs
+++ b/backend/src/api/handlers/sso_admin.rs
@@ -1093,6 +1093,8 @@ mod tests {
             groups_attribute: "memberOf".to_string(),
             admin_group_dn: None,
             use_starttls: false,
+            insecure_skip_verify: false,
+            has_ca_certificate: false,
             is_enabled: true,
             priority: 1,
             created_at: chrono::Utc::now(),
@@ -1103,6 +1105,8 @@ mod tests {
         assert_eq!(json["has_bind_password"], true);
         assert_eq!(json["priority"], 1);
         assert!(json["group_base_dn"].is_null());
+        assert_eq!(json["insecure_skip_verify"], false);
+        assert_eq!(json["has_ca_certificate"], false);
     }
 
     // -----------------------------------------------------------------------

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1705,6 +1705,11 @@ fn build_ldap_request_from_values(
         groups_attribute: env.groups_attr.filter(|v| !v.is_empty()),
         admin_group_dn: env.admin_group_dn.filter(|v| !v.is_empty()),
         use_starttls: Some(use_starttls),
+        // TLS trust for the env-bootstrapped provider stays governed by the
+        // global LDAP_INSECURE_TLS / LDAP_CA_CERT_PATH env fallback (#2782);
+        // the per-provider overrides are set via the admin SSO API.
+        insecure_skip_verify: None,
+        ca_certificate: None,
         is_enabled: Some(true),
         priority: Some(0),
     })

--- a/backend/src/services/auth_config_service.rs
+++ b/backend/src/services/auth_config_service.rs
@@ -84,6 +84,13 @@ pub struct LdapConfigRow {
     pub groups_attribute: String,
     pub admin_group_dn: Option<String>,
     pub use_starttls: bool,
+    /// Skip TLS certificate verification for this provider's LDAPS/STARTTLS
+    /// handshake (migration 174, #2782). Defaults false (secure-by-default).
+    pub insecure_skip_verify: bool,
+    /// Inline PEM CA certificate/chain trusted for this provider's LDAPS/
+    /// STARTTLS handshake (migration 174, #2782). NULL/empty = system trust
+    /// store (plus any `LDAP_CA_CERT_PATH` fallback).
+    pub ca_certificate: Option<String>,
     pub is_enabled: bool,
     pub priority: i32,
     pub created_at: DateTime<Utc>,
@@ -210,6 +217,15 @@ pub struct LdapConfigResponse {
     pub groups_attribute: String,
     pub admin_group_dn: Option<String>,
     pub use_starttls: bool,
+    /// Opt-in flag (migration 174, #2782): when true, TLS certificate
+    /// verification is skipped for this provider's LDAPS/STARTTLS handshake.
+    /// Defaults false (secure-by-default). Matches Harbor's "insecure skip
+    /// verify"; only enable for trusted networks / private CAs you cannot
+    /// import.
+    pub insecure_skip_verify: bool,
+    /// Whether a custom inline CA certificate is configured for this provider
+    /// (migration 174, #2782). The PEM itself is not returned.
+    pub has_ca_certificate: bool,
     pub is_enabled: bool,
     pub priority: i32,
     pub created_at: DateTime<Utc>,
@@ -313,6 +329,15 @@ pub struct CreateLdapConfigRequest {
     pub groups_attribute: Option<String>,
     pub admin_group_dn: Option<String>,
     pub use_starttls: Option<bool>,
+    /// Opt-in (migration 174, #2782): skip TLS certificate verification for
+    /// this provider's LDAPS/STARTTLS handshake. Defaults false
+    /// (secure-by-default). Only enable for trusted networks / private CAs
+    /// you cannot import.
+    pub insecure_skip_verify: Option<bool>,
+    /// Inline PEM CA certificate/chain to trust for this provider's LDAPS/
+    /// STARTTLS handshake (migration 174, #2782). Send an empty string to
+    /// clear a previously stored certificate.
+    pub ca_certificate: Option<String>,
     pub is_enabled: Option<bool>,
     pub priority: Option<i32>,
 }
@@ -333,6 +358,12 @@ pub struct UpdateLdapConfigRequest {
     pub groups_attribute: Option<String>,
     pub admin_group_dn: Option<String>,
     pub use_starttls: Option<bool>,
+    /// See `CreateLdapConfigRequest::insecure_skip_verify` (migration 174,
+    /// #2782). Omit to leave the stored value unchanged.
+    pub insecure_skip_verify: Option<bool>,
+    /// Inline PEM CA certificate/chain (migration 174, #2782). Omit to leave
+    /// unchanged; send an empty string to clear.
+    pub ca_certificate: Option<String>,
     pub is_enabled: Option<bool>,
     pub priority: Option<i32>,
 }
@@ -783,6 +814,7 @@ impl AuthConfigService {
                    user_base_dn, user_filter, group_base_dn, group_filter,
                    email_attribute, display_name_attribute, username_attribute,
                    groups_attribute, admin_group_dn, use_starttls,
+                   insecure_skip_verify, ca_certificate,
                    is_enabled, priority, created_at, updated_at
             FROM ldap_configs
             ORDER BY priority, name
@@ -802,6 +834,7 @@ impl AuthConfigService {
                    user_base_dn, user_filter, group_base_dn, group_filter,
                    email_attribute, display_name_attribute, username_attribute,
                    groups_attribute, admin_group_dn, use_starttls,
+                   insecure_skip_verify, ca_certificate,
                    is_enabled, priority, created_at, updated_at
             FROM ldap_configs
             WHERE id = $1
@@ -826,6 +859,7 @@ impl AuthConfigService {
                    user_base_dn, user_filter, group_base_dn, group_filter,
                    email_attribute, display_name_attribute, username_attribute,
                    groups_attribute, admin_group_dn, use_starttls,
+                   insecure_skip_verify, ca_certificate,
                    is_enabled, priority, created_at, updated_at
             FROM ldap_configs
             WHERE id = $1
@@ -877,6 +911,8 @@ impl AuthConfigService {
         let use_starttls = req.use_starttls.unwrap_or(false);
         let is_enabled = req.is_enabled.unwrap_or(true);
         let priority = req.priority.unwrap_or(0);
+        let insecure_skip_verify = req.insecure_skip_verify.unwrap_or(false);
+        let ca_certificate = req.ca_certificate.filter(|c| !c.is_empty());
 
         let row = sqlx::query_as::<_, LdapConfigRow>(
             r#"
@@ -884,12 +920,13 @@ impl AuthConfigService {
                                       user_base_dn, user_filter, group_base_dn, group_filter,
                                       email_attribute, display_name_attribute, username_attribute,
                                       groups_attribute, admin_group_dn, use_starttls,
-                                      is_enabled, priority)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+                                      is_enabled, priority, insecure_skip_verify, ca_certificate)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
             RETURNING id, name, server_url, bind_dn, bind_password_encrypted,
                       user_base_dn, user_filter, group_base_dn, group_filter,
                       email_attribute, display_name_attribute, username_attribute,
                       groups_attribute, admin_group_dn, use_starttls,
+                      insecure_skip_verify, ca_certificate,
                       is_enabled, priority, created_at, updated_at
             "#,
         )
@@ -910,6 +947,8 @@ impl AuthConfigService {
         .bind(use_starttls)
         .bind(is_enabled)
         .bind(priority)
+        .bind(insecure_skip_verify)
+        .bind(&ca_certificate)
         .fetch_one(pool)
         .await
         .map_err(|e| AppError::Internal(format!("Failed to create LDAP config: {e}")))?;
@@ -928,6 +967,7 @@ impl AuthConfigService {
                    user_base_dn, user_filter, group_base_dn, group_filter,
                    email_attribute, display_name_attribute, username_attribute,
                    groups_attribute, admin_group_dn, use_starttls,
+                   insecure_skip_verify, ca_certificate,
                    is_enabled, priority, created_at, updated_at
             FROM ldap_configs
             WHERE id = $1
@@ -958,6 +998,15 @@ impl AuthConfigService {
         let use_starttls = req.use_starttls.unwrap_or(existing.use_starttls);
         let is_enabled = req.is_enabled.unwrap_or(existing.is_enabled);
         let priority = req.priority.unwrap_or(existing.priority);
+        let insecure_skip_verify = req
+            .insecure_skip_verify
+            .unwrap_or(existing.insecure_skip_verify);
+        // Omitted => keep existing; empty string => clear; non-empty => replace.
+        let ca_certificate = match req.ca_certificate {
+            Some(c) if c.is_empty() => None,
+            Some(c) => Some(c),
+            None => existing.ca_certificate,
+        };
 
         // Preserve existing encrypted password if not provided
         let bind_password_hex: Option<String> = if let Some(new_pw) = &req.bind_password {
@@ -974,12 +1023,14 @@ impl AuthConfigService {
                 user_base_dn = $5, user_filter = $6, group_base_dn = $7, group_filter = $8,
                 email_attribute = $9, display_name_attribute = $10, username_attribute = $11,
                 groups_attribute = $12, admin_group_dn = $13, use_starttls = $14,
-                is_enabled = $15, priority = $16, updated_at = NOW()
-            WHERE id = $17
+                is_enabled = $15, priority = $16, insecure_skip_verify = $17,
+                ca_certificate = $18, updated_at = NOW()
+            WHERE id = $19
             RETURNING id, name, server_url, bind_dn, bind_password_encrypted,
                       user_base_dn, user_filter, group_base_dn, group_filter,
                       email_attribute, display_name_attribute, username_attribute,
                       groups_attribute, admin_group_dn, use_starttls,
+                      insecure_skip_verify, ca_certificate,
                       is_enabled, priority, created_at, updated_at
             "#,
         )
@@ -999,6 +1050,8 @@ impl AuthConfigService {
         .bind(use_starttls)
         .bind(is_enabled)
         .bind(priority)
+        .bind(insecure_skip_verify)
+        .bind(&ca_certificate)
         .bind(id)
         .fetch_one(pool)
         .await
@@ -1033,6 +1086,7 @@ impl AuthConfigService {
                       user_base_dn, user_filter, group_base_dn, group_filter,
                       email_attribute, display_name_attribute, username_attribute,
                       groups_attribute, admin_group_dn, use_starttls,
+                      insecure_skip_verify, ca_certificate,
                       is_enabled, priority, created_at, updated_at
             "#,
         )
@@ -1107,6 +1161,8 @@ impl AuthConfigService {
             &row.groups_attribute,
             row.admin_group_dn.as_deref(),
             row.use_starttls,
+            row.insecure_skip_verify,
+            row.ca_certificate.as_deref(),
         );
 
         let bind_result = svc.verify_bind().await;
@@ -1245,6 +1301,8 @@ impl AuthConfigService {
             groups_attribute: row.groups_attribute,
             admin_group_dn: row.admin_group_dn,
             use_starttls: row.use_starttls,
+            insecure_skip_verify: row.insecure_skip_verify,
+            has_ca_certificate: row.ca_certificate.is_some_and(|c| !c.is_empty()),
             is_enabled: row.is_enabled,
             priority: row.priority,
             created_at: row.created_at,
@@ -1874,6 +1932,8 @@ impl From<CreateLdapConfigRequest> for UpdateLdapConfigRequest {
             groups_attribute: c.groups_attribute,
             admin_group_dn: c.admin_group_dn,
             use_starttls: c.use_starttls,
+            insecure_skip_verify: c.insecure_skip_verify,
+            ca_certificate: c.ca_certificate,
             is_enabled: c.is_enabled,
             priority: c.priority,
         }
@@ -2019,6 +2079,8 @@ mod tests {
             groups_attribute: "memberOf".to_string(),
             admin_group_dn: Some("cn=admins,ou=groups,dc=example,dc=com".to_string()),
             use_starttls: false,
+            insecure_skip_verify: false,
+            ca_certificate: None,
             is_enabled: true,
             priority: 0,
             created_at: now,
@@ -2462,6 +2524,8 @@ mod tests {
             groups_attribute: "memberOf".to_string(),
             admin_group_dn: None,
             use_starttls: false,
+            insecure_skip_verify: false,
+            has_ca_certificate: false,
             is_enabled: true,
             priority: 0,
             created_at: now,
@@ -2470,6 +2534,8 @@ mod tests {
         let json_str = serde_json::to_string(&resp).unwrap();
         assert!(json_str.contains("\"has_bind_password\":true"));
         assert!(json_str.contains("\"use_starttls\":false"));
+        assert!(json_str.contains("\"insecure_skip_verify\":false"));
+        assert!(json_str.contains("\"has_ca_certificate\":false"));
     }
 
     #[test]
@@ -2558,6 +2624,8 @@ mod tests {
             groups_attribute: "memberOf".to_string(),
             admin_group_dn: None,
             use_starttls: false,
+            insecure_skip_verify: false,
+            ca_certificate: None,
             is_enabled: true,
             priority: 0,
             created_at: chrono::Utc::now(),
@@ -2779,6 +2847,8 @@ mod tests {
             groups_attribute: None,
             admin_group_dn: None,
             use_starttls: Some(true),
+            insecure_skip_verify: Some(true),
+            ca_certificate: Some("-----BEGIN CERTIFICATE-----".to_string()),
             is_enabled: Some(true),
             priority: Some(0),
         };
@@ -2788,6 +2858,11 @@ mod tests {
         assert_eq!(u.user_base_dn, Some("ou=users".to_string()));
         assert_eq!(u.bind_dn, Some("cn=admin".to_string()));
         assert_eq!(u.use_starttls, Some(true));
+        assert_eq!(u.insecure_skip_verify, Some(true));
+        assert_eq!(
+            u.ca_certificate.as_deref(),
+            Some("-----BEGIN CERTIFICATE-----")
+        );
     }
 
     // =======================================================================
@@ -3541,6 +3616,128 @@ mod tests {
             assert!(!flipped.map_groups_to_groups);
 
             cleanup_saml(&pool, created.id).await;
+        }
+
+        async fn cleanup_ldap(pool: &PgPool, id: Uuid) {
+            let _ = sqlx::query("DELETE FROM ldap_configs WHERE id = $1")
+                .bind(id)
+                .execute(pool)
+                .await;
+        }
+
+        fn make_create_ldap_req(suffix: &str) -> CreateLdapConfigRequest {
+            CreateLdapConfigRequest {
+                name: format!("ldap-tls-test-{suffix}"),
+                server_url: "ldaps://ad.test.local:636".to_string(),
+                bind_dn: Some("cn=svc,dc=test,dc=local".to_string()),
+                bind_password: Some("secret".to_string()),
+                user_base_dn: "ou=users,dc=test,dc=local".to_string(),
+                user_filter: None,
+                group_base_dn: None,
+                group_filter: None,
+                email_attribute: None,
+                display_name_attribute: None,
+                username_attribute: None,
+                groups_attribute: None,
+                admin_group_dn: None,
+                use_starttls: None,
+                insecure_skip_verify: None,
+                ca_certificate: None,
+                is_enabled: Some(true),
+                priority: Some(0),
+            }
+        }
+
+        /// #2782: the per-provider TLS trust columns must round-trip through
+        /// create/get and be independently updatable (skip-verify toggle and
+        /// inline CA), including clearing the CA with an empty string.
+        #[tokio::test]
+        async fn test_ldap_tls_options_round_trip_and_update() {
+            let Some(pool) = db_helpers::try_pool().await else {
+                return;
+            };
+            if !encryption_key_available() {
+                return;
+            }
+
+            // Defaults: secure-by-default (skip-verify off, no CA).
+            let created = AuthConfigService::create_ldap(&pool, make_create_ldap_req("defaults"))
+                .await
+                .expect("create_ldap");
+            assert!(!created.insecure_skip_verify);
+            assert!(!created.has_ca_certificate);
+
+            // Opt in to both skip-verify and an inline CA.
+            let pem = "-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n";
+            let enabled = AuthConfigService::update_ldap(
+                &pool,
+                created.id,
+                UpdateLdapConfigRequest {
+                    name: None,
+                    server_url: None,
+                    bind_dn: None,
+                    bind_password: None,
+                    user_base_dn: None,
+                    user_filter: None,
+                    group_base_dn: None,
+                    group_filter: None,
+                    email_attribute: None,
+                    display_name_attribute: None,
+                    username_attribute: None,
+                    groups_attribute: None,
+                    admin_group_dn: None,
+                    use_starttls: None,
+                    insecure_skip_verify: Some(true),
+                    ca_certificate: Some(pem.to_string()),
+                    is_enabled: None,
+                    priority: None,
+                },
+            )
+            .await
+            .expect("update_ldap enable");
+            assert!(enabled.insecure_skip_verify);
+            assert!(enabled.has_ca_certificate);
+
+            // The stored PEM survives a fresh read; the decrypted getter also
+            // exposes it for the login/test-connection paths.
+            let (row, _pw) = AuthConfigService::get_ldap_decrypted(&pool, created.id)
+                .await
+                .expect("get_ldap_decrypted");
+            assert!(row.insecure_skip_verify);
+            assert_eq!(row.ca_certificate.as_deref(), Some(pem));
+
+            // Clearing the CA (empty string) drops it; omitting skip-verify
+            // leaves it unchanged.
+            let cleared = AuthConfigService::update_ldap(
+                &pool,
+                created.id,
+                UpdateLdapConfigRequest {
+                    name: None,
+                    server_url: None,
+                    bind_dn: None,
+                    bind_password: None,
+                    user_base_dn: None,
+                    user_filter: None,
+                    group_base_dn: None,
+                    group_filter: None,
+                    email_attribute: None,
+                    display_name_attribute: None,
+                    username_attribute: None,
+                    groups_attribute: None,
+                    admin_group_dn: None,
+                    use_starttls: None,
+                    insecure_skip_verify: None,
+                    ca_certificate: Some(String::new()),
+                    is_enabled: None,
+                    priority: None,
+                },
+            )
+            .await
+            .expect("update_ldap clear ca");
+            assert!(cleared.insecure_skip_verify);
+            assert!(!cleared.has_ca_certificate);
+
+            cleanup_ldap(&pool, created.id).await;
         }
     }
 }

--- a/backend/src/services/ldap_service.rs
+++ b/backend/src/services/ldap_service.rs
@@ -51,6 +51,10 @@ pub struct LdapConfig {
     pub use_starttls: bool,
     /// Path to a PEM file with custom CA certificates for LDAPS/STARTTLS
     pub ca_cert_path: Option<String>,
+    /// Inline PEM CA certificate(s) trusted for this provider's LDAPS/STARTTLS
+    /// handshake (per-provider config, issue #2782). Takes precedence over
+    /// `ca_cert_path` when set.
+    pub ca_cert_pem: Option<String>,
     /// Skip TLS certificate verification (development only)
     pub no_tls_verify: bool,
 }
@@ -129,6 +133,7 @@ impl LdapConfig {
                 .map(|v| v == "true" || v == "1")
                 .unwrap_or(false),
             ca_cert_path,
+            ca_cert_pem: None,
             no_tls_verify,
         })
     }
@@ -201,7 +206,7 @@ impl LdapService {
     #[allow(clippy::too_many_arguments)]
     pub fn from_db_config(
         db: PgPool,
-        _name: &str,
+        name: &str,
         server_url: &str,
         bind_dn: Option<&str>,
         bind_password: Option<&str>,
@@ -215,8 +220,29 @@ impl LdapService {
         groups_attr: &str,
         admin_group_dn: Option<&str>,
         use_starttls: bool,
+        insecure_skip_verify: bool,
+        ca_cert_pem: Option<&str>,
     ) -> Self {
-        let (ca_cert_path, no_tls_verify) = LdapConfig::tls_from_env();
+        // Environment variables remain a deployment-wide fallback: the
+        // effective skip-verify is the per-provider toggle OR the env flag,
+        // and an inline per-provider CA (#2782) takes precedence over the
+        // env-configured CA file path.
+        let (env_ca_cert_path, env_no_tls_verify) = LdapConfig::tls_from_env();
+        let no_tls_verify = insecure_skip_verify || env_no_tls_verify;
+        let ca_cert_pem = ca_cert_pem.filter(|v| !v.is_empty()).map(String::from);
+        let ca_cert_path = if ca_cert_pem.is_some() {
+            None
+        } else {
+            env_ca_cert_path
+        };
+        if no_tls_verify {
+            tracing::warn!(
+                provider = %name,
+                "LDAP TLS certificate verification is DISABLED for this provider \
+                 (insecure skip-verify). Connections are vulnerable to \
+                 man-in-the-middle attacks; do not use in production."
+            );
+        }
         let config = LdapConfig {
             url: server_url.to_string(),
             base_dn: user_base_dn.to_string(),
@@ -233,6 +259,7 @@ impl LdapService {
             admin_group_dn: admin_group_dn.map(String::from),
             use_starttls,
             ca_cert_path,
+            ca_cert_pem,
             no_tls_verify,
         };
         Self {
@@ -496,9 +523,12 @@ impl LdapService {
 
     /// Build LDAP connection settings with TLS configuration.
     ///
-    /// Supports custom CA certificates via `LDAP_CA_CERT_PATH` (or the shared
-    /// `CUSTOM_CA_CERT_PATH` as fallback) and `LDAP_INSECURE_TLS=true` to skip
-    /// certificate verification for development environments.
+    /// Custom CA certificates come from either an inline per-provider PEM
+    /// (`ca_cert_pem`, #2782) or the `LDAP_CA_CERT_PATH` (or shared
+    /// `CUSTOM_CA_CERT_PATH`) environment fallback; the inline value takes
+    /// precedence. `no_tls_verify` (per-provider skip-verify OR
+    /// `LDAP_INSECURE_TLS=true`) skips certificate verification for
+    /// development environments.
     fn build_conn_settings(&self) -> Result<ldap3::LdapConnSettings> {
         use std::time::Duration;
 
@@ -507,12 +537,23 @@ impl LdapService {
             .set_starttls(self.config.use_starttls)
             .set_no_tls_verify(self.config.no_tls_verify);
 
-        if let Some(ca_path) = &self.config.ca_cert_path {
+        // Inline per-provider PEM wins over the env-configured CA file path.
+        let ca_source: Option<(Vec<u8>, String)> = if let Some(pem) = &self.config.ca_cert_pem {
+            Some((
+                pem.as_bytes().to_vec(),
+                "inline provider configuration".to_string(),
+            ))
+        } else if let Some(ca_path) = &self.config.ca_cert_path {
             let pem_bytes = std::fs::read(ca_path).map_err(|e| {
                 AppError::Config(format!("Failed to read LDAP CA cert at {ca_path}: {e}"))
             })?;
+            Some((pem_bytes, ca_path.clone()))
+        } else {
+            None
+        };
 
-            let certs = Self::parse_pem_certificates(&pem_bytes, ca_path)?;
+        if let Some((pem_bytes, source)) = ca_source {
+            let certs = Self::parse_pem_certificates(&pem_bytes, &source)?;
             let mut builder = native_tls::TlsConnector::builder();
             for cert in &certs {
                 builder.add_root_certificate(cert.clone());
@@ -525,7 +566,7 @@ impl LdapService {
                 .map_err(|e| AppError::Config(format!("Failed to build TLS connector: {e}")))?;
             settings = settings.set_connector(connector);
             tracing::info!(
-                path = %ca_path,
+                source = %source,
                 count = certs.len(),
                 "Loaded custom CA certificate(s) for LDAP"
             );
@@ -1156,6 +1197,7 @@ mod tests {
             admin_group_dn: Some("cn=admins,ou=groups,dc=example,dc=com".to_string()),
             use_starttls: false,
             ca_cert_path: None,
+            ca_cert_pem: None,
             no_tls_verify: false,
         }
     }
@@ -1536,6 +1578,8 @@ mod tests {
             "memberOf",
             Some("cn=admins,dc=example,dc=com"),
             false,
+            false,
+            None,
         );
         assert!(!svc.config.no_tls_verify || std::env::var("LDAP_INSECURE_TLS").is_ok());
         assert_eq!(svc.config.url, "ldaps://ad.example.com:636");
@@ -1544,6 +1588,75 @@ mod tests {
             svc.config.admin_group_dn.as_deref(),
             Some("cn=admins,dc=example,dc=com")
         );
+    }
+
+    /// #2782: the per-provider skip-verify toggle must relax verification on
+    /// the resulting connector even when the `LDAP_INSECURE_TLS` env var is
+    /// unset, and a per-provider inline CA must be carried through.
+    #[tokio::test]
+    async fn test_from_db_config_per_provider_skip_verify_and_inline_ca() {
+        const TEST_CA_PEM: &str = include_str!("../../tests/fixtures/test-ca.pem");
+        let db = PgPool::connect_lazy("postgres://localhost/fake").expect("lazy pool");
+        let svc = LdapService::from_db_config(
+            db,
+            "test-ldap",
+            "ldaps://ad.example.com:636",
+            Some("cn=svc,dc=example,dc=com"),
+            Some("password"),
+            "ou=users,dc=example,dc=com",
+            "(sAMAccountName={username})",
+            None,
+            None,
+            "sAMAccountName",
+            "mail",
+            "displayName",
+            "memberOf",
+            None,
+            false,
+            true,
+            Some(TEST_CA_PEM),
+        );
+        // Per-provider toggle relaxes verification regardless of the env var.
+        assert!(svc.config.no_tls_verify);
+        // Inline PEM is carried and the env file-path fallback is suppressed.
+        assert_eq!(svc.config.ca_cert_pem.as_deref(), Some(TEST_CA_PEM));
+        assert!(svc.config.ca_cert_path.is_none());
+        // The connector builder honours both (parses the inline PEM +
+        // accepts-invalid), i.e. no error is returned.
+        svc.build_conn_settings()
+            .expect("inline CA + skip-verify should build a connector");
+    }
+
+    /// #2782: with the per-provider toggle OFF and no env override, the
+    /// connector must keep verifying certificates (secure-by-default).
+    #[tokio::test]
+    async fn test_from_db_config_default_keeps_verification() {
+        // Only meaningful when the env override is not set in this process.
+        if std::env::var("LDAP_INSECURE_TLS").is_ok() {
+            return;
+        }
+        let db = PgPool::connect_lazy("postgres://localhost/fake").expect("lazy pool");
+        let svc = LdapService::from_db_config(
+            db,
+            "test-ldap",
+            "ldaps://ad.example.com:636",
+            None,
+            None,
+            "ou=users,dc=example,dc=com",
+            "(sAMAccountName={username})",
+            None,
+            None,
+            "sAMAccountName",
+            "mail",
+            "displayName",
+            "memberOf",
+            None,
+            false,
+            false,
+            None,
+        );
+        assert!(!svc.config.no_tls_verify);
+        assert!(svc.config.ca_cert_pem.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Customers using LDAPS with a private/enterprise CA had no per-provider way to
either (a) trust a custom CA certificate or (b) skip TLS certificate
verification. The only existing controls were the deployment-wide environment
variables `LDAP_INSECURE_TLS` / `LDAP_CA_CERT_PATH`, which apply globally to
every provider and require host/deploy access an SSO admin using the web UI
does not have. Harbor exposes an "insecure skip verify" toggle on its LDAP
config; this brings the same control (plus an inline custom-CA field) to the
per-provider SSO configuration.

This adds two per-provider columns to `ldap_configs` and wires them through the
LDAP connection builder used by **both** the login bind and the admin
test-connection path (#2744):

- **`insecure_skip_verify`** (bool, default **false** — secure-by-default):
  when enabled, TLS certificate verification is skipped for this provider's
  LDAPS/STARTTLS handshake. Enabling it logs a loud per-provider warning on
  every connection ("verification is DISABLED … vulnerable to
  man-in-the-middle … do not use in production").
- **`ca_certificate`** (inline PEM, nullable): a custom CA certificate/chain
  trusted for this provider's handshake, so operators no longer have to import
  the whole chain into the host trust store or mount a file + set an env var.

The global env vars remain a fallback so existing deployments are unaffected:
the effective skip-verify is `insecure_skip_verify OR LDAP_INSECURE_TLS`, and
an inline per-provider `ca_certificate` takes precedence over the
env-configured `LDAP_CA_CERT_PATH`. Secure-by-default is preserved: with the
toggle off and no env override, verification stays on.

### Investigation: the "regressed since 1.2.0" hypothesis

The customer suspected a regression since 1.2.0. That is **not** what the code
shows: the env-var skip-verify (`LDAP_INSECURE_TLS`) and CA path
(`LDAP_CA_CERT_PATH`) already existed at the `v1.2.0` tag and are still present
at `v1.6.0`, and both versions route login through the DB-backed per-provider
config (`from_db_config`), which reads those settings from the environment.
There was no removed skip-verify option. The real, standing gap — and what the
customer experiences as "no option" — is that the toggle/CA were only ever
reachable via a global env var, never surfaced on the per-provider SSO config
that the admin UI/API drives. This PR closes that gap.


## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

`test_ldap_tls_options_round_trip_and_update` (DB-backed) creates an LDAP
provider (asserts secure defaults: skip-verify off, no CA), enables both the
skip-verify toggle and an inline CA via update, confirms `get_ldap_decrypted`
(the exact row the login and test-connection paths consume) returns them, and
clears the CA via an empty string — exercising the new INSERT/UPDATE/SELECT
SQL end-to-end. `test_from_db_config_per_provider_skip_verify_and_inline_ca`
and `test_from_db_config_default_keeps_verification` assert at the connector
level that the per-provider toggle relaxes verification even with the env var
unset (and builds a connector from the inline CA), while the default keeps
verification on.

## Test Checklist

- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable) — DB-backed CRUD round-trip
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (`cargo nextest run --workspace --lib`: 13893 passed, 0 failed, against a throwaway Postgres with migration 174 applied)

## API Changes

- [ ] New endpoints have `#[utoipa::path]` annotations — no new endpoints
- [x] Request/response types have `#[derive(ToSchema)]` — new fields added to
  existing `CreateLdapConfigRequest` / `UpdateLdapConfigRequest` /
  `LdapConfigResponse` (`ToSchema`)
- [x] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [x] Migration is reversible (if applicable) — `174_ldap_configs_tls_options.sql`
  is `ADD COLUMN IF NOT EXISTS`; reversible via `DROP COLUMN`
- [ ] N/A - no API changes

### Cherry-pick note (release/1.6.x)

Targeted at `main`; intended for backport to `release/1.6.x` (v1.6.0). The
release branch tops out at migration **168**, so `174` applies cleanly as the
next version — but if contiguous numbering is preferred on the release branch,
renumber the migration to `169` there. The touched Rust sites
(`LdapConfig`/`from_db_config`/`build_conn_settings`, the `ldap_configs` CRUD in
`auth_config_service.rs`, and the two `from_db_config` callers) exist with the
same shape on `release/1.6.x`; the AD-group-sync change (#2756, main-only,
post-1.6.0) does not touch these sites, so conflicts should be minimal.

Closes #2782