### PR TITLE
fix(migration): migrate Nexus Go and APT repos + index migrated artifacts

### DIFF
--- a/backend/src/api/handlers/migration.rs
+++ b/backend/src/api/handlers/migration.rs
@@ -565,10 +565,12 @@ fn spawn_migration_worker(
 
     let db = state.db.clone();
     let storage_registry = state.storage_registry.clone();
+    let search_service = state.search_service.clone();
     let fail_db = state.db.clone();
     let job_id = job.id;
     tokio::spawn(async move {
-        let worker = MigrationWorker::new(db, storage_registry, worker_config, cancel_token);
+        let worker = MigrationWorker::new(db, storage_registry, worker_config, cancel_token)
+            .with_search_service(search_service);
         let outcome = if resume {
             worker
                 .resume_job(job_id, client, conflict_resolution, None)

--- a/backend/src/services/artifact_metadata.rs
+++ b/backend/src/services/artifact_metadata.rs
@@ -43,6 +43,7 @@ pub fn parse_name_and_version(
         "npm" | "yarn" | "pnpm" | "bower" => parse_npm(filename, artifact_path),
         "maven" | "gradle" | "sbt" | "ivy" => parse_maven(filename, artifact_path),
         "nuget" => parse_nuget(filename, artifact_path),
+        "go" | "golang" => parse_go(artifact_path, filename),
         _ => fallback(filename),
     }
 }
@@ -234,6 +235,65 @@ fn parse_helm(filename: &str) -> ParsedArtifact {
         };
     }
     fallback(filename)
+}
+
+// ---------------------------------------------------------------------------
+// Go
+// ---------------------------------------------------------------------------
+
+/// Go module-proxy parser (#2784). Go repositories (in Nexus and the GOPROXY
+/// protocol) lay artifacts out as `<module>/@v/<version>.{zip,mod,info}`,
+/// e.g. `github.com/gorilla/mux/@v/v1.8.0.zip`. The module path is the
+/// portion before `/@v/` and the version is the file stem after it. Module
+/// paths encode uppercase letters as `!` followed by the lowercase letter
+/// (e.g. `!azure` == `Azure`), so the recovered name is un-escaped back to
+/// the canonical, human-readable module path the Go tooling and the Packages
+/// tab display.
+///
+/// Non-versioned proxy files (`@v/list`, `@latest`, `@v/<v>.lock`) don't
+/// carry a parseable version and fall through to the filename-as-name
+/// behaviour (no catalog row), matching how other formats treat their index
+/// files.
+fn parse_go(artifact_path: &str, filename: &str) -> ParsedArtifact {
+    if let Some((module_enc, ver_file)) = artifact_path.split_once("/@v/") {
+        if !module_enc.is_empty() {
+            let version = ver_file
+                .strip_suffix(".zip")
+                .or_else(|| ver_file.strip_suffix(".info"))
+                .or_else(|| ver_file.strip_suffix(".mod"))
+                .filter(|v| !v.is_empty())
+                .map(go_unescape_module_path);
+            if version.is_some() {
+                return ParsedArtifact {
+                    name: go_unescape_module_path(module_enc),
+                    version,
+                };
+            }
+        }
+    }
+    fallback(filename)
+}
+
+/// Decode the Go module-proxy case-encoding: an uppercase ASCII letter is
+/// stored as `!` followed by its lowercase form. Any other `!` is preserved
+/// verbatim so malformed input round-trips without panicking.
+fn go_unescape_module_path(encoded: &str) -> String {
+    if !encoded.contains('!') {
+        return encoded.to_string();
+    }
+    let mut out = String::with_capacity(encoded.len());
+    let mut chars = encoded.chars();
+    while let Some(c) = chars.next() {
+        if c == '!' {
+            match chars.next() {
+                Some(next) => out.push(next.to_ascii_uppercase()),
+                None => out.push('!'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
 }
 
 // ---------------------------------------------------------------------------
@@ -695,6 +755,89 @@ mod tests {
         );
         assert_eq!(p.name, "MyPackage");
         assert_eq!(p.version.as_deref(), Some("1.0.0"));
+    }
+
+    // -----------------------------------------------------------------------
+    // Go (#2784)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn go_zip_recovers_module_and_version() {
+        let p = parse_name_and_version("go", "v1.8.0.zip", "github.com/gorilla/mux/@v/v1.8.0.zip");
+        assert_eq!(p.name, "github.com/gorilla/mux");
+        assert_eq!(p.version.as_deref(), Some("v1.8.0"));
+    }
+
+    #[test]
+    fn go_mod_and_info_sidecars_recover_the_same_identity() {
+        let m = parse_name_and_version("go", "v1.8.0.mod", "github.com/gorilla/mux/@v/v1.8.0.mod");
+        let i =
+            parse_name_and_version("go", "v1.8.0.info", "github.com/gorilla/mux/@v/v1.8.0.info");
+        assert_eq!(m.name, "github.com/gorilla/mux");
+        assert_eq!(m.version.as_deref(), Some("v1.8.0"));
+        assert_eq!(i.name, "github.com/gorilla/mux");
+        assert_eq!(i.version.as_deref(), Some("v1.8.0"));
+    }
+
+    #[test]
+    fn go_pseudo_version_is_preserved() {
+        let p = parse_name_and_version(
+            "go",
+            "v0.0.0-20210101000000-abcdef123456.zip",
+            "example.com/x/y/@v/v0.0.0-20210101000000-abcdef123456.zip",
+        );
+        assert_eq!(p.name, "example.com/x/y");
+        assert_eq!(
+            p.version.as_deref(),
+            Some("v0.0.0-20210101000000-abcdef123456")
+        );
+    }
+
+    #[test]
+    fn go_case_escaped_module_path_is_decoded() {
+        // `!azure` decodes to `Azure` per the GOPROXY case-encoding.
+        let p = parse_name_and_version(
+            "go",
+            "v68.0.0.zip",
+            "github.com/!azure/azure-sdk-for-go/@v/v68.0.0.zip",
+        );
+        assert_eq!(p.name, "github.com/Azure/azure-sdk-for-go");
+        assert_eq!(p.version.as_deref(), Some("v68.0.0"));
+    }
+
+    #[test]
+    fn go_golang_alias_uses_the_same_parser() {
+        let p = parse_name_and_version("golang", "v1.0.0.mod", "rsc.io/quote/@v/v1.0.0.mod");
+        assert_eq!(p.name, "rsc.io/quote");
+        assert_eq!(p.version.as_deref(), Some("v1.0.0"));
+    }
+
+    #[test]
+    fn go_index_files_have_no_version() {
+        // `list` and `@latest` are proxy index files, not releases.
+        let list = parse_name_and_version("go", "list", "github.com/gorilla/mux/@v/list");
+        assert_eq!(list.version, None);
+        let latest = parse_name_and_version("go", "@latest", "github.com/gorilla/mux/@latest");
+        assert_eq!(latest.version, None);
+    }
+
+    #[test]
+    fn go_non_proxy_path_falls_back_to_filename() {
+        let p = parse_name_and_version("go", "weird.bin", "weird.bin");
+        assert_eq!(p.name, "weird.bin");
+        assert_eq!(p.version, None);
+    }
+
+    #[test]
+    fn go_unescape_module_path_cases() {
+        assert_eq!(
+            go_unescape_module_path("github.com/gorilla/mux"),
+            "github.com/gorilla/mux"
+        );
+        assert_eq!(go_unescape_module_path("!azure"), "Azure");
+        assert_eq!(go_unescape_module_path("!a!b!c"), "ABC");
+        // Trailing bang round-trips without panicking.
+        assert_eq!(go_unescape_module_path("foo!"), "foo!");
     }
 
     #[test]

--- a/backend/src/services/migration_service.rs
+++ b/backend/src/services/migration_service.rs
@@ -251,6 +251,15 @@ impl MigrationService {
             "raw" => "generic".to_string(),
             // Nexus uses `yum`, Artifact Keeper's equivalent is `rpm`
             "yum" => "rpm".to_string(),
+            // Nexus uses `apt` for Debian/APT repositories; Artifact Keeper's
+            // equivalent format is `debian`. Without this mapping an `apt`
+            // repository normalized to the unknown name `apt`, which
+            // `get_format_compatibility` classifies as `Unsupported`, so the
+            // whole repository failed to migrate (#2784).
+            "apt" => "debian".to_string(),
+            // Some tools report Go module repositories as `golang`; Artifact
+            // Keeper's canonical format is `go`.
+            "golang" => "go".to_string(),
             // RubyGems is sometimes reported as `gems` or `rubygems`
             "gems" => "rubygems".to_string(),
             _ => lower,
@@ -1409,6 +1418,45 @@ mod tests {
             MigrationService::get_format_compatibility("yum"),
             FormatCompatibility::Partial
         );
+
+        // #2784: Nexus `apt` repositories map to AK's `debian` (partial
+        // support, migrated as generic). Before the mapping, `apt`
+        // normalized to the unknown name `apt` and was classified
+        // Unsupported, so the whole repository failed to migrate.
+        assert_eq!(MigrationService::normalize_package_type("apt"), "debian");
+        assert_eq!(
+            MigrationService::get_format_compatibility("apt"),
+            FormatCompatibility::Partial
+        );
+
+        // #2784: `golang` is an alias for AK's `go` (full support).
+        assert_eq!(MigrationService::normalize_package_type("golang"), "go");
+        assert_eq!(
+            MigrationService::get_format_compatibility("golang"),
+            FormatCompatibility::Full
+        );
+        // `go` itself is already the canonical, fully-supported name.
+        assert_eq!(
+            MigrationService::get_format_compatibility("go"),
+            FormatCompatibility::Full
+        );
+    }
+
+    #[test]
+    fn test_prepare_repository_migration_normalizes_nexus_apt() {
+        // #2784: a Nexus `apt` repository must prepare as `debian` with
+        // Partial compatibility so it migrates (as generic) instead of being
+        // rejected as an unsupported format.
+        let repo = RepositoryListItem {
+            key: "apt-hosted".to_string(),
+            repo_type: "hosted".to_string(),
+            package_type: "apt".to_string(),
+            url: None,
+            description: None,
+        };
+        let config = MigrationService::prepare_repository_migration(&repo, None).unwrap();
+        assert_eq!(config.package_type, "debian");
+        assert_eq!(config.format_compatibility, FormatCompatibility::Partial);
     }
 
     #[test]

--- a/backend/src/services/migration_worker.rs
+++ b/backend/src/services/migration_worker.rs
@@ -10,6 +10,7 @@ use crate::models::migration::{MigrationItemType, MigrationJobStatus};
 use crate::services::artifact_service::ArtifactService;
 use crate::services::artifactory_client::ArtifactoryClient;
 use crate::services::migration_service::{ConflictType, MigrationError, MigrationService};
+use crate::services::opensearch_service::{ArtifactDocument, OpenSearchService};
 use crate::services::source_registry::SourceRegistry;
 use crate::storage::{StorageBackend, StorageLocation, StorageRegistry};
 use sha1::Sha1;
@@ -160,6 +161,12 @@ pub struct MigrationWorker {
     storage_registry: Arc<StorageRegistry>,
     config: WorkerConfig,
     cancel_token: CancellationToken,
+    /// Optional search backend. When present, every imported artifact is
+    /// indexed into OpenSearch as it commits so migrated content is
+    /// searchable/visible without waiting for a manual or startup reindex
+    /// (#2784). Best-effort by contract: indexing failures are logged and
+    /// never fail a migration item.
+    search_service: Option<Arc<OpenSearchService>>,
 }
 
 impl MigrationWorker {
@@ -177,6 +184,95 @@ impl MigrationWorker {
             storage_registry,
             config,
             cancel_token,
+            search_service: None,
+        }
+    }
+
+    /// Attach an OpenSearch service so imported artifacts are indexed for
+    /// full-text search as they are migrated (#2784). Returns `self` for
+    /// builder-style chaining at the call site; passing `None` is a no-op and
+    /// leaves migration behaving exactly as before (e.g. when the deployment
+    /// has no OpenSearch configured).
+    pub fn with_search_service(mut self, search_service: Option<Arc<OpenSearchService>>) -> Self {
+        self.search_service = search_service;
+        self
+    }
+
+    /// Best-effort index of a just-committed migrated artifact into
+    /// OpenSearch (#2784).
+    ///
+    /// No-op when no search backend is attached. Loads the artifact's live
+    /// row joined with its repository (matching the fields the live index
+    /// path and `full_reindex_artifacts` use, including the repository's
+    /// canonical `format`) and upserts the document. Any failure — the row
+    /// having been concurrently removed, or the search cluster being
+    /// unavailable — is logged and swallowed so migration never fails an
+    /// item whose content already committed.
+    async fn index_migrated_artifact(&self, repository_id: Uuid, path: &str) {
+        let Some(search) = self.search_service.clone() else {
+            return;
+        };
+
+        let row: Result<Option<MigratedArtifactIndexRow>, _> = sqlx::query_as(
+            r#"
+            SELECT
+                a.id,
+                a.name,
+                a.path,
+                a.version,
+                a.content_type,
+                a.size_bytes,
+                a.created_at,
+                r.key AS repository_key,
+                r.name AS repository_name,
+                r.format::text AS format,
+                r.is_public
+            FROM artifacts a
+            INNER JOIN repositories r ON a.repository_id = r.id
+            WHERE a.repository_id = $1 AND a.path = $2 AND a.is_deleted = false
+            LIMIT 1
+            "#,
+        )
+        .bind(repository_id)
+        .bind(path)
+        .fetch_optional(&self.db)
+        .await;
+
+        let row = match row {
+            Ok(Some(row)) => row,
+            Ok(None) => return,
+            Err(e) => {
+                tracing::warn!(
+                    repository_id = %repository_id,
+                    path = %path,
+                    error = %e,
+                    "Failed to load migrated artifact for OpenSearch indexing"
+                );
+                return;
+            }
+        };
+
+        let doc = ArtifactDocument {
+            id: row.id.to_string(),
+            name: row.name,
+            path: row.path,
+            version: row.version,
+            format: row.format,
+            repository_id: repository_id.to_string(),
+            repository_key: row.repository_key,
+            repository_name: row.repository_name,
+            content_type: row.content_type,
+            size_bytes: row.size_bytes,
+            download_count: 0,
+            is_public: row.is_public,
+            created_at: row.created_at.timestamp(),
+        };
+
+        if let Err(e) = search.index_artifact(&doc).await {
+            tracing::warn!(
+                artifact_id = %doc.id,
+                "Failed to index migrated artifact in OpenSearch: {e}"
+            );
         }
     }
 
@@ -1654,6 +1750,15 @@ impl MigrationWorker {
                         )
                         .await;
                 }
+
+                // #2784: index the freshly-imported artifact into OpenSearch
+                // so migrated content is searchable/visible immediately. The
+                // live upload paths index via `artifact_service`, but the
+                // importer writes `artifacts` directly, so without this a
+                // migrated repository stayed invisible to search until a
+                // manual or startup reindex. Best-effort: a search failure
+                // must never fail an item whose content already committed.
+                self.index_migrated_artifact(repository_id, &path_str).await;
             }
         }
 
