### PR TITLE
fix(auth): scope-gate effective admin for token principals (GHSA-vvc3)

### DIFF
--- a/backend/src/api/middleware/auth.rs
+++ b/backend/src/api/middleware/auth.rs
@@ -149,6 +149,26 @@ impl AuthExtension {
         }
     }
 
+    /// Fold the effective-admin decision at construction time so every
+    /// downstream `is_admin` read (both `require_admin` and the ~34 raw
+    /// `if !auth.is_admin` handler checks) inherits scope awareness from a
+    /// single place.
+    ///
+    /// A principal is an *effective* admin only when it is BOTH owned by an
+    /// admin user AND presenting a credential whose scope ceiling grants the
+    /// `admin` scope. `has_scope` treats `None` (interactive login / basic
+    /// auth) as unrestricted, so this is a no-op for those principals and
+    /// preserves their admin. For a scope-restricted credential (an API token
+    /// or a JWT exchanged from one), `Some(list)` only grants `admin` when the
+    /// list carries `admin` or `*` — both of which live on `ADMIN_ONLY_SCOPES`
+    /// and cannot be minted by a non-admin. This closes GHSA-vvc3: an
+    /// admin-owned but narrow-scoped token (e.g. `read:artifacts`) no longer
+    /// inherits unconditional admin.
+    fn with_scope_gated_admin(mut self) -> Self {
+        self.is_admin = self.is_admin && self.has_scope("admin");
+        self
+    }
+
     /// Return a 403 Forbidden error if the caller is not an admin.
     pub fn require_admin(&self) -> crate::error::Result<()> {
         if self.is_admin {
@@ -202,6 +222,9 @@ impl From<Claims> for AuthExtension {
             allowed_repo_ids: AccessScope::from(claims.allowed_repo_ids),
             iat_ms,
         }
+        // No-op for interactive/CI JWTs (`scopes = None`); demotes an
+        // exchanged JWT that inherited a narrow token ceiling (GHSA-vvc3).
+        .with_scope_gated_admin()
     }
 }
 
@@ -784,7 +807,11 @@ async fn validate_api_token_with_scopes(
         allowed_repo_ids: validation.allowed_repo_ids,
         // API tokens are not JWTs and carry no `iat`.
         iat_ms: None,
-    })
+    }
+    // An admin-owned token only wields admin when its scope ceiling grants
+    // the `admin` scope (or `*`); a narrow-scoped token is demoted to a
+    // non-admin principal here (GHSA-vvc3).
+    .with_scope_gated_admin())
 }
 
 /// Outcome of resolving an authentication credential.
