### PR TITLE
fix(backup): reclaim archive storage in retention cleanup

### DIFF
--- a/backend/src/services/backup_service.rs
+++ b/backend/src/services/backup_service.rs
@@ -785,12 +785,20 @@ impl BackupService {
         Ok(())
     }
 
-    /// Clean up old backups based on retention policy
+    /// Clean up old backups based on retention policy.
+    ///
+    /// Removes the backup archive from storage in addition to the database row.
+    /// Selecting the eligible rows first (rather than issuing a bare `DELETE`)
+    /// is deliberate: once the row is gone its `storage_path` — the only handle
+    /// to the archive — is lost, so a row-only delete would strand the
+    /// `.tar.gz` in object storage forever, the opposite of what a
+    /// space-reclaiming retention job should do (#2787).
     pub async fn cleanup(&self, keep_count: i32, keep_days: i32) -> Result<u64> {
-        // Keep the most recent N backups
-        let result = sqlx::query(
+        // Keep the most recent N completed backups; among the rest, remove those
+        // older than the retention window.
+        let doomed: Vec<(Uuid, Option<String>)> = sqlx::query_as(
             r#"
-            DELETE FROM backups
+            SELECT id, storage_path FROM backups
             WHERE id NOT IN (
                 SELECT id FROM backups
                 WHERE status = 'completed'
@@ -803,11 +811,50 @@ impl BackupService {
         )
         .bind(keep_count as i64)
         .bind(keep_days)
-        .execute(&self.db)
+        .fetch_all(&self.db)
         .await
         .map_err(|e| AppError::Database(e.to_string()))?;
 
-        Ok(result.rows_affected())
+        let mut deleted = 0u64;
+        for (id, storage_path) in doomed {
+            // Best-effort delete the archive before dropping the row. If storage
+            // removal fails, keep the row so a later retention run retries
+            // rather than silently orphaning the archive.
+            if let Some(path) = storage_path.as_deref() {
+                match self.storage.exists(path).await {
+                    Ok(true) => {
+                        if let Err(e) = self.storage.delete(path).await {
+                            tracing::warn!(
+                                backup_id = %id,
+                                storage_path = path,
+                                "backup retention: failed to delete archive, retaining row for retry: {}",
+                                e
+                            );
+                            continue;
+                        }
+                    }
+                    Ok(false) => {}
+                    Err(e) => {
+                        tracing::warn!(
+                            backup_id = %id,
+                            storage_path = path,
+                            "backup retention: failed to stat archive, retaining row for retry: {}",
+                            e
+                        );
+                        continue;
+                    }
+                }
+            }
+
+            sqlx::query("DELETE FROM backups WHERE id = $1")
+                .bind(id)
+                .execute(&self.db)
+                .await
+                .map_err(|e| AppError::Database(e.to_string()))?;
+            deleted += 1;
+        }
+
+        Ok(deleted)
     }
 }
 

--- a/backend/tests/backup_cleanup_reclaims_storage_tests.rs
+++ b/backend/tests/backup_cleanup_reclaims_storage_tests.rs
@@ -1,0 +1,133 @@
+//! Regression test for #2787: `BackupService::cleanup` (the retention path
+//! behind `POST /api/v1/admin/cleanup` with `cleanup_old_backups`) must remove
+//! the backup archive from storage, not just the database row. Deleting only
+//! the row strands the `.tar.gz` archive in object storage forever, because the
+//! `storage_path` handle is lost with the row — the opposite of what a
+//! space-reclaiming retention job is supposed to do.
+//!
+//! Set DATABASE_URL and run:
+//!
+//! DATABASE_URL="postgresql://registry:registry@localhost:30987/artifact_registry" \
+//!   cargo test --test backup_cleanup_reclaims_storage_tests -- --ignored --nocapture
+
+use std::sync::Arc;
+
+use artifact_keeper_backend::services::backup_service::BackupService;
+use artifact_keeper_backend::services::storage_service::{FilesystemBackend, StorageService};
+use bytes::Bytes;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn reset_backups(pool: &PgPool) {
+    // Throwaway DB: isolate this test from any other rows so the global
+    // retention query operates on a known set.
+    sqlx::query("DELETE FROM backups")
+        .execute(pool)
+        .await
+        .expect("reset backups table");
+}
+
+async fn insert_completed_backup(pool: &PgPool, storage_path: &str, age_days: i32) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO backups (backup_type, status, storage_path, size_bytes, created_at)
+        VALUES ('full', 'completed', $1, 1024, NOW() - make_interval(days => $2))
+        RETURNING id
+        "#,
+    )
+    .bind(storage_path)
+    .bind(age_days)
+    .fetch_one(pool)
+    .await
+    .expect("insert backup row")
+}
+
+#[tokio::test]
+#[ignore]
+async fn cleanup_deletes_backup_archive_from_storage() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .expect("failed to connect to database");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = Arc::new(StorageService::new(Arc::new(FilesystemBackend::new(
+        tmp.path().to_path_buf(),
+    ))));
+    let svc = BackupService::new(pool.clone(), storage.clone());
+    reset_backups(&pool).await;
+
+    // An old completed backup whose archive is present in storage.
+    let key = format!("backups/2020/01/01/{}.tar.gz", Uuid::new_v4());
+    let id = insert_completed_backup(&pool, &key, 90).await;
+    storage
+        .put(&key, Bytes::from_static(b"fake-archive-bytes"))
+        .await
+        .expect("seed archive");
+    assert!(
+        storage.exists(&key).await.unwrap(),
+        "precondition: archive should exist before cleanup"
+    );
+
+    // Retention: keep 0 recent, delete anything older than 0 days -> deletes it.
+    let removed = svc.cleanup(0, 0).await.expect("cleanup");
+    assert_eq!(removed, 1, "cleanup should report one backup removed");
+
+    // Row is gone...
+    let row_exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM backups WHERE id = $1)")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(!row_exists, "backup row should be deleted");
+
+    // ...and so is the archive (this is the #2787 defect: previously leaked).
+    assert!(
+        !storage.exists(&key).await.unwrap(),
+        "#2787: backup archive must be removed from storage, not orphaned"
+    );
+}
+
+#[tokio::test]
+#[ignore]
+async fn cleanup_retains_recent_and_young_backups_and_their_archives() {
+    let pool = PgPool::connect(&std::env::var("DATABASE_URL").unwrap())
+        .await
+        .expect("failed to connect to database");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = Arc::new(StorageService::new(Arc::new(FilesystemBackend::new(
+        tmp.path().to_path_buf(),
+    ))));
+    let svc = BackupService::new(pool.clone(), storage.clone());
+    reset_backups(&pool).await;
+
+    // A recent backup (young) must be retained even though it is "extra".
+    let young_key = format!("backups/2020/06/01/{}.tar.gz", Uuid::new_v4());
+    let young_id = insert_completed_backup(&pool, &young_key, 0).await;
+    storage
+        .put(&young_key, Bytes::from_static(b"young"))
+        .await
+        .unwrap();
+
+    // keep_count=0 but keep_days=30 -> the young (age 0) backup is NOT older
+    // than 30 days, so it must survive and its archive must remain.
+    let _ = svc.cleanup(0, 30).await.expect("cleanup");
+
+    let row_exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM backups WHERE id = $1)")
+        .bind(young_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(row_exists, "young backup row must be retained");
+    assert!(
+        storage.exists(&young_key).await.unwrap(),
+        "young backup archive must be retained (legit path intact)"
+    );
+
+    // cleanup of a fresh id.
+    sqlx::query("DELETE FROM backups WHERE id = $1")
+        .bind(young_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

`BackupService::cleanup` — the retention path behind `POST /api/v1/admin/cleanup`
(`cleanup_old_backups: true`) and the operator "clean up old backups" flow — deleted
only the `backups` database row and never removed the corresponding `.tar.gz` archive
from object storage. Because the `storage_path` is stored *on that row*, deleting the
row discards the only handle to the archive, so every retained-out backup archive was
orphaned in storage permanently. For a job whose entire purpose is to reclaim space,
this leaked storage without bound.

This aligns `cleanup` with the existing `delete` path (which already removes the
archive from storage before dropping the row):

- Select the eligible rows (id + `storage_path`) first instead of a bare `DELETE`.
- Remove each archive from storage, then delete its row.
- Best-effort: if a storage delete fails, the row is retained so the next retention
  run retries rather than silently orphaning the archive (idempotent).

Retention semantics (keep most-recent-N, older-than-N-days, completed-only) are
unchanged.

## Regression test (required for `fix/*` PRs)

- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug

Added `backend/tests/backup_cleanup_reclaims_storage_tests.rs` (DB-backed, `#[ignore]`,
same convention as `lifecycle_policy_tests.rs`):

- `cleanup_deletes_backup_archive_from_storage` — seeds a completed backup with its
  archive present, runs `cleanup`, asserts the row **and** the archive are gone. Fails
  on `main` (archive orphaned), passes here.
- `cleanup_retains_recent_and_young_backups_and_their_archives` — asserts an
  in-retention backup and its archive are preserved (legit path intact).

Run:
```
DATABASE_URL=postgres://.../artifact_registry \
  cargo test --test backup_cleanup_reclaims_storage_tests -- --ignored
```

## Test Checklist
- [x] Unit tests added/updated
- [x] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests (46 `backup_service` unit tests pass)

## API Changes
- [ ] N/A - no API changes (behavior of existing `POST /api/v1/admin/cleanup` corrected)

Closes #2787