@@ -2362,6 +2467,23 @@ fn migration_artifact_path(
             _ => format!("{}/{}", repo_key, artifact_path),
         },
     }
+}
+
+/// Row shape for loading a just-committed migrated artifact (joined with its
+/// repository) to build an OpenSearch [`ArtifactDocument`] (#2784).
+#[derive(Debug, sqlx::FromRow)]
+struct MigratedArtifactIndexRow {
+    id: Uuid,
+    name: String,
+    path: String,
+    version: Option<String>,
+    content_type: String,
+    size_bytes: i64,
+    created_at: chrono::DateTime<chrono::Utc>,
+    repository_key: String,
+    repository_name: String,
+    format: String,
+    is_public: bool,
 }
 
 /// The `packages`-catalog identity of a migrated artifact, or `None` when
@@ -6239,6 +6361,18 @@ mod tests {
             migration_catalog_entry("gradle", &OciRole::NotOci, &parsed),
             None
         );
+
+        // #2784: Go modules are non-OCI and carry a version, so they get a
+        // catalog row under the recovered `(module, version)` identity.
+        let go_parsed = crate::services::artifact_metadata::ParsedArtifact {
+            name: "github.com/gorilla/mux".to_string(),
+            version: Some("v1.8.0".to_string()),
+        };
+        let go_entry = migration_catalog_entry("go", &OciRole::NotOci, &go_parsed)
+            .expect("versioned go module must produce a catalog entry");
+        assert_eq!(go_entry.name, "github.com/gorilla/mux");
+        assert_eq!(go_entry.version, "v1.8.0");
+        assert_eq!(go_entry.format, "go");
     }
 
     // -----------------------------------------------------------------------