@@ -2324,6 +2351,150 @@ mod tests {
         let ext = AuthExtension::from(claims);
         assert!(!ext.is_admin);
         assert!(!ext.is_api_token);
+    }
+
+    // -----------------------------------------------------------------------
+    // GHSA-vvc3: effective-admin is scope-gated at construction
+    //
+    // A principal is an *effective* admin only when it is BOTH owned by an
+    // admin user AND presenting a credential whose scope ceiling grants the
+    // `admin` scope. `with_scope_gated_admin` folds that decision at the two
+    // construction points (`From<Claims>` and `validate_api_token_with_scopes`)
+    // so every downstream `is_admin` read inherits it. These tests are pure
+    // (no DB) and fail before the fold was added.
+    // -----------------------------------------------------------------------
+
+    /// Mirror the `AuthExtension` that `validate_api_token_with_scopes`
+    /// produces for a token owned by an ADMIN user with the given scopes, then
+    /// apply the same construction-time fold the production path applies.
+    fn admin_owned_token_ext(scopes: Vec<String>) -> AuthExtension {
+        AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "adminowner".to_string(),
+            email: "adminowner@example.com".to_string(),
+            is_admin: true,
+            is_api_token: true,
+            is_service_account: false,
+            scopes: Some(scopes),
+            allowed_repo_ids: AccessScope::Admin,
+            iat_ms: None,
+        }
+        .with_scope_gated_admin()
+    }
+
+    fn claims_with(is_admin: bool, scopes: Option<Vec<String>>) -> Claims {
+        Claims {
+            sub: Uuid::new_v4(),
+            username: "principal".to_string(),
+            email: "principal@example.com".to_string(),
+            is_admin,
+            allowed_repo_ids: None,
+            iat: 1000,
+            iat_ms: None,
+            exp: 2000,
+            token_type: "access".to_string(),
+            jti: None,
+            family_id: None,
+            scan_pull_repo: None,
+            scopes,
+        }
+    }
+
+    #[test]
+    fn test_scoped_admin_read_token_is_not_effective_admin() {
+        let ext = admin_owned_token_ext(vec!["read:artifacts".to_string()]);
+        assert!(!ext.is_admin);
+        assert!(ext.require_admin().is_err());
+    }
+
+    #[test]
+    fn test_scoped_admin_token_with_admin_scope_is_admin() {
+        let ext = admin_owned_token_ext(vec!["admin".to_string()]);
+        assert!(ext.is_admin);
+        assert!(ext.require_admin().is_ok());
+    }
+
+    #[test]
+    fn test_scoped_admin_token_with_wildcard_scope_is_admin() {
+        let ext = admin_owned_token_ext(vec!["*".to_string()]);
+        assert!(ext.is_admin);
+        assert!(ext.require_admin().is_ok());
+    }
+
+    #[test]
+    fn test_interactive_admin_jwt_preserves_admin() {
+        // scopes = None (interactive login) is unrestricted: admin preserved.
+        let ext = AuthExtension::from(claims_with(true, None));
+        assert!(ext.is_admin);
+        assert!(ext.require_admin().is_ok());
+    }
+
+    #[test]
+    fn test_non_admin_scoped_token_is_not_admin() {
+        // Owner is a non-admin: the fold is a no-op (already `false`).
+        let ext = AuthExtension {
+            user_id: Uuid::new_v4(),
+            username: "user".to_string(),
+            email: "user@example.com".to_string(),
+            is_admin: false,
+            is_api_token: true,
+            is_service_account: false,
+            scopes: Some(vec!["read:artifacts".to_string()]),
+            allowed_repo_ids: AccessScope::Restricted(vec![]),
+            iat_ms: None,
+        }
+        .with_scope_gated_admin();
+        assert!(!ext.is_admin);
+    }
+
+    #[test]
+    fn test_exchanged_jwt_from_read_token_cannot_launder_admin() {
+        // A JWT exchanged from a read-scoped API token carries
+        // `is_api_token = false` but inherits the token's `Some(scopes)`
+        // ceiling. The `From<Claims>` fold must still demote it.
+        let ext = AuthExtension::from(claims_with(true, Some(vec!["read:artifacts".to_string()])));
+        assert!(!ext.is_api_token);
+        assert!(!ext.is_admin);
+        assert!(ext.require_admin().is_err());
+    }
+
+    #[test]
+    fn test_scoped_admin_read_token_denied_self_or_admin_on_other_user() {
+        let ext = admin_owned_token_ext(vec!["read:artifacts".to_string()]);
+        let other = Uuid::new_v4();
+        // Acting on ANOTHER user's resource is denied (no effective admin).
+        assert!(ext.require_self_or_admin(other, "denied").is_err());
+        // Acting on its OWN resource is still allowed.
+        assert!(ext.require_self_or_admin(ext.user_id, "denied").is_ok());
+    }
+
+    #[test]
+    fn test_scoped_admin_read_token_cannot_mint_admin_only_scopes() {
+        // The mint-escalation gate keys on the *effective* admin flag: a
+        // read-scoped admin-owned token is treated as a non-admin caller and
+        // may not grant `admin`.
+        let ext = admin_owned_token_ext(vec!["read:artifacts".to_string()]);
+        assert!(crate::services::token_service::enforce_admin_only_scopes(
+            &["admin".to_string()],
+            ext.is_admin,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_route_level_admin_gate_403_for_scoped_read_token_2xx_for_admin_scope() {
+        // Route-level shape: admin handlers gate on `require_admin()`, whose
+        // `Authorization` error maps to HTTP 403. A read-scoped admin-owned
+        // token (previously bypassable) is now forbidden; an admin-scoped one
+        // passes the gate.
+        let read_tok = admin_owned_token_ext(vec!["read:artifacts".to_string()]);
+        let err = read_tok
+            .require_admin()
+            .expect_err("read token must be denied");
+        assert_eq!(err.into_response().status(), StatusCode::FORBIDDEN);
+
+        let admin_tok = admin_owned_token_ext(vec!["admin".to_string()]);
+        assert!(admin_tok.require_admin().is_ok());
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Admin authorization now requires an admin **owner** AND an **admin-scoped
credential**. Previously, `is_admin` was stamped onto the `AuthExtension`
straight from the owning user's role, so a credential minted with a narrow
scope ceiling (e.g. `read:artifacts`) owned by an admin user inherited
unconditional admin. Because `require_admin()` and the ~34 raw
`if !auth.is_admin` handler reads consult that flag with no scope awareness,
such a credential passed every admin gate. A JWT exchanged from a narrow API
token laundered the same way (it carries `is_api_token = false` but inherits the
token's `Some(scopes)` ceiling).

The fix folds the effective-admin decision into a single private finalizer,
`AuthExtension::with_scope_gated_admin`, applied at the two construction points
where a scope ceiling can exist:

- `impl From<Claims>` — no-op for interactive/CI logins (`scopes = None` =>
  unrestricted => admin preserved); demotes an exchanged JWT that inherited a
  narrow ceiling.
- `validate_api_token_with_scopes` — an admin-owned token only wields admin when
  its scope ceiling grants the `admin` scope (or `*`).

The predicate is `is_admin && has_scope("admin")`. `admin`/`*` live on
`ADMIN_ONLY_SCOPES`, which a non-admin cannot mint, so the only way to hold
effective admin is to be an admin owner presenting an admin-scoped credential.
Because the fold happens at construction, all 150+ `require_admin()` call sites
and the raw `is_admin` reads inherit the fix with no call-site edits.

Basic username/password auth (`From<User>`, `scopes = None`) and the
download-ticket path (already forces `is_admin = false`) are unaffected.

No migration and no runtime bypass knob: remediation for an admin currently
using a narrow-scoped token is to re-mint it with `admin`/`*` scope (covered in
the release notes). References GHSA-vvc3. Milestone 1.6.1.

## Regression test (required for `fix/*` PRs)
- [x] This PR is a `fix/*` AND adds/updates a test that would have caught the bug
- [ ] N/A — this is not a bug fix

Pure (no-DB) unit tests added in the `auth` module cover: a read-scoped
admin-owned token is not an effective admin (`require_admin` 403); `admin` and
`*` scoped tokens remain admin; interactive admin JWT (`scopes = None`) keeps
admin; a non-admin owner stays non-admin; the exchanged-JWT laundering vector is
demoted; `require_self_or_admin` denies a read-scoped admin token on another
user's id but allows its own; the mint-escalation gate treats a read-scoped
admin token as non-admin; and a route-level admin gate returns 403 for a
read-scoped admin token while an admin-scoped token passes.

## Test Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [ ] E2E tests added/updated (if applicable)
- [x] Manually tested locally
- [x] No regressions in existing tests

## API Changes
- [ ] New endpoints have `#[utoipa::path]` annotations
- [ ] Request/response types have `#[derive(ToSchema)]`
- [ ] OpenAPI spec validates: `cargo test --lib test_openapi_spec_is_valid`
- [ ] Migration is reversible (if applicable)
- [x] N/A - no API changes