@@ -6423,6 +6557,117 @@ mod tests {
         // Exactly one catalog row: the walked-in blobs and the digest child
         // content must not surface as packages.
         assert_eq!(catalog_counts(&pool, repo_id).await, (1, 1));
+
+        cleanup_repo(&pool, repo_id).await;
+    }
+
+    /// #2784: a migrated Go module must recover its `(module, version)`
+    /// identity from the GOPROXY `<module>/@v/<version>.zip` layout, land in
+    /// `artifacts` under the canonical module path (not the raw filename),
+    /// AND appear in `packages`/`package_versions` so the Packages tab shows
+    /// it. Pre-fix, Go fell through to the filename-as-name/no-version
+    /// fallback, so no catalog row was ever written. Re-import stays at one
+    /// row (idempotency).
+    #[tokio::test]
+    async fn test_go_import_populates_package_catalog() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2784-go", "go").await;
+
+        // The `.zip` is the module payload; the module path carries slashes
+        // and a case-escaped segment (`!azure` == `Azure`).
+        let path = "github.com/!azure/azure-sdk-for-go/@v/v1.8.0.zip";
+        let mut files = std::collections::HashMap::new();
+        files.insert(
+            path.to_string(),
+            bytes::Bytes::from_static(b"fake go module zip bytes"),
+        );
+
+        transfer_one(&worker, &storage, &files, &repo_key, "go", path)
+            .await
+            .expect("go module transfer must succeed");
+
+        // Catalog row uses the decoded module path + version.
+        assert_eq!(
+            single_catalog_row(&pool, repo_id).await,
+            Some((
+                "github.com/Azure/azure-sdk-for-go".to_string(),
+                "v1.8.0".to_string()
+            )),
+            "migrated go module must appear in the packages catalog"
+        );
+
+        // Artifact row is stored under the canonical module identity, not the
+        // raw `v1.8.0.zip` filename.
+        let artifact: (String, Option<String>) = sqlx::query_as(
+            "SELECT name, version FROM artifacts WHERE repository_id = $1 AND is_deleted = false",
+        )
+        .bind(repo_id)
+        .fetch_one(&pool)
+        .await
+        .expect("query artifact");
+        assert_eq!(artifact.0, "github.com/Azure/azure-sdk-for-go");
+        assert_eq!(artifact.1, Some("v1.8.0".to_string()));
+
+        // Re-import (migration re-run) must be idempotent: same single row.
+        transfer_one(&worker, &storage, &files, &repo_key, "go", path)
+            .await
+            .expect("go re-import must succeed");
+        assert_eq!(
+            catalog_counts(&pool, repo_id).await,
+            (1, 1),
+            "re-running the migration must not duplicate catalog rows"
+        );
+
+        cleanup_repo(&pool, repo_id).await;
+    }
+
+    /// #2784: the `.mod` and `.info` sidecars of a Go module share the same
+    /// `(module, version)`, so they upsert onto the same catalog row rather
+    /// than each creating their own — mirroring how a real GOPROXY module is
+    /// a single logical release across its three files.
+    #[tokio::test]
+    async fn test_go_import_sidecars_share_one_catalog_row() {
+        use crate::api::handlers::test_db_helpers as tdh;
+        let Some(pool) = tdh::try_pool().await else {
+            return;
+        };
+        let (worker, storage, _tmp, repo_id, repo_key) =
+            setup_repo_for_import(&pool, "mig2784-gomod", "go").await;
+
+        let base = "example.com/foo/bar/@v/v0.1.0";
+        let mut files = std::collections::HashMap::new();
+        for ext in ["zip", "mod", "info"] {
+            files.insert(
+                format!("{base}.{ext}"),
+                bytes::Bytes::from(format!("payload-{ext}")),
+            );
+        }
+        for ext in ["zip", "mod", "info"] {
+            transfer_one(
+                &worker,
+                &storage,
+                &files,
+                &repo_key,
+                "go",
+                &format!("{base}.{ext}"),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("go {ext} transfer failed: {e}"));
+        }
+
+        assert_eq!(
+            single_catalog_row(&pool, repo_id).await,
+            Some(("example.com/foo/bar".to_string(), "v0.1.0".to_string())),
+        );
+        assert_eq!(
+            catalog_counts(&pool, repo_id).await,
+            (1, 1),
+            "the three sidecar files of one Go release must share one catalog row"
+        );
 
         cleanup_repo(&pool, repo_id).await;
     }


### PR DESCRIPTION
## Summary

Closes #2784

Nexus migration failed for **APT** and **Go** repositories, and migrated Go
modules never surfaced in the Packages tab or OpenSearch. #2740 populated the
packages catalog for docker/helm/nuget migrations but did not cover Go/APT
import or search indexing. This PR fixes the three distinct root causes:

- **APT repositories were rejected outright.** Nexus reports Debian/APT
  repositories with the format name `apt`, but `normalize_package_type` had no
  mapping for it, so it normalized to the unknown name `apt`, which
  `get_format_compatibility` classifies as `Unsupported`. `create_repository`
  then returned `"Package type 'apt' is not supported for migration"` and the
  whole repository failed to migrate. Added `apt -> debian`, so APT
  repositories now migrate with Partial compatibility (as `generic`), exactly
  like a native Nexus/Artifactory `debian` repository. Also added the common
  `golang -> go` alias.

- **Go modules got no `packages`/`package_versions` catalog rows.** Go
  repositories *did* migrate (the `go` format is Full), but
  `parse_name_and_version` had no Go arm, so Go artifacts fell through to the
  filename-as-name/no-version fallback. With no recovered version,
  `migration_catalog_entry` (the shared #2740 decision helper) returned `None`
  and no catalog row was written, leaving the Packages tab empty for Go, and
  the artifact row was stored under the raw `v1.8.0.zip` filename. Added a Go
  module-proxy parser: it splits the GOPROXY layout
  `<module>/@v/<version>.{zip,mod,info}`, recovers the module path and version,
  and decodes the `!`-case escaping (`!azure` -> `Azure`). Go artifacts now
  land under their canonical module identity and flow through the existing
  shared `PackageService::try_create_or_update_from_artifact` path #2740 uses —
  no per-format divergence.

- **Migrated artifacts were never indexed into OpenSearch.** The importer
  writes the `artifacts` table directly (not via `ArtifactService`), so it
  never called `index_artifact`; migrated content only became searchable after
  a manual/startup reindex. The migration worker now takes an optional
  `OpenSearchService` and, after each item commits, upserts the freshly
  imported artifact via the same shared `index_artifact` document path the live
  upload path uses. This is best-effort (a search failure never fails an item
  whose content already committed) and no-ops when OpenSearch is not
  configured, so it fixes Go/APT visibility and the pre-existing
  migration-wide search gap for every format at once.

### Scope note (APT vs Go)

Go is fixed end-to-end (import + catalog rows + search). For APT the fix makes
the repository migrate and its `.deb` artifacts import and index, consistent
with how AK already treats `debian` (Partial -> `generic`). Full `.deb`
catalog naming (a dedicated Debian parser) is intentionally out of scope for
this patch — the same follow-up posture #2740 took for Maven — because it
needs `.deb` control-field parsing beyond a filename heuristic.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

DB-gated regression tests (verified failing before the fix, passing after):
- `test_go_import_populates_package_catalog` — a migrated Go module
  (`github.com/!azure/azure-sdk-for-go/@v/v1.8.0.zip`) lands in
  `packages`/`package_versions` under the decoded module path + version, the
  `artifacts` row carries the canonical name/version (not the raw filename),
  and re-import stays at exactly one row (idempotency). Proven to fail before
  the fix: catalog row is `None`.
- `test_go_import_sidecars_share_one_catalog_row` — the `.zip`/`.mod`/`.info`
  sidecars of one Go release upsert onto a single catalog row.

Pure unit tests: Go filename/path parsing (zip/mod/info, pseudo-versions,
`!`-case decoding, `golang` alias, non-versioned `list`/`@latest` fallback,
non-proxy fallback), `go_unescape_module_path`, the `migration_catalog_entry`
Go arm, and the `apt -> debian` / `golang -> go` normalization + compatibility
mapping (plus `prepare_repository_migration` for a Nexus `apt` repo).

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (DB-gated migration tests)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (full `--workspace --lib` suite:
  13,901/13,902 passed against a fresh migrated Postgres; the one unrelated
  failure, `repositories::tests::npm_scope_policy_put_get_round_trip_db`, is a
  pre-existing order-dependent assertion untouched by this PR)

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes

## Cherry-pick / backport note (1.6.1 / release/1.6.x)

This PR is built on `main`, where #2740 is present. #2740 landed **after**
v1.6.0, so `migration_catalog_entry`, the catalog-population block, and the
NuGet parser do **not** exist on `v1.6.0` / `release/1.6.x`. Backporting this
change alone will not apply cleanly: the Go parser + `apt`/`golang` mapping +
OpenSearch indexing are self-contained, but the Go **catalog-row** behaviour
depends on the #2740 helper. The clean 1.6.1 path is to cherry-pick #2740
first, then this PR. If #2740 is considered too large for the patch line, the
Go catalog population must be reshaped onto the v1.6.0 import path; the format
mapping + parser + search-indexing parts backport independently.
